### PR TITLE
[Phrase 1]remove api key dependency

### DIFF
--- a/backend/src/core/auth/auth.ts
+++ b/backend/src/core/auth/auth.ts
@@ -838,10 +838,10 @@ export class AuthService {
   }
 
   /**
-   * Generate a new API key
+   * Generate a new API key with 'ik_' prefix (Insforge Key)
    */
   generateApiKey(): string {
-    return crypto.randomBytes(32).toString('hex');
+    return 'ik_' + crypto.randomBytes(32).toString('hex');
   }
 
   /**
@@ -869,8 +869,8 @@ export class AuthService {
       const envApiKey = process.env.ACCESS_API_KEY;
 
       if (envApiKey && envApiKey.trim() !== '') {
-        // Use the provided API key from environment
-        apiKey = envApiKey;
+        // Use the provided API key from environment, ensure it has 'ik_' prefix
+        apiKey = envApiKey.startsWith('ik_') ? envApiKey : 'ik_' + envApiKey;
         await dbManager.setApiKey(apiKey);
         logger.info('✅ API key initialized from ACCESS_API_KEY environment variable');
       } else {

--- a/backend/tests/local/comprehensive-curl-tests.sh
+++ b/backend/tests/local/comprehensive-curl-tests.sh
@@ -107,7 +107,7 @@ if [ -n "$API_KEY" ] && [ "$API_KEY" != "null" ]; then
   # List buckets
   echo -e "\n${BLUE}7a. List Buckets (Array Response)${NC}"
   curl -s "$BASE_URL/storage/buckets" \
-    -H "x-api-key: $API_KEY" | jq '.'
+    -H "Authorization: Bearer $API_KEY" | jq '.'
   echo -e "${GREEN}✓ Returns array of buckets${NC}"
 else
   echo -e "${RED}✗ Could not get API key for storage tests${NC}"

--- a/backend/tests/local/test-e2e.sh
+++ b/backend/tests/local/test-e2e.sh
@@ -178,7 +178,7 @@ fi
 # 10. Test Storage - Create Bucket
 print_info "10. Testing Create Storage Bucket"
 response=$(curl -s -w "\n%{http_code}" -X POST "$TEST_API_BASE/storage/buckets" \
-  -H "x-api-key: $API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d "{
     \"bucketName\": \"$TEST_BUCKET\",
@@ -190,14 +190,14 @@ test_endpoint "Create bucket" "$response" "201"
 print_info "11. Testing Upload File"
 echo "Test file content" > /tmp/test-upload.txt
 response=$(curl -s -w "\n%{http_code}" -X PUT "$TEST_API_BASE/storage/buckets/$TEST_BUCKET/objects/test-file.txt" \
-  -H "x-api-key: $API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -F "file=@/tmp/test-upload.txt")
 test_endpoint "Upload file" "$response" "201"
 
 # 12. Test Download File
 print_info "12. Testing Download File"
 response=$(curl -s -w "\n%{http_code}" "$TEST_API_BASE/storage/buckets/$TEST_BUCKET/objects/test-file.txt" \
-  -H "x-api-key: $API_KEY" \
+  -H "Authorization: Bearer $API_KEY" \
   -o /tmp/test-download.txt)
 test_endpoint "Download file" "$response" "200"
 
@@ -227,7 +227,7 @@ fi
 # 14. Test Delete File
 print_info "14. Testing Delete File"
 response=$(curl -s -w "\n%{http_code}" -X DELETE "$TEST_API_BASE/storage/buckets/$TEST_BUCKET/objects/test-file.txt" \
-  -H "x-api-key: $API_KEY")
+  -H "Authorization: Bearer $API_KEY")
 test_endpoint "Delete file" "$response" "200"
 
 # Clean up temp files

--- a/backend/tests/local/test-public-bucket.sh
+++ b/backend/tests/local/test-public-bucket.sh
@@ -48,7 +48,7 @@ fi
 # Step 1: Create a public bucket
 print_info "1️⃣  Creating PUBLIC bucket: $PUBLIC_BUCKET"
 response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE_URL}/storage/buckets" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -H "Content-Type: application/json" \
   -d "{\"bucketName\": \"${PUBLIC_BUCKET}\", \"isPublic\": true}")
 
@@ -71,7 +71,7 @@ fi
 # Step 2: Create a private bucket
 print_info "2️⃣  Creating PRIVATE bucket: $PRIVATE_BUCKET"
 response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE_URL}/storage/buckets" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -H "Content-Type: application/json" \
   -d "{\"bucketName\": \"${PRIVATE_BUCKET}\", \"isPublic\": false}")
 
@@ -94,11 +94,11 @@ fi
 print_info "3️⃣  Uploading file to PUBLIC bucket..."
 # First delete if exists
 curl -s -X DELETE "${API_BASE_URL}/storage/buckets/${PUBLIC_BUCKET}/objects/${TEST_FILE}" \
-  -H "x-api-key: ${api_key}" > /dev/null 2>&1
+  -H "Authorization: Bearer ${api_key}" > /dev/null 2>&1
 
 echo "This is a test file for public access" > /tmp/public-test.txt
 response=$(curl -s -w "\n%{http_code}" -X PUT "${API_BASE_URL}/storage/buckets/${PUBLIC_BUCKET}/objects/${TEST_FILE}" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -F "file=@/tmp/public-test.txt")
 
 body=$(echo "$response" | sed '$d')
@@ -120,11 +120,11 @@ fi
 print_info "4️⃣  Uploading file to PRIVATE bucket..."
 # First delete if exists
 curl -s -X DELETE "${API_BASE_URL}/storage/buckets/${PRIVATE_BUCKET}/objects/${TEST_FILE}" \
-  -H "x-api-key: ${api_key}" > /dev/null 2>&1
+  -H "Authorization: Bearer ${api_key}" > /dev/null 2>&1
 
 echo "This is a test file for private access" > /tmp/private-test.txt
 response=$(curl -s -w "\n%{http_code}" -X PUT "${API_BASE_URL}/storage/buckets/${PRIVATE_BUCKET}/objects/${TEST_FILE}" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -F "file=@/tmp/private-test.txt")
 
 body=$(echo "$response" | sed '$d')
@@ -166,7 +166,7 @@ fi
 # Step 7: Test accessing PRIVATE file WITH API key
 print_info "7️⃣  Testing PRIVATE file access WITH API key..."
 HTTP_CODE=$(curl -s -o /tmp/private-auth-response.txt -w "%{http_code}" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   "${API_BASE_URL}/storage/buckets/${PRIVATE_BUCKET}/objects/${TEST_FILE}")
 if [ "$HTTP_CODE" -eq 200 ]; then
     print_success "Private file accessible with API key! (Status: ${HTTP_CODE})"
@@ -177,7 +177,7 @@ fi
 
 # Step 8: List all buckets
 print_info "8️⃣  Listing all buckets..."
-response=$(curl -s -w "\n%{http_code}" -H "x-api-key: ${api_key}" "${API_BASE_URL}/storage/buckets")
+response=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer ${api_key}" "${API_BASE_URL}/storage/buckets")
 body=$(echo "$response" | sed '$d')
 status=$(echo "$response" | tail -n 1)
 
@@ -197,7 +197,7 @@ fi
 print_info "9️⃣  Testing POST upload with auto-generated key..."
 echo "This is a test file for POST upload" > /tmp/post-test.txt
 response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE_URL}/storage/buckets/${PUBLIC_BUCKET}/objects" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -F "file=@/tmp/post-test.txt")
 
 body=$(echo "$response" | sed '$d')
@@ -229,7 +229,7 @@ fi
 # Step 10: Update bucket visibility
 print_info "🔟 Testing bucket visibility update (making public bucket private)..."
 response=$(curl -s -w "\n%{http_code}" -X PATCH "${API_BASE_URL}/storage/buckets/${PUBLIC_BUCKET}" \
-  -H "x-api-key: ${api_key}" \
+  -H "Authorization: Bearer ${api_key}" \
   -H "Content-Type: application/json" \
   -d '{"isPublic": false}')
 

--- a/backend/tests/local/test-traditional-rest.sh
+++ b/backend/tests/local/test-traditional-rest.sh
@@ -175,14 +175,14 @@ if [ -n "$API_KEY" ]; then
     export ACCESS_API_KEY="$API_KEY"
     # List buckets
     response=$(curl -s "$API_BASE/storage/buckets" \
-        -H "x-api-key: $API_KEY")
+        -H "Authorization: Bearer $API_KEY")
     test_response_format "Direct array for buckets" "$response" '^\['
     
     # Create a test bucket
     BUCKET_NAME="test-rest-bucket-$(date +%s)"
     response=$(curl -s -X POST "$API_BASE/storage/buckets" \
         -H "Content-Type: application/json" \
-        -H "x-api-key: $API_KEY" \
+        -H "Authorization: Bearer $API_KEY" \
         -d "{\"bucketName\": \"$BUCKET_NAME\", \"isPublic\": true}")
     
     if echo "$response" | grep -q '"bucketName"'; then

--- a/backend/tests/test-config.sh
+++ b/backend/tests/test-config.sh
@@ -235,7 +235,7 @@ cleanup_test_data() {
             for bucket in "${TEST_BUCKETS_CREATED[@]}"; do
                 print_info "  - Deleting bucket: $bucket"
                 delete_response=$(curl -s -w "\n%{http_code}" -X DELETE "$TEST_API_BASE/storage/buckets/$bucket" \
-                    -H "x-api-key: $api_key" 2>/dev/null || echo "500")
+                    -H "Authorization: Bearer $api_key" 2>/dev/null || echo "500")
                 status=$(echo "$delete_response" | tail -n 1)
                 if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
                     echo "    ✓ Deleted"

--- a/docs/insforge-auth-api.md
+++ b/docs/insforge-auth-api.md
@@ -2,9 +2,8 @@
 
 ## Overview
 
-Insforge uses JWT tokens for authentication. Store tokens in localStorage after login.
-**MCP Testing**: Use `x-api-key` header
-**Production**: Use `Authorization: Bearer <token>` header
+Insforge uses JWT tokens and API keys for authentication. Store tokens in localStorage after login.
+**All requests**: Use `Authorization: Bearer <token>` header (for both JWT tokens and API keys)
 
 ## Base URL
 `http://localhost:7130`

--- a/docs/insforge-debug.md
+++ b/docs/insforge-debug.md
@@ -58,7 +58,6 @@ curl.exe -X POST http://localhost:7130/api/database/records/your_table \
 - Backend runs on port 7130
 - **READ operations**: No authentication required
 - **WRITE operations**: Need `Authorization: Bearer <accessToken>` header
-- **x-api-key**: Only for MCP tool testing, not regular API calls
 - POST requests must be arrays `[{...}]`
 - System tables (prefixed with _) need special APIs
 - No escaped characters in JSON

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -46,7 +46,7 @@ Before ANY database operation, call `get-backend-metadata` to get the current da
 - Always define explicit table schemas (no assumptions)
 - Every table gets auto ID, created_at, updated_at fields
 - **Database operations require**: JWT token (Authorization: Bearer header)
-- **API keys are for MCP testing** (use session tokens for production)
+- **API keys are for MCP testing** (use tokens for production)
 - File uploads work automatically with multipart/form-data
 
 ## Authentication Requirements

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -46,7 +46,7 @@ Before ANY database operation, call `get-backend-metadata` to get the current da
 - Always define explicit table schemas (no assumptions)
 - Every table gets auto ID, created_at, updated_at fields
 - **Database operations require**: JWT token (Authorization: Bearer header)
-- **API keys (x-api-key) are ONLY for MCP testing**, not for production applications
+- **API keys are for MCP testing** (use session tokens for production)
 - File uploads work automatically with multipart/form-data
 
 ## Authentication Requirements

--- a/docs/insforge-storage-api.md
+++ b/docs/insforge-storage-api.md
@@ -4,7 +4,7 @@
 
 **Base URL:** `http://localhost:7130`  
 **Authentication:**
-- **Upload operations (PUT/POST/DELETE):** Requires `Authorization: Bearer <session-token>` header
+- **Upload operations (PUT/POST/DELETE):** Requires `Authorization: Bearer <token>` header
 - **Download from public buckets:** No authentication required
 - **List/manage buckets:** Requires authentication  
 **System:** Bucket-based storage with public/private access control
@@ -125,7 +125,7 @@ Example curl:
 ```bash
 # Windows PowerShell: use curl.exe
 curl -X GET "http://localhost:7130/api/storage/buckets/avatars/objects?limit=10&prefix=users/" \
-  -H "x-api-key: YOUR_API_KEY"
+  -H "Authorization: Bearer <token>"
 ```
 
 ### Delete Object
@@ -142,7 +142,7 @@ Example curl:
 ```bash
 # Windows PowerShell: use curl.exe
 curl -X DELETE http://localhost:7130/api/storage/buckets/avatars/objects/user123.jpg \
-  -H "x-api-key: YOUR_API_KEY"
+  -H "Authorization: Bearer <token>"
 ```
 
 ### Update Bucket
@@ -167,13 +167,13 @@ Example curl:
 ```bash
 # Mac/Linux
 curl -X PATCH http://localhost:7130/api/storage/buckets/avatars \
-  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{"isPublic": true}'
 
 # Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
 curl.exe -X PATCH http://localhost:7130/api/storage/buckets/avatars \
-  -H "x-api-key: YOUR_API_KEY" \
+  -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{\"isPublic\": true}'
 ```
@@ -187,7 +187,7 @@ const formData = new FormData();
 formData.append('file', file);
 const upload = await fetch('/api/storage/buckets/images/objects/avatar.jpg', {
   method: 'PUT',
-  headers: { 'x-api-key': apiKey },
+  headers: { 'Authorization': `Bearer ${token}` },
   body: formData
 });
 
@@ -199,7 +199,7 @@ const records = [{
 await fetch('/api/database/profiles', {
   method: 'POST',
   headers: { 
-    'x-api-key': apiKey,
+    'Authorization': `Bearer ${token}`,
     'Content-Type': 'application/json'
   },
   body: JSON.stringify(records)
@@ -213,7 +213,7 @@ const formData = new FormData();
 formData.append('file', file);
 const upload = await fetch('/api/storage/buckets/images/objects', {
   method: 'POST',
-  headers: { 'x-api-key': apiKey },
+  headers: { 'Authorization': `Bearer ${token}` },
   body: formData
 });
 const fileData = await upload.json();
@@ -226,7 +226,7 @@ const records = [{
 await fetch('/api/database/profiles', {
   method: 'POST',
   headers: { 
-    'x-api-key': apiKey,
+    'Authorization': `Bearer ${token}`,
     'Content-Type': 'application/json'
   },
   body: JSON.stringify(records)

--- a/docs/insforge-storage-api.md
+++ b/docs/insforge-storage-api.md
@@ -6,7 +6,8 @@
 **Authentication:**
 - **Upload operations (PUT/POST/DELETE):** Requires `Authorization: Bearer <token>` header
 - **Download from public buckets:** No authentication required
-- **List/manage buckets:** Requires authentication  
+- **List/manage buckets:** Requires authentication 
+- **API keys are for MCP testing** (use tokens for production)
 **System:** Bucket-based storage with public/private access control
 **URL Format**: Response `url` field contains `/api/storage/buckets/{bucket}/objects/{filename}` - correct format for serving files
 


### PR DESCRIPTION
added bearer token to also check api key

to not break existing customers, we will follow depratete x-api key in 3 phases

1. support x-api-key and  token(check both api key and jwt token)
2. After every user upgraded docker, we can start changing mcp to send token(api key)
3. after a while we can remove the x-api key check



created a todo app using mcp to make sure everythig is fine

npm run test e2e: