### PR TITLE
fix: mention allowing underscores in bucket name

### DIFF
--- a/frontend/src/features/storage/components/BucketFormDialog.tsx
+++ b/frontend/src/features/storage/components/BucketFormDialog.tsx
@@ -143,7 +143,7 @@ export function BucketFormDialog({
               </div>
               <p className="text-sm text-zinc-500">
                 {mode === 'create'
-                  ? 'Use lowercase letters, numbers and hyphens only.'
+                  ? 'Use lowercase letters, numbers, hyphens, and underscores only.'
                   : 'Bucket name cannot be changed.'}
               </p>
             </div>


### PR DESCRIPTION
Closes #78.

## Overview

Simply mentions underscores as an allowed character for bucket names in the creation dialog:

## Preview

<img width="569" height="358" alt="image" src="https://github.com/user-attachments/assets/bd22f75c-6765-4054-87be-a0a7049191c8" />

This now aligns with the error message that appears post-validation:

<img width="567" height="390" alt="image" src="https://github.com/user-attachments/assets/7db29caa-0f9a-44d7-b6fc-899f1f8c1375" />

## Future Work

However, as @Fermionic-Lyu alludes to in https://github.com/InsForge/InsForge/issues/78#issuecomment-3172250569, this seems to be indicative of a larger need. Validation happens on the backend, which is the one that [actually gives us the error message](https://github.com/InsForge/InsForge/blob/9e88b1ff01aff8044c291736021156e78178397a/frontend/src/features/storage/components/BucketFormDialog.tsx#L62). This means that displayed hints on the frontend and data requirements on the backend must never diverge. Sharing types/schemas across the stack should solve this.