### PR TITLE
fix: escape LIKE wildcards in storage listObjects search and prefix params

### DIFF
--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -269,7 +269,7 @@ export class StorageService {
       if (prefix) {
         query += ` AND key LIKE $${paramIndex}`;
         countQuery += ` AND key LIKE $${paramIndex}`;
-        params.push(`${prefix}%`);
+        params.push(`${escapeSqlLikePattern(prefix)}%`);
         paramIndex++;
       }
 
@@ -277,7 +277,7 @@ export class StorageService {
       if (searchQuery && searchQuery.trim()) {
         query += ` AND key LIKE $${paramIndex}`;
         countQuery += ` AND key LIKE $${paramIndex}`;
-        const searchPattern = `%${searchQuery.trim()}%`;
+        const searchPattern = `%${escapeSqlLikePattern(searchQuery.trim())}%`;
         params.push(searchPattern);
         paramIndex++;
       }


### PR DESCRIPTION
## Summary

- User-supplied `prefix` and `searchQuery` in `listObjects` were passed directly into PostgreSQL `LIKE` patterns without escaping `_` and `%` wildcard characters
- This caused incorrect query results: files with `_` or `%` in their names would produce overly broad matches
- Applied the existing `escapeSqlLikePattern` utility (already imported in the file) to both parameters before constructing the LIKE patterns

Fixes #903

## Changes

**`backend/src/services/storage/storage.service.ts`**
- `prefix` pattern: `${prefix}%` → `${escapeSqlLikePattern(prefix)}%`
- `searchQuery` pattern: `%${searchQuery.trim()}%` → `%${escapeSqlLikePattern(searchQuery.trim())}%`

## Test plan

- [ ] Upload files with `%` and `_` in their names to a bucket
- [ ] Call `listObjects` with `prefix` set to a string containing `%` or `_` — verify only exact prefix matches are returned
- [ ] Call `listObjects` with `searchQuery` set to a string containing `%` or `_` — verify only files literally containing those characters are returned
- [ ] Verify normal prefix and search queries still work correctly for standard filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of search and filter operations by ensuring special characters in queries and filters are handled correctly, preventing potential issues with result accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->