### PR TITLE
docs: fix inconsistent ampersand escaping in Japanese README

### DIFF
--- a/i18n/README.ja.md
+++ b/i18n/README.ja.md
@@ -170,5 +170,5 @@ InsForge is my backend platform, what is my current backend structure?
 ---
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=InsForge/insforge\&type=Date)](https://www.star-history.com/#InsForge/insforge&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=InsForge/insforge&type=Date)](https://www.star-history.com/#InsForge/insforge&Date)
 


### PR DESCRIPTION
## What
Fixes the Star History chart image URL in `i18n/README.ja.md` which used `\&` instead of `&`.

## Why
All 8 other i18n READMEs use `&` without the backslash. This keeps the codebase consistent.

## How
Removed the backslash from `\&` on line 173 of `i18n/README.ja.md`.

## How to Test
1. Open `i18n/README.ja.md` and compare line 173 with the same line in any other i18n README (e.g., `README.ko.md`)
2. Confirm the Star History chart URL now uses `&` consistently

## Related
- Closes #880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken links in the Japanese README by correcting URL formatting in Star History chart references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->