### PR TITLE
fix: disable "Update Table" button if no changes made

### DIFF
--- a/frontend/src/features/database/components/TableForm.tsx
+++ b/frontend/src/features/database/components/TableForm.tsx
@@ -656,12 +656,10 @@ export function TableForm({
           <Button
             onClick={() => void handleSubmit()}
             disabled={
-              (!form.formState.isValid ||
-                createTableMutation.isPending ||
-                updateTableMutation.isPending ||
-                !form.formState.isDirty) &&
-              !form.formState.isDirty &&
-              !foreignKeysDirty
+              !form.formState.isValid ||
+              createTableMutation.isPending ||
+              updateTableMutation.isPending ||
+              (!form.formState.isDirty && !foreignKeysDirty)
             }
             className="h-10 px-4 text-sm font-medium bg-zinc-950 text-neutral-50 shadow-sm disabled:opacity-40 dark:bg-emerald-300 dark:text-zinc-950 dark:hover:bg-emerald-400"
           >


### PR DESCRIPTION
## Summary
Closes: #488 
<!-- Briefly describe what this PR does -->
Disables the **Update Table** button when no changes are made.  
Button now only enables when the user edits the table name, columns, or foreign keys.


https://github.com/user-attachments/assets/1e56f224-e72c-4884-bfeb-7300272deee4


## How did you test this change?

<!-- Describe how you tested this PR -->
- Opened *Edit Table* view → Verified **Update Table** is initially disabled.
- Changed table name → button enabled
- Added new column → button enabled
- Added or removed a foreign key → button enabled
- Reverted changes → button disabled again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table form validation: the UI now detects unsaved edits in the foreign keys section, prevents submission until those changes are saved or discarded, and clears the unsaved state when the form is closed or a table is successfully created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->