### PR TITLE
[Security] Add regex to forbid system table operations

### DIFF
--- a/backend/src/controllers/database.ts
+++ b/backend/src/controllers/database.ts
@@ -65,6 +65,28 @@ export class DatabaseController {
       }
     }
 
+    // Check for system table operations (tables starting with underscore)
+    // This pattern checks each statement in multi-statement queries, including schema-qualified names
+    const systemTablePattern =
+      /(?:^|\n|;)\s*(?:CREATE|ALTER|DROP|INSERT\s+INTO|UPDATE|DELETE\s+FROM|TRUNCATE)\s+(?:TABLE\s+)?(?:IF\s+(?:NOT\s+)?EXISTS\s+)?(?:\w+\.)?["']?_\w+/im;
+    if (systemTablePattern.test(query)) {
+      throw new AppError(
+        'Cannot modify or create system tables (tables starting with underscore)',
+        403,
+        ERROR_CODES.FORBIDDEN
+      );
+    }
+
+    // Check for RENAME TO system table
+    const renameToSystemTablePattern = /RENAME\s+TO\s+(?:\w+\.)?["']?_\w+/im;
+    if (renameToSystemTablePattern.test(query)) {
+      throw new AppError(
+        'Cannot rename tables to system table names (tables starting with underscore)',
+        403,
+        ERROR_CODES.FORBIDDEN
+      );
+    }
+
     return query;
   }
 


### PR DESCRIPTION
  DDL Operations:
  - CREATE TABLE _users → 403 Forbidden ✓
  - CREATE TABLE IF NOT EXISTS _config → 403 Forbidden ✓
  - DROP TABLE _auth → 403 Forbidden ✓
  - DROP TABLE IF EXISTS _migrations CASCADE → 403 Forbidden ✓
  - ALTER TABLE _auth ADD COLUMN → 403 Forbidden ✓
  - ALTER TABLE _users RENAME TO users_backup → 403 Forbidden ✓
  - TRUNCATE TABLE _auth → 403 Forbidden ✓
  - TRUNCATE _migrations RESTART IDENTITY CASCADE → 403 Forbidden ✓

  DML Operations:
  - INSERT INTO _auth → 403 Forbidden ✓
  - UPDATE _users SET role = 'admin' → 403 Forbidden ✓
  - DELETE FROM _migrations → 403 Forbidden ✓

  Bypass Attempts:
  - Mixed case: DrOp TaBlE _AuTh → 403 Forbidden ✓
  - Extra whitespace: DROP  \t  TABLE   _auth → 403 Forbidden ✓
  - Schema prefix: CREATE TABLE public._admin → 403 Forbidden ✓
  - Quoted identifiers: CREATE TABLE "_system" → 403 Forbidden ✓
  - Unicode escape: CREATE TABLE \u005fhacked → 403 Forbidden ✓
  
  1. ✅ ALTER TABLE test_table RENAME TO _system_table → 403 Forbidden
  2. ✅ ALTER TABLE test_table RENAME TO "_quoted" → 403 Forbidden
  3. ✅ ALTER TABLE test_table RENAME TO public._system → 403 Forbidden
  4. ✅ AlTeR TaBle test_table ReNaMe To _MiXeD_CaSe → 403 Forbidden
  5. ✅ ALTER TABLE test_table  RENAME   TO  _extra_spaces → 403 Forbidden
  
  **I am using AI to test against a regex expression written by AI**
  2025 is so vibeeeeeeeeee