### PR TITLE
fix(storage): refresh buckets and clear invalid selection after delete

### DIFF
--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -232,12 +232,10 @@ export default function StoragePage() {
       try {
         await deleteBucket(bucketName);
 
-        // If the deleted bucket was selected, select the first available bucket
-        if (selectedBucket === bucketName) {
-          const updatedBuckets =
-            queryClient.getQueryData<typeof buckets>(['storage', 'buckets']) || [];
-          setSelectedBucket(updatedBuckets[0]?.name || null);
-        }
+        // Refresh bucket list then select the next available bucket
+        await Promise.all([refetchBuckets()]);
+        const nextBucket = buckets.find((b) => b.name !== bucketName)?.name || null;
+        setSelectedBucket(nextBucket);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Failed to delete bucket';
         showToast(errorMessage, 'error');


### PR DESCRIPTION
Updated handleDeleteBucket to refetch buckets after deletion, ensuring the UI updates immediately without requiring a manual refresh.

Fixes #332