### PR TITLE
[Fix] Update doc link

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -50,7 +50,7 @@ const navigation: NavigationProps[] = [
 const bottomNavigation = [
   {
     name: 'Documentation',
-    href: 'https://github.com/InsForge/InsForge',
+    href: 'https://docs.insforge.dev',
     icon: BookOpen,
     external: true,
   },


### PR DESCRIPTION
The documentation link now correctly links to [https://docs.insforge.dev/introduction](https://docs.insforge.dev)