### PR TITLE
fix(security): block DDL on system/internal schemas in SQL editor

### DIFF
--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -9,7 +9,7 @@ import {
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { ERROR_CODES } from '@/types/error-constants.js';
-import { parseSQLStatements, checkAuthSchemaOperations } from '@/utils/sql-parser.js';
+import { parseSQLStatements, checkAuthSchemaOperations, checkSystemSchemaOperations } from '@/utils/sql-parser.js';
 import { validateTableName } from '@/utils/validations.js';
 import pgFormat from 'pg-format';
 import { parse } from 'csv-parse/sync';
@@ -74,6 +74,10 @@ export class DatabaseAdvanceService {
    * - DELETE operations on auth schema (prevents user deletion via raw SQL)
    * - TRUNCATE operations on auth schema (prevents mass user deletion)
    * - DROP operations on auth schema (prevents destruction of tables, indexes, triggers, functions, views, sequences, schemas, policies, types, domains)
+   * - CREATE/ALTER/DROP FUNCTION on system, schedules, extensions, storage, realtime schemas
+   * - CREATE TRIGGER that references a function from those protected schemas
+   * - Any DDL (CREATE TABLE, ALTER TABLE, DROP) on those protected schemas
+   * - DELETE / TRUNCATE on those protected schemas
    *
    * Allows:
    * - SELECT queries on auth schema (for reading user data)
@@ -103,6 +107,15 @@ export class DatabaseAdvanceService {
         query: query.substring(0, 100),
       });
       throw new AppError(authError, 403, ERROR_CODES.FORBIDDEN);
+    }
+
+    // Block DDL on internal system schemas (system, schedules, extensions, etc.)
+    const systemError = checkSystemSchemaOperations(query);
+    if (systemError) {
+      logger.warn('Blocked operation on system schema', {
+        query: query.substring(0, 100),
+      });
+      throw new AppError(systemError, 403, ERROR_CODES.FORBIDDEN);
     }
 
     return query;

--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -219,6 +219,143 @@ export function checkAuthSchemaOperations(query: string): string | null {
 }
 
 /**
+ * Protected internal schemas that users must not modify via the SQL editor.
+ * Any CREATE, ALTER, or DROP on objects within these schemas is blocked.
+ */
+const PROTECTED_SCHEMAS = new Set(['system', 'schedules', 'extensions', 'storage', 'realtime']);
+
+/**
+ * Check if a query contains dangerous DDL operations on protected internal schemas
+ * (system, schedules, extensions, storage, realtime).
+ * Returns an error message if blocked, null if allowed.
+ */
+export function checkSystemSchemaOperations(query: string): string | null {
+  try {
+    const { stmts } = parseSync(query);
+
+    for (const stmtWrapper of stmts) {
+      const stmt = stmtWrapper.stmt as Record<string, unknown>;
+      const [stmtType, data] = Object.entries(stmt)[0] as [string, Record<string, unknown>];
+
+      // Block CREATE FUNCTION / CREATE OR REPLACE FUNCTION on protected schemas
+      if (stmtType === 'CreateFunctionStmt') {
+        const funcname = (data.funcname as Array<Record<string, unknown>>) || [];
+        if (funcname.length >= 2) {
+          const schemaItem = funcname[0];
+          const schemaName = (schemaItem.String as Record<string, unknown> | undefined)
+            ?.sval as string | undefined;
+          if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+            return `CREATE OR REPLACE FUNCTION on schema "${schemaName}" is not allowed. System functions must not be modified.`;
+          }
+        }
+      }
+
+      // Block CREATE TRIGGER that executes a function in a protected schema
+      if (stmtType === 'CreateTrigStmt') {
+        const funcname = (data.funcname as Array<Record<string, unknown>>) || [];
+        if (funcname.length >= 2) {
+          const schemaItem = funcname[0];
+          const schemaName = (schemaItem.String as Record<string, unknown> | undefined)
+            ?.sval as string | undefined;
+          if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+            return `CREATE TRIGGER using a function from schema "${schemaName}" is not allowed. System trigger functions must not be attached to user tables.`;
+          }
+        }
+      }
+
+      // Block ALTER FUNCTION on protected schemas
+      if (stmtType === 'AlterFunctionStmt') {
+        const func = data.func as Record<string, unknown> | undefined;
+        const objname = (func?.objname as Array<Record<string, unknown>>) || [];
+        if (objname.length >= 2) {
+          const schemaItem = objname[0];
+          const schemaName = (schemaItem.String as Record<string, unknown> | undefined)
+            ?.sval as string | undefined;
+          if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+            return `ALTER FUNCTION on schema "${schemaName}" is not allowed. System functions must not be modified.`;
+          }
+        }
+      }
+
+      // Block DROP on protected schemas (functions, tables, etc.)
+      if (stmtType === 'DropStmt') {
+        const objects = (data.objects as Array<unknown>) || [];
+        for (const obj of objects) {
+          if (typeof obj !== 'object' || obj === null) continue;
+          const objRecord = obj as Record<string, unknown>;
+          let schemaName: string | null = null;
+
+          // DROP SCHEMA: direct String object
+          if (objRecord.String) {
+            const stringObj = objRecord.String as Record<string, unknown>;
+            schemaName = (stringObj.sval as string) ?? null;
+          }
+          // DROP TABLE/INDEX/VIEW/etc: List with [schema, name] items
+          else if (objRecord.List) {
+            const list = objRecord.List as Record<string, unknown>;
+            const items = (list.items as Array<Record<string, unknown>>) || [];
+            if (items.length > 0) {
+              const firstItem = items[0];
+              if (firstItem.String) {
+                schemaName = (firstItem.String as Record<string, unknown>).sval as string;
+              }
+            }
+          }
+          // DROP FUNCTION/PROCEDURE: ObjectWithArgs
+          else if (objRecord.ObjectWithArgs) {
+            const objectWithArgs = objRecord.ObjectWithArgs as Record<string, unknown>;
+            const objname = (objectWithArgs.objname as Array<Record<string, unknown>>) || [];
+            if (objname.length > 0) {
+              const firstItem = objname[0];
+              if (firstItem.String) {
+                schemaName = (firstItem.String as Record<string, unknown>).sval as string;
+              }
+            }
+          }
+
+          if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+            return `DROP operations on schema "${schemaName}" are not allowed. System schemas must not be modified.`;
+          }
+        }
+      }
+
+      // Block CREATE TABLE / ALTER TABLE on protected schemas
+      if (stmtType === 'CreateStmt' || stmtType === 'AlterTableStmt') {
+        const relation = data.relation as Record<string, unknown> | undefined;
+        const schemaName = getSchemaName(relation);
+        if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+          return `DDL operations on schema "${schemaName}" are not allowed. System schemas must not be modified.`;
+        }
+      }
+
+      // Block DELETE / TRUNCATE on protected schemas
+      if (stmtType === 'DeleteStmt') {
+        const relation = data.relation as Record<string, unknown> | undefined;
+        const schemaName = getSchemaName(relation);
+        if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+          return `DELETE operations on schema "${schemaName}" are not allowed.`;
+        }
+      }
+
+      if (stmtType === 'TruncateStmt') {
+        const relations = (data.relations as Array<Record<string, unknown>>) || [];
+        for (const relation of relations) {
+          const schemaName = getSchemaName(relation);
+          if (schemaName && PROTECTED_SCHEMAS.has(schemaName.toLowerCase())) {
+            return `TRUNCATE operations on schema "${schemaName}" are not allowed.`;
+          }
+        }
+      }
+    }
+
+    return null;
+  } catch (parseError) {
+    logger.warn('SQL parse error in checkSystemSchemaOperations, letting query through:', parseError);
+    return null;
+  }
+}
+
+/**
  * Parse a SQL string into individual statements, properly handling:
  * - String literals with embedded semicolons
  * - Escaped quotes

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["node","vitest" ]
+    "types": ["node"]
   },
   "include": ["src/**/*", "../shared-schemas/src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Extends sanitizeQuery() to call a new checkSystemSchemaOperations() function that blocks CREATE/ALTER/DROP FUNCTION, CREATE TRIGGER referencing system functions, and any DDL/DML on the system, schedules, extensions, storage, and realtime schemas via the raw SQL editor.

Also removes the non-existent "vitest" entry from tsconfig types array to resolve TS compiler errors.

## Summary

Extends `sanitizeQuery()` to call a new `checkSystemSchemaOperations()` function in `sql-parser.ts` that blocks:

- `CREATE OR REPLACE FUNCTION` / `ALTER FUNCTION` on `system`, `schedules`, `extensions`, `storage`, `realtime` schemas
- `CREATE TRIGGER` that references a function from those protected schemas
- `DROP`, `CREATE TABLE`, `ALTER TABLE`, `DELETE`, `TRUNCATE` on those protected schemas

This prevents users from overwriting shared system trigger functions (e.g. `system.update_updated_at()`) via the raw SQL editor, which was silently breaking every table that depends on those triggers.

Also removes the non-existent `"vitest"` entry from `backend/tsconfig.json` types array to resolve TS compiler errors.


## How did you test this change?

Manually verified the following queries are blocked with 403 Forbidden:
- `CREATE OR REPLACE FUNCTION system.update_updated_at() ...`
- `CREATE TRIGGER t BEFORE UPDATE ON my_table FOR EACH ROW EXECUTE FUNCTION system.update_updated_at()`
- `DROP FUNCTION system.update_updated_at()`
- `DROP TABLE system.secrets`
- `DELETE FROM system.secrets`

Verified the following are still allowed:
- `SELECT * FROM system.secrets`
- `CREATE TABLE public.foo (id uuid)`
- All existing auth schema protections continue to work



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced SQL query protections to prevent operations on system-critical schemas, blocking function creation/modification, trigger creation, table DDL operations, and data deletion.

* **Chores**
  * Updated TypeScript configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->