### PR TITLE
[UI] Some UI fix & Add responsive layout to support screen width > 1280px

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -9,7 +9,7 @@ import ReactDataGrid, {
 import { Button } from '@/components/radix/Button';
 import { Badge } from '@/components/radix/Badge';
 import { Copy, Check } from 'lucide-react';
-import { cn } from '@/lib/utils/utils';
+import { cn, mapDatabaseTypeToFieldType } from '@/lib/utils/utils';
 import { PaginationControls } from './PaginationControls';
 import ArrowUpIcon from '@/assets/icons/arrow_up.svg';
 import ArrowDownIcon from '@/assets/icons/arrow_down.svg';
@@ -182,7 +182,7 @@ function IdCell({ value }: { value: any }) {
 
   return (
     <div className="w-full h-full flex items-center justify-between group">
-      <span className="font-mono text-sm text-gray-500 truncate" title={String(value)}>
+      <span className="font-mono text-sm truncate" title={String(value)}>
         {value}
       </span>
       <Button
@@ -217,26 +217,7 @@ export function SortableHeaderRenderer({
   columnType?: string;
   showTypeBadge?: boolean;
 }) {
-  const getTypeDisplayName = (type: string) => {
-    const typeMap: { [key: string]: string } = {
-      text: 'text',
-      varchar: 'text',
-      'character varying': 'text',
-      integer: 'number',
-      bigint: 'number',
-      'double precision': 'number',
-      boolean: 'boolean',
-      'timestamp with time zone': 'date',
-      timestamptz: 'date',
-      jsonb: 'json',
-      json: 'json',
-      uuid: 'uuid',
-    };
-    return typeMap[type?.toLowerCase()] || 'text';
-  };
-
-  const typeDisplay = columnType ? getTypeDisplayName(columnType) : '';
-  const isIdColumn = column.key === 'id';
+  const typeDisplay = columnType ? mapDatabaseTypeToFieldType(columnType) : '';
 
   // Determine which arrow to show on hover based on current sort state
   const getNextSortDirection = () => {
@@ -253,14 +234,9 @@ export function SortableHeaderRenderer({
       <div className="flex flex-row gap-1 items-center">
         <span className="truncate text-sm font-medium text-zinc-950">{column.name}</span>
 
-        {columnType && !isIdColumn && showTypeBadge && (
+        {columnType && showTypeBadge && (
           <span className="bg-white px-1.5 py-0.5 border border-border-gray rounded-[6px] text-xs text-zinc-500 font-normal">
             {typeDisplay}
-          </span>
-        )}
-        {isIdColumn && showTypeBadge && (
-          <span className="bg-white px-1.5 py-0.5 border border-border-gray rounded-[6px] text-xs text-zinc-500 font-normal">
-            UUID
           </span>
         )}
 

--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -9,11 +9,12 @@ import ReactDataGrid, {
 import { Button } from '@/components/radix/Button';
 import { Badge } from '@/components/radix/Badge';
 import { Copy, Check } from 'lucide-react';
-import { cn, mapDatabaseTypeToFieldType } from '@/lib/utils/utils';
+import { cn } from '@/lib/utils/utils';
 import { PaginationControls } from './PaginationControls';
 import ArrowUpIcon from '@/assets/icons/arrow_up.svg';
 import ArrowDownIcon from '@/assets/icons/arrow_down.svg';
 import { Checkbox } from './Checkbox';
+import { TypeBadge } from '@/features/database/components/TypeBadge';
 
 // Types
 export interface DataGridColumn {
@@ -217,8 +218,6 @@ export function SortableHeaderRenderer({
   columnType?: string;
   showTypeBadge?: boolean;
 }) {
-  const typeDisplay = columnType ? mapDatabaseTypeToFieldType(columnType) : '';
-
   // Determine which arrow to show on hover based on current sort state
   const getNextSortDirection = () => {
     if (!sortDirection) {
@@ -234,11 +233,7 @@ export function SortableHeaderRenderer({
       <div className="flex flex-row gap-1 items-center">
         <span className="truncate text-sm font-medium text-zinc-950">{column.name}</span>
 
-        {columnType && showTypeBadge && (
-          <span className="bg-white px-1.5 py-0.5 border border-border-gray rounded-[6px] text-xs text-zinc-500 font-normal">
-            {typeDisplay}
-          </span>
-        )}
+        {columnType && showTypeBadge && <TypeBadge type={columnType} />}
 
         {/* Show sort arrow with hover effect */}
         {column.sortable && (

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -2,8 +2,6 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   Home,
   Database,
-  Menu,
-  X,
   UserRoundCog,
   Logs,
   HardDrive,
@@ -27,8 +25,6 @@ import {
 interface AppSidebarProps {
   currentUser: any;
   onLogout: () => void;
-  isMobileOpen: boolean;
-  onMobileToggle: () => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
 }
@@ -59,8 +55,6 @@ const bottomNavigation = [
 export default function AppSidebar({
   currentUser: _currentUser,
   onLogout: _onLogout,
-  isMobileOpen,
-  onMobileToggle,
   isCollapsed,
   onToggleCollapse,
 }: AppSidebarProps) {
@@ -74,13 +68,9 @@ export default function AppSidebar({
         variant={isActive ? 'default' : 'ghost'}
         className={cn(
           'relative transition-all duration-200 ease-in-out group',
-          // Desktop styles
-          'hidden lg:flex',
           isCollapsed ? 'w-12 h-12 p-0 justify-center' : 'w-full h-12 justify-start px-3.5 gap-0',
-          // Hover and active states
           !isActive && 'hover:bg-zinc-100 text-black',
           isActive && 'bg-zinc-950 text-white',
-          // Focus states
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400'
         )}
         onClick={onClick}
@@ -106,7 +96,7 @@ export default function AppSidebar({
               </a>
             </TooltipTrigger>
             {isCollapsed && (
-              <TooltipContent side="right" className="hidden lg:block">
+              <TooltipContent side="right">
                 <p>{item.name}</p>
               </TooltipContent>
             )}
@@ -124,7 +114,7 @@ export default function AppSidebar({
             </Link>
           </TooltipTrigger>
           {isCollapsed && (
-            <TooltipContent side="right" className="hidden lg:block">
+            <TooltipContent side="right">
               <p>{item.name}</p>
             </TooltipContent>
           )}
@@ -133,152 +123,78 @@ export default function AppSidebar({
     );
   };
 
-  const MobileNavItem = ({ item }: { item: any }) => {
-    const isActive = location.pathname === item.href;
-
-    const buttonContent = (
-      <Button
-        variant={isActive ? 'default' : 'ghost'}
-        className={cn(
-          'w-full h-12 justify-start px-3 transition-all duration-200',
-          !isActive && 'hover:bg-gray-100 hover:text-gray-900',
-          isActive && 'bg-gray-900 text-white'
-        )}
-        onClick={onMobileToggle}
-      >
-        <item.icon className="h-5 w-5 mr-3 flex-shrink-0" />
-        <span className="font-medium">{item.name}</span>
-      </Button>
-    );
-
-    if (item.external) {
-      return (
-        <a href={item.href} target="_blank" rel="noopener noreferrer" className="block lg:hidden">
-          {buttonContent}
-        </a>
-      );
-    }
-
-    return (
-      <Link to={item.href} className="block lg:hidden">
-        {buttonContent}
-      </Link>
-    );
-  };
-
   return (
-    <>
-      {/* Mobile menu button */}
-      <Button
-        variant="outline"
-        size="icon"
-        className="lg:hidden fixed top-20 left-4 z-40 bg-white shadow-sm"
-        onClick={onMobileToggle}
-      >
-        {isMobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
-      </Button>
-
-      {/* Mobile backdrop */}
-      {isMobileOpen && (
-        <div
-          className="lg:hidden fixed inset-0 z-40 bg-black/20 backdrop-blur-sm"
-          onClick={onMobileToggle}
-        />
+    <aside
+      className={cn(
+        'fixed left-0 z-40 bg-white border-r border-gray-200 flex flex-col transition-all duration-300 ease-in-out',
+        'top-16 bottom-0',
+        isCollapsed ? 'w-[72px]' : 'w-[240px]'
       )}
-
-      {/* Sidebar */}
-      <aside
-        className={cn(
-          'fixed left-0 z-40 bg-white border-r border-gray-200 flex flex-col transition-all duration-300 ease-in-out',
-          'top-16 bottom-0',
-          // Mobile styles
-          'w-64 lg:w-auto transform lg:transform-none',
-          isMobileOpen ? 'translate-x-0' : '-translate-x-full',
-          // Desktop styles
-          'lg:translate-x-0',
-          isCollapsed ? 'lg:w-[72px]' : 'lg:w-[240px]'
-        )}
-      >
-        {/* Navigation */}
-        <ScrollArea className="flex-1 px-3 lg:px-3 py-4">
-          <nav className="space-y-2">
-            {/* Desktop navigation */}
-            {navigation.map((item) => (
-              <div key={item.name}>
-                <NavItem item={item} />
-              </div>
-            ))}
-
-            {/* Mobile navigation */}
-            {navigation.map((item) => (
-              <div key={`mobile-${item.name}`} className="lg:hidden">
-                <MobileNavItem item={item} />
-              </div>
-            ))}
-          </nav>
-        </ScrollArea>
-
-        {/* Bottom section */}
-        <div className="p-3 space-y-6">
-          {/* Bottom navigation items */}
-          {bottomNavigation.map((item) => (
+    >
+      {/* Navigation */}
+      <ScrollArea className="flex-1 px-3 py-4">
+        <nav className="space-y-2">
+          {navigation.map((item) => (
             <div key={item.name}>
-              <Button
-                variant="ghost"
-                className={cn(
-                  'relative transition-all duration-200 ease-in-out group border border-gray-200 rounded-md',
-                  // Desktop styles
-                  'hidden lg:flex',
-                  isCollapsed
-                    ? 'w-12 h-12 p-0 justify-center'
-                    : 'w-full h-12 justify-start px-3.5 gap-0',
-                  // Hover and active states
-                  'hover:bg-zinc-100 text-black',
-                  // Focus states
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400'
-                )}
-                onClick={() => window.open(item.href, '_blank')}
-              >
-                <item.icon
-                  className={cn(
-                    'transition-all duration-200',
-                    'h-5 w-5 flex-shrink-0',
-                    isCollapsed ? '' : 'mr-3'
-                  )}
-                />
-                {!isCollapsed && <span className="font-medium truncate">{item.name}</span>}
-                {!isCollapsed && item.external && (
-                  <ExternalLink className="h-4 w-4 ml-auto text-zinc-400" />
-                )}
-              </Button>
-              <div className="lg:hidden">
-                <MobileNavItem item={item} />
-              </div>
+              <NavItem item={item} />
             </div>
           ))}
+        </nav>
+      </ScrollArea>
 
-          {/* Collapse button - Desktop only */}
-          <div className="hidden lg:block">
+      {/* Bottom section */}
+      <div className="p-3 space-y-6">
+        {/* Bottom navigation items */}
+        {bottomNavigation.map((item) => (
+          <div key={item.name}>
             <Button
               variant="ghost"
               className={cn(
-                'relative transition-all duration-200 ease-in-out hover:bg-zinc-100',
+                'relative transition-all duration-200 ease-in-out group border border-gray-200 rounded-md',
                 isCollapsed
                   ? 'w-12 h-12 p-0 justify-center'
-                  : 'w-full h-12 justify-start px-3.5 gap-0'
+                  : 'w-full h-12 justify-start px-3.5 gap-0',
+                'hover:bg-zinc-100 text-black',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400'
               )}
-              onClick={onToggleCollapse}
+              onClick={() => window.open(item.href, '_blank')}
             >
-              {isCollapsed ? (
-                <PanelLeftOpen className="h-4 w-4" />
-              ) : (
-                <PanelRightOpen className="h-4 w-4 mr-3" />
+              <item.icon
+                className={cn(
+                  'transition-all duration-200',
+                  'h-5 w-5 flex-shrink-0',
+                  isCollapsed ? '' : 'mr-3'
+                )}
+              />
+              {!isCollapsed && <span className="font-medium truncate">{item.name}</span>}
+              {!isCollapsed && item.external && (
+                <ExternalLink className="h-4 w-4 ml-auto text-zinc-400" />
               )}
-              {!isCollapsed && <span className="font-medium">Collapse</span>}
             </Button>
           </div>
+        ))}
+
+        {/* Collapse button */}
+        <div>
+          <Button
+            variant="ghost"
+            className={cn(
+              'relative transition-all duration-200 ease-in-out hover:bg-zinc-100',
+              isCollapsed
+                ? 'w-12 h-12 p-0 justify-center'
+                : 'w-full h-12 justify-start px-3.5 gap-0'
+            )}
+            onClick={onToggleCollapse}
+          >
+            {isCollapsed ? (
+              <PanelLeftOpen className="h-4 w-4" />
+            ) : (
+              <PanelRightOpen className="h-4 w-4 mr-3" />
+            )}
+            {!isCollapsed && <span className="font-medium">Collapse</span>}
+          </Button>
         </div>
-      </aside>
-    </>
+      </div>
+    </aside>
   );
 }

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -5,7 +5,6 @@ import {
   UserRoundCog,
   Logs,
   HardDrive,
-  Bug,
   Info,
   PanelLeftOpen,
   PanelRightOpen,
@@ -29,7 +28,14 @@ interface AppSidebarProps {
   onToggleCollapse: () => void;
 }
 
-const navigation = [
+interface NavigationProps {
+  name: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  external?: boolean;
+}
+
+const navigation: NavigationProps[] = [
   { name: 'Dashboard', href: '/dashboard', icon: Home },
   { name: 'Authentications', href: '/dashboard/authentication', icon: UserRoundCog },
   { name: 'Database', href: '/dashboard/database', icon: Database },
@@ -37,11 +43,6 @@ const navigation = [
   { name: 'Logs', href: '/dashboard/logs', icon: Logs },
   { name: 'Metadata', href: '/dashboard/metadata', icon: Info },
 ];
-
-// Add debug link only when debug mode is enabled
-if (import.meta.env.VITE_DEBUG_MODE) {
-  navigation.push({ name: 'Debug', href: '/debug', icon: Bug });
-}
 
 const bottomNavigation = [
   {
@@ -60,7 +61,7 @@ export default function AppSidebar({
 }: AppSidebarProps) {
   const location = useLocation();
 
-  const NavItem = ({ item, onClick }: { item: any; onClick?: () => void }) => {
+  const NavItem = ({ item, onClick }: { item: NavigationProps; onClick?: () => void }) => {
     const isActive = location.pathname === item.href;
 
     const buttonContent = (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -9,7 +9,6 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false); // Default to expanded
   const { user, logout } = useAuth();
 
@@ -20,8 +19,6 @@ export default function Layout({ children }: LayoutProps) {
       <AppSidebar
         currentUser={user}
         onLogout={logout}
-        isMobileOpen={sidebarMobileOpen}
-        onMobileToggle={() => setSidebarMobileOpen(!sidebarMobileOpen)}
         isCollapsed={sidebarCollapsed}
         onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
       />
@@ -29,8 +26,8 @@ export default function Layout({ children }: LayoutProps) {
       {/* Main content */}
       <div
         className={cn(
-          'flex-1 transition-all duration-300 ease-in-out overflow-y-auto',
-          sidebarCollapsed ? 'lg:ml-[72px]' : 'lg:ml-[240px]',
+          'flex-1 transition-all duration-300 ease-in-out overflow-y-auto ml-18',
+          !sidebarCollapsed && '2xl:ml-[240px]',
           'mt-16'
         )}
       >

--- a/frontend/src/features/database/components/DatabaseDataGrid.tsx
+++ b/frontend/src/features/database/components/DatabaseDataGrid.tsx
@@ -176,14 +176,14 @@ export function convertSchemaToColumns(
     const isEditable =
       !col.primary_key &&
       [
-        'uuid',
-        'text',
-        'integer',
-        'double precision',
-        'boolean',
-        'timestamp with time zone',
-        'jsonb',
-      ].includes(col.type);
+        ColumnType.UUID,
+        ColumnType.STRING,
+        ColumnType.INTEGER,
+        ColumnType.FLOAT,
+        ColumnType.BOOLEAN,
+        ColumnType.DATETIME,
+        ColumnType.JSON,
+      ].includes(colType);
     const isSortable = !['jsonb', 'json'].includes(col.type?.toLowerCase());
 
     const column: DataGridColumn = {

--- a/frontend/src/features/database/components/FormField.tsx
+++ b/frontend/src/features/database/components/FormField.tsx
@@ -253,7 +253,7 @@ export function FormField({ field, form, tableName }: FormFieldProps) {
                 <Input
                   id={`${tableName}-${field.name}`}
                   type="number"
-                  step={fieldType === 'FLOAT' ? '0.01' : '1'}
+                  step={fieldType === ColumnType.FLOAT ? '0.01' : '1'}
                   value={formField.value ?? ''}
                   onChange={(e) => {
                     const value = e.target.value;
@@ -262,7 +262,7 @@ export function FormField({ field, form, tableName }: FormFieldProps) {
                       formField.onChange(field.nullable ? null : 0);
                     } else {
                       const numValue =
-                        fieldType === 'INTEGER' ? parseInt(value, 10) : parseFloat(value);
+                        fieldType === ColumnType.INTEGER ? parseInt(value, 10) : parseFloat(value);
                       formField.onChange(isNaN(numValue) ? (field.nullable ? null : 0) : numValue);
                     }
                   }}

--- a/frontend/src/features/database/components/TableForm.tsx
+++ b/frontend/src/features/database/components/TableForm.tsx
@@ -402,7 +402,7 @@ export function TableForm({
   return (
     <div className="flex flex-col h-full">
       {/* Content area with slate background */}
-      <div className="flex-1 px-6 bg-slate-100 flex flex-col items-center overflow-auto">
+      <div className="flex-1 bg-slate-100 flex flex-col items-center overflow-auto">
         <div className="flex flex-col gap-6 w-full max-w-[1080px] px-6 py-6">
           {/* Title Bar */}
           <div className="flex items-center justify-between">
@@ -443,15 +443,15 @@ export function TableForm({
               </div>
 
               {/* Columns Table */}
-              <div className="pb-6">
+              <div className="pb-6 overflow-x-auto">
                 {/* Table Headers */}
                 <div className="flex items-center gap-6 px-7 py-2 bg-slate-50 rounded-t text-sm font-medium text-zinc-950">
-                  <div className="w-[280px]">Name</div>
-                  <div className="w-[200px]">Type</div>
-                  <div className="w-[200px]">Default Value</div>
-                  <div className="flex-1 text-center">Nullable</div>
-                  <div className="flex-1 text-center">Unique</div>
-                  <div className="w-5" />
+                  <div className="flex-1 min-w-[175px]">Name</div>
+                  <div className="flex-1 min-w-[175px]">Type</div>
+                  <div className="flex-1 min-w-[175px]">Default Value</div>
+                  <div className="w-18 2xl:w-25 text-center flex-shrink-0">Nullable</div>
+                  <div className="w-18 2xl:w-25 text-center flex-shrink-0">Unique</div>
+                  <div className="w-5 flex-shrink-0" />
                 </div>
 
                 {/* Columns */}
@@ -502,23 +502,25 @@ export function TableForm({
                   {foreignKeys.map((fk) => (
                     <div
                       key={fk.columnName}
-                      className="group flex flex-wrap items-center gap-8 pl-4 pr-2 py-2 rounded-lg border border-zinc-200 bg-white hover:bg-zinc-100 transition-colors duration-150"
+                      className="group flex items-center gap-6 2xl:gap-8 pl-4 pr-2 py-2 rounded-lg border border-zinc-200 bg-white hover:bg-zinc-100 transition-colors duration-150"
                     >
-                      <div className="flex items-center gap-2 flex-1">
-                        <Link className="w-5 h-5 text-zinc-500" />
-                        <span className="font-medium text-sm text-zinc-950">{fk.columnName}</span>
-                        <MoveRight className="w-5 h-5 text-zinc-950" />
-                        <span className="font-medium text-sm text-zinc-950">
+                      <div className="flex items-center gap-2 flex-1 min-w-[188px] overflow-hidden">
+                        <Link className="flex-shrink-0 w-5 h-5 text-zinc-500" />
+                        <span className="font-medium text-sm text-zinc-950 truncate">
+                          {fk.columnName}
+                        </span>
+                        <MoveRight className="flex-shrink-0 w-5 h-5 text-zinc-950" />
+                        <span className="font-medium text-sm text-zinc-950 flex-1 truncate">
                           {fk.reference_table}.{fk.reference_column}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 flex-1">
+                      <div className="flex items-center gap-2 w-47">
                         <span className="font-medium text-sm text-zinc-950 whitespace-nowrap">
                           On Update:
                         </span>
                         <span className="text-sm text-zinc-500">{fk.on_update}</span>
                       </div>
-                      <div className="flex items-center gap-2 flex-1">
+                      <div className="flex items-center gap-2 w-47">
                         <span className="font-medium text-sm text-zinc-950 whitespace-nowrap">
                           On Delete:
                         </span>

--- a/frontend/src/features/database/components/TableFormColumn.tsx
+++ b/frontend/src/features/database/components/TableFormColumn.tsx
@@ -30,7 +30,7 @@ export const TableFormColumn = memo(function TableFormColumn({
       }`}
     >
       {/* Name */}
-      <div className="w-[280px]">
+      <div className="flex-1 min-w-[175px]">
         <div className="relative flex items-center">
           <Controller
             control={control}
@@ -39,7 +39,7 @@ export const TableFormColumn = memo(function TableFormColumn({
               <Input
                 {...field}
                 placeholder="Enter column name"
-                className={`h-10 rounded-md border-zinc-200 text-sm font-normal ${
+                className={`w-full h-10 rounded-md border-zinc-200 text-sm font-normal ${
                   isSystemColumn ? 'bg-zinc-100 text-zinc-950' : 'bg-white text-zinc-950 shadow-sm'
                 }`}
                 disabled={isSystemColumn}
@@ -54,19 +54,19 @@ export const TableFormColumn = memo(function TableFormColumn({
       </div>
 
       {/* Type */}
-      <div className="w-[200px]">
+      <div className="flex-1 min-w-[175px]">
         <ColumnTypeSelect
           control={control}
           name={`columns.${index}.type`}
           disabled={!isNewColumn}
-          className={`h-10 rounded-md border-zinc-200 text-sm font-normal ${
+          className={`w-full h-10 rounded-md border-zinc-200 text-sm font-normal ${
             isSystemColumn ? 'bg-zinc-100' : 'bg-white shadow-sm'
           }`}
         />
       </div>
 
       {/* Default Value */}
-      <div className="w-[200px]">
+      <div className="flex-1 min-w-[175px]">
         <Controller
           control={control}
           name={`columns.${index}.default_value`}
@@ -74,7 +74,7 @@ export const TableFormColumn = memo(function TableFormColumn({
             <Input
               {...field}
               placeholder="Enter default value"
-              className={`h-10 rounded-md border-zinc-200 text-sm font-normal placeholder:text-zinc-500 ${
+              className={`w-full h-10 rounded-md border-zinc-200 text-sm font-normal placeholder:text-zinc-500 ${
                 isSystemColumn ? 'bg-zinc-100' : 'bg-white shadow-sm'
               }`}
               disabled={isSystemColumn}
@@ -84,7 +84,7 @@ export const TableFormColumn = memo(function TableFormColumn({
       </div>
 
       {/* Nullable */}
-      <div className="flex-1 flex justify-center">
+      <div className="w-18 2xl:w-25 flex justify-center flex-shrink-0">
         <Controller
           control={control}
           name={`columns.${index}.nullable`}
@@ -100,7 +100,7 @@ export const TableFormColumn = memo(function TableFormColumn({
       </div>
 
       {/* Unique */}
-      <div className="flex-1 flex justify-center">
+      <div className="w-18 2xl:w-25 flex justify-center flex-shrink-0">
         <Controller
           control={control}
           name={`columns.${index}.is_unique`}
@@ -116,7 +116,7 @@ export const TableFormColumn = memo(function TableFormColumn({
       </div>
 
       {/* Delete */}
-      <div className="w-5 h-5">
+      <div className="w-5 h-5 flex-shrink-0">
         {!isSystemColumn && (
           <button
             type="button"

--- a/frontend/src/features/database/components/TypeBadge.tsx
+++ b/frontend/src/features/database/components/TypeBadge.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/utils/utils';
+import { cn, mapDatabaseTypeToFieldType } from '@/lib/utils/utils';
 
 interface TypeBadgeProps {
   type: string;
@@ -6,34 +6,6 @@ interface TypeBadgeProps {
 }
 
 export function TypeBadge({ type, className }: TypeBadgeProps) {
-  const getDisplayType = (type: string) => {
-    const lowerType = type.toLowerCase();
-
-    if (lowerType.includes('int')) {
-      return 'Int';
-    }
-    if (lowerType.includes('string') || lowerType.includes('text')) {
-      return 'String';
-    }
-    if (lowerType.includes('date') || lowerType.includes('time')) {
-      return 'Date';
-    }
-    if (lowerType.includes('bool')) {
-      return 'Boolean';
-    }
-    if (lowerType.includes('json')) {
-      return 'JSON';
-    }
-    if (lowerType.includes('uuid')) {
-      return 'UUID';
-    }
-    if (lowerType.includes('real') || lowerType.includes('float')) {
-      return 'Float';
-    }
-
-    return type;
-  };
-
   return (
     <div
       className={cn(
@@ -42,7 +14,7 @@ export function TypeBadge({ type, className }: TypeBadgeProps) {
         className
       )}
     >
-      <span className="text-xs font-normal text-zinc-500">{getDisplayType(type)}</span>
+      <span className="text-xs font-normal text-zinc-500">{mapDatabaseTypeToFieldType(type)}</span>
     </div>
   );
 }


### PR DESCRIPTION
1. Fixed type badges to reflect correct column types
2. Made TableForm responsive and maintained the same visual for screen width > 1280px (desktop) (Resolves#17)
3. AppSidebar for screen width < 1536px (2xl) now cover other elements when expanding
4. Removed unwanted responsive for Mobile and Tablets

<img width="1281" height="1303" alt="image" src="https://github.com/user-attachments/assets/ca1ce444-1510-4ec5-abd2-62485692bd04" />
