### PR TITLE
fix: disable auto-generated latest tag in multi-arch Docker build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -44,6 +44,7 @@ jobs:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-amd64
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -93,6 +94,7 @@ jobs:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-arm64
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -134,6 +136,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary
- The `docker/metadata-action` auto-generates a `latest` tag on tag pushes
- The merge-manifests step tries to combine `latest-amd64` + `latest-arm64`, but those images don't exist since the build jobs only push versioned arch-suffixed tags
- Set `latest=false` in all three metadata steps to prevent this

## Context
Follow-up to #1013. The versioned tag (`v2.0.1-express-422`) merged correctly, but the auto-generated `latest` tag caused the workflow to fail.

## Test plan
- [ ] Tag push triggers workflow without `latest` tag error
- [ ] Multi-arch manifest is created correctly for the versioned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable auto-generated `latest` tag in multi-arch Docker build
> Adds `latest=false` to the `flavor` config in all three `docker/metadata-action` steps in [build-image.yml](.github/workflows/build-image.yml) — the amd64 build, arm64 build, and multi-arch manifest steps. This prevents the action from automatically pushing a `latest` tag, leaving only explicitly specified tags (e.g., ref or test_tag) in the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ce726c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging configuration in the build pipeline. The `latest` image tag is no longer generated for new builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->