### PR TITLE
fix(database): honor strict vs relaxed raw SQL sanitizer mode

### DIFF
--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -13,6 +13,7 @@ import {
   parseSQLStatements,
   checkAuthSchemaOperations,
   checkSystemSchemaOperations,
+  checkSystemSchemaOperationsRelaxed,
 } from '@/utils/sql-parser.js';
 import { validateTableName } from '@/utils/validations.js';
 import pgFormat from 'pg-format';
@@ -85,7 +86,7 @@ export class DatabaseAdvanceService {
    * - CREATE TRIGGER on auth tables (for automatic profile creation, etc.)
    * - Other DDL operations on auth schema (ALTER TABLE for indexes, etc.)
    */
-  sanitizeQuery(query: string, _mode: 'strict' | 'relaxed' = 'strict'): string {
+  sanitizeQuery(query: string, mode: 'strict' | 'relaxed' = 'strict'): string {
     // Block database-level operations
     const dangerousPatterns = [
       /DROP\s+DATABASE/i,
@@ -109,8 +110,13 @@ export class DatabaseAdvanceService {
       throw new AppError(authError, 403, ERROR_CODES.FORBIDDEN);
     }
 
-    // Block DDL/DML on system schema
-    const systemError = checkSystemSchemaOperations(query);
+    // Block unsafe system-schema operations by mode.
+    // - strict: blocks system DDL/DML (except SELECT)
+    // - relaxed: allows system INSERT for power-user workflows, still blocks destructive ops
+    const systemError =
+      mode === 'relaxed'
+        ? checkSystemSchemaOperationsRelaxed(query)
+        : checkSystemSchemaOperations(query);
     if (systemError) {
       logger.warn('Blocked operation on system schema', {
         query: query.substring(0, 100),

--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -238,6 +238,26 @@ function getSchemaFromNameList(items: Array<Record<string, unknown>>): string | 
  * Returns an error message if blocked, null if allowed.
  */
 export function checkSystemSchemaOperations(query: string): string | null {
+  return checkSystemSchemaOperationsWithPolicy(query, { allowSystemInsert: false });
+}
+
+/**
+ * Check if a query contains dangerous operations on the system schema in relaxed mode.
+ * Relaxed mode allows INSERT operations on system schema tables but still blocks
+ * destructive/privileged operations (DDL, DROP, UPDATE, DELETE, TRUNCATE, search_path changes).
+ */
+export function checkSystemSchemaOperationsRelaxed(query: string): string | null {
+  return checkSystemSchemaOperationsWithPolicy(query, { allowSystemInsert: true });
+}
+
+interface SystemSchemaPolicy {
+  allowSystemInsert: boolean;
+}
+
+function checkSystemSchemaOperationsWithPolicy(
+  query: string,
+  policy: SystemSchemaPolicy
+): string | null {
   const isSystem = (s: string | null): boolean => s?.toLowerCase() === 'system';
 
   try {
@@ -373,7 +393,7 @@ export function checkSystemSchemaOperations(query: string): string | null {
       // INSERT INTO system.*
       if (stmtType === 'InsertStmt') {
         const relation = data.relation as Record<string, unknown> | undefined;
-        if (isSystem(getSchemaName(relation))) {
+        if (!policy.allowSystemInsert && isSystem(getSchemaName(relation))) {
           return 'INSERT operations on the "system" schema are not allowed.';
         }
       }

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -418,6 +418,28 @@ describe('DatabaseAdvanceService - sanitizeQuery', () => {
     });
   });
 
+  describe('strict vs relaxed mode behavior', () => {
+    test('strict mode blocks INSERT on system schema', () => {
+      const query = "INSERT INTO system.secrets (key, value) VALUES ('a', 'b')";
+      expect(() => service.sanitizeQuery(query, 'strict')).toThrow(AppError);
+    });
+
+    test('relaxed mode allows INSERT on system schema', () => {
+      const query = "INSERT INTO system.secrets (key, value) VALUES ('a', 'b')";
+      expect(() => service.sanitizeQuery(query, 'relaxed')).not.toThrow();
+    });
+
+    test('relaxed mode still blocks destructive operations on system schema', () => {
+      const query = "UPDATE system.secrets SET value = 'x' WHERE key = 'a'";
+      expect(() => service.sanitizeQuery(query, 'relaxed')).toThrow(AppError);
+    });
+
+    test('relaxed mode still blocks dangerous database-level operations', () => {
+      const query = 'DROP DATABASE testdb';
+      expect(() => service.sanitizeQuery(query, 'relaxed')).toThrow(AppError);
+    });
+  });
+
   describe('other blocked operations', () => {
     test('blocks DROP DATABASE', () => {
       const query = 'DROP DATABASE testdb';


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `sanitizeQuery` to enforce strict vs relaxed raw SQL sanitizer mode
> - Adds a `mode` parameter (`'strict' | 'relaxed'`) to `DatabaseAdvanceService.sanitizeQuery` in [database-advance.service.ts](https://github.com/InsForge/InsForge/pull/1089/files#diff-8c5ec353b1320498356d927a119d27831c87d4c5da2ae0cb804039e6598f951d), replacing the previously unused `_mode` parameter.
> - In `relaxed` mode, `INSERT INTO system.*` is permitted; in `strict` mode (default), it is blocked. Both modes continue to block `UPDATE`, `DELETE`, `TRUNCATE`, DDL, and `SET search_path` on the system schema.
> - Implements this via a new policy-based helper `checkSystemSchemaOperationsWithPolicy` in [sql-parser.ts](https://github.com/InsForge/InsForge/pull/1089/files#diff-1f801d23d364dd74c3ab311417f727b405993ae621fde2f9342bf9b392481976), with `checkSystemSchemaOperations` and `checkSystemSchemaOperationsRelaxed` as thin wrappers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b7cd63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable validation modes to database query sanitization: strict mode (default) and relaxed mode. Relaxed mode permits INSERT operations on system schemas while maintaining protections against destructive operations (UPDATE, DELETE, TRUNCATE, DDL).

* **Tests**
  * Added test suite validating mode-dependent behavior for system schema operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->