### PR TITLE
Fixed bottom menu padding issue

### DIFF
--- a/frontend/src/components/layout/PrimaryMenu.tsx
+++ b/frontend/src/components/layout/PrimaryMenu.tsx
@@ -159,7 +159,7 @@ export function PrimaryMenu({
         <div className="flex-1" />
 
         {/* Bottom items */}
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 pr-2">
           {bottomItems?.map((item) => (
             <BottomMenuItem key={item.id} item={item} />
           ))}


### PR DESCRIPTION
## Summary

This padding change was introduced to push the scroll bar away from menu items due to responsiveness and overflow layer. 
I applied the padding to the top nagivation menu, but forgot to apply with the bottom menu.

## How did you test this change?

Before fix:
<img width="360" height="162" alt="image" src="https://github.com/user-attachments/assets/f1d87cca-6fd7-49ae-bc0d-d4c0f7f84b9d" />

After fix:
<img width="269" height="136" alt="image" src="https://github.com/user-attachments/assets/0157e905-c891-4609-bedf-47d6fd7ab131" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing of bottom menu items for better visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->