### PR TITLE
docs(pgvector): fix broken embeddings SDK link

### DIFF
--- a/docs/core-concepts/database/pgvector.mdx
+++ b/docs/core-concepts/database/pgvector.mdx
@@ -7,7 +7,7 @@ description: Store embeddings and perform similarity search with pgvector
 
 InsForge supports **pgvector**, a PostgreSQL extension for vector similarity search. Use it to build semantic search, recommendations, RAG pipelines, or anything that needs "find similar items" functionality.
 
-InsForge also provides a built-in [embeddings SDK](/sdk-reference/ai/embeddings) through the AI gateway, so you can generate and store vectors without configuring external providers.
+InsForge also provides a built-in [embeddings SDK](/sdks/typescript/ai#embeddings-create) through the AI gateway, so you can generate and store vectors without configuring external providers.
 
 ## Enabling the Extension
 


### PR DESCRIPTION
## Summary
- `/sdk-reference/ai/embeddings` 404s; repoint to the existing `/sdks/typescript/ai#embeddings-create` anchor on the pgvector page.

## Test plan
- [x] Verified live page `/sdks/typescript/ai` returns 200 and contains `id="embeddings-create"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken embeddings SDK link in pgvector docs
> Updates the embeddings SDK link in [pgvector.mdx](https://github.com/InsForge/InsForge/pull/1097/files#diff-bc9442c8423654319d19e9752bc58c6afdda4d6b6c722a7865e1d82f8c641344) from `/sdk-reference/ai/embeddings` to `/sdks/typescript/ai#embeddings-create`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9eb9df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an embedded SDK reference link to point to the correct documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->