### PR TITLE
[Experiment] Add experimental endpoints for dynamic documentations

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "jwt"
   ],
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@aws-sdk/client-cloudwatch-logs": "^3.713.0",
     "@aws-sdk/client-s3": "^3.713.0",
     "@insforge/insforge-mcp": "^1.0.8",

--- a/backend/src/api/routes/agent.ts
+++ b/backend/src/api/routes/agent.ts
@@ -1,0 +1,29 @@
+import { Router, Request, Response } from 'express';
+import { AgentAPIDocService } from '@/core/documentation/agent.js';
+import { AppError } from '@/api/middleware/error.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import { successResponse } from '@/utils/response.js';
+import logger from '@/utils/logger.js';
+
+const router = Router();
+const agentAPIDocService = AgentAPIDocService.getInstance();
+
+/**
+ * GET /api/agent-docs
+ * Get AI-native API documentation optimized for LLMs
+ */
+router.get('/', async (_req: Request, res: Response, next) => {
+  try {
+    const agentDocs = await agentAPIDocService.generateAgentDocumentation();
+    successResponse(res, agentDocs);
+  } catch (error) {
+    logger.error('Failed to generate agent API documentation', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    next(
+      new AppError('Failed to generate agent API documentation', 500, ERROR_CODES.INTERNAL_ERROR)
+    );
+  }
+});
+
+export { router as agentDocsRouter };

--- a/backend/src/api/routes/openapi.ts
+++ b/backend/src/api/routes/openapi.ts
@@ -1,0 +1,82 @@
+import { Router, Request, Response } from 'express';
+import { OpenAPIService } from '@/core/documentation/openapi.js';
+import { AppError } from '@/api/middleware/error.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import { successResponse } from '@/utils/response.js';
+import logger from '@/utils/logger.js';
+
+const router = Router();
+const openAPIService = OpenAPIService.getInstance();
+
+/**
+ * GET /api/openapi
+ * Get the OpenAPI specification document
+ */
+router.get('/', async (_req: Request, res: Response, next) => {
+  try {
+    const openAPIDocument = await openAPIService.generateOpenAPIDocument();
+    successResponse(res, openAPIDocument);
+  } catch (error) {
+    logger.error('Failed to generate OpenAPI document', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    next(new AppError('Failed to generate OpenAPI document', 500, ERROR_CODES.INTERNAL_ERROR));
+  }
+});
+
+/**
+ * GET /api/openapi/swagger
+ * Serve Swagger UI HTML page
+ */
+router.get('/swagger', (_req: Request, res: Response) => {
+  const html = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>InsForge API Documentation</title>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+      <style>
+        body {
+          margin: 0;
+          padding: 0;
+        }
+        .swagger-ui .topbar {
+          display: none;
+        }
+      </style>
+    </head>
+    <body>
+      <div id="swagger-ui"></div>
+      <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+      <script>
+        window.onload = () => {
+          window.ui = SwaggerUIBundle({
+            url: '/api/openapi',
+            dom_id: '#swagger-ui',
+            deepLinking: true,
+            presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIBundle.SwaggerUIStandalonePreset
+            ],
+            layout: 'BaseLayout',
+            tryItOutEnabled: true,
+            requestInterceptor: (request) => {
+              // Add API key from localStorage if available
+              const apiKey = localStorage.getItem('insforge_api_key');
+              if (apiKey) {
+                request.headers['x-api-key'] = apiKey;
+              }
+              return request;
+            }
+          });
+        };
+      </script>
+    </body>
+    </html>
+  `;
+  res.type('html').send(html);
+});
+
+export { router as openAPIRouter };

--- a/backend/src/core/documentation/agent.ts
+++ b/backend/src/core/documentation/agent.ts
@@ -1,0 +1,703 @@
+import { MetadataService } from '@/core/metadata/metadata.js';
+import { TableSchema } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+export class AgentAPIDocService {
+  private static instance: AgentAPIDocService;
+  private metadataService: MetadataService;
+
+  private constructor() {
+    this.metadataService = MetadataService.getInstance();
+  }
+
+  static getInstance(): AgentAPIDocService {
+    if (!AgentAPIDocService.instance) {
+      AgentAPIDocService.instance = new AgentAPIDocService();
+    }
+    return AgentAPIDocService.instance;
+  }
+
+  /**
+   * Map internal column types to API-friendly type names
+   */
+  private mapColumnType(type: string): string {
+    const typeMap: Record<string, string> = {
+      string: 'string',
+      datetime: 'date-time string',
+      integer: 'integer',
+      float: 'number',
+      boolean: 'boolean',
+      uuid: 'UUID string',
+      json: 'object/array',
+    };
+    return typeMap[type] || type;
+  }
+
+  /**
+   * Convert table schema to simplified record schema
+   */
+  private tableToRecordSchema(
+    table: TableSchema
+  ): Record<string, { type: string; required: boolean }> {
+    const schema: Record<string, { type: string; required: boolean }> = {};
+
+    for (const column of table.columns) {
+      schema[column.columnName] = {
+        type: this.mapColumnType(column.type),
+        required: !column.isNullable,
+      };
+    }
+
+    return schema;
+  }
+
+  /**
+   * Generate AI-native API documentation
+   */
+  async generateAgentDocumentation(): Promise<any> {
+    try {
+      // Get fresh metadata
+      const metadata = await this.metadataService.getFullMetadata();
+
+      // Filter out system tables
+      const tables = metadata.database.tables.filter((table) => {
+        if (table.tableName.startsWith('_')) {
+          return false;
+        }
+        return true;
+      });
+
+      // Generate table schemas
+      const tableSchemas: Record<string, Record<string, { type: string; required: boolean }>> = {};
+      const tableList: string[] = [];
+
+      for (const table of tables) {
+        tableSchemas[`${table.tableName}RecordSchema`] = this.tableToRecordSchema(table);
+        tableList.push(table.tableName);
+      }
+
+      // Get storage buckets
+      const buckets = metadata.storage?.buckets || [];
+      const bucketList = buckets.map((bucket: any) => bucket.name);
+
+      const document = {
+        version: metadata.version || '1.0.0',
+        baseUrl: process.env.API_BASE_URL || 'http://localhost:7130',
+        securitySchemes: {
+          method: 'bearerToken',
+          bearerHeader: 'Authorization',
+          bearerFormat: 'Bearer {token}',
+        },
+        // Authentication API for user management
+        authenticationApi: {
+          register: {
+            method: 'POST',
+            path: '/api/auth/users',
+            request: {
+              requiresAuth: false,
+              body: {
+                email: 'string - valid email address',
+                password: 'string - user password (min 8 characters)',
+                name: 'string (optional) - user display name',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: {
+                  user: '{id: string, email: string, name: string | null}',
+                  accessToken: 'string - JWT token for authentication',
+                },
+              },
+              error: {
+                status: '400 | 409 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'POST /api/auth/users',
+              body: '{email: "user@example.com", password: "securePassword123", name: "John Doe"}',
+              response:
+                '{user: {id: "uuid", email: "user@example.com", name: "John Doe"}, accessToken: "eyJ..."}',
+            },
+          },
+
+          login: {
+            method: 'POST',
+            path: '/api/auth/sessions',
+            request: {
+              requiresAuth: false,
+              body: {
+                email: 'string - user email address',
+                password: 'string - user password',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: {
+                  user: '{id: string, email: string, name: string | null}',
+                  accessToken: 'string - JWT token for authentication',
+                },
+              },
+              error: {
+                status: '401 | 400 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'POST /api/auth/sessions',
+              body: '{email: "user@example.com", password: "securePassword123"}',
+              response:
+                '{user: {id: "uuid", email: "user@example.com", name: "John Doe"}, accessToken: "eyJ..."}',
+            },
+          },
+
+          getCurrentUser: {
+            method: 'GET',
+            path: '/api/auth/sessions/current',
+            request: {
+              requiresAuth: true,
+              headers: {
+                Authorization: 'Bearer {accessToken}',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: {
+                  user: '{id: string, email: string, role: string}',
+                },
+              },
+              error: {
+                status: '401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'GET /api/auth/sessions/current',
+              headers: 'Authorization: Bearer eyJ...',
+              response: '{user: {id: "uuid", email: "user@example.com", role: "user"}}',
+            },
+          },
+
+          googleOAuth: {
+            method: 'GET',
+            path: '/api/auth/oauth/google',
+            request: {
+              requiresAuth: false,
+              queryParams: {
+                redirect_uri: 'string (optional) - URL to redirect after OAuth completion',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: {
+                  authUrl: 'string - Google OAuth authorization URL',
+                },
+              },
+              error: {
+                status: '500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'GET /api/auth/oauth/google?redirect_uri=http://localhost:3000/dashboard',
+              response: '{authUrl: "https://accounts.google.com/o/oauth2/v2/auth?..."}',
+            },
+          },
+
+          githubOAuth: {
+            method: 'GET',
+            path: '/api/auth/oauth/github',
+            request: {
+              requiresAuth: false,
+              queryParams: {
+                redirect_uri: 'string (optional) - URL to redirect after OAuth completion',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: {
+                  authUrl: 'string - GitHub OAuth authorization URL',
+                },
+              },
+              error: {
+                status: '500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'GET /api/auth/oauth/github?redirect_uri=http://localhost:3000/dashboard',
+              response: '{authUrl: "https://github.com/login/oauth/authorize?..."}',
+            },
+          },
+
+          oauthCallback: {
+            method: 'GET',
+            path: '/api/auth/oauth/{provider}/callback',
+            description: 'OAuth callback endpoint - typically handled automatically by OAuth flow',
+            request: {
+              requiresAuth: false,
+              params: {
+                provider: 'string - OAuth provider (google or github)',
+              },
+              queryParams: {
+                code: 'string - Authorization code from OAuth provider',
+                state: 'string - State parameter for security',
+                token: 'string (optional) - ID token for some flows',
+              },
+            },
+            response: {
+              success: {
+                status: 302,
+                description:
+                  'Redirects to redirect_uri with access_token, user_id, email, and name in query params',
+              },
+              error: {
+                status: 302,
+                description: 'Redirects to redirect_uri with error in query params',
+              },
+            },
+          },
+        },
+
+        // Universal patterns for all tables
+        tableApi: {
+          list: {
+            method: 'GET',
+            path: '/api/database/records/{tableName}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+              },
+              queryParams: {
+                // Pagination
+                limit: 'number (default: 100)',
+                offset: 'number (default: 0)',
+                // Sorting
+                order: 'columnName.asc or columnName.desc',
+                // Selection
+                select: 'comma-separated column names',
+                // Filtering - any column can be used as filter
+                '{columnName}': 'exact match',
+                '{columnName}.eq': 'equals',
+                '{columnName}.neq': 'not equals',
+                '{columnName}.gt': 'greater than',
+                '{columnName}.gte': 'greater than or equal',
+                '{columnName}.lt': 'less than',
+                '{columnName}.lte': 'less than or equal',
+                '{columnName}.like': 'LIKE pattern (use % for wildcard)',
+                '{columnName}.ilike': 'case insensitive LIKE',
+                '{columnName}.is': 'IS (use for null: is.null, is.notnull)',
+                '{columnName}.in': 'IN (comma-separated values in parentheses)',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: 'Array<{tableName}RecordSchema>',
+              },
+              error: {
+                status: '400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request:
+                'GET /api/database/records/products?limit=10&offset=0&status=active&order=created_at.desc',
+              response: '[{...record1}, {...record2}]',
+            },
+          },
+
+          getById: {
+            method: 'GET',
+            path: '/api/database/records/{tableName}/{id}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+                id: 'string - primary key value',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: '{tableName}RecordSchema',
+              },
+              error: {
+                status: '404 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'GET /api/database/records/products/123',
+              response: '{id: "123", name: "Product Name", price: 29.99, ...}',
+            },
+          },
+
+          create: {
+            method: 'POST',
+            path: '/api/database/records/{tableName}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+              },
+              body: '{tableName}RecordSchema (exclude: id, created_at, updated_at)',
+            },
+            response: {
+              success: {
+                status: 201,
+                body: '{tableName}RecordSchema (complete)',
+              },
+              error: {
+                status: '400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'POST /api/database/records/products',
+              body: '{name: "New Product", price: 29.99, category: "electronics"}',
+              response:
+                '{id: "123", name: "New Product", price: 29.99, category: "electronics", created_at: "...", updated_at: "..."}',
+            },
+          },
+
+          update: {
+            method: 'PATCH',
+            path: '/api/database/records/{tableName}/{id}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+                id: 'string - primary key value',
+              },
+              body: 'Partial<{tableName}RecordSchema> (all fields optional, exclude: id, created_at, updated_at)',
+            },
+            response: {
+              success: {
+                status: 200,
+                body: '{tableName}RecordSchema',
+              },
+              error: {
+                status: '404 | 400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'PATCH /api/database/records/products/123',
+              body: '{price: 39.99}',
+              response: '{id: "123", name: "Product Name", price: 39.99, ...}',
+            },
+          },
+
+          delete: {
+            method: 'DELETE',
+            path: '/api/database/records/{tableName}/{id}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+                id: 'string - primary key value',
+              },
+            },
+            response: {
+              success: {
+                status: 204,
+                body: 'null (No Content)',
+              },
+              error: {
+                status: '404 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'DELETE /api/database/records/products/123',
+              response: 'Status: 204',
+            },
+          },
+
+          bulkCreate: {
+            method: 'POST',
+            path: '/api/database/records/{tableName}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+              },
+              body: 'Array<{tableName}RecordSchema> (exclude system fields)',
+            },
+            response: {
+              success: {
+                status: 201,
+                body: 'Array<{tableName}RecordSchema>',
+              },
+              error: {
+                status: '400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'POST /api/database/records/products',
+              body: '[{name: "Product 1", price: 19.99}, {name: "Product 2", price: 29.99}]',
+              response:
+                '[{id: "123", name: "Product 1", price: 19.99, ...}, {id: "124", name: "Product 2", price: 29.99, ...}]',
+            },
+          },
+
+          bulkUpdate: {
+            method: 'PATCH',
+            path: '/api/database/records/{tableName}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+              },
+              queryParams: 'Use filters to select records (same as list operation)',
+              body: 'Partial<{tableName}RecordSchema>',
+            },
+            response: {
+              success: {
+                status: 200,
+                body: 'Array<{tableName}RecordSchema>',
+              },
+              error: {
+                status: '400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'PATCH /api/database/records/products?category=electronics',
+              body: '{discount: 10}',
+              response: '[{id: "123", name: "Product 1", discount: 10, ...}, ...]',
+            },
+          },
+
+          bulkDelete: {
+            method: 'DELETE',
+            path: '/api/database/records/{tableName}',
+            request: {
+              params: {
+                tableName: 'string - name of the table',
+              },
+              queryParams: 'Use filters to select records (same as list operation)',
+            },
+            response: {
+              success: {
+                status: 204,
+                body: 'null (No Content)',
+              },
+              error: {
+                status: '400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'DELETE /api/database/records/products?discontinued=true',
+              response: 'Status: 204',
+            },
+          },
+        },
+
+        // Storage API for file upload and management
+        storageApi: {
+          uploadObject: {
+            method: 'PUT',
+            path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+            request: {
+              requiresAuth: 'user',
+              params: {
+                bucketName: 'string - name of the bucket',
+                objectKey:
+                  'string - full object key/path (can include folders like "images/photo.jpg")',
+              },
+              body: 'multipart/form-data with "file" field containing the file data',
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+            response: {
+              success: {
+                status: 201,
+                body: 'StorageFileSchema',
+              },
+              error: {
+                status: '400 | 409 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'PUT /api/storage/buckets/uploads/objects/images/profile.jpg',
+              formData: 'file: <binary data>',
+              response:
+                '{key: "images/profile.jpg", bucket: "uploads", size: 2048, mimeType: "image/jpeg", ...}',
+            },
+          },
+
+          uploadObjectAutoKey: {
+            method: 'POST',
+            path: '/api/storage/buckets/{bucketName}/objects',
+            request: {
+              requiresAuth: 'user',
+              params: {
+                bucketName: 'string - name of the bucket',
+              },
+              body: 'multipart/form-data with "file" field containing the file data',
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            },
+            response: {
+              success: {
+                status: 201,
+                body: 'StorageFileSchema (with auto-generated key)',
+              },
+              error: {
+                status: '404 | 400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'POST /api/storage/buckets/uploads/objects',
+              formData: 'file: <binary data of photo.jpg>',
+              response:
+                '{key: "photo-1704000000000-abc123.jpg", bucket: "uploads", size: 2048, ...}',
+            },
+          },
+
+          downloadObject: {
+            method: 'GET',
+            path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+            request: {
+              requiresAuth: 'conditional - required only for private buckets',
+              params: {
+                bucketName: 'string - name of the bucket',
+                objectKey: 'string - full object key/path',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                headers: {
+                  'Content-Type': 'file MIME type',
+                  'Content-Length': 'file size in bytes',
+                },
+                body: 'Binary file data',
+              },
+              error: {
+                status: '404 | 400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'GET /api/storage/buckets/uploads/objects/images/profile.jpg',
+              response: '<binary image data>',
+            },
+          },
+
+          deleteObject: {
+            method: 'DELETE',
+            path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+            request: {
+              requiresAuth: 'user',
+              params: {
+                bucketName: 'string - name of the bucket',
+                objectKey: 'string - full object key/path',
+              },
+            },
+            response: {
+              success: {
+                status: 200,
+                body: '{message: string}',
+              },
+              error: {
+                status: '404 | 400 | 401 | 500',
+                body: '{error: string, message: string, statusCode: number}',
+              },
+            },
+            example: {
+              request: 'DELETE /api/storage/buckets/uploads/objects/temp/file.tmp',
+              response: '{message: "Object deleted successfully"}',
+            },
+          },
+        },
+        // Available tables and their schemas
+        tables: {
+          availableTableNames: tableList,
+          schemas: tableSchemas,
+          systemFields: {
+            id: { type: 'uuid', autoGenerated: true, primary: true },
+            created_at: { type: 'datetime', autoGenerated: true },
+            updated_at: { type: 'datetime', autoGenerated: true, autoUpdated: true },
+          },
+        },
+        // Storage schemas
+        storage: {
+          availableBuckets: bucketList,
+          schemas: {
+            StorageFileSchema: {
+              key: { type: 'string', required: true },
+              bucket: { type: 'string', required: true },
+              size: { type: 'number (bytes)', required: true },
+              mimeType: { type: 'string', required: false },
+              uploadedAt: { type: 'datetime string', required: true },
+              url: { type: 'string', required: true },
+            },
+          },
+        },
+
+        // Quick reference for AI
+        quickReference: {
+          authenticationSteps: [
+            '1. Register new users with POST /api/auth/users',
+            '2. Login existing users with POST /api/auth/sessions',
+            '3. Both endpoints return an accessToken for authentication',
+            '4. Include token in Authorization header as "Bearer {token}"',
+            '5. OAuth login available via Google and GitHub providers',
+            '6. Get current user info with GET /api/auth/sessions/current',
+          ],
+          databaseSteps: [
+            '1. Choose a table from tables.availableTableNames',
+            '2. Use the tableApi operations with the chosen table name',
+            '3. For request body, use tables.schemas.{tableName}RecordSchema',
+            '4. Exclude system fields (id, created_at, updated_at) when creating or updating',
+            '5. All update operations accept partial schemas (all fields optional)',
+            '6. Use query parameters for filtering, sorting, and pagination in list operations',
+          ],
+          storageSteps: [
+            '1. Upload files using PUT (specific key) or POST (auto-generated key)',
+            '2. Files are uploaded as multipart/form-data with "file" field',
+            '3. Download files using GET with bucket and object key',
+            '4. Public buckets allow downloading without authentication',
+            '5. Private buckets require authentication for all operations',
+            '6. Organize files using key prefixes like "images/", "documents/", etc.',
+          ],
+          examples: {
+            // Authentication examples
+            register:
+              'POST /api/auth/users with body {email: "user@example.com", password: "password123"}',
+            login:
+              'POST /api/auth/sessions with body {email: "user@example.com", password: "password123"}',
+            getCurrentUser: 'GET /api/auth/sessions/current with Authorization: Bearer {token}',
+            googleLogin: 'GET /api/auth/oauth/google?redirect_uri=http://localhost:3000',
+            githubLogin: 'GET /api/auth/oauth/github?redirect_uri=http://localhost:3000',
+            // Database examples
+            listProducts: 'GET /api/database/records/products?limit=10&category=electronics',
+            createProduct:
+              'POST /api/database/records/products with body {name: "New Product", price: 29.99}',
+            updateProduct: 'PATCH /api/database/records/products/apple with body {price: 39.99}',
+            deleteProduct: 'DELETE /api/database/records/products/apple',
+            // Storage examples
+            uploadFile: 'PUT /api/storage/buckets/uploads/objects/avatar.jpg with FormData file',
+            downloadFile: 'GET /api/storage/buckets/uploads/objects/avatar.jpg',
+            deleteFile: 'DELETE /api/storage/buckets/uploads/objects/temp/old-file.tmp',
+          },
+        },
+      };
+
+      return document;
+    } catch (error) {
+      logger.error('Failed to generate agent API documentation', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
+}

--- a/backend/src/core/documentation/agent.ts
+++ b/backend/src/core/documentation/agent.ts
@@ -278,21 +278,22 @@ export class AgentAPIDocService {
                 limit: 'number (default: 100)',
                 offset: 'number (default: 0)',
                 // Sorting
-                order: 'columnName.asc or columnName.desc',
+                order: '{columnName}.asc or {columnName}.desc',
                 // Selection
-                select: 'comma-separated column names',
-                // Filtering - any column can be used as filter
-                '{columnName}': 'exact match',
-                '{columnName}.eq': 'equals',
-                '{columnName}.neq': 'not equals',
-                '{columnName}.gt': 'greater than',
-                '{columnName}.gte': 'greater than or equal',
-                '{columnName}.lt': 'less than',
-                '{columnName}.lte': 'less than or equal',
-                '{columnName}.like': 'LIKE pattern (use % for wildcard)',
-                '{columnName}.ilike': 'case insensitive LIKE',
-                '{columnName}.is': 'IS (use for null: is.null, is.notnull)',
-                '{columnName}.in': 'IN (comma-separated values in parentheses)',
+                select: 'comma-separated column names (e.g., id,name,email)',
+                // Filtering - PostgREST operators
+                '{columnName}=eq.{value}': 'equals (exact match)',
+                '{columnName}=neq.{value}': 'not equals',
+                '{columnName}=gt.{value}': 'greater than',
+                '{columnName}=gte.{value}': 'greater than or equal',
+                '{columnName}=lt.{value}': 'less than',
+                '{columnName}=lte.{value}': 'less than or equal',
+                '{columnName}=like.{pattern}': 'LIKE pattern (use * as wildcard)',
+                '{columnName}=ilike.{pattern}': 'case-insensitive LIKE (use * as wildcard)',
+                '{columnName}=is.null': 'IS NULL',
+                '{columnName}=not.is.null': 'IS NOT NULL',
+                '{columnName}=in.({value1},{value2},{value3})':
+                  'IN - comma-separated values in parentheses',
               },
             },
             response: {

--- a/backend/src/core/documentation/openapi.ts
+++ b/backend/src/core/documentation/openapi.ts
@@ -1,0 +1,857 @@
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV3,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import { MetadataService } from '@/core/metadata/metadata.js';
+import { TableSchema, ColumnSchema, ColumnType } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+// Extend Zod with OpenAPI functionality
+extendZodWithOpenApi(z);
+
+export class OpenAPIService {
+  private static instance: OpenAPIService;
+  private metadataService: MetadataService;
+
+  private constructor() {
+    this.metadataService = MetadataService.getInstance();
+  }
+
+  static getInstance(): OpenAPIService {
+    if (!OpenAPIService.instance) {
+      OpenAPIService.instance = new OpenAPIService();
+    }
+    return OpenAPIService.instance;
+  }
+
+  /**
+   * Convert column type to Zod schema
+   */
+  private columnToZodType(column: ColumnSchema): z.ZodTypeAny {
+    let baseType: z.ZodTypeAny;
+
+    switch (column.type) {
+      case ColumnType.STRING:
+        baseType = z.string();
+        break;
+      case ColumnType.INTEGER:
+        baseType = z.number().int();
+        break;
+      case ColumnType.FLOAT:
+        baseType = z.number();
+        break;
+      case ColumnType.BOOLEAN:
+        baseType = z.boolean();
+        break;
+      case ColumnType.DATETIME:
+        baseType = z.string().datetime();
+        break;
+      case ColumnType.UUID:
+        baseType = z.string().uuid();
+        break;
+      case ColumnType.JSON:
+        baseType = z.any();
+        break;
+      default:
+        baseType = z.unknown();
+    }
+
+    // Apply nullable/optional modifiers
+    if (column.isNullable) {
+      baseType = baseType.nullable();
+    }
+
+    // Apply default values
+    if (column.defaultValue !== undefined) {
+      baseType = baseType.optional();
+    }
+
+    return baseType;
+  }
+
+  /**
+   * Generate Zod schema for a table
+   */
+  private generateTableSchema(table: TableSchema): z.ZodObject<any> {
+    const schemaFields: Record<string, z.ZodTypeAny> = {};
+
+    for (const column of table.columns) {
+      schemaFields[column.columnName] = this.columnToZodType(column);
+    }
+
+    return z.object(schemaFields);
+  }
+
+  /**
+   * Generate filter schema for query parameters
+   */
+  private generateFilterSchema(table: TableSchema): z.ZodObject<any> {
+    const filterFields: Record<string, z.ZodTypeAny> = {};
+
+    // Standard PostgREST query parameters
+    filterFields['select'] = z.string().optional().describe('Columns to select');
+    filterFields['order'] = z.string().optional().describe('Column to order by');
+    filterFields['limit'] = z.string().optional().describe('Maximum number of rows to return');
+    filterFields['offset'] = z.string().optional().describe('Number of rows to skip');
+
+    // Add column-specific filters
+    for (const column of table.columns) {
+      const columnName = column.columnName;
+
+      // Basic equality filter
+      filterFields[columnName] = z.string().optional().describe(`Filter by ${columnName}`);
+
+      // PostgREST operators
+      filterFields[`${columnName}.eq`] = z.string().optional().describe(`${columnName} equals`);
+      filterFields[`${columnName}.neq`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} not equals`);
+      filterFields[`${columnName}.gt`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} greater than`);
+      filterFields[`${columnName}.gte`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} greater than or equal`);
+      filterFields[`${columnName}.lt`] = z.string().optional().describe(`${columnName} less than`);
+      filterFields[`${columnName}.lte`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} less than or equal`);
+      filterFields[`${columnName}.like`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} LIKE pattern`);
+      filterFields[`${columnName}.ilike`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} ILIKE pattern (case insensitive)`);
+      filterFields[`${columnName}.is`] = z
+        .string()
+        .optional()
+        .describe(`${columnName} IS (for null checks)`);
+      filterFields[`${columnName}.in`] = z.string().optional().describe(`${columnName} IN list`);
+    }
+
+    return z.object(filterFields);
+  }
+
+  /**
+   * Register authentication endpoints
+   */
+  private registerAuthenticationEndpoints(registry: OpenAPIRegistry) {
+    // User registration endpoint
+    registry.registerPath({
+      method: 'post',
+      path: '/api/auth/users',
+      summary: 'Register new user',
+      description: 'Create a new user account',
+      tags: ['Authentication'],
+      request: {
+        body: {
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  email: z.string().email().describe('Valid email address'),
+                  password: z.string().min(8).describe('User password (min 8 characters)'),
+                  name: z.string().optional().describe('User display name'),
+                })
+                .openapi('UserRegistration'),
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'User registered successfully',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  user: z.object({
+                    id: z.string(),
+                    email: z.string(),
+                    name: z.string().nullable(),
+                  }),
+                  accessToken: z.string().describe('JWT token for authentication'),
+                })
+                .openapi('AuthResponse'),
+            },
+          },
+        },
+        400: {
+          description: 'Invalid request',
+        },
+        409: {
+          description: 'User already exists',
+        },
+      },
+    });
+
+    // User login endpoint
+    registry.registerPath({
+      method: 'post',
+      path: '/api/auth/sessions',
+      summary: 'User login',
+      description: 'Authenticate user and create session',
+      tags: ['Authentication'],
+      request: {
+        body: {
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  email: z.string().email().describe('User email address'),
+                  password: z.string().describe('User password'),
+                })
+                .openapi('UserLogin'),
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Login successful',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  user: z.object({
+                    id: z.string(),
+                    email: z.string(),
+                    name: z.string().nullable(),
+                  }),
+                  accessToken: z.string().describe('JWT token for authentication'),
+                })
+                .openapi('AuthResponse'),
+            },
+          },
+        },
+        401: {
+          description: 'Invalid credentials',
+        },
+        400: {
+          description: 'Invalid request',
+        },
+      },
+    });
+
+    // Get current user endpoint
+    registry.registerPath({
+      method: 'get',
+      path: '/api/auth/sessions/current',
+      summary: 'Get current user',
+      description: 'Get information about the currently authenticated user',
+      tags: ['Authentication'],
+      security: [{ BearerAuth: [] }],
+      responses: {
+        200: {
+          description: 'Current user information',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  user: z.object({
+                    id: z.string(),
+                    email: z.string(),
+                    role: z.string(),
+                  }),
+                })
+                .openapi('CurrentUserResponse'),
+            },
+          },
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+
+    // Google OAuth endpoint
+    registry.registerPath({
+      method: 'get',
+      path: '/api/auth/oauth/google',
+      summary: 'Google OAuth',
+      description: 'Initiate Google OAuth authentication',
+      tags: ['Authentication'],
+      request: {
+        query: z
+          .object({
+            redirect_uri: z.string().optional().describe('URL to redirect after OAuth completion'),
+          })
+          .openapi('OAuthRequest'),
+      },
+      responses: {
+        200: {
+          description: 'OAuth URL generated',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  authUrl: z.string().describe('Google OAuth authorization URL'),
+                })
+                .openapi('OAuthUrlResponse'),
+            },
+          },
+        },
+        500: {
+          description: 'Internal server error',
+        },
+      },
+    });
+
+    // GitHub OAuth endpoint
+    registry.registerPath({
+      method: 'get',
+      path: '/api/auth/oauth/github',
+      summary: 'GitHub OAuth',
+      description: 'Initiate GitHub OAuth authentication',
+      tags: ['Authentication'],
+      request: {
+        query: z
+          .object({
+            redirect_uri: z.string().optional().describe('URL to redirect after OAuth completion'),
+          })
+          .openapi('OAuthRequest'),
+      },
+      responses: {
+        200: {
+          description: 'OAuth URL generated',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  authUrl: z.string().describe('GitHub OAuth authorization URL'),
+                })
+                .openapi('OAuthUrlResponse'),
+            },
+          },
+        },
+        500: {
+          description: 'Internal server error',
+        },
+      },
+    });
+
+    // OAuth callback endpoint
+    registry.registerPath({
+      method: 'get',
+      path: '/api/auth/oauth/{provider}/callback',
+      summary: 'OAuth callback',
+      description: 'OAuth callback endpoint - handled automatically by OAuth flow',
+      tags: ['Authentication'],
+      request: {
+        params: z
+          .object({
+            provider: z.enum(['google', 'github']).describe('OAuth provider'),
+          })
+          .openapi('OAuthProvider'),
+        query: z
+          .object({
+            code: z.string().describe('Authorization code from OAuth provider'),
+            state: z.string().describe('State parameter for security'),
+            token: z.string().optional().describe('ID token for some flows'),
+          })
+          .openapi('OAuthCallback'),
+      },
+      responses: {
+        302: {
+          description: 'Redirects to redirect_uri with authentication details or error',
+        },
+      },
+    });
+  }
+
+  /**
+   * Register storage endpoints
+   */
+  private registerStorageEndpoints(registry: OpenAPIRegistry) {
+    // Upload object with specific key
+    registry.registerPath({
+      method: 'put',
+      path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+      summary: 'Upload object',
+      description: 'Upload a file to storage with a specific key',
+      tags: ['Storage'],
+      security: [{ BearerAuth: [] }],
+      request: {
+        params: z
+          .object({
+            bucketName: z.string().describe('Name of the bucket'),
+            objectKey: z.string().describe('Full object key/path (e.g., "images/photo.jpg")'),
+          })
+          .openapi('StorageParams'),
+        body: {
+          content: {
+            'multipart/form-data': {
+              schema: z
+                .object({
+                  file: z.any().describe('File to upload'),
+                })
+                .openapi('FileUpload'),
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: 'File uploaded successfully',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  key: z.string(),
+                  bucket: z.string(),
+                  size: z.number(),
+                  mimeType: z.string().optional(),
+                  uploadedAt: z.string(),
+                  url: z.string(),
+                })
+                .openapi('StorageFile'),
+            },
+          },
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+        409: {
+          description: 'Conflict - file already exists',
+        },
+      },
+    });
+
+    // Upload object with auto-generated key
+    registry.registerPath({
+      method: 'post',
+      path: '/api/storage/buckets/{bucketName}/objects',
+      summary: 'Upload object with auto-key',
+      description: 'Upload a file to storage with an auto-generated key',
+      tags: ['Storage'],
+      security: [{ BearerAuth: [] }],
+      request: {
+        params: z
+          .object({
+            bucketName: z.string().describe('Name of the bucket'),
+          })
+          .openapi('BucketParam'),
+        body: {
+          content: {
+            'multipart/form-data': {
+              schema: z
+                .object({
+                  file: z.any().describe('File to upload'),
+                })
+                .openapi('FileUpload'),
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: 'File uploaded successfully',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  key: z.string(),
+                  bucket: z.string(),
+                  size: z.number(),
+                  mimeType: z.string().optional(),
+                  uploadedAt: z.string(),
+                  url: z.string(),
+                })
+                .openapi('StorageFile'),
+            },
+          },
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+        404: {
+          description: 'Bucket not found',
+        },
+      },
+    });
+
+    // Download object
+    registry.registerPath({
+      method: 'get',
+      path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+      summary: 'Download object',
+      description: 'Download a file from storage',
+      tags: ['Storage'],
+      request: {
+        params: z
+          .object({
+            bucketName: z.string().describe('Name of the bucket'),
+            objectKey: z.string().describe('Full object key/path'),
+          })
+          .openapi('StorageParams'),
+      },
+      responses: {
+        200: {
+          description: 'File content',
+          content: {
+            'application/octet-stream': {
+              schema: z.any().describe('Binary file data'),
+            },
+          },
+        },
+        404: {
+          description: 'File not found',
+        },
+        401: {
+          description: 'Unauthorized (for private buckets)',
+        },
+      },
+    });
+
+    // Delete object
+    registry.registerPath({
+      method: 'delete',
+      path: '/api/storage/buckets/{bucketName}/objects/{objectKey}',
+      summary: 'Delete object',
+      description: 'Delete a file from storage',
+      tags: ['Storage'],
+      security: [{ BearerAuth: [] }],
+      request: {
+        params: z
+          .object({
+            bucketName: z.string().describe('Name of the bucket'),
+            objectKey: z.string().describe('Full object key/path'),
+          })
+          .openapi('StorageParams'),
+      },
+      responses: {
+        200: {
+          description: 'File deleted successfully',
+          content: {
+            'application/json': {
+              schema: z
+                .object({
+                  message: z.string(),
+                })
+                .openapi('DeleteResponse'),
+            },
+          },
+        },
+        404: {
+          description: 'File not found',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+  }
+
+  /**
+   * Register CRUD endpoints for a table
+   */
+  private registerTableEndpoints(registry: OpenAPIRegistry, table: TableSchema) {
+    const tableName = table.tableName;
+    const recordSchema = this.generateTableSchema(table);
+    const filterSchema = this.generateFilterSchema(table);
+
+    // Create schemas with OpenAPI metadata
+    const singleRecordSchema = recordSchema.openapi(`${tableName}Record`);
+    const recordArraySchema = z.array(recordSchema).openapi(`${tableName}RecordArray`);
+    const createRecordSchema = recordSchema.partial().openapi(`Create${tableName}Record`);
+    const updateRecordSchema = recordSchema.partial().openapi(`Update${tableName}Record`);
+
+    // GET /api/database/records/{tableName} - List records
+    registry.registerPath({
+      method: 'get',
+      path: `/api/database/records/${tableName}`,
+      summary: `List ${tableName} records`,
+      description: `Retrieve a list of records from the ${tableName} table with optional filtering`,
+      tags: [tableName],
+      request: {
+        query: filterSchema,
+      },
+      responses: {
+        200: {
+          description: `List of ${tableName} records`,
+          content: {
+            'application/json': {
+              schema: recordArraySchema,
+            },
+          },
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+
+    // POST /api/database/records/{tableName} - Create record
+    registry.registerPath({
+      method: 'post',
+      path: `/api/database/records/${tableName}`,
+      summary: `Create ${tableName} record`,
+      description: `Create a new record in the ${tableName} table`,
+      tags: [tableName],
+      request: {
+        body: {
+          content: {
+            'application/json': {
+              schema: createRecordSchema,
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: `Created ${tableName} record`,
+          content: {
+            'application/json': {
+              schema: singleRecordSchema,
+            },
+          },
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+
+    // GET /api/database/records/{tableName}/{id} - Get single record
+    const primaryKeyColumn = table.columns.find((col) => col.isPrimaryKey);
+    if (primaryKeyColumn) {
+      registry.registerPath({
+        method: 'get',
+        path: `/api/database/records/${tableName}/{id}`,
+        summary: `Get ${tableName} record by ID`,
+        description: `Retrieve a single record from the ${tableName} table by its primary key`,
+        tags: [tableName],
+        request: {
+          params: z.object({
+            id: z.string().describe(`Primary key value`),
+          }),
+        },
+        responses: {
+          200: {
+            description: `${tableName} record`,
+            content: {
+              'application/json': {
+                schema: singleRecordSchema,
+              },
+            },
+          },
+          404: {
+            description: 'Record not found',
+          },
+          401: {
+            description: 'Unauthorized',
+          },
+        },
+      });
+
+      // PATCH /api/database/records/{tableName}/{id} - Update record
+      registry.registerPath({
+        method: 'patch',
+        path: `/api/database/records/${tableName}/{id}`,
+        summary: `Update ${tableName} record`,
+        description: `Update a record in the ${tableName} table`,
+        tags: [tableName],
+        request: {
+          params: z.object({
+            id: z.string().describe(`Primary key value`),
+          }),
+          body: {
+            content: {
+              'application/json': {
+                schema: updateRecordSchema,
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: `Updated ${tableName} record`,
+            content: {
+              'application/json': {
+                schema: singleRecordSchema,
+              },
+            },
+          },
+          404: {
+            description: 'Record not found',
+          },
+          401: {
+            description: 'Unauthorized',
+          },
+        },
+      });
+
+      // DELETE /api/database/records/{tableName}/{id} - Delete record
+      registry.registerPath({
+        method: 'delete',
+        path: `/api/database/records/${tableName}/{id}`,
+        summary: `Delete ${tableName} record`,
+        description: `Delete a record from the ${tableName} table`,
+        tags: [tableName],
+        request: {
+          params: z.object({
+            id: z.string().describe(`Primary key value`),
+          }),
+        },
+        responses: {
+          204: {
+            description: 'Record deleted successfully',
+          },
+          404: {
+            description: 'Record not found',
+          },
+          401: {
+            description: 'Unauthorized',
+          },
+        },
+      });
+    }
+
+    // PATCH /api/database/records/{tableName} - Bulk update
+    registry.registerPath({
+      method: 'patch',
+      path: `/api/database/records/${tableName}`,
+      summary: `Bulk update ${tableName} records`,
+      description: `Update multiple records in the ${tableName} table based on filters`,
+      tags: [tableName],
+      request: {
+        query: filterSchema,
+        body: {
+          content: {
+            'application/json': {
+              schema: updateRecordSchema,
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: `Updated ${tableName} records`,
+          content: {
+            'application/json': {
+              schema: recordArraySchema,
+            },
+          },
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+
+    // DELETE /api/database/records/{tableName} - Bulk delete
+    registry.registerPath({
+      method: 'delete',
+      path: `/api/database/records/${tableName}`,
+      summary: `Bulk delete ${tableName} records`,
+      description: `Delete multiple records from the ${tableName} table based on filters`,
+      tags: [tableName],
+      request: {
+        query: filterSchema,
+      },
+      responses: {
+        204: {
+          description: 'Records deleted successfully',
+        },
+        400: {
+          description: 'Bad request',
+        },
+        401: {
+          description: 'Unauthorized',
+        },
+      },
+    });
+  }
+
+  /**
+   * Generate OpenAPI document
+   */
+  async generateOpenAPIDocument(): Promise<any> {
+    try {
+      // Get fresh metadata
+      const metadata = await this.metadataService.getFullMetadata();
+
+      // Create new registry
+      const registry = new OpenAPIRegistry();
+
+      // Register security scheme
+      registry.registerComponent('securitySchemes', 'ApiKeyAuth', {
+        type: 'apiKey',
+        in: 'header',
+        name: 'x-api-key',
+        description: 'API key for authentication',
+      });
+
+      registry.registerComponent('securitySchemes', 'BearerAuth', {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'JWT token for authentication',
+      });
+
+      // Register authentication endpoints
+      this.registerAuthenticationEndpoints(registry);
+
+      // Register storage endpoints
+      this.registerStorageEndpoints(registry);
+
+      // Register endpoints for each table
+      for (const table of metadata.database.tables) {
+        // Skip system tables
+        if (table.tableName.startsWith('_')) {
+          continue;
+        }
+        this.registerTableEndpoints(registry, table);
+      }
+
+      // Generate OpenAPI document
+      const generator = new OpenApiGeneratorV3(registry.definitions);
+      const document = generator.generateDocument({
+        openapi: '3.0.0',
+        info: {
+          title: 'InsForge Dynamic API',
+          version: metadata.version || '1.0.0',
+          description: 'Automatically generated API documentation for InsForge database tables',
+        },
+        servers: [
+          {
+            url: process.env.API_BASE_URL || 'http://localhost:7130',
+            description: 'API server',
+          },
+        ],
+        security: [{ ApiKeyAuth: [] }, { BearerAuth: [] }],
+      });
+
+      return document;
+    } catch (error) {
+      logger.error('Failed to generate OpenAPI document', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      console.error(error);
+      throw error;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "name": "insforge-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@aws-sdk/client-cloudwatch-logs": "^3.713.0",
         "@aws-sdk/client-s3": "^3.713.0",
         "@insforge/insforge-mcp": "^1.0.8",
@@ -236,6 +237,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz",
+      "integrity": "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -12214,6 +12227,15 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15895,6 +15917,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
The full openapi json can be found at /api/openpi, with its Swagger UI at /api/openapi/swagger
This json file is huge, ~200k characters, which is impractical to feed any agents. But one can use some openapi-generator tools to generate clientAPIs automatically with this openapi json.

The optimized agent json can be found at /api/agent-docs, which is a much smaller json (~ 15k characters) designed for agent use specifically.

Test prompt:
My InsForge backend service is running at <app_url> with real-time documentation available at <app_url>/api/agent-docs. Use the provided endpoints to implement my app.