### PR TITLE
chore: use fake uuid for anonkey

### DIFF
--- a/backend/src/core/auth/auth.ts
+++ b/backend/src/core/auth/auth.ts
@@ -129,7 +129,7 @@ export class AuthService {
    */
   generateAnonToken(): string {
     const payload = {
-      sub: 'anonymous',
+      sub: '12345678-1234-5678-90ab-cdef12345678',
       email: 'anon@insforge.com',
       role: 'anon',
     };


### PR DESCRIPTION
## Summary

Replace anon uid with a uuid fake string, for uid() in RLS

## How did you test this change?

```
{
  "query": "-- Test if this is a valid UUID\nSELECT '12345678-1234-5678-90ab-cdef12345678'::uuid;"
}

SQL query executed completed successfully:
{
  "rows": [
    {
      "uuid": "12345678-1234-5678-90ab-cdef12345678"
    }
  ],
  "rowCount": 1,
  "fields": [
    {
      "name": "uuid",
      "dataTypeID": 2950
    }
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal authentication token generation for anonymous users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->