### PR TITLE
Fix: clear button visibility and rendering for zero linked value

### DIFF
--- a/frontend/src/features/database/components/RecordFormField.tsx
+++ b/frontend/src/features/database/components/RecordFormField.tsx
@@ -184,7 +184,7 @@ function FormNumberEditor({ value, type, onChange, tableName, field }: FormNumbe
         }
       }}
       placeholder={getPlaceholderText(field)}
-      className={`dark:text-white dark:placeholder:text-neutral-400 dark:bg-neutral-900 dark:border-neutral-700 ${field.foreignKey ? 'pr-16' : ''}`}
+      className={`dark:text-white dark:placeholder:text-neutral-400 dark:bg-neutral-900 dark:border-neutral-700 ${field.foreignKey ? 'pr-18' : ''}`}
     />
   );
 }
@@ -310,14 +310,14 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
               <div className="space-y-1">
                 <div className="relative">
                   {modifiedChildren}
-                  <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center">
+                  <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1">
                     {(hasLinkedValue || hasLinkedValue === 0) && (
                       <Button
                         type="button"
                         variant="ghost"
                         size="icon"
                         onClick={() => formField.onChange('')}
-                        className="h-7 w-7 p-1 flex-shrink-0 text-zinc-500 hover:text-red-600 hover:bg-red-100 dark:text-neutral-400 dark:hover:text-red-400 dark:hover:bg-red-800/30"
+                        className="h-7 w-7 p-1 flex-shrink-0 text-zinc-500 hover:text-zinc-700 hover:bg-zinc-100 dark:text-neutral-400 dark:hover:text-neutral-200 dark:hover:bg-neutral-700"
                         title="Clear linked record"
                       >
                         <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Closes: #320 
<!-- Briefly describe what this PR does -->
- button was not rendered when the linked value was 0 due to falsy evaluation. The condition now explicitly checks for zero values, ensuring consistent behavior.

- button's dark mode styling has been adjusted to improve visibility for dark and light mode
## How did you test this change?

Manually tested the component in both light and dark modes

<!-- Describe how you tested this PR -->
<img width="903" height="398" alt="image" src="https://github.com/user-attachments/assets/4ecafeba-c622-4e84-ab94-85aff3c83f4f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recognize numeric zero (0) as a valid linked value so the clear-linked control appears correctly for zero.
* **Style**
  * Added spacing between the clear control and adjacent elements and adjusted input padding when a foreign key is present.
  * Restyled the clear-linked control to a neutral/gray scheme with improved hover feedback in light and dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->