### PR TITLE
modify postgres base image, change auth permission for schedule endpo…

### DIFF
--- a/backend/src/api/routes/schedules.ts
+++ b/backend/src/api/routes/schedules.ts
@@ -1,5 +1,5 @@
 import { Router, Response, NextFunction } from 'express';
-import { AuthRequest, verifyUser } from '@/api/middleware/auth.js';
+import { AuthRequest, verifyAdmin } from '@/api/middleware/auth.js';
 import { ScheduleService } from '@/core/schedule/schedule.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/api/middleware/error.js';
@@ -18,7 +18,7 @@ const router = Router();
 const scheduleService = ScheduleService.getInstance();
 
 // All schedule routes require authentication
-router.use(verifyUser);
+router.use(verifyAdmin);
 
 /**
  * GET /api/schedules

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   postgres:
-    build:
-      context: ./docker-init/db
-      dockerfile: Dockerfile.postgres
+    image: ghcr.io/insforge/postgres:v15.13.0
     container_name: insforge-postgres
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${DB_ENCRYPTION_KEY:-dev-key-change-in-production-your-strong-secret-key}'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    #image: postgres:15.13
-    build:
-      context: ./docker-init/db
-      dockerfile: Dockerfile.postgres
+    image: ghcr.io/insforge/postgres:v15.13.0
     container_name: insforge-postgres
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${DB_ENCRYPTION_KEY:-your-strong-secret-key}'
     environment:

--- a/docker-init/db/Dockerfile.postgres
+++ b/docker-init/db/Dockerfile.postgres
@@ -1,6 +1,0 @@
-FROM postgres:15.13
-
-RUN apt-get update && \
-    apt-get install -y postgresql-15-cron postgresql-15-http && \
-    rm -rf /var/lib/apt/lists/*
-


### PR DESCRIPTION
…ints

## Summary

- change docker-compose: use public postgres image instead of build each time;
- change auth permission for schedule endpoints;

## How did you test this change?

test passed on local.
```
curl -X POST http://localhost:7130/api/schedules \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer {your-api-key}" \
    -d '{
		  "name": "Ping insforge.dev",
		  "cronSchedule": "*/5 * * * *",
		  "functionUrl": "https://api.insforge.dev/.well-known/jwks.json",
		  "httpMethod": "GET",
		  "headers": {
		    "Content-Type": "application/json"
		  },
		  "body": {}
		}'



curl -X GET "http://localhost:7130/api/schedules" \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer {your-api-key}"
```
