### PR TITLE
fix(docs): correct image paths in i18n READMEs

### DIFF
--- a/i18n/README.ar.md
+++ b/i18n/README.ar.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
   
 </div>
@@ -33,7 +33,7 @@
 
 ## أمثلة سريعة:
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -60,12 +60,12 @@ docker compose up
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>تسجيل الدخول إلى InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>تكوين اتصال MCP</em>
       </td>
@@ -81,7 +81,7 @@ InsForge is my backend platform, what is my current backend structure?
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>عينة من استدعاءات الاستجابة الناجحة لأدوات insforge MCP</em>
 </div>
@@ -97,7 +97,7 @@ InsForge is my backend platform, what is my current backend structure?
 ## بنيان
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.es.md
+++ b/i18n/README.es.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Logo de InsForge">
+    <img src="../assets/banner.png" alt="Logo de InsForge">
   </a>
 </div>
 
@@ -41,7 +41,7 @@ Estamos construyendo las funcionalidades de Supabase de una manera nativa para I
 ## Ejemplos de Prompts:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="Flujo de usuario">
+  <img src="../assets/userflow.png" alt="Flujo de usuario">
   <br>
 </td>
 
@@ -72,12 +72,12 @@ Visita el **Panel de Control de InsForge** (por defecto: http://localhost:7131),
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Iniciar Sesión">
+        <img src="../assets/signin.png" alt="Iniciar Sesión">
         <br>
         <em>Inicia sesión en InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="Configuración MCP">
+        <img src="../assets/mcpInstallv2.png" alt="Configuración MCP">
         <br>
         <em>Configura la conexión MCP</em>
       </td>
@@ -95,7 +95,7 @@ InsForge es mi plataforma Backend, ¿cuál es mi estructura actual de Backend?
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Respuesta de Conexión Exitosa" width="600">
+  <img src="../assets/sampleResponse.png" alt="Respuesta de Conexión Exitosa" width="600">
   <br>
   <em>Ejemplo de respuesta exitosa usando las herramientas MCP de InsForge</em>
 </div>
@@ -116,7 +116,7 @@ Empieza a construir tu proyecto en un nuevo directorio.
 ## Arquitectura
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Diagrama de Arquitectura">
+  <img src="../assets/archDiagram.png" alt="Diagrama de Arquitectura">
   <br>
 </div>
 

--- a/i18n/README.fr.md
+++ b/i18n/README.fr.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
   
 </div>
@@ -35,7 +35,7 @@
 ## Exemples de prompt:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -62,12 +62,12 @@ Visitez le tableau de bord InsForge (par défaut : http://localhost:7131), conne
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>Se connecter à InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>Configurez la connexion MCP</em>
       </td>
@@ -83,7 +83,7 @@ InsForge is my backend platform, what is my current backend structure?
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>Exemple de réponse réussie lors de l’appel des outils MCP d’InsForge</em>
 </div>
@@ -100,7 +100,7 @@ Commencez à créer votre projet dans un nouveau répertoire ! Créez votre proc
 
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
 </div>
 <p align="center">
@@ -34,7 +34,7 @@
 ## प्रॉम्प्ट उदाहरण:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -61,12 +61,12 @@ InsForge डैशबोर्ड (डिफ़ॉल्ट: http://localhost:71
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>InsForge में साइन इन करें</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>MCP कनेक्शन कॉन्फ़िगर करें</em>
       </td>
@@ -82,7 +82,7 @@ InsForge मेरा बैकएंड प्लेटफ़ॉर्म ह�
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>insforge MCP टूल को कॉल करने पर सफल प्रतिक्रिया का नमूना</em>
 </div>
@@ -98,7 +98,7 @@ InsForge मेरा बैकएंड प्लेटफ़ॉर्म ह�
 ## आर्किटेक्चर
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
  
 </div>
@@ -42,7 +42,7 @@
 
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -76,12 +76,12 @@ InsForgeダッシュボード（デフォルト: [http://localhost:7131）にア
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>InsForgeにサインイン</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>MCP接続の設定</em>
       </td>
@@ -102,7 +102,7 @@ InsForge is my backend platform, what is my current backend structure?
 
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>insforge MCPツールを呼び出した成功例のレスポンス</em>
 </div>
@@ -125,7 +125,7 @@ InsForge is my backend platform, what is my current backend structure?
 
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.ko.md
+++ b/i18n/README.ko.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
   
 </div>
@@ -37,7 +37,7 @@
 ## 프롬프트 예시:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -64,12 +64,12 @@ InsForge Dashboard (기본 주소: http://localhost:7131) 에 접속 후 로그�
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>Sign in to InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>Configure MCP connection</em>
       </td>
@@ -86,7 +86,7 @@ InsForge is my backend platform, what is my current backend structure?
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>Sample successful response calling insforge MCP tools</em>
 </div>
@@ -103,7 +103,7 @@ InsForge is my backend platform, what is my current backend structure?
 ## 아키텍처
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.pt-BR.md
+++ b/i18n/README.pt-BR.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
 </div>
 
@@ -40,7 +40,7 @@ Criação de aplicações full-stack usando linguagem natural
 ## Exemplos de Prompt:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -67,12 +67,12 @@ Visite o painel do InsForge (padrão: http://localhost:7131), faça login e siga
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>Entrar no InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>Configurar conexão MCP</em>
       </td>
@@ -86,7 +86,7 @@ No seu agente, envie:
 > InsForge é minha plataforma de backend, qual é a estrutura atual do meu backend?
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>Exemplo de resposta bem-sucedida chamando ferramentas MCP do InsForge</em>
 </div>
@@ -103,7 +103,7 @@ Crie seu próximo aplicativo de tarefas, clone do Instagram ou plataforma online
 ## Arquitetura
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 

--- a/i18n/README.ru.md
+++ b/i18n/README.ru.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://insforge.dev">
-    <img src="assets/banner.png" alt="Insforge Logo">
+    <img src="../assets/banner.png" alt="Insforge Logo">
   </a>
 </div>
 <p align="center">
@@ -34,7 +34,7 @@
 ## Примеры промптов:
 
 <td align="center">
-  <img src="assets/userflow.png" alt="userFlow">
+  <img src="../assets/userflow.png" alt="userFlow">
   <br>
 </td>
 
@@ -61,12 +61,12 @@ docker compose up
   <table>
     <tr>
       <td align="center">
-        <img src="assets/signin.png" alt="Sign In">
+        <img src="../assets/signin.png" alt="Sign In">
         <br>
         <em>Войдите в InsForge</em>
       </td>
       <td align="center">
-        <img src="assets/mcpInstallv2.png" alt="MCP Configuration">
+        <img src="../assets/mcpInstallv2.png" alt="MCP Configuration">
         <br>
         <em>Настройте подключение MCP</em>
       </td>
@@ -82,7 +82,7 @@ InsForge — моя бэкенд-платформа, какова моя тек�
 ```
 
 <div align="center">
-  <img src="assets/sampleResponse.png" alt="Successful Connection Response" width="600">
+  <img src="../assets/sampleResponse.png" alt="Successful Connection Response" width="600">
   <br>
   <em>Пример успешного ответа при вызове инструментов InsForge MCP</em>
 </div>
@@ -98,7 +98,7 @@ InsForge — моя бэкенд-платформа, какова моя тек�
 ## Архитектура
 
 <div align="center">
-  <img src="assets/archDiagram.png" alt="Architecture Diagram">
+  <img src="../assets/archDiagram.png" alt="Architecture Diagram">
   <br>
 </div>
 


### PR DESCRIPTION
## Summary

Closes #485 

## How did you test this change?

The banner is now visible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed broken image references in internationalized README files (banner, user flow, sign-in, installation, sample response, architecture diagrams and related visuals) across multiple languages so images display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->