### PR TITLE
health check deno

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -207,11 +207,17 @@ export async function createApp() {
         .set('Access-Control-Allow-Origin', '*')
         .send(responseText);
     } catch (error) {
-      logger.error('Failed to execute function', {
+      logger.error('Failed to proxy to Deno runtime', {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
+        slug: req.params.slug,
       });
-      res.status(502).json({ error: 'Failed to execute function' });
+
+      // Return the actual error from Deno or connection error
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      res.status(502).json({
+        error: errorMessage,
+      });
     }
   });
 

--- a/frontend/src/features/functions/components/FunctionsContent.tsx
+++ b/frontend/src/features/functions/components/FunctionsContent.tsx
@@ -22,7 +22,7 @@ export function FunctionsContent() {
   useEffect(() => {
     if (!isRuntimeAvailable && !toastShownRef.current) {
       toastShownRef.current = true;
-      showToast('Functions runtime is currently unavailable. Please try again later.', 'error');
+      showToast('Function container is unhealthy.', 'error');
     }
   }, [isRuntimeAvailable, showToast]);
 

--- a/frontend/src/features/functions/components/FunctionsContent.tsx
+++ b/frontend/src/features/functions/components/FunctionsContent.tsx
@@ -4,15 +4,28 @@ import { FunctionRow } from './FunctionRow';
 import { CodeEditor } from './FunctionViewer';
 import FunctionEmptyState from './FunctionEmptyState';
 import { useFunctions } from '../hooks/useFunctions';
+import { useToast } from '@/lib/hooks/useToast';
+import { useEffect, useRef } from 'react';
 
 export function FunctionsContent() {
+  const toastShownRef = useRef(false);
+  const { showToast } = useToast();
   const {
     functions,
+    isRuntimeAvailable,
     selectedFunction,
     isLoading: loading,
     selectFunction,
     clearSelection,
   } = useFunctions();
+
+  useEffect(() => {
+    if (!isRuntimeAvailable && !toastShownRef.current) {
+      toastShownRef.current = true;
+      showToast('Functions runtime is currently unavailable. Please try again later.', 'error');
+    }
+  }, [isRuntimeAvailable, showToast]);
+
   // If a function is selected, show the detail view
   if (selectedFunction) {
     return (

--- a/frontend/src/features/functions/components/FunctionsSidebar.tsx
+++ b/frontend/src/features/functions/components/FunctionsSidebar.tsx
@@ -1,16 +1,13 @@
 import { cn } from '@/lib/utils/utils';
+import { useFunctions } from '../hooks/useFunctions';
 
 interface FunctionsSidebarProps {
   selectedSection: 'functions' | 'secrets';
   onSectionSelect: (section: 'functions' | 'secrets') => void;
-  onBackToList?: () => void;
 }
 
-export function FunctionsSidebar({
-  selectedSection,
-  onSectionSelect,
-  onBackToList,
-}: FunctionsSidebarProps) {
+export function FunctionsSidebar({ selectedSection, onSectionSelect }: FunctionsSidebarProps) {
+  const { clearSelection } = useFunctions();
   const sections = [
     {
       id: 'functions' as const,
@@ -36,8 +33,8 @@ export function FunctionsSidebar({
               <button
                 key={section.id}
                 onClick={() => {
-                  if (section.id === 'functions' && onBackToList) {
-                    onBackToList();
+                  if (section.id === 'functions') {
+                    clearSelection();
                   }
                   onSectionSelect(section.id);
                 }}

--- a/frontend/src/features/functions/page/FunctionsPage.tsx
+++ b/frontend/src/features/functions/page/FunctionsPage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { FunctionsSidebar } from '@/features/functions/components/FunctionsSidebar';
 import { FunctionsContent } from '@/features/functions/components/FunctionsContent';
 import { SecretsContent } from '@/features/functions/components/SecretsContent';
-import { useFunctions } from '../hooks/useFunctions';
 
 export default function FunctionsPage() {
   // Load selected section from localStorage on mount
@@ -17,16 +16,9 @@ export default function FunctionsPage() {
     localStorage.setItem('selectedFunctionSection', selectedSection);
   }, [selectedSection]);
 
-  // Use custom hooks for data management
-  const { clearSelection } = useFunctions();
-
   return (
     <div className="h-full flex">
-      <FunctionsSidebar
-        selectedSection={selectedSection}
-        onSectionSelect={setSelectedSection}
-        onBackToList={clearSelection}
-      />
+      <FunctionsSidebar selectedSection={selectedSection} onSectionSelect={setSelectedSection} />
 
       <div className="flex-1 flex flex-col overflow-hidden">
         {selectedSection === 'functions' ? <FunctionsContent /> : <SecretsContent />}

--- a/frontend/src/features/functions/services/functions.service.ts
+++ b/frontend/src/features/functions/services/functions.service.ts
@@ -12,12 +12,23 @@ export interface EdgeFunction {
   deployed_at?: string;
 }
 
+export interface FunctionsResponse {
+  functions: EdgeFunction[];
+  runtime: {
+    status: 'running' | 'unavailable';
+  };
+}
+
 export class FunctionsService {
-  async listFunctions(): Promise<EdgeFunction[]> {
+  async listFunctions(): Promise<FunctionsResponse> {
     const data = await apiClient.request('/functions', {
       headers: apiClient.withAccessToken(),
     });
-    return Array.isArray(data) ? data : [];
+
+    return {
+      functions: Array.isArray(data.functions) ? data.functions : [],
+      runtime: data.runtime || { status: 'unavailable' },
+    };
   }
 
   async getFunctionBySlug(slug: string): Promise<EdgeFunction> {


### PR DESCRIPTION
When deno container is not coming up, we can do better in frontned display and backend error messages

1. For the proxy to deno containers, we include better error messages other than `failed to execute functions`
2. When listing functions, we do a curl health check to ensure deno is healthy


test: 
close deno container; 

 Proxy response when Deno is down: 
```
{"error":"request to
    http://deno:7133/hello-world failed, reason: getaddrinfo
    ENOTFOUND deno"}
```

regular function execution still works