### PR TITLE
feat(storage): allow renaming files in dashboard

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -389,15 +389,7 @@ router.patch(
 
       successResponse(res, renamedFile, 200);
     } catch (error) {
-      if (error instanceof AppError) {
-        next(error);
-      } else if (error instanceof Error && error.message.includes('Invalid')) {
-        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
-      } else if (error instanceof Error && error.message.includes('different')) {
-        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
-      } else {
-        next(error);
-      }
+      next(error);
     }
   }
 );

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -8,6 +8,7 @@ import { dynamicUploadSingle, handleUploadError } from '@/api/middlewares/upload
 import { ERROR_CODES } from '@/types/error-constants.js';
 import {
   createBucketRequestSchema,
+  renameObjectRequestSchema,
   updateBucketRequestSchema,
   updateStorageConfigRequestSchema,
 } from '@insforge/shared-schemas';
@@ -347,6 +348,52 @@ router.post(
           )
         );
       } else if (error instanceof Error && error.message.includes('Invalid')) {
+        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
+      } else {
+        next(error);
+      }
+    }
+  }
+);
+
+// PATCH /api/storage/buckets/:bucketName/objects/:objectKey - Rename object in bucket (requires auth)
+router.patch(
+  '/buckets/:bucketName/objects/*',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { bucketName } = req.params;
+      const objectKey = req.params[0];
+
+      if (!objectKey) {
+        throw new AppError('Object key is required', 400, ERROR_CODES.STORAGE_INVALID_PARAMETER);
+      }
+
+      const validation = renameObjectRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.STORAGE_INVALID_PARAMETER
+        );
+      }
+
+      const storageService = StorageService.getInstance();
+      const renamedFile = await storageService.renameObject(
+        bucketName,
+        objectKey,
+        validation.data.newName,
+        req.user?.id || '',
+        !!req.apiKey || req.user?.role === 'project_admin'
+      );
+
+      successResponse(res, renamedFile, 200);
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+      } else if (error instanceof Error && error.message.includes('Invalid')) {
+        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
+      } else if (error instanceof Error && error.message.includes('different')) {
         next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
       } else {
         next(error);

--- a/backend/src/providers/storage/base.provider.ts
+++ b/backend/src/providers/storage/base.provider.ts
@@ -9,6 +9,7 @@ export interface StorageProvider {
   putObject(bucket: string, key: string, file: Express.Multer.File): Promise<void>;
   getObject(bucket: string, key: string): Promise<Buffer | null>;
   deleteObject(bucket: string, key: string): Promise<void>;
+  renameObject(bucket: string, oldKey: string, newKey: string): Promise<void>;
   createBucket(bucket: string): Promise<void>;
   deleteBucket(bucket: string): Promise<void>;
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -68,6 +68,14 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
+  async renameObject(bucket: string, oldKey: string, newKey: string): Promise<void> {
+    const oldPath = this.getFilePath(bucket, oldKey);
+    const newPath = this.getFilePath(bucket, newKey);
+
+    await fs.mkdir(path.dirname(newPath), { recursive: true });
+    await fs.rename(oldPath, newPath);
+  }
+
   async createBucket(bucket: string): Promise<void> {
     const bucketPath = this.getValidatedPath(bucket);
     await fs.mkdir(bucketPath, { recursive: true });

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -132,10 +132,14 @@ export class S3StorageProvider implements StorageProvider {
 
     const sourceKey = this.getS3Key(bucket, oldKey);
     const destinationKey = this.getS3Key(bucket, newKey);
+    const encodedCopySource = `${this.s3Bucket}/${sourceKey
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')}`;
 
     const copyCommand = new CopyObjectCommand({
       Bucket: this.s3Bucket,
-      CopySource: `${this.s3Bucket}/${sourceKey}`,
+      CopySource: encodedCopySource,
       Key: destinationKey,
     });
 

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
+  CopyObjectCommand,
   ListObjectsV2Command,
   DeleteObjectsCommand,
   HeadObjectCommand,
@@ -122,6 +123,30 @@ export class S3StorageProvider implements StorageProvider {
       Key: this.getS3Key(bucket, key),
     });
     await this.s3Client.send(command);
+  }
+
+  async renameObject(bucket: string, oldKey: string, newKey: string): Promise<void> {
+    if (!this.s3Client) {
+      throw new Error('S3 client not initialized');
+    }
+
+    const sourceKey = this.getS3Key(bucket, oldKey);
+    const destinationKey = this.getS3Key(bucket, newKey);
+
+    const copyCommand = new CopyObjectCommand({
+      Bucket: this.s3Bucket,
+      CopySource: `${this.s3Bucket}/${sourceKey}`,
+      Key: destinationKey,
+    });
+
+    await this.s3Client.send(copyCommand);
+
+    const deleteCommand = new DeleteObjectCommand({
+      Bucket: this.s3Bucket,
+      Key: sourceKey,
+    });
+
+    await this.s3Client.send(deleteCommand);
   }
 
   async createBucket(_bucket: string): Promise<void> {

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -145,6 +145,10 @@ export class S3StorageProvider implements StorageProvider {
 
     await this.s3Client.send(copyCommand);
 
+    // TODO: S3 rename is not atomic — if the delete below fails after a successful copy,
+    // the object will exist under both the old and new keys (orphaned duplicate).
+    // For v1 this is acceptable, but a future fix should use S3 Object Lock or a
+    // cleanup/reconciliation job to detect and remove orphaned originals.
     const deleteCommand = new DeleteObjectCommand({
       Bucket: this.s3Bucket,
       Key: sourceKey,

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -329,6 +329,11 @@ export class StorageService {
         throw new AppError('Object not found', 404, ERROR_CODES.NOT_FOUND);
       }
 
+      const sourceExists = await this.provider.verifyObjectExists(bucket, oldKey);
+      if (!sourceExists.exists) {
+        throw new AppError('Object file not found in storage', 404, ERROR_CODES.NOT_FOUND);
+      }
+
       const destinationResult = await client.query(
         'SELECT 1 FROM storage.objects WHERE bucket = $1 AND key = $2',
         [bucket, newKey]

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -99,6 +99,11 @@ export class StorageService {
 
     const trimmedName = newName.trim();
     const keyParts = oldKey.split('/');
+
+    if (!keyParts[keyParts.length - 1]) {
+      throw new Error('Invalid object key. Only files can be renamed.');
+    }
+
     keyParts[keyParts.length - 1] = trimmedName;
 
     const newKey = keyParts.join('/');

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -81,15 +81,27 @@ export class StorageService {
     const trimmedName = newName.trim();
 
     if (!trimmedName) {
-      throw new Error('Invalid file name. New name cannot be empty.');
+      throw new AppError(
+        'Invalid file name. New name cannot be empty.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
 
     if (trimmedName === '.' || trimmedName === '..') {
-      throw new Error('Invalid file name. "." and ".." are not allowed.');
+      throw new AppError(
+        'Invalid file name. "." and ".." are not allowed.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
 
     if (trimmedName.includes('/') || trimmedName.includes('\\')) {
-      throw new Error('Invalid file name. Path separators are not allowed.');
+      throw new AppError(
+        'Invalid file name. Path separators are not allowed.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
   }
 
@@ -101,7 +113,11 @@ export class StorageService {
     const keyParts = oldKey.split('/');
 
     if (!keyParts[keyParts.length - 1]) {
-      throw new Error('Invalid object key. Only files can be renamed.');
+      throw new AppError(
+        'Invalid object key. Only files can be renamed.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
 
     keyParts[keyParts.length - 1] = trimmedName;
@@ -110,7 +126,11 @@ export class StorageService {
     this.validateKey(newKey);
 
     if (newKey === oldKey) {
-      throw new Error('New file name must be different from the current name.');
+      throw new AppError(
+        'New file name must be different from the current name.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
 
     return newKey;

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -334,6 +334,8 @@ export class StorageService {
         throw new AppError('Object file not found in storage', 404, ERROR_CODES.NOT_FOUND);
       }
 
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`${bucket}/${newKey}`]);
+
       const destinationResult = await client.query(
         'SELECT 1 FROM storage.objects WHERE bucket = $1 AND key = $2',
         [bucket, newKey]

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { Pool } from 'pg';
+import { AppError } from '@/api/middlewares/error.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { StorageRecord } from '@/types/storage.js';
 import {
@@ -14,6 +15,7 @@ import { StorageConfigService } from '@/services/storage/storage-config.service.
 import logger from '@/utils/logger.js';
 import { escapeSqlLikePattern, escapeRegexPattern } from '@/utils/validations.js';
 import { getApiBaseUrl } from '@/utils/environment.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
 
 const DEFAULT_LIST_LIMIT = 100;
 const GIGABYTE_IN_BYTES = 1024 * 1024 * 1024;
@@ -73,6 +75,40 @@ export class StorageService {
     if (key.includes('..') || key.startsWith('/')) {
       throw new Error('Invalid key. Cannot use ".." or start with "/"');
     }
+  }
+
+  private validateRenameName(newName: string): void {
+    const trimmedName = newName.trim();
+
+    if (!trimmedName) {
+      throw new Error('Invalid file name. New name cannot be empty.');
+    }
+
+    if (trimmedName === '.' || trimmedName === '..') {
+      throw new Error('Invalid file name. "." and ".." are not allowed.');
+    }
+
+    if (trimmedName.includes('/') || trimmedName.includes('\\')) {
+      throw new Error('Invalid file name. Path separators are not allowed.');
+    }
+  }
+
+  private buildRenamedKey(oldKey: string, newName: string): string {
+    this.validateKey(oldKey);
+    this.validateRenameName(newName);
+
+    const trimmedName = newName.trim();
+    const keyParts = oldKey.split('/');
+    keyParts[keyParts.length - 1] = trimmedName;
+
+    const newKey = keyParts.join('/');
+    this.validateKey(newKey);
+
+    if (newKey === oldKey) {
+      throw new Error('New file name must be different from the current name.');
+    }
+
+    return newKey;
   }
 
   /**
@@ -249,6 +285,89 @@ export class StorageService {
     }
 
     return false;
+  }
+
+  async renameObject(
+    bucket: string,
+    oldKey: string,
+    newName: string,
+    userId: string,
+    isAdmin: boolean
+  ): Promise<StorageFileSchema> {
+    this.validateBucketName(bucket);
+    this.validateKey(oldKey);
+
+    const newKey = this.buildRenamedKey(oldKey, newName);
+    const client = await this.getPool().connect();
+
+    try {
+      await client.query('BEGIN');
+
+      const sourceResult = isAdmin
+        ? await client.query(
+            `SELECT bucket, key, size, mime_type, uploaded_at, uploaded_by
+             FROM storage.objects
+             WHERE bucket = $1 AND key = $2
+             FOR UPDATE`,
+            [bucket, oldKey]
+          )
+        : await client.query(
+            `SELECT bucket, key, size, mime_type, uploaded_at, uploaded_by
+             FROM storage.objects
+             WHERE bucket = $1 AND key = $2 AND uploaded_by = $3
+             FOR UPDATE`,
+            [bucket, oldKey, userId]
+          );
+
+      const sourceRow = sourceResult.rows[0] as StorageRecord | undefined;
+      if (!sourceRow) {
+        throw new AppError('Object not found', 404, ERROR_CODES.NOT_FOUND);
+      }
+
+      const destinationResult = await client.query(
+        'SELECT 1 FROM storage.objects WHERE bucket = $1 AND key = $2',
+        [bucket, newKey]
+      );
+
+      if (destinationResult.rows.length > 0) {
+        throw new AppError(
+          `Object "${newKey}" already exists in bucket "${bucket}"`,
+          409,
+          ERROR_CODES.ALREADY_EXISTS
+        );
+      }
+
+      await this.provider.renameObject(bucket, oldKey, newKey);
+
+      const updateResult = await client.query(
+        `UPDATE storage.objects
+         SET key = $1
+         WHERE bucket = $2 AND key = $3
+         RETURNING bucket, key, size, mime_type, uploaded_at`,
+        [newKey, bucket, oldKey]
+      );
+
+      await client.query('COMMIT');
+
+      const updatedRow = updateResult.rows[0] as StorageRecord | undefined;
+      if (!updatedRow) {
+        throw new Error('Failed to update renamed object metadata');
+      }
+
+      return {
+        bucket: updatedRow.bucket,
+        key: updatedRow.key,
+        size: updatedRow.size,
+        mimeType: updatedRow.mime_type,
+        uploadedAt: updatedRow.uploaded_at,
+        url: `${getApiBaseUrl()}/api/storage/buckets/${bucket}/objects/${encodeURIComponent(updatedRow.key)}`,
+      };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async listObjects(

--- a/backend/tests/integration/storage-rename.integration.test.ts
+++ b/backend/tests/integration/storage-rename.integration.test.ts
@@ -36,12 +36,7 @@ async function seedFile(bucket: string, key: string, content = 'hello'): Promise
 }
 
 /** Insert a row into storage.objects (FK to storage.buckets must exist). */
-async function seedObjectRow(
-  pool: Pool,
-  bucket: string,
-  key: string,
-  size = 5
-): Promise<void> {
+async function seedObjectRow(pool: Pool, bucket: string, key: string, size = 5): Promise<void> {
   await pool.query(
     `INSERT INTO storage.objects (bucket, key, size, mime_type)
      VALUES ($1, $2, $3, $4)
@@ -93,7 +88,9 @@ describe('StorageService.renameObject (integration)', () => {
     // Wipe all files inside the bucket dir
     const bucketDir = path.join(STORAGE_DIR, TEST_BUCKET);
     const entries = await fs.readdir(bucketDir).catch(() => []);
-    await Promise.all(entries.map((e) => fs.rm(path.join(bucketDir, e), { recursive: true, force: true })));
+    await Promise.all(
+      entries.map((e) => fs.rm(path.join(bucketDir, e), { recursive: true, force: true }))
+    );
   });
 
   // ── tests ─────────────────────────────────────────────────────────────
@@ -109,21 +106,15 @@ describe('StorageService.renameObject (integration)', () => {
     expect(result.key).toBe('cover.png');
     expect(result.bucket).toBe(TEST_BUCKET);
 
-    const { rows } = await pool.query(
-      'SELECT key FROM storage.objects WHERE bucket = $1',
-      [TEST_BUCKET]
-    );
+    const { rows } = await pool.query('SELECT key FROM storage.objects WHERE bucket = $1', [
+      TEST_BUCKET,
+    ]);
     expect(rows).toHaveLength(1);
     expect(rows[0].key).toBe('cover.png');
 
     // Old file gone, new file present
-    await expect(
-      fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'photo.png'))
-    ).rejects.toThrow();
-    const newContent = await fs.readFile(
-      path.join(STORAGE_DIR, TEST_BUCKET, 'cover.png'),
-      'utf8'
-    );
+    await expect(fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'photo.png'))).rejects.toThrow();
+    const newContent = await fs.readFile(path.join(STORAGE_DIR, TEST_BUCKET, 'cover.png'), 'utf8');
     expect(newContent).toBe('hello');
   });
 

--- a/backend/tests/integration/storage-rename.integration.test.ts
+++ b/backend/tests/integration/storage-rename.integration.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Integration tests for StorageService.renameObject
+ *
+ * These tests require a running PostgreSQL instance and exercise the full
+ * rename flow: DB transaction + local filesystem provider + conflict detection.
+ *
+ * Run with:
+ *   npm run test -- storage-rename.integration.test.ts
+ *
+ * Environment variables (defaults match docker-compose.yml):
+ *   POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { Pool } from 'pg';
+import { LocalStorageProvider } from '../../src/providers/storage/local.provider.js';
+import { StorageService } from '../../src/services/storage/storage.service.js';
+import { DatabaseManager } from '../../src/infra/database/database.manager.js';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const TEST_BUCKET = `int-test-rename-${Date.now()}`;
+const STORAGE_DIR = path.resolve(import.meta.dirname, '../..', 'test-integration-storage');
+
+async function getPool(): Promise<Pool> {
+  return DatabaseManager.getInstance().getPool();
+}
+
+/** Write a real file into the provider's storage dir so renameObject finds it. */
+async function seedFile(bucket: string, key: string, content = 'hello'): Promise<void> {
+  const filePath = path.join(STORAGE_DIR, bucket, key);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+/** Insert a row into storage.objects (FK to storage.buckets must exist). */
+async function seedObjectRow(
+  pool: Pool,
+  bucket: string,
+  key: string,
+  size = 5
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO storage.objects (bucket, key, size, mime_type)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT DO NOTHING`,
+    [bucket, key, size, 'text/plain']
+  );
+}
+
+// ── suite ─────────────────────────────────────────────────────────────────────
+
+describe('StorageService.renameObject (integration)', () => {
+  let pool: Pool;
+
+  // ── global setup / teardown ─────────────────────────────────────────────
+
+  beforeAll(async () => {
+    await DatabaseManager.getInstance().initialize();
+    pool = await getPool();
+
+    // Provision test bucket row + storage directory once for the whole suite
+    await pool.query(
+      `INSERT INTO storage.buckets (name, public) VALUES ($1, false) ON CONFLICT DO NOTHING`,
+      [TEST_BUCKET]
+    );
+    await fs.mkdir(path.join(STORAGE_DIR, TEST_BUCKET), { recursive: true });
+
+    // Point the StorageService singleton at our temp local provider
+    const provider = new LocalStorageProvider(STORAGE_DIR);
+    await provider.initialize();
+    const service = StorageService.getInstance() as unknown as {
+      provider: LocalStorageProvider;
+      pool: Pool;
+    };
+    service.provider = provider;
+    service.pool = pool;
+  });
+
+  afterAll(async () => {
+    // Remove test bucket and all its objects (cascade handles DB rows)
+    await pool.query('DELETE FROM storage.buckets WHERE name = $1', [TEST_BUCKET]);
+    await fs.rm(STORAGE_DIR, { recursive: true, force: true });
+  });
+
+  // ── per-test cleanup ──────────────────────────────────────────────────
+
+  afterEach(async () => {
+    // Wipe all object rows for this bucket so tests don't bleed into each other
+    await pool.query('DELETE FROM storage.objects WHERE bucket = $1', [TEST_BUCKET]);
+    // Wipe all files inside the bucket dir
+    const bucketDir = path.join(STORAGE_DIR, TEST_BUCKET);
+    const entries = await fs.readdir(bucketDir).catch(() => []);
+    await Promise.all(entries.map((e) => fs.rm(path.join(bucketDir, e), { recursive: true, force: true })));
+  });
+
+  // ── tests ─────────────────────────────────────────────────────────────
+
+  it('renames a root-level file in both DB and filesystem', async () => {
+    await seedFile(TEST_BUCKET, 'photo.png');
+    await seedObjectRow(pool, TEST_BUCKET, 'photo.png');
+
+    const service = StorageService.getInstance();
+    const result = await service.renameObject(TEST_BUCKET, 'photo.png', 'cover.png', '', true);
+
+    // DB row updated
+    expect(result.key).toBe('cover.png');
+    expect(result.bucket).toBe(TEST_BUCKET);
+
+    const { rows } = await pool.query(
+      'SELECT key FROM storage.objects WHERE bucket = $1',
+      [TEST_BUCKET]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].key).toBe('cover.png');
+
+    // Old file gone, new file present
+    await expect(
+      fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'photo.png'))
+    ).rejects.toThrow();
+    const newContent = await fs.readFile(
+      path.join(STORAGE_DIR, TEST_BUCKET, 'cover.png'),
+      'utf8'
+    );
+    expect(newContent).toBe('hello');
+  });
+
+  it('preserves directory prefix when renaming a nested file', async () => {
+    await seedFile(TEST_BUCKET, 'folder/photo.png');
+    await seedObjectRow(pool, TEST_BUCKET, 'folder/photo.png');
+
+    const service = StorageService.getInstance();
+    const result = await service.renameObject(
+      TEST_BUCKET,
+      'folder/photo.png',
+      'banner.png',
+      '',
+      true
+    );
+
+    expect(result.key).toBe('folder/banner.png');
+
+    await expect(
+      fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'folder', 'photo.png'))
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'folder', 'banner.png'))
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns 409 and leaves both files untouched when destination already exists', async () => {
+    await seedFile(TEST_BUCKET, 'a.png', 'file-a');
+    await seedObjectRow(pool, TEST_BUCKET, 'a.png');
+    await seedFile(TEST_BUCKET, 'b.png', 'file-b');
+    await seedObjectRow(pool, TEST_BUCKET, 'b.png');
+
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'a.png', 'b.png', '', true)
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    // Both DB rows still intact
+    const { rows } = await pool.query(
+      'SELECT key FROM storage.objects WHERE bucket = $1 ORDER BY key',
+      [TEST_BUCKET]
+    );
+    expect(rows.map((r: { key: string }) => r.key)).toEqual(['a.png', 'b.png']);
+
+    // Both files still on disk
+    await expect(fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'a.png'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(STORAGE_DIR, TEST_BUCKET, 'b.png'))).resolves.toBeUndefined();
+  });
+
+  it('returns 404 when the source key does not exist in DB', async () => {
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'ghost.png', 'new.png', '', true)
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('returns 404 when DB row exists but file is missing from storage', async () => {
+    // Insert only the DB row, no actual file
+    await seedObjectRow(pool, TEST_BUCKET, 'orphan.png');
+
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'orphan.png', 'new.png', '', true)
+    ).rejects.toMatchObject({ statusCode: 404, message: 'Object file not found in storage' });
+  });
+
+  it('rejects empty new name with 400', async () => {
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'photo.png', '   ', '', true)
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('rejects dot-segment names with 400', async () => {
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'photo.png', '..', '', true)
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      service.renameObject(TEST_BUCKET, 'photo.png', '.', '', true)
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('rejects names with path separators with 400', async () => {
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'photo.png', 'sub/evil.png', '', true)
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('rejects unchanged name with 400', async () => {
+    const service = StorageService.getInstance();
+    await expect(
+      service.renameObject(TEST_BUCKET, 'photo.png', 'photo.png', '', true)
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('non-admin cannot rename a file uploaded by another user', async () => {
+    await seedFile(TEST_BUCKET, 'secret.png');
+    // Seed with no uploaded_by (NULL) — non-admin query requires uploaded_by match
+    await seedObjectRow(pool, TEST_BUCKET, 'secret.png');
+
+    const service = StorageService.getInstance();
+    // This UUID was not the uploader (uploaded_by is NULL), isAdmin=false
+    await expect(
+      service.renameObject(
+        TEST_BUCKET,
+        'secret.png',
+        'renamed.png',
+        '00000000-0000-0000-0000-000000000999',
+        false
+      )
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -73,4 +73,20 @@ describe('LocalStorageProvider - deleteBucket', () => {
       'Bucket name contains invalid characters'
     );
   });
+
+  it('renames an existing object on disk', async () => {
+    const bucket = 'testBucket';
+    const originalKey = 'folder/photo.png';
+    const renamedKey = 'folder/cover.png';
+    const originalPath = path.join(baseDir, bucket, originalKey);
+    const renamedPath = path.join(baseDir, bucket, renamedKey);
+
+    await fs.mkdir(path.dirname(originalPath), { recursive: true });
+    await fs.writeFile(originalPath, Buffer.from('hello world'));
+
+    await provider.renameObject(bucket, originalKey, renamedKey);
+
+    await expect(fs.access(originalPath)).rejects.toThrow();
+    await expect(fs.readFile(renamedPath, 'utf8')).resolves.toBe('hello world');
+  });
 });

--- a/backend/tests/unit/s3storageprovider.test.ts
+++ b/backend/tests/unit/s3storageprovider.test.ts
@@ -23,7 +23,7 @@ vi.mock('@aws-sdk/client-s3', () => {
   class MockS3Client {
     send = sendMock;
 
-    constructor(_config: Record<string, unknown>) {}
+    constructor() {}
   }
 
   class MockCopyObjectCommand {

--- a/backend/tests/unit/s3storageprovider.test.ts
+++ b/backend/tests/unit/s3storageprovider.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type CommandInput = {
+  Bucket: string;
+  Key: string;
+  CopySource?: string;
+};
+
+const { sendMock } = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockS3Client {
+    send = sendMock;
+
+    constructor(_config: Record<string, unknown>) {}
+  }
+
+  class MockCopyObjectCommand {
+    constructor(public input: CommandInput) {}
+  }
+
+  class MockDeleteObjectCommand {
+    constructor(public input: CommandInput) {}
+  }
+
+  class MockNoopCommand {
+    constructor(public input?: CommandInput | Record<string, unknown>) {}
+  }
+
+  return {
+    S3Client: MockS3Client,
+    PutObjectCommand: MockNoopCommand,
+    GetObjectCommand: MockNoopCommand,
+    DeleteObjectCommand: MockDeleteObjectCommand,
+    CopyObjectCommand: MockCopyObjectCommand,
+    ListObjectsV2Command: MockNoopCommand,
+    DeleteObjectsCommand: MockNoopCommand,
+    HeadObjectCommand: MockNoopCommand,
+  };
+});
+
+import { S3StorageProvider } from '../../src/providers/storage/s3.provider.ts';
+
+describe('S3StorageProvider.renameObject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendMock.mockResolvedValue({});
+  });
+
+  it('URL-encodes CopySource for keys with special characters', async () => {
+    const provider = new S3StorageProvider('test-bucket', 'app-key');
+    provider.initialize();
+
+    await provider.renameObject('assets', 'folder/resume #2026.txt', 'folder/cover.txt');
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock.mock.calls[0][0]).toMatchObject({
+      input: {
+        Bucket: 'test-bucket',
+        CopySource: 'test-bucket/app-key/assets/folder/resume%20%232026.txt',
+        Key: 'app-key/assets/folder/cover.txt',
+      },
+    });
+    expect(sendMock.mock.calls[1][0]).toMatchObject({
+      input: {
+        Bucket: 'test-bucket',
+        Key: 'app-key/assets/folder/resume #2026.txt',
+      },
+    });
+  });
+});

--- a/backend/tests/unit/storage.service.test.ts
+++ b/backend/tests/unit/storage.service.test.ts
@@ -61,6 +61,7 @@ describe('StorageService.renameObject', () => {
           },
         ],
       })
+      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
         rows: [
@@ -87,6 +88,11 @@ describe('StorageService.renameObject', () => {
       uploadedAt: '2026-03-31T12:00:00.000Z',
     });
     expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(
+      3,
+      'SELECT pg_advisory_xact_lock(hashtext($1))',
+      ['assets/cover.png']
+    );
     expect(client.query).toHaveBeenLastCalledWith('COMMIT');
   });
 
@@ -105,6 +111,7 @@ describe('StorageService.renameObject', () => {
           },
         ],
       })
+      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
         rows: [
@@ -215,6 +222,7 @@ describe('StorageService.renameObject', () => {
           },
         ],
       })
+      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce({ rows: [{ exists: true }] })
       .mockResolvedValueOnce(undefined);
 
@@ -227,6 +235,11 @@ describe('StorageService.renameObject', () => {
     });
 
     expect(provider.renameObject).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenNthCalledWith(
+      3,
+      'SELECT pg_advisory_xact_lock(hashtext($1))',
+      ['assets/cover.png']
+    );
     expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
   });
 });

--- a/backend/tests/unit/storage.service.test.ts
+++ b/backend/tests/unit/storage.service.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/infra/database/database.manager.js', () => ({
 describe('StorageService.renameObject', () => {
   const provider = {
     renameObject: vi.fn(),
+    verifyObjectExists: vi.fn(),
   };
 
   const client = {
@@ -42,6 +43,7 @@ describe('StorageService.renameObject', () => {
     service.pool = {
       connect: vi.fn().mockResolvedValue(client),
     };
+    provider.verifyObjectExists.mockResolvedValue({ exists: true });
   });
 
   it('renames a root-level file and preserves metadata', async () => {
@@ -160,6 +162,38 @@ describe('StorageService.renameObject', () => {
       service.renameObject('assets', 'missing.png', 'cover.png', 'user-1', true)
     ).rejects.toMatchObject<AppError>({
       statusCode: 404,
+    });
+
+    expect(provider.renameObject).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+  });
+
+  it('returns 404 when metadata exists but the source file is missing in storage', async () => {
+    provider.verifyObjectExists.mockResolvedValueOnce({ exists: false });
+
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'photo.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+            uploaded_by: 'user-1',
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const service = StorageService.getInstance();
+
+    await expect(
+      service.renameObject('assets', 'photo.png', 'cover.png', 'user-1', true)
+    ).rejects.toMatchObject<AppError>({
+      statusCode: 404,
+      message: 'Object file not found in storage',
     });
 
     expect(provider.renameObject).not.toHaveBeenCalled();

--- a/backend/tests/unit/storage.service.test.ts
+++ b/backend/tests/unit/storage.service.test.ts
@@ -139,6 +139,9 @@ describe('StorageService.renameObject', () => {
     await expect(
       service.renameObject('assets', 'photo.png', 'photo.png', 'user-1', true)
     ).rejects.toThrow('different');
+    await expect(
+      service.renameObject('assets', 'folder/', 'banner.png', 'user-1', true)
+    ).rejects.toThrow('Only files can be renamed');
 
     expect(provider.renameObject).not.toHaveBeenCalled();
   });

--- a/backend/tests/unit/storage.service.test.ts
+++ b/backend/tests/unit/storage.service.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/api/middlewares/error';
+import { StorageService } from '../../src/services/storage/storage.service';
+
+vi.mock('@/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({
+        connect: vi.fn(),
+      }),
+    }),
+  },
+}));
+
+describe('StorageService.renameObject', () => {
+  const provider = {
+    renameObject: vi.fn(),
+  };
+
+  const client = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const service = StorageService.getInstance() as unknown as {
+      provider: typeof provider;
+      pool: { connect: ReturnType<typeof vi.fn> };
+    };
+    service.provider = provider;
+    service.pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+  });
+
+  it('renames a root-level file and preserves metadata', async () => {
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'photo.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+            uploaded_by: 'user-1',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'cover.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const service = StorageService.getInstance();
+    const result = await service.renameObject('assets', 'photo.png', 'cover.png', 'user-1', true);
+
+    expect(provider.renameObject).toHaveBeenCalledWith('assets', 'photo.png', 'cover.png');
+    expect(result).toMatchObject({
+      bucket: 'assets',
+      key: 'cover.png',
+      size: 120,
+      mimeType: 'image/png',
+      uploadedAt: '2026-03-31T12:00:00.000Z',
+    });
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenLastCalledWith('COMMIT');
+  });
+
+  it('renames a nested file while preserving its prefix', async () => {
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'folder/photo.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+            uploaded_by: 'user-1',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'folder/banner.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+          },
+        ],
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const service = StorageService.getInstance();
+    await service.renameObject('assets', 'folder/photo.png', 'banner.png', 'user-1', true);
+
+    expect(provider.renameObject).toHaveBeenCalledWith(
+      'assets',
+      'folder/photo.png',
+      'folder/banner.png'
+    );
+  });
+
+  it('rejects invalid names with path separators or dot segments', async () => {
+    const service = StorageService.getInstance();
+
+    await expect(
+      service.renameObject('assets', 'photo.png', 'folder/new.png', 'user-1', true)
+    ).rejects.toThrow('Invalid file name');
+    await expect(service.renameObject('assets', 'photo.png', '..', 'user-1', true)).rejects.toThrow(
+      'Invalid file name'
+    );
+    await expect(
+      service.renameObject('assets', 'photo.png', 'photo.png', 'user-1', true)
+    ).rejects.toThrow('different');
+
+    expect(provider.renameObject).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the source object does not exist', async () => {
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [],
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const service = StorageService.getInstance();
+
+    await expect(
+      service.renameObject('assets', 'missing.png', 'cover.png', 'user-1', true)
+    ).rejects.toMatchObject<AppError>({
+      statusCode: 404,
+    });
+
+    expect(provider.renameObject).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+  });
+
+  it('returns 409 when the destination key already exists', async () => {
+    client.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bucket: 'assets',
+            key: 'photo.png',
+            size: 120,
+            mime_type: 'image/png',
+            uploaded_at: '2026-03-31T12:00:00.000Z',
+            uploaded_by: 'user-1',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ exists: true }] })
+      .mockResolvedValueOnce(undefined);
+
+    const service = StorageService.getInstance();
+
+    await expect(
+      service.renameObject('assets', 'photo.png', 'cover.png', 'user-1', true)
+    ).rejects.toMatchObject<AppError>({
+      statusCode: 409,
+    });
+
+    expect(provider.renameObject).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
+  });
+});

--- a/backend/tests/unit/storage.service.test.ts
+++ b/backend/tests/unit/storage.service.test.ts
@@ -88,11 +88,9 @@ describe('StorageService.renameObject', () => {
       uploadedAt: '2026-03-31T12:00:00.000Z',
     });
     expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
-    expect(client.query).toHaveBeenNthCalledWith(
-      3,
-      'SELECT pg_advisory_xact_lock(hashtext($1))',
-      ['assets/cover.png']
-    );
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT pg_advisory_xact_lock(hashtext($1))', [
+      'assets/cover.png',
+    ]);
     expect(client.query).toHaveBeenLastCalledWith('COMMIT');
   });
 
@@ -235,11 +233,9 @@ describe('StorageService.renameObject', () => {
     });
 
     expect(provider.renameObject).not.toHaveBeenCalled();
-    expect(client.query).toHaveBeenNthCalledWith(
-      3,
-      'SELECT pg_advisory_xact_lock(hashtext($1))',
-      ['assets/cover.png']
-    );
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT pg_advisory_xact_lock(hashtext($1))', [
+      'assets/cover.png',
+    ]);
     expect(client.query).toHaveBeenLastCalledWith('ROLLBACK');
   });
 });

--- a/backend/vitest.integration.config.ts
+++ b/backend/vitest.integration.config.ts
@@ -14,16 +14,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
-    setupFiles: ['./tests/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', 'frontend/', 'tests/', '**/*.d.ts', '**/*.config.*'],
-    },
-
-    exclude: ['**/node_modules/**', '**/dist/**', '**/tests/integration/**'],
-    testTimeout: 10000,
-    // Run tests sequentially to avoid database conflicts
+    include: ['tests/integration/**/*.test.ts'],
+    testTimeout: 30000,
     pool: 'forks',
     poolOptions: {
       forks: {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,5 +23,6 @@
     }
   },
   "include": ["src", "../packages/dashboard"],
+  "exclude": ["../packages/dashboard/**/*.test.ts", "../packages/dashboard/**/*.test.tsx"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
@@ -86,4 +86,35 @@ describe('RenameFileDialog', () => {
     expect(submitButton).toBeDisabled();
     expect(onRename).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { value: '.', message: 'Invalid file name' },
+    { value: '..', message: 'Invalid file name' },
+    { value: 'folder/cover.png', message: 'File name cannot contain "/" or "\\\\"' },
+  ])('rejects invalid rename input: $value', async ({ value, message }) => {
+    render(
+      <RenameFileDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onRename={onRename}
+        file={{
+          bucket: 'assets',
+          key: 'photo.png',
+          size: 10,
+          mimeType: 'image/png',
+          uploadedAt: '2026-03-31T12:00:00.000Z',
+          url: '/photo.png',
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText('File Name');
+    fireEvent.change(input, { target: { value } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(message.replace('\\\\', '\\'))).toBeInTheDocument();
+    });
+    expect(onRename).not.toHaveBeenCalled();
+  });
 });

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
@@ -84,12 +84,6 @@ describe('RenameFileDialog', () => {
 
     const submitButton = screen.getByRole('button', { name: 'Rename' });
     expect(submitButton).toBeDisabled();
-
-    fireEvent.submit(submitButton.closest('form') as HTMLFormElement);
-
-    await waitFor(() => {
-      expect(screen.getByText('File name is required')).toBeInTheDocument();
-    });
     expect(onRename).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
@@ -1,5 +1,27 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@insforge/ui', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogCloseButton: (props: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      Close
+    </button>
+  ),
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
 import { RenameFileDialog } from './RenameFileDialog';
 
 describe('RenameFileDialog', () => {

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
@@ -91,6 +91,7 @@ describe('RenameFileDialog', () => {
     { value: '.', message: 'Invalid file name' },
     { value: '..', message: 'Invalid file name' },
     { value: 'folder/cover.png', message: 'File name cannot contain "/" or "\\\\"' },
+    { value: 'folder\\cover.png', message: 'File name cannot contain "/" or "\\\\"' },
   ])('rejects invalid rename input: $value', async ({ value, message }) => {
     render(
       <RenameFileDialog

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RenameFileDialog } from './RenameFileDialog';
+
+describe('RenameFileDialog', () => {
+  const onOpenChange = vi.fn();
+  const onRename = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefills the basename and submits the new name', async () => {
+    onRename.mockResolvedValueOnce(undefined);
+
+    render(
+      <RenameFileDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onRename={onRename}
+        file={{
+          bucket: 'assets',
+          key: 'folder/photo.png',
+          size: 10,
+          mimeType: 'image/png',
+          uploadedAt: '2026-03-31T12:00:00.000Z',
+          url: '/photo.png',
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText('File Name');
+    expect(input).toHaveValue('photo.png');
+
+    fireEvent.change(input, { target: { value: 'cover.png' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+    await waitFor(() => {
+      expect(onRename).toHaveBeenCalledWith('cover.png');
+    });
+  });
+
+  it('shows a validation error for an empty name', async () => {
+    render(
+      <RenameFileDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        onRename={onRename}
+        file={{
+          bucket: 'assets',
+          key: 'photo.png',
+          size: 10,
+          mimeType: 'image/png',
+          uploadedAt: '2026-03-31T12:00:00.000Z',
+          url: '/photo.png',
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText('File Name');
+    fireEvent.change(input, { target: { value: '   ' } });
+
+    const submitButton = screen.getByRole('button', { name: 'Rename' });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.submit(submitButton.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(screen.getByText('File name is required')).toBeInTheDocument();
+    });
+    expect(onRename).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogCloseButton,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from '@insforge/ui';
+import type { StorageFileSchema } from '@insforge/shared-schemas';
+
+interface RenameFileDialogProps {
+  file: StorageFileSchema | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRename: (newName: string) => Promise<void>;
+  isRenaming?: boolean;
+}
+
+export function RenameFileDialog({
+  file,
+  open,
+  onOpenChange,
+  onRename,
+  isRenaming = false,
+}: RenameFileDialogProps) {
+  const [newName, setNewName] = useState('');
+  const [error, setError] = useState('');
+
+  const currentName = useMemo(() => {
+    return file?.key.split('/').pop() || '';
+  }, [file]);
+
+  useEffect(() => {
+    if (open) {
+      setNewName(currentName);
+      setError('');
+    }
+  }, [open, currentName]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmedName = newName.trim();
+    if (!trimmedName) {
+      setError('File name is required');
+      return;
+    }
+
+    try {
+      await onRename(trimmedName);
+      handleClose();
+    } catch (renameError) {
+      setError(renameError instanceof Error ? renameError.message : 'Failed to rename file');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent showCloseButton={false}>
+        <form onSubmit={(event) => void handleSubmit(event)} className="flex flex-col">
+          <DialogHeader className="gap-0">
+            <div className="flex w-full items-start gap-3">
+              <div className="min-w-0 flex-1 space-y-1">
+                <DialogTitle>Rename File</DialogTitle>
+                <DialogDescription>
+                  Update the file name while keeping it in the same folder.
+                </DialogDescription>
+              </div>
+              <DialogCloseButton className="relative right-auto top-auto h-7 w-7 rounded p-1" />
+            </div>
+          </DialogHeader>
+          <DialogBody className="gap-2 p-4">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="rename-file-name" className="text-sm leading-5 text-foreground">
+                File Name
+              </label>
+              <Input
+                id="rename-file-name"
+                value={newName}
+                onChange={(event) => {
+                  setNewName(event.target.value);
+                  setError('');
+                }}
+                placeholder="Enter a new file name"
+                autoFocus
+                disabled={isRenaming}
+                className="h-8 rounded px-1.5 py-1.5 text-sm leading-5"
+              />
+              <p className="text-[13px] leading-[18px] text-muted-foreground">
+                Current name: {currentName || 'Unknown file'}
+              </p>
+              {error && <p className="text-[13px] leading-[18px] text-destructive">{error}</p>}
+            </div>
+          </DialogBody>
+          <DialogFooter className="gap-3 p-4">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleClose}
+              className="h-8 px-2"
+              disabled={isRenaming}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="h-8 px-2"
+              disabled={isRenaming || !newName.trim() || newName.trim() === currentName}
+            >
+              {isRenaming ? 'Renaming...' : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -63,10 +63,22 @@ export function RenameFileDialog({
       return;
     }
 
+    if (trimmedName === '.' || trimmedName === '..') {
+      setError('Invalid file name');
+      return;
+    }
+
+    if (trimmedName.includes('/') || trimmedName.includes('\\')) {
+      setError('File name cannot contain "/" or "\\"');
+      return;
+    }
+
     if (!currentName) {
       setError('Only files can be renamed');
       return;
     }
+
+    setError('');
 
     try {
       await onRename(trimmedName);

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -127,7 +127,9 @@ export function RenameFileDialog({
             <Button
               type="submit"
               className="h-8 px-2"
-              disabled={isRenaming || !currentName || !newName.trim() || newName.trim() === currentName}
+              disabled={
+                isRenaming || !currentName || !newName.trim() || newName.trim() === currentName
+              }
             >
               {isRenaming ? 'Renaming...' : 'Rename'}
             </Button>

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -21,6 +21,14 @@ interface RenameFileDialogProps {
   isRenaming?: boolean;
 }
 
+function getCurrentFileName(key?: string): string {
+  if (!key || key.endsWith('/')) {
+    return '';
+  }
+
+  return key.split('/').pop() || '';
+}
+
 export function RenameFileDialog({
   file,
   open,
@@ -32,7 +40,7 @@ export function RenameFileDialog({
   const [error, setError] = useState('');
 
   const currentName = useMemo(() => {
-    return file?.key.split('/').pop() || '';
+    return getCurrentFileName(file?.key);
   }, [file]);
 
   useEffect(() => {
@@ -52,6 +60,11 @@ export function RenameFileDialog({
     const trimmedName = newName.trim();
     if (!trimmedName) {
       setError('File name is required');
+      return;
+    }
+
+    if (!currentName) {
+      setError('Only files can be renamed');
       return;
     }
 
@@ -114,7 +127,7 @@ export function RenameFileDialog({
             <Button
               type="submit"
               className="h-8 px-2"
-              disabled={isRenaming || !newName.trim() || newName.trim() === currentName}
+              disabled={isRenaming || !currentName || !newName.trim() || newName.trim() === currentName}
             >
               {isRenaming ? 'Renaming...' : 'Rename'}
             </Button>

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Download,
   Eye,
+  Pencil,
   Trash2,
   Image,
   FileText,
@@ -28,6 +29,7 @@ import { StorageFileSchema } from '@insforge/shared-schemas';
 import { cn, formatTime } from '../../../lib/utils/utils';
 import { useStorage } from '../hooks/useStorage';
 import { FilePreviewDialog } from './FilePreviewDialog';
+import { RenameFileDialog } from './RenameFileDialog';
 import { useConfirm } from '../../../lib/hooks/useConfirm';
 import { useToast } from '../../../lib/hooks/useToast';
 import { SortColumn } from 'react-data-grid';
@@ -129,6 +131,7 @@ const UploadedAtRenderer = ({ row, column }: RenderCellProps<StorageDataGridRow>
 export function createStorageColumns(
   onPreview?: (file: StorageFileSchema) => void,
   onDownload?: (file: StorageFileSchema) => void,
+  onRename?: (file: StorageFileSchema) => void,
   onDelete?: (file: StorageFileSchema) => void,
   isDownloading?: (key: string) => boolean
 ): DataGridColumn<StorageDataGridRow>[] {
@@ -172,12 +175,12 @@ export function createStorageColumns(
   ];
 
   // Add actions column if any handlers are provided
-  if (onPreview || onDownload || onDelete) {
+  if (onPreview || onDownload || onRename || onDelete) {
     columns.push({
       key: 'actions',
       name: '',
-      minWidth: 108,
-      maxWidth: 108,
+      minWidth: 136,
+      maxWidth: 136,
       resizable: false,
       sortable: false,
       renderCell: ({ row }: RenderCellProps<StorageDataGridRow>) => {
@@ -216,6 +219,20 @@ export function createStorageColumns(
                 <Download className="h-5 w-5 stroke-[1.5]" />
               </Button>
             )}
+            {onRename && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 rounded p-0 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRename(row as StorageFileSchema);
+                }}
+                title="Rename file"
+              >
+                <Pencil className="h-4 w-4 stroke-[1.5]" />
+              </Button>
+            )}
             {onDelete && (
               <Button
                 variant="ghost"
@@ -242,6 +259,7 @@ export function createStorageColumns(
 interface StorageFilesGridProps extends Omit<DataGridProps<StorageDataGridRow>, 'columns'> {
   onPreview?: (file: StorageFileSchema) => void;
   onDownload?: (file: StorageFileSchema) => void;
+  onRename?: (file: StorageFileSchema) => void;
   onDelete?: (file: StorageFileSchema) => void;
   isDownloading?: (key: string) => boolean;
 }
@@ -249,13 +267,14 @@ interface StorageFilesGridProps extends Omit<DataGridProps<StorageDataGridRow>, 
 function StorageFilesGrid({
   onPreview,
   onDownload,
+  onRename,
   onDelete,
   isDownloading,
   ...props
 }: StorageFilesGridProps) {
   const columns = useMemo(
-    () => createStorageColumns(onPreview, onDownload, onDelete, isDownloading),
-    [onPreview, onDownload, onDelete, isDownloading]
+    () => createStorageColumns(onPreview, onDownload, onRename, onDelete, isDownloading),
+    [onPreview, onDownload, onRename, onDelete, isDownloading]
   );
 
   // Ensure each row has an id for selection
@@ -299,7 +318,9 @@ export function StorageDataGrid({
 }: StorageDataGridProps) {
   const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set());
   const [previewFile, setPreviewFile] = useState<StorageFileSchema | null>(null);
+  const [renameFile, setRenameFile] = useState<StorageFileSchema | null>(null);
   const [showPreviewDialog, setShowPreviewDialog] = useState(false);
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [sortColumns, setSortColumns] = useState<SortColumn[]>([]);
   const { showToast } = useToast();
   const { confirm, confirmDialogProps } = useConfirm();
@@ -314,7 +335,8 @@ export function StorageDataGrid({
     setCurrentPage(1);
   }, [searchQuery, bucketName]);
 
-  const { useListObjects, deleteObjects, downloadObject } = useStorage();
+  const { useListObjects, deleteObjects, downloadObject, renameObject, isRenamingObject } =
+    useStorage();
   const {
     data: objectsData,
     isLoading: objectsLoading,
@@ -392,6 +414,26 @@ export function StorageDataGrid({
     setShowPreviewDialog(true);
   }, []);
 
+  const handleRename = useCallback((file: StorageFileSchema) => {
+    setRenameFile(file);
+    setShowRenameDialog(true);
+  }, []);
+
+  const handleRenameSubmit = useCallback(
+    async (newName: string) => {
+      if (!renameFile) {
+        return;
+      }
+
+      await renameObject({
+        bucket: bucketName,
+        key: renameFile.key,
+        newName,
+      });
+    },
+    [bucketName, renameFile, renameObject]
+  );
+
   const handleDelete = useCallback(
     async (file: StorageFileSchema) => {
       const confirmOptions = {
@@ -468,6 +510,7 @@ export function StorageDataGrid({
           onSortColumnsChange={setSortColumns}
           onPreview={handlePreview}
           onDownload={(file) => void handleDownload(file)}
+          onRename={handleRename}
           onDelete={(file) => void handleDelete(file)}
           isDownloading={isDownloading}
           emptyState={
@@ -488,6 +531,19 @@ export function StorageDataGrid({
         onOpenChange={setShowPreviewDialog}
         file={previewFile}
         bucket={bucketName}
+      />
+
+      <RenameFileDialog
+        open={showRenameDialog}
+        onOpenChange={(open) => {
+          setShowRenameDialog(open);
+          if (!open) {
+            setRenameFile(null);
+          }
+        }}
+        file={renameFile}
+        onRename={handleRenameSubmit}
+        isRenaming={isRenamingObject}
       />
     </div>
   );

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -187,6 +187,7 @@ export function createStorageColumns(
         // Type-safe access to the key property
         const fileKey = row.key || String(row['key'] || '');
         const isFileDownloading = isDownloading?.(fileKey) || false;
+        const canRename = Boolean(onRename) && fileKey !== '' && !fileKey.endsWith('/');
 
         return (
           <div className="flex w-full items-center justify-center gap-2">
@@ -219,14 +220,14 @@ export function createStorageColumns(
                 <Download className="h-5 w-5 stroke-[1.5]" />
               </Button>
             )}
-            {onRename && (
+            {canRename && (
               <Button
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 rounded p-0 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onRename(row as StorageFileSchema);
+                  onRename?.(row as StorageFileSchema);
                 }}
                 title="Rename file"
               >

--- a/packages/dashboard/src/features/storage/hooks/useStorage.ts
+++ b/packages/dashboard/src/features/storage/hooks/useStorage.ts
@@ -134,6 +134,19 @@ export function useStorage() {
     },
   });
 
+  const renameObjectMutation = useMutation({
+    mutationFn: ({ bucket, key, newName }: { bucket: string; key: string; newName: string }) =>
+      storageService.renameObject(bucket, key, newName),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['storage'] });
+      showToast('File renamed successfully', 'success');
+    },
+    onError: (error: Error) => {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to rename file';
+      showToast(errorMessage, 'error');
+    },
+  });
+
   // Mutation to create a bucket
   const createBucketMutation = useMutation({
     mutationFn: ({ bucketName, isPublic }: { bucketName: string; isPublic: boolean }) =>
@@ -184,6 +197,7 @@ export function useStorage() {
     isLoadingBuckets,
     isUploadingObject: uploadObjectMutation.isPending,
     isDeletingObject: deleteObjectsMutation.isPending,
+    isRenamingObject: renameObjectMutation.isPending,
     isCreatingBucket: createBucketMutation.isPending,
     isDeletingBucket: deleteBucketMutation.isPending,
     isEditingBucket: editBucketMutation.isPending,
@@ -194,6 +208,7 @@ export function useStorage() {
     // Actions
     uploadObject: uploadObjectMutation.mutateAsync,
     deleteObjects: deleteObjectsMutation.mutate,
+    renameObject: renameObjectMutation.mutateAsync,
     createBucket: createBucketMutation.mutateAsync,
     deleteBucket: deleteBucketMutation.mutateAsync,
     editBucket: editBucketMutation.mutateAsync,

--- a/packages/dashboard/src/features/storage/services/storage.service.test.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    request: requestMock,
+    withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+    getAccessToken: vi.fn(() => 'token'),
+  },
+}));
+
+import { storageService } from './storage.service';
+
+describe('storageService.renameObject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the rename endpoint with the expected payload', async () => {
+    requestMock.mockResolvedValueOnce({ key: 'folder/cover.png' });
+
+    await storageService.renameObject('assets', 'folder/photo.png', 'cover.png');
+
+    expect(requestMock).toHaveBeenCalledWith('/storage/buckets/assets/objects/folder%2Fphoto.png', {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ newName: 'cover.png' }),
+    });
+  });
+});

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -116,6 +116,21 @@ export const storageService = {
     );
   },
 
+  async renameObject(
+    bucketName: string,
+    objectKey: string,
+    newName: string
+  ): Promise<StorageFileSchema> {
+    return apiClient.request(
+      `/storage/buckets/${encodeURIComponent(bucketName)}/objects/${encodeURIComponent(objectKey)}`,
+      {
+        method: 'PATCH',
+        headers: apiClient.withAccessToken(),
+        body: JSON.stringify({ newName }),
+      }
+    );
+  },
+
   async deleteObjects(
     bucketName: string,
     objectKeys: string[]

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -12,5 +12,6 @@
     "outDir": "dist",
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -10,6 +10,10 @@ export const updateBucketRequestSchema = z.object({
   isPublic: z.boolean(),
 });
 
+export const renameObjectRequestSchema = z.object({
+  newName: z.string().min(1, 'New name cannot be empty'),
+});
+
 export const listObjectsResponseSchema = z.object({
   objects: z.array(storageFileSchema),
   pagination: z.object({
@@ -67,6 +71,7 @@ export const getStorageConfigResponseSchema = storageConfigSchema;
 
 export type CreateBucketRequest = z.infer<typeof createBucketRequestSchema>;
 export type UpdateBucketRequest = z.infer<typeof updateBucketRequestSchema>;
+export type RenameObjectRequest = z.infer<typeof renameObjectRequestSchema>;
 export type ListObjectsResponseSchema = z.infer<typeof listObjectsResponseSchema>;
 export type UploadStrategyRequest = z.infer<typeof uploadStrategyRequestSchema>;
 export type UploadStrategyResponse = z.infer<typeof uploadStrategyResponseSchema>;

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -11,7 +11,16 @@ export const updateBucketRequestSchema = z.object({
 });
 
 export const renameObjectRequestSchema = z.object({
-  newName: z.string().min(1, 'New name cannot be empty'),
+  newName: z
+    .string()
+    .trim()
+    .min(1, 'Invalid file name. New name cannot be empty.')
+    .refine((value) => value !== '.' && value !== '..', {
+      message: 'Invalid file name. "." and ".." are not allowed.',
+    })
+    .refine((value) => !/[\\/]/.test(value), {
+      message: 'Invalid file name. Path separators are not allowed.',
+    }),
 });
 
 export const listObjectsResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- add a shared storage rename request contract with 
ewName
- add backend rename support for storage objects, including provider-level rename implementations for local storage and S3
- add a rename action and dialog in the Storage dashboard so files can be renamed without re-uploading

## What changed
- Added PATCH /api/storage/buckets/:bucketName/objects/* to rename an object while keeping it in the same folder
- Implemented StorageService.renameObject(...) with validation for empty names, path separators, . / .., unchanged names, and destination collisions
- Added explicit enameObject support to storage providers:
  - local storage uses filesystem rename
  - S3 uses copy + delete
- Added frontend rename flow through the storage service, React Query hook, and a new rename dialog
- Added row-level rename action in the Storage dashboard file table

## Validation
- targeted eslint on changed files only
- 
pm.cmd run build in shared-schemas
- 
ode .\\node_modules\\typescript\\bin\\tsc -p backend\\tsconfig.json --noEmit
- 
ode .\\node_modules\\typescript\\bin\\tsc -p frontend\\tsconfig.json --noEmit
- backend tests: 
pm.cmd run test -- storage.service.test.ts localstorageprovider.test.ts
- frontend tests: 
pm.cmd run test -- RenameFileDialog.test.tsx storage.service.test.ts

## Notes
- v1 is filename-only rename; it does not move files between folders
- rename fails with a conflict instead of overwriting if the destination filename already exists
- existing upload metadata is preserved except for the object key/url change

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file rename support to the storage dashboard
> - Adds a `PATCH /api/storage/buckets/:bucketName/objects/*` endpoint backed by `StorageService.renameObject`, which validates ownership/admin permissions, checks for key conflicts using `pg_advisory_xact_lock`, updates the DB record, and renames the file via the storage provider.
> - Implements `renameObject` for both local (fs.rename) and S3 (copy-then-delete) providers.
> - Adds a `RenameFileDialog` modal and a pencil icon action button in `StorageDataGrid` for file rows, wired through `useStorage.renameObject`.
> - Shared validation schema `renameObjectRequestSchema` in `packages/shared-schemas` enforces non-empty names, disallows dot-segments, and forbids path separators on both client and server.
> - Risk: S3 rename is non-atomic (copy then delete); a failure between the two steps can leave both source and destination objects present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5db09f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename files from the UI via a Rename dialog and a new Rename action in file actions.
  * Client and server now support renaming files (preserves directory prefix, updates references, transactional backend update).

* **Bug Fixes / Validation**
  * Prevent invalid target names (empty, ".", "..", or containing path separators); UI disables Rename when invalid or unchanged.

* **Tests**
  * Added tests covering rename flows, provider behavior, and validation.

* **Chores**
  * Updated test aliases to support shared schemas and UI in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->