### PR TITLE
[Feature] Add full db schema in metadata

### DIFF
--- a/backend/src/api/routes/metadata.ts
+++ b/backend/src/api/routes/metadata.ts
@@ -148,12 +148,6 @@ router.get('/:tableName', async (req: AuthRequest, res: Response, next: NextFunc
       includeViews
     );
 
-    // Trigger Socket.IO event to notify frontend that MCP is connected
-    if (req.query.mcp === 'true') {
-      const socketService = SocketService.getInstance();
-      //Lyu note: this is triggered everytime when a mcp calls get-metadata. Do we have a better solution for this?
-      socketService.broadcastToRoom('role:project_admin', ServerEvents.MCP_CONNECTED);
-    }
     // When format is 'json', the data contains the tables object
     const jsonData = schemaResponse.data as { tables: Record<string, unknown> };
     const metadata = jsonData.tables;

--- a/backend/src/core/database/advance.ts
+++ b/backend/src/core/database/advance.ts
@@ -7,15 +7,10 @@ import {
   type ImportDatabaseResponse,
   type BulkUpsertResponse,
   type DatabaseMetadataSchema,
-  type TableSchema,
-  type ColumnSchema,
-  type OnDeleteActionSchema,
-  type OnUpdateActionSchema,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { ERROR_CODES } from '@/types/error-constants';
 import { parseSQLStatements } from '@/utils/sql-parser.js';
-import { convertSqlTypeToColumnType } from '@/utils/helpers.js';
 import { validateTableName } from '@/utils/validations.js';
 import format from 'pg-format';
 import { parse } from 'csv-parse/sync';
@@ -1001,182 +996,14 @@ export class DatabaseAdvanceService {
    * Get database metadata
    */
   async getMetadata(): Promise<DatabaseMetadataSchema> {
-    const db = this.dbManager.getDb();
-
     // Get all tables excluding system tables (those starting with _)
-    // Also exclude Better Auth system tables, except for user table
-    const allTables = (await db
-      .prepare(
-        `
-      SELECT table_name as name
-      FROM information_schema.tables
-      WHERE table_schema = 'public'
-      AND table_type = 'BASE TABLE'
-      AND (table_name NOT LIKE '\\_%')
-      ORDER BY table_name
-    `
-      )
-      .all()) as { name: string }[];
-
-    const tableMetadata: TableSchema[] = [];
-
-    for (const table of allTables) {
-      // Get comprehensive column information with constraints in a single query
-      const columns = (await db
-        .prepare(
-          `
-        SELECT
-          c.column_name as name,
-          c.data_type as type,
-          c.is_nullable,
-          c.column_default as dflt_value,
-          c.ordinal_position,
-          CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END as is_primary_key,
-          CASE WHEN uk.column_name IS NOT NULL THEN true ELSE false END as is_unique
-        FROM information_schema.columns c
-        LEFT JOIN (
-          SELECT DISTINCT kcu.column_name
-          FROM information_schema.key_column_usage kcu
-          JOIN information_schema.table_constraints tc
-            ON kcu.constraint_name = tc.constraint_name
-            AND kcu.table_schema = tc.table_schema
-            AND kcu.table_name = tc.table_name
-          WHERE tc.table_schema = 'public'
-            AND tc.table_name = ?
-            AND tc.constraint_type = 'PRIMARY KEY'
-        ) pk ON c.column_name = pk.column_name
-        LEFT JOIN (
-          SELECT DISTINCT kcu.column_name
-          FROM information_schema.key_column_usage kcu
-          JOIN information_schema.table_constraints tc
-            ON kcu.constraint_name = tc.constraint_name
-            AND kcu.table_schema = tc.table_schema
-            AND kcu.table_name = tc.table_name
-          WHERE tc.table_schema = 'public'
-            AND tc.table_name = ?
-            AND tc.constraint_type = 'UNIQUE'
-        ) uk ON c.column_name = uk.column_name
-        WHERE c.table_schema = 'public'
-          AND c.table_name = ?
-        ORDER BY c.ordinal_position
-      `
-        )
-        .all(table.name, table.name, table.name)) as {
-        name: string;
-        type: string;
-        is_nullable: string;
-        dflt_value: string | null;
-        ordinal_position: number;
-        is_primary_key: boolean;
-        is_unique: boolean;
-      }[];
-
-      const columnMetadata: ColumnSchema[] = columns.map((col) => {
-        // Map PostgreSQL types to our type system
-        const type = convertSqlTypeToColumnType(col.type);
-
-        const column: ColumnSchema = {
-          columnName: col.name,
-          type: type,
-          isNullable: col.is_nullable === 'YES',
-          defaultValue: col.dflt_value || undefined,
-          isPrimaryKey: col.is_primary_key,
-          isUnique: col.is_unique,
-        };
-
-        return column;
-      });
-
-      // Get foreign key information
-      const foreignKeys = (await db
-        .prepare(
-          `
-        SELECT DISTINCT
-          kcu.column_name as from_column,
-          ccu.table_name AS foreign_table,
-          ccu.column_name AS foreign_column,
-          rc.delete_rule as on_delete,
-          rc.update_rule as on_update
-        FROM information_schema.table_constraints AS tc
-        JOIN information_schema.key_column_usage AS kcu
-          ON tc.constraint_name = kcu.constraint_name
-          AND tc.table_schema = kcu.table_schema
-          AND kcu.table_name = tc.table_name
-        JOIN information_schema.constraint_column_usage AS ccu
-          ON ccu.constraint_name = tc.constraint_name
-          AND ccu.table_schema = tc.table_schema
-        JOIN information_schema.referential_constraints AS rc
-          ON rc.constraint_name = tc.constraint_name
-          AND rc.constraint_schema = tc.table_schema
-        WHERE tc.constraint_type = 'FOREIGN KEY'
-        AND tc.table_name = ?
-        AND tc.table_schema = 'public'
-      `
-        )
-        .all(table.name)) as {
-        from_column: string;
-        foreign_table: string;
-        foreign_column: string;
-        on_delete: string;
-        on_update: string;
-      }[];
-
-      // Map foreign keys to columns
-      for (const fk of foreignKeys) {
-        const column = columnMetadata.find((col) => col.columnName === fk.from_column);
-        if (column) {
-          column.foreignKey = {
-            referenceTable: fk.foreign_table,
-            referenceColumn: fk.foreign_column,
-            onDelete: fk.on_delete as OnDeleteActionSchema,
-            onUpdate: fk.on_update as OnUpdateActionSchema,
-          };
-        }
-      }
-
-      // Get record count
-      let recordCount = 0;
-      try {
-        // there is a race condition here, if the table is immeditely deleted, so added an extra check to see if the table exists
-        const tableExists = (await db
-          .prepare(
-            `
-          SELECT EXISTS (
-            SELECT 1 FROM pg_class
-            WHERE relname = ?
-            AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
-            AND relkind = 'r'
-          ) as exists
-        `
-          )
-          .get(table.name)) as { exists: boolean } | null;
-
-        if (tableExists?.exists) {
-          const countResult = (await db
-            .prepare(`SELECT COUNT(*) as count FROM "${table.name}"`)
-            .get()) as { count: number } | null;
-          recordCount = countResult?.count || 0;
-        }
-      } catch (error) {
-        // Handle any unexpected errors
-        logger.warn('Could not get record count for table', {
-          table: table.name,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        recordCount = 0;
-      }
-
-      tableMetadata.push({
-        tableName: table.name,
-        columns: columnMetadata,
-        recordCount: recordCount,
-      });
-    }
+    const allTables = await this.dbManager.getUserTables();
+    const dbMetadata = await this.exportDatabase(allTables, 'json', false, false, false, false);
 
     const databaseSize = await this.getDatabaseSizeInGB();
 
     return {
-      tables: tableMetadata,
+      tables: (dbMetadata.data as ExportDatabaseJsonData).tables,
       totalSize: databaseSize,
     };
   }

--- a/backend/src/core/database/manager.ts
+++ b/backend/src/core/database/manager.ts
@@ -149,17 +149,20 @@ export class DatabaseManager {
     }
   }
 
-  async getUserTableCount(): Promise<number> {
+  async getUserTables(): Promise<string[]> {
     const client = await this.pool.connect();
     try {
       const result = await client.query(
-        `SELECT COUNT(*) as count 
-         FROM information_schema.tables 
-         WHERE table_schema = 'public' 
-         AND table_type = 'BASE TABLE'
-         AND table_name NOT LIKE '\\_%'`
+        `
+          SELECT table_name as name
+          FROM information_schema.tables
+          WHERE table_schema = 'public'
+          AND table_type = 'BASE TABLE'
+          AND (table_name NOT LIKE '\\_%')
+          ORDER BY table_name
+        `
       );
-      return parseInt(result.rows[0]?.count || '0', 10);
+      return result.rows.map((row: { name: string }) => row.name);
     } finally {
       client.release();
     }

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -107,7 +107,7 @@ export async function seedBackend(): Promise<void> {
     const apiKey = await secretService.initializeApiKey();
 
     // Get database stats
-    const tableCount = await dbManager.getUserTableCount();
+    const tables = await dbManager.getUserTables();
 
     logger.info(`✅ Database connected to PostgreSQL`, {
       host: process.env.POSTGRES_HOST || 'localhost',
@@ -116,8 +116,8 @@ export async function seedBackend(): Promise<void> {
     });
     // Database connection info is already logged above
 
-    if (tableCount > 0) {
-      logger.info(`✅ Found ${tableCount} user tables`);
+    if (tables.length > 0) {
+      logger.info(`✅ Found ${tables.length} user tables`);
     }
 
     // seed AI configs for cloud environment

--- a/frontend/src/features/dashboard/page/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/page/DashboardPage.tsx
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { metadataService } from '@/features/metadata/services/metadata.service';
+import { useMetadata } from '@/features/metadata/hooks/useMetadata';
 import { Skeleton } from '@/components/radix/Skeleton';
 import { Card, CardContent } from '@/components/radix/Card';
 import {
@@ -24,22 +23,8 @@ import { useUsers } from '@/features/auth';
 export default function DashboardPage() {
   const navigate = useNavigate();
   const location = useLocation();
-
-  const {
-    data: metadata,
-    isLoading,
-    refetch: _refetchMetadata,
-  } = useQuery({
-    queryKey: ['dashboard-metadata'],
-    queryFn: () => metadataService.getFullMetadata(),
-  });
-
+  const { metadata, auth, tables, storage, isLoading } = useMetadata();
   const { totalUsers } = useUsers();
-
-  const { data: fullMetadata, isLoading: isLoadingFullMetadata } = useQuery({
-    queryKey: ['full-metadata'],
-    queryFn: () => metadataService.getFullMetadata(),
-  });
 
   const handleNavigateTo = (to: string, state?: { initialTab?: string }) => {
     const basePath = location.pathname.includes('/cloud')
@@ -128,12 +113,12 @@ export default function DashboardPage() {
                       </>
                     )}
                   </div>
-                  {isLoadingFullMetadata ? (
+                  {isLoading ? (
                     <Skeleton className="h-5 w-36 bg-gray-200 dark:bg-neutral-700" />
                   ) : (
                     <p className="text-base text-gray-500 dark:text-neutral-400">
                       {(() => {
-                        const authCount = metadata?.auth.oauths.length;
+                        const authCount = auth?.oauths.length || 0;
                         return `${authCount} OAuth ${authCount === 1 ? 'provider' : 'providers'} enabled`;
                       })()}
                     </p>
@@ -160,7 +145,7 @@ export default function DashboardPage() {
                     ) : (
                       <>
                         <span className="text-2xl font-normal text-gray-900 dark:text-white tracking-[-0.144px]">
-                          {(metadata?.database.totalSize || 0).toFixed(2)}
+                          {(metadata?.database?.totalSize || 0).toFixed(2)}
                         </span>
                         <span className="text-sm font-normal text-gray-500 dark:text-neutral-400">
                           GB
@@ -168,12 +153,11 @@ export default function DashboardPage() {
                       </>
                     )}
                   </div>
-                  {isLoadingFullMetadata ? (
+                  {isLoading ? (
                     <Skeleton className="h-5 w-16 bg-gray-200 dark:bg-neutral-700" />
                   ) : (
                     <p className="text-base text-gray-500 dark:text-neutral-400">
-                      {fullMetadata?.database?.tables?.length || 0}{' '}
-                      {fullMetadata?.database?.tables?.length === 1 ? 'Table' : 'Tables'}
+                      {tables.length || 0} {tables.length === 1 ? 'Table' : 'Tables'}
                     </p>
                   )}
                 </div>
@@ -198,7 +182,7 @@ export default function DashboardPage() {
                     ) : (
                       <>
                         <span className="text-2xl font-normal text-gray-900 dark:text-white tracking-[-0.144px]">
-                          {(metadata?.storage.totalSize || 0).toFixed(2)}
+                          {(storage?.totalSize || 0).toFixed(2)}
                         </span>
                         <span className="text-sm font-normal text-gray-500 dark:text-neutral-400">
                           GB
@@ -206,12 +190,12 @@ export default function DashboardPage() {
                       </>
                     )}
                   </div>
-                  {isLoadingFullMetadata ? (
+                  {isLoading ? (
                     <Skeleton className="h-5 w-20 bg-gray-200 dark:bg-neutral-700" />
                   ) : (
                     <p className="text-base text-gray-500 dark:text-neutral-400">
-                      {fullMetadata?.storage?.buckets?.length || 0}{' '}
-                      {fullMetadata?.storage?.buckets?.length === 1 ? 'Bucket' : 'Buckets'}
+                      {storage?.buckets?.length || 0}{' '}
+                      {storage?.buckets?.length === 1 ? 'Bucket' : 'Buckets'}
                     </p>
                   )}
                 </div>

--- a/frontend/src/features/database/components/ForeignKeyPopover.tsx
+++ b/frontend/src/features/database/components/ForeignKeyPopover.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/radix/Button';
 import { Label } from '@/components/radix/Label';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/radix/Dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/radix/Select';
-import { metadataService } from '@/features/metadata/services/metadata.service';
+import { useMetadata } from '@/features/metadata/hooks/useMetadata';
 import { databaseService } from '@/features/database/services/database.service';
 import { UseFormReturn } from 'react-hook-form';
 import { TableFormSchema, TableFormForeignKeySchema } from '../schema';
@@ -63,15 +63,11 @@ export function ForeignKeyPopover({
   }, [open, initialValue]);
 
   // Get available tables
-  const { data: metadata } = useQuery({
-    queryKey: ['database-metadata'],
-    queryFn: () => metadataService.getDatabaseMetadata(),
-    enabled: open,
-  });
+  const { tables } = useMetadata({ enabled: open });
 
-  const availableTables = metadata?.tables
-    ? metadata.tables.filter((table) => mode === 'create' || table.tableName !== editTableName)
-    : [];
+  const availableTables = tables.filter(
+    (tableName) => mode === 'create' || tableName !== editTableName
+  );
 
   // Get columns for selected reference table
   const { data: referenceTableSchema } = useQuery({
@@ -206,9 +202,9 @@ export function ForeignKeyPopover({
                   </span>
                 </SelectTrigger>
                 <SelectContent>
-                  {availableTables.map((table) => (
-                    <SelectItem key={table.tableName} value={table.tableName}>
-                      {table.tableName}
+                  {availableTables.map((tableName) => (
+                    <SelectItem key={tableName} value={tableName}>
+                      {tableName}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/features/database/page/DatabasePage.tsx
+++ b/frontend/src/features/database/page/DatabasePage.tsx
@@ -202,15 +202,7 @@ function DatabasePageContent() {
     }
   }, [isLoadingTable, isSorting]);
 
-  const filteredTables = useMemo(
-    () =>
-      metadata?.tables
-        ? metadata.tables
-            .map((table) => table.tableName)
-            .filter((tableName) => !tableName.startsWith('_'))
-        : [],
-    [metadata]
-  );
+  const filteredTables = useMemo(() => Object.keys(metadata?.tables ?? {}), [metadata]);
 
   // Auto-select first table (excluding system tables)
   useEffect(() => {

--- a/frontend/src/features/metadata/hooks/useMetadata.ts
+++ b/frontend/src/features/metadata/hooks/useMetadata.ts
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { metadataService } from '../services/metadata.service';
+
+interface UseMetadataOptions {
+  enabled?: boolean;
+  staleTime?: number;
+}
+
+export function useMetadata(options?: UseMetadataOptions) {
+  const {
+    data: metadata,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['metadata', 'full'],
+    queryFn: () => metadataService.getFullMetadata(),
+    staleTime: options?.staleTime ?? 5 * 60 * 1000, // Cache for 5 minutes by default
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    metadata,
+    auth: metadata?.auth,
+    tables: Object.keys(metadata?.database.tables ?? {}),
+    storage: metadata?.storage,
+    version: metadata?.version || 'Unknown',
+    isLoading,
+    error,
+    refetch,
+  };
+}
+
+export function useApiKey(options?: UseMetadataOptions) {
+  const {
+    data: apiKey,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['metadata', 'apiKey'],
+    queryFn: () => metadataService.fetchApiKey(),
+    staleTime: options?.staleTime ?? 10 * 60 * 1000, // Cache for 10 minutes by default
+    enabled: options?.enabled ?? true,
+  });
+
+  return {
+    apiKey,
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/frontend/src/features/metadata/page/MetadataPage.tsx
+++ b/frontend/src/features/metadata/page/MetadataPage.tsx
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { RefreshCw, Info } from 'lucide-react';
-import { metadataService } from '../services/metadata.service';
+import { useMetadata } from '../hooks/useMetadata';
 import { Skeleton } from '@/components/radix/Skeleton';
 import { Button } from '@/components/radix/Button';
 import { Alert, AlertDescription } from '@/components/radix/Alert';
@@ -14,14 +13,11 @@ import { JsonHighlight } from '@/components';
 
 export default function MetadataPage() {
   const {
-    data: metadata,
+    metadata,
     isLoading,
     error,
     refetch: refetchMetadata,
-  } = useQuery({
-    queryKey: ['metadata'],
-    queryFn: () => metadataService.getFullMetadata(),
-  });
+  } = useMetadata();
 
   const handleRefresh = () => {
     void refetchMetadata();

--- a/frontend/src/features/metadata/page/MetadataPage.tsx
+++ b/frontend/src/features/metadata/page/MetadataPage.tsx
@@ -12,12 +12,7 @@ import {
 import { JsonHighlight } from '@/components';
 
 export default function MetadataPage() {
-  const {
-    metadata,
-    isLoading,
-    error,
-    refetch: refetchMetadata,
-  } = useMetadata();
+  const { metadata, isLoading, error, refetch: refetchMetadata } = useMetadata();
 
   const handleRefresh = () => {
     void refetchMetadata();

--- a/frontend/src/features/metadata/services/metadata.service.ts
+++ b/frontend/src/features/metadata/services/metadata.service.ts
@@ -1,45 +1,16 @@
 import { apiClient } from '@/lib/api/client';
-import {
-  AppMetadataSchema,
-  AuthMetadataSchema,
-  StorageMetadataSchema,
-  DatabaseMetadataSchema,
-} from '@insforge/shared-schemas';
+import { AppMetadataSchema } from '@insforge/shared-schemas';
 
 export class MetadataService {
   async fetchApiKey() {
     const data = await apiClient.request('/metadata/api-key');
     return data.apiKey;
   }
-  // Get full metadata (complete structured format)
+
   async getFullMetadata(): Promise<AppMetadataSchema> {
     return apiClient.request('/metadata', {
       headers: apiClient.withAccessToken(),
     });
-  }
-
-  // Get auth metadata only
-  async getAuthMetadata(): Promise<AuthMetadataSchema> {
-    const fullMetadata = await this.getFullMetadata();
-    return fullMetadata.auth;
-  }
-
-  // Get database metadata only
-  async getDatabaseMetadata(): Promise<DatabaseMetadataSchema> {
-    const fullMetadata = await this.getFullMetadata();
-    return fullMetadata.database;
-  }
-
-  // Get storage metadata only
-  async getStorageMetadata(): Promise<StorageMetadataSchema> {
-    const fullMetadata = await this.getFullMetadata();
-    return fullMetadata.storage;
-  }
-
-  // Get system version
-  async getSystemVersion(): Promise<string> {
-    const fullMetadata = await this.getFullMetadata();
-    return fullMetadata.version || 'Unknown';
   }
 }
 

--- a/frontend/src/features/onboard/components/mcp/McpInstallation.tsx
+++ b/frontend/src/features/onboard/components/mcp/McpInstallation.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils/utils';
 import { CodeBlock } from '@/components/CodeBlock';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/radix/Tabs';
@@ -13,7 +12,7 @@ import {
   type MCPAgent,
   type PlatformType,
 } from './mcp-helper';
-import { metadataService } from '@/features/metadata/services/metadata.service';
+import { useApiKey } from '@/features/metadata/hooks/useMetadata';
 
 interface McpInstallerProps {
   className?: string;
@@ -31,11 +30,7 @@ export function McpInstallation({
   });
   const [activeTab, setActiveTab] = useState<PlatformType>('macos-linux');
 
-  const { data: apiKey } = useQuery({
-    queryKey: ['apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
-    staleTime: Infinity,
-  });
+  const { apiKey } = useApiKey();
 
   const handleTabChange = (value: string) => {
     setActiveTab(value as PlatformType);

--- a/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -17,7 +17,6 @@ import { AuthNode } from './AuthNode';
 import { BucketNode } from './BucketNode';
 import {
   AppMetadataSchema,
-  TableSchema,
   StorageBucketSchema,
   AuthMetadataSchema,
 } from '@insforge/shared-schemas';
@@ -27,8 +26,25 @@ interface SchemaVisualizerProps {
   userCount?: number;
 }
 
+// Define types that match what TableNode expects
+type VisualizerColumn = {
+  columnName: string;
+  type: string;
+  isPrimaryKey?: boolean;
+  foreignKey?: {
+    referenceTable: string;
+    referenceColumn: string;
+  };
+};
+
+type VisualizerTable = {
+  tableName: string;
+  columns: VisualizerColumn[];
+  recordCount: number;
+};
+
 type TableNodeData = {
-  table: TableSchema;
+  table: VisualizerTable;
   referencedColumns: string[];
 };
 
@@ -181,11 +197,59 @@ const getNodeColor = (node: Node<CustomNodeData>) => {
 };
 
 export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps) {
+  // Transform the new metadata structure to the visualizer format
+  const tables = useMemo(() => {
+    const tablesRecord = metadata.database.tables;
+    return Object.entries(tablesRecord).map(([tableName, tableData]): VisualizerTable => {
+      // Check for primary key columns from indexes
+      const primaryKeyColumns = new Set<string>();
+
+      tableData.indexes.forEach((index) => {
+        if (index.isPrimary) {
+          // Extract column names from index definition
+          const match = index.indexdef.match(/\(([^)]+)\)/);
+          if (match) {
+            match[1].split(',').forEach((col) => {
+              primaryKeyColumns.add(col.trim().replace(/"/g, ''));
+            });
+          }
+        }
+      });
+
+      // Transform columns from the new schema format
+      const columns: VisualizerColumn[] = tableData.schema.map((col) => {
+        const column: VisualizerColumn = {
+          columnName: col.columnName,
+          type: col.dataType.toLowerCase().substring(0, 4), // Truncate type to first 4 characters
+          isPrimaryKey: primaryKeyColumns.has(col.columnName),
+          foreignKey: undefined,
+        };
+
+        // Find foreign key info for this column
+        const foreignKey = tableData.foreignKeys.find((fk) => fk.columnName === col.columnName);
+        if (foreignKey) {
+          column.foreignKey = {
+            referenceTable: foreignKey.foreignTableName,
+            referenceColumn: foreignKey.foreignColumnName,
+          };
+        }
+
+        return column;
+      });
+
+      return {
+        tableName,
+        columns,
+        recordCount: tableData.recordCount ?? 0, // Use actual record count from metadata
+      };
+    });
+  }, [metadata.database.tables]);
+
   const initialNodes = useMemo(() => {
     // First, collect all referenced columns for each table
     const referencedColumnsByTable: Record<string, string[]> = {};
 
-    metadata.database.tables.forEach((table) => {
+    tables.forEach((table) => {
       table.columns.forEach((column) => {
         if (column.foreignKey) {
           const targetTable = column.foreignKey.referenceTable;
@@ -201,7 +265,7 @@ export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps)
       });
     });
 
-    const tableNodes: Node<TableNodeData>[] = metadata.database.tables.map((table, _) => ({
+    const tableNodes: Node<TableNodeData>[] = tables.map((table) => ({
       id: table.tableName,
       type: 'tableNode',
       position: { x: 0, y: 0 },
@@ -232,12 +296,12 @@ export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps)
     });
 
     return nodes;
-  }, [metadata, userCount]);
+  }, [metadata, userCount, tables]);
 
   const initialEdges = useMemo(() => {
     const edges: BuiltInEdge[] = [];
 
-    metadata.database.tables.forEach((table) => {
+    tables.forEach((table) => {
       table.columns.forEach((column) => {
         if (column.foreignKey) {
           const edgeId = `${table.tableName}-${column.columnName}-${column.foreignKey.referenceTable}`;
@@ -262,7 +326,7 @@ export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps)
     // Add authentication edges if authData exists
 
     return edges;
-  }, [metadata]);
+  }, [tables]);
 
   const { nodes: layoutedNodes, edges: layoutedEdges } = useMemo(
     () => getLayoutedElements(initialNodes, initialEdges),

--- a/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -12,7 +12,7 @@ import {
   ConnectionMode,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { TableNode } from './TableNode';
+import { TableNode, VisualizerTableSchema, VisualizerTableColumnSchema } from './TableNode';
 import { AuthNode } from './AuthNode';
 import { BucketNode } from './BucketNode';
 import {
@@ -26,25 +26,8 @@ interface SchemaVisualizerProps {
   userCount?: number;
 }
 
-// Define types that match what TableNode expects
-type VisualizerColumn = {
-  columnName: string;
-  type: string;
-  isPrimaryKey?: boolean;
-  foreignKey?: {
-    referenceTable: string;
-    referenceColumn: string;
-  };
-};
-
-type VisualizerTable = {
-  tableName: string;
-  columns: VisualizerColumn[];
-  recordCount: number;
-};
-
 type TableNodeData = {
-  table: VisualizerTable;
+  table: VisualizerTableSchema;
   referencedColumns: string[];
 };
 
@@ -200,7 +183,7 @@ export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps)
   // Transform the new metadata structure to the visualizer format
   const tables = useMemo(() => {
     const tablesRecord = metadata.database.tables;
-    return Object.entries(tablesRecord).map(([tableName, tableData]): VisualizerTable => {
+    return Object.entries(tablesRecord).map(([tableName, tableData]): VisualizerTableSchema => {
       // Check for primary key columns from indexes
       const primaryKeyColumns = new Set<string>();
 
@@ -217,12 +200,11 @@ export function SchemaVisualizer({ metadata, userCount }: SchemaVisualizerProps)
       });
 
       // Transform columns from the new schema format
-      const columns: VisualizerColumn[] = tableData.schema.map((col) => {
-        const column: VisualizerColumn = {
+      const columns = tableData.schema.map((col) => {
+        const column: VisualizerTableColumnSchema = {
           columnName: col.columnName,
           type: col.dataType.toLowerCase().substring(0, 4), // Truncate type to first 4 characters
           isPrimaryKey: primaryKeyColumns.has(col.columnName),
-          foreignKey: undefined,
         };
 
         // Find foreign key info for this column

--- a/frontend/src/features/visualizer/components/TableNode.tsx
+++ b/frontend/src/features/visualizer/components/TableNode.tsx
@@ -2,7 +2,7 @@ import { Database, Circle, Key } from 'lucide-react';
 import { Handle, Position } from '@xyflow/react';
 
 // Define the table structure expected by this component
-interface TableColumn {
+export interface VisualizerTableColumnSchema {
   columnName: string;
   type: string;
   isPrimaryKey?: boolean;
@@ -12,15 +12,15 @@ interface TableColumn {
   };
 }
 
-interface Table {
+export interface VisualizerTableSchema {
   tableName: string;
-  columns: TableColumn[];
+  columns: VisualizerTableColumnSchema[];
   recordCount?: number;
 }
 
 interface TableNodeProps {
   data: {
-    table: Table;
+    table: VisualizerTableSchema;
     referencedColumns?: string[]; // List of column names that are referenced by other tables
   };
 }

--- a/frontend/src/features/visualizer/components/TableNode.tsx
+++ b/frontend/src/features/visualizer/components/TableNode.tsx
@@ -1,10 +1,26 @@
-import { Database, Circle } from 'lucide-react';
+import { Database, Circle, Key } from 'lucide-react';
 import { Handle, Position } from '@xyflow/react';
-import { TableSchema } from '@insforge/shared-schemas';
+
+// Define the table structure expected by this component
+interface TableColumn {
+  columnName: string;
+  type: string;
+  isPrimaryKey?: boolean;
+  foreignKey?: {
+    referenceTable: string;
+    referenceColumn: string;
+  };
+}
+
+interface Table {
+  tableName: string;
+  columns: TableColumn[];
+  recordCount?: number;
+}
 
 interface TableNodeProps {
   data: {
-    table: TableSchema;
+    table: Table;
     referencedColumns?: string[]; // List of column names that are referenced by other tables
   };
 }
@@ -99,6 +115,7 @@ export function TableNode({ data }: TableNodeProps) {
             <div className="flex items-center gap-2.5 flex-1">
               {getColumnIcon(referencedColumns.includes(column.columnName))}
               <span className="text-sm text-neutral-300">{column.columnName}</span>
+              {column.isPrimaryKey && <Key className="w-3 h-3 text-neutral-400" />}
             </div>
             <div className="flex items-center gap-2.5">
               <div className="px-1.5 py-0.5 bg-neutral-800 rounded flex items-center">

--- a/frontend/src/features/visualizer/page/VisualizerPage.tsx
+++ b/frontend/src/features/visualizer/page/VisualizerPage.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { RefreshCw } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
-import { metadataService } from '@/features/metadata/services/metadata.service';
+import { useMetadata } from '@/features/metadata/hooks/useMetadata';
 import { authService } from '@/features/auth/services/auth.service';
 import { SchemaVisualizer, VisualizerSkeleton } from '../components';
 import { Button } from '@/components/radix/Button';
@@ -19,16 +19,11 @@ const VisualizerPage = () => {
   const queryClient = useQueryClient();
 
   const {
-    data: metadata,
+    metadata,
     isLoading: metadataLoading,
     error: metadataError,
     refetch: refetchMetadata,
-  } = useQuery({
-    queryKey: ['metadata'],
-    queryFn: () => metadataService.getFullMetadata(),
-    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
-    gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
-  });
+  } = useMetadata();
 
   const {
     data: userStats,

--- a/shared-schemas/src/database-api.schema.ts
+++ b/shared-schemas/src/database-api.schema.ts
@@ -161,6 +161,7 @@ export const exportJsonDataSchema = z.object({
         })
       ),
       rows: z.array(z.any()).optional(),
+      recordCount: z.number().optional(),
     })
   ),
   functions: z.array(

--- a/shared-schemas/src/metadata.schema.ts
+++ b/shared-schemas/src/metadata.schema.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import { storageBucketSchema } from './storage.schema';
-import { tableSchema } from './database.schema';
 import { oAuthConfigSchema } from './auth.schema';
+import { exportJsonDataSchema } from './database-api.schema';
 
 export const authMetadataSchema = z.object({
   oauths: z.array(oAuthConfigSchema),
 });
 
 export const databaseMetadataSchema = z.object({
-  tables: z.array(tableSchema),
+  tables: exportJsonDataSchema.shape.tables,
   totalSize: z.number(),
 });
 


### PR DESCRIPTION
This PR replaces the original getDatabaseMetadata with exportDatabase in json format for all user tables. In this way, when agent calls get-backend-metata, it will have more information about the database including indexes, policies, triggers, constraints.

Functions, Sequences and Views are not included at moment. Let's ship things progressively.

Notice: this does takes more context space. In my test cases with ~10 tables and ~100 columns, CC is warning me for large MCP response.