### PR TITLE
[Chore] Fix render 0 problem

### DIFF
--- a/frontend/src/features/database/components/ForeignKeyCell.tsx
+++ b/frontend/src/features/database/components/ForeignKeyCell.tsx
@@ -124,7 +124,7 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
                 </div>
               )}
 
-              {record && schema && columns.length && (
+              {record && schema && columns.length > 0 && (
                 <div className="h-full flex flex-col">
                   {/* Mini DataGrid */}
                   <div className="flex-1">

--- a/frontend/src/features/database/components/TableForm.tsx
+++ b/frontend/src/features/database/components/TableForm.tsx
@@ -530,7 +530,7 @@ export function TableForm({
               </div>
 
               {/* Existing foreign keys */}
-              {foreignKeys.length && (
+              {foreignKeys.length > 0 && (
                 <div className="px-6 pb-6 space-y-3">
                   {foreignKeys.map((fk) => (
                     <div

--- a/frontend/src/features/logs/page/AuditsPage.tsx
+++ b/frontend/src/features/logs/page/AuditsPage.tsx
@@ -278,7 +278,7 @@ export default function AuditsPage() {
                     }
                   />
                 </div>
-                {!isLoading && logsData.length && (
+                {!isLoading && (
                   <PaginationControls
                     currentPage={currentPage}
                     totalPages={Math.ceil(totalRecords / pageSize)}


### PR DESCRIPTION
## Summary

PR #478 is creating rendering issues in frontend
<img width="341" height="206" alt="image" src="https://github.com/user-attachments/assets/ffccd6d1-f400-4a30-81a6-32f0c8f96f03" />

We can't use `{sth.length && < .../>}` to do conditional rendering because react will render 0 if the length is 0. I considered adding `react/jsx-no-leaked-render` eslint rule but it turns out to give too many false positives. So let's just keep caution on this issue.

Actually coderabbit pointed this out but didn't get addressed.

## How did you test this change?

Tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed conditional rendering logic for foreign key-related components to ensure UI elements display only when relevant data is present.
* Improved pagination controls display on the Audits page to show consistently, even when no results are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->