### PR TITLE
[Security] Replace API key with token in frontend

### DIFF
--- a/frontend/src/features/ai/hooks/useAIConfigs.ts
+++ b/frontend/src/features/ai/hooks/useAIConfigs.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { aiService } from '@/features/ai/services/ai.service';
-import { metadataService } from '@/features/metadata/services/metadata.service';
 import {
   ListModelsResponse,
   AIConfigurationWithUsageSchema,
@@ -19,13 +18,6 @@ export function useAIConfigs(options: UseAIConfigsOptions = {}) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
 
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   // Fetch AI models configuration
   const {
     data: modelsData,
@@ -35,7 +27,7 @@ export function useAIConfigs(options: UseAIConfigsOptions = {}) {
   } = useQuery<ListModelsResponse>({
     queryKey: ['ai-models'],
     queryFn: () => aiService.getModels(),
-    enabled: enabled && !!apiKey,
+    enabled: enabled,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   });
 
@@ -48,7 +40,7 @@ export function useAIConfigs(options: UseAIConfigsOptions = {}) {
   } = useQuery<AIConfigurationWithUsageSchema[]>({
     queryKey: ['ai-configurations'],
     queryFn: () => aiService.listConfigurations(),
-    enabled: enabled && !!apiKey,
+    enabled: enabled,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   });
 

--- a/frontend/src/features/ai/hooks/useAIUsage.ts
+++ b/frontend/src/features/ai/hooks/useAIUsage.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { aiService } from '@/features/ai/services/ai.service';
-import { metadataService } from '@/features/metadata/services/metadata.service';
 import {
   AIUsageSummarySchema,
   AIUsageRecordSchema,
@@ -17,17 +16,10 @@ interface UseAIUsageSummaryOptions {
 export function useAIUsageSummary(options: UseAIUsageSummaryOptions = {}) {
   const { configId, startDate, endDate, enabled = true } = options;
 
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   return useQuery<AIUsageSummarySchema>({
     queryKey: ['ai-usage-summary', configId, startDate, endDate],
     queryFn: () => aiService.getUsageSummary({ configId, startDate, endDate }),
-    enabled: enabled && !!apiKey,
+    enabled: enabled,
     staleTime: 60 * 1000, // Cache for 1 minute
   });
 }
@@ -43,17 +35,10 @@ interface UseAIUsageRecordsOptions {
 export function useAIUsageRecords(options: UseAIUsageRecordsOptions = {}) {
   const { startDate, endDate, limit = '50', offset = '0', enabled = true } = options;
 
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   return useQuery<ListAIUsageResponse>({
     queryKey: ['ai-usage-records', startDate, endDate, limit, offset],
     queryFn: () => aiService.getUsageRecords({ startDate, endDate, limit, offset }),
-    enabled: enabled && !!apiKey,
+    enabled: enabled,
     staleTime: 60 * 1000, // Cache for 1 minute
   });
 }
@@ -68,17 +53,10 @@ interface UseAIConfigUsageOptions {
 export function useAIConfigUsage(options: UseAIConfigUsageOptions) {
   const { configId, startDate, endDate, enabled = true } = options;
 
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   return useQuery<AIUsageRecordSchema[]>({
     queryKey: ['ai-config-usage', configId, startDate, endDate],
     queryFn: () => aiService.getConfigUsageRecords(configId, { startDate, endDate }),
-    enabled: enabled && !!apiKey && !!configId,
+    enabled: enabled && !!configId,
     staleTime: 60 * 1000, // Cache for 1 minute
   });
 }

--- a/frontend/src/features/ai/services/ai.service.ts
+++ b/frontend/src/features/ai/services/ai.service.ts
@@ -13,7 +13,7 @@ import {
 export class AiService {
   getModels(): Promise<ListModelsResponse> {
     return apiClient.request('/ai/models', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -23,20 +23,20 @@ export class AiService {
   ): Promise<{ id: string; message: string }> {
     return apiClient.request('/ai/configurations', {
       method: 'POST',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
       body: JSON.stringify(data),
     });
   }
 
   async listConfigurations(): Promise<AIConfigurationWithUsageSchema[]> {
     return apiClient.request('/ai/configurations', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
   async getConfiguration(id: string): Promise<AIConfigurationSchema> {
     return apiClient.request(`/ai/configurations/${id}`, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -46,7 +46,7 @@ export class AiService {
   ): Promise<{ message: string }> {
     return apiClient.request(`/ai/configurations/${id}`, {
       method: 'PATCH',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
       body: JSON.stringify(data),
     });
   }
@@ -54,7 +54,7 @@ export class AiService {
   async deleteConfiguration(id: string): Promise<{ message: string }> {
     return apiClient.request(`/ai/configurations/${id}`, {
       method: 'DELETE',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -79,7 +79,7 @@ export class AiService {
     const url = `/ai/usage/summary${queryString ? `?${queryString}` : ''}`;
 
     return apiClient.request(url, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -107,7 +107,7 @@ export class AiService {
     const url = `/ai/usage${queryString ? `?${queryString}` : ''}`;
 
     return apiClient.request(url, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -130,7 +130,7 @@ export class AiService {
     const url = `/ai/usage/config/${configId}${queryString ? `?${queryString}` : ''}`;
 
     return apiClient.request(url, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 }

--- a/frontend/src/features/auth/hooks/useUsers.ts
+++ b/frontend/src/features/auth/hooks/useUsers.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { authService } from '@/features/auth/services/auth.service';
-import { metadataService } from '@/features/metadata/services/metadata.service';
 
 interface UseUsersOptions {
   pageSize?: number;
@@ -12,13 +11,6 @@ interface UseUsersOptions {
 export function useUsers(options: UseUsersOptions = {}) {
   const { pageSize = 20, enabled = true, searchQuery = '' } = options;
   const [currentPage, setCurrentPage] = useState(1);
-
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
 
   // Fetch users data
   const {
@@ -36,7 +28,7 @@ export function useUsers(options: UseUsersOptions = {}) {
       // Use the auth service to get users with search, backend handles filtering
       return authService.getUsers(params.toString(), searchQuery);
     },
-    enabled: enabled && !!apiKey,
+    enabled: enabled,
     placeholderData: (previousData) => previousData, // Keep previous data while loading
   });
 

--- a/frontend/src/features/dashboard/page/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/page/DashboardPage.tsx
@@ -15,22 +15,14 @@ export default function DashboardPage() {
     queryFn: () => metadataService.getDashboardMetadata(),
   });
 
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   const { data: usersData, isLoading: isLoadingUsers } = useQuery({
     queryKey: ['users-count'],
     queryFn: () => authService.getUsers(),
-    enabled: !!apiKey,
   });
 
   const { data: fullMetadata, isLoading: isLoadingFullMetadata } = useQuery({
     queryKey: ['full-metadata'],
     queryFn: () => metadataService.getFullMetadata(),
-    enabled: !!apiKey,
   });
 
   return (

--- a/frontend/src/features/database/page/DatabasePage.tsx
+++ b/frontend/src/features/database/page/DatabasePage.tsx
@@ -94,13 +94,6 @@ export default function DatabasePage() {
     [showToast]
   );
 
-  // Ensure API key is fetched
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
-
   // Fetch metadata
   const {
     data: metadata,
@@ -110,7 +103,6 @@ export default function DatabasePage() {
   } = useQuery({
     queryKey: ['database-metadata'],
     queryFn: () => metadataService.getDatabaseMetadata(),
-    enabled: !!apiKey,
   });
 
   // Fetch table data when selected
@@ -175,7 +167,7 @@ export default function DatabasePage() {
         throw error;
       }
     },
-    enabled: !!selectedTable && !!apiKey,
+    enabled: !!selectedTable,
     placeholderData: (previousData) => previousData, // Keep previous data while loading new sorted data
   });
 
@@ -437,7 +429,7 @@ export default function DatabasePage() {
       }
       return await databaseService.getTableSchema(selectedTable);
     },
-    enabled: !!selectedTable && !!apiKey,
+    enabled: !!selectedTable,
     staleTime: 30 * 1000, // 30 seconds
   });
 
@@ -451,7 +443,7 @@ export default function DatabasePage() {
       const editingTableSchema = await databaseService.getTableSchema(editingTable);
       return editingTableSchema;
     },
-    enabled: !!editingTable && !!apiKey,
+    enabled: !!editingTable,
   });
 
   // Calculate pagination

--- a/frontend/src/features/database/services/database.service.ts
+++ b/frontend/src/features/database/services/database.service.ts
@@ -11,7 +11,7 @@ export class DatabaseService {
   // Table operations
   async listTables(): Promise<string[]> {
     const data = await apiClient.request('/database/tables', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
     // data is already unwrapped by request method and should be an array
     return Array.isArray(data) ? data : [];
@@ -19,7 +19,7 @@ export class DatabaseService {
 
   getTableSchema(tableName: string): Promise<GetTableSchemaResponse> {
     return apiClient.request(`/database/tables/${tableName}/schema`, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -27,7 +27,7 @@ export class DatabaseService {
     const body: CreateTableRequest = { tableName: tableName, columns, rlsEnabled: true };
     return apiClient.request('/database/tables', {
       method: 'POST',
-      headers: apiClient.withApiKey({
+      headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
       }),
       body: JSON.stringify(body),
@@ -37,7 +37,7 @@ export class DatabaseService {
   deleteTable(tableName: string) {
     return apiClient.request(`/database/tables/${tableName}`, {
       method: 'DELETE',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -47,7 +47,7 @@ export class DatabaseService {
   ): Promise<UpdateTableSchemaResponse | void> {
     return apiClient.request(`/database/tables/${tableName}/schema`, {
       method: 'PATCH',
-      headers: apiClient.withApiKey({
+      headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
       }),
       body: JSON.stringify(operations),
@@ -99,7 +99,7 @@ export class DatabaseService {
     const response = await apiClient.request(
       `/database/records/${tableName}?${params.toString()}`,
       {
-        headers: apiClient.withApiKey(),
+        headers: apiClient.withAccessToken(),
       }
     );
 
@@ -125,7 +125,7 @@ export class DatabaseService {
   async getRecords(tableName: string, queryParams: string = '') {
     const url = `/database/records/${tableName}${queryParams ? `?${queryParams}` : ''}`;
     const response = await apiClient.request(url, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
 
     // Traditional REST: check if response is array (direct data) or wrapped
@@ -149,7 +149,7 @@ export class DatabaseService {
 
   getRecord(table: string, id: string) {
     return apiClient.request(`/database/records/${table}?id=eq.${id}`, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
@@ -163,7 +163,7 @@ export class DatabaseService {
     });
     return apiClient.request(`/database/records/${table}`, {
       method: 'POST',
-      headers: apiClient.withApiKey({
+      headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
       }),
       body: JSON.stringify(records),
@@ -181,7 +181,7 @@ export class DatabaseService {
   updateRecord(table: string, id: string, data: any) {
     return apiClient.request(`/database/records/${table}?id=eq.${id}`, {
       method: 'PATCH',
-      headers: apiClient.withApiKey({
+      headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
       }),
       body: JSON.stringify(data),
@@ -191,7 +191,7 @@ export class DatabaseService {
   deleteRecord(table: string, id: string) {
     return apiClient.request(`/database/records/${table}?id=eq.${id}`, {
       method: 'DELETE',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 }

--- a/frontend/src/features/metadata/services/metadata.service.ts
+++ b/frontend/src/features/metadata/services/metadata.service.ts
@@ -10,23 +10,19 @@ import {
 export class MetadataService {
   async fetchApiKey() {
     const data = await apiClient.request('/metadata/api-key');
-    // data is already unwrapped by request method
-    if (data.apiKey) {
-      apiClient.setApiKey(data.apiKey);
-    }
     return data.apiKey;
   }
   // Get full metadata (complete structured format)
   async getFullMetadata(): Promise<AppMetadataSchema> {
     return apiClient.request('/metadata', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 
   // Get dashboard metadata only
   async getDashboardMetadata(): Promise<DashboardMetadataSchema> {
     return apiClient.request('/metadata/dashboard', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   }
 

--- a/frontend/src/features/storage/services/storage.service.ts
+++ b/frontend/src/features/storage/services/storage.service.ts
@@ -15,7 +15,7 @@ export const storageService = {
   // List all buckets
   async listBuckets(): Promise<StorageBucketSchema[]> {
     const response = await apiClient.request('/storage/buckets', {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
     // Traditional REST: API returns array directly
     return response;
@@ -43,7 +43,7 @@ export const storageService = {
 
     const url = `/storage/buckets/${encodeURIComponent(bucketName)}/objects${searchParams.toString() ? `?${searchParams}` : ''}`;
     const response = await apiClient.request(url, {
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
       returnFullResponse: true,
     });
 
@@ -76,7 +76,7 @@ export const storageService = {
       {
         method: 'PUT',
         headers: {
-          'x-api-key': apiClient.getApiKey() || '',
+          'Authorization': `Bearer ${apiClient.getToken()}`,
         },
         body: formData,
       }
@@ -102,7 +102,7 @@ export const storageService = {
   async downloadObject(bucketName: string, objectKey: string): Promise<Blob> {
     const response = await fetch(this.getDownloadUrl(bucketName, objectKey), {
       headers: {
-        'x-api-key': apiClient.getApiKey() || '',
+        'Authorization': `Bearer ${apiClient.getToken()}`,
       },
     });
     if (!response.ok) {
@@ -117,7 +117,7 @@ export const storageService = {
       `/storage/buckets/${encodeURIComponent(bucketName)}/objects/${encodeURIComponent(objectKey)}`,
       {
         method: 'DELETE',
-        headers: apiClient.withApiKey(),
+        headers: apiClient.withAccessToken(),
       }
     );
   },
@@ -126,7 +126,7 @@ export const storageService = {
   async createBucket(bucketName: string, isPublic: boolean = true): Promise<void> {
     await apiClient.request('/storage/buckets', {
       method: 'POST',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
       body: JSON.stringify({ bucketName: bucketName, isPublic: isPublic }),
     });
   },
@@ -135,7 +135,7 @@ export const storageService = {
   async deleteBucket(bucketName: string): Promise<void> {
     await apiClient.request(`/storage/buckets/${encodeURIComponent(bucketName)}`, {
       method: 'DELETE',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
     });
   },
 
@@ -143,7 +143,7 @@ export const storageService = {
   async editBucket(bucketName: string, config: { isPublic: boolean }): Promise<void> {
     await apiClient.request(`/storage/buckets/${encodeURIComponent(bucketName)}`, {
       method: 'PATCH',
-      headers: apiClient.withApiKey(),
+      headers: apiClient.withAccessToken(),
       body: JSON.stringify(config),
     });
   },

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -9,13 +9,11 @@ interface ApiError extends Error {
 
 export class ApiClient {
   private token: string | null = null;
-  private apiKey: string | null = null;
   private tokenRefreshPromise: Promise<void> | null = null;
   private onAuthError?: () => void;
 
   constructor() {
     this.token = localStorage.getItem('insforge_token');
-    this.apiKey = localStorage.getItem('insforge_api_key');
   }
 
   setToken(token: string) {
@@ -30,15 +28,6 @@ export class ApiClient {
 
   getToken() {
     return this.token;
-  }
-
-  setApiKey(apiKey: string) {
-    this.apiKey = apiKey;
-    localStorage.setItem('insforge_api_key', apiKey);
-  }
-
-  getApiKey(): string | null {
-    return this.apiKey;
   }
 
   setAuthErrorHandler(handler?: () => void) {
@@ -80,7 +69,7 @@ export class ApiClient {
         let errorData;
         try {
           errorData = await response.json();
-        } catch (e) {
+        } catch {
           // If parsing JSON fails, throw a generic error
           const error: ApiError = new Error(`HTTP ${response.status}: ${response.statusText}`);
           error.response = { data: null, status: response.status };
@@ -119,7 +108,7 @@ export class ApiClient {
       let responseData = null;
       try {
         responseData = text ? JSON.parse(text) : null;
-      } catch (e) {
+      } catch {
         responseData = text;
       }
 
@@ -166,9 +155,9 @@ export class ApiClient {
     return makeRequest();
   }
 
-  // Helper method to add API key header
-  withApiKey(headers: Record<string, string> = {}) {
-    return this.apiKey ? { ...headers, 'x-api-key': this.apiKey } : headers;
+  // Helper method to add authorization header with token
+  withAccessToken(headers: Record<string, string> = {}) {
+    return this.token ? { ...headers, Authorization: `Bearer ${this.token}` } : headers;
   }
 }
 


### PR DESCRIPTION
This PR makes every API call to use token in Authorization headers instead of api keys. Also remove the storage of api-key in localstorage, this is high security risk.