### PR TITLE
[Enhancement]: remove hardcoded admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ VITE_API_BASE_URL=http://localhost:7130
 JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=change-this-password
+VITE_ADMIN_EMAIL=admin@example.com
+VITE_ADMIN_PASSWORD=change-this-password
+
 
 # Encryption key for secret manager (will use JWT_SECRET if not provided)
 ENCRYPTION_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,15 @@ COPY . .
 
 # Build arguments for Vite environment variables
 ARG VITE_API_BASE_URL
+ARG VITE_ADMIN_EMAIL
+ARG VITE_ADMIN_PASSWORD
 
-# Build frontend with the API URL baked in
+# Set environment variables for the build
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_ADMIN_EMAIL=$VITE_ADMIN_EMAIL
+ENV VITE_ADMIN_PASSWORD=$VITE_ADMIN_PASSWORD
+
+# Build frontend with environment variables baked in
 RUN npm run build
 
 # Expose ports

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,8 @@ services:
       dockerfile: Dockerfile
       args:
         VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:7130}
+        VITE_ADMIN_EMAIL: ${VITE_ADMIN_EMAIL:-admin@example.com}
+        VITE_ADMIN_PASSWORD: ${VITE_ADMIN_PASSWORD:-change-this-password}
     container_name: insforge
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,14 @@ services:
       - insforge-network
 
   insforge:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Pass VITE variables for build time (frontend compilation)
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:7130}
+        VITE_ADMIN_EMAIL: ${VITE_ADMIN_EMAIL:-admin@example.com}
+        VITE_ADMIN_PASSWORD: ${VITE_ADMIN_PASSWORD:-change-this-password}
     image: node:20-alpine
     container_name: insforge
     working_dir: /app

--- a/frontend/src/features/login/page/LoginPage.tsx
+++ b/frontend/src/features/login/page/LoginPage.tsx
@@ -36,8 +36,8 @@ export default function LoginPage() {
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginFormSchema),
     defaultValues: {
-      email: 'admin@example.com',
-      password: 'change-this-password',
+      email: import.meta.env.VITE_ADMIN_EMAIL,
+      password: import.meta.env.VITE_ADMIN_PASSWORD,
     },
   });
 


### PR DESCRIPTION
##  Remove Hardcoded Admin Credentials from Frontend Build

## Closes #102 

### 📋 Summary
Fixed critical authentication issue where default admin credentials were hardcoded in the frontend Docker image, causing login failures when custom `.env` credentials were set in production environments (particularly AWS EC2 deployments).

### 🐛 What Was Wrong?

The login form had **hardcoded** default email/password (`admin@example.com` / `change-this-password`) baked into the frontend Docker image at build time. When users set different credentials in their `.env` file on AWS EC2, the frontend displayed the old hardcoded values, but the backend expected the actual `.env` values.

**Result**: Login always failed! 🚫

### ✅ What Was Fixed?

1. **Made credentials configurable via environment variables**
   - Added `VITE_ADMIN_EMAIL` and `VITE_ADMIN_PASSWORD` to `.env.example`
   - Frontend now reads from `import.meta.env` instead of hardcoded strings

2. **Updated Docker build pipeline**
   - Modified `Dockerfile` to accept build arguments for admin credentials
   - Passed environment variables during frontend compilation
   - Ensures credentials match between frontend and backend

3. **Updated Docker Compose configurations**
   - `docker-compose.yml`: Added build args for dev environment
   - `docker-compose.prod.yml`: Added build args for production environment
   - Both now pass `VITE_ADMIN_EMAIL` and `VITE_ADMIN_PASSWORD` with sensible defaults

4. **Updated login page**
   - `LoginPage.tsx`: Replaced hardcoded values with dynamic environment variables
   - Form now uses `import.meta.env.VITE_ADMIN_EMAIL` and `import.meta.env.VITE_ADMIN_PASSWORD`

### 📁 Files Changed
- `.env.example` - Added new VITE environment variables
- `Dockerfile` - Added build arguments for admin credentials
- `docker-compose.yml` - Added build args configuration
- `docker-compose.prod.yml` - Added build args configuration  
- `frontend/src/features/login/page/LoginPage.tsx` - Removed hardcoded credentials

### Test the Fix:

```bash
# Update Insforge and start services
git pull origin main
docker compose down
docker compose up -d --build
```

```bash
# Test admin login via API
curl -X POST http://13.210.215.151:7130/api/auth/admin/sessions \
  -H "Content-Type: application/json" \
  -d "{\"email\":\"admin@example.com\",\"password\":\"change-this-password\"}"

# Customize email and password  to match your .env file
# Should return JSON with "accessToken" if successful
```

### Login to Dashboard:

1. Open browser: `http://localhost:7131`
2. You should see the **email and password fields pre-filled** with your admin credentials
4. Click "Sign In"
#### Expected Behavior After Fix
- ✅ Login works with your actual credentials
- ✅ Backend logs show: "Admin login successful for: your-email@domain.com"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration and login form to support admin credentials (email and password) as environment variables instead of hard-coded values, enabling more flexible deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->