### PR TITLE
fix: optimize Dockerfile layer caching to reduce image pull sizes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,11 @@ RUN apk add --no-cache tini
 WORKDIR /app
 
 # Run as non-root using the built-in node user (uid 1000)
-RUN mkdir -p /data /insforge-storage /insforge-logs && chown node:node /data /insforge-storage /insforge-logs
+# /data: database dir (matches DatabaseManager default)
+# /app/insforge-storage, /app/insforge-logs: app defaults for standalone docker run
+# /insforge-storage, /insforge-logs: docker-compose volume mount points (overridden via STORAGE_DIR/LOGS_DIR env vars)
+RUN mkdir -p /data /app/insforge-storage /app/insforge-logs /insforge-storage /insforge-logs && \
+    chown node:node /data /app/insforge-storage /app/insforge-logs /insforge-storage /insforge-logs
 
 # tsx is a devDependency but required at runtime for migrate:bootstrap
 RUN npm install -g "tsx@^4.7.1" && npm cache clean --force


### PR DESCRIPTION
## Summary
- Eliminated the 213MB `chown -R` layer by using `COPY --chown=node:node` on each COPY instruction instead
- Reordered runner stage layers: stable layers first (mkdir, tsx, node_modules), volatile layers last (dist, docs, src)
- Code-only releases now only need to pull ~10MB of changed layers instead of re-downloading 200MB+

## Before vs After

| Layer | Before | After |
|-------|--------|-------|
| `chown -R` | 213MB | **0B** (eliminated) |
| `node_modules` | 203MB | 203MB (stable, cached between releases) |
| `dist/` + code | ~10MB | ~10MB (only these change per release) |

## Verified
- [x] Docker build completes successfully
- [x] All files owned by `node` user
- [x] Volume dirs (`/data`, `/insforge-storage`, `/insforge-logs`) owned by `node`
- [x] Container runs as `node` user
- [x] Node.js and Express load correctly inside container

## Test plan
- [ ] Deploy and verify server starts correctly
- [ ] Verify subsequent version pulls only download ~10MB of changed layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize Dockerfile layer caching by replacing recursive chown with targeted ownership
> - Replaces a broad recursive `chown /app` with `COPY --chown=node:node` on individual artifacts (`node_modules`, `dist`, `docs`, `backend/src`, config files) to improve layer cache reuse.
> - Explicitly creates and chowns required runtime directories (`/data`, `/app/insforge-storage`, `/app/insforge-logs`, `/insforge-storage`, `/insforge-logs`) so the `node` user has write access without a full recursive ownership pass.
> - Moves `tsx` global install earlier in the runner stage to a more stable layer position, reducing unnecessary reinstalls on code-only changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a74d4b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build: pre-create and set ownership of runtime directories, ensure copied build artifacts and dependencies have correct ownership, and install the runtime helper earlier to streamline startup and improve container security and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->