### PR TITLE
expose new users table(profile only), and rename _account to _oauth_connections, _user to _accounts

### DIFF
--- a/backend/src/api/routes/auth.ts
+++ b/backend/src/api/routes/auth.ts
@@ -164,8 +164,8 @@ router.get('/users', verifyAdmin, async (req: Request, res: Response, next: Next
         u.updated_at,
         u.password,
         STRING_AGG(a.provider, ',') as providers
-      FROM _user u
-      LEFT JOIN _account a ON u.id = a.user_id
+      FROM _accounts u
+      LEFT JOIN _oauth_connections a ON u.id = a.user_id
     `;
     const params: any[] = [];
 
@@ -215,7 +215,7 @@ router.get('/users', verifyAdmin, async (req: Request, res: Response, next: Next
       };
     });
 
-    let countQuery = 'SELECT COUNT(*) as count FROM _user';
+    let countQuery = 'SELECT COUNT(*) as count FROM _accounts';
     const countParams: any[] = [];
     if (search) {
       countQuery += ' WHERE email LIKE ? OR name LIKE ?';
@@ -261,8 +261,8 @@ router.get(
         u.updated_at,
         u.password,
         STRING_AGG(a.provider, ',') as providers
-      FROM _user u
-      LEFT JOIN _account a ON u.id = a.user_id
+      FROM _accounts u
+      LEFT JOIN _oauth_connections a ON u.id = a.user_id
       WHERE u.id = ?
       GROUP BY u.id
     `
@@ -287,13 +287,13 @@ router.get(
 
       // Add email provider if password exists
       if (dbUser.password) {
-        identities.push({ provider: 'email' });
+        identities.push({ provider: 'Email' });
         providers.push('email');
       }
 
       // Use first provider to determine type: 'email' or 'social'
       const firstProvider = providers[0];
-      const provider_type = firstProvider === 'email' ? 'email' : 'social';
+      const provider_type = firstProvider === 'email' ? 'Email' : 'Social';
 
       // Return snake_case for frontend compatibility
       const user = {
@@ -331,7 +331,7 @@ router.delete('/users', verifyAdmin, async (req: Request, res: Response, next: N
     const db = authService.getDb();
     const placeholders = userIds.map(() => '?').join(',');
 
-    await db.prepare(`DELETE FROM _user WHERE id IN (${placeholders})`).run(...userIds);
+    await db.prepare(`DELETE FROM _accounts WHERE id IN (${placeholders})`).run(...userIds);
 
     const response: DeleteUsersResponse = {
       message: 'Users deleted successfully',

--- a/backend/src/controllers/TablesController.ts
+++ b/backend/src/controllers/TablesController.ts
@@ -30,6 +30,8 @@ const reservedColumns = {
   updated_at: ColumnType.DATETIME,
 };
 
+const userTableFrozenColumns = ['nickname', 'avatar_url'];
+
 export class TablesController {
   private dbManager: DatabaseManager;
   private metadataService: MetadataService;
@@ -424,6 +426,14 @@ export class TablesController {
             `You cannot drop the system column '${col}'`
           );
         }
+        if (tableName === 'users' && userTableFrozenColumns.includes(col)) {
+          throw new AppError(
+            'cannot drop frozen users columns',
+            403,
+            ERROR_CODES.FORBIDDEN,
+            `You cannot drop the frozen users column '${col}'`
+          );
+        }
         await db
           .prepare(
             `
@@ -446,6 +456,14 @@ export class TablesController {
             404,
             ERROR_CODES.DATABASE_FORBIDDEN,
             `You cannot update the system column '${column.columnName}'`
+          );
+        }
+        if (tableName === 'users' && userTableFrozenColumns.includes(column.columnName)) {
+          throw new AppError(
+            'cannot update frozen user columns',
+            403,
+            ERROR_CODES.FORBIDDEN,
+            `You cannot update the frozen users column '${column.columnName}'`
           );
         }
 
@@ -553,6 +571,13 @@ export class TablesController {
     }
 
     if (renameTable && renameTable.newTableName) {
+      if (tableName === 'users') {
+        throw new AppError(
+          'Cannot rename users table',
+          403,
+          ERROR_CODES.FORBIDDEN,
+        );
+      }
       // Prevent renaming to system tables
       if (renameTable.newTableName.startsWith('_')) {
         throw new AppError(
@@ -607,6 +632,13 @@ export class TablesController {
         403,
         ERROR_CODES.DATABASE_FORBIDDEN,
         'System tables cannot be deleted. System tables are prefixed with underscore.'
+      );
+    }
+    if (table === 'users') {
+      throw new AppError(
+        'Cannot delete users table',
+        403,
+        ERROR_CODES.DATABASE_FORBIDDEN,
       );
     }
 

--- a/backend/src/core/auth/auth.ts
+++ b/backend/src/core/auth/auth.ts
@@ -226,7 +226,7 @@ export class AuthService {
    * User registration
    */
   async register(email: string, password: string, name?: string): Promise<CreateUserResponse> {
-    const existingUser = await this.db.prepare('SELECT id FROM _user WHERE email = ?').get(email);
+    const existingUser = await this.db.prepare('SELECT id FROM _accounts WHERE email = ?').get(email);
 
     if (existingUser) {
       throw new Error('User already exists');
@@ -238,15 +238,24 @@ export class AuthService {
     await this.db
       .prepare(
         `
-      INSERT INTO _user (id, email, password, name, email_verified, created_at, updated_at)
+      INSERT INTO _accounts (id, email, password, name, email_verified, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, NOW(), NOW())
     `
       )
       .run(userId, email, hashedPassword, name || null, false);
 
+    await this.db
+      .prepare(
+        `
+      INSERT INTO users (id, nickname, created_at, updated_at)
+      VALUES (?, ?, NOW(), NOW())
+    `
+      )
+      .run(userId, name || null);
+
     const dbUser = await this.db
       .prepare(
-        'SELECT id, email, name, email_verified, created_at, updated_at FROM _user WHERE id = ?'
+        'SELECT id, email, name, email_verified, created_at, updated_at FROM _accounts WHERE id = ?'
       )
       .get(userId);
     const user = this.dbUserToApiUser(dbUser);
@@ -259,7 +268,7 @@ export class AuthService {
    * User login
    */
   async login(email: string, password: string): Promise<CreateSessionResponse> {
-    const dbUser = await this.db.prepare('SELECT * FROM _user WHERE email = ?').get(email);
+    const dbUser = await this.db.prepare('SELECT * FROM _accounts WHERE email = ?').get(email);
 
     if (!dbUser || !dbUser.password) {
       throw new Error('Invalid credentials');
@@ -356,22 +365,22 @@ export class AuthService {
     avatarUrl: string,
     identityData: any
   ): Promise<CreateSessionResponse> {
-    // First, try to find existing user by provider ID in _account table
+    // First, try to find existing user by provider ID in _oauth_connections table
     const account = await this.db
-      .prepare('SELECT * FROM _account WHERE provider = ? AND provider_account_id = ?')
+      .prepare('SELECT * FROM _oauth_connections WHERE provider = ? AND provider_account_id = ?')
       .get(provider, providerId);
 
     if (account) {
       // Found existing OAuth user, update last login time
       await this.db
         .prepare(
-          'UPDATE _account SET updated_at = CURRENT_TIMESTAMP WHERE provider = ? AND provider_account_id = ?'
+          'UPDATE _oauth_connections SET updated_at = CURRENT_TIMESTAMP WHERE provider = ? AND provider_account_id = ?'
         )
         .run(provider, providerId);
 
       const dbUser = await this.db
         .prepare(
-          'SELECT id, email, name, email_verified, created_at, updated_at FROM _user WHERE id = ?'
+          'SELECT id, email, name, email_verified, created_at, updated_at FROM _accounts WHERE id = ?'
         )
         .get(account.user_id);
 
@@ -386,14 +395,14 @@ export class AuthService {
     }
 
     // If not found by provider_id, try to find by email in _user table
-    const existingUser = await this.db.prepare('SELECT * FROM _user WHERE email = ?').get(email);
+    const existingUser = await this.db.prepare('SELECT * FROM _accounts WHERE email = ?').get(email);
 
     if (existingUser) {
-      // Found existing user by email, create _account record to link OAuth
+      // Found existing user by email, create _oauth_connections record to link OAuth
       await this.db
         .prepare(
           `
-        INSERT INTO _account (
+        INSERT INTO _oauth_connections (
           user_id, provider, provider_account_id, 
           provider_data, created_at, updated_at
         )
@@ -443,17 +452,26 @@ export class AuthService {
       await this.db
         .prepare(
           `
-        INSERT INTO _user (id, email, name, email_verified, created_at, updated_at)
+        INSERT INTO _accounts (id, email, name, email_verified, created_at, updated_at)
         VALUES (?, ?, ?, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       `
         )
         .run(userId, email, userName);
 
-      // Create _account record
       await this.db
         .prepare(
           `
-        INSERT INTO _account (
+        INSERT INTO users (id, nickname, avatar_url, created_at, updated_at)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      `
+        )
+        .run(userId, userName, avatarUrl);
+
+      // Create _oauth_connections record
+      await this.db
+        .prepare(
+          `
+        INSERT INTO _oauth_connections (
           user_id, provider, provider_account_id,
           provider_data, created_at, updated_at
         )

--- a/backend/src/core/database/database.ts
+++ b/backend/src/core/database/database.ts
@@ -87,6 +87,16 @@ export class DatabaseManager {
       $$;
     `);
 
+    await client.query(`
+      DO $$
+      BEGIN
+          IF EXISTS (SELECT FROM information_schema.tables 
+                    WHERE table_name = '_account' AND table_schema = 'public') THEN
+              ALTER TABLE _account RENAME TO _oauth_connections;
+          END IF;
+      END $$;
+    `)
+
     // Migrate OAuth configuration from environment variables to database
     await this.migrateOAuthConfig(client);
 

--- a/backend/src/core/metadata/metadata.ts
+++ b/backend/src/core/metadata/metadata.ts
@@ -81,7 +81,7 @@ export class MetadataService {
       FROM information_schema.tables 
       WHERE table_schema = 'public' 
       AND table_type = 'BASE TABLE'
-      AND (table_name NOT LIKE '\\_%' OR table_name = '_user')
+      AND (table_name NOT LIKE '\\_%')
       AND table_name NOT IN ('logs', 'jwks')
       ORDER BY table_name
     `

--- a/backend/src/utils/validations.ts
+++ b/backend/src/utils/validations.ts
@@ -65,24 +65,6 @@ export function isValidIdentifier(identifier: string): boolean {
 export function validateTableName(tableName: string, operation?: 'READ' | 'WRITE'): boolean {
   validateIdentifier(tableName, 'table');
 
-  // Special handling for _user table - check this BEFORE general _ check
-  if (tableName.toLowerCase() === '_user') {
-    // _user table allows read-only access for foreign key references
-    if (operation === 'READ') {
-      return true; // Allow read access to _user table
-    }
-
-    // Provide specific error for write operations on _user table
-    if (operation === 'WRITE') {
-      throw new AppError(
-        'Cannot modify _user table - use Auth API instead',
-        403,
-        ERROR_CODES.FORBIDDEN,
-        'Use /api/auth/* endpoints to create or update users'
-      );
-    }
-  }
-
   // Prevent access to all other system tables (starting with _)
   if (tableName.startsWith('_')) {
     throw new AppError(


### PR DESCRIPTION
curl test by manual:
- [x] auto create users record while both email signup and oauth login;
- [x] read all users data via /api/database/records/users
- [x] only owner can update users record.
- [x] disable delete users record.
- [x] disable delete users table;
- [x] disable delete users frozen column;
- [x] enable delete users un-frozen column; 