### PR TITLE
fix(settings): add rotate API key button to Settings Menu Dialog

### DIFF
--- a/frontend/src/features/dashboard/components/SettingsMenuDialog.tsx
+++ b/frontend/src/features/dashboard/components/SettingsMenuDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Cpu, HardDrive, Plug, Settings } from 'lucide-react';
+import { Cpu, HardDrive, Plug, RefreshCw, Settings } from 'lucide-react';
 import {
   Button,
   CopyButton,
@@ -36,6 +36,7 @@ import { useModal } from '@/lib/contexts/ModalContext';
 import { cn, compareVersions, isIframe, isInsForgeCloudProject } from '@/lib/utils/utils';
 import { MCPSection, CLISection, ConnectionStringSection } from '@/features/connect';
 import { postMessageToParent } from '@/lib/utils/cloudMessaging';
+import { metadataService } from '@/lib/services/metadata.service';
 
 type TabType = 'info' | 'compute' | 'connect';
 
@@ -53,6 +54,7 @@ export default function SettingsMenuDialog() {
   const [instanceInfo, setInstanceInfo] = useState<Omit<InstanceInfoEvent, 'type'> | null>(null);
   const [selectedInstanceType, setSelectedInstanceType] = useState<string | null>(null);
   const [isChangingInstanceType, setIsChangingInstanceType] = useState(false);
+  const [isRotatingApiKey, setIsRotatingApiKey] = useState(false);
 
   const { apiKey, isLoading: isApiKeyLoading } = useApiKey();
   const { version, isLoading: isVersionLoading } = useHealth();
@@ -271,6 +273,35 @@ export default function SettingsMenuDialog() {
     setIsProjectNameFocused(false);
   };
 
+  const handleRotateApiKey = async () => {
+    const confirmed = await confirm({
+      title: 'Rotate API Key',
+      description:
+        'This will generate a new API key. The current key will remain valid for 24 hours to allow for a smooth transition. This action cannot be undone.',
+      confirmText: 'Rotate Key',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    setIsRotatingApiKey(true);
+    try {
+      const result = await metadataService.rotateApiKey(24);
+      queryClient.setQueryData(['metadata', 'apiKey'], result.apiKey);
+      showToast(
+        'API key rotated successfully. The old key will remain valid for 24 hours.',
+        'success'
+      );
+    } catch {
+      showToast('Failed to rotate API key. Please try again.', 'error');
+    } finally {
+      setIsRotatingApiKey(false);
+    }
+  };
+
   const handleChangeInstanceType = () => {
     if (
       !instanceInfo ||
@@ -424,6 +455,17 @@ export default function SettingsMenuDialog() {
                           />
                         )}
                       </div>
+                      <Button
+                        variant="secondary"
+                        onClick={() => void handleRotateApiKey()}
+                        disabled={isApiKeyLoading || isRotatingApiKey}
+                        className="h-8 shrink-0 rounded border-[var(--alpha-8)] bg-card px-3 text-sm font-medium"
+                      >
+                        <RefreshCw
+                          className={cn('mr-1.5 size-3.5', isRotatingApiKey && 'animate-spin')}
+                        />
+                        {isRotatingApiKey ? 'Rotating...' : 'Rotate'}
+                      </Button>
                     </div>
                   </div>
 


### PR DESCRIPTION
Closes #956

## What's Changed
Added a "Rotate" button to the API key section of the Settings Menu Dialog. 
The backend route (`POST /api/secrets/api-key/rotate`) and service method 
(`metadataService.rotateApiKey()`) already existed but were not wired into 
the Settings UI.

## Changes
- Added a "Rotate" button with `RefreshCw` icon next to the API key copy button
- Shows a destructive confirmation dialog with 24-hour grace period warning
- Calls the existing `rotateApiKey()` service method on confirmation
- Displays success/error toasts and auto-refreshes the displayed key
- Button shows a spinner animation during rotation

## Testing
1. Open Settings → General → API Key row now shows a "Rotate" button
2. Click Rotate → confirmation dialog appears
3. Cancel → nothing happens
4. Confirm → API key rotates, success toast shown, key refreshes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rotate API keys directly from the Settings menu.
  * New Rotate button shows a spinning icon and “Rotating...” label while the operation is in progress and is disabled during loading.
  * On success the displayed API key is updated and users receive success or error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->