### PR TITLE
fix: Add pagination to Function runtime logs

### DIFF
--- a/frontend/src/features/logs/pages/FunctionLogsPage.tsx
+++ b/frontend/src/features/logs/pages/FunctionLogsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../components';
 import { formatTime } from '@/lib/utils/utils';
 import { LogSchema } from '@insforge/shared-schemas';
+import { LOGS_PAGE_SIZE } from '../helpers';
 
 type FunctionLogType = 'runtime' | 'build';
 
@@ -23,7 +24,11 @@ export default function FunctionLogsPage() {
   const [selectedLog, setSelectedLog] = useState<LogSchema | null>(null);
 
   const {
+    logs,
     filteredLogs,
+    currentPage,
+    setCurrentPage,
+    totalPages,
     searchQuery: logsSearchQuery,
     setSearchQuery: setLogsSearchQuery,
     severityFilter,
@@ -138,9 +143,13 @@ export default function FunctionLogsPage() {
         ) : (
           <LogsDataGrid
             columnDefs={logsColumns}
-            data={filteredLogs}
+            data={logs}
             loading={logsLoading}
-            showPagination={false}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageSize={LOGS_PAGE_SIZE}
+            totalRecords={filteredLogs.length}
+            onPageChange={setCurrentPage}
             selectedRowId={selectedLog?.id ?? null}
             onRowClick={handleRowClick}
             gridContainerClassName="border-t border-[var(--alpha-8)]"


### PR DESCRIPTION
Closes #938

**Description:**
Added missing pagination controls to the runtime logs tab in `FunctionLogsPage`. It now correctly consumes the paginated `logs`, `currentPage`, `totalPages`, and `setCurrentPage` state exposed by `useLogs` to render standard `<LogsDataGrid>` pagination consistently with other log screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled pagination for the runtime logs grid, allowing users to navigate through multiple pages of logs with proper page controls instead of a single view. Filter and search functionality remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->