### PR TITLE
Restore docker hot reload in windows system

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+    watch: { usePolling: true, interval: 1000 },
   },
   build: {
     outDir: '../dist/frontend',


### PR DESCRIPTION
Changes: 
I added server.watch in the vite config file. It essentially switches the Vite from listening mode to polling mode. WSL2 has known issues with posting the filesystem change message to Dockers running on Windows. Therefore, now Vite will watch changed files every second. Find there is an update, then trigger HMR. 
Ref: https://vite.dev/config/server-options.html#server-watch