### PR TITLE
[T1] docs(skills): vendor Mintlify doc-author skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,33 @@
+# `.claude/skills/` — contributor skill library
+
+Claude Code (and compatible agents) auto-discover skills here. Each subdirectory
+is one skill; a skill's entry point is `SKILL.md`, which starts with YAML
+frontmatter containing at minimum `name` and `description`.
+
+## Current skills
+
+| Skill | Entry point | Purpose |
+|---|---|---|
+| `insforge-dev` | `insforge-dev/SKILL.md` | Maintainers working in this monorepo (backend, dashboard, UI, shared schemas, docs). |
+| `doc-author` | `doc-author/SKILL.md` | Writing and maintaining `docs/*.mdx` pages. **Vendored from [mintlify/docs](https://github.com/mintlify/docs) — see upstream SHA in the attribution block.** InsForge-specific conventions live next to it in [`doc-author/INSFORGE.md`](doc-author/INSFORGE.md). |
+
+## Adding a new skill
+
+1. Create `<skill-name>/SKILL.md` with `name` + `description` frontmatter.
+2. Add the directory to the `.gitignore` allow-list at the repo root
+   (the root-level rules hide `.claude/*` by default).
+3. Update this README with a one-line entry.
+
+## Updating the vendored `doc-author` skill
+
+`doc-author/SKILL.md` is a verbatim copy of Mintlify's upstream. To refresh:
+
+```bash
+scripts/update-mintlify-skill.sh
+```
+
+The script re-downloads the upstream file, updates the commit SHA in the
+attribution header, and fails loudly if Mintlify's license has changed from MIT
+— in which case the vendoring posture needs review before committing. Do not
+hand-edit `doc-author/SKILL.md`; put InsForge-specific overrides in
+`doc-author/INSFORGE.md` instead.

--- a/.claude/skills/doc-author/INSFORGE.md
+++ b/.claude/skills/doc-author/INSFORGE.md
@@ -1,0 +1,41 @@
+# InsForge overlay — doc-author conventions
+
+Local overlay for the vendored Mintlify [`doc-author` skill](./SKILL.md).
+Upstream prose is authoritative; the items below are InsForge-specific and
+override upstream advice only where they conflict.
+
+## Frontmatter: `title` + `description` only
+
+InsForge `docs/*.mdx` uses **only** `title` and `description` in YAML
+frontmatter. Do not add `icon`, `sidebarTitle`, or other Mintlify-supported
+keys unless a neighbouring page already does.
+
+- `docs/quickstart.mdx:1-4` — canonical example
+- `docs/sdks/typescript/auth.mdx:1-4` — SDK-reference style
+
+## No `<ParamField>` — bullet lists for parameters
+
+The repo has zero `<ParamField>` usage. Document parameters as plain markdown
+bullet lists under a `### Parameters` heading.
+
+- `docs/sdks/typescript/auth.mdx:17-22` — canonical pattern
+
+## SDK install = import the snippet, never inline
+
+Every page that shows an SDK install imports the shared snippet:
+
+```mdx
+import Installation from '/snippets/sdk-installation.mdx';
+
+<Installation />
+```
+
+- Snippet body: `docs/snippets/sdk-installation.mdx`
+- Usage: `docs/sdks/typescript/auth.mdx:7-10`,
+  `docs/core-concepts/storage/sdk.mdx:6-8`,
+  `docs/examples/framework-guides/react.mdx:6`
+
+## Voice: second-person imperative
+
+Address the reader as "you"; use imperative verbs. See `docs/quickstart.mdx`
+for the canonical voice.

--- a/.claude/skills/doc-author/SKILL.md
+++ b/.claude/skills/doc-author/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: doc-author
+description: Write, edit, and maintain documentation. Use for collaborative drafting, autonomous writing, or improving existing docs. Defaults to collaborative mode where the human makes final decisions. Built by Mintlify.
+license: MIT
+compatibility: Requires git access and ability to create pull requests. Works with any markdown or MDX documentation. Optimized for Mintlify-powered documentation sites.
+metadata:
+  author: Mintlify
+  url: https://mintlify.com
+  version: "0.2"
+---
+
+<!--
+  Vendored from https://github.com/mintlify/docs (commit 877f90193ea1)
+  Upstream path: .claude/skills/doc-author/SKILL.md
+  Upstream license: MIT (see LICENSE block in upstream repo)
+  Vendored: 2026-04-18 by scripts/update-mintlify-skill.sh
+
+  This file is a VERBATIM copy of Mintlify's doc-author skill body.
+  Do not edit the prose below — local conventions go in ./INSFORGE.md
+  Update with: scripts/update-mintlify-skill.sh
+-->
+
+
+# Write and maintain documentation
+
+This skill guides documentation work—from collaborative drafting with a human to autonomous writing with PR-based review.
+
+## Operating modes
+
+### Collaborative (default)
+
+You're a collaborator. The human drives decisions, you assist. Use this mode unless you have a clear signal to work autonomously.
+
+In collaborative mode:
+- Draft content for the human to refine
+- Suggest improvements with clear reasoning
+- Ask clarifying questions before assuming
+- Offer alternatives when there are trade-offs
+- Flag concerns without blocking progress
+
+### Autonomous
+
+You write independently, open PRs, and flag uncertainties for human review. Use this mode only when:
+- The task is explicitly delegated (e.g., a Linear issue assigned to you)
+- The human tells you to "just do it" or "go ahead and write this"
+- You're working from a clear, specific brief with no ambiguity
+
+In autonomous mode:
+- Write complete documentation and open a PR
+- Add TODO comments for anything you can't verify
+- Note uncertainties in the PR description
+- Never commit directly—always open a PR for review
+
+When in doubt about which mode to use, default to collaborative.
+
+## Core principles
+
+1. **Only document what you can verify.** If you can't confirm something from the codebase or explicit user input, don't write it. Leave a TODO instead.
+2. **Write just enough.** Help users succeed and get back to their work. More docs isn't better docs.
+3. **Match existing patterns.** Read surrounding content before writing. Consistency beats personal preference.
+4. **Flag uncertainty.** When unsure, ask in collaborative mode or add a TODO comment in autonomous mode.
+5. **Ask before assuming.** If something is unclear, ask. Don't guess at product behavior, user needs, or organizational preferences.
+6. **Explain your reasoning.** When you suggest changes, say why. This helps people learn and make better decisions.
+
+## Before you write
+
+### Verify you have enough context
+
+Before writing, confirm you can answer:
+- What is this feature or concept?
+- Who needs this documentation?
+- What should they be able to do after reading?
+
+If you can't answer these from the codebase or user input:
+- **Collaborative mode:** Ask the human
+- **Autonomous mode:** Stop and escalate
+
+### Check for existing content
+
+Search the docs for related content before creating new pages. You may need to:
+- Update an existing page instead of creating a new one
+- Add a section to an existing page
+- Link to existing content rather than duplicating
+
+### Read surrounding content
+
+Before writing, read 2-3 similar pages to understand:
+- Voice and tone patterns
+- Structure and formatting conventions
+- Level of detail provided
+- Component usage patterns
+
+## Working with humans
+
+These practices apply in both modes—collaborative work is more interactive, but even autonomous work benefits from clear communication.
+
+### When to ask questions
+
+Ask before writing when:
+- You don't understand the feature being documented
+- The audience isn't clear
+- You're unsure what level of detail is appropriate
+- There are multiple valid approaches
+
+Good questions:
+- "Who's the primary audience for this page—developers integrating the API or admins configuring the product?"
+- "Should this be a separate page or a new section on the existing [page name]?"
+- "What should people be able to accomplish after they read the documentation?"
+- "The codebase shows two ways to do this. Which should we document, or both?"
+
+### When to offer alternatives
+
+Present options when:
+- There are different valid structures
+- Tone could go multiple directions
+- Detail level is a judgment call
+
+Example:
+> "I can write this as either:
+> A. A quick reference with just the essential steps
+> B. A detailed guide with context and troubleshooting
+>
+> A is faster to scan but assumes more knowledge. B helps beginners but takes longer to read. Which fits your users better?"
+
+### When to flag concerns
+
+Speak up when you notice:
+- Content that might be inaccurate
+- Patterns that differ from the rest of the docs
+- Missing information that users would need
+- Overly complex explanations
+
+Be direct but not blocking:
+> "This explanation assumes the reader knows what webhooks are. Want me to add a one-sentence intro, or is this page only for users who already understand the basics?"
+
+### Handling uncertainty
+
+**When you don't know something:**
+> "I can't tell from the codebase what the default value is. Do you know, or should we check with the team?"
+
+**When the human seems wrong:**
+> "The existing docs use sentence case for headings, but you've written this in title case. Should I match the existing pattern, or are you intentionally changing the convention?"
+
+**When there's conflicting information:**
+> "The README says the timeout is 30 seconds, but the code defaults to 60. Which is correct?"
+
+## Writing standards
+
+### Voice and structure
+
+- Second-person voice ("you")
+- Active voice, direct language
+- Sentence case for headings ("Getting started", not "Getting Started")
+- Lead with context when helpful—explain what before how
+- Prerequisites at the start of procedural content
+
+### What to avoid
+
+**Never use:**
+- Marketing language ("powerful", "seamless", "robust", "cutting-edge")
+- Filler phrases ("it's important to note", "in order to")
+- Excessive conjunctions ("moreover", "furthermore", "additionally")
+- Editorializing ("obviously", "simply", "just", "easily")
+- Emoji in documentation
+
+**Watch for AI-typical patterns:**
+- Overly formal or stilted phrasing
+- Unnecessary repetition of concepts
+- Generic introductions that don't add value
+- Concluding summaries that repeat what was just said
+
+### Code examples
+
+- Keep examples simple and practical
+- Use realistic but generic values (not "foo", "bar", "example")
+- Test that code actually works before including it
+- One clear example is better than multiple variations
+
+## For Mintlify-powered docs
+
+If you're working with a Mintlify-powered documentation site, follow these conventions:
+
+### File format
+
+MDX files with YAML frontmatter:
+
+```mdx
+---
+title: "Clear, descriptive title"
+description: "Concise summary for SEO and navigation."
+keywords: ["relevant", "search", "terms"]
+---
+
+Content starts here.
+```
+
+Every page requires title, description, and keywords in frontmatter.
+
+### File naming
+
+- Use kebab-case: `getting-started.mdx`, `api-reference.mdx`
+- Be descriptive but concise
+- Match existing naming patterns in the directory
+
+### Components
+
+Use Mintlify components appropriately:
+
+**Callouts** for important information:
+```mdx
+<Note>Helpful context</Note>
+<Warning>Something potentially destructive</Warning>
+<Tip>A useful suggestion or best practice</Tip>
+<Info>Information related to the task at hand</Info>
+```
+
+**Steps** for sequential procedures:
+```mdx
+<Steps>
+  <Step title="First step">
+    Instructions for step one.
+  </Step>
+  <Step title="Second step">
+    Instructions for step two.
+  </Step>
+</Steps>
+```
+
+**Code blocks** always need language tags:
+```javascript
+const example = "always specify language";
+```
+
+### Internal links
+
+Use root-relative paths: `/content/components/accordions`, not `../components/accordions` or full URLs.
+
+## Verification guardrails
+
+### What you can document
+
+- Behavior you can verify in the codebase
+- Information explicitly provided by the user
+- Patterns consistent with existing documentation
+- Standard usage based on documented APIs
+
+### What requires a TODO
+
+- Implementation details you can't verify
+- Edge cases you haven't tested
+- Configuration options you're unsure about
+- Behavior that might vary by environment
+
+Format TODOs clearly:
+```mdx
+{/* TODO: Verify the default timeout value - couldn't find in codebase */}
+```
+
+### What requires escalation
+
+Stop and escalate when you encounter:
+
+**Content uncertainty:**
+- You don't understand the feature well enough to document it accurately
+- Existing docs contradict what you see in the codebase
+- The feature seems incomplete or broken
+
+**Scope concerns:**
+- Changes affect multiple pages or navigation structure
+- Content requires product or design input
+- Documentation involves security-sensitive information
+- Content relates to pricing, billing, or legal terms
+- You need to deprecate or significantly change existing content
+
+**Technical blockers:**
+- You can't find the source code for what you're documenting
+- The API or interface has changed significantly
+- You need access to systems or environments you don't have
+
+## Workflow
+
+### 1. Understand the task
+
+Read the issue or request carefully. Identify:
+- What specifically needs to be documented
+- What pages are affected
+- What the user should accomplish after reading
+
+### 2. Research
+
+- Search existing docs for related content
+- Read the relevant source code
+- Check for patterns in similar documentation
+
+### 3. Plan your changes
+
+Before writing, outline:
+- Which files you'll modify or create
+- What sections you'll add
+- What existing content needs updates
+
+In collaborative mode, share this plan with the human before writing.
+
+### 4. Write
+
+- Start with the most important information
+- Keep sections focused and scannable
+- Use components appropriately
+- Add TODOs for anything uncertain
+
+### 5. Self-review
+
+Before presenting work (collaborative) or creating a PR (autonomous), verify:
+
+- [ ] All code blocks have language tags
+- [ ] Frontmatter includes title, description, keywords (if using MDX)
+- [ ] Internal links are correct
+- [ ] No marketing language or filler phrases
+- [ ] Content matches style of surrounding pages
+- [ ] TODOs are clearly marked for uncertain content
+- [ ] New pages are added to navigation (if applicable)
+- [ ] Noted any areas of uncertainty
+
+### 6. Submit
+
+**Collaborative mode:**
+Present drafts as starting points:
+> "Here's a draft based on what I found in the codebase. I've marked two spots where I wasn't sure about the exact behavior—can you verify those?"
+
+**Autonomous mode:**
+Always open a pull request. Never commit directly. PR description should include:
+- What changed and why
+- Any TODOs or uncertainties that need human review
+- Files affected
+- How to test or verify the changes
+
+## Common tasks
+
+### Drafting new content
+
+1. Ask clarifying questions if the scope isn't clear
+2. Read existing related pages to match style
+3. Write a draft, noting any assumptions
+4. Highlight areas where you're uncertain
+
+### Editing existing content
+
+1. Read the full page for context
+2. Identify specific issues (not just "make it better")
+3. Explain what you'd change and why
+4. In collaborative mode, offer to make changes or let the human decide
+
+Be specific:
+> "I'd suggest three changes:
+> 1. Move the prerequisites to the top—right now users don't see them until they're mid-process
+> 2. Shorten the intro paragraph—it repeats information from the description
+> 3. Add a code example after step 3—currently it's abstract without showing the actual syntax"
+
+### Reviewing documentation
+
+- Check for accuracy against the codebase
+- Look for missing information users would need
+- Note inconsistencies with other docs
+- Flag unclear or ambiguous sections
+
+Structure feedback clearly:
+> **Accuracy issues:**
+> - Line 23: The parameter is `timeout`, not `timeoutMs`
+>
+> **Missing information:**
+> - No mention of what happens on failure
+>
+> **Style suggestions:**
+> - The intro could be shorter
+> - Consider using Steps component for the procedure
+
+### Helping with structure
+
+1. Understand what the content covers
+2. Identify the user's goal when reading
+3. Suggest a structure with reasoning
+4. Be open to alternatives
+
+Example:
+> "For a setup guide, I'd suggest:
+> 1. One-sentence overview of what they're setting up
+> 2. Prerequisites (what they need before starting)
+> 3. Steps (the actual procedure)
+> 4. Verification (how to confirm it worked)
+> 5. Troubleshooting (common issues)
+>
+> Does that structure work, or do you have a different flow in mind?"
+
+## Examples
+
+### Good page introduction
+
+```mdx
+---
+title: "Webhooks"
+description: "Receive real-time notifications when events occur in your account."
+keywords: ["webhooks", "events", "notifications"]
+---
+
+Webhooks let your application receive automatic notifications when specific events happen,
+like when a user signs up or a payment succeeds. Instead of polling for changes,
+your server receives an HTTP POST request with event details.
+```
+
+### Poor page introduction (avoid)
+
+```mdx
+---
+title: "Webhooks"
+description: "Learn about our powerful webhook system."
+keywords: ["webhooks"]
+---
+
+Welcome to our comprehensive guide on webhooks! Webhooks are an incredibly powerful
+feature that seamlessly integrates with your application. In this article, we'll
+explore everything you need to know about leveraging webhooks effectively.
+```
+
+### Good procedural content
+
+```mdx
+## Create a webhook endpoint
+
+Before registering a webhook, you need an endpoint to receive events.
+
+<Steps>
+  <Step title="Create an endpoint">
+    Add a POST route to your server that accepts JSON payloads:
+
+    ```javascript
+    app.post('/webhooks', (req, res) => {
+      const event = req.body;
+      // Process the event
+      res.status(200).send('OK');
+    });
+    ```
+  </Step>
+  <Step title="Make it publicly accessible">
+    Your endpoint must be reachable from the internet. During development,
+    use a tool like ngrok to expose your local server.
+  </Step>
+</Steps>
+```
+
+### Appropriate TODO usage
+
+```mdx
+## Rate limits
+
+Webhook deliveries are rate-limited to prevent overwhelming your server.
+
+{/* TODO: Verify exact rate limit - code suggests 100/min but couldn't confirm */}
+
+If a delivery fails, we retry with exponential backoff up to 5 times over 24 hours.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,11 @@ CLAUDE.md
 .claude/*
 !.claude/skills/
 .claude/skills/*
+!.claude/skills/README.md
 !.claude/skills/insforge-dev/
 !.claude/skills/insforge-dev/**
+!.claude/skills/doc-author/
+!.claude/skills/doc-author/**
 .agents/*
 !.agents/skills/
 .agents/skills/*

--- a/scripts/update-mintlify-skill.sh
+++ b/scripts/update-mintlify-skill.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# update-mintlify-skill.sh — refresh the vendored doc-author SKILL.md from
+# upstream https://github.com/mintlify/docs and update the attribution header.
+#
+# The file .claude/skills/doc-author/SKILL.md is a verbatim copy of Mintlify's
+# upstream skill body. This script:
+#   1. Verifies the upstream repo license is still MIT (fails loudly otherwise).
+#   2. Fetches the latest commit SHA for mintlify/docs@main.
+#   3. Re-downloads the upstream SKILL.md.
+#   4. Reassembles the local file with a fresh attribution block.
+#
+# Usage: scripts/update-mintlify-skill.sh [--force]
+#
+#   --force  Skip the "already up-to-date" no-op and rewrite anyway.
+#
+# Requires: curl, gh (authenticated, for the license + SHA queries), jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_FILE="$REPO_ROOT/.claude/skills/doc-author/SKILL.md"
+UPSTREAM_RAW="https://raw.githubusercontent.com/mintlify/docs/main/.claude/skills/doc-author/SKILL.md"
+EXPECTED_LICENSE="MIT"
+FORCE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+command -v gh   >/dev/null || { echo "gh is required (authenticate with 'gh auth login')" >&2; exit 1; }
+command -v jq   >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+[[ -f "$SKILL_FILE" ]] || { echo "missing: $SKILL_FILE" >&2; exit 1; }
+
+# 1. License check — fail loudly if upstream relicensed.
+UPSTREAM_LICENSE="$(gh api /repos/mintlify/docs --jq '.license.spdx_id')"
+if [[ "$UPSTREAM_LICENSE" != "$EXPECTED_LICENSE" ]]; then
+  cat >&2 <<EOF
+WARNING: upstream license changed.
+  expected: $EXPECTED_LICENSE
+  got:      $UPSTREAM_LICENSE
+
+Do NOT run this update blindly. Review mintlify/docs' new LICENSE file and
+confirm vendoring is still permitted. If it is, update EXPECTED_LICENSE in
+this script and the 'Upstream license' line in the attribution block of
+.claude/skills/doc-author/SKILL.md, then rerun with --force.
+EOF
+  exit 3
+fi
+
+# 2. Capture current upstream SHA (short form, 12 chars).
+UPSTREAM_SHA="$(gh api /repos/mintlify/docs/commits/main --jq '.sha' | cut -c1-12)"
+if [[ -z "$UPSTREAM_SHA" ]]; then
+  echo "failed to fetch upstream SHA" >&2
+  exit 1
+fi
+
+# 3. No-op short-circuit: if the local attribution header already names this SHA
+#    and we're not forcing, bail.
+if [[ "$FORCE" -ne 1 ]] && grep -q "commit $UPSTREAM_SHA" "$SKILL_FILE"; then
+  echo "up-to-date: $SKILL_FILE already references $UPSTREAM_SHA"
+  exit 0
+fi
+
+# 4. Fetch upstream body.
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+if ! curl -fsSL "$UPSTREAM_RAW" -o "$TMP"; then
+  echo "failed to fetch $UPSTREAM_RAW" >&2
+  exit 1
+fi
+[[ -s "$TMP" ]] || { echo "downloaded file is empty" >&2; exit 1; }
+
+# Quick sanity check: must start with YAML frontmatter.
+head -n1 "$TMP" | grep -q '^---$' || {
+  echo "upstream SKILL.md no longer starts with YAML frontmatter; aborting" >&2
+  exit 1
+}
+
+# Find the closing '---' of upstream frontmatter (second '---' line).
+FRONTMATTER_END="$(grep -n '^---$' "$TMP" | sed -n '2p' | cut -d: -f1)"
+if [[ -z "$FRONTMATTER_END" ]]; then
+  echo "could not locate closing frontmatter marker in upstream file" >&2
+  exit 1
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# 5. Reassemble: upstream frontmatter + our attribution block + upstream body.
+{
+  sed -n "1,${FRONTMATTER_END}p" "$TMP"
+  cat <<EOF
+
+<!--
+  Vendored from https://github.com/mintlify/docs (commit $UPSTREAM_SHA)
+  Upstream path: .claude/skills/doc-author/SKILL.md
+  Upstream license: $UPSTREAM_LICENSE (see LICENSE block in upstream repo)
+  Vendored: $TODAY by scripts/update-mintlify-skill.sh
+
+  This file is a VERBATIM copy of Mintlify's doc-author skill body.
+  Do not edit the prose below — local conventions go in ./INSFORGE.md
+  Update with: scripts/update-mintlify-skill.sh
+-->
+
+EOF
+  BODY_START=$((FRONTMATTER_END + 1))
+  sed -n "${BODY_START},\$p" "$TMP"
+} > "$SKILL_FILE"
+
+echo "updated $SKILL_FILE -> commit $UPSTREAM_SHA ($UPSTREAM_LICENSE)"


### PR DESCRIPTION
Closes #1119. Supersedes closed PR #1118.

## Summary

- Vendors Mintlify's canonical `doc-author` skill at `.claude/skills/doc-author/SKILL.md` — verbatim body, attribution block, upstream SHA captured for reproducibility.
- Adds a 41-line InsForge-specific overlay at `.claude/skills/doc-author/INSFORGE.md` covering the three local conventions (title+description-only frontmatter, no `<ParamField>`, shared sdk-installation snippet import) with real `docs/*.mdx` file:line citations.
- Reinstates the `.claude/skills/README.md` library index and `.gitignore` allow-list scaffolding from closed PR #1118, updated for the new skill.
- Adds `scripts/update-mintlify-skill.sh` — refreshes the vendored SKILL.md, updates the SHA in the attribution header, and fails loudly (exit 3) if upstream relicenses away from MIT.

## Upstream reference

- Repo: https://github.com/mintlify/docs
- Commit: `877f90193ea1` (main at vendoring time)
- License: **MIT** — verified via `gh api /repos/mintlify/docs --jq '.license.spdx_id'`. MIT permits vendoring with attribution, so the in-file attribution block is sufficient; no separate NOTICE file is added.

## Files

| File | Type | Lines |
|---|---|---|
| `.claude/skills/doc-author/SKILL.md` | new (vendored) | 460 |
| `.claude/skills/doc-author/INSFORGE.md` | new (overlay) | 41 |
| `.claude/skills/README.md` | new | 33 |
| `.gitignore` | modified | +3 |
| `scripts/update-mintlify-skill.sh` | new | 120 |

## Test plan

- [x] `gh api /repos/mintlify/docs --jq '.license.spdx_id'` returns `MIT` at PR-open time
- [x] Upstream body diffs against pristine download: zero prose changes (only one extra blank line from the attribution block)
- [x] `bash -n scripts/update-mintlify-skill.sh` — syntax ok
- [x] `scripts/update-mintlify-skill.sh` — runs clean, no-ops when SHA matches, prints `up-to-date: ... already references 877f90193ea1`
- [x] `scripts/update-mintlify-skill.sh --force` — rewrites file, byte-identical to hand-built version
- [x] `.gitignore` allow-list verified: `git check-ignore -v` confirms new files fall through the project rules (only the user-global `~/.gitignore` catches them, which `git add -f` handled)
- [ ] Manual: relicense drill — temporarily edit `EXPECTED_LICENSE` in the script and confirm the warning block fires with exit 3

## Non-goals

- Does not modify Mintlify's prose.
- Does not publish changes back upstream (that's a separate fork-and-PR workflow if we ever need it).
- Does not apply the skill to actually update any `docs/*.mdx` files — that's ticket #1117.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a contributor skill library with auto-discovery specifications and entry-point format requirements.
  * Established documentation authoring conventions and best practices for consistency.
  * Added comprehensive skill workflow definition and guidelines.

* **Chores**
  * Updated repository configuration to track contributor skill content.
  * Added maintenance script for syncing vendored skill dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->