### PR TITLE
Bump frontend TypeScript lib to ES2022

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Bumps `lib` in `frontend/tsconfig.json` from `ES2020` to `ES2022`.

This fixes the typecheck failure on `Array.prototype.at()` in `useFunctions.ts` and enables other ES2022 built-in types like `Object.hasOwn()`, `structuredClone()`, `Array.findLast()`, and error `cause`.

## Why this is safe

- `lib` only affects **type-checking**, not runtime output — Vite/esbuild handles transpilation
- `target` stays at `ES2020` (unchanged)
- All modern browsers and Node 16+ already support ES2022 APIs at runtime
- No polyfills needed
- Not a breaking change

## Changes

- `frontend/tsconfig.json` — `lib: ["ES2020", ...]` → `lib: ["ES2022", ...]`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump frontend TypeScript `lib` target from ES2020 to ES2022
> Updates [tsconfig.json](https://github.com/InsForge/InsForge/pull/1035/files#diff-5c19f37df4b2357c35db7a97f2f4830e67ccd39200a49040b01e2e49bcac0709) to set `lib` to ES2022, keeping DOM and DOM.Iterable. This makes ES2022 built-ins (e.g. `Array.prototype.at`, `Object.hasOwn`) available in the TypeScript type checker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 374ffe0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to use the latest TypeScript standard library definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->