### PR TITLE
feat: add Discord OAuth2 integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Discord OAuth - Get credentials from https://discord.com/developers/applications
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
 # LinkedIn OAuth - Get credentials from https://www.linkedin.com/developers/apps
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=

--- a/backend/src/core/auth/oauth.ts
+++ b/backend/src/core/auth/oauth.ts
@@ -182,6 +182,8 @@ export class OAuthConfigService {
           scopes = ['openid', 'email', 'profile'];
         } else if (provider === 'github') {
           scopes = ['user:email'];
+        } else if (provider === 'discord') {
+          scopes = ['identify', 'email'];
         } else if (provider === 'linkedin') {
           scopes = ['openid', 'profile', 'email'];
         }

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -89,6 +89,13 @@ export interface GitHubEmailInfo {
   visibility?: string;
 }
 
+export interface DiscordUserInfo {
+  id: string;
+  username: string;
+  email?: string;
+  avatar?: string;
+}
+
 export interface LinkedInUserInfo {
   sub: string;
   email: string;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -94,6 +94,8 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
       # Logs directory
       - LOGS_DIR=/insforge-logs
       # Storage directory (for local file storage when S3 is not configured)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID:-}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET:-}
+      - DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID:-}
+      - DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET:-}
       # Logs directory
       - LOGS_DIR=/insforge-logs
       # Storage directory (for local file storage when S3 is not configured)

--- a/frontend/src/features/auth/components/AddOAuthDialog.tsx
+++ b/frontend/src/features/auth/components/AddOAuthDialog.tsx
@@ -14,8 +14,8 @@ interface AddOAuthDialogProps {
   providers: OAuthProviderInfo[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: (selectedId: 'google' | 'github' | 'linkedin') => void;
-  enabledProviders: Record<'google' | 'github' | 'linkedin', boolean>;
+  onConfirm: (selectedId: 'google' | 'github' | 'discord' | 'linkedin') => void;
+  enabledProviders: Record<'google' | 'github' | 'discord' | 'linkedin', boolean>;
 }
 
 export function AddOAuthDialog({
@@ -25,7 +25,9 @@ export function AddOAuthDialog({
   onConfirm,
   enabledProviders,
 }: AddOAuthDialogProps) {
-  const [selectedId, setSelectedId] = useState<'google' | 'github' | 'linkedin' | null>(null);
+  const [selectedId, setSelectedId] = useState<'google' | 'github' | 'discord' | 'linkedin' | null>(
+    null
+  );
 
   // Reset selection when dialog opens
   useEffect(() => {
@@ -39,7 +41,7 @@ export function AddOAuthDialog({
   // Filter out already enabled providers
   const availableProviders = providers.filter((provider) => !enabledProviders[provider.id]);
 
-  const selectProvider = (id: 'google' | 'github' | 'linkedin') => {
+  const selectProvider = (id: 'google' | 'github' | 'discord' | 'linkedin') => {
     setSelectedId(id);
   };
 

--- a/frontend/src/features/auth/components/AuthMethodTab.tsx
+++ b/frontend/src/features/auth/components/AuthMethodTab.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/radix/Button';
 import { MoreHorizontal, Plus, Trash2, Pencil } from 'lucide-react';
 import Github from '@/assets/logos/github.svg?react';
 import Google from '@/assets/logos/google.svg?react';
+import Discord from '@/assets/logos/discord.svg?react';
 import LinkedIn from '@/assets/logos/linkedin.svg?react';
 import { OAuthEmptyState } from './OAuthEmptyState';
 import { OAuthConfigDialog } from './OAuthConfigDialog';
@@ -33,6 +34,13 @@ const providers: OAuthProviderInfo[] = [
     setupUrl: 'https://github.com/settings/developers',
   },
   {
+    id: 'discord',
+    name: 'Discord OAuth',
+    icon: <Discord className="w-6 h-6" />,
+    description: 'Configure Discord authentication for your users',
+    setupUrl: 'https://discord.com/developers/applications',
+  },
+  {
     id: 'linkedin',
     name: 'LinkedIn OAuth',
     icon: <LinkedIn className="w-6 h-6 text-[#0A66C2] dark:text-[#0A66C2]" />,
@@ -42,7 +50,7 @@ const providers: OAuthProviderInfo[] = [
 ];
 
 export interface OAuthProviderInfo {
-  id: 'google' | 'github' | 'linkedin';
+  id: 'google' | 'github' | 'discord' | 'linkedin';
   name: string;
   icon: ReactElement;
   description: string;
@@ -69,7 +77,7 @@ export function AuthMethodTab() {
   };
 
   const deleteOAuthConfig = async (
-    providerId: 'google' | 'github' | 'linkedin',
+    providerId: 'google' | 'github' | 'linkedin' | 'discord',
     providerName: string
   ) => {
     const shouldDelete = await confirm({
@@ -106,6 +114,7 @@ export function AuthMethodTab() {
     return {
       google: isProviderConfigured('google'),
       github: isProviderConfigured('github'),
+      discord: isProviderConfigured('discord'),
       linkedin: isProviderConfigured('linkedin'),
     };
   }, [isProviderConfigured]);
@@ -115,7 +124,7 @@ export function AuthMethodTab() {
     return providers.every((provider) => enabledProviders[provider.id]);
   }, [enabledProviders]);
 
-  const handleConfirmSelected = (selectedId: 'google' | 'github' | 'linkedin') => {
+  const handleConfirmSelected = (selectedId: 'google' | 'github' | 'discord' | 'linkedin') => {
     // Find the selected provider
     const selectedProvider = providers.find((p) => p.id === selectedId);
     if (!selectedProvider) {

--- a/frontend/src/features/auth/components/UsersDataGrid.tsx
+++ b/frontend/src/features/auth/components/UsersDataGrid.tsx
@@ -33,6 +33,12 @@ const ProviderIcon = ({ provider }: { provider: string }) => {
           color:
             'bg-gray-100 text-gray-700 dark:bg-neutral-800 dark:text-zinc-300 dark:border-gray-500',
         };
+      case 'discord':
+        return {
+          label: 'Discord',
+          color:
+            'bg-gray-100 text-gray-700 dark:bg-neutral-800 dark:text-zinc-300 dark:border-gray-500',
+        };
       case 'linkedin':
         return {
           label: 'LinkedIn',

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -419,6 +419,24 @@ paths:
         '500':
           description: OAuth not configured
 
+  /api/auth/oauth/discord:
+    get:
+      summary: Initiate Discord OAuth flow
+      tags:
+        - Client
+      parameters:
+        - name: redirect_uri
+          in: query
+          schema:
+            type: string
+            format: uri
+          description: URL to redirect after authentication
+      responses:
+        '302':
+          description: Redirect to Discord OAuth
+        '500':
+          description: OAuth not configured
+
   /api/auth/oauth/shared/callback:
     get:
       summary: Shared OAuth callback handler
@@ -462,7 +480,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [google, github]
+            enum: [google, github, discord]
         - name: code
           in: query
           schema:


### PR DESCRIPTION
## Summary

This PR introduces **Discord OAuth2 login integration** across the backend and frontend, allowing users to authenticate using their Discord account. This closes issue #386 

### Key changes:

* **Backend**

  * Added new route: `/api/auth/oauth/discord`
  * Implemented Discord OAuth2 flow in `auth.oauth.ts` and `auth.ts`
  * Updated types in `auth.ts` and seeding logic for OAuth users
  * Extended OpenAPI documentation (`openapi/auth.yaml`)
* **Frontend**

  * Added **Discord** as an authentication provider in `AuthMethodTab.tsx`
* **Infrastructure**

  * Updated `docker-compose.yml` and `docker-compose.prod.yml` for environment variable support
  * Added setup guide: `DISCORD_OAUTH_SETUP.md`

---

## How did you test this change?

1. **Local testing**

   * Created a Discord Developer application following the new `DISCORD_OAUTH_SETUP.md` instructions
   * Configured `.env` with `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`.
   * Started backend and frontend (`docker compose up -d`).
   *  Use curl to get Callback url (`curl -X GET "http://localhost:7130/api/auth/oauth/discord?redirect_uri=http://localhost:7131/dashboard"`)
   * Verified login via Discord redirects correctly and returns valid user tokens

2. **Functional tests**

   * Tested successful login, logout, and token exchange
   * Verified user creation and linking for first-time Discord logins
   * Ensured existing login flows (e.g., GitHub OAuth) remain unaffected

3. **Test*

   ```bash
   npm test:e2e
   ```

   ✅ All tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord OAuth support for sign-up, login, account linking, and admin setup; appears as a selectable provider in dialogs and user identity views (icon/label included).

* **Documentation**
  * API docs updated with Discord OAuth initiation endpoint and callback support.

* **Chores**
  * Added DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET to environment examples and compose files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->