### PR TITLE
feat: support drag-and-drop file upload in Storage

### DIFF
--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -32,7 +32,7 @@ interface BucketFormState {
 export default function StoragePage() {
   const [selectedBucket, setSelectedBucket] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [_isDragging, setIsDragging] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -444,9 +444,11 @@ export default function StoragePage() {
               </div>
             </div>
 
-            {/* Content */}
+            {/* Content (supports drag-and-drop file upload) */}
             <div
-              className="relative flex-1 flex flex-col overflow-hidden"
+              className={
+                'relative flex-1 flex flex-col overflow-hidden' + (isDragging ? ' opacity-25' : '')
+              }
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
               onDrop={handleDrop}

--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -178,7 +178,7 @@ export default function StoragePage() {
     void queryClient.invalidateQueries({ queryKey: ['storage'] });
   };
 
-  const uploadFiles = async (files: FileList | null) => {
+  const uploadFiles = async (files: FileList | File[] | null) => {
     if (!files || files.length === 0 || !selectedBucket) {
       return;
     }
@@ -300,7 +300,16 @@ export default function StoragePage() {
     (event: DragEvent<HTMLDivElement>) => {
       event.preventDefault();
       setIsDragging(false);
-      void handleFileUpload(event.dataTransfer.files);
+
+      // To support only file uploads (not directories), we filter through
+      // dataTransfer.items instead of directly using dataTransfer.files.
+      // Ref: https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+      const fileItems: File[] = Array.from(event.dataTransfer.items)
+        .filter((item) => item.webkitGetAsEntry()?.isFile)
+        .map((item) => item.getAsFile())
+        .filter((item) => item !== null);
+
+      void handleFileUpload(fileItems);
     },
     [handleFileUpload]
   );


### PR DESCRIPTION
Closes #54.

## Overview

This PR leverages the native [HTML5 Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) to support uploading a file(s) by dragging from a user's filesystem UI onto the content area of the Storage page.

For basic UX, a simple opacity decrease of the content area hints to the user that the region is a drop zone. This can be enhanced in future changes.

## Demo

https://github.com/user-attachments/assets/c7b45447-7e32-4e3e-99d1-e4739b1ca161

Note that because the file upload simply reuses logic from `handleFileSelect()`, the flow is identical to if the user had uploaded via the **File Upload** button:

- [x] Upload a single file
- [x] Upload multiple files at once
- [x] Error if uploading a file when there already exists a file with the same name
- [x] Prevent upload of full directories (see below) 

## Note: Handling Directories

One pitfall I will note is that I was initially allowed to upload full directories as well (while the file upload dialog, since it's an `<input type="file">`, prevents you from selecting directories in the first place so they never makes it to the update mutation):

https://github.com/user-attachments/assets/487ea678-88f9-4787-95f1-257da0066feb

I infer that "directory" support may be unintended because while the storage service does not error, a directory does not survive round-trip. That is, the upload results in a file that when downloaded back, is not treated as such (e.g. no conversion to, say, zipfile upon upload/download).

This behavior is fixed in [f726040](https://github.com/InsForge/InsForge/pull/79/commits/f7260401de0e4c708e672741497b2fe986eaa656), where I opt to just silently ignore directories included in the drag-and-drop. This can be enhanced (e.g. descriptive error message) in future changes.