### PR TITLE
Add Trendshift badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
   <a href="https://vercel.com/oss">
     <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
   </a>
+  <br />
+  <a href="https://trendshift.io/repositories/19834" target="_blank">
+    <img src="https://trendshift.io/api/badge/repositories/19834" alt="InsForge%2FInsForge | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
+  </a>
 </div>
 
 ## InsForge


### PR DESCRIPTION
## Summary
- Adds Trendshift trending repository badge to the README header, placed after the Vercel OSS badge

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify badge links to the correct Trendshift page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Trendshift badge to the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->