### PR TITLE
feat: add MiniMax as LLM provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,11 @@ LOGS_DIR=
 # Get your API key from https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
+# MiniMax Configuration (Optional)
+# Get your API key from https://platform.minimaxi.com/
+# Enables direct access to MiniMax models (MiniMax-M2.5) without going through OpenRouter
+MINIMAX_API_KEY=
+
 # Posthog Configuration (Only needed if running development mode locally)
 VITE_PUBLIC_POSTHOG_KEY=
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ graph TB
 - **Authentication**: User management, authentication, and sessions
 - **Database**: Postgres relational database
 - **Storage**: S3 compatible file storage
-- **Model Gateway**: OpenAI compatible API across multiple LLM providers
+- **Model Gateway**: OpenAI compatible API across multiple LLM providers (OpenRouter, MiniMax, and more)
 - **Edge Functions**: Serverless code running on the edge
 - **Site Deployment**: Site build and deployment
 

--- a/backend/src/providers/ai/minimax.provider.ts
+++ b/backend/src/providers/ai/minimax.provider.ts
@@ -1,0 +1,79 @@
+import OpenAI from 'openai';
+import { AppError } from '@/api/middlewares/error.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import logger from '@/utils/logger.js';
+
+export class MiniMaxProvider {
+  private static instance: MiniMaxProvider;
+  private client: OpenAI | null = null;
+
+  private constructor() {}
+
+  static getInstance(): MiniMaxProvider {
+    if (!MiniMaxProvider.instance) {
+      MiniMaxProvider.instance = new MiniMaxProvider();
+    }
+    return MiniMaxProvider.instance;
+  }
+
+  /**
+   * Create the OpenAI-compatible client for MiniMax API
+   */
+  private createClient(apiKey: string): OpenAI {
+    return new OpenAI({
+      baseURL: 'https://api.minimax.io/v1',
+      apiKey,
+    });
+  }
+
+  /**
+   * Get MiniMax API key from environment
+   */
+  async getApiKey(): Promise<string> {
+    const apiKey = process.env.MINIMAX_API_KEY;
+    if (!apiKey) {
+      throw new AppError(
+        'MINIMAX_API_KEY not found in environment variables',
+        500,
+        ERROR_CODES.AI_INVALID_API_KEY
+      );
+    }
+    return apiKey;
+  }
+
+  /**
+   * Get or create the OpenAI-compatible client
+   */
+  private async getClient(): Promise<OpenAI> {
+    if (!this.client) {
+      this.client = this.createClient(await this.getApiKey());
+    }
+    return this.client;
+  }
+
+  /**
+   * Check if MiniMax is properly configured
+   */
+  isConfigured(): boolean {
+    return !!process.env.MINIMAX_API_KEY;
+  }
+
+  /**
+   * Send a request to MiniMax API using the OpenAI-compatible client
+   * @param request - Function that takes an OpenAI client and returns a Promise
+   * @returns The result of the request
+   */
+  async sendRequest<T>(request: (client: OpenAI) => Promise<T>): Promise<T> {
+    const client = await this.getClient();
+
+    try {
+      return await request(client);
+    } catch (error) {
+      logger.error('MiniMax API request failed', {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw error;
+    }
+  }
+}

--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -1,15 +1,33 @@
 import { isCloudEnvironment } from '@/utils/environment.js';
 import { OpenRouterProvider } from '@/providers/ai/openrouter.provider.js';
+import { MiniMaxProvider } from '@/providers/ai/minimax.provider.js';
 import type { RawOpenRouterModel } from '@/types/ai.js';
 import type { AIModelSchema } from '@insforge/shared-schemas';
 import { calculatePricePerMillion, filterAndSortModalities, getProviderOrder } from './helpers.js';
+import logger from '@/utils/logger.js';
 
 export class AIModelService {
   /**
-   * Get all available AI models
-   * Fetches from cloud API if in cloud environment, otherwise from OpenRouter directly
+   * Get all available AI models from all configured providers
    */
   static async getModels(): Promise<AIModelSchema[]> {
+    const models: AIModelSchema[] = [];
+
+    // Fetch OpenRouter models
+    const openRouterModels = await AIModelService.getOpenRouterModels();
+    models.push(...openRouterModels);
+
+    // Add MiniMax models if configured
+    const minimaxModels = AIModelService.getMiniMaxModels();
+    models.push(...minimaxModels);
+
+    return models;
+  }
+
+  /**
+   * Fetch models from OpenRouter API
+   */
+  private static async getOpenRouterModels(): Promise<AIModelSchema[]> {
     const openRouterProvider = OpenRouterProvider.getInstance();
     const configured = openRouterProvider.isConfigured();
 
@@ -39,7 +57,7 @@ export class AIModelService {
     const data = (await response.json()) as { data: RawOpenRouterModel[] };
     const rawModels = data.data || [];
 
-    const models: AIModelSchema[] = rawModels
+    return rawModels
       .map((rawModel) => {
         const { inputPrice, outputPrice } = calculatePricePerMillion(rawModel.pricing);
         return {
@@ -58,7 +76,39 @@ export class AIModelService {
         const orderDiff = getProviderOrder(aCompany) - getProviderOrder(bCompany);
         return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
       });
+  }
 
-    return models || [];
+  /**
+   * Get available MiniMax models (static list since MiniMax uses direct API)
+   * MiniMax offers OpenAI-compatible API with 204K context window
+   */
+  private static getMiniMaxModels(): AIModelSchema[] {
+    const minimaxProvider = MiniMaxProvider.getInstance();
+    if (!minimaxProvider.isConfigured()) {
+      return [];
+    }
+
+    logger.info('MiniMax API key configured, adding MiniMax models');
+
+    return [
+      {
+        id: 'MiniMax-M2.5',
+        modelId: 'MiniMax-M2.5',
+        provider: 'minimax',
+        inputModality: ['text'],
+        outputModality: ['text'],
+        inputPrice: 0.8,
+        outputPrice: 3.2,
+      },
+      {
+        id: 'MiniMax-M2.5-highspeed',
+        modelId: 'MiniMax-M2.5-highspeed',
+        provider: 'minimax',
+        inputModality: ['text'],
+        outputModality: ['text'],
+        inputPrice: 0.8,
+        outputPrice: 3.2,
+      },
+    ];
   }
 }

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { AIUsageService } from './ai-usage.service.js';
 import { AIConfigService } from './ai-config.service.js';
 import { OpenRouterProvider } from '@/providers/ai/openrouter.provider.js';
+import { MiniMaxProvider } from '@/providers/ai/minimax.provider.js';
 import type {
   AIConfigurationSchema,
   ChatCompletionResponse,
@@ -65,6 +66,17 @@ export class ChatCompletionService {
   private aiUsageService = AIUsageService.getInstance();
   private aiConfigService = AIConfigService.getInstance();
   private openRouterProvider = OpenRouterProvider.getInstance();
+  private minimaxProvider = MiniMaxProvider.getInstance();
+
+  /**
+   * Get the appropriate provider based on the AI config's provider field
+   */
+  private getProvider(provider?: string): OpenRouterProvider | MiniMaxProvider {
+    if (provider === 'minimax') {
+      return this.minimaxProvider;
+    }
+    return this.openRouterProvider;
+  }
 
   private constructor() {}
 
@@ -282,7 +294,11 @@ export class ChatCompletionService {
       // Apply system prompt from config if available
       const formattedMessages = this.formatMessages(messages, aiConfig?.systemPrompt);
 
-      // Build request with optional plugins (web search, file parser)
+      // Get the appropriate provider based on config
+      const provider = this.getProvider(aiConfig?.provider);
+      const isOpenRouter = aiConfig?.provider !== 'minimax';
+
+      // Build request with optional plugins (OpenRouter-only: web search, file parser)
       const request: OpenRouterChatCompletionRequest = {
         model: modelId,
         messages: formattedMessages,
@@ -290,14 +306,14 @@ export class ChatCompletionService {
         max_tokens: options.maxTokens ?? 4096,
         top_p: options.topP,
         stream: false,
-        plugins: this.buildPlugins(options),
+        plugins: isOpenRouter ? this.buildPlugins(options) : undefined,
         tools: options.tools,
         tool_choice: options.toolChoice,
         parallel_tool_calls: options.parallelToolCalls,
       };
 
-      // Send request with automatic renewal and retry logic
-      const response = await this.openRouterProvider.sendRequest((client) =>
+      // Send request via the appropriate provider
+      const response = await provider.sendRequest((client) =>
         client.chat.completions.create(
           request as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming
         )
@@ -387,7 +403,11 @@ export class ChatCompletionService {
       // Apply system prompt from config if available
       const formattedMessages = this.formatMessages(messages, aiConfig?.systemPrompt);
 
-      // Build request with optional plugins (web search, file parser)
+      // Get the appropriate provider based on config
+      const provider = this.getProvider(aiConfig?.provider);
+      const isOpenRouter = aiConfig?.provider !== 'minimax';
+
+      // Build request with optional plugins (OpenRouter-only: web search, file parser)
       const request: OpenRouterChatCompletionStreamingRequest = {
         model: modelId,
         messages: formattedMessages,
@@ -395,14 +415,14 @@ export class ChatCompletionService {
         max_tokens: options.maxTokens ?? 4096,
         top_p: options.topP,
         stream: true,
-        plugins: this.buildPlugins(options),
+        plugins: isOpenRouter ? this.buildPlugins(options) : undefined,
         tools: options.tools,
         tool_choice: options.toolChoice,
         parallel_tool_calls: options.parallelToolCalls,
       };
 
-      // Send request with automatic renewal and retry logic
-      const stream = await this.openRouterProvider.sendRequest((client) =>
+      // Send request via the appropriate provider
+      const stream = await provider.sendRequest((client) =>
         client.chat.completions.create(request as OpenAI.Chat.ChatCompletionCreateParamsStreaming)
       );
 

--- a/backend/src/services/ai/embedding.service.ts
+++ b/backend/src/services/ai/embedding.service.ts
@@ -1,4 +1,5 @@
 import { OpenRouterProvider } from '@/providers/ai/openrouter.provider.js';
+import { MiniMaxProvider } from '@/providers/ai/minimax.provider.js';
 import type { EmbeddingsRequest, EmbeddingsResponse } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { AIConfigService } from './ai-config.service.js';
@@ -7,6 +8,7 @@ import { AIUsageService } from './ai-usage.service.js';
 export class EmbeddingService {
   private static instance: EmbeddingService;
   private openRouterProvider = OpenRouterProvider.getInstance();
+  private minimaxProvider = MiniMaxProvider.getInstance();
   private aiConfigService = AIConfigService.getInstance();
   private aiUsageService = AIUsageService.getInstance();
 
@@ -29,7 +31,8 @@ export class EmbeddingService {
     try {
       // Send request with automatic renewal and retry logic (same pattern as chat-completion)
       const aiConfig = await this.aiConfigService.findByModelId(options.model);
-      const response = await this.openRouterProvider.sendRequest((client) =>
+      const provider = aiConfig?.provider === 'minimax' ? this.minimaxProvider : this.openRouterProvider;
+      const response = await provider.sendRequest((client) =>
         client.embeddings.create({
           model: options.model,
           input: options.input,

--- a/backend/src/services/ai/helpers.ts
+++ b/backend/src/services/ai/helpers.ts
@@ -7,6 +7,7 @@ const PROVIDER_ORDER: Record<string, number> = {
   anthropic: 2,
   google: 3,
   amazon: 4,
+  minimax: 5,
 };
 
 /**

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -21,6 +21,10 @@ WORKER_TIMEOUT_MS=60000
 # Get your API key from https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
+# MiniMax Configuration (Optional)
+# Get your API key from https://platform.minimaxi.com/
+MINIMAX_API_KEY=
+
 # OAuth Configuration (Optional)
 # Google OAuth - Get credentials from https://console.cloud.google.com/
 GOOGLE_CLIENT_ID=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -94,6 +94,7 @@ services:
       - ACCESS_API_KEY=${ACCESS_API_KEY:-}
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       # OAuth Configuration
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - CLOUD_API_HOST=${CLOUD_API_HOST:-}
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       # OAuth Configuration
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}


### PR DESCRIPTION
## Summary

- Adds **MiniMax** ([minimax.io](https://api.minimax.io)) as an alternative LLM provider alongside OpenRouter
- MiniMax offers an OpenAI-compatible API, so the implementation reuses the existing OpenAI SDK client pattern
- When `MINIMAX_API_KEY` is configured, MiniMax models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`) appear in the model listing and can be selected for chat completions and embeddings

## Changes

| File | Change |
|------|--------|
| `backend/src/providers/ai/minimax.provider.ts` | **New** — MiniMaxProvider singleton (same pattern as OpenRouterProvider) |
| `backend/src/services/ai/chat-completion.service.ts` | Route requests to MiniMax when provider is configured; skip OpenRouter-specific plugins |
| `backend/src/services/ai/embedding.service.ts` | Route embedding requests to MiniMax when configured |
| `backend/src/services/ai/ai-model.service.ts` | Return MiniMax models from model listing endpoint |
| `backend/src/services/ai/helpers.ts` | Add MiniMax to provider sort order |
| `.env.example` | Add `MINIMAX_API_KEY` |
| `deploy/docker-compose/.env.example` | Add `MINIMAX_API_KEY` |
| `docker-compose.yml` | Pass `MINIMAX_API_KEY` env var |
| `docker-compose.prod.yml` | Pass `MINIMAX_API_KEY` env var |
| `README.md` | Mention MiniMax in Model Gateway description |

## How it works

1. **Provider routing**: `ChatCompletionService.getProvider()` checks the AI config's `provider` field. If `'minimax'`, requests go through MiniMaxProvider; otherwise OpenRouterProvider (default).
2. **Model listing**: When `MINIMAX_API_KEY` is set, `getMiniMaxModels()` returns the two available models with pricing info. These are merged with OpenRouter models in the response.
3. **OpenRouter-specific features**: Plugins (web search, file parser) are OpenRouter-only and are excluded when routing through MiniMax.

## Test plan

- [ ] Set `MINIMAX_API_KEY` in `.env` and verify MiniMax models appear in the model listing
- [ ] Select a MiniMax model and send a chat completion request
- [ ] Verify embedding requests work with MiniMax provider
- [ ] Verify OpenRouter still works as default when no provider override is set
- [ ] Verify the app starts without `MINIMAX_API_KEY` (graceful fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported LLM provider with full integration for model selection and chat/embedding capabilities
  * Users can now configure MiniMax API credentials and select MiniMax models for use

* **Documentation**
  * Updated documentation to reflect MiniMax as an available provider option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
