### PR TITLE
security: reduce JWT access token expiration to 15 minutes

### DIFF
--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -6,8 +6,8 @@ import { ERROR_CODES, NEXT_ACTION } from '@/types/error-constants.js';
 import type { TokenPayloadSchema } from '@insforge/shared-schemas';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
-// TODO: Change access token expiration time to 15 min
-const JWT_EXPIRES_IN = '7d';
+// RESOLVED: Access token expires in 15 minutes now (changed from 7 days)
+const JWT_EXPIRES_IN = '15m';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 /**

--- a/backend/tests/TESTING_TOKEN_EXPIRATION.md
+++ b/backend/tests/TESTING_TOKEN_EXPIRATION.md
@@ -1,0 +1,212 @@
+# Testing JWT Token Expiration (15 minutes)
+
+This guide explains how to test that the JWT token expiration change from 7 days to 15 minutes works correctly.
+
+## What Changed
+
+- **Access token expiration**: Changed from `7d` to `15m` in `token.manager.ts`
+- **Refresh token expiration**: Still `7d` (unchanged)
+- **Impact**: Access tokens now expire after 15 minutes, requiring refresh token flow for long sessions
+
+## Testing Methods
+
+### Method 1: Run Unit Tests (Recommended)
+
+Run the automated unit tests that verify token expiration:
+
+```bash
+cd backend
+npm test -- token-expiration
+```
+
+**What it tests:**
+- ✅ Access tokens are generated with 15 minute expiration
+- ✅ Valid tokens work correctly
+- ✅ ✅ Expired tokens are rejected
+- ✅ Refresh tokens work correctly
+- ✅ Token refresh flow generates new access tokens
+- ✅ CSRF token generation and verification
+- ✅ Token security (algorithm, claims)
+
+### Method 2: Manual API Testing
+
+Test the actual API endpoints:
+
+#### Prerequisites
+- Backend server running on `http://localhost:7130`
+- Admin credentials configured (default: `admin@example.com` / `change-this-password`)
+
+#### On Unix/Mac:
+```bash
+cd backend
+./tests/manual/test-token-expiration.sh
+```
+
+#### On Windows (PowerShell):
+```powershell
+cd backend
+# You can run the curl commands manually or use Git Bash
+```
+
+#### Manual Steps:
+
+1. **Sign in and get tokens:**
+```bash
+curl -X POST http://localhost:7130/api/auth/signin \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@example.com","password":"change-this-password"}'
+```
+
+2. **Use access token:**
+```bash
+# Extract accessToken from response, then:
+curl -X GET http://localhost:7130/api/auth/me \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+3. **Test refresh token flow:**
+```bash
+# Sign in again to get cookies (refresh token is in httpOnly cookie)
+curl -c cookies.txt -X POST http://localhost:7130/api/auth/signin \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@example.com","password":"change-this-password"}'
+
+# Extract csrfToken from response, then refresh:
+curl -b cookies.txt -X POST http://localhost:7130/api/auth/refresh \
+  -H "X-CSRF-Token: YOUR_CSRF_TOKEN"
+```
+
+4. **Verify token expiration (after 15 minutes):**
+```bash
+# Wait 15+ minutes, then try using the original access token
+curl -X GET http://localhost:7130/api/auth/me \
+  -H "Authorization: Bearer ORIGINAL_ACCESS_TOKEN"
+
+# Should return 401 Unauthorized
+```
+
+### Method 3: Quick Verification Script
+
+Create a simple Node.js script to test token expiration:
+
+```javascript
+// test-token-quick.js
+import { TokenManager } from './src/infra/security/token.manager.js';
+import jwt from 'jsonwebtoken';
+
+const tokenManager = TokenManager.getInstance();
+
+// Generate token
+const token = tokenManager.generateToken({
+  sub: 'test-user',
+  email: 'test@example.com',
+  role: 'authenticated',
+});
+
+// Decode and check expiration
+const decoded = jwt.decode(token, { complete: true });
+const exp = decoded.payload.exp;
+const iat = decoded.payload.iat;
+const expirationSeconds = exp - iat;
+
+console.log(`Token expiration: ${expirationSeconds} seconds (${expirationSeconds / 60} minutes)`);
+console.log(`Expected: 900 seconds (15 minutes)`);
+console.log(`✅ Test ${expirationSeconds >= 895 && expirationSeconds <= 905 ? 'PASSED' : 'FAILED'}`);
+```
+
+Run it:
+```bash
+cd backend
+node --loader tsx test-token-quick.js
+```
+
+## What to Verify
+
+### ✅ Must Pass:
+
+1. **Token Generation**
+   - Access tokens are generated successfully
+   - Token expiration is ~15 minutes (900 seconds)
+
+2. **Token Validation**
+   - Valid tokens work for authenticated requests
+   - Expired tokens are rejected with 401
+
+3. **Refresh Flow**
+   - Refresh endpoint works correctly
+   - New access tokens are generated from refresh tokens
+   - New tokens work for authenticated requests
+
+4. **Security**
+   - Tokens use HS256 algorithm
+   - Required claims are present (sub, email, role, exp, iat)
+   - CSRF protection works
+
+### ⚠️ Edge Cases to Test:
+
+1. **Token Expiration Timing**
+   - Token works immediately after generation
+   - Token expires after 15 minutes
+   - Clock skew tolerance (small time differences)
+
+2. **Refresh Token Rotation**
+   - New refresh token is generated on refresh
+   - Old refresh token can't be reused (if rotation is implemented)
+
+3. **Error Handling**
+   - Invalid tokens are rejected
+   - Expired tokens return proper error messages
+   - Missing tokens return proper error messages
+
+## Expected Results
+
+### ✅ Success Indicators:
+
+- Unit tests pass: `npm test -- token-expiration` ✅
+- Access tokens expire after ~15 minutes
+- Refresh token flow works correctly
+- No breaking changes to existing auth flows
+
+### ❌ Failure Indicators:
+
+- Tokens expire after 7 days (old behavior)
+- Refresh token flow doesn't work
+- Valid tokens are rejected
+- Tests fail
+
+## Troubleshooting
+
+### Issue: Tests fail with "JWT_SECRET not set"
+**Solution:** Set `JWT_SECRET` environment variable:
+```bash
+export JWT_SECRET="your-secret-key-min-32-chars"
+```
+
+### Issue: Token expiration is not 15 minutes
+**Check:**
+1. Verify `JWT_EXPIRES_IN = '15m'` in `token.manager.ts`
+2. Restart the server after changes
+3. Clear any cached tokens
+
+### Issue: Refresh token flow fails
+**Check:**
+1. Refresh token cookie is being sent
+2. CSRF token is included in headers
+3. Refresh token hasn't expired (7 days)
+
+## Next Steps After Testing
+
+Once all tests pass:
+
+1. ✅ Update the TODO comment in `token.manager.ts` (remove or mark as done)
+2. ✅ Commit your changes with tests
+3. ✅ Update any documentation about token expiration
+4. ✅ Consider adding monitoring/alerting for token refresh failures
+
+## Related Files
+
+- `backend/src/infra/security/token.manager.ts` - Token generation/verification
+- `backend/src/api/routes/auth/index.routes.ts` - Auth endpoints (signin, refresh)
+- `backend/tests/unit/token-expiration.test.ts` - Unit tests
+- `backend/tests/manual/test-token-expiration.sh` - Manual test script
+

--- a/backend/tests/manual/test-token-expiration.sh
+++ b/backend/tests/manual/test-token-expiration.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# Test script to verify JWT token expiration (15 minutes)
+# This tests the actual API endpoints to ensure tokens expire correctly
+
+set -e
+
+API_BASE="${TEST_API_BASE:-http://localhost:7130/api}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-change-this-password}"
+
+echo "🧪 Testing JWT Token Expiration (15 minutes)"
+echo "============================================"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test 1: Sign in and get tokens
+echo "📝 Test 1: Sign in and get access token"
+echo "----------------------------------------"
+SIGNIN_RESPONSE=$(curl -s -X POST "${API_BASE}/auth/signin" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"email\": \"${ADMIN_EMAIL}\",
+    \"password\": \"${ADMIN_PASSWORD}\"
+  }")
+
+ACCESS_TOKEN=$(echo "$SIGNIN_RESPONSE" | grep -o '"accessToken":"[^"]*' | cut -d'"' -f4)
+CSRF_TOKEN=$(echo "$SIGNIN_RESPONSE" | grep -o '"csrfToken":"[^"]*' | cut -d'"' -f4)
+
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo -e "${RED}❌ Failed to get access token${NC}"
+  echo "Response: $SIGNIN_RESPONSE"
+  exit 1
+fi
+
+echo -e "${GREEN}✅ Successfully obtained access token${NC}"
+echo "Token (first 20 chars): ${ACCESS_TOKEN:0:20}..."
+echo ""
+
+# Test 2: Use access token to make authenticated request
+echo "📝 Test 2: Use access token for authenticated request"
+echo "-----------------------------------------------------"
+AUTH_RESPONSE=$(curl -s -X GET "${API_BASE}/auth/me" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}")
+
+if echo "$AUTH_RESPONSE" | grep -q "email"; then
+  echo -e "${GREEN}✅ Access token is valid and works${NC}"
+else
+  echo -e "${RED}❌ Access token validation failed${NC}"
+  echo "Response: $AUTH_RESPONSE"
+  exit 1
+fi
+echo ""
+
+# Test 3: Decode token to verify expiration time
+echo "📝 Test 3: Verify token expiration time (should be 15 minutes)"
+echo "---------------------------------------------------------------"
+# Extract payload from JWT (middle part)
+PAYLOAD=$(echo "$ACCESS_TOKEN" | cut -d'.' -f2)
+# Add padding if needed
+case $((${#PAYLOAD} % 4)) in
+  2) PAYLOAD="${PAYLOAD}==" ;;
+  3) PAYLOAD="${PAYLOAD}=" ;;
+esac
+
+# Decode base64 (requires base64 command)
+if command -v base64 &> /dev/null; then
+  DECODED=$(echo "$PAYLOAD" | base64 -d 2>/dev/null || echo "$PAYLOAD" | base64 -D 2>/dev/null)
+  EXP_TIME=$(echo "$DECODED" | grep -o '"exp":[0-9]*' | cut -d':' -f2)
+  IAT_TIME=$(echo "$DECODED" | grep -o '"iat":[0-9]*' | cut -d':' -f2)
+  
+  if [ -n "$EXP_TIME" ] && [ -n "$IAT_TIME" ]; then
+    EXPIRATION_SECONDS=$((EXP_TIME - IAT_TIME))
+    EXPECTED_SECONDS=900  # 15 minutes = 900 seconds
+    
+    echo "Token issued at: $IAT_TIME"
+    echo "Token expires at: $EXP_TIME"
+    echo "Expiration duration: ${EXPIRATION_SECONDS} seconds"
+    
+    if [ "$EXPIRATION_SECONDS" -ge 895 ] && [ "$EXPIRATION_SECONDS" -le 905 ]; then
+      echo -e "${GREEN}✅ Token expiration is correct (~15 minutes)${NC}"
+    else
+      echo -e "${YELLOW}⚠️  Token expiration is ${EXPIRATION_SECONDS}s, expected ~900s${NC}"
+    fi
+  else
+    echo -e "${YELLOW}⚠️  Could not decode token expiration time${NC}"
+  fi
+else
+  echo -e "${YELLOW}⚠️  base64 command not available, skipping expiration check${NC}"
+fi
+echo ""
+
+# Test 4: Test refresh token flow
+echo "📝 Test 4: Test refresh token flow"
+echo "-----------------------------------"
+# Get cookies from signin (refresh token is in httpOnly cookie)
+COOKIE_JAR=$(mktemp)
+curl -s -c "$COOKIE_JAR" -X POST "${API_BASE}/auth/signin" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"email\": \"${ADMIN_EMAIL}\",
+    \"password\": \"${ADMIN_PASSWORD}\"
+  }" > /dev/null
+
+# Get CSRF token from signin response
+SIGNIN_RESPONSE2=$(curl -s -b "$COOKIE_JAR" -X POST "${API_BASE}/auth/signin" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"email\": \"${ADMIN_EMAIL}\",
+    \"password\": \"${ADMIN_PASSWORD}\"
+  }")
+CSRF_TOKEN2=$(echo "$SIGNIN_RESPONSE2" | grep -o '"csrfToken":"[^"]*' | cut -d'"' -f4)
+
+# Use refresh endpoint
+REFRESH_RESPONSE=$(curl -s -b "$COOKIE_JAR" -X POST "${API_BASE}/auth/refresh" \
+  -H "X-CSRF-Token: ${CSRF_TOKEN2}")
+
+NEW_ACCESS_TOKEN=$(echo "$REFRESH_RESPONSE" | grep -o '"accessToken":"[^"]*' | cut -d'"' -f4)
+
+if [ -n "$NEW_ACCESS_TOKEN" ]; then
+  echo -e "${GREEN}✅ Refresh token flow works correctly${NC}"
+  echo "New access token obtained via refresh"
+else
+  echo -e "${RED}❌ Refresh token flow failed${NC}"
+  echo "Response: $REFRESH_RESPONSE"
+  rm -f "$COOKIE_JAR"
+  exit 1
+fi
+
+rm -f "$COOKIE_JAR"
+echo ""
+
+# Test 5: Verify new token works
+echo "📝 Test 5: Verify refreshed token works"
+echo "----------------------------------------"
+NEW_AUTH_RESPONSE=$(curl -s -X GET "${API_BASE}/auth/me" \
+  -H "Authorization: Bearer ${NEW_ACCESS_TOKEN}")
+
+if echo "$NEW_AUTH_RESPONSE" | grep -q "email"; then
+  echo -e "${GREEN}✅ Refreshed access token is valid and works${NC}"
+else
+  echo -e "${RED}❌ Refreshed access token validation failed${NC}"
+  echo "Response: $NEW_AUTH_RESPONSE"
+  exit 1
+fi
+echo ""
+
+# Summary
+echo "============================================"
+echo -e "${GREEN}✅ All token expiration tests passed!${NC}"
+echo ""
+echo "Summary:"
+echo "  ✓ Access tokens are generated with 15 minute expiration"
+echo "  ✓ Access tokens work for authenticated requests"
+echo "  ✓ Refresh token flow works correctly"
+echo "  ✓ Refreshed tokens work for authenticated requests"
+echo ""
+echo "Note: To test actual expiration, wait 15+ minutes and try using"
+echo "      the original access token - it should be rejected."
+

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -1,6 +1,11 @@
 import { beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 
+// Set JWT_SECRET for tests if not already set
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = 'test-secret-key-for-jwt-tokens-min-32-chars';
+}
+
 // Clean up test database before each test
 beforeEach(async () => {
   const testDataDir = './test-data';

--- a/backend/tests/unit/token-expiration.test.ts
+++ b/backend/tests/unit/token-expiration.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TokenManager } from '../../src/infra/security/token.manager.js';
+import jwt from 'jsonwebtoken';
+
+describe('Token Expiration (15 minutes)', () => {
+  let tokenManager: TokenManager;
+  const testUserId = 'test-user-123';
+  const testEmail = 'test@example.com';
+
+  beforeEach(() => {
+    // Ensure JWT_SECRET is set (should be set in setup.ts, but double-check)
+    if (!process.env.JWT_SECRET) {
+      process.env.JWT_SECRET = 'test-secret-key-for-jwt-tokens-min-32-chars';
+    }
+    
+    // Reset the singleton instance to ensure fresh state
+    (TokenManager as any).instance = undefined;
+    tokenManager = TokenManager.getInstance();
+  });
+
+  describe('Access Token Generation and Expiration', () => {
+    it('should generate access token with 15 minute expiration', () => {
+      const token = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe('string');
+
+      // Decode token to verify expiration
+      const decoded = jwt.decode(token) as jwt.JwtPayload;
+      expect(decoded).toBeDefined();
+      expect(decoded.sub).toBe(testUserId);
+      expect(decoded.email).toBe(testEmail);
+      expect(decoded.role).toBe('authenticated');
+
+      // Verify expiration time is approximately 15 minutes (900 seconds)
+      if (decoded.exp && decoded.iat) {
+        const expirationSeconds = decoded.exp - decoded.iat;
+        // Should be 15 minutes = 900 seconds (allow 5 second tolerance)
+        expect(expirationSeconds).toBeGreaterThanOrEqual(895);
+        expect(expirationSeconds).toBeLessThanOrEqual(905);
+      }
+    });
+
+    it('should verify valid access token', () => {
+      const token = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      const payload = tokenManager.verifyToken(token);
+
+      expect(payload.sub).toBe(testUserId);
+      expect(payload.email).toBe(testEmail);
+      expect(payload.role).toBe('authenticated');
+    });
+
+    it('should reject expired access token', () => {
+      // Generate a token with very short expiration (1 second)
+      const shortExpirationToken = jwt.sign(
+        {
+          sub: testUserId,
+          email: testEmail,
+          role: 'authenticated',
+        },
+        process.env.JWT_SECRET!,
+        {
+          algorithm: 'HS256',
+          expiresIn: '1s', // 1 second expiration for testing
+        }
+      );
+
+      // Wait for token to expire
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(() => {
+            tokenManager.verifyToken(shortExpirationToken);
+          }).toThrow();
+          resolve();
+        }, 2000); // Wait 2 seconds to ensure expiration
+      });
+    });
+
+    it('should reject invalid token', () => {
+      const invalidToken = 'invalid.token.here';
+
+      expect(() => {
+        tokenManager.verifyToken(invalidToken);
+      }).toThrow();
+    });
+  });
+
+  describe('Refresh Token Flow', () => {
+    it('should generate refresh token with 7 day expiration', () => {
+      const refreshToken = tokenManager.generateRefreshToken(testUserId);
+
+      expect(refreshToken).toBeDefined();
+      expect(typeof refreshToken).toBe('string');
+
+      // Decode token to verify expiration
+      const decoded = jwt.decode(refreshToken) as jwt.JwtPayload;
+      expect(decoded).toBeDefined();
+      expect(decoded.sub).toBe(testUserId);
+      expect(decoded.type).toBe('refresh');
+      expect(decoded.iss).toBe('insforge');
+
+      // Verify expiration time is approximately 7 days (604800 seconds)
+      if (decoded.exp && decoded.iat) {
+        const expirationSeconds = decoded.exp - decoded.iat;
+        // Should be 7 days = 604800 seconds (allow 60 second tolerance)
+        expect(expirationSeconds).toBeGreaterThanOrEqual(604740);
+        expect(expirationSeconds).toBeLessThanOrEqual(604860);
+      }
+    });
+
+    it('should verify valid refresh token', () => {
+      const refreshToken = tokenManager.generateRefreshToken(testUserId);
+
+      const payload = tokenManager.verifyRefreshToken(refreshToken);
+
+      expect(payload.sub).toBe(testUserId);
+      expect(payload.type).toBe('refresh');
+      expect(payload.iss).toBe('insforge');
+    });
+
+    it('should reject invalid refresh token', () => {
+      const invalidToken = 'invalid.refresh.token';
+
+      expect(() => {
+        tokenManager.verifyRefreshToken(invalidToken);
+      }).toThrow();
+    });
+
+    it('should reject access token used as refresh token', () => {
+      const accessToken = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      expect(() => {
+        tokenManager.verifyRefreshToken(accessToken);
+      }).toThrow();
+    });
+
+    it('should generate new access token from refresh token', () => {
+      const refreshToken = tokenManager.generateRefreshToken(testUserId);
+      const payload = tokenManager.verifyRefreshToken(refreshToken);
+
+      // Simulate what the refresh endpoint does
+      const newAccessToken = tokenManager.generateToken({
+        sub: payload.sub,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      expect(newAccessToken).toBeDefined();
+      const verified = tokenManager.verifyToken(newAccessToken);
+      expect(verified.sub).toBe(testUserId);
+    });
+  });
+
+  describe('Token Expiration Edge Cases', () => {
+    it('should handle token expiration correctly with clock skew tolerance', () => {
+      const token = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      // Token should be valid immediately after generation
+      expect(() => {
+        tokenManager.verifyToken(token);
+      }).not.toThrow();
+    });
+
+    it('should generate CSRF token from refresh token', () => {
+      const refreshToken = tokenManager.generateRefreshToken(testUserId);
+      const csrfToken = tokenManager.generateCsrfToken(refreshToken);
+
+      expect(csrfToken).toBeDefined();
+      expect(typeof csrfToken).toBe('string');
+      expect(csrfToken.length).toBeGreaterThan(0);
+
+      // Verify CSRF token can be verified
+      const isValid = tokenManager.verifyCsrfToken(csrfToken, refreshToken);
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject CSRF token from different refresh token', () => {
+      const refreshToken1 = tokenManager.generateRefreshToken(testUserId);
+      const refreshToken2 = tokenManager.generateRefreshToken('different-user');
+      const csrfToken = tokenManager.generateCsrfToken(refreshToken1);
+
+      const isValid = tokenManager.verifyCsrfToken(csrfToken, refreshToken2);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe('Token Security', () => {
+    it('should use HS256 algorithm for tokens', () => {
+      const token = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      // Decode header to verify algorithm
+      const header = jwt.decode(token, { complete: true })?.header;
+      expect(header?.alg).toBe('HS256');
+    });
+
+    it('should include required claims in access token', () => {
+      const token = tokenManager.generateToken({
+        sub: testUserId,
+        email: testEmail,
+        role: 'authenticated',
+      });
+
+      const decoded = jwt.decode(token) as jwt.JwtPayload;
+      expect(decoded.sub).toBeDefined();
+      expect(decoded.email).toBeDefined();
+      expect(decoded.role).toBeDefined();
+      expect(decoded.exp).toBeDefined();
+      expect(decoded.iat).toBeDefined();
+    });
+
+    it('should include required claims in refresh token', () => {
+      const refreshToken = tokenManager.generateRefreshToken(testUserId);
+
+      const decoded = jwt.decode(refreshToken) as jwt.JwtPayload;
+      expect(decoded.sub).toBeDefined();
+      expect(decoded.type).toBe('refresh');
+      expect(decoded.iss).toBe('insforge');
+      expect(decoded.exp).toBeDefined();
+      expect(decoded.iat).toBeDefined();
+    });
+  });
+});
+


### PR DESCRIPTION
- Change access token expiration from 7d to 15m
- Add unit tests verifying token expiration
- Add manual testing scripts and documentation

Addresses security vulnerability with long-lived access tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Access tokens now expire in 15 minutes instead of 7 days. Refresh token expiration unchanged.

* **Documentation**
  * Added comprehensive testing guide for token expiration covering unit tests, manual API testing, and verification procedures.

* **Tests**
  * Added unit tests for token generation, verification, refresh flows, and expiration handling.
  * Added manual testing script for validating token behavior via API endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->