### PR TITLE
modify ratelimiter

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -71,8 +71,9 @@ export async function createApp() {
 
   const limiter = rateLimit({
     windowMs: 15 * 60 * 1000,
-    max: 1000,
+    max: 3000,
     message: 'Too many requests from this IP',
+    skip: (req) => req.path === '/api/health',
   });
 
   // Basic middleware


### PR DESCRIPTION
## Summary

modify ratelimiter: enable 3QPS per IP, and doesn't limit /api/health endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased API rate limit capacity from 1000 to 3000 requests to support higher traffic
  * Health check endpoint now bypasses rate limiting to ensure reliable service monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->