### PR TITLE
[FIX] Fix mime type for get file in buckets

### DIFF
--- a/backend/src/core/storage/storage.ts
+++ b/backend/src/core/storage/storage.ts
@@ -326,7 +326,11 @@ export class StorageService {
     return {
       file,
       metadata: {
-        ...metadata,
+        key: metadata.key,
+        bucket: metadata.bucket,
+        size: metadata.size,
+        mimeType: metadata.mime_type,
+        uploadedAt: metadata.uploaded_at,
         url: `${process.env.API_BASE_URL || 'http://localhost:7130'}/api/storage/buckets/${bucket}/objects/${encodeURIComponent(key)}`,
       },
     };
@@ -356,7 +360,7 @@ export class StorageService {
       const dbManager = DatabaseManager.getInstance();
       await dbManager.logActivity('DELETE', `storage/${bucket}`, key, {
         size: fileInfo.size,
-        mime_type: fileInfo.mimeType,
+        mime_type: fileInfo.mime_type,
       });
     }
 

--- a/backend/src/types/storage.ts
+++ b/backend/src/types/storage.ts
@@ -1,8 +1,14 @@
 // Storage-related type definitions
-import { StorageFileSchema, StorageBucketSchema } from '@insforge/shared-schemas';
+import { StorageBucketSchema } from '@insforge/shared-schemas';
 
 // Base storage record from database
-export type StorageRecord = Omit<StorageFileSchema, 'url'>;
+export interface StorageRecord {
+  key: string;
+  bucket: string;
+  size: number;
+  mime_type?: string;
+  uploaded_at: string;
+}
 
 // Bucket record from _storage_buckets table
 export type BucketRecord = Omit<StorageBucketSchema, 'created_at'>;


### PR DESCRIPTION
Our database uses snake_case, so all data returned from db should be snake_case. This bug incorrectly uses camelCase for file metadata returned from db, causes an undefined mimeType when getting files from buckets.

Interestingly, this never causes any issues but for svg files. I found this bug by noticing that I can't read or download svg files after uploading to the bucket, but all other file formats work well for some reason. Maybe black magic.