### PR TITLE
ci/cd: push image to ecr

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -98,8 +98,10 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_tag || github.ref_name }}
-          GHCR_IMAGE: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          GHCR_IMAGE_RAW: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           ECR_IMAGE: ${{ steps.ecr-login.outputs.registry }}/${{ env.IMAGE_NAME }}
         run: |
+          # Convert GHCR image name to lowercase (Docker requires lowercase)
+          GHCR_IMAGE=$(echo "${GHCR_IMAGE_RAW}" | tr '[:upper:]' '[:lower:]')
           # Copy multi-arch image from GHCR to ECR (preserves all platforms)
           crane copy ${GHCR_IMAGE}:${VERSION} ${ECR_IMAGE}:${VERSION}


### PR DESCRIPTION
## Summary

push image to ECR for cross-region deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed and simplified the container image workflow and image naming.
  * Shifted primary registry to GitHub Container Registry and updated login/build steps.
  * Renamed metadata and build/push steps for clarity.
  * Added a tag-triggered replication job to copy multi-arch images from GHCR to AWS ECR (preserves platforms), including re-auth and tooling install.
  * Minor formatting and step refinements; secret usage unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->