### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ci-premerge-check.yml
+++ b/.github/workflows/ci-premerge-check.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Build Docker image
       uses: docker/build-push-action@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create .env file
         run: |

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4, actions/setup-node@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v4...v6) | build-image.yml, ci-premerge-check.yml, e2e.yml, lint-and-format.yml, unit-tests.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Diff](https://github.com/actions/setup-node/compare/v4...v6) | lint-and-format.yml, unit-tests.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Release Notes

<details>
<summary>Release notes for actions/checkout</summary>

### [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)

## What's Changed
* Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by @TingluoHuang in https://github.com/actions/checkout/pull/2355
* Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356

**Full Changelog**: https://github.com/actions/checkout/compare/v6.0.1...v6.0.2

### [v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)

## What's Changed
* Update all references from v5 and v4 to v6 by @ericsciple in https://github.com/actions/checkout/pull/2314
* Add worktree support for persist-credentials includeIf by @ericsciple in https://github.com/actions/checkout/pull/2327
* Clarify v6 README by @ericsciple in https://github.com/actions/checkout/pull/2328


**Full Changelog**: https://github.com/actions/checkout/compare/v6...v6.0.1

### [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

## What's Changed
* Update README to include Node.js 24 support details and requirements by @salmanmkc in https://github.com/actions/checkout/pull/2248
* Persist creds to a separate file by @ericsciple in https://github.com/actions/checkout/pull/2286
* v6-beta by @ericsciple in https://github.com/actions/checkout/pull/2298
* update readme/changelog for v6 by @ericsciple in https://github.com/actions/checkout/pull/2311


**Full Changelog**: https://github.com/actions/checkout/compare/v5.0.

*...truncated*

### [v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)

## What's Changed
* Port v6 cleanup to v5 by @ericsciple in https://github.com/actions/checkout/pull/2301


**Full Changelog**: https://github.com/actions/checkout/compare/v5...v5.0.1

### [v4.3.1](https://github.com/actions/checkout/releases/tag/v4.3.1)

## What's Changed
* Port v6 cleanup to v4 by @ericsciple in https://github.com/actions/checkout/pull/2305


**Full Changelog**: https://github.com/actions/checkout/compare/v4...v4.3.1

</details>

<details>
<summary>Release notes for actions/setup-node</summary>

### [v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0)

## What's Changed

### Enhancements:
* Support parsing `devEngines` field by @susnux in https://github.com/actions/setup-node/pull/1283
>  When using node-version-file: package.json, setup-node now prefers devEngines.runtime over engines.node.

### Dependency updates:
* Fix npm audit issues by @gowridurgad in https://github.com/actions/setup-node/pull/1491
* Replace uuid with crypto.randomUUID() by @trivikr in https://github.com/actions/setup-node/pull/1378
* Upgrade minimatch from 3.1.

*...truncated*

### [v6.2.0](https://github.com/actions/setup-node/releases/tag/v6.2.0)

## What's Changed

### Documentation
* Documentation update related to absence of Lockfile by @mahabaleshwars in https://github.com/actions/setup-node/pull/1454
* Correct mirror option typos by @MikeMcC399 in https://github.com/actions/setup-node/pull/1442
* Readme update on checkout version v6 by @deining in https://github.com/actions/setup-node/pull/1446
* Readme typo fixes @munyari in https://github.com/actions/setup-node/pull/1226
* Advanced document update on checkout version v6 by @

*...truncated*

### [v6.1.0](https://github.com/actions/setup-node/releases/tag/v6.1.0)

## What's Changed
### Enhancement:
* Remove always-auth configuration handling by @priyagupta108 in https://github.com/actions/setup-node/pull/1436

### Dependency updates:
* Upgrade @actions/cache from 4.0.3 to 4.1.0 by @dependabot[bot] in https://github.com/actions/setup-node/pull/1384
* Upgrade actions/checkout from 5 to 6 by @dependabot[bot] in https://github.com/actions/setup-node/pull/1439
* Upgrade js-yaml from 3.14.1 to 3.14.2 by @dependabot[bot] in https://github.com/actions/setu

*...truncated*

### [v6.0.0](https://github.com/actions/setup-node/releases/tag/v6.0.0)

## What's Changed

**Breaking Changes**

- Limit automatic caching to npm, update workflows and documentation by @priyagupta108 in https://github.com/actions/setup-node/pull/1374

**Dependency Upgrades**

- Upgrade ts-jest from 29.1.2 to 29.4.1 and document breaking changes in v5 by @dependabot[bot] in [#1336](https://github.com/actions/setup-node/pull/1336)
- Upgrade prettier from 2.8.8 to 3.6.2 by @dependabot[bot] in [#1334](https://github.com/actions/setup-node/pull/1334)
- Upgrade 

*...truncated*

### [v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)

## What's Changed

### Breaking Changes
* Enhance caching in setup-node with automatic package manager detection by @priya-kinthali in https://github.com/actions/setup-node/pull/1348

This update, introduces automatic caching when a valid `packageManager` field is present in your `package.json`. This aims to improve workflow performance and make dependency management more seamless. 
To disable this automatic caching, set `package-manager-cache: false`
```yaml
steps:
- uses: actions/chec

*...truncated*

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.

## Validation Warnings

The following issues were detected by [actionlint](https://github.com/rhysd/actionlint):

- `build-image.yml: .github/workflows/build-image.yml:103:9: shellcheck reported issue in this script: SC2086:info:4:12: Double quote to prevent globbing and word splitting [shellcheck]`
- `build-image.yml: |`
- `build-image.yml: 103 |         run: |`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure dependencies to newer versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->