### PR TITLE
[feat]remove the dependency of aws access key in OSS version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,6 @@ DOCKER_SOCKET_LOCATION=/var/run/docker.sock
 # For S3 storage (optional - if not set, will use local filesystem)
 AWS_S3_BUCKET=
 AWS_REGION=us-east-2
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-
 
 # Multi-tenant Cloud Configuration
 # Below only used through cloud available solution

--- a/backend/src/core/storage/storage.ts
+++ b/backend/src/core/storage/storage.ts
@@ -89,15 +89,11 @@ class S3StorageBackend implements StorageBackend {
   ) {}
 
   initialize(): void {
+    // On EC2: Use IAM roles attached to the instance for S3 permissions
+    // The SDK will automatically use the instance's IAM role credentials
+    // No explicit AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY needed, unless for testing
     this.s3Client = new S3Client({
       region: this.region,
-      credentials:
-        process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
-          ? {
-              accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-              secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-            }
-          : undefined,
     });
   }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,8 +86,6 @@ services:
       # Storage Configuration
       - AWS_S3_BUCKET=${AWS_S3_BUCKET:-}
       - AWS_REGION=${AWS_REGION:-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # Multi-tenant Cloud Configuration
       - DEPLOYMENT_ID=${DEPLOYMENT_ID:-}
       - PROJECT_ID=${PROJECT_ID:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,6 @@ services:
       # Storage Configuration
       - AWS_S3_BUCKET=${AWS_S3_BUCKET:-}
       - AWS_REGION=${AWS_REGION:-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # Multi-tenant Cloud Configuration
       - DEPLOYMENT_ID=${DEPLOYMENT_ID:-}
       - PROJECT_ID=${PROJECT_ID:-}


### PR DESCRIPTION
https://github.com/InsForge/insforge-cloud-backend/pull/52
following this, we are using instance profile for ec2 startup. We don't need another set of keys within ec2. 

So I'll remove the dependency of auth key and id for aws. This also avoids lots of confusion