### PR TITLE
allow custom aws access key and id

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,8 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # PostgreSQL connection
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # PostgreSQL connection
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432


### PR DESCRIPTION
previously, our cloud hosting ec2 has permission through iam roles.

However, this would not work on zeabur or self hosting because their container/node will not have the permission.

Thus we should also allow AWS_ACCESS_KEY and it's ID for permissions, so self hoster can get it to work!

This initializes the s3 bucket, and later we will support self hosting with cloud watch logs as well