### PR TITLE
[Fix] Change logs page to analytics page for cloud

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,7 +63,7 @@ function AppRoutes() {
                 <Route path="/authentication" element={<AuthenticationPage />} />
                 <Route path="/database" element={<DatabasePage />} />
                 <Route path="/storage" element={<StoragePage />} />
-                <Route path="/logs" element={<LogsPage />} />
+                <Route path="/analytics" element={<AnalyticsLogsPage />} />
                 <Route path="*" element={<Navigate to="/cloud/dashboard" replace />} />
               </Routes>
             </CloudLayout>


### PR DESCRIPTION
The cloud routes now use AnalyticsPage instead of LogsPage, I hope this is the desired page (we dreprecating logs page, right?)