### PR TITLE
Fix auth refresh issue

### DIFF
--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -6,7 +6,7 @@ import { ERROR_CODES, NEXT_ACTION } from '@/types/error-constants.js';
 import type { TokenPayloadSchema } from '@insforge/shared-schemas';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
-const ACCESS_TOKEN_EXPIRES_IN = '1m';
+const ACCESS_TOKEN_EXPIRES_IN = '15m';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 /**

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -6,7 +6,7 @@ import { ERROR_CODES, NEXT_ACTION } from '@/types/error-constants.js';
 import type { TokenPayloadSchema } from '@insforge/shared-schemas';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
-const ACCESS_TOKEN_EXPIRES_IN = '15m';
+const ACCESS_TOKEN_EXPIRES_IN = '1m';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 /**

--- a/frontend/src/cloud-hosting/CloudHostingDashboard.tsx
+++ b/frontend/src/cloud-hosting/CloudHostingDashboard.tsx
@@ -20,6 +20,7 @@ export function CloudHostingDashboard() {
       mode="cloud-hosting"
       showNavbar={!isInIframe()}
       getAuthorizationCode={getAuthorizationCode}
+      useAuthorizationCodeRefresh={isInIframe()}
       project={projectInfo}
       onRouteChange={reportRouteChange}
       onNavigateToSubscription={navigateToSubscription}

--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -122,7 +122,6 @@ function normalizeProjectInfo(
 export function useCloudHosting() {
   const currentOrigin = getCurrentOrigin();
   const [projectInfo, setProjectInfo] = useState<DashboardProjectInfo>();
-  const queuedAuthorizationCodeRef = useRef<string | null>(null);
   const parentOriginRef = useRef<string | null>(getParentOrigin());
   const openerOriginRef = useRef<string | null>(null);
   const pendingRequestsRef = useRef<PendingRequests>({});
@@ -272,10 +271,8 @@ export function useCloudHosting() {
 
           if (pendingRequestsRef.current.authCode) {
             resolvePendingRequest('authCode', code);
-            return;
           }
 
-          queuedAuthorizationCodeRef.current = code;
           return;
         }
         case 'AUTHORIZATION_CODE_ERROR':
@@ -389,12 +386,6 @@ export function useCloudHosting() {
   }, [postMessageToParent]);
 
   const getAuthorizationCode = useCallback(async (): Promise<string> => {
-    if (queuedAuthorizationCodeRef.current) {
-      const code = queuedAuthorizationCodeRef.current;
-      queuedAuthorizationCodeRef.current = null;
-      return code;
-    }
-
     // Even if the send fails, keep the pending request open so a proactive parent or opener
     // message can still resolve it when the cloud hosting transport finishes initializing.
     postMessageToParent({ type: 'REQUEST_AUTHORIZATION_CODE' });

--- a/packages/dashboard/src/app/InsforgeDashboard.tsx
+++ b/packages/dashboard/src/app/InsforgeDashboard.tsx
@@ -34,12 +34,15 @@ export function InsForgeDashboard(props: InsForgeDashboardProps) {
   } = props;
   const getAuthorizationCode =
     props.mode === 'cloud-hosting' ? props.getAuthorizationCode : undefined;
+  const useAuthorizationCodeRefresh =
+    props.mode === 'cloud-hosting' ? props.useAuthorizationCodeRefresh : undefined;
   const host = useMemo(
     () => ({
       backendUrl: normalizeBackendUrl(backendUrl),
       mode,
       showNavbar,
       getAuthorizationCode,
+      useAuthorizationCodeRefresh,
       onRouteChange,
       onNavigateToSubscription,
       onRenameProject,
@@ -53,6 +56,7 @@ export function InsForgeDashboard(props: InsForgeDashboardProps) {
       mode,
       showNavbar,
       getAuthorizationCode,
+      useAuthorizationCodeRefresh,
       onRouteChange,
       onNavigateToSubscription,
       onRenameProject,

--- a/packages/dashboard/src/lib/config/DashboardHostContext.tsx
+++ b/packages/dashboard/src/lib/config/DashboardHostContext.tsx
@@ -6,6 +6,7 @@ interface DashboardHostContextValue {
   showNavbar?: boolean;
   mode: DashboardMode;
   getAuthorizationCode?: () => Promise<string>;
+  useAuthorizationCodeRefresh?: boolean;
   onRouteChange?: (path: string) => void;
   onNavigateToSubscription?: () => void;
   onRenameProject?: (name: string) => Promise<void>;

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -43,6 +43,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const cloudAuthenticationRef = useRef<Promise<UserSchema | null> | null>(null);
   const shouldAttemptCloudAuthentication =
     isCloudHosting && !location.pathname.startsWith('/dashboard/login');
+  const shouldUseAuthorizationCodeRefresh =
+    isCloudHosting && host.useAuthorizationCodeRefresh === true;
 
   const handleAuthError = useCallback(() => {
     setUser(null);
@@ -133,19 +135,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // Access token refresh handler
   useEffect(() => {
     const handleRefreshAccessToken = async (): Promise<boolean> => {
-      if (shouldAttemptCloudAuthentication) {
+      const refreshed = await loginService.refreshAccessToken();
+      if (refreshed) {
+        return true;
+      }
+
+      if (shouldUseAuthorizationCodeRefresh) {
         const authenticatedUser = await authenticateCloudSession();
         return authenticatedUser !== null;
       }
 
-      return loginService.refreshAccessToken();
+      return false;
     };
 
     apiClient.setRefreshAccessTokenHandler(handleRefreshAccessToken);
     return () => {
       apiClient.setRefreshAccessTokenHandler(undefined);
     };
-  }, [authenticateCloudSession, shouldAttemptCloudAuthentication]);
+  }, [authenticateCloudSession, shouldUseAuthorizationCodeRefresh]);
 
   const checkAuthStatus = useCallback(async () => {
     try {

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -133,17 +133,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // Access token refresh handler
   useEffect(() => {
     const handleRefreshAccessToken = async (): Promise<boolean> => {
-      const refreshed = await loginService.refreshAccessToken();
-      if (refreshed) {
-        return true;
+      if (shouldAttemptCloudAuthentication) {
+        const authenticatedUser = await authenticateCloudSession();
+        return authenticatedUser !== null;
       }
 
-      if (!shouldAttemptCloudAuthentication) {
-        return false;
-      }
-
-      const authenticatedUser = await authenticateCloudSession();
-      return authenticatedUser !== null;
+      return loginService.refreshAccessToken();
     };
 
     apiClient.setRefreshAccessTokenHandler(handleRefreshAccessToken);

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -54,6 +54,7 @@ export interface SelfHostingDashboardProps extends DashboardProps {
 export interface CloudHostingDashboardProps extends DashboardProps {
   mode: 'cloud-hosting';
   getAuthorizationCode: () => Promise<string>;
+  useAuthorizationCodeRefresh?: boolean;
 }
 
 export type InsForgeDashboardProps = SelfHostingDashboardProps | CloudHostingDashboardProps;


### PR DESCRIPTION
## Summary

Resolve an issue that cause the auth failure in cloud projects.

## How did you test this change?

Tested on cloud


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auth token refresh to prioritize cloud session in cloud-hosting contexts
> - In [AuthContext.tsx](https://github.com/InsForge/InsForge/pull/1101/files#diff-6ce2102d4036093a54015c06956feace3bef491f11cc668ac3acd076263cd274), the refresh handler now calls `authenticateCloudSession()` directly when `shouldAttemptCloudAuthentication` is true, instead of trying `loginService.refreshAccessToken()` first and falling back to cloud auth on failure.
> - In [useCloudHosting.ts](https://github.com/InsForge/InsForge/pull/1101/files#diff-696cf7f283d2017f2417aca9430b653bcb9b61493c69d98a7c06ab011111aaa6), `getAuthorizationCode` no longer returns a previously queued authorization code; it always issues a fresh `REQUEST_AUTHORIZATION_CODE` and awaits resolution.
> - Authorization codes received before a pending request existed are now discarded instead of being stored for later retrieval.
> - Behavioral Change: cloud-hosting token refresh order is inverted — cloud session auth is now the primary path, not the fallback.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1101 opened
>
> - Modified `AuthProvider` component in `dashboard` package to implement a two-stage token refresh strategy [2b6df85]
> - Added `useAuthorizationCodeRefresh` flag to dashboard host context and threaded it through cloud-hosting component hierarchy [2b6df85]
> - Configured `CloudHostingDashboard` component to enable authorization-code refresh when rendered inside an iframe [2b6df85]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12a6dec.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cloud session authentication flow and enabled authorization-code refresh when the dashboard is embedded (iframe).
* **Bug Fixes**
  * Stopped buffering incoming authorization codes: codes are now delivered only to active requests (codes arriving before a request will be ignored), reducing unexpected cached-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->