### PR TITLE
[Chore] Disable remaining AI credits for cloud project

### DIFF
--- a/frontend/src/features/ai/page/AIPage.tsx
+++ b/frontend/src/features/ai/page/AIPage.tsx
@@ -14,6 +14,7 @@ import { ModelSelectionDialog } from '@/features/ai/components/ModelSelectionDia
 import { SystemPromptDialog } from '@/features/ai/components/SystemPromptDialog';
 import { AIModelCard } from '@/features/ai/components/AIConfigCard';
 import AIEmptyState from '@/features/ai/components/AIEmptyState';
+import { isInsForgeCloudProject } from '@/lib/utils/utils';
 
 export default function AIPage() {
   const {
@@ -24,7 +25,8 @@ export default function AIPage() {
     deleteConfiguration,
   } = useAIConfigs();
 
-  const { data: credits, error: getAICreditsError } = useAIRemainingCredits();
+  const { data: credits, error: getAICreditsError } =
+    useAIRemainingCredits(!isInsForgeCloudProject());
 
   const { confirm, confirmDialogProps } = useConfirm();
   const { showToast } = useToast();


### PR DESCRIPTION
## Summary

For cloud project, we don't want to show remaining AI credits because this is managed by organization not project.
OSS users can still see it if they provide their own openrouter key.

## How did you test this change?

Tested locally. Tested on cloud.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI credit retrieval to correctly account for project type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->