### PR TITLE
bump version to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Bumps root \`package.json\` and \`package-lock.json\` to 2.0.8.

Cuts a fresh release instead of re-pushing \`v2.0.7\` (which had a failed build due to the merge-manifests bug fixed in #1134). Skipping 2.0.7 cleanly avoids mutating a published tag.

After merge, a \`v2.0.8\` tag will be pushed to trigger the release workflow, which now includes the fix from #1134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.0.8 (patch release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->