### PR TITLE
chore: exclude docs images/videos from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,7 +24,7 @@ npm-debug.log*
 .git/
 .gitignore
 *.md
-docs/
+docs/**
 !docs/agent-docs/**
 !docs/sdks/**
 !docs/snippets/**


### PR DESCRIPTION
Only include agent-docs, sdks, snippets, and instructions file that the backend actually serves. reduce docker image size = faster speed, cheaper network cost



## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

pushed a tag

image size  previously 684 MB

image size is now 622MB                        

functionality: reading agent docs + reading docs still works


In the future we can throughly analyze image size  + all packages. Pretty sure there are a lot of optimization.. but not too urgent as of now.


tested it still reads docs correctly

<img width="261" height="878" alt="Screenshot 2026-02-19 at 11 41 40" src="https://github.com/user-attachments/assets/450bb40f-d8ec-484c-aab1-b4568d01e5f2" />

<img width="293" height="1054" alt="Screenshot 2026-02-19 at 11 57 15" src="https://github.com/user-attachments/assets/26210cb1-8343-4b59-b334-4c06954d4c11" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build behavior for documentation: most docs are now excluded from container builds, while key sections (agent docs, SDKs, code snippets, and specific integration instructions) are explicitly retained to ensure essential documentation stays packaged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->