### PR TITLE
[Fix] Fixed sketchy UI in cell editors

### DIFF
--- a/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
+++ b/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
@@ -46,11 +46,13 @@ export function BooleanCellEditor({
           className
         )}
       >
-        <span className="capitalize">{stringValue}</span>
+        <span>
+          {stringValue === 'true' ? 'True' : stringValue === 'false' ? 'False' : stringValue}
+        </span>
       </SelectTrigger>
       <SelectContent align="start" className="min-w-25">
-        <SelectItem value="true">true</SelectItem>
-        <SelectItem value="false">false</SelectItem>
+        <SelectItem value="true">True</SelectItem>
+        <SelectItem value="false">False</SelectItem>
         {nullable && <SelectItem value="null">null</SelectItem>}
       </SelectContent>
     </Select>

--- a/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
+++ b/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/radix/Select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/radix/Select';
 import type { BooleanCellEditorProps } from './types';
 import { cn } from '@/lib/utils/utils';
 

--- a/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
+++ b/frontend/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from '@/components/radix/Select';
 import type { BooleanCellEditorProps } from './types';
+import { cn } from '@/lib/utils/utils';
 
 export function BooleanCellEditor({
   value,
@@ -40,9 +41,12 @@ export function BooleanCellEditor({
       onOpenChange={handleOpenChange}
     >
       <SelectTrigger
-        className={`w-full h-full border-0 focus:ring-0 focus:ring-offset-0 p-0 text-black dark:text-white dark:placeholder:text-neutral-400 dark:border-neutral-700 ${className || ''}`}
+        className={cn(
+          'w-full h-full border-0 focus:ring-0 focus:ring-offset-0 p-0 text-black dark:text-white dark:placeholder:text-neutral-400 dark:border-neutral-700',
+          className
+        )}
       >
-        <SelectValue />
+        <span className="capitalize">{stringValue}</span>
       </SelectTrigger>
       <SelectContent align="start" className="min-w-25">
         <SelectItem value="true">true</SelectItem>

--- a/frontend/src/components/datagrid/cell-editors/JsonCellEditor.tsx
+++ b/frontend/src/components/datagrid/cell-editors/JsonCellEditor.tsx
@@ -6,7 +6,13 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { cn } from '@/lib/utils/utils';
 import type { JsonCellEditorProps } from './types';
 
-export function JsonCellEditor({ value, nullable, onValueChange, onCancel }: JsonCellEditorProps) {
+export function JsonCellEditor({
+  value,
+  nullable,
+  onValueChange,
+  onCancel,
+  className,
+}: JsonCellEditorProps) {
   const [open, setOpen] = useState(true);
   const [showNullConfirm, setShowNullConfirm] = useState(false);
   const [jsonText, setJsonText] = useState(() => {
@@ -196,7 +202,8 @@ export function JsonCellEditor({ value, nullable, onValueChange, onCancel }: Jso
             variant="ghost"
             className={cn(
               'w-full justify-start text-sm text-left font-normal h-full border-0 p-0 hover:bg-transparent dark:text-white',
-              (!value || value === 'null') && 'text-muted-foreground'
+              (!value || value === 'null') && 'text-muted-foreground',
+              className
             )}
           >
             <FileJson className="mr-2 h-4 w-4" />

--- a/frontend/src/features/database/components/RecordFormField.tsx
+++ b/frontend/src/features/database/components/RecordFormField.tsx
@@ -62,6 +62,7 @@ function FormBooleanEditor({ value, nullable, onChange, hasForeignKey }: FormBoo
         nullable={nullable}
         onValueChange={handleValueChange}
         onCancel={handleCancel}
+        className="h-9 px-4 py-2 dark:bg-neutral-900 border"
       />
     );
   }
@@ -113,6 +114,7 @@ function FormDateEditor({
         nullable={field.isNullable}
         onValueChange={handleValueChange}
         onCancel={handleCancel}
+        className="h-9 px-4 py-2 dark:bg-neutral-900 border dark:border-neutral-700"
       />
     );
   }
@@ -201,6 +203,7 @@ function FormJsonEditor({ value, nullable, onChange, hasForeignKey }: FormJsonEd
         nullable={nullable}
         onValueChange={handleValueChange}
         onCancel={handleCancel}
+        className="h-9 px-4 py-2 dark:bg-neutral-900 border dark:border-neutral-700"
       />
     );
   }

--- a/frontend/src/features/database/components/RecordFormField.tsx
+++ b/frontend/src/features/database/components/RecordFormField.tsx
@@ -16,6 +16,7 @@ import { ColumnSchema, ColumnType } from '@insforge/shared-schemas';
 import { useLinkModal } from '@/features/database/hooks/UseLinkModal';
 import { convertValueForColumn, cn, formatValueForDisplay } from '@/lib/utils/utils';
 import { TypeBadge } from '@/components/TypeBadge';
+import { isValid, parseISO } from 'date-fns';
 
 // Helper function to get appropriate placeholder text
 function getPlaceholderText(field: ColumnSchema): string {
@@ -106,10 +107,27 @@ function FormDateEditor({
     setShowEditor(false);
   };
 
+  const formatDisplayValue = () => {
+    if (!value || value === 'null') {
+      return getPlaceholderText(field);
+    }
+
+    return formatValueForDisplay(value, type);
+  };
+
+  const formatValue = () => {
+    if (!value || value === 'null') {
+      return null;
+    }
+
+    const date = parseISO(value);
+    return isValid(date) ? value : null;
+  };
+
   if (showEditor) {
     return (
       <DateCellEditor
-        value={value}
+        value={formatValue()}
         type={type}
         nullable={field.isNullable}
         onValueChange={handleValueChange}
@@ -118,14 +136,6 @@ function FormDateEditor({
       />
     );
   }
-
-  const formatDisplayValue = () => {
-    if (!value || value === 'null') {
-      return getPlaceholderText(field);
-    }
-
-    return formatValueForDisplay(value, type);
-  };
 
   return (
     <Button

--- a/frontend/src/features/database/helpers.ts
+++ b/frontend/src/features/database/helpers.ts
@@ -101,9 +101,6 @@ export function getInitialValues(columns: ColumnSchema[]): Record<string, unknow
           values[column.columnName] = parseFloat(column.defaultValue);
         }
         break;
-      case ColumnType.STRING:
-        values[column.columnName] = column.defaultValue ?? '';
-        break;
       case ColumnType.UUID:
         if (column.defaultValue && !column.defaultValue.endsWith('()')) {
           // Static UUID default value
@@ -113,28 +110,9 @@ export function getInitialValues(columns: ColumnSchema[]): Record<string, unknow
           values[column.columnName] = '';
         }
         break;
+      case ColumnType.STRING:
       case ColumnType.DATE:
-        if (
-          column.defaultValue &&
-          !column.defaultValue.includes('CURRENT_') &&
-          !column.defaultValue.endsWith('()')
-        ) {
-          values[column.columnName] = column.defaultValue;
-        } else {
-          values[column.columnName] = '';
-        }
-        break;
       case ColumnType.DATETIME:
-        if (
-          column.defaultValue &&
-          !column.defaultValue.includes('CURRENT_') &&
-          !column.defaultValue.endsWith('()')
-        ) {
-          values[column.columnName] = column.defaultValue;
-        } else {
-          values[column.columnName] = '';
-        }
-        break;
       case ColumnType.JSON:
         values[column.columnName] = column.defaultValue ?? '';
         break;

--- a/frontend/src/features/database/helpers.ts
+++ b/frontend/src/features/database/helpers.ts
@@ -114,17 +114,20 @@ export function getInitialValues(columns: ColumnSchema[]): Record<string, unknow
         }
         break;
       case ColumnType.DATE:
-        if (column.defaultValue && !column.defaultValue.endsWith('()')) {
+        if (
+          column.defaultValue &&
+          !column.defaultValue.includes('CURRENT_') &&
+          !column.defaultValue.endsWith('()')
+        ) {
           values[column.columnName] = column.defaultValue;
         } else {
           values[column.columnName] = '';
         }
         break;
       case ColumnType.DATETIME:
-        // Added CURRENT_TIMESTAMP for backward compatibility with existing projects 09/12/2025
         if (
           column.defaultValue &&
-          column.defaultValue !== 'CURRENT_TIMESTAMP' &&
+          !column.defaultValue.includes('CURRENT_') &&
           !column.defaultValue.endsWith('()')
         ) {
           values[column.columnName] = column.defaultValue;

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -107,7 +107,7 @@ export function formatValueForDisplay(value: ConvertedValue, type?: ColumnType):
     case ColumnType.DATE: {
       const date = parse(String(value), 'yyyy-MM-dd', new Date());
       if (!isValid(date)) {
-        return 'Invalid date';
+        return String(value);
       }
       const displayValue = format(date, 'MMM dd, yyyy');
       return displayValue;
@@ -116,7 +116,7 @@ export function formatValueForDisplay(value: ConvertedValue, type?: ColumnType):
     case ColumnType.DATETIME: {
       const date = parseISO(String(value));
       if (!isValid(date)) {
-        return 'Invalid date time';
+        return String(value);
       }
       const displayValue = format(date, 'MMM dd, yyyy, hh:mm a');
       return displayValue;


### PR DESCRIPTION
Changes: Pass className from RecordFormField to cell editors so that their UI when opening selection will align with the UI before opening selection.

https://github.com/user-attachments/assets/a5d0781d-5986-4726-9dcd-9b600564655b

Cell editor value parsing fallback logic: We have a limited user input format for datetime/date cells. There are also very limited options for default values for the datetime/date column for users to input. Therefore, the only weak spot is if the agent creates a datetime/date column, sets a default value like CURRENT_TIMESTAMP, and sets the column as non-nullable. Then, when the user wants to add a new value, we will automatically assign the default value to the form field; however, it cannot be used to parse into a Date object. The old logic will pass the value into the parser, triggering an error and causing a crash. I split the logic. There will be two separate functions, one for formatting values for displaying, and one for formatting values for input. 