### PR TITLE
fix: `updated_at` time stamp modification on updates. 

### DIFF
--- a/backend/migrations/014_add-updated-at-trigger-user-table.sql
+++ b/backend/migrations/014_add-updated-at-trigger-user-table.sql
@@ -1,20 +1,8 @@
 -- Migration: 014 - Add updated_at trigger to users table
 -- Adds the updated_at trigger to the users table for automatic timestamp management
 
-DO $$
-BEGIN
-    -- Add updated_at trigger to users table if not exists
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_trigger 
-        WHERE tgrelid = 'users'::regclass 
-        AND tgname = 'users_update_timestamp'
-    ) THEN
-        CREATE TRIGGER users_update_timestamp 
-        BEFORE UPDATE ON users
-        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-        
-        RAISE NOTICE 'Added updated_at trigger to users table';
-    ELSE
-        RAISE NOTICE 'updated_at trigger already exists on users table';
-    END IF;
-END $$;
+
+DROP TRIGGER IF EXISTS update_users_updated_at ON users;
+CREATE TRIGGER update_users_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION


## Summary

I have modified the column update in the database record field, whenever we update a new field along with the updated values, the `updated_at` timestamp will be updated and sent to the backend. 

This PR fixes #374 

## How did you test this change?

<!-- Describe how you tested this PR -->

I have tested this manually.


<img width="1044" height="156" alt="image" src="https://github.com/user-attachments/assets/b34c3797-9083-43b5-8565-a954175bb732" />
the updated_at timestamp's are automatically updated when i have modifed the nicknames, bio and avatar_urls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a safe, idempotent database migration to ensure user "last updated" timestamps are maintained automatically, improving data consistency and reliability and providing clear deployment notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->