### PR TITLE
docs: Add AWS config env vars and improve JSDoc comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,14 @@ ACCESS_API_KEY=ik_your-api-key-here-32-chars-minimum
 # Only needed if using cloud features
 CLOUD_API_HOST=https://api.insforge.dev
 
+# -----------------------------------------------------------------------------
+# AWS Config Bucket Configuration (Optional)
+# -----------------------------------------------------------------------------
+# Used for loading remote configuration files from S3
+# If not provided, defaults will be used
+AWS_CONFIG_BUCKET=insforge-config
+AWS_CONFIG_REGION=us-east-2
+
 
 
 # -----------------------------------------------------------------------------

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -32,6 +32,12 @@ const reservedColumns = {
 
 const SAFE_FUNCS = new Set(['now()', 'gen_random_uuid()']);
 
+/**
+ * Generate a safe dollar-quoted literal for PostgreSQL
+ * Ensures the tag doesn't conflict with the content by appending underscores
+ * @param s - The string to quote
+ * @returns A dollar-quoted string safe for use in SQL
+ */
 function getSafeDollarQuotedLiteral(s: string) {
   let tag = 'val';
   while (s.includes(`$${tag}$`)) {
@@ -40,6 +46,13 @@ function getSafeDollarQuotedLiteral(s: string) {
   return `$${tag}$${s}$${tag}$`;
 }
 
+/**
+ * Get the system default value for a column type
+ * Returns null for nullable columns or types without defaults
+ * @param columnType - The column type
+ * @param isNullable - Whether the column is nullable
+ * @returns The default value clause or null
+ */
 function getSystemDefault(columnType?: ColumnType, isNullable?: boolean): string | null {
   if (!columnType || isNullable) {
     return null;
@@ -56,6 +69,14 @@ function getSystemDefault(columnType?: ColumnType, isNullable?: boolean): string
   return `DEFAULT ${getSafeDollarQuotedLiteral(def)}`;
 }
 
+/**
+ * Format a default value for PostgreSQL column definition
+ * Handles special functions (now(), gen_random_uuid()) and escapes string values
+ * @param input - The default value input
+ * @param columnType - The column type for system defaults
+ * @param isNullable - Whether the column is nullable
+ * @returns Formatted DEFAULT clause for SQL
+ */
 export function formatDefaultValue(
   input: string | null | undefined,
   columnType?: ColumnType,

--- a/backend/src/utils/s3-config-loader.ts
+++ b/backend/src/utils/s3-config-loader.ts
@@ -1,7 +1,8 @@
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import logger from '@/utils/logger.js';
 
-// TODO: make these configurable in env variables in cloud backend
+// Config bucket settings - can be configured via environment variables
+// See .env.example for AWS_CONFIG_BUCKET and AWS_CONFIG_REGION
 const CONFIG_BUCKET = process.env.AWS_CONFIG_BUCKET || 'insforge-config';
 const CONFIG_REGION = process.env.AWS_CONFIG_REGION || 'us-east-2';
 


### PR DESCRIPTION
## Summary
This PR adds missing environment variable documentation and improves code documentation:

### Changes
1. **.env.example**: Added AWS_CONFIG_BUCKET and AWS_CONFIG_REGION configuration options with documentation
2. **backend/src/utils/s3-config-loader.ts**: Updated TODO comment to reference the new env var documentation
3. **backend/src/services/database/database-table.service.ts**: Added JSDoc comments to helper functions:
   - getSafeDollarQuotedLiteral()
   - getSystemDefault()
   - formatDefaultValue()

### Why
- Improves developer experience by documenting available configuration options
- Better code documentation helps contributors understand utility functions
- Resolves a TODO item for making S3 config bucket settings configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable AWS S3 settings via AWS_CONFIG_BUCKET and AWS_CONFIG_REGION environment variables to enable flexible remote configuration loading with defaults (insforge-config, us-east-2).

* **Documentation**
  * Updated configuration documentation with expanded sections, clearer AWS settings guidance, deployment markers, and improved database default value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->