### PR TITLE
format log string

### DIFF
--- a/frontend/src/features/logs/pages/LogsPage.tsx
+++ b/frontend/src/features/logs/pages/LogsPage.tsx
@@ -66,8 +66,7 @@ export default function LogsPage() {
         renderCell: ({ row }) => {
           // Prioritize body.event_message since body contains the parsed log object
           const body = row.body as Record<string, unknown> | undefined;
-          const displayMessage =
-            (body?.event_message as string) || String(row.eventMessage ?? '');
+          const displayMessage = (body?.event_message as string) || String(row.eventMessage ?? '');
 
           return (
             <p className="text-sm text-gray-900 dark:text-white font-normal leading-6 truncate">


### PR DESCRIPTION
## Summary

format logs, only display event_message for readability.

## How did you test this change?

test passed in local.
<img width="1504" height="445" alt="截屏2026-02-04 19 15 12" src="https://github.com/user-attachments/assets/4783d654-43a0-4589-a08e-bc2fe8631b54" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log message display in the Logs table: the first column now preferentially shows the more complete event message when available, falling back to the previous value if not. Styling and column width behavior are preserved so messages display consistently and remain readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->