### PR TITLE
change auth migration file

### DIFF
--- a/backend/migrations/002_rename-auth-tables.sql
+++ b/backend/migrations/002_rename-auth-tables.sql
@@ -2,21 +2,29 @@
 
 DO $$
 BEGIN
-    -- Rename _account to _oauth_connections
+    -- Handle _account to _oauth_connections
     IF EXISTS (SELECT FROM information_schema.tables 
               WHERE table_name = '_account' AND table_schema = 'public') THEN
-        IF NOT EXISTS (SELECT FROM information_schema.tables 
-                       WHERE table_name = '_oauth_connections' AND table_schema = 'public') THEN
-              ALTER TABLE _account RENAME TO _oauth_connections;
+        IF EXISTS (SELECT FROM information_schema.tables 
+                   WHERE table_name = '_oauth_connections' AND table_schema = 'public') THEN
+            -- Both exist, drop the old one
+            DROP TABLE _account CASCADE;
+        ELSE
+            -- Only old exists, rename it
+            ALTER TABLE _account RENAME TO _oauth_connections;
         END IF;
     END IF;
 
-    -- Rename _user to _accounts
+    -- Handle _user to _accounts
     IF EXISTS (SELECT FROM information_schema.tables 
               WHERE table_name = '_user' AND table_schema = 'public') THEN
-        IF NOT EXISTS (SELECT FROM information_schema.tables 
-                       WHERE table_name = '_accounts' AND table_schema = 'public') THEN
-              ALTER TABLE _user RENAME TO _accounts;
+        IF EXISTS (SELECT FROM information_schema.tables 
+                   WHERE table_name = '_accounts' AND table_schema = 'public') THEN
+            -- Both exist, drop the old one
+            DROP TABLE _user CASCADE;
+        ELSE
+            -- Only old exists, rename it
+            ALTER TABLE _user RENAME TO _accounts;
         END IF;
     END IF;
 END $$;


### PR DESCRIPTION
There is a bug when we have  _oauth_connection tables alreadyu

we run the migration file
000 creates _account table

002 sees that _oauth_connections already exist, so it do nothing. 
We are left with an additional _account table