### PR TITLE
zeabur template fix

### DIFF
--- a/zeabur/template.yml
+++ b/zeabur/template.yml
@@ -316,6 +316,7 @@ spec:
                     default: postgres
                 PGPASSWORD:
                     default: ${POSTGRES_PASSWORD}
+                    expose: true
                 PGRST_OPENAPI_SERVER_PROXY_URI:
                     default: http://localhost:3000
                 PGRST_DB_SCHEMA:
@@ -377,7 +378,7 @@ spec:
                 POSTGRES_USER:
                     default: postgres
                 POSTGRES_PASSWORD:
-                    default: ${POSTGRES_PASSWORD}
+                    default: ${PGPASSWORD}
                 POSTGREST_BASE_URL:
                     default: http://postgrest:3000
                 WORKER_TIMEOUT_MS:
@@ -922,9 +923,9 @@ spec:
                 POSTGRES_USER:
                     default: postgres
                 POSTGRESDB_PASSWORD:
-                    default: ${POSTGRES_PASSWORD}
+                    default: ${PGPASSWORD}
                 DATABASE_URL:
-                    default: postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/insforge
+                    default: postgres://postgres:${PGPASSWORD}@postgres:5432/insforge
                 POSTGREST_BASE_URL:
                     default: http://postgrest:3000
                 # Deno Runtime URL for serverless functions


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
updated the zeabur template and fixed remaining bugs. It will not ask for aws secret keys and ids, as images will be stored in local containers. Also remove the need to generate jwt secrets, as it will be autogenerated


In oss, we use vector container and it creates a volumn to the host 
     `- /var/run/docker.sock:/var/run/docker.sock:ro` 
so it has  access to the host docker daemon located in the ec2.

in k8s, we don't use docker daemon to pull/create images, as we don't have the concept of a host(ec2). instead we have a containerd service. Since we don't have access to underlying zeabur k8s infra, we can't really set up the logs using vector


## How did you test this change?

<!-- Describe how you tested this PR -->

follow zeabur readme: 

npx zeabur@latest template deploy -f template.yml

please first create a project then run the command, else it will fail(bug in cli). Don't try it in the co-working space wifi, it will fail(internet blocked)

Then try out different functionalities, it's slighly laggy but it works 😂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured invocation logging with timestamps, status and duration metrics.
  * Base64 encode/decode utilities made available to function runtimes.
  * Secrets provisioning endpoint exposing active, non-expired secrets.

* **Chores**
  * Bumped core runtime/image to v1.1.6.
  * Standardized JWT handling to a single JWT_SECRET environment variable across services.
  * Removed unused storage and analytics environment defaults; tightened secret selection and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->