### PR TITLE
docs(env): document CloudFront signed URL configuration for S3 storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,20 @@ S3_ACCESS_KEY_ID=
 S3_ENDPOINT_URL=
 S3_SECRET_ACCESS_KEY=
 
+# CloudFront signed URLs (Optional, AWS S3 only)
+# When AWS_CLOUDFRONT_URL is set, storage downloads are served through
+# CloudFront with signed URLs instead of S3 presigned URLs. Ignored when
+# S3_ENDPOINT_URL is set (CloudFront does not front S3-compatible providers).
+# Setup: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html
+#
+# AWS_CLOUDFRONT_URL: CloudFront distribution domain (e.g. https://d1234abcd.cloudfront.net)
+# AWS_CLOUDFRONT_KEY_PAIR_ID: Trusted key group key-pair ID (e.g. K2JCJMDEHXQW5F)
+# AWS_CLOUDFRONT_PRIVATE_KEY: PEM private key. Use \n for newlines when kept on one line.
+# If URL is set but key pair or private key is missing, downloads fall back to S3 presigned URLs.
+AWS_CLOUDFRONT_URL=
+AWS_CLOUDFRONT_KEY_PAIR_ID=
+AWS_CLOUDFRONT_PRIVATE_KEY=
+
 # -----------------------------------------------------------------------------
 # Logging Configuration
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`.env.example` was missing `AWS_CLOUDFRONT_URL`, `AWS_CLOUDFRONT_KEY_PAIR_ID`, and `AWS_CLOUDFRONT_PRIVATE_KEY`. All three are read by the S3 storage provider (`backend/src/providers/storage/s3.provider.ts:229-264`) to generate CloudFront signed download URLs for AWS S3, and already passed through in `docker-compose.yml:102-104` and `docker-compose.prod.yml:93-95`. Users wanting to enable CloudFront-fronted storage previously had to grep source to discover the variable names and semantics.

The new block documents:
- What the feature does (CloudFront signed URLs vs. S3 presigned)
- When it activates (AWS S3 only; ignored when `S3_ENDPOINT_URL` is set)
- Link to AWS trusted-signer setup docs
- Fallback behavior when partially configured

No code changes. No new variables. Only documents env vars already read by the codebase.

## Test plan
- [x] Verified each variable against `backend/src/providers/storage/s3.provider.ts:229, 235-236`
- [x] Verified pass-through in `docker-compose.yml:102-104` and `docker-compose.prod.yml:93-95`
- [x] Comment-only additions, format matches existing sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional CloudFront configuration parameters for S3-backed storage downloads. When configured, CloudFront signed URLs are used for downloads; otherwise, the system falls back to S3 presigned URLs. Configuration is ignored when using alternative S3 endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->