### PR TITLE
fix(database): guard oversized record browse cells

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ PORT=7130
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=insforge
+RECORD_BROWSE_CELL_MAX_BYTES=262144
+RECORD_BROWSE_MAX_ROWS=1000
 
 # API Base URLs - Update if running on different host/port
 API_BASE_URL=http://localhost:7130

--- a/backend/src/api/routes/database/browse.routes.ts
+++ b/backend/src/api/routes/database/browse.routes.ts
@@ -1,0 +1,48 @@
+import { Router, Response, NextFunction } from 'express';
+import { AuthRequest, verifyAdmin } from '@/api/middlewares/auth.js';
+import { paginatedResponse } from '@/utils/response.js';
+import { DatabaseBrowseService } from '@/services/database/database-browse.service.js';
+import { AppError } from '@/api/middlewares/error.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+
+const router = Router();
+const browseService = DatabaseBrowseService.getInstance();
+
+function parseInteger(value: unknown, fallback: number) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new AppError(
+      `Invalid numeric query parameter: ${value}`,
+      400,
+      ERROR_CODES.INVALID_INPUT,
+      'Please provide numeric values for limit and offset.'
+    );
+  }
+
+  return parsed;
+}
+
+router.use(verifyAdmin);
+
+router.get('/:tableName', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { tableName } = req.params;
+    const offset = parseInteger(req.query.offset, 0);
+    const result = await browseService.browseTable(tableName, {
+      limit: parseInteger(req.query.limit, 10),
+      offset,
+      order: typeof req.query.order === 'string' ? req.query.order : undefined,
+      search: typeof req.query.search === 'string' ? req.query.search : undefined,
+    });
+
+    paginatedResponse(res, result.rows, result.total, offset);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { router as databaseBrowseRouter };

--- a/backend/src/api/routes/database/index.routes.ts
+++ b/backend/src/api/routes/database/index.routes.ts
@@ -1,4 +1,5 @@
 import { Router, Response, NextFunction } from 'express';
+import { databaseBrowseRouter } from './browse.routes.js';
 import { databaseTablesRouter } from './tables.routes.js';
 import { databaseRecordsRouter } from './records.routes.js';
 import { databaseRpcRouter } from './rpc.routes.js';
@@ -12,6 +13,7 @@ const router = Router();
 const databaseService = DatabaseService.getInstance();
 
 // Mount database sub-routes
+router.use('/browse', databaseBrowseRouter);
 router.use('/tables', databaseTablesRouter);
 router.use('/records', databaseRecordsRouter);
 router.use('/rpc', databaseRpcRouter);

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -11,6 +11,8 @@ export interface AppConfig {
     username: string;
     password: string;
     databaseName: string;
+    recordBrowseCellMaxBytes: number;
+    recordBrowseMaxRows: number;
   };
   cloud: {
     storageBucket: string;
@@ -42,6 +44,8 @@ export const config: AppConfig = {
     username: process.env.POSTGRES_USERNAME || 'user',
     password: process.env.POSTGRES_PASSWORD || 'password',
     databaseName: process.env.POSTGRES_NAME || 'insforge',
+    recordBrowseCellMaxBytes: parseInt(process.env.RECORD_BROWSE_CELL_MAX_BYTES || '262144', 10),
+    recordBrowseMaxRows: parseInt(process.env.RECORD_BROWSE_MAX_ROWS || '1000', 10),
   },
   cloud: {
     storageBucket: process.env.AWS_S3_BUCKET || 'insforge-test-bucket',

--- a/backend/src/services/database/database-browse.service.ts
+++ b/backend/src/services/database/database-browse.service.ts
@@ -1,0 +1,181 @@
+import { Pool } from 'pg';
+import {
+  ColumnSchema,
+  ColumnType,
+  guardedValueDisplayText,
+  guardedValueFlag,
+} from '@insforge/shared-schemas';
+import { AppError } from '@/api/middlewares/error.js';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { config } from '@/infra/config/app.config.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import { DatabaseTableService } from './database-table.service.js';
+import { escapeSqlLikePattern, validateIdentifier } from '@/utils/validations.js';
+
+type BrowseQuery = {
+  limit?: number;
+  offset?: number;
+  order?: string;
+  search?: string;
+};
+
+type BrowseResult = {
+  rows: Record<string, unknown>[];
+  total: number;
+};
+
+const TEXT_COLUMN_TYPES = new Set(['text', 'character varying', 'character']);
+const JSON_COLUMN_TYPES = new Set(['json', 'jsonb']);
+const BINARY_COLUMN_TYPES = new Set(['bytea']);
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function quoteIdentifier(identifier: string) {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function quoteLiteral(value: string) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export class DatabaseBrowseService {
+  private static instance: DatabaseBrowseService;
+  private pool: Pool | null = null;
+  private tableService = DatabaseTableService.getInstance();
+
+  private constructor() {}
+
+  static getInstance() {
+    if (!DatabaseBrowseService.instance) {
+      DatabaseBrowseService.instance = new DatabaseBrowseService();
+    }
+    return DatabaseBrowseService.instance;
+  }
+
+  private getPool() {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  private buildGuardExpression(columnName: string, sqlType: string) {
+    const safeColumnName = quoteIdentifier(columnName);
+    const normalizedType = sqlType.toLowerCase();
+
+    if (TEXT_COLUMN_TYPES.has(normalizedType)) {
+      return `octet_length(t.${safeColumnName})`;
+    }
+
+    if (JSON_COLUMN_TYPES.has(normalizedType)) {
+      return `octet_length(t.${safeColumnName}::text)`;
+    }
+
+    if (BINARY_COLUMN_TYPES.has(normalizedType)) {
+      return `octet_length(t.${safeColumnName})`;
+    }
+
+    return `octet_length(to_jsonb(t.${safeColumnName})::text)`;
+  }
+
+  private buildColumnPairs(columns: ColumnSchema[], columnTypeMap: Record<string, string>) {
+    return columns
+      .map((column) => {
+        const columnName = column.columnName;
+        const sqlType = columnTypeMap[columnName] ?? String(column.type);
+        const guardExpression = this.buildGuardExpression(columnName, sqlType);
+
+        return `${quoteLiteral(columnName)}, CASE
+          WHEN ${guardExpression} > ${config.database.recordBrowseCellMaxBytes}
+            THEN jsonb_build_object(${quoteLiteral(guardedValueFlag)}, true, 'message', ${quoteLiteral(guardedValueDisplayText)})
+          ELSE to_jsonb(t.${quoteIdentifier(columnName)})
+        END`;
+      })
+      .join(', ');
+  }
+
+  private parseOrderClause(order: string | undefined, allowedColumns: Set<string>) {
+    if (!order) {
+      if (allowedColumns.has('created_at')) {
+        return ' ORDER BY t."created_at" DESC';
+      }
+      if (allowedColumns.has('id')) {
+        return ' ORDER BY t."id" DESC';
+      }
+      return '';
+    }
+
+    const clauses = order
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const [columnName, direction = 'asc'] = part.split('.');
+        validateIdentifier(columnName, 'column');
+
+        if (!allowedColumns.has(columnName)) {
+          throw new AppError(
+            `Invalid sort column: ${columnName}`,
+            400,
+            ERROR_CODES.INVALID_INPUT,
+            'Please sort using a valid column from the selected table.'
+          );
+        }
+
+        const normalizedDirection = direction.toLowerCase();
+        if (normalizedDirection !== 'asc' && normalizedDirection !== 'desc') {
+          throw new AppError(
+            `Invalid sort direction: ${direction}`,
+            400,
+            ERROR_CODES.INVALID_INPUT,
+            'Sort direction must be either asc or desc.'
+          );
+        }
+
+        return `t.${quoteIdentifier(columnName)} ${normalizedDirection.toUpperCase()}`;
+      });
+
+    return clauses.length ? ` ORDER BY ${clauses.join(', ')}` : '';
+  }
+
+  async browseTable(tableName: string, query: BrowseQuery): Promise<BrowseResult> {
+    validateIdentifier(tableName, 'table');
+
+    const schema = await this.tableService.getTableSchema(tableName);
+    const allowedColumns = new Set(schema.columns.map((column) => column.columnName));
+    const columnTypeMap = await DatabaseManager.getColumnTypeMap(tableName);
+    const limit = clamp(query.limit ?? 10, 1, config.database.recordBrowseMaxRows);
+    const offset = Math.max(query.offset ?? 0, 0);
+    const orderClause = this.parseOrderClause(query.order, allowedColumns);
+    const search = query.search?.trim();
+    const searchableColumns = schema.columns.filter((column) => column.type === ColumnType.STRING);
+    const hasSearchFilter = Boolean(search && searchableColumns.length);
+    const whereClause = hasSearchFilter
+      ? ` WHERE ${searchableColumns.map((column) => `t.${quoteIdentifier(column.columnName)}::text ILIKE $1 ESCAPE '\\'`).join(' OR ')}`
+      : '';
+    const params = hasSearchFilter ? [`%${escapeSqlLikePattern(search ?? '')}%`] : [];
+    const columnPairs = this.buildColumnPairs(schema.columns, columnTypeMap);
+    const pool = this.getPool();
+    const countQuery = `SELECT COUNT(*)::int AS total FROM ${quoteIdentifier(tableName)} t${whereClause}`;
+    const dataQuery = `
+      SELECT jsonb_build_object(${columnPairs}) AS row_data
+      FROM ${quoteIdentifier(tableName)} t
+      ${whereClause}
+      ${orderClause}
+      LIMIT ${limit}
+      OFFSET ${offset}
+    `;
+
+    const [countResult, dataResult] = await Promise.all([
+      pool.query<{ total: number }>(countQuery, params),
+      pool.query<{ row_data: Record<string, unknown> }>(dataQuery, params),
+    ]);
+
+    return {
+      rows: dataResult.rows.map((row) => row.row_data),
+      total: countResult.rows[0]?.total ?? 0,
+    };
+  }
+}

--- a/backend/tests/unit/database-browse.test.ts
+++ b/backend/tests/unit/database-browse.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { Pool } from 'pg';
+import { DatabaseBrowseService } from '../../src/services/database/database-browse.service';
+import { DatabaseManager } from '../../src/infra/database/database.manager';
+import { AppError } from '../../src/api/middlewares/error';
+import { ColumnType, guardedValueDisplayText, guardedValueFlag } from '@insforge/shared-schemas';
+
+type ServiceState = {
+  pool: Pool | null;
+  tableService: {
+    getTableSchema: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe('database browse route authentication', () => {
+  const browseSource = readFileSync(
+    resolve(__dirname, '../../src/api/routes/database/browse.routes.ts'),
+    'utf-8'
+  );
+
+  test('applies verifyAdmin middleware to the dedicated browse route', () => {
+    expect(browseSource).toContain('import { AuthRequest, verifyAdmin }');
+    expect(browseSource).toMatch(/router\.use\(\s*verifyAdmin\s*\)/);
+  });
+
+  test('is mounted separately from records routes', () => {
+    const indexSource = readFileSync(
+      resolve(__dirname, '../../src/api/routes/database/index.routes.ts'),
+      'utf-8'
+    );
+
+    expect(indexSource).toContain("router.use('/browse', databaseBrowseRouter);");
+  });
+});
+
+describe('DatabaseBrowseService', () => {
+  const service = DatabaseBrowseService.getInstance();
+  const serviceState = service as unknown as ServiceState;
+  const originalPool = serviceState.pool;
+  const originalTableService = serviceState.tableService;
+
+  beforeEach(() => {
+    serviceState.tableService = {
+      getTableSchema: vi.fn().mockResolvedValue({
+        tableName: 'big_test',
+        columns: [
+          { columnName: 'id', type: ColumnType.UUID },
+          { columnName: 'name', type: ColumnType.STRING },
+          { columnName: 'payload', type: ColumnType.JSON },
+          { columnName: 'blob', type: 'bytea' },
+          { columnName: 'created_at', type: ColumnType.DATETIME },
+        ],
+        recordCount: 4,
+      }),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    serviceState.pool = originalPool;
+    serviceState.tableService = originalTableService;
+  });
+
+  test('builds guarded queries with typed size checks and escaped search', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ total: 4 }] })
+      .mockResolvedValueOnce({ rows: [{ row_data: { id: '1' } }] });
+
+    serviceState.pool = { query } as unknown as Pool;
+
+    vi.spyOn(DatabaseManager, 'getColumnTypeMap').mockResolvedValue({
+      id: 'uuid',
+      name: 'text',
+      payload: 'jsonb',
+      blob: 'bytea',
+      created_at: 'timestamp with time zone',
+    });
+
+    await service.browseTable('big_test', {
+      limit: 5000,
+      offset: 2,
+      order: 'name.desc',
+      search: '50%_match',
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+
+    const [countSql, countParams] = query.mock.calls[0] as [string, string[]];
+    const [dataSql, dataParams] = query.mock.calls[1] as [string, string[]];
+
+    expect(countSql).toContain('COUNT(*)::int AS total');
+    expect(countSql).toContain(`ILIKE $1 ESCAPE '\\'`);
+    expect(countParams).toEqual(['%50\\%\\_match%']);
+
+    expect(dataSql).toContain(`'name', CASE`);
+    expect(dataSql).toContain(`octet_length(t."name")`);
+    expect(dataSql).toContain(`octet_length(t."payload"::text)`);
+    expect(dataSql).toContain(`octet_length(t."blob")`);
+    expect(dataSql).toContain(
+      `jsonb_build_object('${guardedValueFlag}', true, 'message', '${guardedValueDisplayText}')`
+    );
+    expect(dataSql).toContain('ORDER BY t."name" DESC');
+    expect(dataSql).toContain('LIMIT 1000');
+    expect(dataSql).toContain('OFFSET 2');
+    expect(dataParams).toEqual(['%50\\%\\_match%']);
+  });
+
+  test('uses safe default ordering when created_at is missing', async () => {
+    serviceState.tableService = {
+      getTableSchema: vi.fn().mockResolvedValue({
+        tableName: 'simple_table',
+        columns: [
+          { columnName: 'id', type: ColumnType.UUID },
+          { columnName: 'title', type: ColumnType.STRING },
+        ],
+        recordCount: 1,
+      }),
+    };
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ row_data: { id: '1', title: 'ok' } }] });
+
+    serviceState.pool = { query } as unknown as Pool;
+
+    vi.spyOn(DatabaseManager, 'getColumnTypeMap').mockResolvedValue({
+      id: 'uuid',
+      title: 'text',
+    });
+
+    await service.browseTable('simple_table', {});
+
+    const [dataSql] = query.mock.calls[1] as [string];
+    expect(dataSql).toContain('ORDER BY t."id" DESC');
+  });
+
+  test('rejects invalid sort columns', async () => {
+    vi.spyOn(DatabaseManager, 'getColumnTypeMap').mockResolvedValue({
+      id: 'uuid',
+      name: 'text',
+      payload: 'jsonb',
+      blob: 'bytea',
+      created_at: 'timestamp with time zone',
+    });
+
+    await expect(
+      service.browseTable('big_test', {
+        order: 'missing.asc',
+      })
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  test('does not bind a search placeholder when the table has no text columns', async () => {
+    serviceState.tableService = {
+      getTableSchema: vi.fn().mockResolvedValue({
+        tableName: 'binary_table',
+        columns: [
+          { columnName: 'id', type: ColumnType.UUID },
+          { columnName: 'blob', type: 'bytea' },
+        ],
+        recordCount: 1,
+      }),
+    };
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ row_data: { id: '1' } }] });
+
+    serviceState.pool = { query } as unknown as Pool;
+
+    vi.spyOn(DatabaseManager, 'getColumnTypeMap').mockResolvedValue({
+      id: 'uuid',
+      blob: 'bytea',
+    });
+
+    await service.browseTable('binary_table', { search: 'abc' });
+
+    const [, countParams] = query.mock.calls[0] as [string, string[]];
+    const [, dataParams] = query.mock.calls[1] as [string, string[]];
+    expect(countParams).toEqual([]);
+    expect(dataParams).toEqual([]);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - RECORD_BROWSE_CELL_MAX_BYTES=${RECORD_BROWSE_CELL_MAX_BYTES:-262144}
+      - RECORD_BROWSE_MAX_ROWS=${RECORD_BROWSE_MAX_ROWS:-1000}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Deno Runtime URL for serverless functions

--- a/frontend/src/components/datagrid/DefaultCellRenderer.tsx
+++ b/frontend/src/components/datagrid/DefaultCellRenderer.tsx
@@ -1,7 +1,7 @@
 import { ColumnType } from '@insforge/shared-schemas';
 import type { ConvertedValue, DataGridRowType } from './datagridTypes';
 import { RenderCellProps } from 'react-data-grid';
-import { cn, formatValueForDisplay, isEmptyValue } from '@/lib/utils/utils';
+import { cn, formatValueForDisplay, isEmptyValue, isGuardedBrowseValue } from '@/lib/utils/utils';
 import { Badge } from '@insforge/ui';
 import IdCell from './IdCell';
 
@@ -11,13 +11,14 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     text: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayValue = formatValueForDisplay(value, ColumnType.STRING);
       return (
         <div className="w-full h-full flex items-center">
           <span
             className={cn(
               'truncate',
-              isNull ? 'text-muted-foreground italic pr-1' : 'dark:text-zinc-300'
+              isNull || isGuarded ? 'text-muted-foreground italic pr-1' : 'dark:text-zinc-300'
             )}
             title={displayValue}
           >
@@ -30,13 +31,14 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     boolean: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayValue = formatValueForDisplay(value, ColumnType.BOOLEAN);
       return (
         <div className="w-full h-full flex items-center justify-start">
           <Badge
             className={cn(
               'py-0.5 px-1.5 border border-transparent text-white',
-              isNull && 'text-muted-foreground italic'
+              (isNull || isGuarded) && 'text-muted-foreground italic'
             )}
           >
             {displayValue}
@@ -48,6 +50,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     datetime: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayValue = formatValueForDisplay(value, ColumnType.DATETIME);
       const isError = displayValue === 'Invalid date time';
 
@@ -56,7 +59,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
           <span
             className={cn(
               'truncate',
-              isNull
+              isNull || isGuarded
                 ? 'text-muted-foreground italic pr-1'
                 : isError
                   ? 'text-red-500'
@@ -73,6 +76,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     date: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayValue = formatValueForDisplay(value, ColumnType.DATE);
       const isError = displayValue === 'Invalid date';
 
@@ -81,7 +85,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
           <span
             className={cn(
               'truncate',
-              isNull
+              isNull || isGuarded
                 ? 'text-muted-foreground italic pr-1'
                 : isError
                   ? 'text-red-500'
@@ -98,6 +102,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     json: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayText = formatValueForDisplay(value, ColumnType.JSON);
       const isError = displayText === 'Invalid JSON';
 
@@ -106,7 +111,7 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
           <span
             className={cn(
               'truncate text-sm max-w-full overflow-hidden whitespace-nowrap',
-              isNull
+              isNull || isGuarded
                 ? 'text-muted-foreground italic pr-1'
                 : isError
                   ? 'text-red-500'
@@ -129,12 +134,13 @@ function createDefaultCellRenderer<TRow extends DataGridRowType>() {
     email: ({ row, column }: RenderCellProps<TRow>) => {
       const value = row[column.key] as ConvertedValue;
       const isNull = isEmptyValue(value);
+      const isGuarded = isGuardedBrowseValue(value);
       const displayValue = formatValueForDisplay(value, ColumnType.STRING);
       return (
         <span
           className={cn(
             'text-sm truncate',
-            isNull
+            isNull || isGuarded
               ? 'text-muted-foreground italic pr-1'
               : 'text-gray-800 font-medium dark:text-zinc-300'
           )}

--- a/frontend/src/features/database/services/record.service.ts
+++ b/frontend/src/features/database/services/record.service.ts
@@ -1,7 +1,6 @@
 import { ConvertedValue } from '@/components/datagrid/datagridTypes';
 import { apiClient } from '@/lib/api/client';
-import { ColumnSchema, BulkUpsertResponse } from '@insforge/shared-schemas';
-import { tableService } from './table.service';
+import { BulkUpsertResponse } from '@insforge/shared-schemas';
 
 export class RecordService {
   /**
@@ -25,29 +24,10 @@ export class RecordService {
     params.set('limit', limit.toString());
     params.set('offset', offset.toString());
 
-    // Construct PostgREST filter directly in frontend if search query is provided
     if (searchQuery && searchQuery.trim()) {
-      const searchValue = searchQuery.trim();
-
-      // Get table schema to identify text columns
-      const schema = await tableService.getTableSchema(tableName);
-      const textColumns = schema.columns
-        .filter((col: ColumnSchema) => {
-          const type = col.type.toLowerCase();
-          return type === 'string';
-        })
-        .map((col: ColumnSchema) => col.columnName);
-
-      if (textColumns.length) {
-        // Create PostgREST OR filter for text columns
-        const orFilters = textColumns
-          .map((column: string) => `${column}.ilike.*${searchValue}*`)
-          .join(',');
-        params.set('or', `(${orFilters})`);
-      }
+      params.set('search', searchQuery.trim());
     }
 
-    // Add sorting if provided - PostgREST uses "order" parameter
     if (sortColumns && sortColumns.length) {
       const orderParam = sortColumns
         .map((col) => `${col.columnKey}.${col.direction.toLowerCase()}`)
@@ -58,7 +38,7 @@ export class RecordService {
     const response: {
       data: { [key: string]: ConvertedValue }[];
       pagination: { offset: number; limit: number; total: number };
-    } = await apiClient.request(`/database/records/${tableName}?${params.toString()}`, {
+    } = await apiClient.request(`/database/browse/${tableName}?${params.toString()}`, {
       headers: {
         Prefer: 'count=exact',
       },

--- a/frontend/src/lib/utils/__tests__/utils.test.ts
+++ b/frontend/src/lib/utils/__tests__/utils.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { cn, isEmptyValue, compareVersions, formatTime, formatDate } from '../utils';
+import {
+  cn,
+  isEmptyValue,
+  compareVersions,
+  formatTime,
+  formatDate,
+  formatValueForDisplay,
+  isGuardedBrowseValue,
+} from '../utils';
+import { ColumnType, guardedValueDisplayText, guardedValueFlag } from '@insforge/shared-schemas';
 
 describe('cn', () => {
   it('merges class names', () => {
@@ -81,5 +90,26 @@ describe('formatDate', () => {
 
   it('returns original string for invalid timestamp', () => {
     expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('guarded browse values', () => {
+  const guardedValue = {
+    [guardedValueFlag]: true as const,
+    message: guardedValueDisplayText,
+  };
+
+  it('detects the guarded sentinel object only', () => {
+    expect(isGuardedBrowseValue(guardedValue)).toBe(true);
+    expect(isGuardedBrowseValue(guardedValueDisplayText)).toBe(false);
+    expect(isGuardedBrowseValue({ message: guardedValueDisplayText })).toBe(false);
+  });
+
+  it('formats guarded values using the sentinel message for string columns', () => {
+    expect(formatValueForDisplay(guardedValue, ColumnType.STRING)).toBe(guardedValueDisplayText);
+  });
+
+  it('formats guarded values using the sentinel message for json columns', () => {
+    expect(formatValueForDisplay(guardedValue, ColumnType.JSON)).toBe(guardedValueDisplayText);
   });
 });

--- a/frontend/src/lib/utils/utils.ts
+++ b/frontend/src/lib/utils/utils.ts
@@ -1,4 +1,8 @@
-import { ColumnType } from '@insforge/shared-schemas';
+import {
+  ColumnType,
+  guardedValueDisplayText,
+  isGuardedValue as isSharedGuardedValue,
+} from '@insforge/shared-schemas';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { z } from 'zod';
@@ -99,6 +103,10 @@ export function formatValueForDisplay(value: ConvertedValue, type?: ColumnType):
     return 'null';
   }
 
+  if (isGuardedBrowseValue(value)) {
+    return value.message || guardedValueDisplayText;
+  }
+
   // Handle different column types
   switch (type) {
     case ColumnType.BOOLEAN:
@@ -146,6 +154,12 @@ export function formatValueForDisplay(value: ConvertedValue, type?: ColumnType):
       return String(value);
     }
   }
+}
+
+export function isGuardedBrowseValue(
+  value: unknown
+): value is { __GuardedValue: true; message: string } {
+  return isSharedGuardedValue(value);
 }
 
 /**

--- a/shared-schemas/src/guarded-value.schema.ts
+++ b/shared-schemas/src/guarded-value.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const guardedValueFlag = '__GuardedValue';
+export const guardedValueDisplayText = 'data too large to show';
+
+export const guardedValueSchema = z.object({
+  [guardedValueFlag]: z.literal(true),
+  message: z.string(),
+});
+
+export type GuardedValue = z.infer<typeof guardedValueSchema>;
+
+export function isGuardedValue(value: unknown): value is GuardedValue {
+  return guardedValueSchema.safeParse(value).success;
+}

--- a/shared-schemas/src/index.ts
+++ b/shared-schemas/src/index.ts
@@ -22,3 +22,4 @@ export * from './deployments.schema';
 export * from './deployments-api.schema';
 export * from './schedules.schema';
 export * from './schedules-api.schema';
+export * from './guarded-value.schema';


### PR DESCRIPTION
## Summary

Closes #848 

This PR adds a safeguard for database record browsing so very large cell payloads are not inlined into the normal Tables page response path.

Changes included:

- Added a backend guard for `/api/database/records/...` browse responses that replaces oversized string/JSON like cell values with a stable placeholder object instead of returning the full payload.
- Added a shared guarded-value contract using `__GuardedValue` so the frontend can detect oversized browse values consistently.
- Updated the frontend Tables rendering path to show muted helper text, `data too large to show`, for guarded values instead of attempting to pretty-print them.
- Made the browse threshold configurable via `RECORD_BROWSE_CELL_MAX_BYTES` and documented it in `.env.example`.
- Added unit tests for backend guard behavior and frontend guarded-value formatting.

This keeps normal sized values working as before while preventing a single pathological row from putting unnecessary memory pressure on the backend/frontend during exploratory record browsing.

## How did you test this change?

Manual verification:

- Created a `big_test` table with large payload rows and verified baseline behavior before the change.
- Verified row payload sizes in SQL Editor using `octet_length(...)`.
- Set `RECORD_BROWSE_CELL_MAX_BYTES` to different values and restarted the `insforge` service to confirm threshold behavior.
- Confirmed that values above the configured threshold render as `data too large to show` in the Tables page, while values within the threshold still render normally.

Automated verification:

- `cd backend && npx vitest run tests/unit/record-browse-guard.service.test.ts`
- `cd frontend && npx vitest run src/lib/utils/__tests__/utils.test.ts`
- `npm run typecheck`

Suggested screenshots to attach to the PR:

1. Before change: normal table browsing view showing the large payload values inline.
<img width="1365" height="599" alt="Screenshot 2026-03-14 190108" src="https://github.com/user-attachments/assets/ea1bdddf-a011-4aaf-9c8c-114015d23de9" />

2. Data size reference: SQL Editor output showing the size for each `big_test` row.
<img width="1365" height="598" alt="Screenshot 2026-03-14 195352" src="https://github.com/user-attachments/assets/c1f3054c-acce-497a-8a07-b8e59afa315d" />

3. After change: Tables page with `RECORD_BROWSE_CELL_MAX_BYTES=640000`, where only the row within threshold remains visible and oversized rows show `data too large to show`.
<img width="1365" height="595" alt="Screenshot 2026-03-14 195523" src="https://github.com/user-attachments/assets/1ec0e646-ae02-4708-8030-0bc375d25e06" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse view for database records with pagination, safe sorting, and search; large cell payloads show a guarded placeholder ("data too large to show") in grids.

* **Configuration**
  * New environment variable RECORD_BROWSE_CELL_MAX_BYTES to configure max cell display size (default 256KB).

* **Tests**
  * Added unit and frontend tests covering browse helpers and guarded-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->