### PR TITLE
INS-74: Support C test in new onboarding

### DIFF
--- a/frontend/src/cloud-hosting/CloudHostingDashboard.tsx
+++ b/frontend/src/cloud-hosting/CloudHostingDashboard.tsx
@@ -13,6 +13,7 @@ export function CloudHostingDashboard() {
     requestInstanceInfo,
     requestInstanceTypeChange,
     updateVersion,
+    requestUserInfo,
   } = useCloudHosting();
 
   return (
@@ -29,6 +30,7 @@ export function CloudHostingDashboard() {
       onRequestInstanceInfo={requestInstanceInfo}
       onRequestInstanceTypeChange={requestInstanceTypeChange}
       onUpdateVersion={updateVersion}
+      onRequestUserInfo={requestUserInfo}
     />
   );
 }

--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { DashboardInstanceInfo, DashboardProjectInfo } from '@insforge/dashboard';
+import type {
+  DashboardInstanceInfo,
+  DashboardProjectInfo,
+  DashboardUserInfo,
+} from '@insforge/dashboard';
 
 type InstanceTypeChangeResult = {
   success: boolean;
@@ -18,7 +22,8 @@ type PendingRequestKey =
   | 'instanceTypeChange'
   | 'renameProject'
   | 'deleteProject'
-  | 'updateVersion';
+  | 'updateVersion'
+  | 'userInfo';
 
 type PendingRequest<T> = {
   resolve: (value: T) => void;
@@ -33,6 +38,7 @@ type PendingRequestValues = {
   renameProject: void;
   deleteProject: void;
   updateVersion: void;
+  userInfo: DashboardUserInfo;
 };
 
 type PendingRequests = {
@@ -151,6 +157,9 @@ export function useCloudHosting() {
           return;
         case 'updateVersion':
           pendingRequestsRef.current.updateVersion = pendingRequest as PendingRequest<void>;
+          return;
+        case 'userInfo':
+          pendingRequestsRef.current.userInfo = pendingRequest as PendingRequest<DashboardUserInfo>;
           return;
       }
     },
@@ -288,6 +297,20 @@ export function useCloudHosting() {
         }
         case 'PROJECT_INFO': {
           setProjectInfo((previous) => normalizeProjectInfo(previous, currentOrigin, message));
+          return;
+        }
+        case 'USER_INFO': {
+          const userId = typeof message.userId === 'string' ? message.userId : '';
+          const email = typeof message.email === 'string' ? message.email : '';
+          if (!userId || !email) {
+            rejectPendingRequest('userInfo', 'Received an invalid user info payload');
+            return;
+          }
+          resolvePendingRequest('userInfo', {
+            userId,
+            email,
+            name: typeof message.name === 'string' ? message.name : undefined,
+          });
           return;
         }
         case 'INSTANCE_INFO': {
@@ -443,6 +466,13 @@ export function useCloudHosting() {
     return createPendingRequest('updateVersion', 'Project version update');
   }, [createPendingRequest, postMessageToParent]);
 
+  const requestUserInfo = useCallback(async (): Promise<DashboardUserInfo> => {
+    if (!postMessageToParent({ type: 'REQUEST_USER_INFO' })) {
+      throw new Error('Unable to request user info from the parent window');
+    }
+    return createPendingRequest('userInfo', 'User info request');
+  }, [createPendingRequest, postMessageToParent]);
+
   const navigateToSubscription = useCallback(() => {
     void postMessageToParent({ type: 'NAVIGATE_TO_SUBSCRIPTION' });
   }, [postMessageToParent]);
@@ -464,5 +494,6 @@ export function useCloudHosting() {
     deleteProject,
     updateVersion,
     navigateToSubscription,
+    requestUserInfo,
   };
 }

--- a/packages/dashboard/src/app/InsforgeDashboard.tsx
+++ b/packages/dashboard/src/app/InsforgeDashboard.tsx
@@ -31,6 +31,7 @@ export function InsForgeDashboard(props: InsForgeDashboardProps) {
     onRequestInstanceInfo,
     onRequestInstanceTypeChange,
     onUpdateVersion,
+    onRequestUserInfo,
   } = props;
   const getAuthorizationCode =
     props.mode === 'cloud-hosting' ? props.getAuthorizationCode : undefined;
@@ -50,6 +51,7 @@ export function InsForgeDashboard(props: InsForgeDashboardProps) {
       onRequestInstanceInfo,
       onRequestInstanceTypeChange,
       onUpdateVersion,
+      onRequestUserInfo,
     }),
     [
       backendUrl,
@@ -64,6 +66,7 @@ export function InsForgeDashboard(props: InsForgeDashboardProps) {
       onRequestInstanceInfo,
       onRequestInstanceTypeChange,
       onUpdateVersion,
+      onRequestUserInfo,
     ]
   );
   const [queryClient] = useState(

--- a/packages/dashboard/src/features/dashboard/components/connect/NewCLISection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/NewCLISection.tsx
@@ -102,9 +102,10 @@ function CommandBox({ command }: CommandBoxProps) {
 
 interface NewCLISectionProps {
   className?: string;
+  isCTest?: boolean;
 }
 
-export function NewCLISection({ className }: NewCLISectionProps) {
+export function NewCLISection({ className, isCTest = false }: NewCLISectionProps) {
   const { projectId } = useProjectId();
   const { projectInfo } = useCloudProjectInfo();
 
@@ -119,13 +120,15 @@ export function NewCLISection({ className }: NewCLISectionProps) {
         className
       )}
     >
-      {/* Header */}
-      <div className="flex max-w-[640px] flex-col gap-3">
-        <h3 className="text-2xl font-medium leading-8 text-foreground">Get Started</h3>
-        <p className="text-sm leading-6 text-muted-foreground">
-          Run these commands to create a new web app with your credentials.
-        </p>
-      </div>
+      {/* Header — hidden when isCTest (title is external in c test) */}
+      {!isCTest && (
+        <div className="flex max-w-[640px] flex-col gap-3">
+          <h3 className="text-2xl font-medium leading-8 text-foreground">Get Started</h3>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Run these commands to create a new web app with your credentials.
+          </p>
+        </div>
+      )}
 
       {/* Steps */}
       <div className="flex flex-col">
@@ -149,7 +152,7 @@ export function NewCLISection({ className }: NewCLISectionProps) {
           number={3}
           title="View Your App"
           description="Open your browser to see the app running locally"
-          isLast
+          isLast={!isCTest}
         >
           <div className="flex items-center gap-1 pl-1">
             <a
@@ -163,6 +166,12 @@ export function NewCLISection({ className }: NewCLISectionProps) {
             <ExternalLink className="size-4 text-primary" />
           </div>
         </Step>
+
+        {isCTest && (
+          <Step number={4} title="Add a To Do to your app" description="" isLast>
+            <></>
+          </Step>
+        )}
       </div>
     </div>
   );

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -91,8 +91,8 @@ const getStepperDismissKey = (projectId?: string) =>
 const getGetStartedPassedKey = (projectId?: string) =>
   `insforge-ctest-get-started-passed-${projectId || 'default'}`;
 
-const getStepCompletedKey = (projectId?: string) =>
-  `insforge-ctest-step-completed-${projectId || 'default'}`;
+const getStepDoneKey = (projectId: string | null | undefined, stepKey: StepKey) =>
+  `insforge-ctest-step-${stepKey}-done-${projectId || 'default'}`;
 
 // --- Sub-components ---
 
@@ -358,7 +358,6 @@ export default function CTestDashboardPage() {
   const { projectId } = useProjectId();
   const stepperDismissKey = getStepperDismissKey(projectId ?? undefined);
   const getStartedPassedKey = getGetStartedPassedKey(projectId ?? undefined);
-  const stepCompletedKey = getStepCompletedKey(projectId ?? undefined);
 
   const [isStepperDismissed, setIsStepperDismissed] = useState(false);
   const [hasPassedGetStarted, setHasPassedGetStarted] = useState(false);
@@ -394,27 +393,18 @@ export default function CTestDashboardPage() {
     if (projectId === undefined) {
       return;
     }
+    const loaded: Partial<Record<StepKey, boolean>> = {};
     try {
-      const raw = localStorage.getItem(stepCompletedKey);
-      if (!raw) {
-        setStickyCompletedSteps({});
-        return;
-      }
-      const parsed: unknown = JSON.parse(raw);
-      if (
-        parsed &&
-        typeof parsed === 'object' &&
-        !Array.isArray(parsed) &&
-        Object.values(parsed).every((v) => typeof v === 'boolean')
-      ) {
-        setStickyCompletedSteps(parsed as Partial<Record<StepKey, boolean>>);
-      } else {
-        setStickyCompletedSteps({});
+      for (const step of PROMPT_STEPS) {
+        if (localStorage.getItem(getStepDoneKey(projectId, step.key)) === 'true') {
+          loaded[step.key] = true;
+        }
       }
     } catch {
-      setStickyCompletedSteps({});
+      // ignore
     }
-  }, [projectId, stepCompletedKey]);
+    setStickyCompletedSteps(loaded);
+  }, [projectId]);
 
   const shouldShowLoadingState =
     isMetadataLoading ||
@@ -492,24 +482,27 @@ export default function CTestDashboardPage() {
     if (projectId === undefined) {
       return;
     }
-    const merged: Partial<Record<StepKey, boolean>> = { ...stickyCompletedSteps };
-    let changed = false;
     for (const step of PROMPT_STEPS) {
-      if (liveCompletedSteps[step.key] && !merged[step.key]) {
-        merged[step.key] = true;
-        changed = true;
+      if (liveCompletedSteps[step.key]) {
+        try {
+          localStorage.setItem(getStepDoneKey(projectId, step.key), 'true');
+        } catch {
+          // ignore
+        }
       }
     }
-    if (!changed) {
-      return;
-    }
-    setStickyCompletedSteps(merged);
-    try {
-      localStorage.setItem(stepCompletedKey, JSON.stringify(merged));
-    } catch {
-      // ignore
-    }
-  }, [projectId, stepCompletedKey, liveCompletedSteps, stickyCompletedSteps]);
+    setStickyCompletedSteps((prev) => {
+      let changed = false;
+      const next: Partial<Record<StepKey, boolean>> = { ...prev };
+      for (const step of PROMPT_STEPS) {
+        if (liveCompletedSteps[step.key] && !next[step.key]) {
+          next[step.key] = true;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [projectId, liveCompletedSteps]);
 
   const handleDismissStepper = useCallback(() => {
     if (projectId === undefined) {

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -25,6 +25,7 @@ import { useDeploymentMetadata } from '../../deployments/hooks/useDeploymentMeta
 import { NewCLISection } from '../components/connect/NewCLISection';
 import { MCPSection } from '../components/connect';
 import stepBgDecoration from '../../../assets/images/step_bg_decoration.svg';
+import DiscordIcon from '../../../assets/logos/discord.svg?react';
 
 // --- Prompt Stepper Data ---
 
@@ -104,7 +105,6 @@ function MetricCard({
   return (
     <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded border border-[var(--alpha-8)] bg-card">
       <div className="flex h-[120px] flex-col p-4">
-        {/* Header row */}
         <div className="flex h-[22px] items-center gap-1.5">
           <div className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground">
             {icon}
@@ -121,8 +121,6 @@ function MetricCard({
             </button>
           )}
         </div>
-
-        {/* Value row — pinned 60px from top (matching Figma y=76 - padding=16) */}
         <div className="mt-[38px] flex items-baseline justify-between">
           <div className="flex items-baseline gap-1">
             <p className="text-[20px] font-medium leading-7 text-foreground">{value}</p>
@@ -143,7 +141,7 @@ function MetricCard({
   );
 }
 
-// --- Prompt display (renders numbered lines as an ordered list) ---
+// --- Prompt display ---
 
 function PromptDisplay({ text }: { text: string }) {
   const lines = text.split('\n');
@@ -192,7 +190,7 @@ function PromptDisplay({ text }: { text: string }) {
   );
 }
 
-// --- Step circle (simple outline, green when active/completed, gray otherwise) ---
+// --- Step circle ---
 
 function StepCircle({ completed, active }: { completed: boolean; active: boolean }) {
   if (completed) {
@@ -228,10 +226,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
 
   return (
     <div className="flex flex-col gap-6 rounded-lg border border-[var(--alpha-8)] bg-card p-6">
-      {/* Header */}
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
-          <p className="text-[20px] font-medium leading-7 text-foreground">Next Step</p>
+          <p className="text-[20px] font-medium leading-7 text-foreground">
+            Congratulations! Your backend has been successfully set up.
+          </p>
           {allCompleted ? (
             <Button
               type="button"
@@ -253,13 +252,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
           ) : null}
         </div>
         <p className="text-[13px] leading-[18px] text-muted-foreground">
-          Copy and Paste prompt to your agent to start building
+          Now open your coding agent and start building your project with prompts
         </p>
       </div>
 
-      {/* Stepper content - inner bordered container */}
       <div className="flex overflow-hidden rounded border border-[var(--alpha-8)]">
-        {/* Step list (left) */}
         <div className="flex w-1/2 max-w-[440px] shrink-0 flex-col border-r border-[var(--alpha-8)]">
           {PROMPT_STEPS.map((step, index) => {
             const isActive = index === activeStep;
@@ -291,19 +288,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
           })}
         </div>
 
-        {/* Step detail (right) */}
         <div className="relative flex flex-1 flex-col items-start self-stretch overflow-hidden bg-[var(--special-toast,#323232)] p-6">
           <div className="relative z-10 flex max-w-[640px] flex-col items-start gap-3">
-            {/* Icon */}
             <div className="h-12 w-12">{currentStep.icon}</div>
-
-            {/* Title */}
             <p className="text-[20px] font-medium leading-7 text-foreground">{currentStep.title}</p>
-
-            {/* Prompt text */}
             <PromptDisplay text={currentStep.prompt} />
-
-            {/* Action buttons */}
             <div className="flex items-center gap-2">
               <CopyButton
                 text={currentStep.prompt}
@@ -324,8 +313,6 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
               )}
             </div>
           </div>
-
-          {/* Decorative background graphic */}
           <img
             src={stepBgDecoration}
             alt=""
@@ -337,7 +324,7 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
   );
 }
 
-function NewDashboardLoadingState() {
+function CTestLoadingState() {
   return (
     <main className="h-full min-h-0 min-w-0 overflow-y-auto bg-semantic-0">
       <div className="mx-auto flex w-full flex-col gap-6 px-10 py-8">
@@ -346,12 +333,9 @@ function NewDashboardLoadingState() {
           <Skeleton className="h-5 w-16 rounded" />
           <Skeleton className="h-6 w-20 rounded-full" />
         </div>
-        <div className="grid grid-cols-4 gap-3">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-[120px] rounded" />
-          ))}
+        <div className="flex items-center justify-center py-12">
+          <Skeleton className="h-[400px] w-full max-w-[640px] rounded" />
         </div>
-        <Skeleton className="h-[360px] rounded" />
       </div>
     </main>
   );
@@ -359,7 +343,7 @@ function NewDashboardLoadingState() {
 
 // --- Main Page ---
 
-export default function NewDashboardPage() {
+export default function CTestDashboardPage() {
   const navigate = useNavigate();
   const isCloudHostingMode = useIsCloudHostingMode();
   const isCloudProject = isInsForgeCloudProject();
@@ -426,21 +410,18 @@ export default function NewDashboardPage() {
   const bucketCount = storage?.buckets?.length ?? 0;
   const functionCount = metadata?.functions.length ?? 0;
 
-  // --- Step completion detection (real-time via socket → React Query invalidation) ---
+  // Todo table has data — triggers transition from Get Started to full dashboard
+  const todoHasData = (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) > 0;
+
   const completedSteps = useMemo(
     () => [
-      // Step 1: Add sample data — todo table has records
-      (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) > 0,
-      // Step 2: Sign up first user — totalUsers already excludes admin & anon
+      todoHasData,
       (totalUsers ?? 0) >= 1,
-      // Step 3: Upload a file — todo-attachments bucket has files
       (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
-      // Step 4: Add LLM feature — AI gateway has been used
       (aiUsageSummary?.totalRequests ?? 0) > 0,
-      // Step 5: Deploy your app — a deployment exists
       !!currentDeploymentId,
     ],
-    [tables, totalUsers, storage, aiUsageSummary, currentDeploymentId]
+    [todoHasData, totalUsers, storage, aiUsageSummary, currentDeploymentId]
   );
 
   const handleDismissStepper = useCallback(() => {
@@ -456,9 +437,49 @@ export default function NewDashboardPage() {
   const appUrl = getBackendUrl();
 
   if (shouldShowLoadingState) {
-    return <NewDashboardLoadingState />;
+    return <CTestLoadingState />;
   }
 
+  // Phase 1: Todo has no data — show centered Get Started with 4 steps
+  if (!todoHasData) {
+    return (
+      <main className="flex h-full min-h-0 min-w-0 flex-col bg-semantic-0">
+        <div className="flex flex-1 flex-col items-center overflow-y-auto pt-[120px]">
+          {/* Get Started title — outside the card */}
+          <h2 className="w-full max-w-[640px] text-center text-2xl font-medium leading-8 text-foreground">
+            Get Started
+          </h2>
+
+          {/* Stepper card */}
+          <div className="mt-6 w-full max-w-[640px]">
+            {canShowCli ? (
+              <NewCLISection isCTest />
+            ) : (
+              <MCPSection apiKey={displayApiKey} appUrl={appUrl} isLoading={isApiKeyLoading} />
+            )}
+          </div>
+        </div>
+
+        {/* Bottom help bar */}
+        <div className="flex items-center justify-center px-4 pb-10 pt-6">
+          <p className="flex items-center gap-1 text-sm leading-6 text-muted-foreground">
+            <span>Need help? Join our</span>
+            <a
+              href="https://discord.gg/DvBtaEc9Jz"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[#818cf8] hover:text-[#99a3ff]"
+            >
+              <DiscordIcon className="size-5" />
+              <span>Discord</span>
+            </a>
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Phase 2: Todo has data — show full dashboard with metrics + stepper
   return (
     <main className="h-full min-h-0 min-w-0 overflow-y-auto bg-semantic-0">
       <div className="flex w-full flex-col gap-12 px-10 py-8">
@@ -473,7 +494,6 @@ export default function NewDashboardPage() {
               {instanceType}
             </Badge>
           )}
-          {/* Health badge */}
           <div className="flex items-center rounded-full bg-[var(--special-toast,#323232)] px-2 py-1">
             <div
               className={`mr-1.5 h-2 w-2 rounded-full ${isHealthy ? 'bg-emerald-400' : 'bg-amber-400'}`}
@@ -482,14 +502,16 @@ export default function NewDashboardPage() {
           </div>
         </div>
 
-        {/* Get Started - CLI or MCP onboarding */}
-        {canShowCli ? (
-          <NewCLISection />
-        ) : (
-          <MCPSection apiKey={displayApiKey} appUrl={appUrl} isLoading={isApiKeyLoading} />
+        {/* Prompt Stepper */}
+        {!isStepperDismissed && (
+          <PromptStepper
+            onDismiss={handleDismissStepper}
+            completedSteps={completedSteps}
+            showDismiss={agentConnected}
+          />
         )}
 
-        {/* Metric Cards - 120px height, 4 cols, 12px gap */}
+        {/* Metric Cards */}
         <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
           <MetricCard
             label="User"
@@ -521,15 +543,6 @@ export default function NewDashboardPage() {
             onNavigate={() => void navigate('/dashboard/functions/list')}
           />
         </div>
-
-        {/* Next Step - Prompt Stepper */}
-        {!isStepperDismissed && (
-          <PromptStepper
-            onDismiss={handleDismissStepper}
-            completedSteps={completedSteps}
-            showDismiss={agentConnected}
-          />
-        )}
       </div>
     </main>
   );

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -80,6 +80,9 @@ const PROMPT_STEPS: PromptStep[] = [
 const getStepperDismissKey = (projectId?: string) =>
   `insforge-prompt-stepper-dismissed-${projectId || 'default'}`;
 
+const getGetStartedPassedKey = (projectId?: string) =>
+  `insforge-ctest-get-started-passed-${projectId || 'default'}`;
+
 // --- Sub-components ---
 
 interface MetricCardProps {
@@ -343,11 +346,13 @@ export default function CTestDashboardPage() {
   const { currentDeploymentId, isLoading: isDeploymentLoading } = useDeploymentMetadata();
   const { projectId } = useProjectId();
   const stepperDismissKey = getStepperDismissKey(projectId ?? undefined);
+  const getStartedPassedKey = getGetStartedPassedKey(projectId ?? undefined);
 
   const [isStepperDismissed, setIsStepperDismissed] = useState(false);
+  const [hasPassedGetStarted, setHasPassedGetStarted] = useState(false);
 
   useEffect(() => {
-    if (!projectId) {
+    if (projectId === undefined) {
       return;
     }
     try {
@@ -357,6 +362,18 @@ export default function CTestDashboardPage() {
       // ignore
     }
   }, [projectId, stepperDismissKey]);
+
+  useEffect(() => {
+    if (projectId === undefined) {
+      return;
+    }
+    try {
+      const passed = localStorage.getItem(getStartedPassedKey) === 'true';
+      setHasPassedGetStarted(passed);
+    } catch {
+      // ignore
+    }
+  }, [projectId, getStartedPassedKey]);
 
   const shouldShowLoadingState =
     isMetadataLoading ||
@@ -395,7 +412,21 @@ export default function CTestDashboardPage() {
   const todoHasData = todoRecordCount > 0;
   // Step 1 completion requires at least 4 records
   const todoStepComplete = todoRecordCount >= 4;
-  const shouldShowGetStarted = !metadataError && !todoHasData;
+  // Once the user has passed Get Started (todo had data at least once),
+  // never show it again — even if the agent later deletes records (e.g. due to RLS).
+  const shouldShowGetStarted = !metadataError && !hasPassedGetStarted && !todoHasData;
+
+  useEffect(() => {
+    if (projectId === undefined || hasPassedGetStarted || !todoHasData) {
+      return;
+    }
+    try {
+      localStorage.setItem(getStartedPassedKey, 'true');
+      setHasPassedGetStarted(true);
+    } catch {
+      // ignore
+    }
+  }, [projectId, getStartedPassedKey, hasPassedGetStarted, todoHasData]);
 
   const completedSteps = useMemo(
     () => [

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -440,13 +440,16 @@ export default function CTestDashboardPage() {
   );
 
   const handleDismissStepper = useCallback(() => {
+    if (projectId === undefined) {
+      return;
+    }
     setIsStepperDismissed(true);
     try {
       localStorage.setItem(stepperDismissKey, 'true');
     } catch {
       // ignore
     }
-  }, [stepperDismissKey]);
+  }, [projectId, stepperDismissKey]);
 
   const displayApiKey = isApiKeyLoading ? 'ik_' + '*'.repeat(32) : apiKey || '';
   const appUrl = getBackendUrl();

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -20,8 +20,11 @@ import DiscordIcon from '../../../assets/logos/discord.svg?react';
 
 // --- Prompt Stepper Data ---
 
+type StepKey = 'database' | 'auth' | 'storage' | 'ai' | 'deployment';
+
 interface PromptStep {
   id: number;
+  key: StepKey;
   category: string;
   title: string;
   prompt: string;
@@ -32,6 +35,7 @@ interface PromptStep {
 const PROMPT_STEPS: PromptStep[] = [
   {
     id: 1,
+    key: 'database',
     category: 'Database',
     title: 'Add sample data',
     prompt:
@@ -41,6 +45,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 2,
+    key: 'auth',
     category: 'Authentication',
     title: 'Sign up your first user',
     prompt:
@@ -50,6 +55,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 3,
+    key: 'storage',
     category: 'Storage',
     title: 'Upload a file',
     prompt:
@@ -59,6 +65,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 4,
+    key: 'ai',
     category: 'Model Gateway',
     title: 'Add LLM feature',
     prompt:
@@ -68,6 +75,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 5,
+    key: 'deployment',
     category: 'Deployment',
     title: 'Deploy your site',
     prompt:
@@ -82,6 +90,9 @@ const getStepperDismissKey = (projectId?: string) =>
 
 const getGetStartedPassedKey = (projectId?: string) =>
   `insforge-ctest-get-started-passed-${projectId || 'default'}`;
+
+const getStepCompletedKey = (projectId?: string) =>
+  `insforge-ctest-step-completed-${projectId || 'default'}`;
 
 // --- Sub-components ---
 
@@ -347,9 +358,13 @@ export default function CTestDashboardPage() {
   const { projectId } = useProjectId();
   const stepperDismissKey = getStepperDismissKey(projectId ?? undefined);
   const getStartedPassedKey = getGetStartedPassedKey(projectId ?? undefined);
+  const stepCompletedKey = getStepCompletedKey(projectId ?? undefined);
 
   const [isStepperDismissed, setIsStepperDismissed] = useState(false);
   const [hasPassedGetStarted, setHasPassedGetStarted] = useState(false);
+  const [stickyCompletedSteps, setStickyCompletedSteps] = useState<
+    Partial<Record<StepKey, boolean>>
+  >({});
 
   useEffect(() => {
     if (projectId === undefined) {
@@ -374,6 +389,32 @@ export default function CTestDashboardPage() {
       // ignore
     }
   }, [projectId, getStartedPassedKey]);
+
+  useEffect(() => {
+    if (projectId === undefined) {
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(stepCompletedKey);
+      if (!raw) {
+        setStickyCompletedSteps({});
+        return;
+      }
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        Object.values(parsed).every((v) => typeof v === 'boolean')
+      ) {
+        setStickyCompletedSteps(parsed as Partial<Record<StepKey, boolean>>);
+      } else {
+        setStickyCompletedSteps({});
+      }
+    } catch {
+      setStickyCompletedSteps({});
+    }
+  }, [projectId, stepCompletedKey]);
 
   const shouldShowLoadingState =
     isMetadataLoading ||
@@ -428,16 +469,48 @@ export default function CTestDashboardPage() {
     }
   }, [projectId, getStartedPassedKey, hasPassedGetStarted, todoHasData]);
 
-  const completedSteps = useMemo(
-    () => [
-      todoStepComplete,
-      (totalUsers ?? 0) >= 1,
-      (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
-      (aiUsageSummary?.totalRequests ?? 0) > 0,
-      !!currentDeploymentId,
-    ],
+  const liveCompletedSteps = useMemo<Record<StepKey, boolean>>(
+    () => ({
+      database: todoStepComplete,
+      auth: (totalUsers ?? 0) >= 1,
+      storage:
+        (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
+      ai: (aiUsageSummary?.totalRequests ?? 0) > 0,
+      deployment: !!currentDeploymentId,
+    }),
     [todoStepComplete, totalUsers, storage, aiUsageSummary, currentDeploymentId]
   );
+
+  const completedSteps = useMemo<boolean[]>(
+    () =>
+      PROMPT_STEPS.map(
+        (step) => liveCompletedSteps[step.key] || stickyCompletedSteps[step.key] === true
+      ),
+    [liveCompletedSteps, stickyCompletedSteps]
+  );
+
+  useEffect(() => {
+    if (projectId === undefined) {
+      return;
+    }
+    const merged: Partial<Record<StepKey, boolean>> = { ...stickyCompletedSteps };
+    let changed = false;
+    for (const step of PROMPT_STEPS) {
+      if (liveCompletedSteps[step.key] && !merged[step.key]) {
+        merged[step.key] = true;
+        changed = true;
+      }
+    }
+    if (!changed) {
+      return;
+    }
+    setStickyCompletedSteps(merged);
+    try {
+      localStorage.setItem(stepCompletedKey, JSON.stringify(merged));
+    } catch {
+      // ignore
+    }
+  }, [projectId, stepCompletedKey, liveCompletedSteps, stickyCompletedSteps]);
 
   const handleDismissStepper = useCallback(() => {
     if (projectId === undefined) {

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -414,19 +414,22 @@ export default function CTestDashboardPage() {
   const bucketCount = storage?.buckets?.length ?? 0;
   const functionCount = metadata?.functions.length ?? 0;
 
-  // Todo table has at least 4 records — triggers transition from Get Started to full dashboard
-  const todoHasData = (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) >= 4;
+  const todoRecordCount = tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0;
+  // Any todo record → transition away from Get Started to full dashboard
+  const todoHasData = todoRecordCount > 0;
+  // Step 1 completion requires at least 4 records
+  const todoStepComplete = todoRecordCount >= 4;
   const shouldShowGetStarted = !metadataError && !todoHasData;
 
   const completedSteps = useMemo(
     () => [
-      todoHasData,
+      todoStepComplete,
       (totalUsers ?? 0) >= 1,
       (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
       (aiUsageSummary?.totalRequests ?? 0) > 0,
       !!currentDeploymentId,
     ],
-    [todoHasData, totalUsers, storage, aiUsageSummary, currentDeploymentId]
+    [todoStepComplete, totalUsers, storage, aiUsageSummary, currentDeploymentId]
   );
 
   const handleDismissStepper = useCallback(() => {

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -2,16 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge, Button, CopyButton } from '@insforge/ui';
 import { Skeleton } from '../../../components';
-import {
-  Braces,
-  Check,
-  Database,
-  ExternalLink,
-  HardDrive,
-  User,
-  Sparkles,
-  Rocket,
-} from 'lucide-react';
+import { Braces, Database, ExternalLink, HardDrive, User, Sparkles, Rocket } from 'lucide-react';
 import StepUserIcon from '../../../assets/icons/step_user.svg?react';
 import StepUploadIcon from '../../../assets/icons/step_upload.svg?react';
 import { useMetadata, useApiKey, useProjectId } from '../../../lib/hooks/useMetadata';
@@ -31,6 +22,7 @@ import DiscordIcon from '../../../assets/logos/discord.svg?react';
 
 interface PromptStep {
   id: number;
+  category: string;
   title: string;
   prompt: string;
   icon: React.ReactNode;
@@ -40,6 +32,7 @@ interface PromptStep {
 const PROMPT_STEPS: PromptStep[] = [
   {
     id: 1,
+    category: 'Database',
     title: 'Add sample data',
     prompt:
       "Use InsForge Skills to add 4 todo items to InsForge backend's todo table:\n\n1. Add sign in for users\n2. Add file upload\n3. Use AI to turn text into tasks\n4. Deploy your app",
@@ -48,6 +41,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 2,
+    category: 'Authentication',
     title: 'Sign up your first user',
     prompt:
       'Use InsForge Skills to add user authentication to this app using InsForge Auth.\n\nUsers should be able to:\n1. Sign up / Sign in with Email\n2. Add Google OAuth\n3. Sign out\n\nAlso update the database and access control so each record belongs to a user:\n1. Add a `user_id` column to the relevant table(s)\n2. Set `user_id` automatically when a new record is created\n3. Restrict reads and writes so users can only access their own data\n4. Add the required row level security policies for this\n\nUpdate the app UI and backend logic so authentication is fully wired up and only signed in users can create and view their own records.',
@@ -56,6 +50,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 3,
+    category: 'Storage',
     title: 'Upload a file',
     prompt:
       'Use InsForge Skills to add file upload to this app.\nUsers should be able to upload a file and attach it to a task.\nShow the uploaded file in the task UI.\nUse InsForge Storage for file uploads.',
@@ -64,6 +59,7 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 4,
+    category: 'Model Gateway',
     title: 'Add LLM feature',
     prompt:
       'Use InsForge Skills to add an AI feature to this todo app that turns text into tasks using the InsForge AI Gateway.\nUsers should be able to type natural language and have the app create one or more todo items automatically.',
@@ -72,7 +68,8 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 5,
-    title: 'Deploy your app',
+    category: 'Deployment',
+    title: 'Deploy your site',
     prompt:
       'Use InsForge Skills to deploy this app on InsForge, after deploying, share the live URL.',
     icon: <Rocket className="size-12 text-[rgb(var(--disabled))]" />,
@@ -190,26 +187,6 @@ function PromptDisplay({ text }: { text: string }) {
   );
 }
 
-// --- Step circle ---
-
-function StepCircle({ completed, active }: { completed: boolean; active: boolean }) {
-  if (completed) {
-    return (
-      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 border-primary">
-        <Check className="h-3 w-3 text-primary" />
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className={`h-5 w-5 shrink-0 rounded-full border-2 ${
-        active ? 'border-primary' : 'border-muted-foreground/40'
-      }`}
-    />
-  );
-}
-
 // --- Prompt Stepper ---
 
 interface PromptStepperProps {
@@ -229,7 +206,7 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <p className="text-[20px] font-medium leading-7 text-foreground">
-            Congratulations! Your backend has been successfully set up.
+            Start building with Prompts
           </p>
           {allCompleted ? (
             <Button
@@ -252,7 +229,7 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
           ) : null}
         </div>
         <p className="text-[13px] leading-[18px] text-muted-foreground">
-          Now open your coding agent and start building your project with prompts
+          Copy these prompts into your agent to explore what InsForge can do
         </p>
       </div>
 
@@ -270,12 +247,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
                   isActive ? 'bg-[var(--special-toast,#323232)]' : 'hover:bg-[var(--alpha-4)]'
                 }`}
               >
-                <div className="flex items-center gap-1">
-                  <StepCircle completed={!!isCompleted} active={isActive} />
+                <div className="flex items-center">
                   <span
-                    className={`text-sm leading-5 ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
+                    className={`rounded bg-[var(--alpha-8)] px-1.5 py-0.5 text-xs leading-5 ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
                   >
-                    Step {step.id}
+                    {step.category}
                   </span>
                 </div>
                 <p

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -305,7 +305,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
                 <Button
                   type="button"
                   size="sm"
-                  onClick={() => void navigate(currentStep.navigateTo!.path)}
+                  onClick={() => {
+                    if (currentStep.navigateTo) {
+                      void navigate(currentStep.navigateTo.path);
+                    }
+                  }}
                   className="h-9 rounded border border-[var(--alpha-8)] bg-transparent px-3 text-sm font-medium text-foreground hover:bg-[var(--alpha-4)]"
                 >
                   {currentStep.navigateTo.label}
@@ -412,6 +416,7 @@ export default function CTestDashboardPage() {
 
   // Todo table has at least 4 records — triggers transition from Get Started to full dashboard
   const todoHasData = (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) >= 4;
+  const shouldShowGetStarted = !metadataError && !todoHasData;
 
   const completedSteps = useMemo(
     () => [
@@ -441,7 +446,7 @@ export default function CTestDashboardPage() {
   }
 
   // Phase 1: Todo has no data — show centered Get Started with 4 steps
-  if (!todoHasData) {
+  if (shouldShowGetStarted) {
     return (
       <main className="flex h-full min-h-0 min-w-0 flex-col bg-semantic-0">
         <div className="flex flex-1 flex-col items-center overflow-y-auto pt-[120px]">

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -410,8 +410,8 @@ export default function CTestDashboardPage() {
   const bucketCount = storage?.buckets?.length ?? 0;
   const functionCount = metadata?.functions.length ?? 0;
 
-  // Todo table has data — triggers transition from Get Started to full dashboard
-  const todoHasData = (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) > 0;
+  // Todo table has at least 4 records — triggers transition from Get Started to full dashboard
+  const todoHasData = (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) >= 4;
 
   const completedSteps = useMemo(
     () => [

--- a/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/CTestDashboardPage.tsx
@@ -473,8 +473,7 @@ export default function CTestDashboardPage() {
     () => ({
       database: todoStepComplete,
       auth: (totalUsers ?? 0) >= 1,
-      storage:
-        (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
+      storage: (storage?.buckets?.find((b) => b.name === 'todo-attachments')?.objectCount ?? 0) > 0,
       ai: (aiUsageSummary?.totalRequests ?? 0) > 0,
       deployment: !!currentDeploymentId,
     }),

--- a/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
@@ -316,7 +316,11 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
                 <Button
                   type="button"
                   size="sm"
-                  onClick={() => void navigate(currentStep.navigateTo!.path)}
+                  onClick={() => {
+                    if (currentStep.navigateTo) {
+                      void navigate(currentStep.navigateTo.path);
+                    }
+                  }}
                   className="h-9 rounded border border-[var(--alpha-8)] bg-transparent px-3 text-sm font-medium text-foreground hover:bg-[var(--alpha-4)]"
                 >
                   {currentStep.navigateTo.label}

--- a/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
@@ -33,6 +33,7 @@ interface PromptStep {
   title: string;
   prompt: string;
   icon: React.ReactNode;
+  navigateTo?: { label: string; path: string };
 }
 
 const PROMPT_STEPS: PromptStep[] = [
@@ -42,6 +43,7 @@ const PROMPT_STEPS: PromptStep[] = [
     prompt:
       "Use InsForge Skills to add 4 todo items to InsForge backend's todo table:\n\n1. Add sign in for users\n2. Add file upload\n3. Use AI to turn text into tasks\n4. Deploy your app",
     icon: <Database className="size-12 text-[rgb(var(--disabled))]" />,
+    navigateTo: { label: 'Go to Database', path: '/dashboard/database/tables' },
   },
   {
     id: 2,
@@ -49,6 +51,7 @@ const PROMPT_STEPS: PromptStep[] = [
     prompt:
       'Use InsForge Skills to add user authentication to this app using InsForge Auth.\n\nUsers should be able to:\n1. Sign up / Sign in with Email\n2. Add Google OAuth\n3. Sign out\n\nAlso update the database and access control so each record belongs to a user:\n1. Add a `user_id` column to the relevant table(s)\n2. Set `user_id` automatically when a new record is created\n3. Restrict reads and writes so users can only access their own data\n4. Add the required row level security policies for this\n\nUpdate the app UI and backend logic so authentication is fully wired up and only signed in users can create and view their own records.',
     icon: <StepUserIcon className="size-12 text-[rgb(var(--disabled))]" />,
+    navigateTo: { label: 'Go to User', path: '/dashboard/authentication/users' },
   },
   {
     id: 3,
@@ -56,6 +59,7 @@ const PROMPT_STEPS: PromptStep[] = [
     prompt:
       'Use InsForge Skills to add file upload to this app.\nUsers should be able to upload a file and attach it to a task.\nShow the uploaded file in the task UI.\nUse InsForge Storage for file uploads.',
     icon: <StepUploadIcon className="size-12 text-[rgb(var(--disabled))]" />,
+    navigateTo: { label: 'Go to Storage', path: '/dashboard/storage' },
   },
   {
     id: 4,
@@ -63,6 +67,7 @@ const PROMPT_STEPS: PromptStep[] = [
     prompt:
       'Use InsForge Skills to add an AI feature to this todo app that turns text into tasks using the InsForge AI Gateway.\nUsers should be able to type natural language and have the app create one or more todo items automatically.',
     icon: <Sparkles className="size-12 text-[rgb(var(--disabled))]" />,
+    navigateTo: { label: 'Go to Model Gateway', path: '/dashboard/ai' },
   },
   {
     id: 5,
@@ -70,6 +75,7 @@ const PROMPT_STEPS: PromptStep[] = [
     prompt:
       'Use InsForge Skills to deploy this app on InsForge, after deploying, share the live URL.',
     icon: <Rocket className="size-12 text-[rgb(var(--disabled))]" />,
+    navigateTo: { label: 'Go to Deployment', path: '/dashboard/deployments' },
   },
 ];
 
@@ -215,6 +221,7 @@ interface PromptStepperProps {
 }
 
 function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: PromptStepperProps) {
+  const navigate = useNavigate();
   const [activeStep, setActiveStep] = useState(0);
   const currentStep = PROMPT_STEPS[activeStep];
   const allCompleted = completedSteps.every(Boolean);
@@ -296,14 +303,26 @@ function PromptStepper({ onDismiss, completedSteps, showDismiss = false }: Promp
             {/* Prompt text */}
             <PromptDisplay text={currentStep.prompt} />
 
-            {/* Copy Prompt button */}
-            <CopyButton
-              text={currentStep.prompt}
-              showText
-              copyText="Copy Prompt"
-              copiedText="Copied!"
-              className="h-9 rounded bg-primary px-2 text-sm font-medium text-[rgb(var(--inverse))] hover:bg-primary/90"
-            />
+            {/* Action buttons */}
+            <div className="flex items-center gap-2">
+              <CopyButton
+                text={currentStep.prompt}
+                showText
+                copyText="Copy Prompt"
+                copiedText="Copied!"
+                className="h-9 rounded bg-primary px-2 text-sm font-medium text-[rgb(var(--inverse))] hover:bg-primary/90"
+              />
+              {currentStep.navigateTo && (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => void navigate(currentStep.navigateTo!.path)}
+                  className="h-9 rounded border border-[var(--alpha-8)] bg-transparent px-3 text-sm font-medium text-foreground hover:bg-[var(--alpha-4)]"
+                >
+                  {currentStep.navigateTo.label}
+                </Button>
+              )}
+            </div>
           </div>
 
           {/* Decorative background graphic */}

--- a/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/NewDashboardPage.tsx
@@ -429,8 +429,8 @@ export default function NewDashboardPage() {
   // --- Step completion detection (real-time via socket → React Query invalidation) ---
   const completedSteps = useMemo(
     () => [
-      // Step 1: Add sample data — todo table has records
-      (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) > 0,
+      // Step 1: Add sample data — todo table has at least 4 records
+      (tables?.find((t) => t.tableName === 'todo')?.recordCount ?? 0) >= 4,
       // Step 2: Sign up first user — totalUsers already excludes admin & anon
       (totalUsers ?? 0) >= 1,
       // Step 3: Upload a file — todo-attachments bucket has files

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -12,6 +12,7 @@ export type {
   DashboardMode,
   DashboardProjectInfo,
   DashboardProps,
+  DashboardUserInfo,
   InsForgeDashboardProps,
   SelfHostingDashboardProps,
 } from './types';

--- a/packages/dashboard/src/layout/AppLayout.tsx
+++ b/packages/dashboard/src/layout/AppLayout.tsx
@@ -97,7 +97,8 @@ export default function AppLayout({ children }: LayoutProps) {
             </main>
           </div>
         </div>
-        {getFeatureFlag('dashboard-v2-experiment') === 'test' ? (
+        {getFeatureFlag('dashboard-v2-experiment') === 'test' ||
+        getFeatureFlag('dashboard-v2-experiment') === 'c_test' ? (
           <ConnectDialogV2 open={isConnectDialogOpen} onOpenChange={setIsConnectDialogOpen} />
         ) : (
           <ConnectDialog open={isConnectDialogOpen} onOpenChange={setIsConnectDialogOpen} />

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -30,13 +30,15 @@ export const identifyUser = (
     return Promise.resolve();
   }
   posthog.identify(userId, properties);
-  return new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => resolve(), 5000);
-    posthog.onFeatureFlags(() => {
-      clearTimeout(timeout);
-      resolve();
-    });
-  });
+  // posthog.identify triggers a new /decide request for the identified user.
+  // Wait for it to complete before returning, so callers can rely on
+  // getFeatureFlag returning the post-identify variant.
+  //
+  // Do NOT use posthog.onFeatureFlags here: if PostHog already loaded flags
+  // for the anonymous device id (which happens on init), onFeatureFlags fires
+  // synchronously with that stale cache. Await would resolve immediately and
+  // the next getFeatureFlag would return the anonymous variant.
+  return new Promise<void>((resolve) => setTimeout(resolve, 2000));
 };
 
 export const trackPostHog = (eventName: string, properties?: Record<string, unknown>) => {

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -1,7 +1,5 @@
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
-import { useEffect } from 'react';
-import { isIframe } from '../utils/utils';
 
 const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY || '';
 
@@ -11,57 +9,27 @@ if (POSTHOG_KEY) {
       api_host: 'https://us.i.posthog.com',
       capture_exceptions: true,
       debug: import.meta.env.DEV,
-      session_recording: {
-        recordCrossOriginIframes: true,
-      },
     });
   } catch (error) {
     console.error('[PostHog] ❌ Error initializing PostHog', error);
   }
 }
 
-// Module-level flag to survive React StrictMode remounts
-let hasIdentifiedUser = false;
-
 export const PostHogAnalyticsProvider = ({ children }: { children: React.ReactNode }) => {
-  useEffect(() => {
-    if (!isIframe() || !POSTHOG_KEY) {
-      return;
-    }
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type !== 'USER_INFO') {
-        return;
-      }
-
-      const { userId, email, name } = event.data;
-      if (hasIdentifiedUser) {
-        return;
-      }
-
-      posthog.identify(userId, { email, name });
-      hasIdentifiedUser = true;
-    };
-
-    window.addEventListener('message', handleMessage);
-
-    const sendRequest = () => {
-      if (!hasIdentifiedUser) {
-        window.parent.postMessage({ type: 'REQUEST_USER_INFO' }, '*');
-      }
-    };
-
-    sendRequest();
-
-    return () => {
-      window.removeEventListener('message', handleMessage);
-    };
-  }, []);
-
   if (POSTHOG_KEY) {
     return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
   }
   return <>{children}</>;
+};
+
+export const identifyUser = (userId: string, properties?: Record<string, unknown>) => {
+  if (!POSTHOG_KEY) {
+    return Promise.resolve();
+  }
+  posthog.identify(userId, properties);
+  return new Promise<void>((resolve) => {
+    posthog.onFeatureFlags(() => resolve());
+  });
 };
 
 export const trackPostHog = (eventName: string, properties?: Record<string, unknown>) => {

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -22,13 +22,20 @@ export const PostHogAnalyticsProvider = ({ children }: { children: React.ReactNo
   return <>{children}</>;
 };
 
-export const identifyUser = (userId: string, properties?: Record<string, unknown>) => {
+export const identifyUser = (
+  userId: string,
+  properties?: Record<string, unknown>
+): Promise<void> => {
   if (!POSTHOG_KEY) {
     return Promise.resolve();
   }
   posthog.identify(userId, properties);
   return new Promise<void>((resolve) => {
-    posthog.onFeatureFlags(() => resolve());
+    const timeout = setTimeout(() => resolve(), 5000);
+    posthog.onFeatureFlags(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
   });
 };
 

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -29,16 +29,43 @@ export const identifyUser = (
   if (!POSTHOG_KEY) {
     return Promise.resolve();
   }
-  posthog.identify(userId, properties);
-  // posthog.identify triggers a new /decide request for the identified user.
-  // Wait for it to complete before returning, so callers can rely on
-  // getFeatureFlag returning the post-identify variant.
+
+  // Detect whether feature flags are already loaded in posthog-js. When we
+  // register a callback via onFeatureFlags, posthog-js fires it synchronously
+  // with cached flags if a prior /decide has already completed (typically the
+  // anonymous-id init request). We use this to decide whether to skip the
+  // "stale" first callback and wait for the next one (triggered by the
+  // identify-initiated /decide).
   //
-  // Do NOT use posthog.onFeatureFlags here: if PostHog already loaded flags
-  // for the anonymous device id (which happens on init), onFeatureFlags fires
-  // synchronously with that stale cache. Await would resolve immediately and
-  // the next getFeatureFlag would return the anonymous variant.
-  return new Promise<void>((resolve) => setTimeout(resolve, 2000));
+  // DEPENDENCY: relies on posthog-js's sync-fire-if-loaded behavior for
+  // onFeatureFlags. Verified in posthog-js 1.364.x. If upgrading posthog-js
+  // major version, re-verify this behavior in the changelog.
+  let preloaded = false;
+  posthog.onFeatureFlags(() => {
+    preloaded = true;
+  });
+  const target = preloaded ? 2 : 1;
+
+  posthog.identify(userId, properties);
+
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => resolve(), 5000);
+    let fires = 0;
+    posthog.onFeatureFlags(() => {
+      fires++;
+      if (fires >= target) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+  });
+};
+
+export const getCurrentDistinctId = (): string | undefined => {
+  if (!POSTHOG_KEY) {
+    return undefined;
+  }
+  return posthog.get_distinct_id();
 };
 
 export const trackPostHog = (eventName: string, properties?: Record<string, unknown>) => {

--- a/packages/dashboard/src/lib/config/DashboardHostContext.tsx
+++ b/packages/dashboard/src/lib/config/DashboardHostContext.tsx
@@ -1,5 +1,10 @@
 import { createContext, useContext } from 'react';
-import type { DashboardInstanceInfo, DashboardMode, DashboardProjectInfo } from '../../types';
+import type {
+  DashboardInstanceInfo,
+  DashboardMode,
+  DashboardProjectInfo,
+  DashboardUserInfo,
+} from '../../types';
 
 interface DashboardHostContextValue {
   backendUrl?: string;
@@ -16,6 +21,7 @@ interface DashboardHostContextValue {
     instanceType: string
   ) => Promise<{ success: boolean; instanceType?: string; error?: string }>;
   onUpdateVersion?: () => Promise<void>;
+  onRequestUserInfo?: () => Promise<DashboardUserInfo>;
 }
 
 const DashboardHostContext = createContext<DashboardHostContextValue | null>(null);

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { loginService } from '../../features/login/services/login.service';
 import { useDashboardHost } from '../config/DashboardHostContext';
 import { apiClient } from '../api/client';
+import { identifyUser } from '../analytics/posthog';
 import type { UserSchema } from '@insforge/shared-schemas';
 
 interface AuthContextType {
@@ -70,6 +71,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const applyAuthenticatedUser = useCallback(
     async (nextUser: UserSchema): Promise<void> => {
+      await identifyUser(nextUser.id, { email: nextUser.email, name: nextUser.profile?.name });
       setUser(nextUser);
       setIsAuthenticated(true);
       await invalidateAuthQueries();
@@ -161,6 +163,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const currentUser = await loginService.getCurrentUser();
       if (currentUser) {
+        await identifyUser(currentUser.id, { email: currentUser.email, name: currentUser.profile?.name });
         setUser(currentUser);
         setIsAuthenticated(true);
         return currentUser;

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -35,6 +35,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const host = useDashboardHost();
   const isCloudHosting = host.mode === 'cloud-hosting';
   const getAuthorizationCode = isCloudHosting ? host.getAuthorizationCode : null;
+  const onRequestUserInfo = isCloudHosting ? host.onRequestUserInfo : undefined;
   const location = useLocation();
   const [user, setUser] = useState<UserSchema | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
@@ -69,14 +70,29 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     ]);
   }, [queryClient]);
 
+  const performPostHogIdentify = useCallback(async (): Promise<void> => {
+    if (!onRequestUserInfo) {
+      return;
+    }
+    try {
+      const cloudUser = await onRequestUserInfo();
+      await identifyUser(cloudUser.userId, {
+        email: cloudUser.email,
+        name: cloudUser.name,
+      });
+    } catch (err) {
+      console.warn('[PostHog] Failed to identify cloud user', err);
+    }
+  }, [onRequestUserInfo]);
+
   const applyAuthenticatedUser = useCallback(
     async (nextUser: UserSchema): Promise<void> => {
-      await identifyUser(nextUser.id, { email: nextUser.email, name: nextUser.profile?.name });
+      await performPostHogIdentify();
       setUser(nextUser);
       setIsAuthenticated(true);
       await invalidateAuthQueries();
     },
-    [invalidateAuthQueries]
+    [invalidateAuthQueries, performPostHogIdentify]
   );
 
   const exchangeAuthorizationCode = useCallback(
@@ -163,10 +179,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const currentUser = await loginService.getCurrentUser();
       if (currentUser) {
-        await identifyUser(currentUser.id, {
-          email: currentUser.email,
-          name: currentUser.profile?.name,
-        });
+        await performPostHogIdentify();
         setUser(currentUser);
         setIsAuthenticated(true);
         return currentUser;
@@ -190,7 +203,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } finally {
       setIsLoading(false);
     }
-  }, [authenticateCloudSession, shouldAttemptCloudAuthentication]);
+  }, [authenticateCloudSession, performPostHogIdentify, shouldAttemptCloudAuthentication]);
 
   const logout = useCallback(async () => {
     await loginService.logout();

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { loginService } from '../../features/login/services/login.service';
 import { useDashboardHost } from '../config/DashboardHostContext';
 import { apiClient } from '../api/client';
-import { identifyUser } from '../analytics/posthog';
+import { getCurrentDistinctId, identifyUser } from '../analytics/posthog';
 import type { UserSchema } from '@insforge/shared-schemas';
 
 interface AuthContextType {
@@ -76,6 +76,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
     try {
       const cloudUser = await onRequestUserInfo();
+      // Skip identify + /decide wait if posthog-js is already identified as
+      // this user (common on F5 refresh or same-session re-mount): calling
+      // posthog.identify with the same id is a no-op, so the counter-based
+      // wait would hit its 5s timeout for nothing.
+      if (getCurrentDistinctId() === cloudUser.userId) {
+        return;
+      }
       await identifyUser(cloudUser.userId, {
         email: cloudUser.email,
         name: cloudUser.name,

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -163,7 +163,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const currentUser = await loginService.getCurrentUser();
       if (currentUser) {
-        await identifyUser(currentUser.id, { email: currentUser.email, name: currentUser.profile?.name });
+        await identifyUser(currentUser.id, {
+          email: currentUser.email,
+          name: currentUser.profile?.name,
+        });
         setUser(currentUser);
         setIsAuthenticated(true);
         return currentUser;

--- a/packages/dashboard/src/lib/utils/utils.ts
+++ b/packages/dashboard/src/lib/utils/utils.ts
@@ -160,10 +160,6 @@ export function isEmptyValue(value: unknown): boolean {
   return value === null || value === undefined;
 }
 
-export const isIframe = () => {
-  return window.self !== window.top;
-};
-
 export const isInsForgeCloudProject = () => {
   try {
     return new URL(getDashboardBackendUrl()).hostname.endsWith('.insforge.app');

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -5,7 +5,6 @@ import LoginPage from '../features/login/pages/LoginPage';
 import CloudLoginPage from '../features/login/pages/CloudLoginPage';
 import DashboardLayout from '../features/dashboard/components/DashboardLayout';
 import DashboardPage from '../features/dashboard/pages/DashboardPage';
-import NewDashboardPage from '../features/dashboard/pages/NewDashboardPage';
 import CTestDashboardPage from '../features/dashboard/pages/CTestDashboardPage';
 import { getFeatureFlag } from '../lib/analytics/posthog';
 import DatabaseLayout from '../features/database/components/DatabaseLayout';
@@ -49,11 +48,9 @@ import DeploymentDomainsPage from '../features/deployments/pages/DeploymentDomai
 function AuthenticatedRoutes() {
   const dashboardVariant = getFeatureFlag('dashboard-v2-experiment');
   const DashboardHomePage =
-    dashboardVariant === 'c_test'
+    dashboardVariant === 'c_test' || dashboardVariant === 'test'
       ? CTestDashboardPage
-      : dashboardVariant === 'test'
-        ? NewDashboardPage
-        : DashboardPage;
+      : DashboardPage;
 
   return (
     <AppLayout>

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -46,7 +46,7 @@ import DeploymentOverviewPage from '../features/deployments/pages/DeploymentOver
 import DeploymentEnvVarsPage from '../features/deployments/pages/DeploymentEnvVarsPage';
 import DeploymentDomainsPage from '../features/deployments/pages/DeploymentDomainsPage';
 
-export function AppRoutes() {
+function AuthenticatedRoutes() {
   const dashboardVariant = getFeatureFlag('dashboard-v2-experiment');
   const DashboardHomePage =
     dashboardVariant === 'c_test'
@@ -56,6 +56,77 @@ export function AppRoutes() {
         : DashboardPage;
 
   return (
+    <AppLayout>
+      <Routes>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<DashboardLayout />}>
+          <Route index element={<DashboardHomePage />} />
+        </Route>
+        <Route path="/dashboard/authentication" element={<AuthenticationLayout />}>
+          <Route index element={<Navigate to="users" replace />} />
+          <Route path="users" element={<UsersPage />} />
+          <Route path="auth-methods" element={<AuthMethodsPage />} />
+          <Route path="email" element={<EmailPage />} />
+        </Route>
+        <Route path="/dashboard/database" element={<DatabaseLayout />}>
+          <Route index element={<Navigate to="tables" replace />} />
+          <Route path="tables" element={<TablesPage />} />
+          <Route path="indexes" element={<IndexesPage />} />
+          <Route path="functions" element={<DatabaseFunctionsPage />} />
+          <Route path="triggers" element={<TriggersPage />} />
+          <Route path="policies" element={<PoliciesPage />} />
+          <Route
+            path="sql-editor"
+            element={<Navigate to="/dashboard/sql-editor" replace />}
+          />
+          <Route path="templates" element={<TemplatesPage />} />
+        </Route>
+        <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>
+          <Route index element={<SQLEditorPage />} />
+        </Route>
+        <Route path="/dashboard/storage" element={<StorageLayout />}>
+          <Route index element={<BucketsPage />} />
+        </Route>
+        <Route path="/dashboard/logs" element={<LogsLayout />}>
+          <Route index element={<Navigate to="MCP" replace />} />
+          <Route path="MCP" element={<MCPLogsPage />} />
+          <Route path="audits" element={<AuditsPage />} />
+          <Route path="function.logs" element={<FunctionLogsPage />} />
+          <Route path=":source" element={<LogsPage />} />
+        </Route>
+        <Route path="/dashboard/functions" element={<FunctionsLayout />}>
+          <Route index element={<Navigate to="list" replace />} />
+          <Route path="list" element={<FunctionsPage />} />
+          <Route path="secrets" element={<SecretsPage />} />
+          <Route path="schedules" element={<SchedulesPage />} />
+        </Route>
+        <Route path="/dashboard/visualizer" element={<VisualizerLayout />}>
+          <Route index element={<VisualizerPage />} />
+        </Route>
+        <Route path="/dashboard/ai" element={<AILayout />}>
+          <Route index element={<AIPage />} />
+        </Route>
+        <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
+          <Route index element={<Navigate to="channels" replace />} />
+          <Route path="channels" element={<RealtimeChannelsPage />} />
+          <Route path="messages" element={<RealtimeMessagesPage />} />
+          <Route path="permissions" element={<RealtimePermissionsPage />} />
+        </Route>
+        <Route path="/dashboard/deployments" element={<DeploymentsLayout />}>
+          <Route index element={<Navigate to="overview" replace />} />
+          <Route path="overview" element={<DeploymentOverviewPage />} />
+          <Route path="logs" element={<DeploymentLogsPage />} />
+          <Route path="env-vars" element={<DeploymentEnvVarsPage />} />
+          <Route path="domains" element={<DeploymentDomainsPage />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+      </Routes>
+    </AppLayout>
+  );
+}
+
+export function AppRoutes() {
+  return (
     <Routes>
       <Route path="/dashboard/login" element={<LoginPage />} />
       <Route path="/cloud/login" element={<CloudLoginPage />} />
@@ -63,72 +134,7 @@ export function AppRoutes() {
         path="/*"
         element={
           <RequireAuth>
-            <AppLayout>
-              <Routes>
-                <Route path="/" element={<Navigate to="/dashboard" replace />} />
-                <Route path="/dashboard" element={<DashboardLayout />}>
-                  <Route index element={<DashboardHomePage />} />
-                </Route>
-                <Route path="/dashboard/authentication" element={<AuthenticationLayout />}>
-                  <Route index element={<Navigate to="users" replace />} />
-                  <Route path="users" element={<UsersPage />} />
-                  <Route path="auth-methods" element={<AuthMethodsPage />} />
-                  <Route path="email" element={<EmailPage />} />
-                </Route>
-                <Route path="/dashboard/database" element={<DatabaseLayout />}>
-                  <Route index element={<Navigate to="tables" replace />} />
-                  <Route path="tables" element={<TablesPage />} />
-                  <Route path="indexes" element={<IndexesPage />} />
-                  <Route path="functions" element={<DatabaseFunctionsPage />} />
-                  <Route path="triggers" element={<TriggersPage />} />
-                  <Route path="policies" element={<PoliciesPage />} />
-                  <Route
-                    path="sql-editor"
-                    element={<Navigate to="/dashboard/sql-editor" replace />}
-                  />
-                  <Route path="templates" element={<TemplatesPage />} />
-                </Route>
-                <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>
-                  <Route index element={<SQLEditorPage />} />
-                </Route>
-                <Route path="/dashboard/storage" element={<StorageLayout />}>
-                  <Route index element={<BucketsPage />} />
-                </Route>
-                <Route path="/dashboard/logs" element={<LogsLayout />}>
-                  <Route index element={<Navigate to="MCP" replace />} />
-                  <Route path="MCP" element={<MCPLogsPage />} />
-                  <Route path="audits" element={<AuditsPage />} />
-                  <Route path="function.logs" element={<FunctionLogsPage />} />
-                  <Route path=":source" element={<LogsPage />} />
-                </Route>
-                <Route path="/dashboard/functions" element={<FunctionsLayout />}>
-                  <Route index element={<Navigate to="list" replace />} />
-                  <Route path="list" element={<FunctionsPage />} />
-                  <Route path="secrets" element={<SecretsPage />} />
-                  <Route path="schedules" element={<SchedulesPage />} />
-                </Route>
-                <Route path="/dashboard/visualizer" element={<VisualizerLayout />}>
-                  <Route index element={<VisualizerPage />} />
-                </Route>
-                <Route path="/dashboard/ai" element={<AILayout />}>
-                  <Route index element={<AIPage />} />
-                </Route>
-                <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
-                  <Route index element={<Navigate to="channels" replace />} />
-                  <Route path="channels" element={<RealtimeChannelsPage />} />
-                  <Route path="messages" element={<RealtimeMessagesPage />} />
-                  <Route path="permissions" element={<RealtimePermissionsPage />} />
-                </Route>
-                <Route path="/dashboard/deployments" element={<DeploymentsLayout />}>
-                  <Route index element={<Navigate to="overview" replace />} />
-                  <Route path="overview" element={<DeploymentOverviewPage />} />
-                  <Route path="logs" element={<DeploymentLogsPage />} />
-                  <Route path="env-vars" element={<DeploymentEnvVarsPage />} />
-                  <Route path="domains" element={<DeploymentDomainsPage />} />
-                </Route>
-                <Route path="*" element={<Navigate to="/dashboard" replace />} />
-              </Routes>
-            </AppLayout>
+            <AuthenticatedRoutes />
           </RequireAuth>
         }
       />

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -6,6 +6,7 @@ import CloudLoginPage from '../features/login/pages/CloudLoginPage';
 import DashboardLayout from '../features/dashboard/components/DashboardLayout';
 import DashboardPage from '../features/dashboard/pages/DashboardPage';
 import NewDashboardPage from '../features/dashboard/pages/NewDashboardPage';
+import CTestDashboardPage from '../features/dashboard/pages/CTestDashboardPage';
 import { getFeatureFlag } from '../lib/analytics/posthog';
 import DatabaseLayout from '../features/database/components/DatabaseLayout';
 import SQLEditorLayout from '../features/database/components/SQLEditorLayout';
@@ -47,7 +48,12 @@ import DeploymentDomainsPage from '../features/deployments/pages/DeploymentDomai
 
 export function AppRoutes() {
   const dashboardVariant = getFeatureFlag('dashboard-v2-experiment');
-  const DashboardHomePage = dashboardVariant === 'test' ? NewDashboardPage : DashboardPage;
+  const DashboardHomePage =
+    dashboardVariant === 'c_test'
+      ? CTestDashboardPage
+      : dashboardVariant === 'test'
+        ? NewDashboardPage
+        : DashboardPage;
 
   return (
     <Routes>

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -75,10 +75,7 @@ function AuthenticatedRoutes() {
           <Route path="functions" element={<DatabaseFunctionsPage />} />
           <Route path="triggers" element={<TriggersPage />} />
           <Route path="policies" element={<PoliciesPage />} />
-          <Route
-            path="sql-editor"
-            element={<Navigate to="/dashboard/sql-editor" replace />}
-          />
+          <Route path="sql-editor" element={<Navigate to="/dashboard/sql-editor" replace />} />
           <Route path="templates" element={<TemplatesPage />} />
         </Route>
         <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -10,6 +10,12 @@ export interface DashboardProjectInfo {
   status?: 'active' | 'paused' | 'restoring' | string;
 }
 
+export interface DashboardUserInfo {
+  userId: string;
+  email: string;
+  name?: string;
+}
+
 export interface DashboardInstanceInfo {
   currentInstanceType: string;
   planName: string;
@@ -45,6 +51,7 @@ export interface DashboardProps {
     instanceType: string
   ) => Promise<{ success: boolean; instanceType?: string; error?: string }>;
   onUpdateVersion?: () => Promise<void>;
+  onRequestUserInfo?: () => Promise<DashboardUserInfo>;
 }
 
 export interface SelfHostingDashboardProps extends DashboardProps {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
Test through tag: [v2.0.6-ctest8](https://github.com/InsForge/InsForge/tree/refs/tags/v2.0.6-ctest8)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add C-test variant dashboard page with guided onboarding stepper and PostHog user identification
> - Adds [`CTestDashboardPage`](https://github.com/InsForge/InsForge/pull/1105/files#diff-4e9c4112f6b73fce314f521f84a76f2100028f7f7f57c9aeb92ed38b6c18c848) as a new dashboard home variant for the `c_test` feature flag, showing a prompt stepper, metrics, and a conditional 'Get Started' flow with localStorage-based state.
> - Extends [`useCloudHosting`](https://github.com/InsForge/InsForge/pull/1105/files#diff-696cf7f283d2017f2417aca9430b653bcb9b61493c69d98a7c06ab011111aaa6) with a `requestUserInfo()` method that uses `postMessage` to fetch user info from the parent window, and threads `onRequestUserInfo` through the host context down to consumers.
> - Moves PostHog user identification out of the provider into [`AuthContext`](https://github.com/InsForge/InsForge/pull/1105/files#diff-6ce2102d4036093a54015c06956feace3bef491f11cc668ac3acd076263cd274), which now requests cloud user info via the host and calls `identifyUser()` before setting authenticated state, waiting for feature flags to resolve.
> - Updates [`AppRoutes`](https://github.com/InsForge/InsForge/pull/1105/files#diff-c22275f3f786ab893302862c0831269fc75644a99b6fbf59e3292d44e76e1433) and [`AppLayout`](https://github.com/InsForge/InsForge/pull/1105/files#diff-08f46d5c216b17b19fe069df8c2f8acea6dfa19ec01dd3d4477bd6649f33aeab) to route `c_test` and `test` flag values to the new dashboard and connect dialog.
> - Behavioral Change: PostHog identification no longer happens automatically via the provider's iframe listener; it now occurs explicitly during auth flow, which changes the timing of feature flag availability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c1ebe3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CTest dashboard: two-phase onboarding/loading, project header, metrics grid, and a five-step onboarding stepper with copy + navigate actions and per-project dismiss persistence
  * Cross-window user identification for analytics when embedded in an iframe
  * New flag-driven connect variant and an optional CTest mode for the CLI onboarding flow

* **UI Improvements**
  * Adjusted metric card spacing and simplified project health badge layout
  * Added a Discord help bar on the CTest onboarding screen

* **Routing**
  * Experiment routing updated to surface the CTest dashboard and connect variant for the c_test flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->