### PR TITLE
Hide method selection unless in cloud env

### DIFF
--- a/frontend/src/features/onboard/components/OnboardingModal.tsx
+++ b/frontend/src/features/onboard/components/OnboardingModal.tsx
@@ -58,12 +58,14 @@ export function OnboardingModal() {
             <h3 className="text-gray-900 dark:text-white text-2xl font-semibold leading-8 tracking-[-0.144px]">
               Connect Project
             </h3>
-            {isInsForgeCloudProject() && <InstallMethodTabs
-              tabs={DEFAULT_MODAL_TABS}
-              value={installMethod}
-              onChange={setInstallMethod}
-              className="dark:bg-neutral-900 bg-neutral-200"
-            />}
+            {isInsForgeCloudProject() && (
+              <InstallMethodTabs
+                tabs={DEFAULT_MODAL_TABS}
+                value={installMethod}
+                onChange={setInstallMethod}
+                className="dark:bg-neutral-900 bg-neutral-200"
+              />
+            )}
           </div>
 
           {/* Tab Content */}


### PR DESCRIPTION
## Summary

Hide the onboarding method selection tab unless in cloud env.

## How did you test this change?

<img width="1987" height="1202" alt="image" src="https://github.com/user-attachments/assets/1b8f8e48-0d2d-4513-bb67-4493d561fd5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the onboarding modal to properly handle installation method display based on project type. The tabbed installation method selection now appears only for applicable project configurations, streamlining the onboarding experience and removing unnecessary UI options for projects that don't require them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->