### PR TITLE
chore: add GitHub links to docs sidebar and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ---
 
+<p align="center">⭐ <b>Star us on GitHub</b> to get notified about new releases!</p>
+
 <!-- LINK GROUPS -->
 
 [docker-btn]: ./deploy/buttons/docker.png

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -247,6 +247,11 @@
           "anchor": "Roadmap",
           "href": "https://feedback.insforge.dev/roadmap",
           "icon": "route"
+        },
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/InsForge",
+          "icon": "github"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Added GitHub link to docs sidebar (below Community, Blog, Roadmap)
- Added "Star us on GitHub" callout to the bottom of the README


Every of our extenal site should backlink to our github

efforts to increase github stars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with promotional call-to-action content sections for improved visibility.
  * Added GitHub repository link to the global documentation navigation menu for direct access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->