### PR TITLE
[Chore] Hide users table

### DIFF
--- a/frontend/src/features/database/services/table.service.ts
+++ b/frontend/src/features/database/services/table.service.ts
@@ -13,7 +13,8 @@ export class TableService {
       headers: apiClient.withAccessToken(),
     });
     // data is already unwrapped by request method and should be an array
-    return Array.isArray(data) ? data : [];
+    // Filter out the 'users' table
+    return Array.isArray(data) ? data.filter((table) => table !== 'users') : [];
   }
 
   getAllTableSchemas(): Promise<GetTableSchemaResponse[]> {


### PR DESCRIPTION
Hide users table to avoid confusion. AI agent can still read this table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The 'users' table is no longer displayed in table listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->