### PR TITLE
docs: update Sealos one-click deploy link and icon URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In addition to running InsForge locally, you can also launch InsForge using a pr
 
 | Railway | Zeabur | Sealos |
 | --- | --- | --- |
-| [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/insforge) | [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Q82M3Y) | [![Deploy on Sealos](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://template.hzh.sealos.run/deploy?templateName=insforge) |
+| [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/insforge) | [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Q82M3Y) | [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/insforge) |
 
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Update Sealos one-click deployment link to https://sealos.io/products/app-store/insforge
- Update Sealos icon URL to https://sealos.io/Deploy-on-Sealos.svg

## Files
- README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sealos one-click deployment button with new deployment link and resources for streamlined cloud deployment access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->