### PR TITLE
Add `POSTGRES_HOST` env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ POSTGRES_DB=insforge
 # -----------------------------------------------------------------------------
 
 # PostgreSQL
+POSTGRES_HOST=localhost
+
 POSTGRES_PORT=5432
 
 # PostgREST API


### PR DESCRIPTION
## Summary

Add `POSTGRES_HOST` env var, default to `localhost`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the environment configuration template with an additional PostgreSQL connection parameter, providing a default host value for database setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->