### PR TITLE
fix(storage): clear file selection when switching buckets

### DIFF
--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -106,6 +106,11 @@ export default function StoragePage() {
     }
   }, [buckets, selectedBucket]);
 
+  // Clear selected files when switching buckets
+  useEffect(() => {
+    setSelectedFiles(new Set());
+  }, [selectedBucket]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {


### PR DESCRIPTION
# Fixes #330

## Summary
When selecting files in one bucket and switching to another, the delete button persisted showing selections from the previous bucket. This happened because `selectedFiles` wasn’t cleared when `selectedBucket` changed.

## Changes Made
- Added a `useEffect` that clears `selectedFiles` whenever the user switches buckets.
- Ensures the delete button only appears for files in the currently active bucket.

```typescript
// Clear selected files when switching buckets
useEffect(() => {
  setSelectedFiles(new Set());
}, [selectedBucket]);
```

## How to Test

1. Open bucket-a and select two files→ The Delete 2 Files button should appear
2. Switch to bucket-b→ The Delete button should disappear since no files are selected in this bucket
3. Switch back to bucket-a→ The previous selections are cleared
4. Select files again and delete→ Only files in the active bucket should be deleted

---

## Screenshots

## Before Fix
**bucket-a (2 files selected)**
<img width="1380" alt="Before - bucket-a with selections" 
  src="https://github.com/user-attachments/assets/16aaf0a4-82e2-4a60-b847-868335aa259c" />

**bucket-b (delete button incorrectly shows)**
<img width="1410" alt="Before - bucket-b showing stale delete button" 
  src="https://github.com/user-attachments/assets/ef034ef4-a7d2-4073-9766-8b9b33bf490f" />

## After Fix
**bucket-a (2 files selected)**
<img width="1397" alt="After - bucket-a with selections" 
  src="https://github.com/user-attachments/assets/8fa75397-ddab-4ab9-b8b6-9f0bcf165510" />

**bucket-b (delete button correctly hidden)**
<img width="1398" alt="After - bucket-b without delete button" 
  src="https://github.com/user-attachments/assets/3ff512bd-d012-43b3-923d-797bbd48fb27" />