### PR TITLE
fix: harden SECURITY DEFINER functions and RLS policy

### DIFF
--- a/backend/src/infra/database/migrations/028_secure-schedules-encryption-functions.sql
+++ b/backend/src/infra/database/migrations/028_secure-schedules-encryption-functions.sql
@@ -5,8 +5,8 @@
 REVOKE EXECUTE ON FUNCTION schedules.encrypt_headers(p_headers jsonb) FROM public;
 REVOKE EXECUTE ON FUNCTION schedules.decrypt_headers(p_encrypted_headers text) FROM public;
 
-ALTER FUNCTION schedules.encrypt_headers(p_headers jsonb) SET search_path = '';
-ALTER FUNCTION schedules.decrypt_headers(p_encrypted_headers text) SET search_path = '';
+ALTER FUNCTION schedules.encrypt_headers(p_headers jsonb) SET search_path = pg_catalog, public;
+ALTER FUNCTION schedules.decrypt_headers(p_encrypted_headers text) SET search_path = pg_catalog, public;
 
 -- Wrap auth.uid() in subquery so it is evaluated once per query instead of once per row
 DROP POLICY IF EXISTS "Users can update own profile" ON auth.users;


### PR DESCRIPTION
## Summary
- Revoke `public` execute access from `schedules.encrypt_headers` and `schedules.decrypt_headers` — these are internal functions only called by other `schedules.*` functions
- Lock down `search_path` on both SECURITY DEFINER functions to prevent search_path hijacking
- Wrap `auth.uid()` in subquery in the "Users can update own profile" RLS policy so it is evaluated once per query instead of once per row

## Test plan
- [ ] Run migration against a dev database and verify no errors
- [ ] Confirm `SELECT schedules.encrypt_headers('{}')` fails as `anon` role (permission denied)
- [ ] Confirm RLS policy on `auth.users` still works correctly for authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden SECURITY DEFINER functions and RLS policy for schedule header encryption
> - Revokes `EXECUTE` on `schedules.encrypt_headers` and `schedules.decrypt_headers` from the `public` role, restricting access to explicitly granted roles only.
> - Sets `search_path` to empty on both functions to prevent unqualified object resolution inside the function body.
> - Drops and recreates the `Users can update own profile` RLS policy on `auth.users`, wrapping `auth.uid()` in a subquery (`SELECT auth.uid()`) in both `USING` and `WITH CHECK` clauses to prevent function inlining.
> - Risk: Any role relying on implicit public `EXECUTE` access to either header function will now receive a permission denied error.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1027 opened
>
> - Set search_path to 'pg_catalog, public' for `schedules.encrypt_headers` and `schedules.decrypt_headers` SECURITY DEFINER functions [efe3c49]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dcb1b39. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reinforced database security by tightening encryption function permissions and reducing attack surface to mitigate search-path hijacking.
  * Strengthened row-level security for user profile updates so users can only update their own profiles, improving data protection and integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->