### PR TITLE
docs: fix docs to let sdk always latest version

### DIFF
--- a/docs/insforge-instructions-sdk.md
+++ b/docs/insforge-instructions-sdk.md
@@ -74,7 +74,7 @@ module.exports = async function(request) {
 ## Setup
 
 ```bash
-npm install @insforge/sdk
+npm install @insforge/sdk@latest
 ```
 
 ```javascript


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

fix instruction docs to always latest version of sdk

We are on our way to depracate this and direcly read it from mintlify, but until then, we still want to fix this as it's just 1 line change

## How did you test this change?

<!-- Describe how you tested this PR -->

npm install @insforge/sdk@latest
 this isntallation works just as fine
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to recommend installing the latest version of @insforge/sdk for improved access to the most recent features and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->