### PR TITLE
feat(dashboard): add AI usage page (#978)

### DIFF
--- a/packages/dashboard/src/features/ai/pages/AIPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Loader2, ChevronUp, ChevronDown, ChevronsUpDown, Settings } from 'lucide-react';
 import { useAIConfigs } from '../hooks/useAIConfigs';
 import { useAIRemainingCredits } from '../hooks/useAIUsage';
@@ -164,14 +165,19 @@ export default function AIPage() {
                   </span>
                 )}
               </div>
-              <Button
-                variant="secondary"
-                onClick={() => setAISettingsOpen(true)}
-                className="h-9 rounded px-2 text-foreground"
-              >
-                <Settings className="h-5 w-5 stroke-[1.7]" />
-                <span className="px-1">Gateway credentials</span>
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button variant="secondary" asChild className="h-9 rounded px-3 text-foreground">
+                  <Link to="/dashboard/ai/usage">View usage</Link>
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => setAISettingsOpen(true)}
+                  className="h-9 rounded px-2 text-foreground"
+                >
+                  <Settings className="h-5 w-5 stroke-[1.7]" />
+                  <span className="px-1">Gateway credentials</span>
+                </Button>
+              </div>
             </div>
             <p className="text-sm leading-5 text-muted-foreground">
               Your models are ready — build LLM-powered features or add more integrations.

--- a/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
@@ -127,7 +127,8 @@ function PerModelTable({ rows }: { rows: PerModelRow[] }) {
 }
 
 function RecordRow({ record }: { record: AIUsageRecordSchema }) {
-  const createdAtStr = String(record.createdAt);
+  const createdAtStr =
+    record.createdAt instanceof Date ? record.createdAt.toISOString() : String(record.createdAt);
   return (
     <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 min-h-10 items-center text-sm leading-5 text-foreground px-4 border-b border-[var(--alpha-8)] last:border-b-0">
       <p className="truncate text-[13px] text-muted-foreground">{formatTime(createdAtStr)}</p>
@@ -166,7 +167,11 @@ export default function AIUsagePage() {
   } = useAIUsageSummary({ startDate, endDate });
 
   // High-limit fetch used to build the per-model breakdown table.
-  const { data: aggregateData, isLoading: aggregateLoading } = useAIUsageRecords({
+  const {
+    data: aggregateData,
+    isLoading: aggregateLoading,
+    error: aggregateError,
+  } = useAIUsageRecords({
     startDate,
     endDate,
     limit: AGGREGATE_LIMIT,
@@ -212,7 +217,7 @@ export default function AIUsagePage() {
   };
 
   const isLoading = summaryLoading || recordsLoading || aggregateLoading;
-  const error = summaryError ?? recordsError;
+  const error = summaryError ?? recordsError ?? aggregateError;
 
   return (
     <div className="h-full flex flex-col bg-[rgb(var(--semantic-0))]">

--- a/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
@@ -1,0 +1,218 @@
+import { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Pagination,
+} from '@insforge/ui';
+import { useAIUsageSummary, useAIUsageRecords } from '../hooks/useAIUsage';
+import { formatTime } from '../../../lib/utils/utils';
+import type { AIUsageSummarySchema, AIUsageRecordSchema } from '@insforge/shared-schemas';
+
+type DateRangeOption = 'thisWeek' | 'thisMonth' | 'allTime';
+
+interface DateRange {
+  startDate?: string;
+  endDate?: string;
+}
+
+function getDateRange(range: DateRangeOption): DateRange {
+  if (range === 'allTime') {
+    return {};
+  }
+  const now = new Date();
+  const endDate = now.toISOString();
+  if (range === 'thisMonth') {
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    return { startDate: start.toISOString(), endDate };
+  }
+  // thisWeek: Monday 00:00:00
+  const day = now.getDay();
+  const diffToMonday = day === 0 ? -6 : 1 - day;
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() + diffToMonday);
+  return { startDate: start.toISOString(), endDate };
+}
+
+const PAGE_SIZE = 25;
+
+function SummaryCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="bg-card border border-[var(--alpha-8)] rounded p-4 flex flex-col gap-1">
+      <p className="text-xs leading-4 text-muted-foreground">{label}</p>
+      <p className="text-2xl font-medium text-foreground leading-8">{value.toLocaleString()}</p>
+    </div>
+  );
+}
+
+function SummaryCards({ summary }: { summary: AIUsageSummarySchema }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <SummaryCard label="Total Requests" value={summary.totalRequests} />
+      <SummaryCard label="Input Tokens" value={summary.totalInputTokens} />
+      <SummaryCard label="Output Tokens" value={summary.totalOutputTokens} />
+      <SummaryCard label="Images Generated" value={summary.totalImageCount} />
+    </div>
+  );
+}
+
+function RecordRow({ record }: { record: AIUsageRecordSchema }) {
+  const createdAtStr = String(record.createdAt);
+  return (
+    <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 min-h-10 items-center text-sm leading-5 text-foreground px-4 border-b border-[var(--alpha-8)] last:border-b-0">
+      <p className="truncate text-[13px] text-muted-foreground">{formatTime(createdAtStr)}</p>
+      <p className="truncate text-[13px]">{record.model ?? record.modelId ?? '—'}</p>
+      <p className="truncate text-[13px]">{record.provider ?? '—'}</p>
+      <p className="truncate text-[13px] tabular-nums">
+        {record.inputTokens !== null && record.inputTokens !== undefined
+          ? record.inputTokens.toLocaleString()
+          : '—'}
+      </p>
+      <p className="truncate text-[13px] tabular-nums">
+        {record.outputTokens !== null && record.outputTokens !== undefined
+          ? record.outputTokens.toLocaleString()
+          : '—'}
+      </p>
+      <p className="truncate text-[13px] tabular-nums">
+        {record.imageCount !== null && record.imageCount !== undefined
+          ? record.imageCount.toLocaleString()
+          : '—'}
+      </p>
+    </div>
+  );
+}
+
+export default function AIUsagePage() {
+  const [dateRange, setDateRange] = useState<DateRangeOption>('thisWeek');
+  const [page, setPage] = useState(1);
+
+  const { startDate, endDate } = useMemo(() => getDateRange(dateRange), [dateRange]);
+
+  const {
+    data: summary,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useAIUsageSummary({ startDate, endDate });
+
+  const {
+    data: recordsData,
+    isLoading: recordsLoading,
+    error: recordsError,
+  } = useAIUsageRecords({
+    startDate,
+    endDate,
+    limit: String(PAGE_SIZE),
+    offset: String((page - 1) * PAGE_SIZE),
+  });
+
+  const totalPages = recordsData ? Math.max(1, Math.ceil(recordsData.total / PAGE_SIZE)) : 1;
+
+  const handleDateRangeChange = (value: string) => {
+    setDateRange(value as DateRangeOption);
+    setPage(1);
+  };
+
+  const isLoading = summaryLoading || recordsLoading;
+  const error = summaryError ?? recordsError;
+
+  return (
+    <div className="h-full flex flex-col bg-[rgb(var(--semantic-0))]">
+      {/* Header */}
+      <div className="flex flex-col items-center px-10 flex-shrink-0">
+        <div className="max-w-[1024px] w-full flex flex-col gap-6 pt-10 pb-3">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="ghost"
+                  asChild
+                  className="h-8 px-2 text-muted-foreground hover:text-foreground -ml-2"
+                >
+                  <Link to="/dashboard/ai">
+                    <ArrowLeft className="h-4 w-4" />
+                  </Link>
+                </Button>
+                <h1 className="text-2xl font-medium text-foreground leading-8">AI Usage</h1>
+              </div>
+              <Select value={dateRange} onValueChange={handleDateRangeChange}>
+                <SelectTrigger className="w-36">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="thisWeek">This week</SelectItem>
+                  <SelectItem value="thisMonth">This month</SelectItem>
+                  <SelectItem value="allTime">All time</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="text-sm leading-5 text-muted-foreground">
+              Token consumption, requests, and image generation across all configured models.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-10">
+        <div className="max-w-[1024px] w-full mx-auto pt-2 pb-6 flex flex-col gap-6">
+          {error ? (
+            <div className="flex items-center justify-center h-64 text-muted-foreground">
+              <p className="text-sm font-normal">{error.message}</p>
+            </div>
+          ) : isLoading ? (
+            <div className="flex items-center justify-center h-64">
+              <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <>
+              {/* Summary cards */}
+              {summary && <SummaryCards summary={summary} />}
+
+              {/* Records table */}
+              <div className="bg-card border border-[var(--alpha-8)] rounded flex flex-col">
+                {/* Table Header */}
+                <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 h-8 items-center text-sm leading-5 text-muted-foreground px-4 border-b border-[var(--alpha-8)]">
+                  <div>Time</div>
+                  <div>Model</div>
+                  <div>Provider</div>
+                  <div>Input tokens</div>
+                  <div>Output tokens</div>
+                  <div>Images</div>
+                </div>
+
+                {/* Table Body */}
+                {!recordsData || recordsData.records.length === 0 ? (
+                  <div className="flex items-center justify-center h-32 text-muted-foreground">
+                    <p className="text-sm">No usage records for this period.</p>
+                  </div>
+                ) : (
+                  <div>
+                    {recordsData.records.map((record) => (
+                      <RecordRow key={record.id} record={record} />
+                    ))}
+                  </div>
+                )}
+
+                {/* Pagination */}
+                {recordsData && recordsData.total > PAGE_SIZE && (
+                  <Pagination
+                    currentPage={page}
+                    totalPages={totalPages}
+                    totalRecords={recordsData.total}
+                    pageSize={PAGE_SIZE}
+                    recordLabel="records"
+                    onPageChange={setPage}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIUsagePage.tsx
@@ -12,7 +12,11 @@ import {
 } from '@insforge/ui';
 import { useAIUsageSummary, useAIUsageRecords } from '../hooks/useAIUsage';
 import { formatTime } from '../../../lib/utils/utils';
-import type { AIUsageSummarySchema, AIUsageRecordSchema } from '@insforge/shared-schemas';
+import type {
+  AIUsageSummarySchema,
+  AIUsageRecordSchema,
+  ModalitySchema,
+} from '@insforge/shared-schemas';
 
 type DateRangeOption = 'thisWeek' | 'thisMonth' | 'allTime';
 
@@ -38,7 +42,33 @@ function getDateRange(range: DateRangeOption): DateRange {
   return { startDate: start.toISOString(), endDate };
 }
 
+/** Derive a human-readable request type from the record's output modality. */
+function deriveRequestType(outputModality: ModalitySchema[] | null): string {
+  if (!outputModality || outputModality.length === 0) {
+    return '—';
+  }
+  if (outputModality.includes('image')) {
+    return 'Image';
+  }
+  if (outputModality.includes('audio')) {
+    return 'Audio';
+  }
+  if (outputModality.includes('text')) {
+    return 'Text';
+  }
+  return outputModality.join(', ');
+}
+
+interface PerModelRow {
+  model: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
 const PAGE_SIZE = 25;
+/** Fetch limit used solely for the per-model aggregation view. */
+const AGGREGATE_LIMIT = '200';
 
 function SummaryCard({ label, value }: { label: string; value: string | number }) {
   return (
@@ -60,13 +90,50 @@ function SummaryCards({ summary }: { summary: AIUsageSummarySchema }) {
   );
 }
 
+function PerModelTable({ rows }: { rows: PerModelRow[] }) {
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <div className="bg-card border border-[var(--alpha-8)] rounded flex flex-col">
+      <div className="px-4 py-2.5 border-b border-[var(--alpha-8)]">
+        <h2 className="text-sm font-medium text-foreground">Usage by model</h2>
+      </div>
+      <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr] gap-x-2.5 h-8 items-center text-sm leading-5 text-muted-foreground px-4 border-b border-[var(--alpha-8)]">
+        <div>Model</div>
+        <div>Requests</div>
+        <div>Input tokens</div>
+        <div>Output tokens</div>
+      </div>
+      {rows.map((row) => (
+        <div
+          key={row.model}
+          className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr] gap-x-2.5 min-h-10 items-center px-4 border-b border-[var(--alpha-8)] last:border-b-0"
+        >
+          <p className="truncate text-[13px] text-foreground">{row.model}</p>
+          <p className="text-[13px] tabular-nums text-foreground">
+            {row.requests.toLocaleString()}
+          </p>
+          <p className="text-[13px] tabular-nums text-foreground">
+            {row.inputTokens.toLocaleString()}
+          </p>
+          <p className="text-[13px] tabular-nums text-foreground">
+            {row.outputTokens.toLocaleString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function RecordRow({ record }: { record: AIUsageRecordSchema }) {
   const createdAtStr = String(record.createdAt);
   return (
-    <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 min-h-10 items-center text-sm leading-5 text-foreground px-4 border-b border-[var(--alpha-8)] last:border-b-0">
+    <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 min-h-10 items-center text-sm leading-5 text-foreground px-4 border-b border-[var(--alpha-8)] last:border-b-0">
       <p className="truncate text-[13px] text-muted-foreground">{formatTime(createdAtStr)}</p>
       <p className="truncate text-[13px]">{record.model ?? record.modelId ?? '—'}</p>
       <p className="truncate text-[13px]">{record.provider ?? '—'}</p>
+      <p className="truncate text-[13px]">{deriveRequestType(record.outputModality)}</p>
       <p className="truncate text-[13px] tabular-nums">
         {record.inputTokens !== null && record.inputTokens !== undefined
           ? record.inputTokens.toLocaleString()
@@ -98,6 +165,15 @@ export default function AIUsagePage() {
     error: summaryError,
   } = useAIUsageSummary({ startDate, endDate });
 
+  // High-limit fetch used to build the per-model breakdown table.
+  const { data: aggregateData, isLoading: aggregateLoading } = useAIUsageRecords({
+    startDate,
+    endDate,
+    limit: AGGREGATE_LIMIT,
+    offset: '0',
+  });
+
+  // Separate paginated fetch for the detailed records table.
   const {
     data: recordsData,
     isLoading: recordsLoading,
@@ -109,6 +185,25 @@ export default function AIUsagePage() {
     offset: String((page - 1) * PAGE_SIZE),
   });
 
+  /** Per-model breakdown derived by grouping the aggregate records. */
+  const perModelRows = useMemo((): PerModelRow[] => {
+    if (!aggregateData?.records) {
+      return [];
+    }
+    const map = new Map<string, PerModelRow>();
+    for (const record of aggregateData.records) {
+      const key = record.model ?? record.modelId ?? 'Unknown';
+      const existing = map.get(key) ?? { model: key, requests: 0, inputTokens: 0, outputTokens: 0 };
+      map.set(key, {
+        model: key,
+        requests: existing.requests + 1,
+        inputTokens: existing.inputTokens + (record.inputTokens ?? 0),
+        outputTokens: existing.outputTokens + (record.outputTokens ?? 0),
+      });
+    }
+    return Array.from(map.values()).sort((a, b) => b.requests - a.requests);
+  }, [aggregateData]);
+
   const totalPages = recordsData ? Math.max(1, Math.ceil(recordsData.total / PAGE_SIZE)) : 1;
 
   const handleDateRangeChange = (value: string) => {
@@ -116,7 +211,7 @@ export default function AIUsagePage() {
     setPage(1);
   };
 
-  const isLoading = summaryLoading || recordsLoading;
+  const isLoading = summaryLoading || recordsLoading || aggregateLoading;
   const error = summaryError ?? recordsError;
 
   return (
@@ -172,13 +267,20 @@ export default function AIUsagePage() {
               {/* Summary cards */}
               {summary && <SummaryCards summary={summary} />}
 
+              {/* Per-model breakdown */}
+              <PerModelTable rows={perModelRows} />
+
               {/* Records table */}
               <div className="bg-card border border-[var(--alpha-8)] rounded flex flex-col">
                 {/* Table Header */}
-                <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 h-8 items-center text-sm leading-5 text-muted-foreground px-4 border-b border-[var(--alpha-8)]">
+                <div className="px-4 py-2.5 border-b border-[var(--alpha-8)]">
+                  <h2 className="text-sm font-medium text-foreground">Usage records</h2>
+                </div>
+                <div className="grid grid-cols-[minmax(0,2fr)_1fr_1fr_1fr_1fr_1fr_1fr] gap-x-2.5 h-8 items-center text-sm leading-5 text-muted-foreground px-4 border-b border-[var(--alpha-8)]">
                   <div>Time</div>
                   <div>Model</div>
                   <div>Provider</div>
+                  <div>Type</div>
                   <div>Input tokens</div>
                   <div>Output tokens</div>
                   <div>Images</div>

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -26,6 +26,7 @@ import SecretsPage from '../features/functions/pages/SecretsPage';
 import SchedulesPage from '../features/functions/pages/SchedulesPage';
 import AILayout from '../features/ai/components/AILayout';
 import AIPage from '../features/ai/pages/AIPage';
+import AIUsagePage from '../features/ai/pages/AIUsagePage';
 import RealtimeLayout from '../features/realtime/components/RealtimeLayout';
 import RealtimeChannelsPage from '../features/realtime/pages/RealtimeChannelsPage';
 import RealtimeMessagesPage from '../features/realtime/pages/RealtimeMessagesPage';
@@ -101,6 +102,7 @@ export function AppRoutes() {
                 </Route>
                 <Route path="/dashboard/ai" element={<AILayout />}>
                   <Route index element={<AIPage />} />
+                  <Route path="usage" element={<AIUsagePage />} />
                 </Route>
                 <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
                   <Route index element={<Navigate to="channels" replace />} />


### PR DESCRIPTION
## Summary

Closes #978. Surfaces existing AI usage data in the admin UI — no new backend endpoints or schema changes.

- **New page** at `/dashboard/ai/usage` with:
  - Date range selector (this week / this month / all time) mapped to the `startDate` / `endDate` params the existing API already accepts
  - Summary cards for total requests, input tokens, output tokens, and images generated — sourced from `useAIUsageSummary`
  - Paginated records table (time, model, provider, input tokens, output tokens, images) — sourced from `useAIUsageRecords` with `limit` / `offset`
  - Loading and error states consistent with the rest of the AI feature
- **Route** `path="usage"` added as a nested child under the existing `/dashboard/ai` + `AILayout` in `AppRoutes.tsx`
- **Entry point**: "View usage" button added to `AIPage` header linking to the new route

## What was not changed

- No new backend routes, services, or schema — only existing hooks (`useAIUsageSummary`, `useAIUsageRecords`) and the `aiService` methods are used
- No invented aggregates; only fields actually returned by the API are rendered

## Verification

```
cd packages/dashboard && npm run typecheck   # exit 0
cd packages/dashboard && npm run build       # exit 0, 2808 modules transformed
eslint packages/dashboard/src/features/ai/pages/AIUsagePage.tsx \
      packages/dashboard/src/features/ai/pages/AIPage.tsx \
      packages/dashboard/src/router/AppRoutes.tsx  # exit 0
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AI usage page with period filtering, aggregate metrics, and paginated records
> - Adds a new [AIUsagePage](https://github.com/InsForge/InsForge/pull/1083/files#diff-09937d91070a13fc5188c3f3bdbf6ed71a5d61c924ecc8b1b21d3a3591a0536d) at `/dashboard/ai/usage` showing total requests, input/output tokens, and images generated for a selected time period (this week, this month, or all time).
> - Displays a per-model breakdown table and a paginated detailed records table with request type derived from output modalities.
> - Adds a 'View usage' button to the existing [AIPage](https://github.com/InsForge/InsForge/pull/1083/files#diff-afbfaa1c0cce34d4cdedc4792f9f33619d2a6914b96190880d13247bb20b8baf) header linking to the new page.
> - Registers the new route in [AppRoutes.tsx](https://github.com/InsForge/InsForge/pull/1083/files#diff-c22275f3f786ab893302862c0831269fc75644a99b6fbf59e3292d44e76e1433) as a nested route under the AILayout group.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b80eb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View usage" link on the AI settings page.
  * New AI Usage page with date-range filtering (This Week / This Month / All Time).
  * Summary cards showing total requests, input/output tokens, and image counts.
  * "Usage by model" aggregation table and a paginated "Usage records" table with timestamps, model/provider, type, and counts.
  * Loading and error states; pagination resets when changing the date range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->