### PR TITLE
Allow onboarding modal to scroll to fit for short screens.

### DIFF
--- a/frontend/src/features/onboard/components/OnboardingModal.tsx
+++ b/frontend/src/features/onboard/components/OnboardingModal.tsx
@@ -46,18 +46,18 @@ export function OnboardingModal() {
   return (
     <Dialog open={isOnboardingModalOpen} onOpenChange={handleModalClose}>
       <TooltipProvider>
-        <DialogContent className="max-w-[640px] bg-white dark:bg-neutral-800 dark:border-neutral-700 p-0 gap-6">
+        <DialogContent className="max-w-[640px] max-h-[calc(100vh-48px)] flex flex-col bg-white dark:bg-neutral-800 dark:border-neutral-700 p-0 gap-6">
           <DialogTitle className="sr-only">Connect Project</DialogTitle>
 
           {/* Header Section */}
-          <div className="flex flex-col gap-6 px-6 pt-6">
+          <div className="flex flex-col gap-6 px-6 pt-6 shrink-0">
             <h3 className="text-gray-900 dark:text-white text-2xl font-semibold leading-8 tracking-[-0.144px]">
               Connect Project
             </h3>
           </div>
 
           {/* Tab Content */}
-          <div className="flex flex-col gap-10 px-6 overflow-hidden">
+          <div className="flex flex-col gap-10 px-6 overflow-y-auto min-h-0 flex-1">
             <McpConnectionSection apiKey={displayApiKey} appUrl={appUrl} isLoading={isLoading} />
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
@@ -98,7 +98,7 @@ export function OnboardingModal() {
           </div>
 
           {/* Help Section */}
-          <div className="flex items-center justify-between p-6 border-t border-neutral-200 dark:border-neutral-700">
+          <div className="flex items-center justify-between p-6 border-t border-neutral-200 dark:border-neutral-700 shrink-0">
             <Link
               to="/dashboard/settings?tab=connect"
               onClick={() => setOnboardingModalOpen(false)}


### PR DESCRIPTION
## Summary

Based on some session replay, we can see that some users' screen height was not enough to display the full onboarding model. The onboarding modal doesn't have a height-adjustment that will overflow the screen and block the user's interactions. 
Therefore, it is necessary to add a scrollbar in the modal. 

## How did you test this change?

Before this fix:

https://github.com/user-attachments/assets/4c4693b3-5797-4b69-89dd-deb53523183b

After this fix:

https://github.com/user-attachments/assets/b43f3f84-8d9c-4e61-91a6-1e8cac9fb188

Won't affect regular screen:
<img width="1920" height="1030" alt="62465cff-8041-4df4-982f-d163b55797a6" src="https://github.com/user-attachments/assets/de6a9a82-c4e9-4c9b-8a68-6da97083cd42" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OnboardingModal content area now supports smooth scrolling for better handling of extended content.
  * Header and footer elements maintain fixed positioning while content scrolls independently.
  * Layout structure improvements ensure better responsiveness and consistent spacing.
  * Enhanced modal behavior provides improved user experience across varying content lengths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->