### PR TITLE
🐛 Fixed incorrect html element structure

### DIFF
--- a/frontend/src/features/database/components/ForeignKeyCell.tsx
+++ b/frontend/src/features/database/components/ForeignKeyCell.tsx
@@ -139,13 +139,15 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
             </button>
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b border-border-gray dark:border-neutral-700">
-              <p className="text-xs font-medium text-muted-foreground dark:text-white flex items-center gap-1.5">
-                Referencing record from
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs font-medium text-muted-foreground dark:text-white">
+                  Referencing record from
+                </span>
                 <TypeBadge
                   type={`${foreignKey.table}.${foreignKey.column}`}
                   className="dark:bg-neutral-800"
                 />
-              </p>
+              </div>
             </div>
 
             {/* Content */}

--- a/frontend/src/features/database/components/LinkRecordModal.tsx
+++ b/frontend/src/features/database/components/LinkRecordModal.tsx
@@ -242,13 +242,15 @@ export function LinkRecordModal({
           <DialogTitle className="text-lg font-semibold text-zinc-950 dark:text-white">
             Link Record
           </DialogTitle>
-          <p className="text-sm text-zinc-500 dark:text-neutral-400 flex items-center gap-1.5">
-            Select a record to reference from
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm text-zinc-500 dark:text-neutral-400">
+              Select a record to reference from
+            </span>
             <TypeBadge
               type={`${referenceTable}.${referenceColumn}`}
               className="dark:bg-neutral-700"
             />
-          </p>
+          </div>
         </DialogHeader>
 
         {/* Search Bar */}


### PR DESCRIPTION
Issue: https://github.com/InsForge/InsForge/issues/212

The error was caused by invalid HTML nesting. I mistakenly placed a <div> element inside a <p> element, which is not allowed in HTML. 

After the changes, opening the link record modal or rendering a foreign key cell will no longer trigger console errors.
<img width="1566" height="1250" alt="image" src="https://github.com/user-attachments/assets/4fa85a59-6bc7-42c2-95cb-ad138b3ab0d7" />
