### PR TITLE
fix(#898 logs): enable pagination on main logs page

### DIFF
--- a/frontend/src/features/logs/pages/LogsPage.tsx
+++ b/frontend/src/features/logs/pages/LogsPage.tsx
@@ -12,17 +12,22 @@ import {
 } from '../components';
 import { formatTime } from '@/lib/utils/utils';
 import { LogSchema } from '@insforge/shared-schemas';
+import { LOGS_PAGE_SIZE } from '../helpers';
 
 export default function LogsPage() {
   const { source = 'insforge.logs' } = useParams<{ source?: string }>();
   const [selectedLog, setSelectedLog] = useState<LogSchema | null>(null);
 
   const {
+    logs,
     filteredLogs,
     searchQuery: logsSearchQuery,
     setSearchQuery: setLogsSearchQuery,
     severityFilter,
     setSeverityFilter,
+    currentPage,
+    setCurrentPage,
+    totalPages,
     isLoading: logsLoading,
     error: logsError,
     getSeverity,
@@ -119,9 +124,13 @@ export default function LogsPage() {
         ) : (
           <LogsDataGrid
             columnDefs={logsColumns}
-            data={filteredLogs}
+            data={logs}
             loading={logsLoading}
-            showPagination={false}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageSize={LOGS_PAGE_SIZE}
+            totalRecords={filteredLogs.length}
+            onPageChange={setCurrentPage}
             selectedRowId={selectedLog?.id ?? null}
             onRowClick={handleRowClick}
             gridContainerClassName="border-t border-[var(--alpha-8)]"


### PR DESCRIPTION
## Summary
Fixes the main logs page so it uses the paginated logs slice returned by `useLogs` and shows pagination controls in the UI.
Closes https://github.com/InsForge/InsForge/issues/898
## Changes
- use paginated `logs` from `useLogs` instead of `filteredLogs`
- pass `currentPage`, `totalPages`, `pageSize`, `totalRecords`, and `onPageChange` to `LogsDataGrid`
- remove the wiring that disabled pagination on the main logs page

## Bug
The main logs page had pagination logic available in `useLogs`, but `LogsPage` rendered the full filtered list and hid pagination controls.

## Verification
- opened the main logs page with more than 50 log entries
- confirmed pagination controls are visible
- confirmed the table shows paginated results instead of the full filtered list
- confirmed page navigation works

## Screenshots
<img width="1470" height="923" alt="截屏2026-03-15 下午10 37 12" src="https://github.com/user-attachments/assets/bc5dd2fa-c5ea-4794-af88-8ca05f138fcf" />

<img width="1470" height="952" alt="截屏2026-03-15 下午10 37 29" src="https://github.com/user-attachments/assets/4f0396f2-2fdd-4714-ae42-6fb72bd6f086" />

<img width="1470" height="935" alt="截屏2026-03-15 下午10 48 34" src="https://github.com/user-attachments/assets/e1e18e26-eb14-4510-8b24-0c647b5604ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to the logs interface, enabling users to navigate through log entries with page-by-page browsing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->