### PR TITLE
feat/allow user to navigate visualizer through the minimap ui

### DIFF
--- a/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/frontend/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -387,7 +387,13 @@ export function SchemaVisualizer({
             fitViewOptions={{ padding: 1, duration: 300, maxZoom: 2, minZoom: 1 }}
           />
         )}
-        {showMiniMap && <MiniMap nodeColor={(node: Node<CustomNodeData>) => getNodeColor(node)} />}
+        {showMiniMap && (
+          <MiniMap
+            nodeColor={(node: Node<CustomNodeData>) => getNodeColor(node)}
+            pannable
+            zoomable
+          />
+        )}
       </ReactFlow>
     </div>
   );


### PR DESCRIPTION
## Summary

allows the user to drag within the minimap to see parts of the visualizer map that isn't in view

<img width="1764" height="944" alt="Screenshot 2026-01-07 at 11 18 38 AM" src="https://github.com/user-attachments/assets/0fc7f464-99d7-4ce2-9779-2ae0492797dd" />

## How did you test this change?

played around with the functionality in local dev 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MiniMap now supports pan and zoom interactions for improved navigation of schema visualizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->