### PR TITLE
[FIX] Forbids modifying system columns

### DIFF
--- a/frontend/src/features/database/components/ForeignKeyPopover.tsx
+++ b/frontend/src/features/database/components/ForeignKeyPopover.tsx
@@ -154,7 +154,11 @@ export function ForeignKeyPopover({
                   {columns
                     .filter((col) => col.columnName)
                     .map((col, index) => (
-                      <SelectItem key={col.columnName || index} value={col.columnName}>
+                      <SelectItem
+                        key={col.columnName || index}
+                        value={col.columnName}
+                        disabled={col.isSystemColumn}
+                      >
                         {col.columnName} ({col.type})
                       </SelectItem>
                     ))}


### PR DESCRIPTION
<img width="1307" height="827" alt="image" src="https://github.com/user-attachments/assets/5121aeb9-a009-4762-aad3-49dec0c16715" />
Drop/Update/Add foreign keys on system columns is now forbidden.



<img width="728" height="637" alt="image" src="https://github.com/user-attachments/assets/0821874f-44e8-483d-bf37-197fa939bcca" />

Disable the system column selection in ForeignKeyPopover.