### PR TITLE
feat: add file size limit info to bucket edit dialog (Cloud only)

### DIFF
--- a/frontend/src/features/storage/components/BucketFormDialog.tsx
+++ b/frontend/src/features/storage/components/BucketFormDialog.tsx
@@ -163,7 +163,7 @@ export function BucketFormDialog({
                   File Size Limit
                 </Label>
                 <div className="w-70 flex flex-col gap-1">
-                  <p className="text-sm text-zinc-950 dark:text-white">10MB per file</p>
+                  <p className="text-sm text-zinc-950 dark:text-white">50MB per file</p>
                   <p className="text-xs font-medium text-zinc-500 dark:text-neutral-400">
                     Need a higher limit? Reach out to us on{' '}
                     <a


### PR DESCRIPTION
## Summary
- Add file size limit info (10MB per file) to bucket edit modal
- Only visible for Cloud version users
- Include Discord link for users who need higher limits

## Test plan
- [ ] Open Storage page
- [ ] Click edit button on a bucket
- [ ] Verify "File Size Limit" section appears (Cloud only)
- [ ] Verify Discord link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File Size Limit information now displays when editing buckets in InsForge Cloud projects, including a disclaimer and Discord contact option for support inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->