### PR TITLE
update system prompt forimage gen and fix type

### DIFF
--- a/backend/src/core/ai/usage.ts
+++ b/backend/src/core/ai/usage.ts
@@ -84,7 +84,7 @@ export class AIUsageService {
     }
   }
 
-  async trackImageGeneartionUsage(
+  async trackImageGenerationUsage(
     configId: string,
     imageCount: number,
     imageResolution?: string,


### PR DESCRIPTION
I wrote so much code for image generation system prompt, then realized it doesn't work.

Fall back to simple method of prepending system prompt ontop of image gen

also fixed some typos along the way


test:

system prompt:
Generate an image create a 1/7 scale model, in a realistic style and environment. Place the figure on a computer desk, using a circular transparent acrylic base without any text.On the computer screen, display the ZBrush modeling process of the figure.Next to the computer screen, place a TAMIYA-style toy packaging box printedwith the original artwork.

actual prompt: generate a pikachu

<img width="1081" height="1004" alt="Screenshot 2025-09-12 at 18 30 51" src="https://github.com/user-attachments/assets/1eb5df6b-1d93-4562-bac5-e15fb3ce28d9" />

