### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract metadata for GHCR
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -50,7 +50,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ECR_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_ECR_REGION }}
@@ -85,14 +85,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Install crane
-        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987  # v0.5
 
       - name: Copy multi-arch image to ECR
         env:

--- a/.github/workflows/ci-premerge-check.yml
+++ b/.github/workflows/ci-premerge-check.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Build Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: false


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `aws-actions/configure-aws-credentials` | [`v4`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4) | [`v6`](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6) | [Diff](https://github.com/aws-actions/configure-aws-credentials/compare/v4...v6) | build-image.yml |
| `docker/build-push-action` | [`v5`](https://github.com/docker/build-push-action/releases/tag/v5) | [`v7`](https://github.com/docker/build-push-action/releases/tag/v7) | [Diff](https://github.com/docker/build-push-action/compare/v5...v7) | build-image.yml, ci-premerge-check.yml |
| `docker/login-action` | [`v3`](https://github.com/docker/login-action/releases/tag/v3) | [`v4`](https://github.com/docker/login-action/releases/tag/v4) | [Diff](https://github.com/docker/login-action/compare/v3...v4) | build-image.yml |
| `docker/metadata-action` | [`v5`](https://github.com/docker/metadata-action/releases/tag/v5) | [`v6`](https://github.com/docker/metadata-action/releases/tag/v6) | [Diff](https://github.com/docker/metadata-action/compare/v5...v6) | build-image.yml |
| `docker/setup-buildx-action` | [`v3`](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-buildx-action/releases/tag/v4) | [Diff](https://github.com/docker/setup-buildx-action/compare/v3...v4) | build-image.yml |
| `docker/setup-qemu-action` | [`v3`](https://github.com/docker/setup-qemu-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-qemu-action/releases/tag/v4) | [Diff](https://github.com/docker/setup-qemu-action/compare/v3...v4) | build-image.yml |
| `imjasonh/setup-crane` | [`31b88ef`](https://github.com/imjasonh/setup-crane/commit/31b88efe9de28ae0ffa220711af4b60be9435f6e) | [`6da1ae0`](https://github.com/imjasonh/setup-crane/commit/6da1ae018866400525525ce74ff892880c099987) | [Diff](https://github.com/imjasonh/setup-crane/compare/31b88efe9de2...6da1ae018866) | build-image.yml |

## Release Notes

<details>
<summary>Release notes for docker/setup-qemu-action</summary>

### [v4.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/setup-qemu-action/pull/245
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/setup-qemu-action/pull/241
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/setup-qemu-action/pull/244
* Bump @docker/actions-toolkit from 0.67.0 to 0.77.0 in https://github.com/docker

*...truncated*

### [v3.7.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.7.0)

* Bump @docker/actions-toolkit from 0.56.0 to 0.67.0 in https://github.com/docker/setup-qemu-action/pull/217 https://github.com/docker/setup-qemu-action/pull/230
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/setup-qemu-action/pull/220
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/setup-qemu-action/pull/218
* Bump tmp from 0.2.3 to 0.2.4 in https://github.com/docker/setup-qemu-action/pull/221
* Bump undici from 5.28.4 to 5.29.0 in https://github

*...truncated*

### [v3.6.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0)

* Display binfmt version by @crazy-max in https://github.com/docker/setup-qemu-action/pull/202

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.5.0...v3.6.0

### [v3.5.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.5.0)

* Bump @docker/actions-toolkit from 0.54.0 to 0.56.0 in https://github.com/docker/setup-qemu-action/pull/205

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.4.0...v3.5.0

### [v3.4.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.4.0)

* Bump @docker/actions-toolkit from 0.49.0 to 0.54.0 in https://github.com/docker/setup-qemu-action/pull/193 https://github.com/docker/setup-qemu-action/pull/197

**Full Changelog**: https://github.com/docker/setup-qemu-action/compare/v3.3.0...v3.4.0

</details>

<details>
<summary>Release notes for docker/setup-buildx-action</summary>

### [v4.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/setup-buildx-action/pull/483
* Remove deprecated inputs/outputs by @crazy-max in https://github.com/docker/setup-buildx-action/pull/464
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/setup-buildx-action/pull/481
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/dock

*...truncated*

### [v3.12.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0)

* Deprecate `install` input by @crazy-max in https://github.com/docker/setup-buildx-action/pull/455
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/setup-buildx-action/pull/434
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/setup-buildx-action/pull/436
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/setup-buildx-action/pull/432
* Bump undici from 5.28.4 to 5.29.0 in https://github.com/docker/setup-buildx-action/pu

*...truncated*

### [v3.11.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1)

* Fix `keep-state` not being respected by @crazy-max in https://github.com/docker/setup-buildx-action/pull/429

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.11.0...v3.11.1

### [v3.11.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.0)

* Keep BuildKit state support by @crazy-max in https://github.com/docker/setup-buildx-action/pull/427
* Remove aliases created when installing by default by @hashhar in https://github.com/docker/setup-buildx-action/pull/139
* Bump @docker/actions-toolkit from 0.56.0 to 0.62.1 in https://github.com/docker/setup-buildx-action/pull/422 https://github.com/docker/setup-buildx-action/pull/425

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.10.0...v3.11.0

### [v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)

* Bump @docker/actions-toolkit from 0.54.0 to 0.56.0 in https://github.com/docker/setup-buildx-action/pull/408

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.9.0...v3.10.0

</details>

<details>
<summary>Release notes for docker/login-action</summary>

### [v4.0.0](https://github.com/docker/login-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/login-action/pull/929
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/login-action/pull/927
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/login-action/pull/919
* Bump @aws-sdk/client-ecr from 3.890.0 to 3.1000.0 in https://github.com/docker/login-action/pu

*...truncated*

### [v3.7.0](https://github.com/docker/login-action/releases/tag/v3.7.0)

* Add `scope` input to set scopes for the authentication token by @crazy-max in https://github.com/docker/login-action/pull/912
* Add support for AWS European Sovereign Cloud ECR by @dphi in https://github.com/docker/login-action/pull/914
* Ensure passwords are redacted with `registry-auth` input by @crazy-max in https://github.com/docker/login-action/pull/911
* build(deps): bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/login-action/pull/915

**Full Changelog**: https://g

*...truncated*

### [v3.6.0](https://github.com/docker/login-action/releases/tag/v3.6.0)

* Add `registry-auth` input for raw authentication to registries by @crazy-max in https://github.com/docker/login-action/pull/887
* Bump @aws-sdk/client-ecr to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @aws-sdk/client-ecr-public to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/logi

*...truncated*

### [v3.5.0](https://github.com/docker/login-action/releases/tag/v3.5.0)

* Support dual-stack endpoints for AWS ECR by @Spacefish @crazy-max in https://github.com/docker/login-action/pull/874 https://github.com/docker/login-action/pull/876
* Bump @aws-sdk/client-ecr to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @aws-sdk/client-ecr-public to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @docker/actions-toolkit from 0.57.0 to 0.6

*...truncated*

### [v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)

* Bump @actions/core from 1.10.1 to 1.11.1 in https://github.com/docker/login-action/pull/791
* Bump @aws-sdk/client-ecr to 3.766.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @aws-sdk/client-ecr-public to 3.758.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @docker/actions-toolkit from 0.35.0 to 0.57.0 in https://github.com/docker/login-action/pull/801 https://github.com

*...truncated*

</details>

<details>
<summary>Release notes for docker/metadata-action</summary>

### [v6.0.0](https://github.com/docker/metadata-action/releases/tag/v6.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/metadata-action/pull/605
* List inputs now preserve `#` inside values while still supporting full-line `#` comments by @crazy-max in https://github.com/docker/metadata-action/pull/607
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/metadata-action/pull/602
* Bump lodash from 4.17.

*...truncated*

### [v5.10.0](https://github.com/docker/metadata-action/releases/tag/v5.10.0)

* Bump @docker/actions-toolkit from 0.66.0 to 0.68.0 in https://github.com/docker/metadata-action/pull/559 https://github.com/docker/metadata-action/pull/569
* Bump js-yaml from 3.14.1 to 3.14.2 in https://github.com/docker/metadata-action/pull/564

**Full Changelog**: https://github.com/docker/metadata-action/compare/v5.9.0...v5.10.0

### [v5.9.0](https://github.com/docker/metadata-action/releases/tag/v5.9.0)

* Add `tag-names` output to return tag names without image base name by @crazy-max in https://github.com/docker/metadata-action/pull/553
* Bump @babel/runtime-corejs3 from 7.14.7 to 7.28.2 in https://github.com/docker/metadata-action/pull/539
* Bump @docker/actions-toolkit from 0.62.1 to 0.66.0 in https://github.com/docker/metadata-action/pull/555
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/metadata-action/pull/540
* Bump csv-parse from 5.6.0 to 6.1.0 in https:/

*...truncated*

### [v5.8.0](https://github.com/docker/metadata-action/releases/tag/v5.8.0)

* New `is_not_default_branch` global expression by @crazy-max in https://github.com/docker/metadata-action/pull/535
* Allow to match part of the git tag or value for semver/pep440 types by @crazy-max in https://github.com/docker/metadata-action/pull/536 https://github.com/docker/metadata-action/pull/537
* Bump @actions/github from 6.0.0 to 6.0.1 in https://github.com/docker/metadata-action/pull/523
* Bump @docker/actions-toolkit from 0.56.0 to 0.62.1 in https://github.com/docker/metadata-acti

*...truncated*

### [v5.7.0](https://github.com/docker/metadata-action/releases/tag/v5.7.0)

* Global expressions support for labels and annotations by @crazy-max in https://github.com/docker/metadata-action/pull/489
* Support disabling outputs as environment variables by @omus in https://github.com/docker/metadata-action/pull/497
* Bump @docker/actions-toolkit from 0.44.0 to 0.56.0 in https://github.com/docker/metadata-action/pull/507 https://github.com/docker/metadata-action/pull/509
* Bump csv-parse from 5.5.6 to 5.6.0 in https://github.com/docker/metadata-action/pull/482
* Bump 

*...truncated*

</details>

<details>
<summary>Release notes for docker/build-push-action</summary>

### [v7.0.0](https://github.com/docker/build-push-action/releases/tag/v7.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/build-push-action/pull/1470
* Remove deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs by @crazy-max in https://github.com/docker/build-push-action/pull/1473
* Remove legacy export-build tool support for build summary by @crazy-max in https://github.com/docker/build-push-action/pull/1474


*...truncated*

### [v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2)

* Preserve port in `GIT_AUTH_TOKEN` host by @crazy-max in https://github.com/docker/build-push-action/pull/1458

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.1...v6.19.2

### [v6.19.1](https://github.com/docker/build-push-action/releases/tag/v6.19.1)

* Derive `GIT_AUTH_TOKEN` host from GitHub server URL by @crazy-max in https://github.com/docker/build-push-action/pull/1456

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.0...v6.19.1

### [v6.19.0](https://github.com/docker/build-push-action/releases/tag/v6.19.0)

* Scope default git auth token to `github.com` by @crazy-max in https://github.com/docker/build-push-action/pull/1451
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/build-push-action/pull/1396
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/build-push-action/pull/1391
* Bump js-yaml from 3.14.1 to 3.14.2 in https://github.com/docker/build-push-action/pull/1429
* Bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/build-push-action/pul

*...truncated*

### [v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)

* Bump @docker/actions-toolkit from 0.61.0 to 0.62.1 in https://github.com/docker/build-push-action/pull/1381

> [!NOTE]
> [Build summary](https://docs.docker.com/build/ci/github-actions/build-summary/) is now supported with [Docker Build Cloud](https://docs.docker.com/build-cloud/).

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.17.0...v6.18.0

</details>

<details>
<summary>Release notes for aws-actions/configure-aws-credentials</summary>

### [v6.0.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.0.0)

## [6.0.0](https://github.com/aws-actions/configure-aws-credentials/compare/v5.1.1...v6.0.0) (2026-02-04)


### ⚠ BREAKING CHANGES

* Update action to use node24 _Note this requires GitHub action runner version [v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later_ ([#1632](https://github.com/aws-actions/configure-aws-credentials/pull/1632)) ([a7a2c11](https://github.com/aws-actions/configure-aws-credentials/commit/a7a2c1125c67f40a1e95768f4e4a7d8f019f87af)) 

### Fe

*...truncated*

### [v5.1.1](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5.1.1)

## [5.1.1](https://github.com/aws-actions/configure-aws-credentials/compare/v5.1.0...v5.1.1) (2025-11-24)


### Miscellaneous Chores

* release 5.1.1 ([56d6a58](https://github.com/aws-actions/configure-aws-credentials/commit/56d6a583f00f6bad6d19d91d53a7bc3b8143d0e9))
* various dependency updates

### [v5.1.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5.1.0)

## [5.1.0](https://github.com/aws-actions/configure-aws-credentials/compare/v5.0.0...v5.1.0) (2025-10-06)


### Features

* Add global timeout support ([#1487](https://github.com/aws-actions/configure-aws-credentials/issues/1487)) ([1584b8b](https://github.com/aws-actions/configure-aws-credentials/commit/1584b8b0e2062557287c28fbe9b8920df434e866))
* add no-proxy support ([#1482](https://github.com/aws-actions/configure-aws-credentials/issues/1482)) ([dde9b22](https://github.com/aws-actions/

*...truncated*

### [v5.0.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5.0.0)

## [5.0.0](https://github.com/aws-actions/configure-aws-credentials/compare/v4.3.1...v5.0.0) (2025-09-03)


### ⚠ BREAKING CHANGES

* Cleanup input handling. Changes invalid boolean input behavior (see #1445)

### Features

* add skip OIDC option ([#1458](https://github.com/aws-actions/configure-aws-credentials/issues/1458)) ([8c45f6b](https://github.com/aws-actions/configure-aws-credentials/commit/8c45f6b08196feb86cfdbe431541d5571d9ab2c2))
* Cleanup input handling. Changes invalid boo

*...truncated*

### [v4.3.1](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.3.1)

## [4.3.1](https://github.com/aws-actions/configure-aws-credentials/compare/v4.3.0...v4.3.1) (2025-08-04)


### Bug Fixes

* update readme to 4.3.1 ([#1424](https://github.com/aws-actions/configure-aws-credentials/issues/1424)) ([be2e7ad](https://github.com/aws-actions/configure-aws-credentials/commit/be2e7ad815e27b890489a89ce2717b0f9e26b56e))

</details>

<details>
<summary>Release notes for imjasonh/setup-crane</summary>

### [v0.5](https://github.com/imjasonh/setup-crane/releases/tag/v0.5)

## What's Changed
* Skip release lookup and retry download errors by @markusthoemmes in https://github.com/imjasonh/setup-crane/pull/17

## New Contributors
* @markusthoemmes made their first contribution in https://github.com/imjasonh/setup-crane/pull/17

**Full Changelog**: https://github.com/imjasonh/setup-crane/compare/v0.4...v0.5

</details>

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.

## Validation Warnings

The following issues were detected by [actionlint](https://github.com/rhysd/actionlint):

- `build-image.yml: .github/workflows/build-image.yml:103:9: shellcheck reported issue in this script: SC2086:info:4:12: Double quote to prevent globbing and word splitting [shellcheck]`
- `build-image.yml: |`
- `build-image.yml: 103 |         run: |`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build pipelines to use newer versions of Docker and deployment tools.
  * Enhanced build process with improved caching strategies and metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->