### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [InsForge]


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to display the "Sponsor" button on the repository page
- Links to the existing InsForge GitHub Sponsors page (https://github.com/sponsors/InsForge)


this is referenced through https://github.com/supabase/supabase/blob/master/.github/FUNDING.yml

<img width="306" height="164" alt="Screenshot 2026-02-15 at 16 58 46" src="https://github.com/user-attachments/assets/98e3a4bf-8e44-4bbe-85ec-07be74074ef3" />
we should be able to see this after mergving

## Test plan
- [x] Verify the "Sponsor" button appears on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository funding configuration.

*Note: This is an administrative update with no changes to user-facing features or functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->