### PR TITLE
feat(migrations): accept any numeric prefix for migration versions

### DIFF
--- a/backend/src/infra/database/migrations/033_relax-custom-migrations-version-check.sql
+++ b/backend/src/infra/database/migrations/033_relax-custom-migrations-version-check.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system.custom_migrations DROP CONSTRAINT IF EXISTS custom_migrations_version_check;
+ALTER TABLE system.custom_migrations ADD CONSTRAINT custom_migrations_version_check CHECK (version ~ '^[0-9]+$');

--- a/backend/src/infra/database/migrations/033_relax-custom-migrations-version-check.sql
+++ b/backend/src/infra/database/migrations/033_relax-custom-migrations-version-check.sql
@@ -1,2 +1,2 @@
 ALTER TABLE system.custom_migrations DROP CONSTRAINT IF EXISTS custom_migrations_version_check;
-ALTER TABLE system.custom_migrations ADD CONSTRAINT custom_migrations_version_check CHECK (version ~ '^[0-9]+$');
+ALTER TABLE system.custom_migrations ADD CONSTRAINT custom_migrations_version_check CHECK (version ~ '^[0-9]{1,64}$');

--- a/backend/src/services/database/database-migration.service.ts
+++ b/backend/src/services/database/database-migration.service.ts
@@ -62,7 +62,7 @@ export class DatabaseMigrationService {
         statements,
         created_at AS "createdAt"
       FROM system.custom_migrations
-      ORDER BY version DESC
+      ORDER BY version::numeric DESC
     `);
 
     return {
@@ -98,14 +98,16 @@ export class DatabaseMigrationService {
       const versionResult = await client.query<{
         latestVersion: string | null;
       }>(`
-        SELECT MAX(version) AS "latestVersion"
+        SELECT version AS "latestVersion"
         FROM system.custom_migrations
+        ORDER BY version::numeric DESC
+        LIMIT 1
       `);
 
       const latestVersion = versionResult.rows[0]?.latestVersion ?? null;
       const version = input.version;
 
-      if (latestVersion && version <= latestVersion) {
+      if (latestVersion && BigInt(version) <= BigInt(latestVersion)) {
         throw new AppError(
           'Migration version must be newer than the latest applied migration.',
           409,

--- a/docs/sdks/rest/database.mdx
+++ b/docs/sdks/rest/database.mdx
@@ -593,7 +593,7 @@ POST /api/database/migrations
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Numeric migration version. Accepts Drizzle-style sequential prefixes (e.g. `0001`) or a `YYYYMMDDHHmmss` timestamp. Versions are compared numerically. |
+| `version` | string | Yes | Numeric migration version (up to 64 digits). Accepts Drizzle-style sequential prefixes (e.g. `0001`) or a `YYYYMMDDHHmmss` timestamp. Versions are compared numerically. |
 | `name` | string | Yes | Migration name |
 | `sql` | string | Yes | SQL text to parse and execute |
 

--- a/docs/sdks/rest/database.mdx
+++ b/docs/sdks/rest/database.mdx
@@ -593,7 +593,7 @@ POST /api/database/migrations
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Migration version in `YYYYMMDDHHmmss` format. |
+| `version` | string | Yes | Numeric migration version. Accepts Drizzle-style sequential prefixes (e.g. `0001`) or a `YYYYMMDDHHmmss` timestamp. Versions are compared numerically. |
 | `name` | string | Yes | Migration name |
 | `sql` | string | Yes | SQL text to parse and execute |
 

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -489,7 +489,8 @@ paths:
                 version:
                   type: string
                   description: Numeric migration version. Accepts Drizzle-style sequential prefixes (e.g. `0001`) or a `YYYYMMDDHHmmss` timestamp. Versions are compared numerically.
-                  pattern: '^\d+$'
+                  pattern: '^\d{1,64}$'
+                  maxLength: 64
                 name:
                   type: string
                   description: Migration name
@@ -572,7 +573,7 @@ components:
       properties:
         version:
           type: string
-          pattern: '^\d+$'
+          pattern: '^\d{1,64}$'
         name:
           type: string
         statements:

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -488,8 +488,8 @@ paths:
               properties:
                 version:
                   type: string
-                  description: Migration version in YYYYMMDDHHmmss format.
-                  pattern: '^\d{14}$'
+                  description: Numeric migration version. Accepts Drizzle-style sequential prefixes (e.g. `0001`) or a `YYYYMMDDHHmmss` timestamp. Versions are compared numerically.
+                  pattern: '^\d+$'
                 name:
                   type: string
                   description: Migration name
@@ -572,7 +572,7 @@ components:
       properties:
         version:
           type: string
-          pattern: '^\d{14}$'
+          pattern: '^\d+$'
         name:
           type: string
         statements:

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -244,7 +244,7 @@ export const bulkUpsertResponseSchema = z.object({
 });
 
 export const createMigrationRequestSchema = z.object({
-  version: z.string().regex(/^\d{14}$/, 'Migration version must use YYYYMMDDHHmmss format.'),
+  version: z.string().regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
   name: z
     .string()
     .trim()

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -244,7 +244,9 @@ export const bulkUpsertResponseSchema = z.object({
 });
 
 export const createMigrationRequestSchema = z.object({
-  version: z.string().regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
+  version: z
+    .string()
+    .regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
   name: z
     .string()
     .trim()

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -246,7 +246,10 @@ export const bulkUpsertResponseSchema = z.object({
 export const createMigrationRequestSchema = z.object({
   version: z
     .string()
-    .regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
+    .regex(
+      /^\d{1,64}$/,
+      'Migration version must be a numeric string of at most 64 digits (e.g. 0001 or 20260418091500).'
+    ),
   name: z
     .string()
     .trim()

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -105,7 +105,10 @@ export const databaseTriggerSchema = z.object({
 export const migrationSchema = z.object({
   version: z
     .string()
-    .regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
+    .regex(
+      /^\d{1,64}$/,
+      'Migration version must be a numeric string of at most 64 digits (e.g. 0001 or 20260418091500).'
+    ),
   name: z.string().min(1),
   statements: z.array(z.string()).min(1),
   createdAt: z.string(),

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -103,7 +103,7 @@ export const databaseTriggerSchema = z.object({
 });
 
 export const migrationSchema = z.object({
-  version: z.string().regex(/^\d{14}$/, 'Migration version must use YYYYMMDDHHmmss format.'),
+  version: z.string().regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
   name: z.string().min(1),
   statements: z.array(z.string()).min(1),
   createdAt: z.string(),

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -103,7 +103,9 @@ export const databaseTriggerSchema = z.object({
 });
 
 export const migrationSchema = z.object({
-  version: z.string().regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
+  version: z
+    .string()
+    .regex(/^\d+$/, 'Migration version must be numeric (e.g. 0001 or 20260418091500).'),
   name: z.string().min(1),
   statements: z.array(z.string()).min(1),
   createdAt: z.string(),


### PR DESCRIPTION
## Summary

Relax the 14-digit timestamp requirement on custom migration versions end-to-end so that orm-style sequential numbering (e.g. `0001`) is accepted alongside `YYYYMMDDHHmmss` timestamps. Versions are now compared numerically at every layer.

Motivation: the 14-digit format is a policy, not a physical constraint. Users bringing existing Drizzle migrations today get 400 `INVALID_INPUT` from the Zod schema before anything reaches the DB. This PR pairs with a CLI-side relaxation in InsForge/CLI.

## Changes

**`packages/shared-schemas`**
- `createMigrationRequestSchema.version`: regex `\d{14}` → `\d+`, error message updated to mention both accepted forms.
- `migrationSchema.version`: same relaxation for response/read schema.

**Database migration (`backend/src/infra/database/migrations/033_relax-custom-migrations-version-check.sql`)**
- Drop and re-add `custom_migrations_version_check` so the table-level CHECK becomes `^[0-9]+$`. Existing 14-digit rows remain valid — this is purely an expansion of accepted values.

**`backend/src/services/database/database-migration.service.ts`**
- `listMigrations`: `ORDER BY version DESC` → `ORDER BY version::numeric DESC` so that e.g. `10` sorts after `2` instead of before.
- `createMigration`: fetch latest via `ORDER BY version::numeric DESC LIMIT 1` instead of `MAX(version)` (which was lexicographic).
- `createMigration`: compare incoming version against latest using `BigInt(version) <= BigInt(latestVersion)` — previously `version <= latestVersion` was JavaScript string comparison, which rejected `"10"` as older than `"2"`.

**Docs & OpenAPI**
- `openapi/tables.yaml` + `docs/sdks/rest/database.mdx`: update `pattern` to `^\d+$` and field description.

## Test plan

- [x] Typecheck: no new errors in edited files (`database-api.schema.ts`, `database.schema.ts`, `database-migration.service.ts`, `migrations.routes.ts`). Pre-existing unrelated Zod-version errors in other schema files are not touched.
- [ ] Run backend unit + integration suite on CI.
- [ ] Manual: apply migration \`033\` on a dev DB; \`POST /api/database/migrations\` with \`{ \"version\": \"0001\", ... }\` succeeds; subsequent \`POST\` with \`{ \"version\": \"2\" }\` is rejected as not newer; \`{ \"version\": \"10\" }\` succeeds; \`GET /api/database/migrations\` returns them ordered 10, 2, 0001 (descending numeric).
- [ ] Smoke test paired with the CLI PR in InsForge/CLI so a Drizzle-style migrations directory round-trips through \`migrations up --all\`.

## Rollout notes

- Fresh installs are unaffected (`032` creates the constraint, `033` immediately relaxes it; migration bootstrap runs them in order).
- Existing deployments run `033` on next boot, which relaxes the CHECK in place. Existing 14-digit rows still satisfy `^[0-9]+$`.
- No data migration required.

## Related

Paired with InsForge/CLI#81 which relaxes the client-side filename regex and sort logic. **Land this PR before the CLI PR** — otherwise the CLI will send relaxed versions to an unrelaxed backend and 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration version handling now treats versions as numeric (up to 64 digits), enforcing numeric comparison and ordering and updating validation to accept flexible digit-only formats (e.g., `0001`, `20260418091500`).
  * Database constraint for migration versions updated to require 1–64 digits.

* **Documentation**
  * API docs and schemas updated to reflect the relaxed numeric-only version format and revised validation/error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->