### PR TITLE
🐛 Added backward support for datetime default value support

### DIFF
--- a/frontend/src/features/database/helpers.ts
+++ b/frontend/src/features/database/helpers.ts
@@ -121,7 +121,11 @@ export function getInitialValues(columns: ColumnSchema[]): Record<string, any> {
         }
         break;
       case ColumnType.DATETIME:
-        if (column.defaultValue && !column.defaultValue.endsWith('()')) {
+        if (
+          column.defaultValue &&
+          column.defaultValue !== 'CURRENT_TIMESTAMP' &&
+          !column.defaultValue.endsWith('()')
+        ) {
           values[column.columnName] = column.defaultValue;
         } else {
           values[column.columnName] = '';


### PR DESCRIPTION
Changes: Re-added the value handler for when the default value of a datetime type column is CURRENT_TIMESTAMP.