### PR TITLE
fix: rate limit Vercel file uploads to prevent 429 errors

### DIFF
--- a/backend/src/providers/deployments/vercel.provider.ts
+++ b/backend/src/providers/deployments/vercel.provider.ts
@@ -851,21 +851,26 @@ export class VercelProvider {
   }
 
   /**
-   * Upload multiple files to Vercel in parallel
+   * Upload multiple files to Vercel with limited concurrency
    */
   async uploadFiles(
     files: Array<{ path: string; content: Buffer }>
   ): Promise<Array<{ file: string; sha: string; size: number }>> {
-    const uploadPromises = files.map(async ({ path, content }) => {
-      const sha = await this.uploadFile(content);
-      return {
-        file: path,
-        sha,
-        size: content.length,
-      };
-    });
+    const maxConcurrency = 10;
+    const results: Array<{ file: string; sha: string; size: number }> = [];
 
-    return Promise.all(uploadPromises);
+    for (let i = 0; i < files.length; i += maxConcurrency) {
+      const batch = files.slice(i, i + maxConcurrency);
+      const batchResults = await Promise.all(
+        batch.map(async ({ path, content }) => {
+          const sha = await this.uploadFile(content);
+          return { file: path, sha, size: content.length };
+        })
+      );
+      results.push(...batchResults);
+    }
+
+    return results;
   }
 
   /**

--- a/backend/tests/unit/vercel-upload-batching.test.ts
+++ b/backend/tests/unit/vercel-upload-batching.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VercelProvider } from '../../src/providers/deployments/vercel.provider';
+
+// Mock dependencies so we don't hit real APIs
+vi.mock('../../src/utils/environment.js', () => ({
+  isCloudEnvironment: () => false,
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({}),
+  },
+}));
+
+describe('VercelProvider.uploadFiles batching', () => {
+  let provider: VercelProvider;
+  let uploadFileSpy: ReturnType<typeof vi.spyOn>;
+  let concurrentCount: number;
+  let peakConcurrent: number;
+
+  beforeEach(() => {
+    // Reset singleton for clean tests
+    // @ts-expect-error accessing private static for test reset
+    VercelProvider.instance = undefined;
+    provider = VercelProvider.getInstance();
+
+    concurrentCount = 0;
+    peakConcurrent = 0;
+
+    // Mock uploadFile to track concurrency
+    uploadFileSpy = vi.spyOn(provider, 'uploadFile').mockImplementation(async (content: Buffer) => {
+      concurrentCount++;
+      if (concurrentCount > peakConcurrent) {
+        peakConcurrent = concurrentCount;
+      }
+      // Simulate network delay so concurrent calls overlap
+      await new Promise((r) => setTimeout(r, 10));
+      concurrentCount--;
+      return `sha-${content.length}`;
+    });
+  });
+
+  it('uploads all files and returns correct results', async () => {
+    const files = Array.from({ length: 25 }, (_, i) => ({
+      path: `file-${i}.txt`,
+      content: Buffer.from(`content-${i}`),
+    }));
+
+    const results = await provider.uploadFiles(files);
+
+    expect(results).toHaveLength(25);
+    expect(uploadFileSpy).toHaveBeenCalledTimes(25);
+    results.forEach((r, i) => {
+      expect(r.file).toBe(`file-${i}.txt`);
+      expect(r.sha).toMatch(/^sha-/);
+      expect(r.size).toBeGreaterThan(0);
+    });
+  });
+
+  it('limits concurrency to 10 at a time', async () => {
+    const files = Array.from({ length: 25 }, (_, i) => ({
+      path: `file-${i}.txt`,
+      content: Buffer.from(`content-${i}`),
+    }));
+
+    await provider.uploadFiles(files);
+
+    expect(peakConcurrent).toBeLessThanOrEqual(10);
+    expect(peakConcurrent).toBeGreaterThan(1); // still parallel within a batch
+  });
+
+  it('handles fewer files than batch size', async () => {
+    const files = Array.from({ length: 3 }, (_, i) => ({
+      path: `file-${i}.txt`,
+      content: Buffer.from(`content-${i}`),
+    }));
+
+    const results = await provider.uploadFiles(files);
+
+    expect(results).toHaveLength(3);
+    expect(uploadFileSpy).toHaveBeenCalledTimes(3);
+    expect(peakConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  it('handles empty file list', async () => {
+    const results = await provider.uploadFiles([]);
+
+    expect(results).toHaveLength(0);
+    expect(uploadFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles exactly one batch (10 files)', async () => {
+    const files = Array.from({ length: 10 }, (_, i) => ({
+      path: `file-${i}.txt`,
+      content: Buffer.from(`content-${i}`),
+    }));
+
+    const results = await provider.uploadFiles(files);
+
+    expect(results).toHaveLength(10);
+    expect(peakConcurrent).toBeLessThanOrEqual(10);
+  });
+
+  it('propagates upload errors without swallowing them', async () => {
+    uploadFileSpy.mockRejectedValueOnce(new Error('rate limited'));
+
+    const files = [{ path: 'fail.txt', content: Buffer.from('fail') }];
+
+    await expect(provider.uploadFiles(files)).rejects.toThrow('rate limited');
+  });
+});


### PR DESCRIPTION
## Summary
- `uploadFiles()` was firing all file uploads concurrently via `Promise.all`, causing Vercel's `/v2/files` API to return 429 (Too Many Requests) when deploying projects with 70+ files
- Now batches uploads in groups of 10 concurrent requests, preventing rate limit errors while keeping uploads fast
- Added unit tests verifying concurrency is capped, results are correct, and errors propagate

## Test plan
- [x] Unit tests pass (`vitest run tests/unit/vercel-upload-batching.test.ts`) — 6/6 passing
- [ ] Deploy a project with 70+ files and confirm no 429 errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rate limit `VercelProvider.uploadFiles` to 10 concurrent uploads to prevent 429 errors
> Previously, all files were uploaded in parallel via a single `Promise.all`, which caused Vercel to return 429 rate limit errors on large deployments. `uploadFiles` in [vercel.provider.ts](https://github.com/InsForge/InsForge/pull/1009/files#diff-96cc15ac23da2b9a783375ab8b88a64191e9ce5e84fa65214bc12ed3feab370f) now processes files in batches of 10, awaiting each batch before starting the next while preserving result order. A new unit test suite in [vercel-upload-batching.test.ts](https://github.com/InsForge/InsForge/pull/1009/files#diff-d018abaef657369c50d853eb0a4610b54455a7614c94d03e138f59b14c3f5348) verifies concurrency limits, correct result aggregation, edge cases, and error propagation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea26ec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * File uploads are now processed in sequential batches with a maximum of 10 concurrent uploads.

* **Tests**
  * Added comprehensive test coverage for upload batching behavior to verify reliability and concurrency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->