### PR TITLE
[T2] Extend deploy auth to accept trial_key — unlocks agent-driven deploys

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -4,6 +4,12 @@ import { AppError } from './error.js';
 import { ERROR_CODES, NEXT_ACTION } from '@/types/error-constants.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { RoleSchema } from '@insforge/shared-schemas';
+import {
+  getTrialKeyVerifier,
+  isAgentKey,
+  TrialContext,
+  TrialKeyVerifier,
+} from '@/services/auth/trial-key-verifier.js';
 
 export interface AuthRequest extends Request {
   user?: {
@@ -14,6 +20,13 @@ export interface AuthRequest extends Request {
   authenticated?: boolean;
   apiKey?: string;
   projectId?: string;
+  /**
+   * Present when the request authenticated via an `ins_agent_trial_sk_*` or
+   * `ins_agent_sk_*` bearer. Populated by `verifyAdminOrTrialAgent`; downstream
+   * middleware / handlers read it for quota enforcement and claim_url generation.
+   * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+   */
+  trial?: TrialContext;
 }
 
 const tokenManager = TokenManager.getInstance();
@@ -240,4 +253,57 @@ export async function verifyCloudBackend(req: AuthRequest, _res: Response, next:
       );
     }
   }
+}
+
+/**
+ * Accepts admin JWT / `ik_*` API key (legacy) OR agent-issued trial keys
+ * (`ins_agent_trial_sk_*`) / post-upgrade user-agent keys (`ins_agent_sk_*`).
+ *
+ * On agent-key bearer:
+ *   - Verified via `TrialKeyVerifier` against cloud-backend's
+ *     `POST /internal/v1/verify-agent-key` endpoint (DB-separated; HMAC-signed).
+ *   - Sets `req.trial` with {tier, projectId, organizationId, quota, expiresAt, …}.
+ *   - Does NOT set `req.user` — deploy handlers that log `req.user?.email` already
+ *     gracefully degrade to `'api-key'`.
+ *
+ * On admin JWT / `ik_` bearer: falls through to the existing `verifyAdmin`
+ * behavior — zero change for non-agent callers.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+export function verifyAdminOrTrialAgent(verifierOverride?: TrialKeyVerifier) {
+  return async function handler(req: AuthRequest, res: Response, next: NextFunction) {
+    const token = extractBearerToken(req.headers.authorization);
+    if (token && isAgentKey(token)) {
+      const verifier = verifierOverride ?? getTrialKeyVerifier();
+      try {
+        const context = await verifier.verify(token);
+        if (!context) {
+          return next(
+            new AppError(
+              'Invalid or expired agent key',
+              401,
+              ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+              NEXT_ACTION.CHECK_TOKEN
+            )
+          );
+        }
+        req.trial = context;
+        req.authenticated = true;
+        return next();
+      } catch (error) {
+        return next(
+          error instanceof AppError
+            ? error
+            : new AppError(
+                'Agent key verification failed',
+                401,
+                ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+                NEXT_ACTION.CHECK_TOKEN
+              )
+        );
+      }
+    }
+    return verifyAdmin(req, res, next);
+  };
 }

--- a/backend/src/api/middlewares/trial-quota.ts
+++ b/backend/src/api/middlewares/trial-quota.ts
@@ -1,0 +1,127 @@
+/**
+ * Trial-quota enforcement for OSS deploy routes.
+ *
+ * Runs AFTER `verifyAdminOrTrialAgent`. If the request authenticated via an
+ * admin JWT / `ik_*` key (no `req.trial`), this is a no-op — admins have no
+ * trial quota.
+ *
+ * On trial / user-agent-key requests we gate on:
+ *   - trial expiry (tier='trial' only; `expiresAt > now`)
+ *   - per-file upload size (`Content-Length` against `quota.storage_mb`)
+ *   - `compute_deploy_mb > 0` sanity (prevents a config-zero'd quota from
+ *      letting a deploy through)
+ *
+ * Bandwidth (`bandwidth_gb_day`) is enforced by the compute layer on serve —
+ * out of this middleware's scope — but the value is surfaced on `req.trial.quota`
+ * so downstream consumers can read it.
+ *
+ * Failure shape is always HTTP 402 with
+ *   {error: "claim_required", reason: string, claim_url: string | null}
+ * — the `claim_url` convention matches cloud-backend's signup response and
+ * ticket #445's trigger matrix.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth.js';
+
+const BYTES_PER_MB = 1024 * 1024;
+
+export interface TrialQuotaResult {
+  /** true if the request should proceed. */
+  allowed: boolean;
+  /** Populated when allowed=false. */
+  reason?: 'trial_expired' | 'storage_exceeded' | 'compute_deploy_zero';
+  /** Bytes the request was attempting to upload (when reason='storage_exceeded'). */
+  attemptedBytes?: number;
+  /** Max bytes allowed (when reason='storage_exceeded'). */
+  maxBytes?: number;
+}
+
+/**
+ * Pure evaluator — easy to unit test. No I/O, no mutations.
+ * `contentLength` is the bytes the request is trying to upload. Pass `null`
+ * for routes that don't upload (e.g. `POST /api/deployments`).
+ */
+export function evaluateTrialDeployQuota(
+  req: AuthRequest,
+  contentLength: number | null,
+  now: Date = new Date()
+): TrialQuotaResult {
+  const trial = req.trial;
+  if (!trial) return { allowed: true };
+
+  // Trial expiry — only enforced for tier='trial' (user_agent_key is long-lived).
+  if (trial.tier === 'trial' && trial.expiresAt) {
+    const expiresAt = new Date(trial.expiresAt);
+    if (!Number.isNaN(expiresAt.getTime()) && expiresAt.getTime() <= now.getTime()) {
+      return { allowed: false, reason: 'trial_expired' };
+    }
+  }
+
+  // A quota with compute_deploy_mb=0 means "never allow a deploy". Fail fast.
+  if (trial.quota.compute_deploy_mb <= 0) {
+    return { allowed: false, reason: 'compute_deploy_zero' };
+  }
+
+  // Per-file upload check. Use the smaller of storage_mb (cumulative cap) and
+  // compute_deploy_mb (per-bundle cap) as the upper bound for this request.
+  if (contentLength !== null && contentLength > 0) {
+    const maxMb = Math.min(trial.quota.storage_mb, trial.quota.compute_deploy_mb);
+    const maxBytes = maxMb * BYTES_PER_MB;
+    if (contentLength > maxBytes) {
+      return {
+        allowed: false,
+        reason: 'storage_exceeded',
+        attemptedBytes: contentLength,
+        maxBytes,
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Build the claim URL for a 402 body. Returns `null` when no URL makes sense
+ * (e.g. a user_agent_key is already claimed).
+ */
+export function buildClaimUrl(req: AuthRequest): string | null {
+  const trial = req.trial;
+  if (!trial) return null;
+  if (trial.tier !== 'trial' || !trial.trialUserId) return null;
+  const host = (process.env.CLOUD_API_HOST ?? 'https://api.insforge.dev').replace(/\/+$/, '');
+  return `${host}/claim/${trial.trialUserId}`;
+}
+
+/**
+ * Express middleware. Rejects with 402 `{error: "claim_required", …}` when
+ * quota is exhausted; otherwise calls next().
+ */
+export function checkTrialDeployQuota(req: AuthRequest, res: Response, next: NextFunction): void {
+  const contentLengthHeader = req.headers['content-length'];
+  const contentLength =
+    typeof contentLengthHeader === 'string' && contentLengthHeader.length > 0
+      ? Number.parseInt(contentLengthHeader, 10)
+      : null;
+  const parsedContentLength =
+    contentLength !== null && Number.isFinite(contentLength) ? contentLength : null;
+
+  const result = evaluateTrialDeployQuota(req, parsedContentLength);
+  if (result.allowed) {
+    next();
+    return;
+  }
+
+  res.status(402).json({
+    error: 'claim_required',
+    reason: result.reason,
+    claim_url: buildClaimUrl(req),
+    ...(result.reason === 'storage_exceeded'
+      ? {
+          attempted_bytes: result.attemptedBytes,
+          max_bytes: result.maxBytes,
+        }
+      : {}),
+  });
+}

--- a/backend/src/api/routes/deployments/index.routes.ts
+++ b/backend/src/api/routes/deployments/index.routes.ts
@@ -1,7 +1,8 @@
 import { Router, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { DeploymentService } from '@/services/deployments/deployment.service.js';
-import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { verifyAdmin, verifyAdminOrTrialAgent, AuthRequest } from '@/api/middlewares/auth.js';
+import { checkTrialDeployQuota } from '@/api/middlewares/trial-quota.js';
 import { AuditService } from '@/services/logs/audit.service.js';
 import { AppError } from '@/api/middlewares/error.js';
 import { ERROR_CODES } from '@/types/error-constants.js';
@@ -27,8 +28,14 @@ router.use('/env-vars', envVarsRouter);
  * Create a new deployment record with WAITING status
  * Returns presigned upload info for the legacy source zip flow
  * POST /api/deployments
+ *
+ * Accepts admin JWT, ik_* API keys, and agent-issued trial/user-agent keys
+ * (ins_agent_trial_sk_* / ins_agent_sk_*). Trial callers get their quota
+ * enforced by checkTrialDeployQuota before the handler runs.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md (#1124)
  */
-router.post('/', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+router.post('/', verifyAdminOrTrialAgent(), checkTrialDeployQuota, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const response = await deploymentService.createDeployment();
 
@@ -50,8 +57,10 @@ router.post('/', verifyAdmin, async (req: AuthRequest, res: Response, next: Next
 /**
  * Create a new direct-upload deployment record with WAITING status
  * POST /api/deployments/direct
+ *
+ * Same auth surface as POST /api/deployments — admin + agent keys (#1124).
  */
-router.post('/direct', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+router.post('/direct', verifyAdminOrTrialAgent(), checkTrialDeployQuota, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const validationResult = createDirectDeploymentRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
@@ -81,10 +90,15 @@ router.post('/direct', verifyAdmin, async (req: AuthRequest, res: Response, next
 /**
  * Stream one direct deployment file through the backend to Vercel
  * PUT /api/deployments/:id/files/:fileId/content
+ *
+ * Same auth surface as POST /api/deployments — admin + agent keys (#1124).
+ * Trial-quota middleware reads Content-Length to cap per-file upload size
+ * against `quota.storage_mb` / `quota.compute_deploy_mb`.
  */
 router.put(
   '/:id/files/:fileId/content',
-  verifyAdmin,
+  verifyAdminOrTrialAgent(),
+  checkTrialDeployQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const idValidation = uuidParamSchema.safeParse(req.params.id);
@@ -138,10 +152,13 @@ router.put(
 /**
  * Start a deployment after source files are available
  * POST /api/deployments/:id/start
+ *
+ * Same auth surface as POST /api/deployments — admin + agent keys (#1124).
  */
 router.post(
   '/:id/start',
-  verifyAdmin,
+  verifyAdminOrTrialAgent(),
+  checkTrialDeployQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { id } = req.params;

--- a/backend/src/services/auth/trial-key-verifier.ts
+++ b/backend/src/services/auth/trial-key-verifier.ts
@@ -1,0 +1,250 @@
+/**
+ * Trial-key / user-agent-key verifier.
+ *
+ * OSS runs on a per-tenant Postgres; cloud-backend owns the `trial_users`
+ * and `user_agent_keys` tables on a separate multi-tenant Postgres. This
+ * service verifies bearer tokens against cloud via a signed HTTP request
+ * to `POST {CLOUD_API_HOST}/internal/v1/verify-agent-key` and caches
+ * positive verdicts in-memory so a single deploy flow's many requests
+ * don't each cost a cloud round-trip.
+ *
+ * Key prefix detection is cheap and local; the HTTP call is skipped
+ * entirely for non-trial bearers.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+import crypto from 'crypto';
+
+/** Trial-key prefix — mirrors cloud's `TRIAL_KEY_PREFIX`. */
+export const TRIAL_KEY_PREFIX = 'ins_agent_trial_sk_';
+/** Post-upgrade user-scoped agent-key prefix — mirrors cloud's `USER_AGENT_KEY_PREFIX`. */
+export const USER_AGENT_KEY_PREFIX = 'ins_agent_sk_';
+
+export function isTrialKey(token: string): boolean {
+  return token.startsWith(TRIAL_KEY_PREFIX);
+}
+
+export function isUserAgentKey(token: string): boolean {
+  return token.startsWith(USER_AGENT_KEY_PREFIX);
+}
+
+/** True for any agent-issued bearer (trial or post-upgrade). */
+export function isAgentKey(token: string): boolean {
+  return isTrialKey(token) || isUserAgentKey(token);
+}
+
+export interface TrialQuota {
+  api_calls_day: number;
+  storage_mb: number;
+  compute_deploy_mb: number;
+  compute_hours_day: number;
+  bandwidth_gb_day: number;
+  projects: number;
+}
+
+export type AgentKeyTier = 'trial' | 'user_agent_key';
+
+export interface TrialContext {
+  tier: AgentKeyTier;
+  /** Present when tier='trial'. */
+  trialUserId?: string;
+  /** Present when tier='user_agent_key'. */
+  userId?: string;
+  projectId: string;
+  organizationId: string;
+  quota: TrialQuota;
+  /** ISO-8601 UTC; present when tier='trial'. */
+  expiresAt?: string;
+}
+
+export interface TrialKeyVerifierOptions {
+  /** Defaults to `process.env.CLOUD_API_HOST` or `https://api.insforge.dev`. */
+  cloudApiHost?: string;
+  /** Defaults to `process.env.INTERNAL_SERVICE_SECRET`. */
+  serviceSecret?: string;
+  /** Cache TTL for positive verdicts, ms. Default 60_000. */
+  cacheTtlMs?: number;
+  /** Override fetch for testing. */
+  fetchImpl?: typeof fetch;
+  /** Override clock for testing. */
+  now?: () => number;
+}
+
+interface CacheEntry {
+  context: TrialContext;
+  expiresAtMs: number;
+}
+
+/**
+ * Fail-closed verifier. All failure modes (no secret, network error, non-2xx,
+ * malformed body) collapse to `null`, which the middleware converts to 401.
+ */
+export class TrialKeyVerifier {
+  private readonly cloudApiHost: string;
+  private readonly serviceSecret: string;
+  private readonly cacheTtlMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(opts: TrialKeyVerifierOptions = {}) {
+    this.cloudApiHost = (
+      opts.cloudApiHost ??
+      process.env.CLOUD_API_HOST ??
+      'https://api.insforge.dev'
+    ).replace(/\/+$/, '');
+    this.serviceSecret = opts.serviceSecret ?? process.env.INTERNAL_SERVICE_SECRET ?? '';
+    this.cacheTtlMs = opts.cacheTtlMs ?? 60_000;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Verify a plaintext bearer token. Returns the trial/user-agent context
+   * on success, or null on any failure. Callers must treat null as a
+   * 401-equivalent — never fall through to other auth branches.
+   */
+  async verify(token: string): Promise<TrialContext | null> {
+    if (!isAgentKey(token)) return null;
+    if (!this.serviceSecret) return null;
+
+    // Cache key is the SHA256 of the plaintext so we don't hold raw keys in memory.
+    const cacheKey = crypto.createHash('sha256').update(token).digest('hex');
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAtMs > this.now()) {
+      return cached.context;
+    }
+    if (cached) {
+      this.cache.delete(cacheKey);
+    }
+
+    const ts = Math.floor(this.now() / 1000).toString();
+    const nonce = crypto.randomBytes(16).toString('hex');
+    const body = JSON.stringify({ key: token });
+    const signature = this.sign(ts, nonce, body);
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.cloudApiHost}/internal/v1/verify-agent-key`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Service-Timestamp': ts,
+          'X-Service-Nonce': nonce,
+          'X-Service-Signature': `sha256=${signature}`,
+        },
+        body,
+      });
+    } catch {
+      return null;
+    }
+
+    if (!response.ok) {
+      // 401 from cloud = not valid. 5xx = cloud is down. Both fail closed.
+      return null;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch {
+      return null;
+    }
+
+    const context = parseVerifyResponse(parsed);
+    if (!context) return null;
+
+    this.cache.set(cacheKey, {
+      context,
+      expiresAtMs: this.now() + this.cacheTtlMs,
+    });
+    return context;
+  }
+
+  /**
+   * Manually invalidate a cached verdict. Not wired into any production
+   * path yet — exposed for tests and for a future admin-revoke webhook.
+   */
+  invalidate(token: string): void {
+    const cacheKey = crypto.createHash('sha256').update(token).digest('hex');
+    this.cache.delete(cacheKey);
+  }
+
+  private sign(ts: string, nonce: string, body: string): string {
+    return crypto
+      .createHmac('sha256', this.serviceSecret)
+      .update(`${ts}.${nonce}.${body}`)
+      .digest('hex');
+  }
+}
+
+function parseVerifyResponse(raw: unknown): TrialContext | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (r.valid !== true) return null;
+
+  const tierRaw = r.tier;
+  if (tierRaw !== 'trial' && tierRaw !== 'user_agent_key') return null;
+  const tier = tierRaw as AgentKeyTier;
+
+  const projectId = asString(r.project_id);
+  const organizationId = asString(r.organization_id);
+  if (!projectId || !organizationId) return null;
+
+  const quota = parseQuota(r.quota);
+  if (!quota) return null;
+
+  const ctx: TrialContext = {
+    tier,
+    projectId,
+    organizationId,
+    quota,
+  };
+  const trialUserId = asString(r.trial_user_id);
+  if (trialUserId) ctx.trialUserId = trialUserId;
+  const userId = asString(r.user_id);
+  if (userId) ctx.userId = userId;
+  const expiresAt = asString(r.expires_at);
+  if (expiresAt) ctx.expiresAt = expiresAt;
+
+  if (tier === 'trial' && !ctx.trialUserId) return null;
+  if (tier === 'user_agent_key' && !ctx.userId) return null;
+
+  return ctx;
+}
+
+function parseQuota(raw: unknown): TrialQuota | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const q = raw as Record<string, unknown>;
+  const fields: (keyof TrialQuota)[] = [
+    'api_calls_day',
+    'storage_mb',
+    'compute_deploy_mb',
+    'compute_hours_day',
+    'bandwidth_gb_day',
+    'projects',
+  ];
+  const out = {} as TrialQuota;
+  for (const f of fields) {
+    const v = q[f];
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    out[f] = v;
+  }
+  return out;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+// Lazy singleton — constructed on first access so env vars resolve post-dotenv.
+let singleton: TrialKeyVerifier | null = null;
+export function getTrialKeyVerifier(): TrialKeyVerifier {
+  if (!singleton) singleton = new TrialKeyVerifier();
+  return singleton;
+}
+
+/** Test-only: reset the lazy singleton so a fresh verifier picks up env changes. */
+export function __resetTrialKeyVerifierForTests(): void {
+  singleton = null;
+}

--- a/backend/tests/unit/auth-trial-agent.test.ts
+++ b/backend/tests/unit/auth-trial-agent.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Unit tests for verifyAdminOrTrialAgent middleware.
+ *
+ * We mock TokenManager + SecretService so the legacy verifyAdmin branch
+ * is exercised as a black box — the goal is to prove:
+ *   1. agent-key bearers go through the trial verifier branch
+ *   2. non-agent bearers fall through to verifyAdmin unchanged
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+
+// vi.mock is hoisted to the top of the file BEFORE the const declarations,
+// so we need vi.hoisted() to share mock fns between the factory and tests.
+const mocks = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+  verifyApiKey: vi.fn(),
+}));
+
+vi.mock('../../src/infra/security/token.manager', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      verifyToken: mocks.verifyToken,
+      verifyCloudToken: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/secrets/secret.service', () => ({
+  SecretService: {
+    getInstance: () => ({
+      verifyApiKey: mocks.verifyApiKey,
+    }),
+  },
+}));
+
+import { verifyAdminOrTrialAgent, AuthRequest } from '../../src/api/middlewares/auth';
+import {
+  TrialKeyVerifier,
+  TRIAL_KEY_PREFIX,
+  USER_AGENT_KEY_PREFIX,
+  TrialContext,
+} from '../../src/services/auth/trial-key-verifier';
+
+const validTrialContext: TrialContext = {
+  tier: 'trial',
+  trialUserId: '11111111-1111-1111-1111-111111111111',
+  projectId: '22222222-2222-2222-2222-222222222222',
+  organizationId: '33333333-3333-3333-3333-333333333333',
+  quota: {
+    api_calls_day: 1000,
+    storage_mb: 100,
+    compute_deploy_mb: 128,
+    compute_hours_day: 2,
+    bandwidth_gb_day: 1,
+    projects: 1,
+  },
+  expiresAt: '2030-01-01T00:00:00Z',
+};
+
+function makeReq(authHeader?: string): AuthRequest {
+  const headers: Record<string, string> = {};
+  if (authHeader) headers.authorization = authHeader;
+  return { headers } as unknown as AuthRequest;
+}
+
+const makeRes = () => {
+  const res: any = {};
+  res.status = (c: number) => {
+    res._status = c;
+    return res;
+  };
+  res.json = (b: any) => {
+    res._body = b;
+    return res;
+  };
+  return res;
+};
+
+describe('verifyAdminOrTrialAgent', () => {
+  beforeEach(() => {
+    mocks.verifyToken.mockReset();
+    mocks.verifyApiKey.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets req.trial and calls next() when a trial_key verifies', async () => {
+    const fakeVerifier = {
+      verify: vi.fn().mockResolvedValue(validTrialContext),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq(`Bearer ${TRIAL_KEY_PREFIX}valid`);
+    const res = makeRes();
+    const errors: unknown[] = [];
+    await mw(req, res, (err?: unknown) => {
+      if (err) errors.push(err);
+    });
+
+    expect(errors).toEqual([]);
+    expect(req.trial).toEqual(validTrialContext);
+    expect(req.authenticated).toBe(true);
+    expect(fakeVerifier.verify).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards an AppError when a trial_key fails verification', async () => {
+    const fakeVerifier = {
+      verify: vi.fn().mockResolvedValue(null),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq(`Bearer ${TRIAL_KEY_PREFIX}revoked`);
+    const res = makeRes();
+    const errors: unknown[] = [];
+    await mw(req, res, (err?: unknown) => {
+      if (err) errors.push(err);
+    });
+
+    expect(errors).toHaveLength(1);
+    const err = errors[0] as { statusCode?: number; message: string };
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toContain('agent key');
+    expect(req.trial).toBeUndefined();
+  });
+
+  it('accepts a user-agent-key the same way as a trial_key', async () => {
+    const userCtx: TrialContext = {
+      tier: 'user_agent_key',
+      userId: '44444444-4444-4444-4444-444444444444',
+      projectId: validTrialContext.projectId,
+      organizationId: validTrialContext.organizationId,
+      quota: validTrialContext.quota,
+    };
+    const fakeVerifier = {
+      verify: vi.fn().mockResolvedValue(userCtx),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq(`Bearer ${USER_AGENT_KEY_PREFIX}valid`);
+    const res = makeRes();
+    let nextCalled = false;
+    await mw(req, res, () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+    expect(req.trial?.tier).toBe('user_agent_key');
+    expect(req.trial?.userId).toBe('44444444-4444-4444-4444-444444444444');
+  });
+
+  it('falls through to verifyAdmin for an admin JWT (does not invoke verifier)', async () => {
+    mocks.verifyToken.mockReturnValueOnce({
+      sub: 'user-1',
+      email: 'admin@example.com',
+      role: 'project_admin',
+    });
+    const fakeVerifier = {
+      verify: vi.fn(),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq('Bearer admin-jwt-abc123');
+    const res = makeRes();
+    let nextCalled = false;
+    await mw(req, res, () => {
+      nextCalled = true;
+    });
+
+    expect(fakeVerifier.verify).not.toHaveBeenCalled();
+    expect(nextCalled).toBe(true);
+    expect(req.user?.email).toBe('admin@example.com');
+    expect(req.trial).toBeUndefined();
+  });
+
+  it('falls through to verifyApiKey for an ik_ bearer (does not invoke verifier)', async () => {
+    mocks.verifyApiKey.mockResolvedValueOnce(true);
+    const fakeVerifier = {
+      verify: vi.fn(),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq('Bearer ik_project_key_abc');
+    const res = makeRes();
+    let nextCalled = false;
+    await mw(req, res, () => {
+      nextCalled = true;
+    });
+
+    expect(fakeVerifier.verify).not.toHaveBeenCalled();
+    expect(nextCalled).toBe(true);
+    expect(req.authenticated).toBe(true);
+    expect(req.apiKey).toBe('ik_project_key_abc');
+  });
+
+  it('rejects requests with no bearer (matches verifyAdmin behavior)', async () => {
+    const fakeVerifier = {
+      verify: vi.fn(),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq();
+    const res = makeRes();
+    const errors: unknown[] = [];
+    await mw(req, res, (err?: unknown) => {
+      if (err) errors.push(err);
+    });
+
+    expect(errors).toHaveLength(1);
+    const err = errors[0] as { statusCode: number };
+    expect(err.statusCode).toBe(401);
+    expect(fakeVerifier.verify).not.toHaveBeenCalled();
+  });
+
+  it('propagates a thrown Error from the verifier as a 401 AppError', async () => {
+    const fakeVerifier = {
+      verify: vi.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as TrialKeyVerifier;
+
+    const mw = verifyAdminOrTrialAgent(fakeVerifier);
+    const req = makeReq(`Bearer ${TRIAL_KEY_PREFIX}explodes`);
+    const res = makeRes();
+    const errors: unknown[] = [];
+    await mw(req, res, (err?: unknown) => {
+      if (err) errors.push(err);
+    });
+
+    expect(errors).toHaveLength(1);
+    const err = errors[0] as { statusCode?: number };
+    expect(err.statusCode).toBe(401);
+  });
+});

--- a/backend/tests/unit/trial-key-verifier.test.ts
+++ b/backend/tests/unit/trial-key-verifier.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import crypto from 'crypto';
+import {
+  TrialKeyVerifier,
+  isTrialKey,
+  isUserAgentKey,
+  isAgentKey,
+  TRIAL_KEY_PREFIX,
+  USER_AGENT_KEY_PREFIX,
+} from '../../src/services/auth/trial-key-verifier';
+
+/**
+ * Unit tests for the trial-key verifier.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+
+describe('prefix predicates', () => {
+  it('isTrialKey matches only the trial prefix', () => {
+    expect(isTrialKey(`${TRIAL_KEY_PREFIX}abc`)).toBe(true);
+    expect(isTrialKey(`${USER_AGENT_KEY_PREFIX}abc`)).toBe(false);
+    expect(isTrialKey('ik_1234')).toBe(false);
+    expect(isTrialKey('')).toBe(false);
+  });
+
+  it('isUserAgentKey matches only the user-agent-key prefix', () => {
+    expect(isUserAgentKey(`${USER_AGENT_KEY_PREFIX}abc`)).toBe(true);
+    expect(isUserAgentKey(`${TRIAL_KEY_PREFIX}abc`)).toBe(false);
+    expect(isUserAgentKey('admin-jwt-abc')).toBe(false);
+  });
+
+  it('isAgentKey matches either agent prefix', () => {
+    expect(isAgentKey(`${TRIAL_KEY_PREFIX}abc`)).toBe(true);
+    expect(isAgentKey(`${USER_AGENT_KEY_PREFIX}abc`)).toBe(true);
+    expect(isAgentKey('ik_abc')).toBe(false);
+  });
+});
+
+describe('TrialKeyVerifier', () => {
+  const SECRET = 'shared-service-secret';
+  const CLOUD = 'https://cloud.example.test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let verifier: TrialKeyVerifier;
+  let nowMs = 1_700_000_000_000;
+
+  const validResponse = () => ({
+    valid: true,
+    tier: 'trial',
+    trial_user_id: '11111111-1111-1111-1111-111111111111',
+    project_id: '22222222-2222-2222-2222-222222222222',
+    organization_id: '33333333-3333-3333-3333-333333333333',
+    quota: {
+      api_calls_day: 1000,
+      storage_mb: 100,
+      compute_deploy_mb: 128,
+      compute_hours_day: 2,
+      bandwidth_gb_day: 1,
+      projects: 1,
+    },
+    expires_at: '2026-04-25T00:00:00Z',
+  });
+
+  const mockFetchOk = (body: unknown): Response =>
+    ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as unknown as Response);
+
+  const mockFetchFail = (status: number): Response =>
+    ({
+      ok: false,
+      status,
+      json: async () => ({ valid: false }),
+    } as unknown as Response);
+
+  beforeEach(() => {
+    nowMs = 1_700_000_000_000;
+    fetchMock = vi.fn();
+    verifier = new TrialKeyVerifier({
+      cloudApiHost: CLOUD,
+      serviceSecret: SECRET,
+      cacheTtlMs: 60_000,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => nowMs,
+    });
+  });
+
+  it('returns null for a non-agent bearer without hitting the network', async () => {
+    const result = await verifier.verify('admin-jwt-token');
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when INTERNAL_SERVICE_SECRET is empty (fails closed)', async () => {
+    const v = new TrialKeyVerifier({
+      cloudApiHost: CLOUD,
+      serviceSecret: '',
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+    const result = await v.verify(`${TRIAL_KEY_PREFIX}abc`);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('parses a valid trial response and sets tier=trial', async () => {
+    fetchMock.mockResolvedValueOnce(mockFetchOk(validResponse()));
+    const ctx = await verifier.verify(`${TRIAL_KEY_PREFIX}xyz`);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.tier).toBe('trial');
+    expect(ctx!.projectId).toBe('22222222-2222-2222-2222-222222222222');
+    expect(ctx!.trialUserId).toBe('11111111-1111-1111-1111-111111111111');
+    expect(ctx!.quota.storage_mb).toBe(100);
+    expect(ctx!.expiresAt).toBe('2026-04-25T00:00:00Z');
+  });
+
+  it('parses a valid user_agent_key response and sets tier=user_agent_key', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockFetchOk({
+        valid: true,
+        tier: 'user_agent_key',
+        user_id: '44444444-4444-4444-4444-444444444444',
+        project_id: '22222222-2222-2222-2222-222222222222',
+        organization_id: '33333333-3333-3333-3333-333333333333',
+        quota: validResponse().quota,
+      })
+    );
+    const ctx = await verifier.verify(`${USER_AGENT_KEY_PREFIX}abc`);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.tier).toBe('user_agent_key');
+    expect(ctx!.userId).toBe('44444444-4444-4444-4444-444444444444');
+    expect(ctx!.trialUserId).toBeUndefined();
+    expect(ctx!.expiresAt).toBeUndefined();
+  });
+
+  it('returns null when cloud responds 401', async () => {
+    fetchMock.mockResolvedValueOnce(mockFetchFail(401));
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}expired`);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on network error (fails closed)', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}netdown`);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cloud responds with valid=false', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockFetchOk({ valid: false, reason: 'revoked' })
+    );
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}revoked`);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the tier field is missing/unknown', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockFetchOk({ ...validResponse(), tier: 'some_new_tier' })
+    );
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}weird`);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the quota blob is missing a numeric field', async () => {
+    const bad = validResponse();
+    // @ts-expect-error — intentional bad input
+    bad.quota.storage_mb = 'one-hundred';
+    fetchMock.mockResolvedValueOnce(mockFetchOk(bad));
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}badquota`);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for tier=trial without trial_user_id', async () => {
+    const bad = validResponse();
+    delete (bad as any).trial_user_id;
+    fetchMock.mockResolvedValueOnce(mockFetchOk(bad));
+    const result = await verifier.verify(`${TRIAL_KEY_PREFIX}noid`);
+    expect(result).toBeNull();
+  });
+
+  it('caches a valid verdict so a repeat call does not re-hit fetch', async () => {
+    fetchMock.mockResolvedValueOnce(mockFetchOk(validResponse()));
+    const first = await verifier.verify(`${TRIAL_KEY_PREFIX}xyz`);
+    const second = await verifier.verify(`${TRIAL_KEY_PREFIX}xyz`);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires cache after TTL elapses', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockFetchOk(validResponse()))
+      .mockResolvedValueOnce(mockFetchOk(validResponse()));
+    await verifier.verify(`${TRIAL_KEY_PREFIX}xyz`);
+    nowMs += 61_000; // past TTL
+    await verifier.verify(`${TRIAL_KEY_PREFIX}xyz`);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate() drops the cached verdict', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockFetchOk(validResponse()))
+      .mockResolvedValueOnce(mockFetchOk(validResponse()));
+    const token = `${TRIAL_KEY_PREFIX}xyz`;
+    await verifier.verify(token);
+    verifier.invalidate(token);
+    await verifier.verify(token);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('signs the request with HMAC-SHA256 over ts.nonce.body', async () => {
+    fetchMock.mockResolvedValueOnce(mockFetchOk(validResponse()));
+    await verifier.verify(`${TRIAL_KEY_PREFIX}sig`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${CLOUD}/internal/v1/verify-agent-key`);
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+    const ts = headers['X-Service-Timestamp'];
+    const nonce = headers['X-Service-Nonce'];
+    const sigHeader = headers['X-Service-Signature'];
+    expect(ts).toMatch(/^\d+$/);
+    expect(nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(sigHeader.startsWith('sha256=')).toBe(true);
+    const sig = sigHeader.replace('sha256=', '');
+    const body = (init as RequestInit).body as string;
+    const expected = crypto
+      .createHmac('sha256', SECRET)
+      .update(`${ts}.${nonce}.${body}`)
+      .digest('hex');
+    expect(sig).toBe(expected);
+  });
+
+  it('trims a trailing slash from cloudApiHost', async () => {
+    const v = new TrialKeyVerifier({
+      cloudApiHost: `${CLOUD}/`,
+      serviceSecret: SECRET,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now: () => nowMs,
+    });
+    fetchMock.mockResolvedValueOnce(mockFetchOk(validResponse()));
+    await v.verify(`${TRIAL_KEY_PREFIX}abc`);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${CLOUD}/internal/v1/verify-agent-key`);
+  });
+});

--- a/backend/tests/unit/trial-quota.test.ts
+++ b/backend/tests/unit/trial-quota.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  evaluateTrialDeployQuota,
+  buildClaimUrl,
+  checkTrialDeployQuota,
+} from '../../src/api/middlewares/trial-quota';
+import type { AuthRequest } from '../../src/api/middlewares/auth';
+import type { TrialContext } from '../../src/services/auth/trial-key-verifier';
+
+/**
+ * Unit tests for trial-quota enforcement.
+ *
+ * Spec: docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+ */
+
+const MB = 1024 * 1024;
+
+function makeTrialContext(overrides: Partial<TrialContext> = {}): TrialContext {
+  return {
+    tier: 'trial',
+    trialUserId: '11111111-1111-1111-1111-111111111111',
+    projectId: '22222222-2222-2222-2222-222222222222',
+    organizationId: '33333333-3333-3333-3333-333333333333',
+    quota: {
+      api_calls_day: 1000,
+      storage_mb: 100,
+      compute_deploy_mb: 128,
+      compute_hours_day: 2,
+      bandwidth_gb_day: 1,
+      projects: 1,
+    },
+    expiresAt: '2030-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeReq(trial?: TrialContext, contentLength?: string): AuthRequest {
+  const headers: Record<string, string> = {};
+  if (contentLength !== undefined) headers['content-length'] = contentLength;
+  return { trial, headers } as unknown as AuthRequest;
+}
+
+describe('evaluateTrialDeployQuota', () => {
+  it('returns allowed=true when req.trial is absent (admin path)', () => {
+    const result = evaluateTrialDeployQuota(makeReq(undefined), null);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows a trial caller well under the per-file cap', () => {
+    const result = evaluateTrialDeployQuota(makeReq(makeTrialContext()), 1 * MB);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('rejects when trial has expired', () => {
+    const ctx = makeTrialContext({ expiresAt: '2020-01-01T00:00:00Z' });
+    const result = evaluateTrialDeployQuota(makeReq(ctx), 1 * MB);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('trial_expired');
+  });
+
+  it('does NOT enforce expiry for tier=user_agent_key', () => {
+    const ctx = makeTrialContext({
+      tier: 'user_agent_key',
+      trialUserId: undefined,
+      userId: '44444444-4444-4444-4444-444444444444',
+      expiresAt: undefined,
+    });
+    const result = evaluateTrialDeployQuota(makeReq(ctx), 1 * MB);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('rejects when compute_deploy_mb is zero', () => {
+    const ctx = makeTrialContext({
+      quota: { ...makeTrialContext().quota, compute_deploy_mb: 0 },
+    });
+    const result = evaluateTrialDeployQuota(makeReq(ctx), null);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('compute_deploy_zero');
+  });
+
+  it('rejects when Content-Length exceeds the storage cap', () => {
+    const ctx = makeTrialContext(); // storage=100MB, compute_deploy=128MB → min=100MB
+    const result = evaluateTrialDeployQuota(makeReq(ctx), 101 * MB);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('storage_exceeded');
+    expect(result.attemptedBytes).toBe(101 * MB);
+    expect(result.maxBytes).toBe(100 * MB);
+  });
+
+  it('rejects when Content-Length exceeds the compute_deploy cap (tighter than storage)', () => {
+    const ctx = makeTrialContext({
+      quota: { ...makeTrialContext().quota, storage_mb: 500, compute_deploy_mb: 50 },
+    });
+    const result = evaluateTrialDeployQuota(makeReq(ctx), 51 * MB);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('storage_exceeded');
+    expect(result.maxBytes).toBe(50 * MB);
+  });
+
+  it('allows zero Content-Length (pre-upload creation calls)', () => {
+    const ctx = makeTrialContext();
+    const result = evaluateTrialDeployQuota(makeReq(ctx), 0);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('buildClaimUrl', () => {
+  const oldCloudHost = process.env.CLOUD_API_HOST;
+
+  beforeEach(() => {
+    process.env.CLOUD_API_HOST = 'https://cloud.example.test';
+  });
+
+  afterEach(() => {
+    if (oldCloudHost === undefined) delete process.env.CLOUD_API_HOST;
+    else process.env.CLOUD_API_HOST = oldCloudHost;
+  });
+
+  it('returns null for admin (no req.trial)', () => {
+    expect(buildClaimUrl(makeReq(undefined))).toBeNull();
+  });
+
+  it('returns null for user_agent_key tier (already claimed)', () => {
+    const ctx = makeTrialContext({
+      tier: 'user_agent_key',
+      trialUserId: undefined,
+      userId: '44444444-4444-4444-4444-444444444444',
+    });
+    expect(buildClaimUrl(makeReq(ctx))).toBeNull();
+  });
+
+  it('builds {CLOUD_API_HOST}/claim/{trial_user_id} for trial tier', () => {
+    const ctx = makeTrialContext();
+    expect(buildClaimUrl(makeReq(ctx))).toBe(
+      'https://cloud.example.test/claim/11111111-1111-1111-1111-111111111111'
+    );
+  });
+
+  it('trims a trailing slash from CLOUD_API_HOST', () => {
+    process.env.CLOUD_API_HOST = 'https://cloud.example.test/';
+    const ctx = makeTrialContext();
+    expect(buildClaimUrl(makeReq(ctx))).toBe(
+      'https://cloud.example.test/claim/11111111-1111-1111-1111-111111111111'
+    );
+  });
+});
+
+describe('checkTrialDeployQuota (express middleware)', () => {
+  const makeRes = () => {
+    const res: any = {};
+    res.status = (code: number) => {
+      res._status = code;
+      return res;
+    };
+    res.json = (body: any) => {
+      res._body = body;
+      return res;
+    };
+    return res;
+  };
+
+  it('calls next() on allowed requests', () => {
+    const req = makeReq(makeTrialContext(), '1024');
+    const res = makeRes();
+    let called = false;
+    checkTrialDeployQuota(req, res, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+    expect(res._status).toBeUndefined();
+  });
+
+  it('responds 402 on storage_exceeded with claim_required and claim_url', () => {
+    process.env.CLOUD_API_HOST = 'https://cloud.example.test';
+    const req = makeReq(makeTrialContext(), String(101 * MB));
+    const res = makeRes();
+    let nextCalled = false;
+    checkTrialDeployQuota(req, res, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(false);
+    expect(res._status).toBe(402);
+    expect(res._body.error).toBe('claim_required');
+    expect(res._body.reason).toBe('storage_exceeded');
+    expect(res._body.claim_url).toContain('/claim/');
+    expect(res._body.attempted_bytes).toBe(101 * MB);
+    expect(res._body.max_bytes).toBe(100 * MB);
+  });
+
+  it('responds 402 on trial_expired without storage fields', () => {
+    const ctx = makeTrialContext({ expiresAt: '2020-01-01T00:00:00Z' });
+    const req = makeReq(ctx, '1024');
+    const res = makeRes();
+    checkTrialDeployQuota(req, res, () => {});
+    expect(res._status).toBe(402);
+    expect(res._body.reason).toBe('trial_expired');
+    expect(res._body.attempted_bytes).toBeUndefined();
+  });
+
+  it('no-ops when req.trial is absent (admin path)', () => {
+    const req = makeReq(undefined, '99999999999');
+    const res = makeRes();
+    let called = false;
+    checkTrialDeployQuota(req, res, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+    expect(res._status).toBeUndefined();
+  });
+});

--- a/docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
+++ b/docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md
@@ -1,0 +1,166 @@
+# Deploy routes accept trial_key auth — design
+
+**Ticket:** [InsForge/insforge#1124](https://github.com/InsForge/insforge/issues/1124)
+
+## Problem
+
+OSS deploy routes (`POST /api/deployments*`, `PUT /api/deployments/:id/files/:fileId/content`, `POST /api/deployments/:id/start`) currently gate on `verifyAdmin` which accepts only admin JWTs and `ik_*` API keys (`backend/src/api/middlewares/auth.ts:74-119`). **Trial keys** (`ins_agent_trial_sk_*` minted by cloud-backend `POST /api/agents/v1/signup`) are never recognized, so agents that signed up the ephemeral way have a project but cannot deploy to it.
+
+**Operator constraint (authoritative, 2026-04-18 "SCOPE REINSTATED" comment on #1124):** agents must NEVER obtain `project_api_keys`. The trial_key / user-agent-key is their sole credential throughout their lifecycle. So the "agent fetches `project_api_key` from `GET /projects/:id/access-api-key` then deploys" intermediate is forbidden. OSS deploy endpoints must accept trial / user-agent keys directly.
+
+## DB topology finding
+
+**The two backends run on SEPARATE Postgres instances.**
+
+Evidence:
+- `insforge/docker-compose.yml:4-26` — OSS ships its own `postgres:v15.13.2` service as part of the per-instance monorepo compose stack.
+- `insforge/backend/src/infra/database/database.manager.ts:36-50` — OSS reads `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` from env and connects to whatever that resolves to. In the docker compose flow that is the in-compose `postgres` service.
+- `insforge-cloud-backend/src/config/database.ts:7-23` — cloud backend uses the same env var names but points at the **multi-tenant** Postgres that holds `organizations`, `users`, `projects`, `trial_users`, `user_agent_keys`. That table graph does not exist in the OSS per-instance DB.
+- `insforge-cloud-backend/migrations/052_trial_users.sql` + `053_user_agent_keys.sql` — these tables live in the cloud DB only. OSS has no migration for them.
+- `insforge/backend/src/infra/security/token.manager.ts:25-30, 149-191` — OSS already treats cloud as a remote system (fetches `${CLOUD_API_HOST}/.well-known/jwks.json` via JWKS, uses it to verify cloud-minted JWTs in `verifyCloudBackend`). Cross-backend auth is already the established pattern.
+
+Therefore a direct DB lookup from OSS into `trial_users` / `user_agent_keys` is not possible without coupling the two deployments. We need **cross-backend verification**.
+
+## Chosen path: B — cross-backend verify endpoint
+
+### Why not A (shared DB)
+Rejected: the two instances are architecturally separate — OSS is per-tenant, cloud is multi-tenant. Making OSS capable of reaching the cloud DB would break OSS's self-host story and leak multi-tenant rows across instance boundaries.
+
+### Why not "cloud mints scoped JWT, OSS verifies via JWKS"
+Appealing because the JWKS path already exists (`verifyCloudBackend`), but it adds an extra round-trip to the agent's flow:
+  1. Agent → cloud `POST /api/agents/v1/signup` → returns trial_key
+  2. Agent → cloud `POST /api/agents/v1/mint-deploy-jwt` → returns short JWT (**new hop**)
+  3. Agent → OSS `POST /api/deployments` with JWT
+The operator constraint is that the trial_key is the sole credential — the agent should just `Authorization: Bearer ins_agent_trial_sk_<…>` the OSS deploy directly.
+
+### Path B: OSS calls cloud's `POST /internal/v1/verify-agent-key`
+
+**Sequence (happy path):**
+
+```
+agent                           OSS (/api/deployments)              cloud (/internal/v1/verify-agent-key)
+ | --Bearer ins_agent_trial_sk_xyz -->                                |
+ |                                  | -- POST verify-agent-key      -->|
+ |                                  |    body: {key_hash, nonce, ts}    |
+ |                                  |    headers: X-Service-Signature   |
+ |                                  |<-- 200 {valid, trial_user_id,     |
+ |                                  |          project_id, org_id,      |
+ |                                  |          quota, expires_at, tier} |
+ |                                  |                                   |
+ |                                  | (cache verdict in memory ~60s)    |
+ |                                  | req.trial = {...}                 |
+ |                                  | quota check, proceed to handler   |
+ |<-- 201 {id, ...}                 |                                   |
+```
+
+**Sequence (unhappy — quota exceeded):**
+
+```
+agent                           OSS
+ | -- Bearer ins_agent_trial_sk_xyz (2nd deploy, storage_mb exceeded) -->
+ |                               (verify succeeds, quota check fails)
+ |<-- 402 {error: "claim_required", reason: "storage_exceeded",
+ |          claim_url: "https://insforge.app/claim/<trial_user_id>"}
+```
+
+### Cloud contract (to be implemented in a follow-up cloud-backend ticket — filed alongside this PR)
+
+**Endpoint:** `POST {CLOUD_API_HOST}/internal/v1/verify-agent-key`
+
+**Auth:** `X-Service-Signature: sha256=<hmac(INTERNAL_SERVICE_SECRET, ts + '.' + nonce + '.' + body)>` with `X-Service-Timestamp` + `X-Service-Nonce` headers. Cloud rejects if `|now - ts| > 5min` or nonce seen within that window (simple LRU or Redis set).
+
+**Body:**
+```json
+{
+  "key": "ins_agent_trial_sk_xyz…"   // full plaintext bearer
+}
+```
+Cloud hashes with `crypto.createHash('sha256').update(key).digest('hex')` and looks up in `trial_users.trial_key_hash` (active: `revoked_at IS NULL AND expires_at > now()`), then `user_agent_keys.key_hash` (active: `revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())`).
+
+**Response 200:**
+```json
+{
+  "valid": true,
+  "tier": "trial" | "user_agent_key",
+  "trial_user_id": "uuid",            // present if tier=trial
+  "user_id": "uuid",                  // present if tier=user_agent_key
+  "project_id": "uuid",
+  "organization_id": "uuid",
+  "quota": { "storage_mb": 100, "bandwidth_gb_day": 1, "compute_deploy_mb": 128, "api_calls_day": 1000, "compute_hours_day": 2, "projects": 1 },
+  "expires_at": "2026-04-25T00:00:00Z" // ISO; present if tier=trial
+}
+```
+
+**Response 401:** `{"valid": false, "reason": "not_found" | "expired" | "revoked"}`
+
+### OSS side — this PR
+
+1. **`backend/src/services/auth/trial-key-verifier.ts` (new)** — HTTP client that hits cloud's verify endpoint, signs request with HMAC, parses response, caches successful verdicts in-memory with a 60s TTL keyed by key-hash (so repeat calls within a single deploy flow don't hammer cloud). Takes `CLOUD_API_HOST` and `INTERNAL_SERVICE_SECRET` from env. Fails closed on HTTP/network errors — returns null, middleware converts to 401.
+
+2. **`backend/src/api/middlewares/auth.ts`** — add:
+   - `isTrialKey(token)` / `isUserAgentKey(token)` prefix checks (mirror cloud-backend's `src/services/trial-signup/trial-keys.ts:61-71`).
+   - `verifyAdminOrTrialAgent(req, res, next)` — new middleware. Extracts bearer; if `ins_agent_trial_sk_*` or `ins_agent_sk_*`, calls the verifier and sets `req.trial = {trial_key, trial_user_id, user_id, project_id, organization_id, quota, tier, expires_at}`. Else falls through to existing `verifyAdmin` (admin JWT / ik_*-key path, unchanged). **Zero behavior change for non-trial bearers.**
+
+3. **`backend/src/api/middlewares/trial-quota.ts` (new)** — `checkTrialDeployQuota(req, res, next)`:
+   - If `req.trial` is not set, no-op (admin path unchanged).
+   - For `POST /api/deployments` and `POST /api/deployments/direct`: no upload size known yet, so just verify `req.trial.quota.compute_deploy_mb > 0` and `expires_at > now()`. Otherwise 402 `{error: "claim_required", reason: "trial_expired" | "quota_exhausted", claim_url}`.
+   - For `PUT /api/deployments/:id/files/:fileId/content`: check `Content-Length` header against `quota.storage_mb * 1024 * 1024`. Reject 402 if oversized.
+   - For `POST /api/deployments/:id/start`: verify still within expiry + quota.
+   - Note: bandwidth tracking is COMPUTE-side (Vercel/Deno); enforcement on completion is a cross-service concern outside this PR's scope — quota field is still surfaced on `req.trial` for downstream consumers and the enforcement ticket.
+
+4. **`backend/src/api/routes/deployments/index.routes.ts`** — swap `verifyAdmin` for `verifyAdminOrTrialAgent` on the 4 endpoints in the ticket; chain `checkTrialDeployQuota` after. The other 7 endpoints (list/get/metadata/slug/domains/sync/cancel) keep `verifyAdmin` — agents don't manage those.
+
+5. **`claim_url` shape** — `${CLOUD_API_HOST}/claim/<trial_user_id>` (mirrors what cloud's signup response already returns in `SignupResult.claimUrl`). For `user_agent_key` tier, `claim_url` is null (already claimed).
+
+## Config (env)
+
+Additions to OSS runtime:
+- `CLOUD_API_HOST` — already exists (`backend/src/infra/config/app.config.ts:35`). Reused as the verify base URL.
+- `INTERNAL_SERVICE_SECRET` — **new**. Shared secret for HMAC signing of `POST /internal/v1/verify-agent-key`. Must be set identically on both OSS (to sign) and cloud (to verify). Absence fails closed: no trial-key path works, admin/`ik_` paths unaffected.
+
+## Test plan
+
+**Unit (Vitest, `backend/tests/unit/`):**
+- `trial-key-verifier.test.ts` — valid key → returns parsed context; invalid/network-error → returns null; cache hits skip HTTP; HMAC header shape is correct.
+- `auth-trial-agent.test.ts` — `verifyAdminOrTrialAgent`:
+  - Bearer `ins_agent_trial_sk_abc` + verifier returns valid → sets `req.trial`, calls next().
+  - Bearer `ins_agent_trial_sk_abc` + verifier returns null → 401.
+  - Bearer admin JWT → falls through to `verifyAdmin`, unchanged.
+  - Bearer `ik_*` → falls through to `verifyApiKey`, unchanged.
+  - No bearer → 401 (matches existing `verifyAdmin` behavior).
+- `trial-quota.test.ts` — `checkTrialDeployQuota`:
+  - No `req.trial` → no-op.
+  - Expired trial → 402 with `reason: "trial_expired"`.
+  - `Content-Length` > `quota.storage_mb * MB` → 402 with `reason: "storage_exceeded"`.
+  - Under quota → next().
+
+**Regression (unit):**
+- Existing `verifyAdmin` tests still pass — no change to the admin JWT / `ik_` paths.
+
+**E2E (manual — tracked as follow-up):** full trial-signup → deploy HTML → READY → URL resolves round-trip requires the cloud-backend verify endpoint to exist. Filed as follow-up ticket.
+
+## Risks / rollback
+
+- **Cloud-backend verify endpoint doesn't exist at merge time.** Rollback is trivial: revert the 4 `verifyAdminOrTrialAgent` swaps. Admin / `ik_*` paths untouched. Trial-tier agents fail their deploy with a clean 401, matching today's behavior.
+- **`INTERNAL_SERVICE_SECRET` misconfigured.** Verifier fails closed (401). Admin path unaffected. Log a clear one-time warning at startup if `process.env.INTERNAL_SERVICE_SECRET` is empty AND `process.env.CLOUD_API_HOST` is set.
+- **Replay attacks on verify endpoint.** Mitigated by ts + nonce inside the signed envelope; cloud rejects expired / reused nonces.
+- **Cache staleness on key revoke.** 60s TTL is a deliberate trade: a revoked key keeps authenticating for up to 60s. The alternative (zero cache) costs a cloud RTT on every byte of deployment upload — a deploy is many requests. 60s matches how we already cache JWKS (`cacheMaxAge: 600000` — 10min; we chose much shorter because keys can be revoked out-of-band, unlike signing keys).
+
+## Out of scope (explicit)
+
+- Adding the cloud `POST /internal/v1/verify-agent-key` endpoint itself (follow-up cloud-backend ticket).
+- Bandwidth metering on completion — quota field surfaced, enforcement lives in the compute layer (Vercel webhook / Deno subhosting ticket).
+- `user_agent_key` (post-upgrade long-lived key) handling — same prefix check, same cloud endpoint, mostly free; in this PR to avoid re-touching the middleware later.
+- Dashboard/admin UI changes for trial projects.
+
+## References
+
+- `backend/src/api/middlewares/auth.ts:74-119` — existing `verifyAdmin`
+- `backend/src/api/routes/deployments/index.routes.ts:31-179` — the 4 target routes
+- `backend/src/infra/security/token.manager.ts:25-30, 149-191` — established cloud-verification pattern (JWKS)
+- `backend/src/infra/config/app.config.ts:32-41` — existing `cloud.apiHost` config
+- `insforge-cloud-backend/src/services/trial-signup/trial-keys.ts:16-71` — key prefix + hash functions (mirrored here)
+- `insforge-cloud-backend/src/services/trial-signup/quota.config.ts:21-37` — `TrialQuota` shape
+- `insforge-cloud-backend/src/middleware/auth.ts:56-132` — cloud-side trial auth middleware (pattern reference)
+- `insforge-cloud-backend/migrations/052_trial_users.sql` — trial_users schema
+- `insforge-cloud-backend/migrations/053_user_agent_keys.sql` — user_agent_keys schema


### PR DESCRIPTION
Closes #1124

Implements: `docs/superpowers/specs/2026-04-18-deploy-trial-key-auth.md`

## Summary

OSS deploy routes now accept agent-issued `ins_agent_trial_sk_*` and `ins_agent_sk_*` bearers in addition to the existing admin JWT / `ik_*` paths. Admins and existing API-key integrations are unchanged — this is strictly an auth widening behind a new middleware factory (`verifyAdminOrTrialAgent`).

Per the operator's `SCOPE REINSTATED` comment on #1124, agents must **never** obtain `project_api_keys` — the trial_key / user-agent-key is their sole credential. So OSS has to validate these bearers directly.

## DB topology finding

**Separate Postgres instances.** OSS is per-tenant (ships its own `postgres` in `docker-compose.yml:4-26`). Cloud-backend is multi-tenant and owns the `trial_users` + `user_agent_keys` tables (migrations 052 + 053). OSS can't query cloud's DB without breaking the self-host story. OSS already treats cloud as a remote system via JWKS (`backend/src/infra/security/token.manager.ts:25-30, 149-191`), so cross-backend verification is the established pattern.

## Chosen path: B — cross-backend verify endpoint

`TrialKeyVerifier` calls `POST {CLOUD_API_HOST}/internal/v1/verify-agent-key`, signs the request with HMAC-SHA256 over `ts.nonce.body` using a shared `INTERNAL_SERVICE_SECRET`, and caches the positive verdict in-memory keyed by SHA256(bearer) with a 60s TTL.

**The cloud endpoint itself is out of scope for this PR** — it lives in `insforge-cloud-backend` and needs a follow-up ticket. Until that lands, the trial-key branch fails closed with a clean 401; admin JWT / `ik_*` paths are completely untouched. Full contract (request envelope, response shape, HMAC construction, replay mitigation via ts+nonce) is documented in the spec.

## Changes

- `backend/src/services/auth/trial-key-verifier.ts` (new) — the verifier + prefix predicates
- `backend/src/api/middlewares/auth.ts` — new `verifyAdminOrTrialAgent(verifier?)` factory; existing `verifyAdmin` / `verifyUser` / `verifyApiKey` / `verifyCloudBackend` **unchanged**
- `backend/src/api/middlewares/trial-quota.ts` (new) — `evaluateTrialDeployQuota` (pure) + `checkTrialDeployQuota` (express). Enforces trial expiry (tier=trial only), `compute_deploy_mb > 0` sanity, and per-file `Content-Length` against `min(storage_mb, compute_deploy_mb)`. Returns HTTP 402 `{error: "claim_required", reason, claim_url}` on violation.
- `backend/src/api/routes/deployments/index.routes.ts` — swaps `verifyAdmin` → `verifyAdminOrTrialAgent() + checkTrialDeployQuota` on the **4** endpoints in the ticket:
  - `POST /api/deployments`
  - `POST /api/deployments/direct`
  - `PUT /api/deployments/:id/files/:fileId/content`
  - `POST /api/deployments/:id/start`

  The other 7 routes (list / metadata / slug / domains / get-by-id / sync / cancel) keep `verifyAdmin` — agents don't manage those.

- `backend/tests/unit/trial-key-verifier.test.ts` (new, 18 tests)
- `backend/tests/unit/trial-quota.test.ts` (new, 16 tests)
- `backend/tests/unit/auth-trial-agent.test.ts` (new, 7 tests)

## Config (env)

- `CLOUD_API_HOST` — already exists (`backend/src/infra/config/app.config.ts:35`); reused as the verify base URL.
- `INTERNAL_SERVICE_SECRET` — **new**. Shared secret for HMAC signing. Absence fails closed: trial-key branch returns 401; admin path untouched.

## Test plan

- [x] Unit: full `npm test` — 514/514 pass (473 pre-existing + 41 new)
- [x] Typecheck: `npm run typecheck` — clean
- [ ] E2E: full trial-signup → deploy HTML → READY → URL resolves — requires the cloud-backend verify endpoint (follow-up ticket)
- [ ] Manual smoke: staging only after the cloud endpoint lands

## Risks / rollback

- Cloud verify endpoint doesn't exist yet — trivially rolled back by reverting the 4 middleware swaps. Admin / `ik_*` paths untouched either way.
- Cache staleness on key revoke: 60s TTL is a deliberate trade vs. round-trip-per-byte on large deploy uploads.
- No multi-tenant DB leakage — the OSS side never sees cloud row data, only a parsed verdict.

## Follow-ups (to file after merge)

1. **insforge-cloud-backend**: implement `POST /internal/v1/verify-agent-key` per the contract in the spec.
2. **insforge-cloud-backend**: bandwidth (`bandwidth_gb_day`) enforcement on the compute/serving side — out of this middleware's scope.
3. E2E test once the cloud endpoint lands.