### PR TITLE
docs(email): document Custom SMTP and editable email templates

### DIFF
--- a/docs/core-concepts/authentication/architecture.mdx
+++ b/docs/core-concepts/authentication/architecture.mdx
@@ -83,6 +83,10 @@ InsForge supports both `code` and `link` methods for email verification and pass
 - `redirectTo` must be included in `allowedRedirectUrls` before link-based flows can use it.
 - If `allowedRedirectUrls` is empty, InsForge allows all redirects for smoother development UX. Do not rely on that behavior in production.
 
+<Note>
+Verification and password-reset emails are sent through InsForge Cloud by default. To send them from your own server with custom subject lines and HTML, configure [Custom SMTP](/core-concepts/email/custom-smtp) under **Authentication → Email** in the dashboard — the four `email-verification-*` and `reset-password-*` templates are fully editable.
+</Note>
+
 For link-based email verification:
 
 - The email link opens `GET /api/auth/email/verify-link?token=...`

--- a/docs/core-concepts/email/architecture.mdx
+++ b/docs/core-concepts/email/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Email Architecture
-description: Transactional email delivery powered by AWS SES
+description: Transactional email delivery via InsForge Cloud or your own SMTP server
 ---
 
 <Warning>
@@ -9,7 +9,7 @@ description: Transactional email delivery powered by AWS SES
 
 ## Overview
 
-InsForge provides a managed email service for sending transactional emails. Built on AWS SES, it offers high deliverability and scalability without requiring you to configure email infrastructure.
+InsForge provides a managed email service for sending transactional emails. By default, mail is delivered through InsForge Cloud (built on AWS SES) for high deliverability without infrastructure setup. You can also configure a [custom SMTP server](/core-concepts/email/custom-smtp) to send through your own provider — the same API powers both paths.
 
 ## Technology Stack
 
@@ -17,15 +17,22 @@ InsForge provides a managed email service for sending transactional emails. Buil
 graph TB
     Client[Client Application] --> SDK[InsForge SDK]
     SDK --> API[Email API]
-    API --> Cloud[InsForge Cloud]
+    API --> Service[EmailService]
+    Service --> Decision{SMTP enabled?}
+    Decision -->|No| Cloud[InsForge Cloud]
     Cloud --> SES[AWS SES]
+    Decision -->|Yes| SMTP[Your SMTP server]
     SES --> Inbox[Recipient Inbox]
+    SMTP --> Inbox
 
     style Client fill:#1e293b,stroke:#475569,color:#e2e8f0
     style SDK fill:#1e40af,stroke:#3b82f6,color:#dbeafe
     style API fill:#166534,stroke:#22c55e,color:#dcfce7
+    style Service fill:#166534,stroke:#22c55e,color:#dcfce7
+    style Decision fill:#7c3aed,stroke:#a78bfa,color:#ede9fe
     style Cloud fill:#7c3aed,stroke:#a78bfa,color:#ede9fe
     style SES fill:#ea580c,stroke:#f97316,color:#fed7aa
+    style SMTP fill:#0e7490,stroke:#06b6d4,color:#cffafe
     style Inbox fill:#0e7490,stroke:#06b6d4,color:#cffafe
 ```
 
@@ -33,20 +40,20 @@ graph TB
 
 1. **SDK Call** - Your application calls `emails.send()` with recipients and HTML content
 2. **API Processing** - Request is validated and authenticated
-3. **Cloud Delivery** - InsForge Cloud queues and sends via AWS SES
-4. **Delivery** - Email is delivered to recipient inboxes
+3. **Provider Resolution** - `EmailService` checks per-call whether custom SMTP is enabled
+4. **Delivery** - The email is queued through AWS SES (cloud) or your SMTP server, then delivered to the recipient
 
 ```mermaid
 sequenceDiagram
     participant App as Your App
     participant SDK as InsForge SDK
     participant API as Email API
-    participant SES as AWS SES
+    participant Provider as Cloud (SES) or your SMTP
 
     App->>SDK: emails.send({to, subject, html})
     SDK->>API: POST /api/email/send-raw
-    API->>SES: Queue for delivery
-    SES-->>API: Accepted
+    API->>Provider: Route based on SMTP config
+    Provider-->>API: Accepted
     API-->>SDK: Success
     SDK-->>App: {data, error}
 ```
@@ -58,12 +65,20 @@ sequenceDiagram
     AWS SES infrastructure with optimized sending reputation
   </Card>
 
+  <Card title="Custom SMTP" icon="server" href="/core-concepts/email/custom-smtp">
+    Bring your own SMTP server and route every email — including auth flows — through your provider
+  </Card>
+
   <Card title="Multiple Recipients" icon="users">
     Send to up to 50 recipients per request with CC/BCC support
   </Card>
 
   <Card title="Custom Sender" icon="signature">
     Customize the sender display name for your brand
+  </Card>
+
+  <Card title="Editable Templates" icon="envelope-open-text" href="/core-concepts/email/custom-smtp#email-templates">
+    With custom SMTP enabled, customize the subject and HTML of every authentication email
   </Card>
 
   <Card title="HTML Content" icon="code">

--- a/docs/core-concepts/email/custom-smtp.mdx
+++ b/docs/core-concepts/email/custom-smtp.mdx
@@ -1,0 +1,138 @@
+---
+title: Custom SMTP
+description: Send authentication and transactional email through your own SMTP server
+---
+
+<Warning>
+  Email is an experimental feature. APIs and behavior may change.
+</Warning>
+
+## Overview
+
+By default, InsForge sends email through its managed cloud (AWS SES). When you configure a custom SMTP server, every outgoing email — both authentication emails (verification, password reset) and `emails.send()` calls — is routed through your provider instead. Switch back at any time by toggling SMTP off; no data migration required.
+
+Use custom SMTP when you want to:
+
+- Send from your own deliverability reputation and domain
+- Comply with data-residency requirements that forbid third-party SES
+- Self-host InsForge without depending on the cloud email backend
+- Customize the look and copy of authentication emails
+
+## How Routing Works
+
+```mermaid
+graph LR
+    SDK[SDK / Auth flow] --> Service[EmailService]
+    Service --> Check{SMTP enabled?}
+    Check -->|Yes| SMTP[Your SMTP server]
+    Check -->|No| Cloud[InsForge Cloud → AWS SES]
+
+    style SDK fill:#1e40af,stroke:#3b82f6,color:#dbeafe
+    style Service fill:#166534,stroke:#22c55e,color:#dcfce7
+    style Check fill:#7c3aed,stroke:#a78bfa,color:#ede9fe
+    style SMTP fill:#0e7490,stroke:#06b6d4,color:#cffafe
+    style Cloud fill:#ea580c,stroke:#f97316,color:#fed7aa
+```
+
+The provider is resolved per-call, so saving SMTP config takes effect immediately — no restart, no redeploy.
+
+## Configuration
+
+Custom SMTP is configured from the dashboard under **Authentication → Email**. The page has two cards: **SMTP Provider** (server credentials) and **Email Templates** (authentication-email content).
+
+<Steps>
+  <Step title="Open the Email settings page">
+    In the dashboard, navigate to **Authentication → Email**.
+  </Step>
+
+  <Step title="Toggle &quot;Enable Custom SMTP&quot;">
+    Flip the switch at the top of the **SMTP Provider** card. The form fields become editable.
+  </Step>
+
+  <Step title="Enter your SMTP server details">
+    Fill in host, port, username, password, sender email, and sender name. Required for every save.
+  </Step>
+
+  <Step title="Save">
+    InsForge connects to your SMTP server with `transporter.verify()` before persisting. Invalid credentials or unreachable hosts are rejected up-front, so a saved config is always a working config.
+  </Step>
+
+  <Step title="Customize templates (optional)">
+    With SMTP enabled, the **Email Templates** card unlocks. Edit the four authentication-email templates to match your brand.
+  </Step>
+</Steps>
+
+### Field reference
+
+| Field | Description |
+|-------|-------------|
+| **Host** | Hostname or public IP of your SMTP server. Private IPs (`10.x`, `172.16.x`, `192.168.x`, `127.x`, `169.254.x`, IPv6 link-local) are rejected. |
+| **Port** | One of `25`, `465`, `587`, `2525`. Port `465` uses implicit TLS; the others use STARTTLS. |
+| **Username** | SMTP authentication username. |
+| **Password** | SMTP authentication password. Encrypted at rest with AES-256-GCM and never returned by the API — only a `hasPassword: boolean` flag. |
+| **Sender email** | The `From:` address on every outgoing email. |
+| **Sender name** | Display name shown alongside the sender email. |
+| **Min interval (seconds)** | Per-recipient cooldown between sends. Defaults to `60`. Prevents accidental spam loops. |
+
+<Note>
+Self-signed TLS certificates are not supported — nodemailer rejects them by default. Use a publicly-trusted certificate on your SMTP server.
+</Note>
+
+## Email Templates
+
+When SMTP is enabled, all four authentication-email templates are rendered locally from `email.templates` instead of by InsForge Cloud. The seeded defaults work out of the box; customize them only when you want to.
+
+| Template type | When it sends |
+|---------------|---------------|
+| `email-verification-code` | New-user verification with a numeric code |
+| `email-verification-link` | New-user verification with a clickable link |
+| `reset-password-code` | Password reset with a numeric code |
+| `reset-password-link` | Password reset with a clickable link |
+
+### Template variables
+
+Templates use `{{ variable }}` placeholders. Available variables depend on the template type:
+
+| Variable | Available in | Notes |
+|----------|--------------|-------|
+| `{{ token }}` | `*-code` templates | The 6-digit verification or reset code |
+| `{{ link }}` | `*-link` templates | Full verification or reset URL. Must start with `http://` or `https://` — non-HTTP values are replaced with `#` |
+| `{{ name }}` | All templates | Recipient's display name (system-injected, cannot be overridden) |
+| `{{ email }}` | All templates | Recipient's email address (system-injected, cannot be overridden) |
+
+All variable values are HTML-escaped before substitution to prevent XSS. The `name` and `email` variables are always set by InsForge from the user record, so end users cannot spoof them.
+
+<Tip>
+Edit a template's HTML directly in the **Email Templates** card. The dashboard shows a live preview as you type.
+</Tip>
+
+## Security
+
+- **Encrypted credentials.** Passwords are encrypted with AES-256-GCM before they hit the database. The plaintext only exists in memory at send time.
+- **Forced sender.** When SMTP is enabled, the `From:` header is always built from your configured sender email and name, even if the SDK call passed a custom `from`. This prevents callers from spoofing senders through your server.
+- **SSRF protection.** Hostnames are resolved and any answer pointing at a private, loopback, link-local, or carrier-NAT range is rejected before connecting.
+- **Connect-on-save.** Saving an enabled config performs a real SMTP handshake. Bad credentials or unreachable hosts fail fast.
+- **Audit log.** Every save is recorded with action `UPDATE_SMTP_CONFIG`; template edits log `UPDATE_EMAIL_TEMPLATE`.
+
+## Rate Limiting
+
+The **min interval (seconds)** field caps how often a single recipient address can receive email. Sends within the cooldown return HTTP `429` with a `retryAfter` hint. Set to `0` to disable.
+
+This limit is enforced only when SMTP is enabled — the cloud provider has its own per-plan limits documented in [Email Architecture](/core-concepts/email/architecture#rate-limits).
+
+## API Reference
+
+All endpoints require an admin token.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/auth/smtp-config` | Read SMTP config (password masked) |
+| `PUT` | `/api/auth/smtp-config` | Create or update SMTP config; verifies connection when `enabled = true` |
+| `GET` | `/api/auth/email-templates` | List all email templates |
+| `PUT` | `/api/auth/email-templates/:type` | Update a single template's subject and body |
+
+The `:type` path parameter must be one of `email-verification-code`, `email-verification-link`, `reset-password-code`, or `reset-password-link`.
+
+## Switching Back
+
+To revert to InsForge Cloud delivery, flip **Enable Custom SMTP** off and save. The configuration is preserved in the database (so you can re-enable later without re-entering credentials), but every send reverts to the cloud provider on the next request.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,7 +77,8 @@
               {
                 "group": "Email (Experimental)",
                 "pages": [
-                  "core-concepts/email/architecture"
+                  "core-concepts/email/architecture",
+                  "core-concepts/email/custom-smtp"
                 ]
               },
               {

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -25,6 +25,10 @@ Send custom HTML emails to one or more recipients.
 - `from` (string, optional) - Custom sender name, max 100 characters
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
+<Note>
+When [Custom SMTP](/core-concepts/email/custom-smtp) is enabled for your project, the `from` field is ignored — the sender name and email are always taken from your SMTP configuration to prevent spoofing through your server.
+</Note>
+
 ### Returns
 
 ```typescript


### PR DESCRIPTION
## Summary

- New **Custom SMTP** page (`docs/core-concepts/email/custom-smtp.mdx`) covering routing, dashboard setup, fields/ports, template variables, security model, rate limiting, and admin API endpoints
- **Email Architecture** page now shows the Cloud-vs-SMTP routing decision in both diagrams, with feature cards linking to the new page
- **TypeScript Email SDK** reference notes that the `from` field is ignored when Custom SMTP is enabled (sender is forced from SMTP config to prevent spoofing)
- **Authentication Architecture** page mentions that verification and password-reset emails can be routed through Custom SMTP with editable templates
- `docs.json` registers the new page under the Email (Experimental) group

The feature itself shipped earlier (admin endpoints, dashboard UI, providers, templates seeded) but docs still described email as cloud-only.

## Test plan

- [x] `npx mintlify dev` boots clean — only the three pre-existing `sdks/typescript/ui-components/*` warnings, none from this change
- [x] All four edited/new pages return HTTP 200 locally and contain the expected rendered content (steps, diagrams, tables, internal links)
- [x] `docs.json` validates as JSON; new page appears in the sidebar under Email (Experimental)
- [ ] Reviewer: spot-check the Mintlify production preview once it builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented Custom SMTP configuration for flexible email delivery routing alongside InsForge Cloud option.
  * Added setup guidance with security controls, validation requirements, and dashboard instructions.
  * Clarified editable authentication email templates with custom subject lines and HTML support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->