### PR TITLE
fix: Re-fetching after deleting a bucket

### DIFF
--- a/frontend/src/features/storage/page/StoragePage.tsx
+++ b/frontend/src/features/storage/page/StoragePage.tsx
@@ -236,7 +236,7 @@ export default function StoragePage() {
     if (shouldDelete) {
       try {
         await deleteBucket(bucketName);
-
+        await refetchBuckets();
         // If the deleted bucket was selected, select the first available bucket
         if (selectedBucket === bucketName) {
           const updatedBuckets =


### PR DESCRIPTION
## Summary

Closes: #376 

<!-- Briefly describe what this PR does -->
After deleting a bucket, the component now explicitly refetches the bucket list to update the UI immediately.

## How did you test this change?

<!-- Describe how you tested this PR -->

Deleted a bucket from the Storage page
Verified that the bucket disappeared instantly from the sidebar

https://github.com/user-attachments/assets/ed9e5e5e-9d9c-45b0-a03d-837113d1a16f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After deleting a storage bucket, the list updates immediately, removing the deleted item and reflecting the current state without needing a page refresh or navigation. This resolves cases where users briefly saw stale buckets after deletion and provides clearer confirmation that the action succeeded. Overall, the storage page stays synchronized with server data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->