### PR TITLE
feat: persist Tables page column widths

### DIFF
--- a/frontend/src/components/datagrid/DataGrid.tsx
+++ b/frontend/src/components/datagrid/DataGrid.tsx
@@ -35,6 +35,7 @@ export interface DataGridProps<TRow extends DataGridRowType = DataGridRow> {
   onSelectedRowsChange?: (selectedRows: Set<string>) => void;
   sortColumns?: SortColumn[];
   onSortColumnsChange?: (sortColumns: SortColumn[]) => void;
+  onColumnResize?: (columnKey: string, width: number) => void;
   onCellClick?: (args: CellClickArgs<TRow>, event: CellMouseEvent) => void;
   currentPage?: number;
   totalPages?: number;
@@ -76,6 +77,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   onSelectedRowsChange,
   sortColumns,
   onSortColumnsChange,
+  onColumnResize,
   onCellClick,
   currentPage,
   totalPages,
@@ -245,6 +247,22 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
     selectionHeaderLabel,
   ]);
 
+  const handleGridColumnResize = useCallback(
+    (idx: number, width: number) => {
+      if (!onColumnResize) {
+        return;
+      }
+
+      const column = gridColumns[idx];
+      if (!column || column.key === SELECT_COLUMN_KEY) {
+        return;
+      }
+
+      onColumnResize(String(column.key), width);
+    },
+    [gridColumns, onColumnResize]
+  );
+
   // Loading state - only show full loading screen if not sorting
   if (loading && !isSorting) {
     return (
@@ -277,6 +295,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             onSelectedRowsChange={onSelectedRowsChange}
             sortColumns={sortColumns || []}
             onSortColumnsChange={onSortColumnsChange}
+            onColumnResize={handleGridColumnResize}
             onCellClick={onCellClick}
             rowClass={rowClass}
             className={cn(

--- a/frontend/src/features/database/components/DatabaseDataGrid.tsx
+++ b/frontend/src/features/database/components/DatabaseDataGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   DataGrid,
   createDefaultCellRenderer,
@@ -18,6 +18,77 @@ import { ForeignKeyCell } from './ForeignKeyCell';
 // Create a type adapter for database records
 // Database records are dynamic and must have string id for DataGrid compatibility
 type DatabaseDataGridRow = DataGridRowType;
+
+type PersistedColumnWidths = Record<string, number>;
+
+interface DatabaseGridPreferences {
+  columnWidthsByTable?: Record<string, PersistedColumnWidths>;
+}
+
+const DATABASE_GRID_PREFERENCES_STORAGE_KEY = 'database-grid-preferences';
+const DEFAULT_COLUMN_WIDTH = 'minmax(200px, 1fr)';
+
+function loadPersistedColumnWidths(
+  tableName?: string,
+  schema?: TableSchema
+): PersistedColumnWidths {
+  if (typeof window === 'undefined' || !tableName) {
+    return {};
+  }
+
+  try {
+    const stored = localStorage.getItem(DATABASE_GRID_PREFERENCES_STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+
+    const parsed = JSON.parse(stored) as DatabaseGridPreferences;
+    const savedWidths = parsed.columnWidthsByTable?.[tableName];
+    if (!savedWidths || typeof savedWidths !== 'object') {
+      return {};
+    }
+
+    const validColumnNames = new Set(schema?.columns.map((column) => column.columnName) ?? []);
+
+    return Object.fromEntries(
+      Object.entries(savedWidths).filter(
+        ([columnName, width]) =>
+          validColumnNames.has(columnName) &&
+          typeof width === 'number' &&
+          Number.isFinite(width) &&
+          width > 0
+      )
+    );
+  } catch (error) {
+    console.error('Failed to load database grid widths from localStorage:', error);
+    return {};
+  }
+}
+
+function persistColumnWidths(tableName: string, columnWidths: PersistedColumnWidths) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const stored = localStorage.getItem(DATABASE_GRID_PREFERENCES_STORAGE_KEY);
+    const parsed = stored ? (JSON.parse(stored) as DatabaseGridPreferences) : {};
+    const columnWidthsByTable = {
+      ...(parsed.columnWidthsByTable ?? {}),
+      [tableName]: columnWidths,
+    };
+
+    localStorage.setItem(
+      DATABASE_GRID_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        ...parsed,
+        columnWidthsByTable,
+      })
+    );
+  } catch (error) {
+    console.error('Failed to save database grid widths to localStorage:', error);
+  }
+}
 
 // Custom cell editor wrapper components that handle database-specific logic
 function DatabaseTextCellEditor({
@@ -175,7 +246,8 @@ function DatabaseJsonCellEditor({
 export function convertSchemaToColumns(
   schema?: TableSchema,
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>,
-  onJumpToTable?: (tableName: string) => void
+  onJumpToTable?: (tableName: string) => void,
+  columnWidths: PersistedColumnWidths = {}
 ): DataGridColumn<DatabaseDataGridRow>[] {
   if (!schema?.columns) {
     return [];
@@ -205,7 +277,7 @@ export function convertSchemaToColumns(
       key: col.columnName,
       name: col.columnName,
       type: col.type as ColumnType,
-      width: 'minmax(200px, 1fr)',
+      width: columnWidths[col.columnName] ?? DEFAULT_COLUMN_WIDTH,
       resizable: true,
       sortable: isSortable,
       editable: isEditable,
@@ -297,14 +369,47 @@ export function DatabaseDataGrid({
   onJumpToTable,
   ...props
 }: DatabaseDataGridProps) {
+  const tableName = schema?.tableName;
+  const schemaSignature = useMemo(
+    () => schema?.columns.map((column) => column.columnName).join('|') ?? '',
+    [schema]
+  );
+  const [columnWidths, setColumnWidths] = useState<PersistedColumnWidths>(() =>
+    loadPersistedColumnWidths(tableName, schema)
+  );
+
+  useEffect(() => {
+    setColumnWidths(loadPersistedColumnWidths(tableName, schema));
+  }, [schema, schemaSignature, tableName]);
+
+  const handleColumnResize = useCallback(
+    (columnKey: string, width: number) => {
+      if (!tableName || !Number.isFinite(width) || width <= 0) {
+        return;
+      }
+
+      setColumnWidths((previous) => {
+        const next = {
+          ...previous,
+          [columnKey]: width,
+        };
+
+        persistColumnWidths(tableName, next);
+        return next;
+      });
+    },
+    [tableName]
+  );
+
   const columns = useMemo(() => {
-    return convertSchemaToColumns(schema, onCellEdit, onJumpToTable);
-  }, [schema, onCellEdit, onJumpToTable]);
+    return convertSchemaToColumns(schema, onCellEdit, onJumpToTable, columnWidths);
+  }, [schema, onCellEdit, onJumpToTable, columnWidths]);
 
   return (
     <DataGrid<DatabaseDataGridRow>
       {...props}
       columns={columns}
+      onColumnResize={handleColumnResize}
       showSelection={true}
       showPagination={true}
     />


### PR DESCRIPTION
## Summary
- persist resized Tables page column widths in localStorage per table and per column
- restore saved widths when reopening the same table while falling back to defaults for new or changed columns
- thread column resize events through the shared DataGrid wrapper so DatabaseDataGrid can save width updates safely

## Testing
- `npx eslint frontend/src/components/datagrid/DataGrid.tsx frontend/src/features/database/components/DatabaseDataGrid.tsx`
- `npm run typecheck:frontend`
- `npm run build:frontend`

Closes #847


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Data grid columns are now resizable, enabling users to adjust column widths to better view their data.
  * Column width adjustments are automatically saved and restored per table, eliminating the need to reconfigure the view on each visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->