### PR TITLE
[Chore] Remove auto collapse

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -12,7 +12,7 @@ interface LayoutProps {
 export default function Layout({ children }: LayoutProps) {
   const { user, logout } = useAuth();
 
-  // Default to collapsed on small screens, expanded on large screens
+  // Sidebar is expanded by default; user can toggle via UI
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const handleToggleCollapse = () => {


### PR DESCRIPTION
## Summary

Remove the logic of auto collapsing the sidebar depending on the screen size


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic sidebar collapse/expand tied to viewport size; the sidebar is now consistently expanded by default.
  * Preserved manual toggle control so users can still collapse/expand the sidebar as desired, ensuring predictable and user-driven layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->