### PR TITLE
fix: add docs to runner stage to fix fetch-docs ENOENT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY frontend/package.json    ./frontend/package.json
 COPY auth/package.json        ./auth/package.json
 COPY shared-schemas/package.json ./shared-schemas/package.json
 COPY ui/package.json          ./ui/package.json
+COPY docs /app/docs
 
 # Strip prepare/build scripts from shared-schemas to prevent tsc
 # from running during install (source files aren't copied yet).
@@ -112,6 +113,7 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/backend/src ./backend/src
 COPY --from=build /app/backend/tsconfig.json ./backend/tsconfig.json
 COPY --from=build /app/shared-schemas/src ./shared-schemas/src
+COPY --from=build /app/docs ./docs
 
 # Package manifests for npm scripts
 COPY --from=build /app/backend/package.json ./backend/package.json


### PR DESCRIPTION
## Summary
Fixes #1000
Fixes the `fetch-docs` ENOENT error in production Docker setup.

The issue was caused by the `/app/docs` directory not being available in the final (runner) container image. Although the docs were copied during the build stage, they were not included in the final runtime stage due to the multi-stage Docker build.

This PR adds:
- `COPY --from=build /app/docs ./docs` to the runner stage in the Dockerfile

This ensures that documentation files are available at runtime, allowing the backend to successfully read from `/app/docs`.

---

## How did you test this change?

1. Built and started the production setup:
   ```bash
   docker compose -f docker-compose.prod.yml up --build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `fetch-docs` ENOENT by adding docs directory to Dockerfile runner stage
> The `docs` directory was missing from the final container image, causing a file-not-found error at runtime. Fixes this by copying `docs` into the `deps` stage build context and adding a `COPY --from=build` step to include the built docs under `/app/docs` in the runner image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4050779.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configuration to include documentation files at runtime, ensuring documentation is accessible during both build and execution stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->