### PR TITLE
fix mcp docs windows and mac

### DIFF
--- a/docs/insforge-auth-api.md
+++ b/docs/insforge-auth-api.md
@@ -65,10 +65,15 @@ Response:
 ```
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X POST http://localhost:7130/api/auth/v2/admin/sign-in \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"change-this-password"}'
+
+# Windows PowerShell (use curl.exe)
+curl.exe -X POST http://localhost:7130/api/auth/v2/admin/sign-in \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"admin@example.com\",\"password\":\"change-this-password\"}"
+  -d '{\"email\":\"admin@example.com\",\"password\":\"change-this-password\"}'
 ```
 
 ## Error Response Format
@@ -132,10 +137,15 @@ Response (when disableRedirect: true):
 ```
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X POST http://localhost:7130/api/auth/v2/sign-in/social \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"google","callbackURL":"http://localhost:7131/dashboard","disableRedirect":true}'
+
+# Windows PowerShell (use curl.exe)
+curl.exe -X POST http://localhost:7130/api/auth/v2/sign-in/social \
   -H "Content-Type: application/json" \
-  -d "{\"provider\":\"google\",\"callbackURL\":\"http://localhost:7131/dashboard\",\"disableRedirect\":true}"
+  -d '{\"provider\":\"google\",\"callbackURL\":\"http://localhost:7131/dashboard\",\"disableRedirect\":true}'
 ```
 
 #### OAuth Callback

--- a/docs/insforge-db-api.md
+++ b/docs/insforge-db-api.md
@@ -53,8 +53,7 @@ Response: Array of records with auto-generated `id`, `created_at`, `updated_at` 
 
 Example:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
-# No authentication needed for reading!
+# Windows PowerShell: use curl.exe
 curl -X GET "http://localhost:7130/api/database/records/posts?limit=10"
 ```
 
@@ -113,12 +112,19 @@ Response format (WITH `Prefer: return=representation` header):
 
 Example:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X POST http://localhost:7130/api/database/records/comments \
+  -H 'Authorization: Bearer YOUR_SESSION_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -H 'Prefer: return=representation' \
+  -d '[{"user_id": "from-localStorage", "post_id": "post-uuid", "content": "Great!"}]'
+
+# Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
+curl.exe -X POST http://localhost:7130/api/database/records/comments \
   -H "Authorization: Bearer YOUR_SESSION_TOKEN" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d "[{\"user_id\": \"from-localStorage\", \"post_id\": \"post-uuid\", \"content\": \"Great!\"}]"
+  -d '[{\"user_id\": \"from-localStorage\", \"post_id\": \"post-uuid\", \"content\": \"Great!\"}]'
 ```
 
 ### Update Record
@@ -176,12 +182,19 @@ Response format (WITH `Prefer: return=representation` header):
 
 Example:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X PATCH "http://localhost:7130/api/database/records/users?id=eq.UUID" \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -H 'Prefer: return=representation' \
+  -d '{"name": "Jane Doe"}'
+
+# Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
+curl.exe -X PATCH "http://localhost:7130/api/database/records/users?id=eq.UUID" \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d '{"name": "Jane Doe"}'
+  -d '{\"name\": \"Jane Doe\"}'
 ```
 
 ### Delete Record
@@ -219,7 +232,7 @@ Response format (WITH `Prefer: return=representation` header):
 
 Example:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl -X DELETE "http://localhost:7130/api/database/records/users?id=eq.UUID" \
   -H "Authorization: Bearer TOKEN" \
   -H "Prefer: return=representation"
@@ -252,7 +265,7 @@ Example error:
 
 For paginated results, use the `Range` header:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl "http://localhost:7130/api/database/records/posts" \
   -H "Range: 0-9" \
   -H "Prefer: count=exact"
@@ -294,18 +307,23 @@ const userId = localStorage.getItem('user_id');
 ```
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
 # ❌ WRONG - Missing user_id
 curl -X POST http://localhost:7130/api/database/records/comments \
   -H "Authorization: Bearer TOKEN" \
-  -d "[{\"content\": \"Great post\"}]"
+  -d '[{"content": "Great post"}]'
 
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
 # ✅ CORRECT - Includes user_id
+# Mac/Linux
 curl -X POST http://localhost:7130/api/database/records/comments \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Prefer: return=representation' \
+  -d '[{"content": "Great post!", "user_id": "user-uuid-from-localStorage"}]'
+
+# Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
+curl.exe -X POST http://localhost:7130/api/database/records/comments \
   -H "Authorization: Bearer TOKEN" \
   -H "Prefer: return=representation" \
-  -d "[{\"content\": \"Great post!\", \"user_id\": \"user-uuid-from-localStorage\"}]"
+  -d '[{\"content\": \"Great post!\", \"user_id\": \"user-uuid-from-localStorage\"}]'
 ```
 
 **Required for all user-related operations:**

--- a/docs/insforge-debug.md
+++ b/docs/insforge-debug.md
@@ -32,17 +32,25 @@ Before debugging, you MUST read all documentation to understand how the API work
 ### Example Debug Tests
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
 # Test GET endpoint
+# Windows PowerShell: use curl.exe
 curl -X GET http://localhost:7130/api/database/records/your_table \
   -H "Authorization: Bearer YOUR_TOKEN" | jq .
 
 # Test POST with array format
+# Mac/Linux
 curl -X POST http://localhost:7130/api/database/records/your_table \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -H 'Prefer: return=representation' \
+  -d '[{"field": "value"}]' | jq .
+
+# Windows PowerShell (use curl.exe) - different quotes for nested JSON
+curl.exe -X POST http://localhost:7130/api/database/records/your_table \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Prefer: return=representation" \
-  -d "[{\"field\": \"value\"}]" | jq .
+  -d '[{\"field\": \"value\"}]' | jq .
 ```
 
 ## Key Rules

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -111,7 +111,7 @@ curl -X POST http://localhost:7130/api/database/records/posts \
   -H "x-api-key: your-api-key" \
   -H "Authorization: Bearer your-jwt-token" \
   -H "Content-Type: application/json" \
-  -d "[{\"title\": \"Test Post\", \"content\": \"Test content\"}]"
+  -d '[{\"title\": \"Test Post\", \"content\": \"Test content\"}]'
 
 # Works on both Windows and Unix (Windows PowerShell: use curl.exe)
 # Example: Test querying records (requires both API key and JWT token)
@@ -123,7 +123,7 @@ curl http://localhost:7130/api/database/records/posts?id=eq.123 \
 # Example: Test authentication
 curl -X POST http://localhost:7130/api/auth/register \
   -H "Content-Type: application/json" \
-  -d "{\"email\": \"test@example.com\", \"password\": \"testpass123\"}"
+  -d '{\"email\": \"test@example.com\", \"password\": \"testpass123\"}'
 ```
 
 Always include:

--- a/docs/insforge-project.md
+++ b/docs/insforge-project.md
@@ -19,10 +19,15 @@ You are an exceptional software developer using Insforge Backend to assist build
 4. **When debugging** → Test to see actual vs expected responses
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X POST http://localhost:7130/api/[endpoint] \
+  -H 'Content-Type: application/json' \
+  -d '[{"key": "value"}]' | jq .
+
+# Windows PowerShell (use curl.exe) - different quotes for nested JSON
+curl.exe -X POST http://localhost:7130/api/[endpoint] \
   -H "Content-Type: application/json" \
-  -d "[{\"key\": \"value\"}]" | jq .
+  -d '[{\"key\": \"value\"}]' | jq .
 ```
 
 **You WILL get it wrong without testing. Test early, test often.**
@@ -100,13 +105,20 @@ The `user` table is **protected** by Better Auth:
 Always test with cURL before UI integration:
 - Include `Authorization: Bearer TOKEN` for auth
 - Add `Prefer: return=representation` to see created data
-- Use escaped double quotes for universal compatibility
+- Windows PowerShell: use curl.exe
 
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X POST http://localhost:7130/api/database/records/posts \
+  -H 'Authorization: Bearer TOKEN' \
+  -H 'Content-Type: application/json' \
+  -H 'Prefer: return=representation' \
+  -d '[{"user_id": "from-localStorage", "caption": "Test"}]'
+
+# Windows PowerShell (use curl.exe) - different quotes for nested JSON
+curl.exe -X POST http://localhost:7130/api/database/records/posts \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d "[{\"user_id\": \"from-localStorage\", \"caption\": \"Test\"}]"
+  -d '[{\"user_id\": \"from-localStorage\", \"caption\": \"Test\"}]'
 ```

--- a/docs/insforge-storage-api.md
+++ b/docs/insforge-storage-api.md
@@ -47,7 +47,7 @@ Returns:
 
 Example curl:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl -X PUT http://localhost:7130/api/storage/buckets/avatars/objects/user123.jpg \
   -H "Authorization: Bearer YOUR_SESSION_TOKEN" \
   -F "file=@/path/to/image.jpg"
@@ -58,7 +58,7 @@ curl -X PUT http://localhost:7130/api/storage/buckets/avatars/objects/user123.jp
 
 Request:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl -X POST http://localhost:7130/api/storage/buckets/posts/objects \
   -H "Authorization: Bearer YOUR_SESSION_TOKEN" \
   -F "file=@/path/to/image.jpg"
@@ -123,7 +123,7 @@ Pagination headers:
 
 Example curl:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl -X GET "http://localhost:7130/api/storage/buckets/avatars/objects?limit=10&prefix=users/" \
   -H "x-api-key: YOUR_API_KEY"
 ```
@@ -140,7 +140,7 @@ Returns:
 
 Example curl:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Windows PowerShell: use curl.exe
 curl -X DELETE http://localhost:7130/api/storage/buckets/avatars/objects/user123.jpg \
   -H "x-api-key: YOUR_API_KEY"
 ```
@@ -165,11 +165,17 @@ Returns:
 
 Example curl:
 ```bash
-# Works on both Windows and Unix (Windows PowerShell: use curl.exe)
+# Mac/Linux
 curl -X PATCH http://localhost:7130/api/storage/buckets/avatars \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{"isPublic": true}'
+
+# Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
+curl.exe -X PATCH http://localhost:7130/api/storage/buckets/avatars \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"isPublic": true}'
+  -d '{\"isPublic\": true}'
 ```
 
 ## Database Integration


### PR DESCRIPTION
list out windows and mac exammpels since they differ too much...


windoes need '' and \" in beneath

mac just needs ""