### PR TITLE
[FIX] Fix get user endpoints in doc

### DIFF
--- a/docs/insforge-auth-api.md
+++ b/docs/insforge-auth-api.md
@@ -170,7 +170,7 @@ Example - Create table with user reference:
       "nullable": false,
       "is_unique": false,
       "foreign_key": {
-        "reference_table": "user",
+        "reference_table": "_user",
         "reference_column": "id",
         "on_delete": "CASCADE",
         "on_update": "CASCADE"

--- a/docs/insforge-auth-api.md
+++ b/docs/insforge-auth-api.md
@@ -32,7 +32,7 @@ Headers: `Authorization: Bearer <accessToken>`
 
 Returns: `{"user": {"id": "...", "email": "...", "role": "authenticated"}}`
 
-**Note**: Returns LIMITED fields (id, email, type, role). For full user data including name/image, query `/api/database/records/user?id=eq.<user_id>`
+**Note**: Returns LIMITED fields (id, email, type, role). For full user data including name/image, query `/api/database/records/_user?id=eq.<user_id>`
 
 **Common errors:**
 - `401` with `"code": "MISSING_AUTHORIZATION_HEADER"` → No token provided
@@ -148,7 +148,7 @@ After processing, backend redirects to your specified `redirectUrl` with JWT tok
 
 ### User Table (Read-Only)
 The `user` table is **system-managed**:
-- **✅ READ** via: `GET /api/database/records/user`
+- **✅ READ** via: `GET /api/database/records/_user`
 - **❌ NO WRITE** - use Auth API instead
 - **✅ Foreign keys allowed**
 - Schema: `id`, `email`, `name`, `image`, `email_verified`, `created_at`, `updated_at`
@@ -197,7 +197,7 @@ The authentication system manages:
 
 1. `/api/auth/sessions/current` returns `{"user": {...}}` - nested, not root level
 2. `/api/auth/sessions/current` only has: id, email, role (limited fields)
-3. Full user data: `GET /api/database/records/user?id=eq.<id>`
+3. Full user data: `GET /api/database/records/_user?id=eq.<id>`
 4. POST to database requires `[{...}]` array format always
 5. Auth endpoints (register/login): no headers needed
 6. Protected endpoints: `Authorization: Bearer <accessToken>`

--- a/docs/insforge-db-api.md
+++ b/docs/insforge-db-api.md
@@ -183,14 +183,14 @@ Response format (WITH `Prefer: return=representation` header):
 Example:
 ```bash
 # Mac/Linux
-curl -X PATCH "http://localhost:7130/api/database/records/users?id=eq.UUID" \
+curl -X PATCH "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
   -H 'Authorization: Bearer TOKEN' \
   -H 'Content-Type: application/json' \
   -H 'Prefer: return=representation' \
   -d '{"name": "Jane Doe"}'
 
 # Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
-curl.exe -X PATCH "http://localhost:7130/api/database/records/users?id=eq.UUID" \
+curl.exe -X PATCH "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
@@ -233,7 +233,7 @@ Response format (WITH `Prefer: return=representation` header):
 Example:
 ```bash
 # Windows PowerShell: use curl.exe
-curl -X DELETE "http://localhost:7130/api/database/records/users?id=eq.UUID" \
+curl -X DELETE "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
   -H "Authorization: Bearer TOKEN" \
   -H "Prefer: return=representation"
 ```
@@ -281,7 +281,7 @@ Without `Prefer: count=exact`, you get: `Content-Range: 0-9/*` (no total count)
 ## 🚨 Critical: User Table is Read-Only
 
 **The `_user` table is managed by the JWT authentication system:**
-- **✅ READ**: `GET /api/database/records/user` - Works!
+- **✅ READ**: `GET /api/database/records/_user` - Works!
 - **❌ WRITE**: POST/PUT/PATCH/DELETE returns `403 FORBIDDEN`
 - **Solution**: For additional user data, create `user_profiles` table:
 ```json

--- a/docs/insforge-db-api.md
+++ b/docs/insforge-db-api.md
@@ -289,7 +289,7 @@ Without `Prefer: count=exact`, you get: `Content-Range: 0-9/*` (no total count)
   "table_name": "user_profiles",
   "columns": [
     {"name": "user_id", "type": "string", "nullable": false, "is_unique": true,
-     "foreign_key": {"reference_table": "user", "reference_column": "id", 
+     "foreign_key": {"reference_table": "_user", "reference_column": "id", 
                      "on_delete": "CASCADE", "on_update": "CASCADE"}},
     {"name": "bio", "type": "string", "nullable": true},
     {"name": "avatar_url", "type": "string", "nullable": true}

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -82,12 +82,12 @@ curl -X POST http://localhost:7130/api/database/records/products \
 
 ### User Table (Read-Only Access)
 The `_user` table is a **system-managed table** from the JWT authentication system:
-- **✅ CAN READ** via `GET /api/database/records/user`
+- **✅ CAN READ** via `GET /api/database/records/_user`
 - **❌ CANNOT MODIFY** through database API - use Auth API instead
 - **✅ CAN REFERENCE** by other tables using `user_id` foreign keys
 
 To work with users:
-- Read users: `GET /api/database/records/user`
+- Read users: `GET /api/database/records/_user`
 - Create users: Use `POST /api/auth/users`
 - Authenticate: Use `POST /api/auth/sessions`
 - Store additional data: Create your own `user_profiles` table

--- a/docs/insforge-project.md
+++ b/docs/insforge-project.md
@@ -40,7 +40,7 @@ When in doubt, read instructions documents again.
 
 ### User Table (Read-Only)
 The `_user` table is **protected** by the JWT authentication system:
-- **✅ CAN READ** via `GET /api/database/records/user`
+- **✅ CAN READ** via `GET /api/database/records/_user`
 - **❌ CANNOT MODIFY** (POST/PUT/PATCH/DELETE) - use Auth API instead
 - **✅ CAN reference** with foreign keys
 - Get `user_id` from `localStorage.getItem('user_id')` after login


### PR DESCRIPTION
`/api/database/records/user` -> `/api/database/records/_user`

The previous one will return 
{
    "code": "42P01",
    "details": null,
    "hint": null,
    "message": "relation \"public.user\" does not exist"
}