### PR TITLE
[FIX] Fix showing incorrect null for zero value in number column

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -70,13 +70,17 @@ export interface DataGridProps {
 
 // Default cell renderers
 export const DefaultCellRenderers = {
-  text: ({ row, column }: any) => (
-    <div className="w-full h-full flex items-center">
-      <span className="truncate dark:text-zinc-300" title={String(row[column.key] || 'null')}>
-        {row[column.key] || 'null'}
-      </span>
-    </div>
-  ),
+  text: ({ row, column }: any) => {
+    const value = row[column.key];
+    const displayValue = value === null || value === undefined ? 'null' : String(value);
+    return (
+      <div className="w-full h-full flex items-center">
+        <span className="truncate dark:text-zinc-300" title={displayValue}>
+          {displayValue}
+        </span>
+      </div>
+    );
+  },
 
   boolean: ({ row, column }: any) => {
     const value = row[column.key];
@@ -151,14 +155,18 @@ export const DefaultCellRenderers = {
     return <IdCell value={value} />;
   },
 
-  email: ({ row, column }: any) => (
-    <span
-      className="text-sm text-gray-800 font-medium truncate dark:text-zinc-300"
-      title={row[column.key] || 'null'}
-    >
-      {row[column.key] || 'null'}
-    </span>
-  ),
+  email: ({ row, column }: any) => {
+    const value = row[column.key];
+    const displayValue = value === null || value === undefined ? 'null' : String(value);
+    return (
+      <span
+        className="text-sm text-gray-800 font-medium truncate dark:text-zinc-300"
+        title={displayValue}
+      >
+        {displayValue}
+      </span>
+    );
+  },
 
   badge: ({ row, column, options }: any) => {
     const value = row[column.key];

--- a/frontend/src/lib/utils/database-utils.ts
+++ b/frontend/src/lib/utils/database-utils.ts
@@ -29,13 +29,15 @@ export function convertValueForColumn(
       if (newValue === '' || newValue === null) {
         convertedValue = null;
       } else {
-        convertedValue = parseInt(String(newValue), 10);
-        if (isNaN(convertedValue) || String(convertedValue) !== String(newValue)) {
+        const stringValue = String(newValue).trim();
+        // Check if the input is a valid integer format first
+        if (!/^-?\d+$/.test(stringValue)) {
           return {
             success: false,
             error: 'Please enter a valid integer',
           };
         }
+        convertedValue = parseInt(stringValue, 10);
         // PostgreSQL integer range: -2,147,483,648 to 2,147,483,647
         if (convertedValue < -2147483648 || convertedValue > 2147483647) {
           return {
@@ -68,13 +70,16 @@ export function convertValueForColumn(
       if (newValue === '' || newValue === null) {
         convertedValue = null;
       } else {
-        convertedValue = parseFloat(String(newValue));
-        if (isNaN(convertedValue) || String(convertedValue) !== String(newValue)) {
+        const stringValue = String(newValue).trim();
+        // Check if the input is a valid number format first
+        // This regex allows for integers, decimals, scientific notation
+        if (!/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(stringValue)) {
           return {
             success: false,
             error: 'Please enter a valid number',
           };
         }
+        convertedValue = parseFloat(stringValue);
         // PostgreSQL double precision range: approximately ±1.7976931348623157E+308
         if (!isFinite(convertedValue)) {
           return {
@@ -93,13 +98,16 @@ export function convertValueForColumn(
       if (newValue === '' || newValue === null) {
         convertedValue = null;
       } else {
-        convertedValue = parseFloat(String(newValue));
-        if (isNaN(convertedValue)) {
+        const stringValue = String(newValue).trim();
+        // Check if the input is a valid number format first
+        // This regex allows for integers, decimals, scientific notation
+        if (!/^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(stringValue)) {
           return {
             success: false,
             error: 'Please enter a valid number',
           };
         }
+        convertedValue = parseFloat(stringValue);
         // PostgreSQL real range: approximately ±3.40282347E+38
         if (!isFinite(convertedValue)) {
           return {


### PR DESCRIPTION
The value of 0 in number columns incorrectly shows 'null'. This is now fixed. 

Also fixed a bug that prevents updating a float type field to be '0.0' or '0.00'

You can also use scientific notation for float type now