### PR TITLE
update enabled to use shared key if ture

### DIFF
--- a/backend/src/core/auth/auth.ts
+++ b/backend/src/core/auth/auth.ts
@@ -142,7 +142,7 @@ export class AuthService {
           config[provider].clientId = value.clientId || '';
           config[provider].clientSecret = value.clientSecret || '';
           config[provider].redirectUri = value.redirectUri || config[provider].redirectUri;
-          config[provider].enabled = value.enabled || false;
+          config[provider].enabled = value.enabled || enableSharedKeys;
           config[provider].useSharedKeys = value.useSharedKeys || enableSharedKeys;
         }
       } catch (e) {


### PR DESCRIPTION
Instead of reading database config only, we also check if it's enabledSharedKeys.

If on cloud we enabledSharedKeys, this means oauth is enabled, agent should be able to understand the metadata 
<img width="685" height="237" alt="Screenshot 2025-09-05 at 22 47 23" src="https://github.com/user-attachments/assets/50531a00-986b-4946-b1cb-8e5efb649b28" />
