### PR TITLE
[Fix] Optimize logs page visuals

### DIFF
--- a/frontend/src/features/logs/components/LogsContent.tsx
+++ b/frontend/src/features/logs/components/LogsContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useLogs } from '../hooks/useLogs';
 import { useMcpUsage } from '../hooks/useMcpUsage';
@@ -53,12 +53,20 @@ function formatTime(timestamp: string): string {
 }
 
 export function LogsContent({ source }: LogsContentProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
   const isMcpLogs = source === 'MCP';
-  const [mcpSearchQuery, setMcpSearchQuery] = useState('');
 
   // MCP logs data
-  const { records: mcpLogs, isLoading: mcpLoading, error: mcpError } = useMcpUsage();
+  const {
+    records: mcpLogs,
+    filteredRecords: filteredMcpRecords,
+    searchQuery: mcpSearchQuery,
+    setSearchQuery: setMcpSearchQuery,
+    currentPage: mcpCurrentPage,
+    setCurrentPage: setMcpCurrentPage,
+    totalPages: mcpTotalPages,
+    isLoading: mcpLoading,
+    error: mcpError,
+  } = useMcpUsage();
 
   // Regular logs data
   const {
@@ -72,40 +80,9 @@ export function LogsContent({ source }: LogsContentProps) {
     setCurrentPage,
     totalPages,
     isLoading: logsLoading,
-    isLoadingMore,
-    hasMore,
     error: logsError,
-    loadMoreLogs,
     getSeverity,
   } = useLogs(isMcpLogs ? '' : source);
-
-  // Handle scroll to load more (only for regular logs)
-  const handleScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      if (isMcpLogs) {
-        return;
-      }
-      const { scrollTop } = e.currentTarget;
-      if (scrollTop <= 100 && hasMore && !isLoadingMore) {
-        void loadMoreLogs();
-      }
-    },
-    [isMcpLogs, hasMore, isLoadingMore, loadMoreLogs]
-  );
-
-  // Filtered MCP logs
-  const filteredMcpRecords = useMemo(() => {
-    let filtered = mcpLogs;
-
-    // Apply search filter
-    if (mcpSearchQuery) {
-      filtered = filtered.filter((record) =>
-        record.tool_name.toLowerCase().includes(mcpSearchQuery.toLowerCase())
-      );
-    }
-
-    return filtered;
-  }, [mcpLogs, mcpSearchQuery]);
 
   // MCP columns
   const mcpColumns = useMemo(
@@ -229,7 +206,7 @@ export function LogsContent({ source }: LogsContentProps) {
       </div>
 
       {/* Table */}
-      <div className="flex-1 overflow-auto px-4" ref={scrollRef} onScroll={handleScroll}>
+      <div className="flex-1 overflow-auto px-4">
         {isMcpLogs ? (
           mcpError ? (
             <div className="flex items-center justify-center h-full">
@@ -238,7 +215,7 @@ export function LogsContent({ source }: LogsContentProps) {
           ) : (
             <LogsTable<McpUsageRecord>
               columns={mcpColumns}
-              data={filteredMcpRecords}
+              data={mcpLogs}
               isLoading={mcpLoading}
               emptyMessage={mcpSearchQuery ? 'No MCP logs match your search' : 'No MCP logs found'}
             />
@@ -248,37 +225,41 @@ export function LogsContent({ source }: LogsContentProps) {
             <EmptyState title="Error loading logs" description={String(logsError)} />
           </div>
         ) : (
-          <>
-            <LogsTable<LogSchema>
-              columns={logsColumns}
-              data={paginatedLogs}
-              isLoading={logsLoading}
-              emptyMessage={
-                logsSearchQuery || severityFilter.length < 3
-                  ? 'No logs match your search criteria'
-                  : 'No logs found'
-              }
-            />
-            {isLoadingMore && (
-              <div className="py-4 text-center bg-neutral-800">
-                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white mx-auto" />
-              </div>
-            )}
-          </>
+          <LogsTable<LogSchema>
+            columns={logsColumns}
+            data={paginatedLogs}
+            isLoading={logsLoading}
+            emptyMessage={
+              logsSearchQuery || severityFilter.length < 3
+                ? 'No logs match your search criteria'
+                : 'No logs found'
+            }
+          />
         )}
       </div>
 
-      {/* Footer with Pagination - only for regular logs */}
-      {!isMcpLogs && !logsLoading && filteredLogs.length && (
-        <PaginationControls
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
-          totalRecords={filteredLogs.length}
-          pageSize={100}
-          recordLabel="Logs"
-        />
-      )}
+      {/* Footer with Pagination */}
+      {isMcpLogs
+        ? !mcpLoading && (
+            <PaginationControls
+              currentPage={mcpCurrentPage}
+              totalPages={mcpTotalPages}
+              onPageChange={setMcpCurrentPage}
+              totalRecords={filteredMcpRecords.length}
+              pageSize={50}
+              recordLabel="logs"
+            />
+          )
+        : !logsLoading && (
+            <PaginationControls
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+              totalRecords={filteredLogs.length}
+              pageSize={50}
+              recordLabel="logs"
+            />
+          )}
     </div>
   );
 }

--- a/frontend/src/features/logs/components/LogsTable.tsx
+++ b/frontend/src/features/logs/components/LogsTable.tsx
@@ -56,7 +56,7 @@ export function LogsTable<T = Record<string, unknown>>({
             </div>
           </div>
         ) : !data.length ? (
-          <div className="flex items-center justify-center h-full min-h-[200px]">
+          <div className="flex flex-1 items-center justify-center min-h-[100px]">
             <p className="text-sm text-gray-600 dark:text-neutral-400">{emptyMessage}</p>
           </div>
         ) : (

--- a/frontend/src/features/logs/hooks/useLogs.ts
+++ b/frontend/src/features/logs/hooks/useLogs.ts
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { logService } from '../services/log.service';
 import type { LogSchema } from '@insforge/shared-schemas';
 
-const PAGE_SIZE = 100;
-const FETCH_SIZE = 500;
+const PAGE_SIZE = 50;
+const FETCH_SIZE = 200;
 
 export function useLogs(source: string) {
   const [searchQuery, setSearchQuery] = useState('');

--- a/frontend/src/features/logs/services/usage.service.ts
+++ b/frontend/src/features/logs/services/usage.service.ts
@@ -14,7 +14,7 @@ export class UsageService {
   /**
    * Get MCP usage records
    */
-  async getMcpUsage(success: boolean = true, limit: number = 500): Promise<McpUsageRecord[]> {
+  async getMcpUsage(success: boolean = true, limit: number = 200): Promise<McpUsageRecord[]> {
     const params = new URLSearchParams({
       success: success.toString(),
       limit: limit.toString(),


### PR DESCRIPTION
## Summary

1. Add missing pagination for MCP logs
2. Add missing pagination for source without any logs (to be consistent with current table design)
3. Adjust logs query limit from 500 -> 200, and only show 50 logs per page

<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/b35cf202-4430-4da2-b26e-f78d6e3980ea" />
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/d2f56a92-071d-4cd3-962e-2e752fb3a0c0" />


## How did you test this change?

Tested in local. This is just frontend UI visual adjustments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search and pagination controls now available for MCP logs
  * Explicit pagination controls replace infinite-scroll navigation

* **Refactor**
  * Log page size optimized to 50 records per page
  * Improved empty-state container layout for better flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->