### PR TITLE
rename oauth redirect param

### DIFF
--- a/backend/src/api/routes/auth.ts
+++ b/backend/src/api/routes/auth.ts
@@ -347,11 +347,11 @@ router.delete('/users', verifyAdmin, async (req: Request, res: Response, next: N
 // OAuth endpoints following naming convention: /oauth/:provider and /oauth/:provider/callback
 router.get('/oauth/google', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { redirectUrl } = req.query;
+    const { redirect_uri } = req.query;
 
     const jwtPayload = {
       provider: 'google',
-      redirectUrl: redirectUrl ? (redirectUrl as string) : undefined,
+      redirectUrl: redirect_uri ? (redirect_uri as string) : undefined,
       createdAt: Date.now(),
     };
     const state = jwt.sign(jwtPayload, process.env.JWT_SECRET || 'default_secret', {
@@ -375,10 +375,10 @@ router.get('/oauth/google', async (req: Request, res: Response, next: NextFuncti
 
 router.get('/oauth/github', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { redirectUrl } = req.query;
+    const { redirect_uri } = req.query;
     const jwtPayload = {
       provider: 'github',
-      redirectUrl: redirectUrl ? (redirectUrl as string) : undefined,
+      redirectUrl: redirect_uri ? (redirect_uri as string) : undefined,
       createdAt: Date.now(),
     };
     const state = jwt.sign(jwtPayload, process.env.JWT_SECRET || 'default_secret', {

--- a/examples/oauth/frontend-oauth-example.html
+++ b/examples/oauth/frontend-oauth-example.html
@@ -149,7 +149,7 @@
                 showStatus('Getting Google authorization link...', 'info');
                 redirect_url = 'http://localhost/'; // window.location.href
                 // Get authorization URL
-                const response = await fetch(`${API_BASE}/auth/oauth/google?redirectUrl=${encodeURIComponent(redirect_url)}`);
+                const response = await fetch(`${API_BASE}/auth/oauth/google?redirect_uri=${encodeURIComponent(redirect_url)}`);
                 const data = await response.json();
                 
                 if (data.authUrl) {
@@ -177,7 +177,7 @@
                 
                 showStatus('Getting GitHub authorization link...', 'info');
                 redirect_url = 'http://localhost/';
-                const response = await fetch(`${API_BASE}/auth/oauth/github?redirectUrl=${encodeURIComponent(redirect_url)}`);
+                const response = await fetch(`${API_BASE}/auth/oauth/github?redirect_uri=${encodeURIComponent(redirect_url)}`);
                 const data = await response.json();
                 console.log('GitHub OAuth response:', data);
 

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -341,7 +341,7 @@ paths:
     get:
       summary: Initiate Google OAuth flow
       parameters:
-        - name: redirect_url
+        - name: redirect_uri
           in: query
           schema:
             type: string
@@ -357,7 +357,7 @@ paths:
     get:
       summary: Initiate GitHub OAuth flow
       parameters:
-        - name: redirect_url
+        - name: redirect_uri
           in: query
           schema:
             type: string


### PR DESCRIPTION
- tested with examples/oauth/frontend-oauth-example.html
- good news: except for redirectUrl, the codebase already follows snake_case
  convention consistently for query parameters(public interface), no other camelCase query parameters were found.