### PR TITLE
[MCP] Update get table schema endpoint

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/insforge-mcp",
-  "version": "1.0.48",
+  "version": "1.0.50",
   "description": "MCP (Model Context Protocol) server for Insforge backend-as-a-service",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -587,7 +587,7 @@ server.tool(
   withUsageTracking('get-table-schema', async ({ apiKey, tableName }) => {
     try {
       const actualApiKey = getApiKey(apiKey);
-      const response = await fetch(`${API_BASE_URL}/api/database/tables/${tableName}/schema`, {
+      const response = await fetch(`${API_BASE_URL}/api/metadata/${tableName}`, {
         method: 'GET',
         headers: {
           'x-api-key': actualApiKey,

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,7 @@
     },
     "mcp": {
       "name": "@insforge/insforge-mcp",
-      "version": "1.0.48",
+      "version": "1.0.50",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",


### PR DESCRIPTION
This PR makes MCP to use the new get table schema endpoint written by Junwen: /api/metadata/:tableName

Tested and it's working properly, projects before v0.2.5 may break because it doesn't have this endpoint.

TBD:
After calling get-table-schema tool, agents still want to use run-raw-sql tool to do another check (it may want to understand the schema better, or it doesn't trust the result returned by the get-table-schema tool). I think it may be caused by the two following reasons:
1. The full instruction is returned in context, diluting the actual tool response.
2. Run raw sql is just way too powerful. We may only need this one tool for the whole database.