### PR TITLE
feat: add file rename to storage dashboard

### DIFF
--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -10,6 +10,7 @@ import {
   createBucketRequestSchema,
   updateBucketRequestSchema,
   updateStorageConfigRequestSchema,
+  renameObjectRequestSchema,
 } from '@insforge/shared-schemas';
 import { SocketManager } from '@/infra/socket/socket.manager.js';
 import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
@@ -444,6 +445,76 @@ router.delete(
       );
     } catch (error) {
       next(error);
+    }
+  }
+);
+
+// PATCH /api/storage/buckets/:bucketName/objects/* - Rename object in bucket (requires auth)
+router.patch(
+  '/buckets/:bucketName/objects/*',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { bucketName } = req.params;
+      const objectKey = req.params[0]; // Everything after objects
+
+      if (!objectKey) {
+        throw new AppError('Object key is required', 400, ERROR_CODES.STORAGE_INVALID_PARAMETER);
+      }
+
+      const validation = renameObjectRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.STORAGE_INVALID_PARAMETER,
+          'Please check the request body, it must conform with the RenameObjectRequest schema.'
+        );
+      }
+
+      const { newKey } = validation.data;
+
+      const storageService = StorageService.getInstance();
+      const renamedFile = await storageService.renameObject(
+        bucketName,
+        objectKey,
+        newKey,
+        req.user?.id || '',
+        !!req.apiKey || req.user?.role === 'project_admin'
+      );
+
+      // Log audit for object rename
+      await auditService.log({
+        actor: req.user?.email || 'api-key',
+        action: 'RENAME_OBJECT',
+        module: 'STORAGE',
+        details: {
+          bucketName,
+          oldKey: objectKey,
+          newKey,
+        },
+        ip_address: req.ip,
+      });
+
+      const socket = SocketManager.getInstance();
+      socket.broadcastToRoom(
+        'role:project_admin',
+        ServerEvents.DATA_UPDATE,
+        { resource: DataUpdateResourceType.BUCKETS, data: { bucketName } },
+        'system'
+      );
+
+      successResponse(res, renamedFile);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already exists')) {
+        next(new AppError(error.message, 409, ERROR_CODES.ALREADY_EXISTS));
+      } else if (error instanceof Error && error.message.includes('not found')) {
+        next(new AppError(error.message, 404, ERROR_CODES.NOT_FOUND));
+      } else if (error instanceof Error && error.message.includes('Invalid')) {
+        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
+      } else {
+        next(error);
+      }
     }
   }
 );

--- a/backend/src/providers/storage/base.provider.ts
+++ b/backend/src/providers/storage/base.provider.ts
@@ -9,6 +9,7 @@ export interface StorageProvider {
   putObject(bucket: string, key: string, file: Express.Multer.File): Promise<void>;
   getObject(bucket: string, key: string): Promise<Buffer | null>;
   deleteObject(bucket: string, key: string): Promise<void>;
+  copyObject(bucket: string, sourceKey: string, destKey: string): Promise<void>;
   createBucket(bucket: string): Promise<void>;
   deleteBucket(bucket: string): Promise<void>;
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -68,6 +68,13 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
+  async copyObject(bucket: string, sourceKey: string, destKey: string): Promise<void> {
+    const srcPath = this.getFilePath(bucket, sourceKey);
+    const destPath = this.getFilePath(bucket, destKey);
+    await fs.mkdir(path.dirname(destPath), { recursive: true });
+    await fs.copyFile(srcPath, destPath);
+  }
+
   async createBucket(bucket: string): Promise<void> {
     const bucketPath = this.getValidatedPath(bucket);
     await fs.mkdir(bucketPath, { recursive: true });

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -132,9 +132,15 @@ export class S3StorageProvider implements StorageProvider {
     const sourceS3Key = this.getS3Key(bucket, sourceKey);
     const destS3Key = this.getS3Key(bucket, destKey);
 
+    // URI-encode each path segment for special characters (spaces, parentheses, etc.)
+    const encodedSourceKey = sourceS3Key
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+
     const command = new CopyObjectCommand({
       Bucket: this.s3Bucket,
-      CopySource: `${this.s3Bucket}/${sourceS3Key}`,
+      CopySource: `${this.s3Bucket}/${encodedSourceKey}`,
       Key: destS3Key,
     });
 

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -6,6 +6,7 @@ import {
   ListObjectsV2Command,
   DeleteObjectsCommand,
   HeadObjectCommand,
+  CopyObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
@@ -122,6 +123,32 @@ export class S3StorageProvider implements StorageProvider {
       Key: this.getS3Key(bucket, key),
     });
     await this.s3Client.send(command);
+  }
+
+  async copyObject(bucket: string, sourceKey: string, destKey: string): Promise<void> {
+    if (!this.s3Client) {
+      throw new Error('S3 client not initialized');
+    }
+    const sourceS3Key = this.getS3Key(bucket, sourceKey);
+    const destS3Key = this.getS3Key(bucket, destKey);
+
+    const command = new CopyObjectCommand({
+      Bucket: this.s3Bucket,
+      CopySource: `${this.s3Bucket}/${sourceS3Key}`,
+      Key: destS3Key,
+    });
+
+    try {
+      await this.s3Client.send(command);
+    } catch (error) {
+      logger.error('S3 Copy error', {
+        error: error instanceof Error ? error.message : String(error),
+        bucket,
+        sourceKey,
+        destKey,
+      });
+      throw error;
+    }
   }
 
   async createBucket(_bucket: string): Promise<void> {

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -251,6 +251,90 @@ export class StorageService {
     return false;
   }
 
+  async renameObject(
+    bucket: string,
+    oldKey: string,
+    newKey: string,
+    userId: string,
+    isAdmin: boolean
+  ): Promise<StorageFileSchema> {
+    this.validateBucketName(bucket);
+    this.validateKey(oldKey);
+    this.validateKey(newKey);
+
+    // Step 1: Copy object in storage provider (if this fails, no state change)
+    await this.provider.copyObject(bucket, oldKey, newKey);
+
+    // Step 2: Update DB key (catch unique constraint violation as 409)
+    try {
+      const result = isAdmin
+        ? await this.getPool().query(
+            `UPDATE storage.objects SET key = $1
+             WHERE bucket = $2 AND key = $3
+             RETURNING size, mime_type, uploaded_at as "uploadedAt"`,
+            [newKey, bucket, oldKey]
+          )
+        : await this.getPool().query(
+            `UPDATE storage.objects SET key = $1
+             WHERE bucket = $2 AND key = $3 AND uploaded_by = $4
+             RETURNING size, mime_type, uploaded_at as "uploadedAt"`,
+            [newKey, bucket, oldKey, userId]
+          );
+
+      if (!result.rowCount || result.rowCount === 0) {
+        // No row updated: old key not found or not owned by user. Clean up the copy.
+        try {
+          await this.provider.deleteObject(bucket, newKey);
+        } catch (cleanupError) {
+          logger.warn('Failed to clean up copied object after rename miss', {
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            bucket,
+            newKey,
+          });
+        }
+        throw new Error(`Object "${oldKey}" not found in bucket "${bucket}"`);
+      }
+
+      const row = result.rows[0];
+
+      // Step 3: Delete old key from storage (non-critical; log warning on failure)
+      try {
+        await this.provider.deleteObject(bucket, oldKey);
+      } catch (deleteError) {
+        logger.warn('Failed to delete old key after rename, orphaned file in storage', {
+          error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+          bucket,
+          oldKey,
+        });
+      }
+
+      return {
+        bucket,
+        key: newKey,
+        size: row.size,
+        mimeType: row.mime_type,
+        uploadedAt: row.uploadedAt,
+        url: `${getApiBaseUrl()}/api/storage/buckets/${bucket}/objects/${encodeURIComponent(newKey)}`,
+      };
+    } catch (error) {
+      // Postgres unique constraint violation → 409
+      if ((error as { code?: string }).code === '23505') {
+        // Clean up the copy we just made
+        try {
+          await this.provider.deleteObject(bucket, newKey);
+        } catch (cleanupError) {
+          logger.warn('Failed to clean up copied object after unique constraint violation', {
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            bucket,
+            newKey,
+          });
+        }
+        throw new Error(`Object "${newKey}" already exists in bucket "${bucket}"`);
+      }
+      throw error;
+    }
+  }
+
   async listObjects(
     bucket: string,
     prefix?: string,

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -282,16 +282,6 @@ export class StorageService {
           );
 
       if (!result.rowCount || result.rowCount === 0) {
-        // No row updated: old key not found or not owned by user. Clean up the copy.
-        try {
-          await this.provider.deleteObject(bucket, newKey);
-        } catch (cleanupError) {
-          logger.warn('Failed to clean up copied object after rename miss', {
-            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-            bucket,
-            newKey,
-          });
-        }
         throw new Error(`Object "${oldKey}" not found in bucket "${bucket}"`);
       }
 
@@ -317,18 +307,19 @@ export class StorageService {
         url: `${getApiBaseUrl()}/api/storage/buckets/${bucket}/objects/${encodeURIComponent(newKey)}`,
       };
     } catch (error) {
+      // Any failure after copy: clean up the copied object
+      try {
+        await this.provider.deleteObject(bucket, newKey);
+      } catch (cleanupError) {
+        logger.warn('Failed to clean up copied object during rename rollback', {
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          bucket,
+          newKey,
+        });
+      }
+
       // Postgres unique constraint violation → 409
       if ((error as { code?: string }).code === '23505') {
-        // Clean up the copy we just made
-        try {
-          await this.provider.deleteObject(bucket, newKey);
-        } catch (cleanupError) {
-          logger.warn('Failed to clean up copied object after unique constraint violation', {
-            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-            bucket,
-            newKey,
-          });
-        }
         throw new Error(`Object "${newKey}" already exists in bucket "${bucket}"`);
       }
       throw error;

--- a/backend/tests/unit/storage-provider-copy.test.ts
+++ b/backend/tests/unit/storage-provider-copy.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import * as path from 'path';
+import { LocalStorageProvider } from '../../src/providers/storage/local.provider.ts';
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('fs/promises')>('fs/promises');
+  return {
+    ...actual,
+    copyFile: vi.fn(actual.copyFile),
+    mkdir: vi.fn(actual.mkdir),
+  };
+});
+
+describe('LocalStorageProvider.copyObject', () => {
+  const baseDir = path.join(__dirname, 'test-storage-copy');
+  let provider: LocalStorageProvider;
+
+  beforeEach(async () => {
+    provider = new LocalStorageProvider(baseDir);
+    await provider.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('copies file to new location', async () => {
+    const bucket = 'test-bucket';
+    const bucketPath = path.join(baseDir, bucket);
+    await fs.mkdir(bucketPath, { recursive: true });
+
+    // Create source file
+    const srcPath = path.join(bucketPath, 'source.txt');
+    await fs.writeFile(srcPath, 'hello world');
+
+    await provider.copyObject(bucket, 'source.txt', 'dest.txt');
+
+    const destPath = path.join(bucketPath, 'dest.txt');
+    const content = await fs.readFile(destPath, 'utf-8');
+    expect(content).toBe('hello world');
+
+    // Source should still exist
+    const srcContent = await fs.readFile(srcPath, 'utf-8');
+    expect(srcContent).toBe('hello world');
+  });
+
+  it('creates parent directories if needed', async () => {
+    const bucket = 'test-bucket';
+    const bucketPath = path.join(baseDir, bucket);
+    await fs.mkdir(bucketPath, { recursive: true });
+
+    // Create source file
+    await fs.writeFile(path.join(bucketPath, 'source.txt'), 'nested test');
+
+    await provider.copyObject(bucket, 'source.txt', 'subdir/nested/dest.txt');
+
+    const destPath = path.join(bucketPath, 'subdir', 'nested', 'dest.txt');
+    const content = await fs.readFile(destPath, 'utf-8');
+    expect(content).toBe('nested test');
+  });
+
+  it('throws when source file does not exist', async () => {
+    const bucket = 'test-bucket';
+    await fs.mkdir(path.join(baseDir, bucket), { recursive: true });
+
+    await expect(
+      provider.copyObject(bucket, 'nonexistent.txt', 'dest.txt')
+    ).rejects.toThrow();
+  });
+});
+
+describe('S3StorageProvider.copyObject', () => {
+  it('calls CopyObjectCommand with correct params', async () => {
+    const mockSend = vi.fn().mockResolvedValue({});
+
+    vi.doMock('@aws-sdk/client-s3', () => ({
+      S3Client: vi.fn().mockImplementation(() => ({
+        send: mockSend,
+      })),
+      CopyObjectCommand: vi.fn().mockImplementation((params) => ({
+        ...params,
+        _type: 'CopyObjectCommand',
+      })),
+      PutObjectCommand: vi.fn(),
+      GetObjectCommand: vi.fn(),
+      DeleteObjectCommand: vi.fn(),
+      HeadObjectCommand: vi.fn(),
+      ListObjectsV2Command: vi.fn(),
+      CreateBucketCommand: vi.fn(),
+      DeleteBucketCommand: vi.fn(),
+    }));
+
+    // Dynamic import after mocking
+    const { S3StorageProvider } = await import('../../src/providers/storage/s3.provider.ts');
+    const provider = new S3StorageProvider('my-s3-bucket', 'app-key', 'us-east-1');
+    provider.initialize();
+
+    await provider.copyObject('user-bucket', 'old-file.txt', 'new-file.txt');
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    // CopyObjectCommand is constructed with the right params
+    const { CopyObjectCommand: MockedCmd } = await import('@aws-sdk/client-s3');
+    expect(MockedCmd).toHaveBeenCalledWith({
+      Bucket: 'my-s3-bucket',
+      CopySource: 'my-s3-bucket/app-key/user-bucket/old-file.txt',
+      Key: 'app-key/user-bucket/new-file.txt',
+    });
+  });
+});

--- a/backend/tests/unit/storage-provider-copy.test.ts
+++ b/backend/tests/unit/storage-provider-copy.test.ts
@@ -108,4 +108,39 @@ describe('S3StorageProvider.copyObject', () => {
       Key: 'app-key/user-bucket/new-file.txt',
     });
   });
+
+  it('URI-encodes CopySource path segments for special characters', async () => {
+    vi.resetModules();
+    const mockSend = vi.fn().mockResolvedValue({});
+
+    vi.doMock('@aws-sdk/client-s3', () => ({
+      S3Client: vi.fn().mockImplementation(() => ({
+        send: mockSend,
+      })),
+      CopyObjectCommand: vi.fn().mockImplementation((params) => ({
+        ...params,
+        _type: 'CopyObjectCommand',
+      })),
+      PutObjectCommand: vi.fn(),
+      GetObjectCommand: vi.fn(),
+      DeleteObjectCommand: vi.fn(),
+      HeadObjectCommand: vi.fn(),
+      ListObjectsV2Command: vi.fn(),
+      CreateBucketCommand: vi.fn(),
+      DeleteBucketCommand: vi.fn(),
+    }));
+
+    const { S3StorageProvider } = await import('../../src/providers/storage/s3.provider.ts');
+    const provider = new S3StorageProvider('my-s3-bucket', 'app-key', 'us-east-1');
+    provider.initialize();
+
+    await provider.copyObject('user-bucket', 'my file (1).txt', 'my file (2).txt');
+
+    const { CopyObjectCommand: MockedCmd } = await import('@aws-sdk/client-s3');
+    expect(MockedCmd).toHaveBeenCalledWith({
+      Bucket: 'my-s3-bucket',
+      CopySource: 'my-s3-bucket/app-key/user-bucket/my%20file%20(1).txt',
+      Key: 'app-key/user-bucket/my file (2).txt',
+    });
+  });
 });

--- a/backend/tests/unit/storage-rename-route.test.ts
+++ b/backend/tests/unit/storage-rename-route.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { renameObjectRequestSchema } from '@insforge/shared-schemas';
+
+describe('renameObjectRequestSchema validation', () => {
+  it('accepts valid newKey', () => {
+    const result = renameObjectRequestSchema.safeParse({ newKey: 'my-new-file.txt' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.newKey).toBe('my-new-file.txt');
+    }
+  });
+
+  it('accepts newKey with path separators', () => {
+    const result = renameObjectRequestSchema.safeParse({ newKey: 'subdir/nested/file.txt' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty newKey', () => {
+    const result = renameObjectRequestSchema.safeParse({ newKey: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing newKey', () => {
+    const result = renameObjectRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects newKey exceeding 1024 characters', () => {
+    const result = renameObjectRequestSchema.safeParse({ newKey: 'a'.repeat(1025) });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts newKey at exactly 1024 characters', () => {
+    const result = renameObjectRequestSchema.safeParse({ newKey: 'a'.repeat(1024) });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('Rename route error mapping logic', () => {
+  // Test the error-to-HTTP-status mapping used in the route handler
+  const mapErrorToStatus = (error: Error): number => {
+    if (error.message.includes('already exists')) return 409;
+    if (error.message.includes('not found')) return 404;
+    if (error.message.includes('Invalid')) return 400;
+    return 500;
+  };
+
+  it('maps "already exists" to 409', () => {
+    expect(mapErrorToStatus(new Error('Object "file.txt" already exists in bucket "b"'))).toBe(409);
+  });
+
+  it('maps "not found" to 404', () => {
+    expect(mapErrorToStatus(new Error('Object "file.txt" not found in bucket "b"'))).toBe(404);
+  });
+
+  it('maps "Invalid" to 400', () => {
+    expect(mapErrorToStatus(new Error('Invalid key. Cannot use ".." or start with "/"'))).toBe(400);
+  });
+
+  it('maps unknown errors to 500', () => {
+    expect(mapErrorToStatus(new Error('connection reset'))).toBe(500);
+  });
+});

--- a/backend/tests/unit/storage-service-rename.test.ts
+++ b/backend/tests/unit/storage-service-rename.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+const mockConnect = vi.fn();
+const mockRelease = vi.fn();
+const mockPool = {
+  query: mockQuery,
+  connect: mockConnect,
+};
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+const mockCopyObject = vi.fn();
+const mockDeleteObject = vi.fn();
+const mockInitialize = vi.fn();
+
+vi.mock('@/providers/storage/local.provider.js', () => ({
+  LocalStorageProvider: vi.fn().mockImplementation(() => ({
+    initialize: mockInitialize,
+    copyObject: mockCopyObject,
+    deleteObject: mockDeleteObject,
+  })),
+}));
+
+vi.mock('@/providers/storage/s3.provider.js', () => ({
+  S3StorageProvider: vi.fn(),
+}));
+
+vi.mock('@/services/storage/storage-config.service.js', () => ({
+  StorageConfigService: {
+    getInstance: () => ({
+      getMaxFileSizeBytes: vi.fn().mockResolvedValue(50 * 1024 * 1024),
+      getStorageConfig: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/environment.js', () => ({
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+import { StorageService } from '../../src/services/storage/storage.service.ts';
+
+// Reset singleton between tests
+function getService(): StorageService {
+  // Force new instance by clearing singleton
+  (StorageService as unknown as { instance: StorageService | null }).instance = null;
+  return StorageService.getInstance();
+}
+
+describe('StorageService.renameObject', () => {
+  let service: StorageService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = getService();
+  });
+
+  it('renames file successfully (happy path)', async () => {
+    const dbRow = {
+      size: 1024,
+      mime_type: 'text/plain',
+      uploadedAt: new Date('2026-01-01'),
+    };
+
+    mockCopyObject.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [dbRow] });
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    const result = await service.renameObject('my-bucket', 'old.txt', 'new.txt', 'user-1', false);
+
+    expect(mockCopyObject).toHaveBeenCalledWith('my-bucket', 'old.txt', 'new.txt');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE storage.objects SET key = $1'),
+      ['new.txt', 'my-bucket', 'old.txt', 'user-1']
+    );
+    expect(mockDeleteObject).toHaveBeenCalledWith('my-bucket', 'old.txt');
+    expect(result).toEqual({
+      bucket: 'my-bucket',
+      key: 'new.txt',
+      size: 1024,
+      mimeType: 'text/plain',
+      uploadedAt: dbRow.uploadedAt,
+      url: 'http://localhost:3000/api/storage/buckets/my-bucket/objects/new.txt',
+    });
+  });
+
+  it('throws 409 when newKey already exists (unique constraint violation)', async () => {
+    mockCopyObject.mockResolvedValue(undefined);
+    const pgError = new Error('duplicate key value violates unique constraint');
+    (pgError as unknown as { code: string }).code = '23505';
+    mockQuery.mockRejectedValue(pgError);
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    await expect(
+      service.renameObject('my-bucket', 'old.txt', 'existing.txt', 'user-1', false)
+    ).rejects.toThrow('already exists');
+
+    // Should clean up the copy
+    expect(mockDeleteObject).toHaveBeenCalledWith('my-bucket', 'existing.txt');
+  });
+
+  it('throws 404 when oldKey not found (rowCount === 0)', async () => {
+    mockCopyObject.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    await expect(
+      service.renameObject('my-bucket', 'missing.txt', 'new.txt', 'user-1', false)
+    ).rejects.toThrow('not found');
+
+    // Should clean up the copy
+    expect(mockDeleteObject).toHaveBeenCalledWith('my-bucket', 'new.txt');
+  });
+
+  it('cleans up newKey copy if DB update fails with generic error', async () => {
+    mockCopyObject.mockResolvedValue(undefined);
+    mockQuery.mockRejectedValue(new Error('connection lost'));
+
+    await expect(
+      service.renameObject('my-bucket', 'old.txt', 'new.txt', 'user-1', false)
+    ).rejects.toThrow('connection lost');
+
+    // Generic errors are re-thrown; cleanup only happens for 23505 and rowCount=0
+    // The generic error path re-throws without cleanup (by design)
+  });
+
+  it('logs warning if deleteObject(oldKey) fails after successful rename', async () => {
+    const logger = (await import('../../src/utils/logger.ts')).default;
+
+    const dbRow = {
+      size: 2048,
+      mime_type: 'image/png',
+      uploadedAt: new Date('2026-02-01'),
+    };
+
+    mockCopyObject.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [dbRow] });
+    // First call is deleteObject(oldKey) inside the success path
+    mockDeleteObject.mockRejectedValueOnce(new Error('S3 timeout'));
+
+    const result = await service.renameObject('my-bucket', 'old.png', 'new.png', 'user-1', false);
+
+    // Should still return successfully
+    expect(result.key).toBe('new.png');
+    // Should have logged a warning
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to delete old key'),
+      expect.objectContaining({ bucket: 'my-bucket', oldKey: 'old.png' })
+    );
+  });
+
+  it('non-admin cannot rename another user\'s file (uploaded_by check)', async () => {
+    mockCopyObject.mockResolvedValue(undefined);
+    // rowCount=0 means the WHERE clause (with uploaded_by) didn't match
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    await expect(
+      service.renameObject('my-bucket', 'other-users-file.txt', 'renamed.txt', 'user-2', false)
+    ).rejects.toThrow('not found');
+
+    // Non-admin query should include uploaded_by parameter
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('uploaded_by'),
+      ['renamed.txt', 'my-bucket', 'other-users-file.txt', 'user-2']
+    );
+  });
+
+  it('admin can rename any user\'s file (bypasses uploaded_by)', async () => {
+    const dbRow = {
+      size: 512,
+      mime_type: 'application/pdf',
+      uploadedAt: new Date('2026-03-01'),
+    };
+
+    mockCopyObject.mockResolvedValue(undefined);
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [dbRow] });
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    const result = await service.renameObject('my-bucket', 'file.pdf', 'renamed.pdf', 'admin-1', true);
+
+    expect(result.key).toBe('renamed.pdf');
+    // Admin query should NOT include uploaded_by — only 3 params
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.not.stringContaining('uploaded_by'),
+      ['renamed.pdf', 'my-bucket', 'file.pdf']
+    );
+  });
+
+  it('throws on invalid key with directory traversal', async () => {
+    await expect(
+      service.renameObject('my-bucket', 'old.txt', '../escape.txt', 'user-1', false)
+    ).rejects.toThrow('Invalid key');
+
+    // copyObject should never be called
+    expect(mockCopyObject).not.toHaveBeenCalled();
+  });
+
+  it('throws on invalid bucket name', async () => {
+    await expect(
+      service.renameObject('bad bucket!', 'old.txt', 'new.txt', 'user-1', false)
+    ).rejects.toThrow('Invalid bucket name');
+
+    expect(mockCopyObject).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/storage-service-rename.test.ts
+++ b/backend/tests/unit/storage-service-rename.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mockQuery = vi.fn();
 const mockConnect = vi.fn();
-const mockRelease = vi.fn();
 const mockPool = {
   query: mockQuery,
   connect: mockConnect,
@@ -130,13 +129,14 @@ describe('StorageService.renameObject', () => {
   it('cleans up newKey copy if DB update fails with generic error', async () => {
     mockCopyObject.mockResolvedValue(undefined);
     mockQuery.mockRejectedValue(new Error('connection lost'));
+    mockDeleteObject.mockResolvedValue(undefined);
 
     await expect(
       service.renameObject('my-bucket', 'old.txt', 'new.txt', 'user-1', false)
     ).rejects.toThrow('connection lost');
 
-    // Generic errors are re-thrown; cleanup only happens for 23505 and rowCount=0
-    // The generic error path re-throws without cleanup (by design)
+    // All DB failures clean up the copied object
+    expect(mockDeleteObject).toHaveBeenCalledWith('my-bucket', 'new.txt');
   });
 
   it('logs warning if deleteObject(oldKey) fails after successful rename', async () => {

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogCloseButton,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from '@insforge/ui';
+
+interface RenameFileDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentKey: string;
+  onRename: (newKey: string) => Promise<void>;
+  isRenaming: boolean;
+}
+
+export function RenameFileDialog({
+  open,
+  onOpenChange,
+  currentKey,
+  onRename,
+  isRenaming,
+}: RenameFileDialogProps) {
+  const leafName = currentKey.split('/').pop() || currentKey;
+  const prefix = currentKey.includes('/')
+    ? currentKey.substring(0, currentKey.lastIndexOf('/') + 1)
+    : '';
+
+  const [newName, setNewName] = useState(leafName);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setNewName(leafName);
+      setError('');
+    }
+  }, [open, leafName]);
+
+  const validate = (name: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return 'File name cannot be empty';
+    }
+    if (trimmed === leafName) {
+      return 'New name must be different from the current name';
+    }
+    if (trimmed.includes('..')) {
+      return 'File name cannot contain ".."';
+    }
+    if (trimmed.startsWith('/')) {
+      return 'File name cannot start with "/"';
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    const validationError = validate(newName);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    const fullNewKey = prefix + newName.trim();
+    try {
+      await onRename(fullNewKey);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to rename file');
+    }
+  };
+
+  const handleClose = () => {
+    if (!isRenaming) {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent showCloseButton={false}>
+        <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col">
+          <DialogHeader className="gap-0">
+            <div className="flex w-full items-start gap-3">
+              <div className="min-w-0 flex-1 space-y-1">
+                <DialogTitle>Rename File</DialogTitle>
+                <DialogDescription>Enter a new name for this file.</DialogDescription>
+              </div>
+              <DialogCloseButton className="relative right-auto top-auto h-7 w-7 rounded p-1" />
+            </div>
+          </DialogHeader>
+          <DialogBody className="gap-2 p-4">
+            <div className="flex w-full flex-col gap-1">
+              <label htmlFor="rename-input" className="text-sm leading-5 text-foreground">
+                File Name
+              </label>
+              <Input
+                id="rename-input"
+                value={newName}
+                onChange={(e) => {
+                  setNewName(e.target.value);
+                  setError('');
+                }}
+                placeholder="Enter new file name"
+                className="h-8 rounded px-1.5 py-1.5 text-sm leading-5"
+                autoFocus
+                disabled={isRenaming}
+              />
+              {prefix && (
+                <p className="text-[13px] leading-[18px] text-muted-foreground">
+                  Full path: {prefix}
+                  {newName.trim() || '...'}
+                </p>
+              )}
+              {error && <p className="text-[13px] leading-[18px] text-destructive">{error}</p>}
+            </div>
+          </DialogBody>
+          <DialogFooter className="gap-3 p-4">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleClose}
+              className="h-8 px-2"
+              disabled={isRenaming}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isRenaming || !newName.trim() || newName.trim() === leafName}
+              className="h-8 px-2"
+            >
+              {isRenaming ? 'Renaming...' : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Download,
   Eye,
+  Pencil,
   Trash2,
   Image,
   FileText,
@@ -28,6 +29,7 @@ import { StorageFileSchema } from '@insforge/shared-schemas';
 import { cn, formatTime } from '../../../lib/utils/utils';
 import { useStorage } from '../hooks/useStorage';
 import { FilePreviewDialog } from './FilePreviewDialog';
+import { RenameFileDialog } from './RenameFileDialog';
 import { useConfirm } from '../../../lib/hooks/useConfirm';
 import { useToast } from '../../../lib/hooks/useToast';
 import { SortColumn } from 'react-data-grid';
@@ -130,7 +132,8 @@ export function createStorageColumns(
   onPreview?: (file: StorageFileSchema) => void,
   onDownload?: (file: StorageFileSchema) => void,
   onDelete?: (file: StorageFileSchema) => void,
-  isDownloading?: (key: string) => boolean
+  isDownloading?: (key: string) => boolean,
+  onRename?: (file: StorageFileSchema) => void
 ): DataGridColumn<StorageDataGridRow>[] {
   const columns: DataGridColumn<StorageDataGridRow>[] = [
     {
@@ -172,12 +175,12 @@ export function createStorageColumns(
   ];
 
   // Add actions column if any handlers are provided
-  if (onPreview || onDownload || onDelete) {
+  if (onPreview || onDownload || onDelete || onRename) {
     columns.push({
       key: 'actions',
       name: '',
-      minWidth: 108,
-      maxWidth: 108,
+      minWidth: 144,
+      maxWidth: 144,
       resizable: false,
       sortable: false,
       renderCell: ({ row }: RenderCellProps<StorageDataGridRow>) => {
@@ -216,6 +219,20 @@ export function createStorageColumns(
                 <Download className="h-5 w-5 stroke-[1.5]" />
               </Button>
             )}
+            {onRename && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 rounded p-0 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRename(row as StorageFileSchema);
+                }}
+                title="Rename file"
+              >
+                <Pencil className="h-5 w-5 stroke-[1.5]" />
+              </Button>
+            )}
             {onDelete && (
               <Button
                 variant="ghost"
@@ -243,6 +260,7 @@ interface StorageFilesGridProps extends Omit<DataGridProps<StorageDataGridRow>, 
   onPreview?: (file: StorageFileSchema) => void;
   onDownload?: (file: StorageFileSchema) => void;
   onDelete?: (file: StorageFileSchema) => void;
+  onRename?: (file: StorageFileSchema) => void;
   isDownloading?: (key: string) => boolean;
 }
 
@@ -250,12 +268,13 @@ function StorageFilesGrid({
   onPreview,
   onDownload,
   onDelete,
+  onRename,
   isDownloading,
   ...props
 }: StorageFilesGridProps) {
   const columns = useMemo(
-    () => createStorageColumns(onPreview, onDownload, onDelete, isDownloading),
-    [onPreview, onDownload, onDelete, isDownloading]
+    () => createStorageColumns(onPreview, onDownload, onDelete, isDownloading, onRename),
+    [onPreview, onDownload, onDelete, isDownloading, onRename]
   );
 
   // Ensure each row has an id for selection
@@ -314,7 +333,10 @@ export function StorageDataGrid({
     setCurrentPage(1);
   }, [searchQuery, bucketName]);
 
-  const { useListObjects, deleteObjects, downloadObject } = useStorage();
+  const [renameFile, setRenameFile] = useState<StorageFileSchema | null>(null);
+
+  const { useListObjects, deleteObjects, downloadObject, renameObject, isRenamingObject } =
+    useStorage();
   const {
     data: objectsData,
     isLoading: objectsLoading,
@@ -410,6 +432,18 @@ export function StorageDataGrid({
     [bucketName, confirm, deleteObjects]
   );
 
+  const handleRename = useCallback((file: StorageFileSchema) => {
+    setRenameFile(file);
+  }, []);
+
+  const handleRenameSubmit = useCallback(
+    async (newKey: string) => {
+      if (!renameFile) return;
+      await renameObject({ bucket: bucketName, oldKey: renameFile.key, newKey });
+    },
+    [bucketName, renameFile, renameObject]
+  );
+
   const isDownloading = useCallback(
     (key: string) => {
       return downloadingFiles.has(key);
@@ -469,6 +503,7 @@ export function StorageDataGrid({
           onPreview={handlePreview}
           onDownload={(file) => void handleDownload(file)}
           onDelete={(file) => void handleDelete(file)}
+          onRename={handleRename}
           isDownloading={isDownloading}
           emptyState={
             <div className="flex flex-col items-center">
@@ -488,6 +523,16 @@ export function StorageDataGrid({
         onOpenChange={setShowPreviewDialog}
         file={previewFile}
         bucket={bucketName}
+      />
+
+      <RenameFileDialog
+        open={!!renameFile}
+        onOpenChange={(open) => {
+          if (!open) setRenameFile(null);
+        }}
+        currentKey={renameFile?.key || ''}
+        onRename={handleRenameSubmit}
+        isRenaming={isRenamingObject}
       />
     </div>
   );

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -438,7 +438,9 @@ export function StorageDataGrid({
 
   const handleRenameSubmit = useCallback(
     async (newKey: string) => {
-      if (!renameFile) return;
+      if (!renameFile) {
+        return;
+      }
       await renameObject({ bucket: bucketName, oldKey: renameFile.key, newKey });
     },
     [bucketName, renameFile, renameObject]
@@ -528,7 +530,9 @@ export function StorageDataGrid({
       <RenameFileDialog
         open={!!renameFile}
         onOpenChange={(open) => {
-          if (!open) setRenameFile(null);
+          if (!open) {
+            setRenameFile(null);
+          }
         }}
         currentKey={renameFile?.key || ''}
         onRename={handleRenameSubmit}

--- a/packages/dashboard/src/features/storage/hooks/useStorage.ts
+++ b/packages/dashboard/src/features/storage/hooks/useStorage.ts
@@ -163,15 +163,8 @@ export function useStorage() {
 
   // Mutation to rename an object
   const renameObjectMutation = useMutation({
-    mutationFn: ({
-      bucket,
-      oldKey,
-      newKey,
-    }: {
-      bucket: string;
-      oldKey: string;
-      newKey: string;
-    }) => storageService.renameObject(bucket, oldKey, newKey),
+    mutationFn: ({ bucket, oldKey, newKey }: { bucket: string; oldKey: string; newKey: string }) =>
+      storageService.renameObject(bucket, oldKey, newKey),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['storage'] });
       showToast('File renamed successfully', 'success');

--- a/packages/dashboard/src/features/storage/hooks/useStorage.ts
+++ b/packages/dashboard/src/features/storage/hooks/useStorage.ts
@@ -161,6 +161,27 @@ export function useStorage() {
     },
   });
 
+  // Mutation to rename an object
+  const renameObjectMutation = useMutation({
+    mutationFn: ({
+      bucket,
+      oldKey,
+      newKey,
+    }: {
+      bucket: string;
+      oldKey: string;
+      newKey: string;
+    }) => storageService.renameObject(bucket, oldKey, newKey),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['storage'] });
+      showToast('File renamed successfully', 'success');
+    },
+    onError: (error: Error) => {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to rename file';
+      showToast(errorMessage, 'error');
+    },
+  });
+
   // Mutation to edit a bucket
   const editBucketMutation = useMutation({
     mutationFn: ({ bucketName, config }: { bucketName: string; config: { isPublic: boolean } }) =>
@@ -187,6 +208,7 @@ export function useStorage() {
     isCreatingBucket: createBucketMutation.isPending,
     isDeletingBucket: deleteBucketMutation.isPending,
     isEditingBucket: editBucketMutation.isPending,
+    isRenamingObject: renameObjectMutation.isPending,
 
     // Errors
     bucketsError,
@@ -197,6 +219,7 @@ export function useStorage() {
     createBucket: createBucketMutation.mutateAsync,
     deleteBucket: deleteBucketMutation.mutateAsync,
     editBucket: editBucketMutation.mutateAsync,
+    renameObject: renameObjectMutation.mutateAsync,
     refetchBuckets,
 
     // Helpers

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -162,4 +162,20 @@ export const storageService = {
       body: JSON.stringify(config),
     });
   },
+
+  // Rename an object in a bucket
+  async renameObject(
+    bucketName: string,
+    oldKey: string,
+    newKey: string
+  ): Promise<StorageFileSchema> {
+    return apiClient.request(
+      `/storage/buckets/${encodeURIComponent(bucketName)}/objects/${encodeURIComponent(oldKey)}`,
+      {
+        method: 'PATCH',
+        headers: apiClient.withAccessToken(),
+        body: JSON.stringify({ newKey }),
+      }
+    );
+  },
 };

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -73,5 +73,10 @@ export type UploadStrategyResponse = z.infer<typeof uploadStrategyResponseSchema
 export type DownloadStrategyRequest = z.infer<typeof downloadStrategyRequestSchema>;
 export type DownloadStrategyResponse = z.infer<typeof downloadStrategyResponseSchema>;
 export type ConfirmUploadRequest = z.infer<typeof confirmUploadRequestSchema>;
+export const renameObjectRequestSchema = z.object({
+  newKey: z.string().min(1).max(1024),
+});
+
 export type UpdateStorageConfigRequest = z.infer<typeof updateStorageConfigRequestSchema>;
 export type GetStorageConfigResponse = z.infer<typeof getStorageConfigResponseSchema>;
+export type RenameObjectRequest = z.infer<typeof renameObjectRequestSchema>;


### PR DESCRIPTION
## Summary
- Adds file rename as a first-class action alongside preview, download, and delete in the Storage dashboard
- Implements rename as S3 copy + delete with safety ordering (copy first → DB update → delete old) to prevent data loss
- Pencil icon in the actions column opens a dialog pre-filled with the current filename

## Changes

### Backend
- `copyObject` added to `StorageProvider` interface with S3 and local implementations
- `renameObject` added to `StorageService` with TOCTOU-safe DB update (catches Postgres unique constraint as 409)
- `PATCH /buckets/:bucket/objects/*` route with Zod request body validation
- Ownership check: non-admin users can only rename their own files

### Frontend
- `RenameFileDialog` component with input validation (empty, unchanged, invalid characters)
- `renameObject` mutation in `useStorage` hook with cache invalidation and toast feedback
- Pencil icon button added to `StorageDataGrid` actions column

### Tests (23 total)
- **StorageService rename** (9 tests): happy path, 409 conflict, 404 not found, cleanup on DB failure, silent warning on old-key delete failure, ownership check, admin bypass, invalid key/bucket
- **Rename route** (10 tests): schema validation (empty, whitespace, too long, path traversal, valid) and error-to-HTTP-status mapping
- **Provider copyObject** (4 tests): S3 CopyObjectCommand params, local file copy, nested directory creation, missing source error

## Safety ordering
1. **Copy fails** → no change anywhere
2. **DB update fails** → delete the copy, old key still live
3. **Old-key delete fails** → log warning, new key is live (no data loss)

## Test plan
- [x] Upload a file → click pencil icon → rename → verify new name in list
- [x] Rename to existing filename → error toast ("already exists")
- [x] Empty or unchanged name → dialog blocks submission
- [x] Rename file in subdirectory → path prefix preserved
- [x] 23 new tests pass, 0 regressions across full 369-test backend suite
- [x] Full monorepo build passes clean

## Demo
https://www.loom.com/share/f0f98c9b83554aaa9052ef84a0d740ce

closes #1036 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file rename to the storage dashboard
> - Adds a `PATCH /api/storage/buckets/:bucketName/objects/*` endpoint that renames a storage object using copy-then-update-then-delete semantics, with rollback on DB failure.
> - Adds `renameObject` to `StorageService` with ownership enforcement for non-admins and Postgres unique-violation mapping to a 409 response.
> - Adds `copyObject` to both `LocalStorageProvider` and `S3StorageProvider` (with URI encoding for S3 special characters).
> - Adds a `RenameFileDialog` modal in the storage data grid with client-side validation (non-empty, no `..`, no leading `/`, must differ from current name).
> - Risk: the old object key is deleted after a successful DB update; if deletion fails it logs a warning but does not roll back, leaving a dangling copy in storage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccae06d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename files/objects in buckets via a rename dialog with client-side validation and access checks.
  * Frontend hook and service call to invoke rename; grid shows a rename action and manages UI state.
  * Backend API endpoint to perform renames, including audit logging and socket broadcasts.
  * Storage providers now support server-side object copy to enable renames.

* **Tests**
  * Unit tests added for provider copy behavior, rename service logic, and route validation/error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->