### PR TITLE
fixed: /api/deployments/slug doesn't work due to the order of declaration

### DIFF
--- a/backend/src/api/routes/deployments/index.routes.ts
+++ b/backend/src/api/routes/deployments/index.routes.ts
@@ -135,6 +135,38 @@ router.get(
 );
 
 /**
+ * Update custom slug for the project
+ * PUT /api/deployments/slug
+ */
+router.put('/slug', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const validationResult = updateSlugRequestSchema.safeParse(req.body);
+    if (!validationResult.success) {
+      throw new AppError(
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    const result = await deploymentService.updateSlug(validationResult.data.slug);
+
+    // Log audit
+    await auditService.log({
+      actor: req.user?.email || 'api-key',
+      action: 'UPDATE_DEPLOYMENT_SLUG',
+      module: 'DEPLOYMENTS',
+      details: { slug: result.slug, domain: result.domain },
+      ip_address: req.ip,
+    });
+
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
  * Get deployment by database ID
  * GET /api/deployments/:id
  */
@@ -209,37 +241,5 @@ router.post(
     }
   }
 );
-
-/**
- * Update custom slug for the project
- * PUT /api/deployments/slug
- */
-router.put('/slug', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const validationResult = updateSlugRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
-    }
-
-    const result = await deploymentService.updateSlug(validationResult.data.slug);
-
-    // Log audit
-    await auditService.log({
-      actor: req.user?.email || 'api-key',
-      action: 'UPDATE_DEPLOYMENT_SLUG',
-      module: 'DEPLOYMENTS',
-      details: { slug: result.slug, domain: result.domain },
-      ip_address: req.ip,
-    });
-
-    successResponse(res, result);
-  } catch (error) {
-    next(error);
-  }
-});
 
 export { router as deploymentsRouter };


### PR DESCRIPTION
## Summary

change the declaration order for /api/deployments/slug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate deployment slug update endpoint for improved code maintainability while preserving existing functionality and behavior including admin verification, validation, and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->