### PR TITLE
chore: require lint/typecheck/test before PR in insforge-dev skills

### DIFF
--- a/.agents/skills/insforge-dev/SKILL.md
+++ b/.agents/skills/insforge-dev/SKILL.md
@@ -51,3 +51,17 @@ Then use the narrowest package skill that matches the task:
 - `npm run typecheck` does not cover `packages/dashboard/` or `packages/shared-schemas/`, so run package-specific validation when either package changes.
 - Use the package-specific validation steps in the child skill when the work is isolated to one package.
 - When reporting back, state what changed, what you validated, and what you could not validate.
+
+## Pre-PR Checklist (Mandatory Before Pushing to a PR)
+
+Before opening a PR or pushing new commits to an existing PR branch, run **all** of the following from the repo root and do not proceed while any of them fail on files your change touches:
+
+1. `npx turbo run typecheck` — must pass across all packages.
+2. `npx turbo run lint` — must pass. If the failure is pre-existing in `main` and unrelated to your change, scope it:
+   - Run `npx eslint <your-changed-files>` and confirm your files are clean.
+   - Call out the pre-existing debt in the PR body so reviewers know it is not yours.
+   - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
+3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
+4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+
+Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/.claude/skills/insforge-dev/SKILL.md
+++ b/.claude/skills/insforge-dev/SKILL.md
@@ -51,3 +51,17 @@ Then use the narrowest package skill that matches the task:
 - `npm run typecheck` does not cover `packages/dashboard/` or `packages/shared-schemas/`, so run package-specific validation when either package changes.
 - Use the package-specific validation steps in the child skill when the work is isolated to one package.
 - When reporting back, state what changed, what you validated, and what you could not validate.
+
+## Pre-PR Checklist (Mandatory Before Pushing to a PR)
+
+Before opening a PR or pushing new commits to an existing PR branch, run **all** of the following from the repo root and do not proceed while any of them fail on files your change touches:
+
+1. `npx turbo run typecheck` — must pass across all packages.
+2. `npx turbo run lint` — must pass. If the failure is pre-existing in `main` and unrelated to your change, scope it:
+   - Run `npx eslint <your-changed-files>` and confirm your files are clean.
+   - Call out the pre-existing debt in the PR body so reviewers know it is not yours.
+   - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
+3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
+4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+
+Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/.codex/skills/insforge-dev/SKILL.md
+++ b/.codex/skills/insforge-dev/SKILL.md
@@ -51,3 +51,17 @@ Then use the narrowest package skill that matches the task:
 - `npm run typecheck` does not cover `packages/dashboard/` or `packages/shared-schemas/`, so run package-specific validation when either package changes.
 - Use the package-specific validation steps in the child skill when the work is isolated to one package.
 - When reporting back, state what changed, what you validated, and what you could not validate.
+
+## Pre-PR Checklist (Mandatory Before Pushing to a PR)
+
+Before opening a PR or pushing new commits to an existing PR branch, run **all** of the following from the repo root and do not proceed while any of them fail on files your change touches:
+
+1. `npx turbo run typecheck` — must pass across all packages.
+2. `npx turbo run lint` — must pass. If the failure is pre-existing in `main` and unrelated to your change, scope it:
+   - Run `npx eslint <your-changed-files>` and confirm your files are clean.
+   - Call out the pre-existing debt in the PR body so reviewers know it is not yours.
+   - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
+3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
+4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+
+Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/backend/src/api/routes/docs/index.routes.ts
+++ b/backend/src/api/routes/docs/index.routes.ts
@@ -102,46 +102,46 @@ const LEGACY_DOCS_MAP: Record<DocTypeSchema, string> = {
   'functions-sdk': 'sdks/typescript/functions.mdx',
   'ai-integration-sdk': 'sdks/typescript/ai.mdx',
   'real-time': 'agent-docs/real-time.md',
-  'deployment': 'agent-docs/deployment.md',
+  deployment: 'agent-docs/deployment.md',
 };
 
 // SDK documentation map for GET /api/docs/:docFeature/:docLanguage endpoint
 // Supports feature × language combinations with type safety
 const SDK_DOCS_MAP: Record<SdkFeatureSchema, Partial<Record<SdkLanguageSchema, string>>> = {
-  'db': {
-    'typescript': 'sdks/typescript/database.mdx',
-    'swift': 'sdks/swift/database.mdx',
-    'kotlin': 'sdks/kotlin/database.mdx',
+  db: {
+    typescript: 'sdks/typescript/database.mdx',
+    swift: 'sdks/swift/database.mdx',
+    kotlin: 'sdks/kotlin/database.mdx',
     'rest-api': 'sdks/rest/database.mdx',
   },
-  'storage': {
-    'typescript': 'sdks/typescript/storage.mdx',
-    'swift': 'sdks/swift/storage.mdx',
-    'kotlin': 'sdks/kotlin/storage.mdx',
+  storage: {
+    typescript: 'sdks/typescript/storage.mdx',
+    swift: 'sdks/swift/storage.mdx',
+    kotlin: 'sdks/kotlin/storage.mdx',
     'rest-api': 'sdks/rest/storage.mdx',
   },
-  'functions': {
-    'typescript': 'sdks/typescript/functions.mdx',
-    'swift': 'sdks/swift/functions.mdx',
-    'kotlin': 'sdks/kotlin/functions.mdx',
+  functions: {
+    typescript: 'sdks/typescript/functions.mdx',
+    swift: 'sdks/swift/functions.mdx',
+    kotlin: 'sdks/kotlin/functions.mdx',
     'rest-api': 'sdks/rest/functions.mdx',
   },
-  'auth': {
-    'typescript': 'sdks/typescript/auth.mdx',
-    'swift': 'sdks/swift/auth.mdx',
-    'kotlin': 'sdks/kotlin/auth.mdx',
+  auth: {
+    typescript: 'sdks/typescript/auth.mdx',
+    swift: 'sdks/swift/auth.mdx',
+    kotlin: 'sdks/kotlin/auth.mdx',
     'rest-api': 'sdks/rest/auth.mdx',
   },
-  'ai': {
-    'typescript': 'sdks/typescript/ai.mdx',
-    'swift': 'sdks/swift/ai.mdx',
-    'kotlin': 'sdks/kotlin/ai.mdx',
+  ai: {
+    typescript: 'sdks/typescript/ai.mdx',
+    swift: 'sdks/swift/ai.mdx',
+    kotlin: 'sdks/kotlin/ai.mdx',
     'rest-api': 'sdks/rest/ai.mdx',
   },
-  'realtime': {
-    'typescript': 'sdks/typescript/realtime.mdx',
-    'swift': 'sdks/swift/realtime.mdx',
-    'kotlin': 'sdks/kotlin/realtime.mdx',
+  realtime: {
+    typescript: 'sdks/typescript/realtime.mdx',
+    swift: 'sdks/swift/realtime.mdx',
+    kotlin: 'sdks/kotlin/realtime.mdx',
     'rest-api': 'sdks/rest/realtime.mdx',
   },
 };
@@ -241,7 +241,8 @@ router.get('/', (_req: Request, res: Response, next: NextFunction) => {
     for (const [feature, languages] of Object.entries(SDK_DOCS_MAP)) {
       for (const [language, filename] of Object.entries(languages)) {
         if (filename) {
-          const type = language === 'rest-api' ? `${feature}-${language}` : `${feature}-sdk-${language}`;
+          const type =
+            language === 'rest-api' ? `${feature}-${language}` : `${feature}-sdk-${language}`;
           sdkDocs.push({
             type,
             filename,


### PR DESCRIPTION
## Summary
- Adds a **Pre-PR Checklist** to the `insforge-dev` skill (mirrored across `.claude/`, `.agents/`, and `.codex/`) requiring `turbo run typecheck`, `turbo run lint`, `turbo run test`, and `turbo run build` to pass before pushing to a PR branch.
- Pre-existing lint debt outside the diff may be called out in the PR body; auto-fixable errors inside the diff must be fixed.
- Auto-fixes 26 pre-existing prettier errors in `backend/src/api/routes/docs/index.routes.ts` that were failing `turbo run lint` on `main`. Pure whitespace/quote formatting — no behavior change.

## Motivation
Lint was silently red on `main`, so recent branches (including #1062 `feat/compute-services`) inherited a failing `turbo run lint` check. Codifying the pre-push checklist catches these locally in <1 min instead of waiting on CI.

## Test plan
- [x] `npx turbo run lint` — now green across all 5 packages
- [x] `npx turbo run typecheck` — green
- [x] `npx turbo run build` — green
- [x] Docs route still loads / no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require typecheck, lint, test, and build checks before PRs in insforge-dev skill
> Adds a mandatory Pre-PR Checklist section to the `insforge-dev` [SKILL.md](.agents/skills/insforge-dev/SKILL.md) files across all agent contexts (`.agents`, `.claude`, `.codex`). The checklist specifies required commands and guidance on handling pre-existing lint failures and auto-fixes before pushing to a PR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a4f7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Pre-PR Checklist documentation across multiple skill guides, specifying mandatory verification steps (typechecking, linting, testing, and conditional builds) required before submitting pull requests.

* **Style**
  * Improved code formatting consistency in documentation routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->