### PR TITLE
fix typo in auth logs

### DIFF
--- a/backend/src/core/auth/auth.ts
+++ b/backend/src/core/auth/auth.ts
@@ -629,7 +629,7 @@ export class AuthService {
     const clientSecret = await oauthConfigService.getClientSecretByProvider('google');
 
     if (!clientSecret) {
-      throw new Error('Google Client Secret not conifgured.');
+      throw new Error('Google Client Secret not configured.');
     }
 
     // Create OAuth2Client with fresh config


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Fixed typo in /backend/src/core/auth/auth.ts:632

Previously:
throw new Error('Google Client Secret not conifgured.');

Changed:
throw new Error('Google Client Secret not configured.');


<!-- Describe how you tested this PR -->

Resolved #346 
