### PR TITLE
fix docker config to read from env instead of hardcode localhost

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,8 +62,8 @@ services:
     environment:
       - PORT=7130
       - PROJECT_ROOT=/app
-      - API_BASE_URL=http://localhost:7130
-      - VITE_API_BASE_URL=http://localhost:7130
+      - API_BASE_URL=${API_BASE_URL}
+      - VITE_API_BASE_URL=${VITE_API_BASE_URL}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,8 @@ services:
     environment:
       - PORT=7130
       - PROJECT_ROOT=/app
-      - API_BASE_URL=http://localhost:7130
-      - VITE_API_BASE_URL=http://localhost:7130
+      - API_BASE_URL=${API_BASE_URL}
+      - VITE_API_BASE_URL=${VITE_API_BASE_URL}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}


### PR DESCRIPTION
Currently docker is always assuming localhost 7130 for a lot of places... this is the first step to let it deploy to correct values.


Next step:

change cloud backend configuration to load on appkey.[region].insforge.app as API_BASE_URL and VITE.

