### PR TITLE
update function timeout to 60 sec

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -138,8 +138,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGREST_BASE_URL=http://postgrest:3000
-      # Worker timeout (30 seconds default)
-      - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-30000}
+      # Worker timeout (60 seconds default)
+      - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-60000}
       # Encryption keys for decrypting function secrets
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,8 +155,8 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGREST_BASE_URL=http://postgrest:3000
-      # Worker timeout (30 seconds default)
-      - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-30000}
+      # Worker timeout (60 seconds default)
+      - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-60000}
       # Encryption keys for decrypting function secrets
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -7,7 +7,7 @@ const port = parseInt(Deno.env.get('PORT') ?? '7133');
 console.log(`Deno serverless runtime running on port ${port}`);
 
 // Configuration
-const WORKER_TIMEOUT_MS = parseInt(Deno.env.get('WORKER_TIMEOUT_MS') ?? '30000');
+const WORKER_TIMEOUT_MS = parseInt(Deno.env.get('WORKER_TIMEOUT_MS') ?? '60000');
 
 // Worker template code - loaded on first use
 let workerTemplateCode: string | null = null;


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

Timeout set to 60 sec.  Originally set to 30 sec as it's not suppoed to run long running workloads since afraid it may exceed ec2 usage limit 🤔。 but apparently ppl are running longer workloads, and it runs successfully.

## How did you test this change?

<!-- Describe how you tested this PR -->
local host function calling still works. Didn't explictly tested the t=30+ second case but changes seems self explanatory,..