### PR TITLE
fix: reject anon role tokens in verifyToken to block unauthenticated AI endpoint access

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -182,6 +182,16 @@ export function verifyToken(req: AuthRequest, _res: Response, next: NextFunction
       );
     }
 
+    // Reject anon tokens — they are public keys and must not access authenticated endpoints
+    if (payload.role === 'anon') {
+      throw new AppError(
+        'Authenticated access required',
+        403,
+        ERROR_CODES.AUTH_UNAUTHORIZED,
+        NEXT_ACTION.CHECK_TOKEN
+      );
+    }
+
     // Set user info on request
     setRequestUser(req, payload);
 


### PR DESCRIPTION
## Summary

Block anon role tokens from accessing authenticated endpoints by adding an explicit role check in verifyToken. Previously, the anon key — which is publicly distributed to client apps via the Connect dialog — could be used to call AI endpoints (/api/ai/chat/completion, /api/ai/image/generation, /api/ai/embeddings) without real user authentication, since verifyUser only checked that a valid JWT existed, not what role it had.

## How did you test this change?
Traced the full exploit path through the codebase:

- Confirmed verifyToken previously accepted any valid JWT regardless of role
- Confirmed the SDK falls back to the anon key when no user is logged in and sends it as a Bearer token on all requests (including AI calls)
- Confirmed the anon key is publicly distributed via the Connect dialog and intended to be embedded in client apps
- Verified the fix throws a 403 Authenticated access required for any token with role: "anon", consistent with how verifyAdmin enforces its role check

fixes #987 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous users are now blocked from accessing authenticated endpoints with a 403 Forbidden response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->