### PR TITLE
[Fix] Include 402 error as well

### DIFF
--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -340,9 +340,13 @@ export class AIClientService {
     try {
       return await request(client);
     } catch (error) {
-      // Check if error is a 403 insufficient credits error in cloud environment
-      if (isCloudEnvironment() && error instanceof OpenAI.APIError && error.status === 403) {
-        logger.info('Received 403 insufficient credits, renewing API key...');
+      // Check if error is a 402/403 insufficient credits error in cloud environment
+      if (
+        isCloudEnvironment() &&
+        error instanceof OpenAI.APIError &&
+        (error.status === 402 || error.status === 403)
+      ) {
+        logger.info(`Received ${error.status} insufficient credits, renewing API key...`);
         await this.renewCloudApiKey();
 
         // Retry with exponential backoff (3 attempts)


### PR DESCRIPTION
## Summary

In some cases openrouter returns 402 error instead of 403. We need to include it as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for insufficient API credits scenarios in cloud environments.
  * Added automatic retry mechanism with exponential backoff when credit-related errors occur.
  * Automatic API key renewal and request retry (up to three attempts) when credentials need refreshing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->