### PR TITLE
[FIX] Fix parameter in listObjects response to correctly show file type

### DIFF
--- a/backend/src/core/storage/storage.ts
+++ b/backend/src/core/storage/storage.ts
@@ -399,12 +399,14 @@ export class StorageService {
     query += ' ORDER BY key LIMIT ? OFFSET ?';
     const queryParams = [...params, limit, offset];
 
-    const objects = (await db.prepare(query).all(...queryParams)) as StorageRecord[];
+    const objects = await db.prepare(query).all(...queryParams);
     const total = ((await db.prepare(countQuery).get(...params)) as { count: number }).count;
 
     return {
       objects: objects.map((obj) => ({
         ...obj,
+        mimeType: obj.mime_type,
+        uploadedAt: obj.uploaded_at,
         url: `/api/storage/buckets/${bucket}/objects/${encodeURIComponent(obj.key)}`,
       })),
       total,

--- a/frontend/src/features/storage/components/StorageDataGrid.tsx
+++ b/frontend/src/features/storage/components/StorageDataGrid.tsx
@@ -123,7 +123,7 @@ export function createStorageColumns(
       renderCell: MimeTypeRenderer,
     },
     {
-      key: 'uploaded_at',
+      key: 'uploadedAt',
       name: 'Uploaded',
       width: '1fr',
       resizable: true,


### PR DESCRIPTION
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/431e0503-8547-4ab1-bf12-ccfb0ae03d9e" />

The file type was unknown because backend provides mime_type but frontend expects mimeType. This is fixed now.
