### PR TITLE
remove deno  container for now to speed up build time

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -74,8 +74,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGREST_BASE_URL=http://postgrest:3000
-      # Deno Runtime URL
-      - DENO_RUNTIME_URL=http://deno:7133
+      # Deno Runtime URL (disabled)
+      # - DENO_RUNTIME_URL=http://deno:7133
       # OAuth Configuration
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
@@ -92,41 +92,42 @@ services:
     restart: unless-stopped
     networks:
       - insforge-network
-
-  deno:
-    image: denoland/deno:alpine-2.0.6
-    container_name: insforge-deno
-    working_dir: /app
-    depends_on:
-      - postgres
-      - postgrest
-    ports:
-      - "7133:7133"
-    environment:
-      - DENO_ENV=${DENO_ENV:-development}
-      - DENO_DIR=/deno-dir
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - POSTGREST_BASE_URL=http://postgrest:3000
-    volumes:
-      - ./functions:/app/functions
-      - deno_cache:/deno-dir
-    command: >
-      sh -c "
-        echo 'Downloading Deno dependencies...' &&
-        deno cache functions/server.ts &&
-        echo 'Starting Deno server...' &&
-        # Minimal permissions: net (server), env (config), read (worker template only)
-        deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --watch functions/server.ts
-      "
-    restart: unless-stopped
-    networks:
-      - insforge-network
-
+  
+  # Deno service disabled for now
+  # deno:
+  #   image: denoland/deno:alpine-2.0.6
+  #   container_name: insforge-deno
+  #   working_dir: /app
+  #   depends_on:
+  #     - postgres
+  #     - postgrest
+  #   ports:
+  #     - "7133:7133"
+  #   environment:
+  #     - DENO_ENV=${DENO_ENV:-development}
+  #     - DENO_DIR=/deno-dir
+  #     # PostgreSQL connection
+  #     - POSTGRES_HOST=postgres
+  #     - POSTGRES_PORT=5432
+  #     - POSTGRES_DB=${POSTGRES_DB:-insforge}
+  #     - POSTGRES_USER=${POSTGRES_USER:-postgres}
+  #     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+  #     - POSTGREST_BASE_URL=http://postgrest:3000
+  #   volumes:
+  #     - ./functions:/app/functions
+  #     - deno_cache:/deno-dir
+  #   command: >
+  #     sh -c "
+  #       echo 'Downloading Deno dependencies...' &&
+  #       deno cache functions/server.ts &&
+  #       echo 'Starting Deno server...' &&
+  #       # Minimal permissions: net (server), env (config), read (worker template only)
+  #       deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --watch functions/server.ts
+  #     "
+  #   restart: unless-stopped
+  #   networks:
+  #     - insforge-network
+  
   analytics:
     container_name: insforge-analytics
     image: supabase/logflare:1.14.2
@@ -221,8 +222,8 @@ services:
 volumes:
   postgres-data:
     driver: local
-  deno_cache:
-    driver: local
+  # deno_cache:
+  #   driver: local
 
 networks:
   insforge-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGREST_BASE_URL=http://postgrest:3000
-      # Deno Runtime URL
-      - DENO_RUNTIME_URL=http://deno:7133
+      # Deno Runtime URL (disabled)
+      # - DENO_RUNTIME_URL=http://deno:7133
       # OAuth Configuration
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
@@ -105,39 +105,40 @@ services:
     networks:
       - insforge-network
 
-  deno:
-    image: denoland/deno:alpine-2.0.6
-    container_name: insforge-deno
-    working_dir: /app
-    depends_on:
-      - postgres
-      - postgrest
-    ports:
-      - "7133:7133"
-    environment:
-      - DENO_ENV=${DENO_ENV:-development}
-      - DENO_DIR=/deno-dir
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - POSTGREST_BASE_URL=http://postgrest:3000
-    volumes:
-      - ./functions:/app/functions
-      - deno_cache:/deno-dir
-    command: >
-      sh -c "
-        echo 'Downloading Deno dependencies...' &&
-        deno cache functions/server.ts &&
-        echo 'Starting Deno server...' &&
-        # Minimal permissions: net (server), env (config), read (worker template only)
-        deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --watch functions/server.ts
-      "
-    restart: unless-stopped
-    networks:
-      - insforge-network
+  # Deno service disabled for now
+  # deno:
+  #   image: denoland/deno:alpine-2.0.6
+  #   container_name: insforge-deno
+  #   working_dir: /app
+  #   depends_on:
+  #     - postgres
+  #     - postgrest
+  #   ports:
+  #     - "7133:7133"
+  #   environment:
+  #     - DENO_ENV=${DENO_ENV:-development}
+  #     - DENO_DIR=/deno-dir
+  #     # PostgreSQL connection
+  #     - POSTGRES_HOST=postgres
+  #     - POSTGRES_PORT=5432
+  #     - POSTGRES_DB=${POSTGRES_DB:-insforge}
+  #     - POSTGRES_USER=${POSTGRES_USER:-postgres}
+  #     - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+  #     - POSTGREST_BASE_URL=http://postgrest:3000
+  #   volumes:
+  #     - ./functions:/app/functions
+  #     - deno_cache:/deno-dir
+  #   command: >
+  #     sh -c "
+  #       echo 'Downloading Deno dependencies...' &&
+  #       deno cache functions/server.ts &&
+  #       echo 'Starting Deno server...' &&
+  #       # Minimal permissions: net (server), env (config), read (worker template only)
+  #       deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --watch functions/server.ts
+  #     "
+  #   restart: unless-stopped
+  #   networks:
+  #     - insforge-network
 
   analytics:
     container_name: insforge-analytics
@@ -241,8 +242,8 @@ volumes:
     driver: local
   shared_schemas_node_modules:
     driver: local
-  deno_cache:
-    driver: local
+  # deno_cache:
+  #   driver: local
 
 networks:
   insforge-network:


### PR DESCRIPTION
This is pushed to main as requested by Hang. :) 

To reduce the startup time abit and help with user experience , and this shouldn't impact mcp or any performance

test:
docker compose down -v
docker compose  up

UI still works, can build with mcp