### PR TITLE
Fix insforge-instructions-sdk.md backtick

### DIFF
--- a/docs/insforge-instructions-sdk.md
+++ b/docs/insforge-instructions-sdk.md
@@ -377,7 +377,7 @@ console.log(otherUser.nickname); // Direct access to properties
 - **Internal Networking**: Use `BACKEND_INTERNAL_URL` environment variable (defaults to `http://insforge:7130` for Docker container communication)
 
 ### Edge Functions Invocation (SDK)
-- **Simple API**: `client.functions.invoke(slug, options)
+- **Simple API**: `client.functions.invoke(slug, options)`
 - **Auto-authentication**: SDK automatically includes auth token from logged-in user
 - **Flexible body**: Accepts any JSON-serializable data
 - **HTTP methods**: Supports GET, POST, PUT, PATCH, DELETE (default: POST)


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Adds backtick to `client.functions.invoke(slug, options)`


<!-- Describe how you tested this PR -->
Open preview through vscode

Resolves #345 