### PR TITLE
fix: Specific error message

### DIFF
--- a/frontend/src/features/database/components/TableForm.tsx
+++ b/frontend/src/features/database/components/TableForm.tsx
@@ -237,7 +237,7 @@ export function TableForm({
     onError: (err) => {
       const errorMessage = err.message || 'Failed to create table';
       setError(errorMessage);
-      showToast('Failed to create table', 'error');
+      showToast(errorMessage, 'error');
     },
   });
 
@@ -377,7 +377,7 @@ export function TableForm({
 
       const errorMessage = err.message || 'Failed to update table';
       setError(errorMessage);
-      showToast('Failed to update table', 'error');
+      showToast(errorMessage, 'error');
     },
   });
 


### PR DESCRIPTION

## Summary

<!-- Briefly describe what this PR does -->

This PR fixes #454 

It displays the error message in the toast, rather than just displaying table creation failed. 

## How did you test this change?

<!-- Describe how you tested this PR -->
<img width="963" height="569" alt="image" src="https://github.com/user-attachments/assets/76b7199b-5806-45b4-9794-9c71d217757a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when creating tables to display specific error details instead of generic messages.
  * Improved error messages when updating tables to display specific error details instead of generic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->