### PR TITLE
fix: allow admin refresh token without admin record

### DIFF
--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -1281,11 +1281,16 @@ export class AuthService {
    * Delete multiple users by IDs
    */
   async deleteUsers(userIds: string[]): Promise<number> {
+    const filtered = userIds.filter((id) => id !== ADMIN_ID);
+    if (filtered.length === 0) {
+      return 0;
+    }
+
     const pool = this.getPool();
-    const placeholders = userIds.map((_, i) => `$${i + 1}`).join(',');
+    const placeholders = filtered.map((_, i) => `$${i + 1}`).join(',');
     const result = await pool.query(
       `DELETE FROM auth.users WHERE id IN (${placeholders})`,
-      userIds
+      filtered
     );
 
     return result.rowCount || 0;


### PR DESCRIPTION
## Summary

allow admin access dashboard even without admin record in auth.users.

## How did you test this change?

- [x] delete admin record from auth.users
- [x] admin login dashboard
- [x] admin access tables and do some operations as previous.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin account is now reliably available even if its record is missing.
  * Prevented accidental deletion of the admin account when bulk-deleting users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->