### PR TITLE
fix(build-image): source multi-arch manifest from version-specific per-arch tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -144,11 +144,16 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
 
       - name: Create and push multi-arch manifest
+        env:
+          GHCR_IMAGE_RAW: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          SOURCE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_tag || github.ref_name }}
         run: |
+          GHCR_IMAGE=$(echo "${GHCR_IMAGE_RAW}" | tr '[:upper:]' '[:lower:]')
           for TAG in $(echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n'); do
             docker buildx imagetools create \
               --tag "${TAG}" \
-              "${TAG}-amd64" "${TAG}-arm64"
+              "${GHCR_IMAGE}:${SOURCE_VERSION}-amd64" \
+              "${GHCR_IMAGE}:${SOURCE_VERSION}-arm64"
           done
 
   push-to-ecr:


### PR DESCRIPTION
## Problem

The v2.0.7 release workflow failed during the merge-manifests step with:

\`\`\`
ERROR: ghcr.io/insforge/insforge-oss:latest-amd64: not found
\`\`\`

## Root Cause

Commit 77bda7ae (\"ci(build-image): publish :latest on stable v* tag releases\") added \`type=raw,value=latest\` to **only** the \`merge-manifests\` metadata step. But the \`build-amd64\` / \`build-arm64\` jobs still have \`latest=false\` in their flavor, so \`latest-amd64\` / \`latest-arm64\` are never pushed.

The merge loop was:

\`\`\`bash
for TAG in $(echo \"\${{ steps.meta.outputs.tags }}\" | tr ',' '\\n'); do
  docker buildx imagetools create --tag \"\${TAG}\" \"\${TAG}-amd64\" \"\${TAG}-arm64\"
done
\`\`\`

It iterates destinations (\`v2.0.7\`, \`latest\`) and assumes a matching per-arch source exists for each. First iteration: \`v2.0.7\` → sources \`v2.0.7-amd64\` ✓. Second: \`latest\` → tries \`latest-amd64\` → 404.

## Fix

Always source from the version-specific per-arch tags and iterate **only** destinations. Every destination tag (\`v2.0.7\`, \`latest\`, \`test_tag\`) now points at the same two real per-arch images.

## Test plan
- [ ] Trigger \`workflow_dispatch\` with a throwaway \`test_tag\` to verify the manifest builds without touching \`latest\`
- [ ] Push a \`vX.Y.Z\` tag (or retry v2.0.7) and confirm both \`:vX.Y.Z\` and \`:latest\` manifests are published to GHCR
- [ ] Confirm ECR mirror receives both \`:VERSION\` and \`:latest\` on stable tag pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build and push workflow to improve consistency in multi-architecture image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->