### PR TITLE
docs: remove coming soon label from Sealos deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ I'm using InsForge as my backend platform, call InsForge MCP's fetch-docs tool t
 
 In addition to running InsForge locally, you can also launch InsForge using a pre-configured setup. This allows you to get up and running quickly with InsForge without installing Docker on your local machine.
 
-| Railway | Zeabur | Sealos (coming soon) |
+| Railway | Zeabur | Sealos |
 | --- | --- | --- |
 | [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/insforge) | [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Q82M3Y) | [![Deploy on Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://template.hzh.sealos.run/deploy?templateName=insforge) |
 


### PR DESCRIPTION
## Summary
- Removes the "(coming soon)" label from the Sealos deployment option in the README, as Sealos deployment is now available.

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the One-click Deployment table to reflect the current availability status of the Sealos deployment option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->