### PR TITLE
fix docs for image genration

### DIFF
--- a/docs/insforge-instructions-sdk.md
+++ b/docs/insforge-instructions-sdk.md
@@ -324,6 +324,16 @@ const response = await client.ai.images.generate({
 // Access response - OpenAI format
 console.log(response.data[0].b64_json);  // Base64 encoded image string (OpenAI format)
 console.log(response.data[0].content);   // AI's text response about the image or prompt
+
+const base64Image = response.data[0].b64_json;
+const buffer = Buffer.from(base64Image, 'base64');
+const blob = new Blob([buffer], { type: 'image/png' });
+
+// Upload to Insforge storage
+const fileName = `image-${Date.now()}.png`;
+const { data: uploadData, error: uploadError } = await client.storage
+  .from('chat-images')
+  .upload(fileName, blob);
 ```
 
 ## Complete Example


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

This pr fixed the docs for coding agents to learn from. Previously it likes to save the base64 image direcly to db, now that i give the example, I suspect it will be very unlikely it writes code like this again.


## How did you test this change?

<!-- Describe how you tested this PR -->


I manually created a project it by default used the code i wrote in docs.. 

<img width="726" height="371" alt="Screenshot 2025-10-10 at 15 57 21" src="https://github.com/user-attachments/assets/76e21afd-7e35-4e64-9ac2-467017e7b9b6" />