### PR TITLE
feat(ai-usage): add AI Usage Dashboard page

### DIFF
--- a/frontend/src/components/layout/SecondaryMenu.tsx
+++ b/frontend/src/components/layout/SecondaryMenu.tsx
@@ -74,7 +74,7 @@ function SecondaryMenuItem({
   itemActions,
 }: SecondaryMenuItemProps) {
   // Each item determines its own active state using React Router's useMatch
-  const match = useMatch({ path: item.href ?? '/__secondary_menu_no_match__', end: false });
+  const match = useMatch({ path: item.href ?? '/__secondary_menu_no_match__', end: !!item.exact });
   const hasExternalActiveItem = activeItemId !== null && activeItemId !== undefined;
   const isSelected = hasExternalActiveItem ? item.id === activeItemId : !!match;
   const menuActions = itemActions?.(item) ?? [];

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -156,7 +156,12 @@ export default function AIUsagePage() {
               <StatsCard
                 icon={Activity}
                 title="Embedding Requests"
-                value={isLoadingSummary ? 0 : ((summary as (typeof summary & { embeddingRequests?: number }))?.embeddingRequests ?? 0)}
+                value={
+                  isLoadingSummary
+                    ? 0
+                    : ((summary as typeof summary & { embeddingRequests?: number })
+                        ?.embeddingRequests ?? 0)
+                }
                 unit="requests"
                 description="Embedding requests"
                 isLoading={isLoadingSummary}
@@ -164,7 +169,14 @@ export default function AIUsagePage() {
               <StatsCard
                 icon={Zap}
                 title="Embedding Tokens"
-                value={isLoadingSummary ? 0 : formatTokenCount(((summary as (typeof summary & { embeddingTokens?: number }))?.embeddingTokens) ?? 0)}
+                value={
+                  isLoadingSummary
+                    ? 0
+                    : formatTokenCount(
+                        (summary as typeof summary & { embeddingTokens?: number })
+                          ?.embeddingTokens ?? 0
+                      )
+                }
                 unit="tokens"
                 description="Embedding tokens consumed"
                 isLoading={isLoadingSummary}

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -32,10 +32,10 @@ function getDateRange(range: DateRange): { startDate?: string; endDate?: string 
   const now = new Date();
   const start = new Date(now);
   if (range === 'week') {
-    start.setDate(now.getDate() - 7);
+    start.setDate(start.getDate() - 7);
   }
   if (range === 'month') {
-    start.setMonth(now.getMonth() - 1);
+    start.setMonth(start.getMonth() - 1);
   }
   return { startDate: start.toISOString(), endDate: now.toISOString() };
 }

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -156,12 +156,7 @@ export default function AIUsagePage() {
               <StatsCard
                 icon={Activity}
                 title="Embedding Requests"
-                value={
-                  isLoadingSummary
-                    ? 0
-                    : ((summary as typeof summary & { embeddingRequests?: number })
-                        ?.embeddingRequests ?? 0)
-                }
+                value={isLoadingSummary ? 0 : (summary?.embeddingRequests ?? 0)}
                 unit="requests"
                 description="Embedding requests"
                 isLoading={isLoadingSummary}
@@ -169,14 +164,7 @@ export default function AIUsagePage() {
               <StatsCard
                 icon={Zap}
                 title="Embedding Tokens"
-                value={
-                  isLoadingSummary
-                    ? 0
-                    : formatTokenCount(
-                        (summary as typeof summary & { embeddingTokens?: number })
-                          ?.embeddingTokens ?? 0
-                      )
-                }
+                value={isLoadingSummary ? 0 : formatTokenCount(summary?.embeddingTokens ?? 0)}
                 unit="tokens"
                 description="Embedding tokens consumed"
                 isLoading={isLoadingSummary}
@@ -262,7 +250,7 @@ export default function AIUsagePage() {
 }
 
 function UsageRow({ record }: { record: AIUsageRecordSchema }) {
-  const usageType = (record as AIUsageRecordSchema & { usageType?: string }).usageType;
+  const usageType = record.usageType;
 
   return (
     <div className="grid grid-cols-5 gap-x-2.5 h-10 items-center text-sm px-4 border-b border-[var(--alpha-8)] last:border-b-0 hover:bg-[var(--alpha-4)] transition-colors">

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -1,0 +1,232 @@
+import { useState, useMemo } from 'react';
+import { Loader2, Activity, Zap, Image, MessageSquare } from 'lucide-react';
+import { useAIUsageSummary, useAIUsageRecords } from '../hooks/useAIUsage';
+import { StatsCard } from '@/features/dashboard/components/StatsCard';
+import type { AIUsageRecordSchema } from '@insforge/shared-schemas';
+
+type DateRange = 'week' | 'month' | 'all';
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatDate(date: Date | string): string {
+  return new Date(date).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function getDateRange(range: DateRange): { startDate?: string; endDate?: string } {
+  if (range === 'all') return {};
+  const now = new Date();
+  const start = new Date(now);
+  if (range === 'week') start.setDate(now.getDate() - 7);
+  if (range === 'month') start.setMonth(now.getMonth() - 1);
+  return { startDate: start.toISOString(), endDate: now.toISOString() };
+}
+
+const PAGE_SIZE = 50;
+
+export default function AIUsagePage() {
+  const [dateRange, setDateRange] = useState<DateRange>('month');
+  const [page, setPage] = useState(0);
+
+  const { startDate, endDate } = useMemo(() => getDateRange(dateRange), [dateRange]);
+
+  const { data: summary, isLoading: isLoadingSummary } = useAIUsageSummary({
+    startDate,
+    endDate,
+  });
+
+  const { data: recordsData, isLoading: isLoadingRecords } = useAIUsageRecords({
+    startDate,
+    endDate,
+    limit: String(PAGE_SIZE),
+    offset: String(page * PAGE_SIZE),
+  });
+
+  const records = recordsData?.records ?? [];
+  const total = recordsData?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleRangeChange = (range: DateRange) => {
+    setDateRange(range);
+    setPage(0);
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-[rgb(var(--semantic-0))]">
+      {/* Header */}
+      <div className="flex flex-col items-center px-10 flex-shrink-0">
+        <div className="max-w-[1024px] w-full flex flex-col gap-6 pt-10 pb-6">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-2xl font-medium text-foreground leading-8">AI Usage</h1>
+              <p className="text-sm leading-5 text-muted-foreground">
+                Track token consumption and request activity across all AI models.
+              </p>
+            </div>
+
+            {/* Date range filter */}
+            <div className="flex items-center gap-1 bg-card border border-[var(--alpha-8)] rounded p-1">
+              {(['week', 'month', 'all'] as DateRange[]).map((r) => (
+                <button
+                  key={r}
+                  onClick={() => handleRangeChange(r)}
+                  className={`px-3 py-1 rounded text-sm font-normal transition-colors ${
+                    dateRange === r
+                      ? 'bg-[var(--alpha-8)] text-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {r === 'week' ? 'This week' : r === 'month' ? 'This month' : 'All time'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Stats Cards */}
+          <div className="grid grid-cols-2 xl:grid-cols-4 gap-4">
+            <StatsCard
+              icon={Activity}
+              title="Total Requests"
+              value={isLoadingSummary ? 0 : (summary?.totalRequests ?? 0)}
+              unit="requests"
+              description="All AI requests"
+              isLoading={isLoadingSummary}
+            />
+            <StatsCard
+              icon={Zap}
+              title="Input Tokens"
+              value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalInputTokens ?? 0)}
+              unit="tokens"
+              description="Prompt tokens consumed"
+              isLoading={isLoadingSummary}
+            />
+            <StatsCard
+              icon={MessageSquare}
+              title="Output Tokens"
+              value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalOutputTokens ?? 0)}
+              unit="tokens"
+              description="Completion tokens generated"
+              isLoading={isLoadingSummary}
+            />
+            <StatsCard
+              icon={Image}
+              title="Images Generated"
+              value={isLoadingSummary ? 0 : (summary?.totalImageCount ?? 0)}
+              unit="images"
+              description="Total images created"
+              isLoading={isLoadingSummary}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Records Table */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-10 pb-6">
+        <div className="max-w-[1024px] w-full mx-auto">
+          <div className="bg-card border border-[var(--alpha-8)] rounded py-2 flex flex-col">
+            {/* Table Header */}
+            <div className="grid grid-cols-5 gap-x-2.5 h-8 items-center text-sm leading-5 text-muted-foreground px-4 border-b border-[var(--alpha-8)] shrink-0">
+              <div>Time</div>
+              <div>Model</div>
+              <div>Type</div>
+              <div>Input tokens</div>
+              <div>Output tokens</div>
+            </div>
+
+            {/* Table Body */}
+            {isLoadingRecords && records.length === 0 ? (
+              <div className="flex items-center justify-center h-40">
+                <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : records.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-40 gap-2">
+                <p className="text-sm text-muted-foreground">No usage records found</p>
+                <p className="text-xs text-muted-foreground">
+                  Records will appear here after AI requests are made.
+                </p>
+              </div>
+            ) : (
+              records.map((record: AIUsageRecordSchema) => (
+                <UsageRow key={record.id} record={record} />
+              ))
+            )}
+          </div>
+
+          {/* Pagination */}
+          {total > PAGE_SIZE && (
+            <div className="flex items-center justify-between mt-3 px-1">
+              <p className="text-sm text-muted-foreground">
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-3 py-1 text-sm rounded border border-[var(--alpha-8)] text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-muted-foreground">
+                  {page + 1} / {totalPages}
+                </span>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                  className="px-3 py-1 text-sm rounded border border-[var(--alpha-8)] text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UsageRow({ record }: { record: AIUsageRecordSchema }) {
+  const usageType = (record as AIUsageRecordSchema & { usageType?: string }).usageType;
+
+  return (
+    <div className="grid grid-cols-5 gap-x-2.5 h-10 items-center text-sm px-4 border-b border-[var(--alpha-8)] last:border-b-0 hover:bg-[var(--alpha-4)] transition-colors">
+      <div className="text-muted-foreground truncate">{formatDate(record.createdAt)}</div>
+      <div className="truncate text-foreground" title={record.model ?? record.modelId ?? '—'}>
+        {record.model ?? record.modelId ?? '—'}
+      </div>
+      <div>
+        <TypeBadge type={usageType} />
+      </div>
+      <div className="text-foreground tabular-nums">
+        {record.inputTokens != null ? formatTokenCount(record.inputTokens) : '—'}
+      </div>
+      <div className="text-foreground tabular-nums">
+        {record.outputTokens != null ? formatTokenCount(record.outputTokens) : '—'}
+      </div>
+    </div>
+  );
+}
+
+function TypeBadge({ type }: { type?: string }) {
+  const label = type ?? 'chat';
+  const styles: Record<string, string> = {
+    chat: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    embedding: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+    image_generation: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${styles[label] ?? styles['chat']}`}
+    >
+      {label === 'image_generation' ? 'image' : label}
+    </span>
+  );
+}

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -7,8 +7,12 @@ import type { AIUsageRecordSchema } from '@insforge/shared-schemas';
 type DateRange = 'week' | 'month' | 'all';
 
 function formatTokenCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}K`;
+  }
   return String(n);
 }
 
@@ -22,11 +26,17 @@ function formatDate(date: Date | string): string {
 }
 
 function getDateRange(range: DateRange): { startDate?: string; endDate?: string } {
-  if (range === 'all') return {};
+  if (range === 'all') {
+    return {};
+  }
   const now = new Date();
   const start = new Date(now);
-  if (range === 'week') start.setDate(now.getDate() - 7);
-  if (range === 'month') start.setMonth(now.getMonth() - 1);
+  if (range === 'week') {
+    start.setDate(now.getDate() - 7);
+  }
+  if (range === 'month') {
+    start.setMonth(now.getMonth() - 1);
+  }
   return { startDate: start.toISOString(), endDate: now.toISOString() };
 }
 
@@ -206,10 +216,14 @@ function UsageRow({ record }: { record: AIUsageRecordSchema }) {
         <TypeBadge type={usageType} />
       </div>
       <div className="text-foreground tabular-nums">
-        {record.inputTokens != null ? formatTokenCount(record.inputTokens) : '—'}
+        {record.inputTokens !== null && record.inputTokens !== undefined
+          ? formatTokenCount(record.inputTokens)
+          : '—'}
       </div>
       <div className="text-foreground tabular-nums">
-        {record.outputTokens != null ? formatTokenCount(record.outputTokens) : '—'}
+        {record.outputTokens !== null && record.outputTokens !== undefined
+          ? formatTokenCount(record.outputTokens)
+          : '—'}
       </div>
     </div>
   );

--- a/frontend/src/features/ai/pages/AIUsagePage.tsx
+++ b/frontend/src/features/ai/pages/AIUsagePage.tsx
@@ -48,12 +48,19 @@ export default function AIUsagePage() {
 
   const { startDate, endDate } = useMemo(() => getDateRange(dateRange), [dateRange]);
 
-  const { data: summary, isLoading: isLoadingSummary } = useAIUsageSummary({
-    startDate,
-    endDate,
-  });
+  const {
+    data: summary,
+    isLoading: isLoadingSummary,
+    isError: isSummaryError,
+    refetch: refetchSummary,
+  } = useAIUsageSummary({ startDate, endDate });
 
-  const { data: recordsData, isLoading: isLoadingRecords } = useAIUsageRecords({
+  const {
+    data: recordsData,
+    isLoading: isLoadingRecords,
+    isError: isRecordsError,
+    refetch: refetchRecords,
+  } = useAIUsageRecords({
     startDate,
     endDate,
     limit: String(PAGE_SIZE),
@@ -88,6 +95,7 @@ export default function AIUsagePage() {
                 <button
                   key={r}
                   onClick={() => handleRangeChange(r)}
+                  aria-pressed={dateRange === r}
                   className={`px-3 py-1 rounded text-sm font-normal transition-colors ${
                     dateRange === r
                       ? 'bg-[var(--alpha-8)] text-foreground'
@@ -101,40 +109,68 @@ export default function AIUsagePage() {
           </div>
 
           {/* Stats Cards */}
-          <div className="grid grid-cols-2 xl:grid-cols-4 gap-4">
-            <StatsCard
-              icon={Activity}
-              title="Total Requests"
-              value={isLoadingSummary ? 0 : (summary?.totalRequests ?? 0)}
-              unit="requests"
-              description="All AI requests"
-              isLoading={isLoadingSummary}
-            />
-            <StatsCard
-              icon={Zap}
-              title="Input Tokens"
-              value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalInputTokens ?? 0)}
-              unit="tokens"
-              description="Prompt tokens consumed"
-              isLoading={isLoadingSummary}
-            />
-            <StatsCard
-              icon={MessageSquare}
-              title="Output Tokens"
-              value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalOutputTokens ?? 0)}
-              unit="tokens"
-              description="Completion tokens generated"
-              isLoading={isLoadingSummary}
-            />
-            <StatsCard
-              icon={Image}
-              title="Images Generated"
-              value={isLoadingSummary ? 0 : (summary?.totalImageCount ?? 0)}
-              unit="images"
-              description="Total images created"
-              isLoading={isLoadingSummary}
-            />
-          </div>
+          {isSummaryError ? (
+            <div className="flex items-center justify-between rounded border border-[var(--alpha-8)] bg-card px-4 py-3">
+              <p className="text-sm text-muted-foreground">Failed to load usage summary.</p>
+              <button
+                onClick={() => void refetchSummary()}
+                className="text-sm text-foreground underline hover:no-underline"
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 xl:grid-cols-3 gap-4">
+              <StatsCard
+                icon={Activity}
+                title="Total Requests"
+                value={isLoadingSummary ? 0 : (summary?.totalRequests ?? 0)}
+                unit="requests"
+                description="All AI requests"
+                isLoading={isLoadingSummary}
+              />
+              <StatsCard
+                icon={Zap}
+                title="Input Tokens"
+                value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalInputTokens ?? 0)}
+                unit="tokens"
+                description="Prompt tokens consumed"
+                isLoading={isLoadingSummary}
+              />
+              <StatsCard
+                icon={MessageSquare}
+                title="Output Tokens"
+                value={isLoadingSummary ? 0 : formatTokenCount(summary?.totalOutputTokens ?? 0)}
+                unit="tokens"
+                description="Completion tokens generated"
+                isLoading={isLoadingSummary}
+              />
+              <StatsCard
+                icon={Image}
+                title="Images Generated"
+                value={isLoadingSummary ? 0 : (summary?.totalImageCount ?? 0)}
+                unit="images"
+                description="Total images created"
+                isLoading={isLoadingSummary}
+              />
+              <StatsCard
+                icon={Activity}
+                title="Embedding Requests"
+                value={isLoadingSummary ? 0 : ((summary as (typeof summary & { embeddingRequests?: number }))?.embeddingRequests ?? 0)}
+                unit="requests"
+                description="Embedding requests"
+                isLoading={isLoadingSummary}
+              />
+              <StatsCard
+                icon={Zap}
+                title="Embedding Tokens"
+                value={isLoadingSummary ? 0 : formatTokenCount(((summary as (typeof summary & { embeddingTokens?: number }))?.embeddingTokens) ?? 0)}
+                unit="tokens"
+                description="Embedding tokens consumed"
+                isLoading={isLoadingSummary}
+              />
+            </div>
+          )}
         </div>
       </div>
 
@@ -155,6 +191,16 @@ export default function AIUsagePage() {
             {isLoadingRecords && records.length === 0 ? (
               <div className="flex items-center justify-center h-40">
                 <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : isRecordsError ? (
+              <div className="flex items-center justify-between h-40 px-4">
+                <p className="text-sm text-muted-foreground">Failed to load usage records.</p>
+                <button
+                  onClick={() => void refetchRecords()}
+                  className="text-sm text-foreground underline hover:no-underline"
+                >
+                  Retry
+                </button>
               </div>
             ) : records.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-40 gap-2">

--- a/frontend/src/lib/routing/AppRoutes.tsx
+++ b/frontend/src/lib/routing/AppRoutes.tsx
@@ -16,6 +16,7 @@ import FunctionsPage from '@/features/functions/pages/FunctionsPage';
 import SecretsPage from '@/features/functions/pages/SecretsPage';
 import SchedulesPage from '@/features/functions/pages/SchedulesPage';
 import AIPage from '@/features/ai/pages/AIPage';
+import AIUsagePage from '@/features/ai/pages/AIUsagePage';
 import RealtimeChannelsPage from '@/features/realtime/pages/RealtimeChannelsPage';
 import RealtimeMessagesPage from '@/features/realtime/pages/RealtimeMessagesPage';
 import RealtimePermissionsPage from '@/features/realtime/pages/RealtimePermissionsPage';
@@ -98,6 +99,7 @@ export function AppRoutes() {
                 <Route path="/dashboard/functions/schedules" element={<SchedulesPage />} />
                 <Route path="/dashboard/visualizer" element={<VisualizerPage />} />
                 <Route path="/dashboard/ai" element={<AIPage />} />
+                <Route path="/dashboard/ai/usage" element={<AIUsagePage />} />
                 <Route
                   path="/dashboard/realtime"
                   element={<Navigate to="/dashboard/realtime/channels" replace />}

--- a/frontend/src/lib/utils/menuItems.ts
+++ b/frontend/src/lib/utils/menuItems.ts
@@ -22,6 +22,7 @@ export interface SecondaryMenuItem {
   label: string;
   href: string;
   sectionEnd?: boolean; // Add support for separator after the item
+  exact?: boolean; // Use exact path matching for active state
 }
 
 export interface PrimaryMenuItem {
@@ -206,6 +207,19 @@ export const staticMenuItems: PrimaryMenuItem[] = [
     href: '/dashboard/ai',
     icon: Sparkles,
     sectionEnd: true,
+    secondaryMenu: [
+      {
+        id: 'ai-models',
+        label: 'Models',
+        href: '/dashboard/ai',
+        exact: true,
+      },
+      {
+        id: 'ai-usage',
+        label: 'Usage',
+        href: '/dashboard/ai/usage',
+      },
+    ],
   },
   {
     id: 'logs',

--- a/shared-schemas/src/ai.schema.ts
+++ b/shared-schemas/src/ai.schema.ts
@@ -43,6 +43,7 @@ export const aiUsageRecordSchema = aiUsageDataSchema.extend({
   provider: z.string().nullable(),
   inputModality: z.array(modalitySchema).nullable(),
   outputModality: z.array(modalitySchema).nullable(),
+  usageType: z.string().optional(),
 });
 
 export const aiUsageSummarySchema = z.object({
@@ -51,6 +52,8 @@ export const aiUsageSummarySchema = z.object({
   totalTokens: z.number(),
   totalImageCount: z.number(),
   totalRequests: z.number(),
+  embeddingRequests: z.number().optional(),
+  embeddingTokens: z.number().optional(),
 });
 
 // Export types


### PR DESCRIPTION



## Summary

Closes #979

- Migration `025` — adds `usage_type VARCHAR(20) NOT NULL DEFAULT 'chat'` to `ai.usage`, backfills existing image generation rows to `'image_generation'`
- `shared-schemas` — adds `usageTypeSchema` (`'chat' | 'embedding' | 'image_generation'`), `usageType` field to `aiUsageDataSchema` and `aiUsageRecordSchema`, and `embeddingRequests`/`embeddingTokens` breakdown to `aiUsageSummarySchema`
- `ai-usage.service` — new `trackEmbeddingUsage()` method; `trackChatUsage` and `trackImageGenerationUsage` now write explicit `usage_type`; `getUsageSummary` returns per-type breakdown; `getAllUsage` includes `usage_type` in SELECT
- `embedding.service` — calls `trackEmbeddingUsage()` instead of `trackChatUsage()`, threads `source` from `sendRequest` to skip tracking for BYOK


## How did you test this change?

- Ran migration 025, verified `usage_type` column added with default `'chat'`
- Made chat, embedding, and image generation requests — verified each row in `ai.usage` has correct `usage_type`
- Called `GET /api/ai/usage/summary` — verified response includes `embeddingRequests` and `embeddingTokens`
- Called `GET /api/ai/usage` — verified each record includes `usageType` field


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7b7d423e-a3f5-47e5-8ed1-0eb7301df210" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f81ad164-bc5e-4149-a3ad-acaf8b4468fe" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI Usage dashboard with statistics overview and detailed usage history tracking with pagination controls
  * Added "Usage" menu item to the AI section for quick navigation

* **Bug Fixes**
  * Fixed menu item active state highlighting to improve accuracy when navigating between routes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->