### PR TITLE
fix(db): make migration 027 idempotent

### DIFF
--- a/backend/src/infra/database/migrations/027_add-redirect-url-whitelist.sql
+++ b/backend/src/infra/database/migrations/027_add-redirect-url-whitelist.sql
@@ -1,9 +1,17 @@
 -- Rename auth.configs to auth.config, add allowed_redirect_urls,
 -- and persist per-request redirect targets for email OTP flows.
-ALTER TABLE IF EXISTS auth.configs RENAME TO config;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'auth' AND table_name = 'configs')
+     AND NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'auth' AND table_name = 'config')
+  THEN
+    ALTER TABLE auth.configs RENAME TO config;
+  END IF;
+END $$;
 
 -- Keep the trigger name aligned with the renamed auth.config table.
 DROP TRIGGER IF EXISTS update_configs_updated_at ON auth.config;
+DROP TRIGGER IF EXISTS update_config_updated_at ON auth.config;
 CREATE TRIGGER update_config_updated_at
 BEFORE UPDATE ON auth.config
 FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
@@ -13,13 +21,20 @@ FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
 ALTER TABLE auth.config
 ADD COLUMN IF NOT EXISTS allowed_redirect_urls TEXT[] DEFAULT '{}'::TEXT[];
 
--- Migrate existing values
-UPDATE auth.config
-SET allowed_redirect_urls = ARRAY[sign_in_redirect_to]
-WHERE sign_in_redirect_to IS NOT NULL AND sign_in_redirect_to != '';
+-- Migrate existing values and drop the original column
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'auth' AND table_name = 'config' AND column_name = 'sign_in_redirect_to'
+  ) THEN
+    UPDATE auth.config
+    SET allowed_redirect_urls = ARRAY[sign_in_redirect_to]
+    WHERE sign_in_redirect_to IS NOT NULL AND sign_in_redirect_to != '';
 
--- Drop original column
-ALTER TABLE auth.config DROP COLUMN IF EXISTS sign_in_redirect_to;
+    ALTER TABLE auth.config DROP COLUMN sign_in_redirect_to;
+  END IF;
+END $$;
 
 -- Store the validated redirect target alongside email OTP records so
 -- backend-owned action links can complete auth flows before redirecting.

--- a/backend/tests/unit/redirect-url-whitelist-migration.test.ts
+++ b/backend/tests/unit/redirect-url-whitelist-migration.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDir,
+  '../../src/infra/database/migrations/027_add-redirect-url-whitelist.sql'
+);
+
+describe('027_add-redirect-url-whitelist migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  // ── Idempotent rename ────────────────────────────────────────────────
+  it('wraps the configs→config rename in a DO block that checks both source and target', () => {
+    // Must check that auth.configs EXISTS before renaming
+    expect(sql).toMatch(
+      /information_schema\.tables\s+WHERE\s+table_schema\s*=\s*'auth'\s+AND\s+table_name\s*=\s*'configs'/i
+    );
+    // Must check that auth.config does NOT already exist
+    expect(sql).toMatch(
+      /NOT\s+EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+information_schema\.tables\s+WHERE\s+table_schema\s*=\s*'auth'\s+AND\s+table_name\s*=\s*'config'/i
+    );
+  });
+
+  it('does NOT use bare ALTER TABLE ... RENAME (non-idempotent)', () => {
+    // The RENAME must only appear inside the DO block, not as a top-level statement.
+    // Split on DO $$ boundaries and check that no top-level RENAME exists.
+    const outsideDoBlocks = sql.replace(/DO\s*\$\$[\s\S]*?\$\$/g, '');
+    expect(outsideDoBlocks).not.toMatch(/ALTER TABLE.*RENAME TO/i);
+  });
+
+  // ── Trigger idempotency ──────────────────────────────────────────────
+  it('drops old trigger name (update_configs_updated_at) before creating new one', () => {
+    expect(sql).toMatch(/DROP TRIGGER IF EXISTS update_configs_updated_at ON auth\.config/i);
+  });
+
+  it('drops new trigger name before CREATE to handle re-runs', () => {
+    expect(sql).toMatch(/DROP TRIGGER IF EXISTS update_config_updated_at ON auth\.config/i);
+  });
+
+  it('creates the update_config_updated_at trigger', () => {
+    expect(sql).toMatch(
+      /CREATE TRIGGER update_config_updated_at\s+BEFORE UPDATE ON auth\.config/i
+    );
+  });
+
+  // ── allowed_redirect_urls column ─────────────────────────────────────
+  it('adds allowed_redirect_urls with IF NOT EXISTS', () => {
+    expect(sql).toMatch(
+      /ADD COLUMN IF NOT EXISTS allowed_redirect_urls TEXT\[\]\s+DEFAULT\s+'\{\}'/i
+    );
+  });
+
+  // ── sign_in_redirect_to migration is guarded ─────────────────────────
+  it('checks sign_in_redirect_to column exists before migrating data', () => {
+    expect(sql).toMatch(
+      /information_schema\.columns[\s\S]*?column_name\s*=\s*'sign_in_redirect_to'/i
+    );
+  });
+
+  it('does NOT use a bare ALTER TABLE DROP COLUMN for sign_in_redirect_to', () => {
+    const outsideDoBlocks = sql.replace(/DO\s*\$\$[\s\S]*?\$\$/g, '');
+    expect(outsideDoBlocks).not.toMatch(/DROP COLUMN.*sign_in_redirect_to/i);
+  });
+
+  // ── email_otps redirect_to column ────────────────────────────────────
+  it('adds redirect_to column to auth.email_otps with IF NOT EXISTS', () => {
+    expect(sql).toMatch(
+      /ALTER TABLE auth\.email_otps\s+ADD COLUMN IF NOT EXISTS redirect_to TEXT/i
+    );
+  });
+
+  // ── Ordering ─────────────────────────────────────────────────────────
+  it('runs after migration 026', () => {
+    const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const idx027 = migrations.indexOf('027_add-redirect-url-whitelist.sql');
+    const idx026 = migrations.indexOf('026_create-custom-oauth-configs.sql');
+    expect(idx026).toBeGreaterThanOrEqual(0);
+    expect(idx027).toBeGreaterThan(idx026);
+  });
+});


### PR DESCRIPTION
## Summary
- Migration 027 (`ALTER TABLE auth.configs RENAME TO config`) fails with `relation "config" already exists` (42P07) on re-run because `RENAME TO` doesn't check target name conflicts
- Wraps rename in a `DO` block that checks both source (`auth.configs`) and target (`auth.config`) via `information_schema`
- Guards the `sign_in_redirect_to` data migration + column drop behind a column existence check
- Adds `DROP TRIGGER IF EXISTS` before `CREATE TRIGGER` for re-run safety
- Adds 11 unit tests verifying all idempotency guards

## Test plan
- [x] All 499 unit tests pass (`vitest run`)
- [x] New test file validates every idempotency guard in the migration SQL
- [ ] Deploy to EC2 and run `npm run migrate:up` — migration 027 should succeed now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make migration 027 idempotent by guarding table rename, trigger recreation, and column drop
> - Wraps the `auth.configs` → `auth.config` rename in a `DO` block that only executes when the source table exists and the target does not, preventing errors on reruns.
> - Guards the `sign_in_redirect_to` data migration and column drop behind a column-existence check so it is skipped if already applied.
> - Adds `DROP TRIGGER IF EXISTS` for both old and new trigger names before recreating `update_config_updated_at`, avoiding conflicts on reruns.
> - Adds a unit test suite in [redirect-url-whitelist-migration.test.ts](https://github.com/InsForge/InsForge/pull/1087/files#diff-6ab9769fb11e9b75995f73e4d06af9f4a77613bdb5788cbfd490dcc1499eb09c) that asserts each idempotency guard is present in the SQL file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9ef4c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for redirect URL whitelisting in authentication configurations.
  * Introduced a new redirect field for email one-time passwords.

* **Tests**
  * Added comprehensive test coverage for database migration reliability and idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->