### PR TITLE
[UI/Refinement] Changed 'add user' button's color in dark theme

### DIFF
--- a/frontend/src/components/DataGrid.tsx
+++ b/frontend/src/components/DataGrid.tsx
@@ -488,7 +488,7 @@ export function DataGrid({
                   {emptyStateActionText && onEmptyStateAction && (
                     <button
                       onClick={onEmptyStateAction}
-                      className="inline-flex items-center text-sm font-medium text-chart-blue-dark focus:outline-none focus:ring-0 dark:text-zinc-400"
+                      className="inline-flex items-center text-sm font-medium text-chart-blue-dark focus:outline-none focus:ring-0 dark:text-emerald-300"
                     >
                       {emptyStateActionText}
                     </button>


### PR DESCRIPTION
<img width="2552" height="690" alt="image" src="https://github.com/user-attachments/assets/ccc5d6fd-5d97-47e1-aa84-b58f716ea724" />

The design remains the same in the light theme:
<img width="2552" height="579" alt="image" src="https://github.com/user-attachments/assets/d07d46af-820c-4f62-8bc0-a30b79307a31" />

Resolves: https://github.com/InsForge/insforge-cloud/issues/63

Have confirmed this update with Peter.