### PR TITLE
delete docs related to system tables or _users

### DIFF
--- a/docs/insforge-db-api.md
+++ b/docs/insforge-db-api.md
@@ -181,23 +181,6 @@ Response format (WITH `Prefer: return=representation` header):
 ]
 ```
 
-Example:
-```bash
-# Mac/Linux
-curl -X PATCH "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
-  -H 'Authorization: Bearer TOKEN' \
-  -H 'Content-Type: application/json' \
-  -H 'Prefer: return=representation' \
-  -d '{"name": "Jane Doe"}'
-
-# Windows PowerShell (use curl.exe) - different quotes needed for nested JSON
-curl.exe -X PATCH "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
-  -H "Authorization: Bearer TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "Prefer: return=representation" \
-  -d '{\"name\": \"Jane Doe\"}'
-```
-
 ### Delete Record
 **DELETE** `/api/database/records/:tableName?id=eq.uuid`
 
@@ -230,15 +213,6 @@ Response format (WITH `Prefer: return=representation` header):
 // If record didn't exist (already deleted or never existed):
 []
 ```
-
-Example:
-```bash
-# Windows PowerShell: use curl.exe
-curl -X DELETE "http://localhost:7130/api/database/records/_users?id=eq.UUID" \
-  -H "Authorization: Bearer TOKEN" \
-  -H "Prefer: return=representation"
-```
-
 
 ## Error Response Format
 

--- a/docs/insforge-debug.md
+++ b/docs/insforge-debug.md
@@ -16,7 +16,6 @@ Before debugging, you MUST read all documentation to understand how the API work
 **Table created but API fails** → Check field names match schema exactly
 **Array required** → PostgREST requires POST requests as arrays `[{...}]`
 **Foreign key error** → Parent record must exist before child
-**Auth tables** → Use Auth API for _user tables, not Database API
 **Permission denied** → Write operations need `Authorization: Bearer <accessToken>`
 **JWSError** → JWT token expired or invalid - user needs to login again
 **PATCH increment fails** → PostgREST doesn't support SQL expressions like `count + 1`

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -80,14 +80,7 @@ curl -X POST http://localhost:7130/api/database/records/products \
 ```
 ## System Tables
 
-### User Table (Read-Only Access)
-The `_user` table is a **system-managed table** from the JWT authentication system:
-- **✅ CAN READ** via `GET /api/database/records/_user`
-- **❌ CANNOT MODIFY** through database API - use Auth API instead
-- **✅ CAN REFERENCE** by other tables using `user_id` foreign keys
-
 To work with users:
-- Read users: `GET /api/database/records/_user`
 - Create users: Use `POST /api/auth/users`
 - Authenticate: Use `POST /api/auth/sessions`
 - Store additional data: Create your own `user_profiles` table

--- a/docs/insforge-instructions.md
+++ b/docs/insforge-instructions.md
@@ -78,12 +78,6 @@ curl -X POST http://localhost:7130/api/database/records/products \
   -H "Content-Type: application/json" \
   -d "[{\"name\": \"Product\", \"price\": 99.99}]"
 ```
-## System Tables
-
-To work with users:
-- Create users: Use `POST /api/auth/users`
-- Authenticate: Use `POST /api/auth/sessions`
-- Store additional data: Create your own `user_profiles` table
 
 ## Example: Comment Upvoting Feature
 

--- a/docs/insforge-project.md
+++ b/docs/insforge-project.md
@@ -36,15 +36,6 @@ curl.exe -X POST http://localhost:7130/api/[endpoint] \
 
 When in doubt, read instructions documents again.
 
-## 🚨 System Tables
-
-### User Table (Read-Only)
-The `_user` table is **protected** by the JWT authentication system:
-- **✅ CAN READ** via `GET /api/database/records/_user`
-- **❌ CANNOT MODIFY** (POST/PUT/PATCH/DELETE) - use Auth API instead
-- **✅ CAN reference** with foreign keys
-- Get `user_id` from `localStorage.getItem('user_id')` after login
-
 ## 🚨 CRUD Operations - PostgREST NOT RESTful
 ### PostgREST Database API Behavior
 


### PR DESCRIPTION
deleting all occurrences of _users. This is legacy tables. Given this table is now hidden,. Hiding all aspects of systems tables as we technically don't have system tables.

This is confusing mcp right now.


I really hope with SDK we don't need to maintain long and nasty docs like this. Which are all over the places.

We can teach the AI more about the new users table. but i want to try more occurrences of when  it fails. and if it corre t itself.






