### PR TITLE
fix(secrets): deduplicate and enforce UNIQUE(key) on system.secrets

### DIFF
--- a/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
+++ b/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
@@ -1,0 +1,80 @@
+-- Migration: 035 - Deduplicate system.secrets and ensure UNIQUE(key).
+--
+-- Background: some installs have multiple is_active=true rows for the same
+-- key value (e.g. two rows with key='API_KEY'), produced when a manual SQL
+-- operation or a concurrent boot inserted a row on top of an existing one
+-- on a DB that lacked a UNIQUE(key) constraint. With duplicates present,
+-- read queries (UPDATE ... WHERE key = $1) match more than one row and
+-- Postgres returns them in non-deterministic order, so the same client API
+-- key validates as match/mismatch unpredictably and the user perceives the
+-- API key as "rotating" without an actual rotation event.
+--
+-- This migration heals existing duplicates and adds the missing UNIQUE
+-- constraint so neither the boot path, a manual psql session, nor a future
+-- partial migration can re-create the state. It is idempotent.
+
+-- 1. Collapse duplicates: keep the most recently created row per key,
+--    rename the rest with a unique _DUP_<id> suffix and mark them inactive
+--    + immediately expired so read paths ignore them but audit history is
+--    preserved. Skips rows already in the API_KEY_OLD_* grace-period
+--    namespace (those are intentional rotation history).
+DO $$
+DECLARE
+  dup_key TEXT;
+BEGIN
+  FOR dup_key IN
+    SELECT key
+    FROM system.secrets
+    WHERE key NOT LIKE 'API_KEY_OLD_%'
+    GROUP BY key
+    HAVING count(*) > 1
+  LOOP
+    UPDATE system.secrets
+    SET key = key || '_DUP_' || id::text,
+        is_active = false,
+        expires_at = NOW()
+    WHERE key = dup_key
+      AND id <> (
+        SELECT id
+        FROM system.secrets
+        WHERE key = dup_key
+        ORDER BY created_at DESC
+        LIMIT 1
+      );
+    RAISE NOTICE 'Collapsed duplicates for key=%', dup_key;
+  END LOOP;
+END $$;
+
+-- 2. Add UNIQUE(key) if missing. Idempotent — checks for an equivalent
+--    constraint or unique index on (key) before adding.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'system'
+      AND t.relname = 'secrets'
+      AND c.contype = 'u'
+      AND (
+        SELECT array_agg(a.attname)
+        FROM unnest(c.conkey) ck
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ck
+      ) = ARRAY['key']
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM pg_index i
+    JOIN pg_class t ON t.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+    WHERE n.nspname = 'system'
+      AND t.relname = 'secrets'
+      AND i.indisunique
+      AND a.attname = 'key'
+      AND array_length(i.indkey::int[], 1) = 1
+  ) THEN
+    ALTER TABLE system.secrets ADD CONSTRAINT secrets_key_unique UNIQUE (key);
+    RAISE NOTICE 'Added UNIQUE constraint secrets_key_unique on system.secrets(key)';
+  END IF;
+END $$;

--- a/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
+++ b/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
@@ -68,7 +68,10 @@ BEGIN
       AND t.relname = 'secrets'
       AND c.contype = 'u'
       AND (
-        SELECT array_agg(a.attname)
+        -- Cast attname (type: name) to text so the comparison against
+        -- ARRAY['key'] (type: text[]) doesn't fail with
+        -- "operator does not exist: name[] = text[]".
+        SELECT array_agg(a.attname::text)
         FROM unnest(c.conkey) ck
         JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ck
       ) = ARRAY['key']

--- a/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
+++ b/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
@@ -35,10 +35,20 @@ BEGIN
         expires_at = NOW()
     WHERE key = dup_key
       AND id <> (
+        -- Prefer a row that the read paths would actually accept
+        -- (is_active=true AND not-expired). If none qualifies, fall back
+        -- to newest by created_at so we still pick deterministically.
         SELECT id
         FROM system.secrets
         WHERE key = dup_key
-        ORDER BY created_at DESC
+        ORDER BY
+          CASE
+            WHEN is_active = true
+             AND (expires_at IS NULL OR expires_at > NOW()) THEN 0
+            ELSE 1
+          END,
+          created_at DESC,
+          id DESC
         LIMIT 1
       );
     RAISE NOTICE 'Collapsed duplicates for key=%', dup_key;
@@ -71,8 +81,12 @@ BEGIN
     WHERE n.nspname = 'system'
       AND t.relname = 'secrets'
       AND i.indisunique
+      AND i.indisvalid       -- skip indexes still being built / never validated
+      AND i.indisready       -- skip indexes not yet ready for inserts
+      AND i.indpred IS NULL  -- not a partial index (would skip rows)
+      AND i.indexprs IS NULL -- not an expression index (different semantics)
+      AND i.indnkeyatts = 1  -- single-column index
       AND a.attname = 'key'
-      AND array_length(i.indkey::int[], 1) = 1
   ) THEN
     ALTER TABLE system.secrets ADD CONSTRAINT secrets_key_unique UNIQUE (key);
     RAISE NOTICE 'Added UNIQUE constraint secrets_key_unique on system.secrets(key)';

--- a/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
+++ b/backend/src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql
@@ -13,6 +13,14 @@
 -- constraint so neither the boot path, a manual psql session, nor a future
 -- partial migration can re-create the state. It is idempotent.
 
+-- 0. Block concurrent writers for the duration of this migration so a
+--    concurrent INSERT can't slip new duplicates between the dedupe
+--    step and the ADD CONSTRAINT step (which would make the latter fail).
+--    SHARE ROW EXCLUSIVE blocks INSERT/UPDATE/DELETE but lets SELECTs
+--    through; the lock releases automatically when the migration's
+--    surrounding transaction commits.
+LOCK TABLE system.secrets IN SHARE ROW EXCLUSIVE MODE;
+
 -- 1. Collapse duplicates: keep the most recently created row per key,
 --    rename the rest with a unique _DUP_<id> suffix and mark them inactive
 --    + immediately expired so read paths ignore them but audit history is

--- a/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
+++ b/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -10,7 +10,16 @@ const migrationPath = path.resolve(
 );
 
 describe('035_fix-secrets-deduplicate-and-unique migration', () => {
-  const sql = fs.readFileSync(migrationPath, 'utf8');
+  let sql = '';
+
+  beforeAll(() => {
+    // Defer the read so the "file exists" test below can fail cleanly
+    // with a clear assertion message instead of an ENOENT thrown during
+    // describe-block evaluation.
+    if (fs.existsSync(migrationPath)) {
+      sql = fs.readFileSync(migrationPath, 'utf8');
+    }
+  });
 
   it('migration file exists', () => {
     expect(fs.existsSync(migrationPath)).toBe(true);
@@ -50,10 +59,12 @@ describe('035_fix-secrets-deduplicate-and-unique migration', () => {
     expect(sql).toMatch(/key\s+NOT LIKE\s+'API_KEY_OLD_%'/i);
   });
 
-  it('keeps the most recently created row as the tiebreaker', () => {
-    // The exclusion subquery includes created_at DESC as a tiebreaker after
-    // the active/unexpired prioritization (see test below).
-    expect(sql).toMatch(/created_at\s+DESC[\s\S]*?LIMIT\s+1/i);
+  it('uses created_at DESC then id DESC as deterministic tiebreakers', () => {
+    // The exclusion subquery includes created_at DESC as the primary
+    // tiebreaker (after active/unexpired prioritization), then id DESC as
+    // a final tiebreaker so the survivor is fully deterministic even when
+    // multiple rows share a created_at value.
+    expect(sql).toMatch(/created_at\s+DESC\s*,\s*id\s+DESC[\s\S]*?LIMIT\s+1/i);
   });
 
   it('prioritizes is_active=true AND non-expired rows when picking the survivor', () => {

--- a/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
+++ b/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
@@ -48,9 +48,20 @@ describe('035_fix-secrets-deduplicate-and-unique migration', () => {
     expect(sql).toMatch(/key\s+NOT LIKE\s+'API_KEY_OLD_%'/i);
   });
 
-  it('keeps the most recently created row as the survivor', () => {
-    // The exclusion subquery picks newest-by-created_at as the row to keep.
-    expect(sql).toMatch(/ORDER BY\s+created_at\s+DESC\s+LIMIT\s+1/i);
+  it('keeps the most recently created row as the tiebreaker', () => {
+    // The exclusion subquery includes created_at DESC as a tiebreaker after
+    // the active/unexpired prioritization (see test below).
+    expect(sql).toMatch(/created_at\s+DESC[\s\S]*?LIMIT\s+1/i);
+  });
+
+  it('prioritizes is_active=true AND non-expired rows when picking the survivor', () => {
+    // If duplicates include both an active-non-expired row and an
+    // inactive/expired one, the migration must keep the active one even if
+    // the inactive row has a newer created_at — otherwise we'd deactivate
+    // the only row that the read paths actually accept.
+    expect(sql).toMatch(
+      /CASE[\s\S]*?is_active\s*=\s*true[\s\S]*?expires_at\s+IS\s+NULL\s+OR\s+expires_at\s*>\s*NOW\(\)[\s\S]*?END/i
+    );
   });
 
   it('renames duplicates with a _DUP_<id> suffix to keep them globally unique', () => {
@@ -89,10 +100,21 @@ describe('035_fix-secrets-deduplicate-and-unique migration', () => {
     expect(sql).toMatch(/'key'/);
   });
 
-  it('skips constraint add if a unique index on (key) already exists', () => {
-    // Some installs may have a unique index without a named constraint
-    // (e.g., from Postgres auto-generation on UNIQUE column declarations).
-    expect(sql).toMatch(/pg_index[\s\S]*?indisunique/i);
+  it('skips constraint add only for a valid, complete, single-column unique index on (key)', () => {
+    // pg_index.indisunique alone is not enough — partial, expression, and
+    // not-yet-validated unique indexes can exist and don't enforce
+    // unconditional uniqueness. The migration must require:
+    //   indisunique + indisvalid + indisready
+    //   indpred IS NULL  (not partial)
+    //   indexprs IS NULL (not expression)
+    //   indnkeyatts = 1  (single-column)
+    expect(sql).toMatch(/pg_index/i);
+    expect(sql).toMatch(/indisunique/);
+    expect(sql).toMatch(/indisvalid/);
+    expect(sql).toMatch(/indisready/);
+    expect(sql).toMatch(/indpred\s+IS\s+NULL/i);
+    expect(sql).toMatch(/indexprs\s+IS\s+NULL/i);
+    expect(sql).toMatch(/indnkeyatts\s*=\s*1/i);
   });
 
   it('adds the constraint with a descriptive name', () => {

--- a/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
+++ b/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDir,
+  '../../src/infra/database/migrations/035_fix-secrets-deduplicate-and-unique.sql'
+);
+
+describe('035_fix-secrets-deduplicate-and-unique migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('runs after migration 034', () => {
+    const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const idx035 = migrations.indexOf('035_fix-secrets-deduplicate-and-unique.sql');
+    const idx034 = migrations.indexOf('034_extend-storage-objects-for-s3-protocol.sql');
+    expect(idx034).toBeGreaterThanOrEqual(0);
+    expect(idx035).toBeGreaterThan(idx034);
+  });
+
+  it('targets the system.secrets table', () => {
+    expect(sql).toMatch(/system\.secrets/);
+    // Make sure we're not accidentally touching some other secrets table
+    expect(sql).not.toMatch(/public\.secrets|auth\.secrets/);
+  });
+
+  // ── Step 1: Dedupe ────────────────────────────────────────────────────
+  it('wraps the dedupe step in a DO block for idempotency', () => {
+    expect(sql).toMatch(/DO\s*\$\$[\s\S]*?FOR\s+\w+\s+IN[\s\S]*?LOOP[\s\S]*?END\s+LOOP[\s\S]*?\$\$/i);
+  });
+
+  it('only collapses keys that have more than one row', () => {
+    expect(sql).toMatch(/GROUP BY key\s+HAVING\s+count\(\*\)\s*>\s*1/i);
+  });
+
+  it('skips API_KEY_OLD_* rows so rotation history is preserved', () => {
+    expect(sql).toMatch(/key\s+NOT LIKE\s+'API_KEY_OLD_%'/i);
+  });
+
+  it('keeps the most recently created row as the survivor', () => {
+    // The exclusion subquery picks newest-by-created_at as the row to keep.
+    expect(sql).toMatch(/ORDER BY\s+created_at\s+DESC\s+LIMIT\s+1/i);
+  });
+
+  it('renames duplicates with a _DUP_<id> suffix to keep them globally unique', () => {
+    // The renamed key embeds the row's UUID, so even without UNIQUE(key)
+    // already enforced, two rename targets cannot collide.
+    expect(sql).toMatch(/key\s*=\s*key\s*\|\|\s*'_DUP_'\s*\|\|\s*id::text/i);
+  });
+
+  it('marks renamed duplicates as inactive', () => {
+    expect(sql).toMatch(/is_active\s*=\s*false/i);
+  });
+
+  it('expires renamed duplicates immediately so read paths skip them', () => {
+    // Reads filter `expires_at IS NULL OR expires_at > NOW()`, so setting
+    // expires_at = NOW() makes the orphan invisible to validation.
+    expect(sql).toMatch(/expires_at\s*=\s*NOW\(\)/i);
+  });
+
+  // ── Step 2: UNIQUE(key) constraint ────────────────────────────────────
+  it('wraps the constraint add in a DO block for idempotency', () => {
+    // The constraint add must be inside a DO block (so it can branch on
+    // existence checks), not a bare ALTER TABLE that would error on re-run.
+    const lines = sql.split('\n');
+    const alterLine = lines.find((l) => /ALTER TABLE.*ADD CONSTRAINT/i.test(l));
+    expect(alterLine).toBeDefined();
+
+    // Confirm the ALTER lives inside a DO block, not at top-level.
+    const doBlocks = sql.match(/DO\s*\$\$[\s\S]*?\$\$/g) ?? [];
+    const inAnyDoBlock = doBlocks.some((block) => /ALTER TABLE.*ADD CONSTRAINT/i.test(block));
+    expect(inAnyDoBlock).toBe(true);
+  });
+
+  it('skips constraint add if an equivalent unique constraint already exists', () => {
+    // Looks at pg_constraint for a UNIQUE constraint on the (key) column.
+    expect(sql).toMatch(/pg_constraint[\s\S]*?contype\s*=\s*'u'/i);
+    expect(sql).toMatch(/'key'/);
+  });
+
+  it('skips constraint add if a unique index on (key) already exists', () => {
+    // Some installs may have a unique index without a named constraint
+    // (e.g., from Postgres auto-generation on UNIQUE column declarations).
+    expect(sql).toMatch(/pg_index[\s\S]*?indisunique/i);
+  });
+
+  it('adds the constraint with a descriptive name', () => {
+    expect(sql).toMatch(/CONSTRAINT\s+secrets_key_unique\s+UNIQUE\s*\(\s*key\s*\)/i);
+  });
+
+  it('does NOT use a bare top-level ALTER TABLE ADD CONSTRAINT (non-idempotent)', () => {
+    const outsideDoBlocks = sql.replace(/DO\s*\$\$[\s\S]*?\$\$/g, '');
+    expect(outsideDoBlocks).not.toMatch(/ALTER TABLE.*ADD CONSTRAINT/i);
+  });
+
+  // ── Safety: no destructive operations ─────────────────────────────────
+  it('does not DELETE any rows', () => {
+    // Dedupe is by rename, not by DELETE. Keeping rows preserves audit history
+    // and leaves recovery options open if a wrong row is picked as survivor.
+    expect(sql).not.toMatch(/\bDELETE\s+FROM\s+system\.secrets\b/i);
+  });
+
+  it('does not DROP the secrets table or any of its columns', () => {
+    expect(sql).not.toMatch(/DROP\s+TABLE.*secrets/i);
+    expect(sql).not.toMatch(/DROP\s+COLUMN/i);
+  });
+});

--- a/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
+++ b/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
@@ -37,7 +37,9 @@ describe('035_fix-secrets-deduplicate-and-unique migration', () => {
 
   // ── Step 1: Dedupe ────────────────────────────────────────────────────
   it('wraps the dedupe step in a DO block for idempotency', () => {
-    expect(sql).toMatch(/DO\s*\$\$[\s\S]*?FOR\s+\w+\s+IN[\s\S]*?LOOP[\s\S]*?END\s+LOOP[\s\S]*?\$\$/i);
+    expect(sql).toMatch(
+      /DO\s*\$\$[\s\S]*?FOR\s+\w+\s+IN[\s\S]*?LOOP[\s\S]*?END\s+LOOP[\s\S]*?\$\$/i
+    );
   });
 
   it('only collapses keys that have more than one row', () => {

--- a/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
+++ b/backend/tests/unit/secrets-deduplicate-and-unique-migration.test.ts
@@ -44,6 +44,14 @@ describe('035_fix-secrets-deduplicate-and-unique migration', () => {
     expect(sql).not.toMatch(/public\.secrets|auth\.secrets/);
   });
 
+  it('locks the table to close the dedupe→constraint race window', () => {
+    // Without this lock, a concurrent writer can re-introduce duplicates
+    // between step 1 (dedupe) and step 2 (ADD CONSTRAINT), making the
+    // constraint add fail. SHARE ROW EXCLUSIVE blocks writers but lets
+    // SELECTs through.
+    expect(sql).toMatch(/LOCK\s+TABLE\s+system\.secrets\s+IN\s+SHARE\s+ROW\s+EXCLUSIVE\s+MODE/i);
+  });
+
   // ── Step 1: Dedupe ────────────────────────────────────────────────────
   it('wraps the dedupe step in a DO block for idempotency', () => {
     expect(sql).toMatch(


### PR DESCRIPTION
## Summary

Some installs accumulate multiple `is_active=true` rows for the same key in `system.secrets` (typically `key='API_KEY'`). With duplicates present, read queries (`UPDATE ... WHERE key = $1` without `LIMIT 1`) match more than one row and Postgres returns them in non-deterministic order, so the same client API key validates as match/mismatch unpredictably — the user perceives the API key as "rotating" with no rotation event in the audit log.

This migration:

- Collapses duplicates per key — keeps the newest active row, renames the rest to `<key>_DUP_<uuid>` with `is_active=false` and `expires_at=NOW()`. Rows are preserved as audit history; read paths already filter `expires_at > NOW() AND is_active = true` so they're invisible to validation.
- Adds `UNIQUE(key)` to `system.secrets`, idempotently. Once in place, neither the boot path, a manual psql session, nor a half-applied migration can re-create the state — the database returns a clean `duplicate key value` error instead of silently corrupting the table.

The migration skips the constraint add if an equivalent unique constraint or unique index on `(key)` already exists, so it is safe on installs that already have one.

## Why no application code changes

Read paths (`getSecretByKey`, `checkSecretByKey`, `verifyApiKey`) and the rotation flow (`rotateApiKey`) all assume one row per key. With `UNIQUE(key)` enforced at the database, that assumption is now backed by Postgres rather than left to application convention. Existing code keeps working without modification — the rare race window between `getSecretByKey` and `createSecret` now produces a hard error on `INSERT` rather than a silent duplicate, which is the desired failure mode.

The grace-period rotation design is unaffected: rotated keys are renamed to `API_KEY_OLD_<timestamp>`, which is a distinct key value, so the unique constraint and the grace overlap coexist by design.

## Repro / verification

On an affected install:

```sql
-- Before: duplicates visible
SELECT key, count(*) FROM system.secrets
WHERE key NOT LIKE 'API_KEY_OLD_%'
GROUP BY key HAVING count(*) > 1;
```

After running the migration:

```sql
-- After: no duplicates, constraint present
SELECT key, count(*) FROM system.secrets GROUP BY key HAVING count(*) > 1;
-- (zero rows)

\d system.secrets
-- shows: "secrets_key_unique" UNIQUE CONSTRAINT, btree (key)
```

Validation requests that were previously flapping between rows now consistently match the surviving live row.

## Test plan

- [ ] Migration runs cleanly on a DB with no duplicates (no-op except adding the constraint, idempotent on re-run)
- [ ] Migration runs cleanly on a DB with duplicate `API_KEY` rows — collapses to one active row, adds constraint
- [ ] Migration is idempotent — re-running on a healed DB is a no-op
- [ ] After migration, `rotateApiKey` still produces exactly one `is_active=true API_KEY` row plus the renamed `API_KEY_OLD_<ts>` grace-period row
- [ ] After migration, attempting to `INSERT INTO system.secrets (key, …) VALUES ('API_KEY', …)` returns `duplicate key value violates unique constraint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deduplicated secret entries by deactivating and expiring duplicate keys, and added a UNIQUE constraint to prevent future duplicates.
* **Tests**
  * Added unit tests to validate deduplication behavior, duplicate renaming/expiry, and conditional uniqueness enforcement to ensure the migration is safe and repeatable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->