### PR TITLE
🐛 Fixed default boolean value for optional boolean value column

### DIFF
--- a/frontend/src/features/database/helpers.ts
+++ b/frontend/src/features/database/helpers.ts
@@ -75,7 +75,7 @@ export function buildDynamicSchema(columns: ColumnSchema[]) {
       case 'boolean':
         fieldSchema = z.boolean();
         if (column.nullable) {
-          fieldSchema = fieldSchema.optional();
+          fieldSchema = fieldSchema.nullable().optional();
         }
         break;
       case 'datetime':
@@ -122,7 +122,7 @@ export function getInitialValues(columns: ColumnSchema[]): Record<string, any> {
     // Set default values based on type
     switch (column.type) {
       case 'boolean':
-        values[column.name] = false;
+        values[column.name] = column.nullable ? null : false;
         break;
       case 'INTEGER':
       case 'integer':


### PR DESCRIPTION
<img width="811" height="737" alt="1754034766381" src="https://github.com/user-attachments/assets/fc772b5b-2247-4f40-9e40-bebc92eb500d" />

Now, if the boolean value column is nullable, the default value for a new record will be null instead of false. 