### PR TITLE
Replace soft delete with hard delete for secrets

### DIFF
--- a/backend/src/api/routes/secrets/index.routes.ts
+++ b/backend/src/api/routes/secrets/index.routes.ts
@@ -93,9 +93,9 @@ router.post('/', verifyAdmin, async (req: AuthRequest, res: Response, next: Next
 
     let result: { id: string };
 
-    if (secret !== null && secret?.isActive) {
+    if (secret && secret?.isActive) {
       throw new AppError(`Secret already exists: ${key}`, 409, ERROR_CODES.INVALID_INPUT);
-    } else if (secret !== null && !secret?.isActive && secret?.id) {
+    } else if (secret && !secret?.isActive && secret?.id) {
       const success = await secretService.updateSecret(secret?.id, {
         value,
         isActive: true,


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Fixes #714 

Changed the Soft delete to hard delete to create the secrets with same name

## How did you test this change?

<!-- Describe how you tested this PR -->
1. Created a secret with name `TEST_SECRET` 
<img width="1005" height="541" alt="image" src="https://github.com/user-attachments/assets/1012eb7f-4c48-4a9a-9012-8dc0b7e25fe4" />

2. Deleted it 
<img width="942" height="599" alt="image" src="https://github.com/user-attachments/assets/462deab1-261f-4b0b-9446-f8b75932dae0" />
<img width="867" height="600" alt="image" src="https://github.com/user-attachments/assets/33e1bd99-5014-497a-add6-163d5fc99429" />


3. Created one more with `TEST_SECRET` name.
<img width="1004" height="550" alt="image" src="https://github.com/user-attachments/assets/a477f654-5682-4dad-b32c-bba476610934" />

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a secret now reactivates a matching inactive secret and uses its ID, avoiding duplicates.
  * Attempts to create a secret with an already active key still return an error.
  * Secret creation/update operations reliably return the secret ID used for audit and deployment actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->