### PR TITLE
fix: warn on missing ENCRYPTION_KEY to prevent data loss during JWT_SECRET rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,10 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=change-this-password
 
 # Encryption key for secrets and database encryption
-# If not provided, JWT_SECRET will be used
+# IMPORTANT: Set this to a separate 32+ character secret from JWT_SECRET.
+# If not set, JWT_SECRET is used as fallback — but rotating JWT_SECRET will
+# permanently corrupt all stored secrets (API keys, OAuth tokens, etc.).
+# Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=
 
 # API Key for authenticated requests

--- a/backend/src/infra/security/encryption.manager.ts
+++ b/backend/src/infra/security/encryption.manager.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import logger from '@/utils/logger.js';
 
 /**
  * EncryptionManager - Handles encryption/decryption operations
@@ -12,6 +13,13 @@ export class EncryptionManager {
       const key = process.env.ENCRYPTION_KEY || process.env.JWT_SECRET;
       if (!key) {
         throw new Error('ENCRYPTION_KEY or JWT_SECRET must be set for secrets encryption');
+      }
+      if (!process.env.ENCRYPTION_KEY) {
+        logger.warn(
+          'ENCRYPTION_KEY is not set — falling back to JWT_SECRET for secrets encryption. ' +
+            'WARNING: rotating JWT_SECRET without setting a dedicated ENCRYPTION_KEY will corrupt all stored secrets. ' +
+            'Set ENCRYPTION_KEY to a separate 32+ character secret in your environment.'
+        );
       }
       this.encryptionKey = crypto.createHash('sha256').update(key).digest();
     }


### PR DESCRIPTION
## Summary

- When `ENCRYPTION_KEY` is not configured, the `EncryptionManager` silently falls back to `JWT_SECRET` with no warning
- Self-hosters who later rotate `JWT_SECRET` (a normal security practice) will permanently corrupt all stored encrypted secrets
- This PR adds a `logger.warn` at first use if `ENCRYPTION_KEY` is absent, and improves the `.env.example` comment to explicitly document the data-loss risk

Fixes #905

## Changes

**`backend/src/infra/security/encryption.manager.ts`**
- Added `import logger from '@/utils/logger.js'`
- Added `logger.warn(...)` when `process.env.ENCRYPTION_KEY` is not set, warning that JWT_SECRET rotation will corrupt stored secrets

**`.env.example`**
- Expanded the `ENCRYPTION_KEY` comment to explicitly warn about the data-loss scenario and recommend setting it to a separate 32+ character secret

## Test plan

- [ ] Start the server without `ENCRYPTION_KEY` set — verify a warning log message appears on first encrypt/decrypt call
- [ ] Start the server with `ENCRYPTION_KEY` set — verify no warning appears
- [ ] Verify existing encrypt/decrypt functionality is unaffected (behavior unchanged, only a warning added)
- [ ] Confirm `.env.example` comment clearly explains the risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ENCRYPTION_KEY configuration guidance with clearer setup instructions and fallback behavior explanation.

* **Chores**
  * Added warning logs to alert when JWT_SECRET is used as encryption fallback, noting risks from JWT_SECRET rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->