### PR TITLE
fix: entirely remove admin credentials from frontend build

### DIFF
--- a/frontend/src/features/login/page/LoginPage.tsx
+++ b/frontend/src/features/login/page/LoginPage.tsx
@@ -36,8 +36,8 @@ export default function LoginPage() {
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginFormSchema),
     defaultValues: {
-      email: 'admin@example.com',
-      password: 'change-this-password',
+      email: '',
+      password: '',
     },
   });
 
@@ -148,8 +148,18 @@ export default function LoginPage() {
                 >
                   Sign in
                 </ButtonWithLoading>
+
+                <Alert className="text-xs">
+                  <AlertDescription>
+                    <strong>First time?</strong> Check your backend logs for admin credentials:
+                    <code className="block mt-1 text-xs bg-muted p-2 rounded">
+                      docker-compose logs insforge | grep &quot;Admin&quot;
+                    </code>
+                  </AlertDescription>
+                </Alert>
+
                 <p className="text-xs text-center text-muted-foreground">
-                  Use the credentials configured in your .env file
+                  Configured via ADMIN_EMAIL and ADMIN_PASSWORD in .env
                 </p>
               </CardFooter>
             </form>


### PR DESCRIPTION
## Remove Credentials from Frontend Entirely
### How it works:
- Don't pre-fill credentials at all
- Show credentials only in backend logs (already implemented)
- Add a helpful hint on the login page directing users to logs

This appears to be a better approach to #482 and #476 .

Baking credentials into the frontend bundle is a security anti-pattern, even for "defaults". Anyone can inspect the compiled JavaScript and extract them. 

If this is accepted,  #482 and #476 ( and associated issues ) can be closed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added informational alert in the login form detailing how to obtain admin credentials.

* **Documentation**
  * Updated login page guidance text to reference environment variable configuration method.
  * Login form default values now start empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->