### PR TITLE
🐛 Fixed default value triggered error

### DIFF
--- a/frontend/src/features/functions/hooks/useFunctions.ts
+++ b/frontend/src/features/functions/hooks/useFunctions.ts
@@ -22,10 +22,7 @@ export function useFunctions() {
 
   // Extract functions and runtime status from response
   const functions = useMemo(() => functionsData?.functions || [], [functionsData]);
-  const runtimeStatus = useMemo(
-    () => functionsData?.runtime?.status || 'running',
-    [functionsData]
-  );
+  const runtimeStatus = useMemo(() => functionsData?.runtime?.status || 'running', [functionsData]);
 
   // Function to fetch and set selected function details
   const selectFunction = useCallback(

--- a/frontend/src/features/functions/hooks/useFunctions.ts
+++ b/frontend/src/features/functions/hooks/useFunctions.ts
@@ -23,7 +23,7 @@ export function useFunctions() {
   // Extract functions and runtime status from response
   const functions = useMemo(() => functionsData?.functions || [], [functionsData]);
   const runtimeStatus = useMemo(
-    () => functionsData?.runtime?.status || 'unavailable',
+    () => functionsData?.runtime?.status || 'running',
     [functionsData]
   );
 


### PR DESCRIPTION
Issue: The user would still see the error message saying "Function container is unhealthy" even though everything is fine.

Cause: In React, the default value is passed into components during mounting. Therefore, if the default value is "unhealthy," an error message will be displayed in the initial rendering.

Fix: Changed the default value from "unhealthy" to "running" to avoid displaying the error message in the initial rendering. It will still pop out as normal if the backend returns "unhealthy".

https://github.com/user-attachments/assets/955488c4-bbfa-4c75-8179-9f4ed43a8d1f

