### PR TITLE
ci(build-image): publish :latest on stable v* tag releases

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -141,6 +141,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
 
       - name: Create and push multi-arch manifest
         run: |
@@ -185,8 +186,12 @@ jobs:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_tag || github.ref_name }}
           GHCR_IMAGE_RAW: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           ECR_IMAGE: ${{ steps.ecr-login.outputs.registry }}/${{ env.IMAGE_NAME }}
+          TAG_LATEST: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
         run: |
           # Convert GHCR image name to lowercase (Docker requires lowercase)
           GHCR_IMAGE=$(echo "${GHCR_IMAGE_RAW}" | tr '[:upper:]' '[:lower:]')
           # Copy multi-arch image from GHCR to ECR (preserves all platforms)
           crane copy ${GHCR_IMAGE}:${VERSION} ${ECR_IMAGE}:${VERSION}
+          if [[ "${TAG_LATEST}" == "true" ]]; then
+            crane copy ${GHCR_IMAGE}:${VERSION} ${ECR_IMAGE}:latest
+          fi


### PR DESCRIPTION
Adds a :latest tag to both the GHCR multi-arch manifest and the ECR mirror, gated to tag pushes on v* that do not contain a hyphen. This tracks stable releases only and ignores internal test tags (e.g. v2.0.7-test), pre-releases (v2.0.0-rc1), and workflow_dispatch builds.

Lets open-source templates (deploy/docker-compose, deploy/zeabur) point at :latest in the future instead of repeatedly bumping pinned tags.


so in the future   v2.0.7  we can just use latest. We cam use this for our opensource or templates... We don't want to constantly udpate it..

## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
