### PR TITLE
chore:  response of chat completion to follow the response schema

### DIFF
--- a/backend/src/core/ai/chat.ts
+++ b/backend/src/core/ai/chat.ts
@@ -123,7 +123,7 @@ export class ChatService {
         text: response.choices[0]?.message?.content || '',
         metadata: {
           model: options.model,
-          ...tokenUsage,
+          usage: tokenUsage,
         },
       };
     } catch (error) {


### PR DESCRIPTION


## Summary

<!-- Briefly describe what this PR does -->

This issue changes the response of the chat completion to follow the schema definition of the chat completion response, which affected the token usage value while accessing from SDK. 

The issue is reported on discord.  

## How did you test this change?

By manually calling the chat completion through SDK and now the SDK responded with actual values of the prompt usage tokens..

```json 

{
  "id": "chatcmpl-1760859372000",
  "object": "chat.completion",
  "created": 1760859372,
  "model": "google/gemini-2.5-flash",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Hello! I'm doing well, thank you for asking. I'm ready and eager to assist you. How can I help you today?"
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "promptTokens": 6,
    "completionTokens": 30,
    "totalTokens": 36
  }
}

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized chat response metadata structure to provide token usage information in a dedicated property for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->