### PR TITLE
fix mcp usage limit

### DIFF
--- a/backend/src/api/routes/usage.ts
+++ b/backend/src/api/routes/usage.ts
@@ -50,21 +50,18 @@ usageRouter.get('/stats', verifyCloudBackend, async (req, res, next) => {
     const dbManager = DatabaseManager.getInstance();
     const db = dbManager.getDb();
 
-    // Get MCP tool usage count within date range
-    const endDatePlusOne = new Date(end_date as string);
-    endDatePlusOne.setDate(endDatePlusOne.getDate() + 1);
-
+    // Date parameters are ignored for MCP because:
+    // 1. MCP usage should accumulate continuously
+    // 2. Cloud backend calculates deltas between snapshots
     const mcpResult = await db
       .prepare(
         `
       SELECT COUNT(*) as count 
       FROM _mcp_usage 
-      WHERE success = true 
-        AND created_at >= $1 
-        AND created_at < $2
+      WHERE success = true
     `
       )
-      .get(new Date(start_date as string), endDatePlusOne);
+      .get();
     const mcpUsageCount = parseInt(mcpResult?.count || '0');
 
     // Get database size (in bytes)


### PR DESCRIPTION
fix mcp usage is 0.

Code changes are mimial, but it took me a LONG to find this...


This is 2 bugs combined together.

1. redis queue usage is not scheduled after i changed it's behavior. I have to force a refresh on cloud.
2. MCP count should not filter by date. We calculate snapshots on the cloud backend. And we add the increase/delta between 
3. The failed to collect message on cloud watch is noise... it backoff and retried successfully.

test:

give this pr a test <img width="1022" height="61" alt="Screenshot 2025-09-20 at 17 07 55" src="https://github.com/user-attachments/assets/ea084126-1473-4446-816b-b58b3b9691f0" />


restarted my machine.  tried mcp 

<img width="893" height="71" alt="Screenshot 2025-09-20 at 17 09 50" src="https://github.com/user-attachments/assets/87d4fbdf-d035-452e-bdf4-2a23499efd82" />
