### PR TITLE
fix: improve validation error messages for missing email/password

### DIFF
--- a/backend/src/api/routes/auth.ts
+++ b/backend/src/api/routes/auth.ts
@@ -29,7 +29,7 @@ router.post('/users', async (req: Request, res: Response, next: NextFunction) =>
     const validationResult = createUserRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
       throw new AppError(
-        validationResult.error.errors[0]?.message || 'Invalid input',
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
         400,
         ERROR_CODES.INVALID_INPUT
       );
@@ -50,7 +50,7 @@ router.post('/sessions', async (req: Request, res: Response, next: NextFunction)
     const validationResult = createSessionRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
       throw new AppError(
-        validationResult.error.errors[0]?.message || 'Invalid input',
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
         400,
         ERROR_CODES.INVALID_INPUT
       );
@@ -71,7 +71,7 @@ router.post('/admin/sessions', async (req: Request, res: Response, next: NextFun
     const validationResult = createAdminSessionRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
       throw new AppError(
-        validationResult.error.errors[0]?.message || 'Invalid input',
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
         400,
         ERROR_CODES.INVALID_INPUT
       );
@@ -250,7 +250,7 @@ router.delete('/users', verifyAdmin, async (req: Request, res: Response, next: N
     const validationResult = deleteUsersRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
       throw new AppError(
-        validationResult.error.errors[0]?.message || 'Invalid input',
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
         400,
         ERROR_CODES.INVALID_INPUT
       );

--- a/backend/tests/local/test-traditional-rest.sh
+++ b/backend/tests/local/test-traditional-rest.sh
@@ -71,7 +71,7 @@ response=$(curl -s -X POST "$API_BASE/auth/sessions" \
     -H "Content-Type: application/json" \
     -d '{}')
 test_response_format "Error response" "$response" '"error":"INVALID_INPUT"'
-test_response_format "Message field" "$response" '"message":"Email is required"'
+test_response_format "Message field" "$response" '"message":"email: Required, password: Required"'
 
 # 4. Test Invalid Endpoint (404)
 print_info "4. Testing Invalid Endpoint (404)"

--- a/backend/tests/local/test-traditional-rest.sh
+++ b/backend/tests/local/test-traditional-rest.sh
@@ -71,7 +71,7 @@ response=$(curl -s -X POST "$API_BASE/auth/sessions" \
     -H "Content-Type: application/json" \
     -d '{}')
 test_response_format "Error response" "$response" '"error":"INVALID_INPUT"'
-test_response_format "Message field" "$response" '"message":"Email and password are required"'
+test_response_format "Message field" "$response" '"message":"Email is required"'
 
 # 4. Test Invalid Endpoint (404)
 print_info "4. Testing Invalid Endpoint (404)"

--- a/shared-schemas/src/auth.schema.ts
+++ b/shared-schemas/src/auth.schema.ts
@@ -12,13 +12,13 @@ import { z } from 'zod';
 export const userIdSchema = z.string().uuid('Invalid user ID format');
 
 export const emailSchema = z
-  .string()
+  .string({ required_error: 'Email is required' })
   .email('Invalid email format')
   .toLowerCase()
   .trim();
 
 export const passwordSchema = z
-  .string()
+  .string({ required_error: 'Password is required' })
   .min(6, 'Password must be at least 6 characters')
   .max(32, 'Password must be less than 32 characters');
 

--- a/shared-schemas/src/auth.schema.ts
+++ b/shared-schemas/src/auth.schema.ts
@@ -12,13 +12,13 @@ import { z } from 'zod';
 export const userIdSchema = z.string().uuid('Invalid user ID format');
 
 export const emailSchema = z
-  .string({ required_error: 'Email is required' })
+  .string()
   .email('Invalid email format')
   .toLowerCase()
   .trim();
 
 export const passwordSchema = z
-  .string({ required_error: 'Password is required' })
+  .string()
   .min(6, 'Password must be at least 6 characters')
   .max(32, 'Password must be less than 32 characters');
 


### PR DESCRIPTION
When adding the shared schema i realized that there is making 1 e2e test failing.. This proves that we need auto e2e

change parsing logic of auth to match the others.Fix test error message