### PR TITLE
[FIX] Fixed fileitem type unmatch issue

### DIFF
--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -343,9 +343,9 @@ export default function StoragePage() {
           const f = item.getAsFile();
           return f ? [f] : [];
         });
-        // Alternative Solution: 
-        // .map((item) => item.getAsFile())
-        // .filter((item): item is File => item !== null);
+      // Alternative Solution:
+      // .map((item) => item.getAsFile())
+      // .filter((item): item is File => item !== null);
 
       void handleFileUpload(fileItems);
     },

--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -339,8 +339,13 @@ export default function StoragePage() {
       // Ref: https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
       const fileItems: File[] = Array.from(event.dataTransfer.items)
         .filter((item) => item.webkitGetAsEntry()?.isFile)
-        .map((item) => item.getAsFile())
-        .filter((item) => item !== null);
+        .flatMap((item) => {
+          const f = item.getAsFile();
+          return f ? [f] : [];
+        });
+        // Alternative Solution: 
+        // .map((item) => item.getAsFile())
+        // .filter((item): item is File => item !== null);
 
       void handleFileUpload(fileItems);
     },


### PR DESCRIPTION
Issue: #277 

Cause: `getAsFile()` will return an item with type as `File | null`, then the array becomes type `(File | null)[]`. Even though we add the func `filter()` to remove `null` values, the type of this array didn't shrink to `File`. 

Fix: We either filter out null values early or claim items are type `File` in the filter function.