### PR TITLE
fix: use native ARM runner for multi-arch Docker build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,6 +42,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-amd64
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -89,6 +91,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-arm64
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -139,7 +143,7 @@ jobs:
           for TAG in $(echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n'); do
             docker buildx imagetools create \
               --tag "${TAG}" \
-              "${TAG}" "${TAG}"
+              "${TAG}-amd64" "${TAG}-arm64"
           done
 
   push-to-ecr:


### PR DESCRIPTION
## Summary
- Split single QEMU-emulated multi-platform build into two parallel native jobs
- `build-amd64` runs on `ubuntu-latest` (x86)
- `build-arm64` runs on `ubuntu-24.04-arm` (native ARM — no QEMU)
- `merge-manifests` combines both into a multi-arch image
- Removed `setup-qemu-action` (no longer needed)
- Scoped GHA build cache per architecture

## Context
PR #1011 temporarily removed arm64 to unblock builds, but production now runs on `t4g` (Graviton/ARM) instances which need arm64 images. This restores arm64 support using native runners instead of flaky QEMU emulation.

## Test plan
- [ ] Workflow builds both amd64 and arm64 without SIGILL/exit 132
- [ ] Multi-arch manifest is created and pushed to GHCR
- [ ] ECR copy works correctly with the multi-arch image
- [ ] Image runs on t4g (ARM) instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image builds split into parallel AMD64 and ARM64 builds for faster, architecture-specific pipelines.
  * Optimized per-architecture caching and tagging with clear architecture suffixes.
  * Consolidated multi-architecture manifests so a single image reference supports both platforms.
  * Build pipeline ordering updated to ensure manifests are created before downstream publish steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use native ARM runner for multi-arch Docker builds in CI
> - Replaces the single QEMU-emulated build job with two native jobs: `build-amd64` (ubuntu-latest) and `build-arm64` (ubuntu-24.04-arm), each pushing an arch-suffixed image tag.
> - Adds a `merge-manifests` job that combines both arch images into a single multi-arch manifest using `docker buildx imagetools create`.
> - Updates the `push-to-ecr` job to depend on `merge-manifests` instead of the old build job.
> - Removes the QEMU setup step entirely; build cache scopes are now architecture-specific.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80372b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->