### PR TITLE
Fix hot reloading docker containers in windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - PROJECT_ROOT=/app
       - API_BASE_URL=${API_BASE_URL:-}
       - VITE_API_BASE_URL=${VITE_API_BASE_URL:-}
+      # Hot Reloading in Windows
       - CHOKIDAR_USEPOLLING=true
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}


### PR DESCRIPTION
## Summary

Closes: #355 

**Before**
Hot reload inside docker container not working on Windows for local development

**After**
Hot reloading inside docker container working on Windows

Added polling-based file watching environment variable `CHOKIDAR_USEPOLLING`

Optimized volume mounts with `:delegated` flag

## How did you test this change?

<!-- Describe how you tested this PR -->

Locally changing Frontend and Backend code on Windows.


https://github.com/user-attachments/assets/c9d68cfa-86eb-4b4a-a82d-7008fc2423ac


