### PR TITLE
fix(frontend): replace Array.at() with bracket access for ES2020 compatibility

### DIFF
--- a/frontend/src/features/functions/hooks/useFunctions.ts
+++ b/frontend/src/features/functions/hooks/useFunctions.ts
@@ -8,7 +8,7 @@ function getDeploymentFailureMessage(buildLogs?: string[]): string {
   const logs = buildLogs?.map((log) => log.trim()).filter(Boolean) ?? [];
 
   const explicitError =
-    logs.find((log) => log.toLowerCase().includes('[error]')) ?? logs.at(-1) ?? null;
+    logs.find((log) => log.toLowerCase().includes('[error]')) ?? logs[logs.length - 1] ?? null;
 
   if (!explicitError) {
     return 'Function saved, but deployment failed.';


### PR DESCRIPTION
## Summary

Replaces Array.prototype.at(-1) with array[array.length - 1] in useFunctions.ts to fix a typecheck failure. The frontend tsconfig.json targets ES2020, but .at() requires ES2022.
## How did you test this change?

<!-- Describe how you tested this PR -->
 Ran npm run typecheck:frontend — passes cleanly after the fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Array.at(-1)` with bracket access in `getDeploymentFailureMessage` for ES2020 compatibility
> Changes `logs.at(-1)` to `logs[logs.length - 1]` in [useFunctions.ts](https://github.com/InsForge/InsForge/pull/1034/files#diff-47e7e2d469869047c935cfc042c39489f092f8252641bb771c16155892e70866) to avoid using `Array.prototype.at()`, which is not available in ES2020 targets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9d8627.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error message retrieval logic for improved compatibility across JavaScript environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->