### PR TITLE
fix: updated the prompt dialog height relative to the screen size

### DIFF
--- a/frontend/src/features/dashboard/components/PromptDialog.tsx
+++ b/frontend/src/features/dashboard/components/PromptDialog.tsx
@@ -25,7 +25,7 @@ export function PromptDialog({ open, onOpenChange, promptTemplate }: PromptDialo
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl p-0 bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 overflow-hidden">
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0 bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 overflow-y-auto">
         {/* Content area with border bottom */}
         <div className="flex flex-col gap-10 p-6 border-b border-gray-200 dark:border-neutral-700">
           {/* Header and Prompt Section */}


### PR DESCRIPTION

## Summary

Modified the Prompt dialog component to have a relative screen size and made it scroll able for large sizes. 
fixes #602 

## How did you test this change?

scroll able dialog  

<img width="772" height="584" alt="image" src="https://github.com/user-attachments/assets/40a7874b-2016-4f8c-b249-31464b68fc09" />
<img width="772" height="584" alt="image" src="https://github.com/user-attachments/assets/518ba51f-9488-4c5a-9052-74705955ad4a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog content overflow: dialogs now properly display content that exceeds the visible area, with scrolling enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->