### PR TITLE
🐛 Fixed datetime rendering in user datagrid

### DIFF
--- a/frontend/src/features/auth/components/UsersDataGrid.tsx
+++ b/frontend/src/features/auth/components/UsersDataGrid.tsx
@@ -155,7 +155,7 @@ export function createUsersColumns(): DataGridColumn[] {
       width: '1fr',
       resizable: true,
       sortable: true,
-      renderCell: DefaultCellRenderers.date,
+      renderCell: DefaultCellRenderers.datetime,
     },
     {
       key: 'updated_at',
@@ -163,7 +163,7 @@ export function createUsersColumns(): DataGridColumn[] {
       width: '1fr',
       resizable: true,
       sortable: true,
-      renderCell: DefaultCellRenderers.date,
+      renderCell: DefaultCellRenderers.datetime,
     },
   ];
 }


### PR DESCRIPTION
From
<img width="2247" height="884" alt="image" src="https://github.com/user-attachments/assets/c038c0f7-a69a-405d-b1c5-05431ddde6a8" />
to
<img width="2265" height="926" alt="image" src="https://github.com/user-attachments/assets/580f443b-d967-4a6c-8103-559360ba88a9" />
Solved datetime rendering.