### PR TITLE
fix: updated the primary key to be used instead of id column

### DIFF
--- a/frontend/src/components/datagrid/DataGrid.tsx
+++ b/frontend/src/components/datagrid/DataGrid.tsx
@@ -66,6 +66,9 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   showTypeBadge = true,
 }: DataGridProps<TRow>) {
   const { resolvedTheme } = useTheme();
+
+  const defaultRowKeyGetter = useCallback((row: TRow) => row.id || Math.random().toString(), []);
+  const keyGetter = rowKeyGetter || defaultRowKeyGetter;
   // Convert columns to react-data-grid format
   const gridColumns = useMemo(() => {
     const cols: Column<TRow>[] = [];
@@ -82,13 +85,13 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
         resizable: false,
         renderCell: ({ row, tabIndex }) => (
           <Checkbox
-            checked={selectedRows.has(String(row.id))}
+            checked={selectedRows.has(keyGetter(row))}
             onChange={(checked) => {
               const newSelectedRows = new Set(selectedRows);
               if (checked) {
-                newSelectedRows.add(String(row.id));
+                newSelectedRows.add(String(keyGetter(row)));
               } else {
-                newSelectedRows.delete(String(row.id));
+                newSelectedRows.delete(String(keyGetter(row)));
               }
               onSelectedRowsChange(newSelectedRows);
             }}
@@ -176,11 +179,8 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
     sortColumns,
     showSelection,
     showTypeBadge,
+    keyGetter,
   ]);
-
-  // Default row key getter
-  const defaultRowKeyGetter = useCallback((row: TRow) => row.id || Math.random().toString(), []);
-  const keyGetter = rowKeyGetter || defaultRowKeyGetter;
 
   // Loading state - only show full loading screen if not sorting
   if (loading && !isSorting) {

--- a/frontend/src/features/database/services/record.service.ts
+++ b/frontend/src/features/database/services/record.service.ts
@@ -143,8 +143,13 @@ export class RecordService {
     return this.createRecords(table, [data]);
   }
 
-  updateRecord(table: string, id: string, data: { [key: string]: ConvertedValue }) {
-    return apiClient.request(`/database/records/${table}?id=eq.${id}`, {
+  updateRecord(
+    table: string,
+    pkColumn: string,
+    pkValue: string,
+    data: { [key: string]: ConvertedValue }
+  ) {
+    return apiClient.request(`/database/records/${table}?${pkColumn}=eq.${pkValue}`, {
       method: 'PATCH',
       headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
@@ -154,12 +159,12 @@ export class RecordService {
   }
 
   // PostgREST supports bulk deletes via in.() filter
-  deleteRecords(table: string, ids: string[]) {
-    if (!ids.length) {
+  deleteRecords(table: string, pkColumn: string, pkValues: string[]) {
+    if (!pkValues.length) {
       return Promise.resolve();
     }
-    const idFilter = `in.(${ids.join(',')})`;
-    return apiClient.request(`/database/records/${table}?id=${idFilter}`, {
+    const pkFilter = `in.(${pkValues.join(',')})`;
+    return apiClient.request(`/database/records/${table}?${pkColumn}=${pkFilter}`, {
       method: 'DELETE',
       headers: apiClient.withAccessToken(),
     });


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

This PR closes #490 

In UI the data selection is done only through the id column, now it is modified to use the primary column 

## How did you test this change?

<!-- Describe how you tested this PR -->

Deleted the 3 rows where the primary column is product_code

<img width="1366" height="632" alt="image" src="https://github.com/user-attachments/assets/cd827b40-8112-4772-b191-4bf73c2856b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom primary key columns in database tables, enabling compatibility with non-standard primary key configurations beyond the default 'id' column.

* **Bug Fixes**
  * Row selection and record editing now correctly identify records using the configured primary key column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->