### PR TITLE
fix: Hide delete button when table is 'users'

### DIFF
--- a/frontend/src/features/database/page/DatabasePage.tsx
+++ b/frontend/src/features/database/page/DatabasePage.tsx
@@ -431,11 +431,13 @@ function DatabasePageContent() {
                             itemType="record"
                             onClear={() => setSelectedRows(new Set())}
                           />
-                          <DeleteActionButton
-                            selectedCount={selectedRows.size}
-                            itemType="record"
-                            onDelete={() => void handleBulkDelete(Array.from(selectedRows))}
-                          />
+                          {selectedTable !== 'users' && (
+                            <DeleteActionButton
+                              selectedCount={selectedRows.size}
+                              itemType="record"
+                              onDelete={() => void handleBulkDelete(Array.from(selectedRows))}
+                            />
+                          )}
                         </div>
                       ) : (
                         <SearchInput


### PR DESCRIPTION
## Summary

Closes #378 

Hide bulk delete button for `users` table. Because RLS explicitly disallows `DELETE` on users (policy: Disable delete for users), showing the button causes confusion and misleading errors.

## How did you test this change?

Re-built the UI and tested the scenario manually to confirm the Delete button hidden on `users` table
