### PR TITLE
fix: remove mock data from deployments env var service

### DIFF
--- a/frontend/src/features/deployments/services/deployments.service.ts
+++ b/frontend/src/features/deployments/services/deployments.service.ts
@@ -95,31 +95,6 @@ export class DeploymentsService {
   }
 
   async getEnvVar(id: string): Promise<DeploymentEnvVarWithValue> {
-    // TODO: Remove mock data after testing
-    const mockValues: Record<string, DeploymentEnvVarWithValue> = {
-      'mock-1': {
-        id: 'mock-1',
-        key: 'DATABASE_URL',
-        value: 'postgresql://user:password@localhost:5432/mydb',
-        type: 'encrypted',
-      },
-      'mock-2': {
-        id: 'mock-2',
-        key: 'API_SECRET_KEY',
-        value: 'sk_live_abc123xyz789secretkey',
-        type: 'secret',
-      },
-      'mock-3': {
-        id: 'mock-3',
-        key: 'NEXT_PUBLIC_APP_URL',
-        value: 'https://myapp.insforge.site',
-        type: 'plain',
-      },
-    };
-    if (mockValues[id]) {
-      return mockValues[id];
-    }
-
     const data = (await apiClient.request(`/deployments/env-vars/${encodeURIComponent(id)}`, {
       headers: apiClient.withAccessToken(),
     })) as GetEnvVarResponse;


### PR DESCRIPTION
## Summary
- Removed hardcoded mock data from `getEnvVar()` in `deployments.service.ts`
- Mock values for `mock-1`, `mock-2`, `mock-3` were intercepting real API calls and returning fake data silently
- Now always fetches from `/deployments/env-vars/:id` API endpoint

Fixes #974

## Test plan
- [ ] Open an env var in the Deployments section — real data should load from API
- [ ] No mock/hardcoded values returned for any env var ID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed environment variable retrieval to consistently fetch from the backend instead of using hardcoded mock values, ensuring accurate configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->