### PR TITLE
add ec2_compute to partnership usage

### DIFF
--- a/docs/partnership.mdx
+++ b/docs/partnership.mdx
@@ -347,7 +347,8 @@ Partner platforms can:
         "total_egress_bytes": 2097152,
         "total_ai_credits": 1.5,
         "total_email_requests": 50,
-        "total_function_calls": 300
+        "total_function_calls": 300,
+        "total_ec2_compute": 3600
       },
       "daily_usage": [
         {
@@ -359,7 +360,8 @@ Partner platforms can:
           "egress_bytes": 204800,
           "ai_credits": 0.15,
           "email_requests": 5,
-          "function_calls": 30
+          "function_calls": 30,
+          "ec2_compute": 3600
         }
       ]
     }


### PR DESCRIPTION
## Summary

add ec2_compute to project's usage under partnership

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added EC2 compute metrics to usage tracking documentation.
* Enhanced usage summaries to include total EC2 compute and daily EC2 compute data fields for improved visibility into resource consumption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->