### PR TITLE
[FIX] Logs page bugs

### DIFF
--- a/frontend/src/features/logs/components/LogsContent.tsx
+++ b/frontend/src/features/logs/components/LogsContent.tsx
@@ -254,7 +254,9 @@ export function LogsContent({ source }: LogsContentProps) {
               data={paginatedLogs}
               isLoading={logsLoading}
               emptyMessage={
-                filteredLogs.length === 0 ? 'No logs match your search criteria' : 'No logs found'
+                logsSearchQuery || severityFilter.length < 3
+                  ? 'No logs match your search criteria'
+                  : 'No logs found'
               }
             />
             {isLoadingMore && (

--- a/frontend/src/features/logs/hooks/useLogs.ts
+++ b/frontend/src/features/logs/hooks/useLogs.ts
@@ -47,10 +47,10 @@ export function useLogs(source: string) {
     }
   }, [initialLogsData]);
 
-  // Reset page when search or severity filter changes
+  // Reset page when search, severity filter, or source changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchQuery, severityFilter]);
+  }, [searchQuery, severityFilter, source]);
 
   // Load more older logs
   const loadMoreLogs = useCallback(async () => {


### PR DESCRIPTION
## Summary

1. Switching sources won't reset current page number

2. Fix wording for empty list

## How did you test this change?

Tested locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logs table now displays a more accurate empty state: shows “No logs match your search criteria” when a search or narrowed severity filter is applied; otherwise shows “No logs found.”
  * Pagination resets when changing the log source, preventing stale or empty pages after switching sources.

* **New Features**
  * Improved logs browsing experience with clearer feedback for filtered searches and automatic page reset on source changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->