### PR TITLE
docs: add Made with InsForge badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,66 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 [![Star History Chart](https://api.star-history.com/svg?repos=InsForge/insforge&type=Date)](https://www.star-history.com/#InsForge/insforge&Date)
 
+## Badges
+
+Show your project is built with InsForge.
+
+### Made with InsForge
+
+<a href="https://insforge.dev">
+  <img
+    width="168"
+    height="30"
+    src="https://insforge.dev/badge-made-with-insforge.svg"
+    alt="Made with InsForge"
+  />
+</a>
+
+**Markdown:**
+```md
+[![Made with InsForge](https://insforge.dev/badge-made-with-insforge.svg)](https://insforge.dev)
+```
+
+**HTML:**
+```html
+<a href="https://insforge.dev">
+  <img
+    width="168"
+    height="30"
+    src="https://insforge.dev/badge-made-with-insforge.svg"
+    alt="Made with InsForge"
+  />
+</a>
+```
+
+### Made with InsForge (dark)
+
+<a href="https://insforge.dev">
+  <img
+    width="168"
+    height="30"
+    src="https://insforge.dev/badge-made-with-insforge-dark.svg"
+    alt="Made with InsForge"
+  />
+</a>
+
+**Markdown:**
+```md
+[![Made with InsForge](https://insforge.dev/badge-made-with-insforge-dark.svg)](https://insforge.dev)
+```
+
+**HTML:**
+```html
+<a href="https://insforge.dev">
+  <img
+    width="168"
+    height="30"
+    src="https://insforge.dev/badge-made-with-insforge-dark.svg"
+    alt="Made with InsForge"
+  />
+</a>
+```
+
 ## Translations
 
 - [Arabic | العربية](/i18n/README.ar.md)


### PR DESCRIPTION
## Summary
- Add a **Badges** section to the README with light and dark "Made with InsForge" badge variants
- Includes markdown and HTML embed snippets for easy copy-paste
- Badge SVGs are served from insforge.dev (added in InsForge/insforge-cloud#296)

## Test plan
- [x] Verify badges render in the README once insforge-cloud PR is deployed
- [x] Confirm embed snippets are correct and copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Made with InsForge" badge sections with standard and dark variants, including Markdown and HTML embedding examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->