### PR TITLE
fix(auth): prevent admin email conflict with regular users (#668)

### DIFF
--- a/backend/src/infra/database/migrations/025_fix-admin-user-email-conflict.sql
+++ b/backend/src/infra/database/migrations/025_fix-admin-user-email-conflict.sql
@@ -1,0 +1,56 @@
+-- Migration: 025 - Fix admin user email conflict with regular users
+-- Issue: #668 - Admin user will conflict with regular user if using same email
+--
+-- Problem: The auth.users table has a simple UNIQUE constraint on email.
+-- When the admin email is set, a regular app user cannot register with the
+-- same email because they share the same uniqueness namespace.
+--
+-- Solution: Replace the single UNIQUE(email) constraint with partial unique
+-- indexes scoped by user type. This allows an admin and a regular user to
+-- share the same email without conflict, while still preventing duplicate
+-- emails within each user type.
+
+-- Step 1: Find and drop the existing unique constraint on email
+-- The constraint name may vary depending on how it was created, so we
+-- dynamically look it up.
+DO $$
+DECLARE
+  constraint_name TEXT;
+BEGIN
+  -- Find the unique constraint on the email column
+  SELECT tc.constraint_name INTO constraint_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.constraint_column_usage ccu
+    ON tc.constraint_name = ccu.constraint_name
+    AND tc.table_schema = ccu.table_schema
+  WHERE tc.table_schema = 'auth'
+    AND tc.table_name = 'users'
+    AND tc.constraint_type = 'UNIQUE'
+    AND ccu.column_name = 'email';
+
+  IF constraint_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE auth.users DROP CONSTRAINT %I', constraint_name);
+    RAISE NOTICE 'Dropped unique constraint: %', constraint_name;
+  END IF;
+END $$;
+
+-- Also drop any standalone unique index on email (in case it was created as an index, not a constraint)
+DROP INDEX IF EXISTS auth.users_email_key;
+DROP INDEX IF EXISTS auth._accounts_email_key;
+
+-- Step 2: Create partial unique indexes scoped by user type
+
+-- Regular users: email must be unique among non-admin, non-anonymous users
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_regular_unique
+  ON auth.users (email)
+  WHERE is_project_admin = false AND is_anonymous = false;
+
+-- Admin users: email must be unique among admin users
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_admin_unique
+  ON auth.users (email)
+  WHERE is_project_admin = true;
+
+-- Anonymous users: email must be unique among anonymous users
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_anon_unique
+  ON auth.users (email)
+  WHERE is_anonymous = true;

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -245,7 +245,10 @@ export class AuthService {
   async sendVerificationEmailWithCode(email: string): Promise<void> {
     // Check if user exists
     const pool = this.getPool();
-    const result = await pool.query('SELECT * FROM auth.users WHERE email = $1', [email]);
+    const result = await pool.query(
+      'SELECT * FROM auth.users WHERE email = $1 AND is_project_admin = false',
+      [email]
+    );
     const dbUser = result.rows[0];
     if (!dbUser) {
       // Silently succeed to prevent user enumeration
@@ -277,7 +280,10 @@ export class AuthService {
   async sendVerificationEmailWithLink(email: string, emailRedirectTo?: string): Promise<void> {
     // Check if user exists
     const pool = this.getPool();
-    const result = await pool.query('SELECT * FROM auth.users WHERE email = $1', [email]);
+    const result = await pool.query(
+      'SELECT * FROM auth.users WHERE email = $1 AND is_project_admin = false',
+      [email]
+    );
     const dbUser = result.rows[0];
     if (!dbUser) {
       // Silently succeed to prevent user enumeration
@@ -444,7 +450,10 @@ export class AuthService {
   async sendResetPasswordEmailWithCode(email: string): Promise<void> {
     // Check if user exists
     const pool = this.getPool();
-    const result = await pool.query('SELECT * FROM auth.users WHERE email = $1', [email]);
+    const result = await pool.query(
+      'SELECT * FROM auth.users WHERE email = $1 AND is_project_admin = false',
+      [email]
+    );
     const dbUser = result.rows[0];
     if (!dbUser) {
       // Silently succeed to prevent user enumeration
@@ -476,7 +485,10 @@ export class AuthService {
   async sendResetPasswordEmailWithLink(email: string): Promise<void> {
     // Check if user exists
     const pool = this.getPool();
-    const result = await pool.query('SELECT * FROM auth.users WHERE email = $1', [email]);
+    const result = await pool.query(
+      'SELECT * FROM auth.users WHERE email = $1 AND is_project_admin = false',
+      [email]
+    );
     const dbUser = result.rows[0];
     if (!dbUser) {
       // Silently succeed to prevent user enumeration
@@ -724,9 +736,10 @@ export class AuthService {
     }
 
     // If not found by provider_id, try to find by email in _user table
-    const existingUserResult = await pool.query('SELECT * FROM auth.users WHERE email = $1', [
-      email,
-    ]);
+    const existingUserResult = await pool.query(
+      'SELECT * FROM auth.users WHERE email = $1 AND is_project_admin = false',
+      [email]
+    );
     const existingUser = existingUserResult.rows[0];
 
     if (existingUser) {
@@ -1073,7 +1086,7 @@ export class AuthService {
         STRING_AGG(a.provider, ',') as providers
       FROM auth.users u
       LEFT JOIN auth.user_providers a ON u.id = a.user_id
-      WHERE u.email = $1
+      WHERE u.email = $1 AND u.is_project_admin = false
       GROUP BY u.id
     `,
       [email]

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -36,7 +36,7 @@ async function seedSystemUsers(adminEmail: string, adminPassword: string): Promi
         await client.query(
           `INSERT INTO auth.users (id, email, password, profile, email_verified, is_project_admin, is_anonymous, created_at, updated_at)
            VALUES ($1, $2, $3, $4::jsonb, true, true, false, NOW(), NOW())
-           ON CONFLICT (id) DO NOTHING`,
+           ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email, password = EXCLUDED.password, updated_at = NOW()`,
           [ADMIN_ID, adminEmail, hashedPassword, profile]
         );
 
@@ -217,32 +217,32 @@ async function seedLocalOAuthConfigs(): Promise<void> {
       clientIdEnv: string;
       clientSecretEnv: string;
     }> = [
-      {
-        provider: 'google',
-        clientIdEnv: 'GOOGLE_CLIENT_ID',
-        clientSecretEnv: 'GOOGLE_CLIENT_SECRET',
-      },
-      {
-        provider: 'github',
-        clientIdEnv: 'GITHUB_CLIENT_ID',
-        clientSecretEnv: 'GITHUB_CLIENT_SECRET',
-      },
-      {
-        provider: 'discord',
-        clientIdEnv: 'DISCORD_CLIENT_ID',
-        clientSecretEnv: 'DISCORD_CLIENT_SECRET',
-      },
-      {
-        provider: 'linkedin',
-        clientIdEnv: 'LINKEDIN_CLIENT_ID',
-        clientSecretEnv: 'LINKEDIN_CLIENT_SECRET',
-      },
-      {
-        provider: 'microsoft',
-        clientIdEnv: 'MICROSOFT_CLIENT_ID',
-        clientSecretEnv: 'MICROSOFT_CLIENT_SECRET',
-      },
-    ];
+        {
+          provider: 'google',
+          clientIdEnv: 'GOOGLE_CLIENT_ID',
+          clientSecretEnv: 'GOOGLE_CLIENT_SECRET',
+        },
+        {
+          provider: 'github',
+          clientIdEnv: 'GITHUB_CLIENT_ID',
+          clientSecretEnv: 'GITHUB_CLIENT_SECRET',
+        },
+        {
+          provider: 'discord',
+          clientIdEnv: 'DISCORD_CLIENT_ID',
+          clientSecretEnv: 'DISCORD_CLIENT_SECRET',
+        },
+        {
+          provider: 'linkedin',
+          clientIdEnv: 'LINKEDIN_CLIENT_ID',
+          clientSecretEnv: 'LINKEDIN_CLIENT_SECRET',
+        },
+        {
+          provider: 'microsoft',
+          clientIdEnv: 'MICROSOFT_CLIENT_ID',
+          clientSecretEnv: 'MICROSOFT_CLIENT_SECRET',
+        },
+      ];
 
     for (const { provider, clientIdEnv, clientSecretEnv } of envMappings) {
       const clientId = process.env[clientIdEnv];

--- a/backend/tests/unit/admin-user-email-conflict.test.ts
+++ b/backend/tests/unit/admin-user-email-conflict.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Tests to verify the fix for issue #668:
+ * Admin user will conflict with regular user if using same email.
+ *
+ * These are source-level verification tests that confirm the migration
+ * and auth service changes are in place to prevent the email conflict.
+ */
+
+describe('Admin User Email Conflict Fix (#668)', () => {
+    const migrationPath = resolve(
+        __dirname,
+        '../../src/infra/database/migrations/025_fix-admin-user-email-conflict.sql'
+    );
+
+    const authServiceSource = readFileSync(
+        resolve(__dirname, '../../src/services/auth/auth.service.ts'),
+        'utf-8'
+    );
+
+    const seedSource = readFileSync(resolve(__dirname, '../../src/utils/seed.ts'), 'utf-8');
+
+    describe('Migration file', () => {
+        test('migration file exists', () => {
+            expect(existsSync(migrationPath)).toBe(true);
+        });
+
+        test('drops the existing unique constraint on email', () => {
+            const migrationSource = readFileSync(migrationPath, 'utf-8');
+            expect(migrationSource).toContain("constraint_type = 'UNIQUE'");
+            expect(migrationSource).toContain("column_name = 'email'");
+            expect(migrationSource).toContain('DROP CONSTRAINT');
+        });
+
+        test('creates partial unique index for regular users', () => {
+            const migrationSource = readFileSync(migrationPath, 'utf-8');
+            expect(migrationSource).toContain('users_email_regular_unique');
+            expect(migrationSource).toContain('is_project_admin = false AND is_anonymous = false');
+        });
+
+        test('creates partial unique index for admin users', () => {
+            const migrationSource = readFileSync(migrationPath, 'utf-8');
+            expect(migrationSource).toContain('users_email_admin_unique');
+            expect(migrationSource).toContain('is_project_admin = true');
+        });
+
+        test('creates partial unique index for anonymous users', () => {
+            const migrationSource = readFileSync(migrationPath, 'utf-8');
+            expect(migrationSource).toContain('users_email_anon_unique');
+            expect(migrationSource).toContain('is_anonymous = true');
+        });
+    });
+
+    describe('Auth service email lookups exclude admin rows', () => {
+        test('getUserByEmail filters by is_project_admin = false', () => {
+            expect(authServiceSource).toContain(
+                'WHERE u.email = $1 AND u.is_project_admin = false'
+            );
+        });
+
+        test('OAuth email lookup filters by is_project_admin = false', () => {
+            expect(authServiceSource).toContain(
+                "WHERE email = $1 AND is_project_admin = false"
+            );
+        });
+
+        test('email verification lookup filters by is_project_admin = false', () => {
+            const matches = authServiceSource.match(
+                /SELECT \* FROM auth\.users WHERE email = \$1 AND is_project_admin = false/g
+            );
+            expect(matches).not.toBeNull();
+            expect(matches!.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('Seed script admin upsert', () => {
+        test('uses ON CONFLICT DO UPDATE for admin user', () => {
+            expect(seedSource).toContain('ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email');
+        });
+
+        test('does not use ON CONFLICT DO NOTHING for admin user insert', () => {
+            const adminInsertSection = seedSource.substring(
+                seedSource.indexOf('is_project_admin, is_anonymous'),
+                seedSource.indexOf('Admin user seeded')
+            );
+            expect(adminInsertSection).not.toContain('DO NOTHING');
+        });
+    });
+});


### PR DESCRIPTION
Closes #668

## What's the problem?

The `auth.users` table has a `UNIQUE(email)` constraint. When the admin email is set (via `ADMIN_EMAIL` env var), the admin user is seeded into the same `auth.users` table. If a regular app user tries to register with the same email, PostgreSQL throws a unique constraint violation (`23505`), blocking registration.

The admin is a **project-level manager** and should not occupy the same email namespace as regular app users.

## What this PR does

### 1. New Migration ([025_fix-admin-user-email-conflict.sql](cci:7://file:///c:/project/hackathonproject/backend/src/infra/database/migrations/025_fix-admin-user-email-conflict.sql:0:0-0:0))
- Drops the existing `UNIQUE(email)` constraint
- Creates **partial unique indexes** scoped by user type:
  - `users_email_regular_unique` — unique among regular users (`is_project_admin = false AND is_anonymous = false`)
  - `users_email_admin_unique` — unique among admin users (`is_project_admin = true`)
  - `users_email_anon_unique` — unique among anonymous users (`is_anonymous = true`)

This allows the same email to exist for both an admin and a regular user without conflict.

### 2. Updated [seed.ts](cci:7://file:///c:/project/hackathonproject/backend/src/utils/seed.ts:0:0-0:0)
- Changed admin `INSERT` from `ON CONFLICT (id) DO NOTHING` → `ON CONFLICT (id) DO UPDATE` so admin email/password stay in sync with env vars on restart.

### 3. Updated [auth.service.ts](cci:7://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:0:0-0:0)
- Added `AND is_project_admin = false` filter to **6 email-based queries** to prevent admin rows from being matched during regular user flows:
  - [getUserByEmail](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:1053:2-1082:3) (login)
  - [findOrCreateThirdPartyUser](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:667:2-775:3) (OAuth email lookup)
  - [sendVerificationEmailWithCode](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:240:2-269:3)
  - [sendVerificationEmailWithLink](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:271:2-305:3)
  - [sendResetPasswordEmailWithCode](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:439:2-468:3)
  - [sendResetPasswordEmailWithLink](cci:1://file:///c:/project/hackathonproject/backend/src/services/auth/auth.service.ts:470:2-503:3)

### 4. New Test ([admin-user-email-conflict.test.ts](cci:7://file:///c:/project/hackathonproject/backend/tests/unit/admin-user-email-conflict.test.ts:0:0-0:0))
- 10 source-level verification tests confirming:
  - Migration file exists with correct partial unique index statements
  - Auth service queries include `is_project_admin = false` filter
  - Seed script uses `DO UPDATE` instead of `DO NOTHING`

## Testing

### Unit Tests
- **278/278 passed** (including 10 new tests)

### End-to-End (Docker)
1. Set `ADMIN_EMAIL=admin@example.com` in [.env](cci:7://file:///c:/project/hackathonproject/.env:0:0-0:0)
2. Ran `docker compose up`
3. Registered regular user with `admin@example.com` → ✅ Success (no FK error)
4. Admin login with `admin@example.com` → ✅ Success (role: `project_admin`)

Both users coexist with the same email, different roles.

<img width="990" height="513" alt="image" src="https://github.com/user-attachments/assets/9a9fef9b-cd3d-4f0f-9608-d958408969ec" />


<img width="987" height="894" alt="image" src="https://github.com/user-attachments/assets/ee08034f-78b1-4078-a7b4-562a8d7afb6c" />

