### PR TITLE
feat(functions): expose in-process dispatch + depth guard in router

### DIFF
--- a/backend/src/providers/functions/deno-subhosting.provider.ts
+++ b/backend/src/providers/functions/deno-subhosting.provider.ts
@@ -726,7 +726,7 @@ export default _legacyModule.exports as (req: Request) => Promise<Response>;
       // Empty router when no functions
       return `
 // Auto-generated router (no functions)
-Deno.serve(async (req: Request) => {
+const dispatch = async (req: Request): Promise<Response> => {
   const url = new URL(req.url);
   const pathname = url.pathname;
 
@@ -747,7 +747,11 @@ Deno.serve(async (req: Request) => {
     status: 404,
     headers: { "Content-Type": "application/json" }
   });
-});
+};
+
+(globalThis as any).__insforge_dispatch__ = dispatch;
+
+Deno.serve(dispatch);
 `;
     }
 
@@ -759,79 +763,102 @@ Deno.serve(async (req: Request) => {
 
     return `
 // Auto-generated router
+import { AsyncLocalStorage } from "node:async_hooks";
 ${imports}
 
 const routes: Record<string, (req: Request) => Promise<Response>> = {
 ${routes}
 };
 
-Deno.serve(async (req: Request) => {
-  const url = new URL(req.url);
-  const pathname = url.pathname;
+// Per-request call-depth tracking to catch recursive function invocations
+// (in-process dispatch bypasses Deno Subhosting's network-level 508 guard).
+const MAX_DEPTH = 8;
+const depthStore = new AsyncLocalStorage<number>();
 
-  // Health check
-  if (pathname === "/health" || pathname === "/") {
+const dispatch = async (req: Request): Promise<Response> => {
+  const currentDepth = depthStore.getStore() ?? 0;
+  if (currentDepth >= MAX_DEPTH) {
     return new Response(JSON.stringify({
-      status: "ok",
-      type: "insforge-functions",
-      functions: Object.keys(routes),
-      timestamp: new Date().toISOString(),
+      error: "Loop Detected",
+      message: "Function call depth exceeded " + MAX_DEPTH + ". Possible recursive invocation.",
     }), {
+      status: 508,
       headers: { "Content-Type": "application/json" }
     });
   }
 
-  // Extract function slug
-  const pathParts = pathname.split("/").filter(Boolean);
-  const slug = pathParts[0];
+  return await depthStore.run(currentDepth + 1, async () => {
+    const url = new URL(req.url);
+    const pathname = url.pathname;
 
-  if (!slug || !routes[slug]) {
-    return new Response(JSON.stringify({
-      error: "Function not found",
-      available: Object.keys(routes),
-    }), {
-      status: 404,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
-
-  // Execute function
-  try {
-    const handler = routes[slug];
-
-    // If there's a subpath, create modified request
-    const subpath = pathParts.slice(1).join("/");
-    let funcReq = req;
-    if (subpath) {
-      const newUrl = new URL(req.url);
-      newUrl.pathname = "/" + subpath;
-      funcReq = new Request(newUrl.toString(), req);
+    // Health check
+    if (pathname === "/health" || pathname === "/") {
+      return new Response(JSON.stringify({
+        status: "ok",
+        type: "insforge-functions",
+        functions: Object.keys(routes),
+        timestamp: new Date().toISOString(),
+      }), {
+        headers: { "Content-Type": "application/json" }
+      });
     }
 
-    const startTime = Date.now();
-    const response = await handler(funcReq);
-    const duration = Date.now() - startTime;
+    // Extract function slug
+    const pathParts = pathname.split("/").filter(Boolean);
+    const slug = pathParts[0];
 
-    console.log(JSON.stringify({
-      timestamp: new Date().toISOString(),
-      slug,
-      method: req.method,
-      status: response.status,
-      duration: duration + "ms",
-    }));
+    if (!slug || !routes[slug]) {
+      return new Response(JSON.stringify({
+        error: "Function not found",
+        available: Object.keys(routes),
+      }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
 
-    return response;
-  } catch (error) {
-    console.error("Function error:", error);
-    return new Response(JSON.stringify({
-      error: "Function execution failed",
-      message: (error as Error).message,
-    }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
-});
+    // Execute function
+    try {
+      const handler = routes[slug];
+
+      // If there's a subpath, create modified request
+      const subpath = pathParts.slice(1).join("/");
+      let funcReq = req;
+      if (subpath) {
+        const newUrl = new URL(req.url);
+        newUrl.pathname = "/" + subpath;
+        funcReq = new Request(newUrl.toString(), req);
+      }
+
+      const startTime = Date.now();
+      const response = await handler(funcReq);
+      const duration = Date.now() - startTime;
+
+      console.log(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        slug,
+        method: req.method,
+        status: response.status,
+        duration: duration + "ms",
+      }));
+
+      return response;
+    } catch (error) {
+      console.error("Function error:", error);
+      return new Response(JSON.stringify({
+        error: "Function execution failed",
+        message: (error as Error).message,
+      }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+};
+
+(globalThis as any).__insforge_dispatch__ = dispatch;
+
+Deno.serve(dispatch);
 `;
   }
 


### PR DESCRIPTION
## Summary

- Auto-generated router now publishes its dispatch handler on `globalThis.__insforge_dispatch__`, enabling the SDK to invoke sibling functions in-process and avoid Deno Subhosting's `508 Loop Detected` error when a function calls another function in the same deployment.
- Adds an `AsyncLocalStorage`-based depth counter (`MAX_DEPTH = 8`) that replaces the network-level loop guard which in-process calls bypass. Recursive invocations now return a meaningful `508` JSON response instead of stack-overflowing.
- Router logic (health check, slug lookup, subpath rewrite, request log, error wrapping) is unchanged — only wrapped in `depthStore.run(...)` and the callback is extracted into a named `dispatch` const.
- Empty-router branch also exposes `dispatch` on `globalThis` for shape consistency (no depth guard needed — no user code can recurse).

Pairs with SDK-side changes that probe for `__insforge_dispatch__` at `functions.invoke` time ([design doc](../insforge-sdk-js/docs/superpowers/specs/2026-04-15-functions-in-process-dispatch-design.md)).

## Backward compatibility

| SDK | Router | Behavior |
|---|---|---|
| Old | Old | HTTP, loop bug present (status quo) |
| New | Old | HTTP (global absent), loop bug present until router redeployed |
| Old | New | HTTP (old SDK ignores global), loop bug present until SDK updated |
| New | New | In-process dispatch, no loop |

Both sides degrade safely; no synchronized rollout required.

## Test plan

- [x] Deploy a project with two functions where function B calls function A via the SDK — confirm no `508 Loop Detected` from Deno
- [x] Verify external HTTP requests still route correctly (`/health`, `/{slug}`, `/{slug}/subpath`)
- [x] Verify a deliberately recursive function (A → A via SDK) returns `508` with `Loop Detected` body after 8 hops, not stack overflow
- [ ] Verify empty-function project still serves `/health` and returns `404` for other paths
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose `__insforge_dispatch__` globally and add call-depth guard to generated router
> - Refactors the generated `main.ts` in [`deno-subhosting.provider.ts`](https://github.com/InsForge/InsForge/pull/1106/files#diff-fa96ad9576e64eb8fa08927c7d329e7b917ec18ce6dca3147944d57c68ea9c16) to define a named `dispatch` async function, assign it to `globalThis.__insforge_dispatch__`, and pass it to `Deno.serve` instead of using an inline handler.
> - Adds a call-depth limit of 8 using `AsyncLocalStorage` from `node:async_hooks`; requests that exceed this depth return a 508 JSON error.
> - The empty-router case also adopts the `dispatch` exposure pattern without adding depth tracking.
> - Behavioral Change: routers now return HTTP 508 instead of looping indefinitely when recursive in-process dispatch exceeds depth 8.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20666ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added recursion depth monitoring to detect infinite request loops. When the maximum nesting level is exceeded, the service returns a "Loop Detected" error response to prevent system failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->