### PR TITLE
Fix typo in README.md architecture diagram alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Start building your project in a new directory! Build your next todo app, Instag
 
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Carch">
+  <img src="assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 


### PR DESCRIPTION
## Summary

Closes: #342 

Fixes incorrect alt text in the architecture diagram image.

**Before**
`<img src="assets/archDiagram.png" alt="Carch">`

**After**
`<img src="assets/archDiagram.png" alt="Architecture Diagram">`

## How did you test this change?


