### PR TITLE
udpate docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,7 +35,7 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
     ports:
       - "5430:3000"
     depends_on:
@@ -121,7 +121,7 @@ services:
       - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-30000}
       # Encryption keys for decrypting function secrets
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
-      - JWT_SECRET=${JWT_SECRET}
+      - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
     volumes:
       - ./functions:/app/functions
       - deno_cache:/deno-dir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst
@@ -135,7 +135,7 @@ services:
       - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-30000}
       # Encryption keys for decrypting function secrets
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
-      - JWT_SECRET=${JWT_SECRET}
+      - JWT_SECRET=${JWT_SECRET:-dev-secret-change-in-production}
     volumes:
       - ./functions:/app/functions
       - deno_cache:/deno-dir


### PR DESCRIPTION
make jwt secret optional. This is to ease the friction for OSS self hosting. If developers care about security they can change it. But on zeabur this should be an optional field