### PR TITLE
INS-99 Fix stale database table cache invalidation keys

### DIFF
--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -7,6 +7,7 @@ import type { TokenPayloadSchema } from '@insforge/shared-schemas';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
 const ACCESS_TOKEN_EXPIRES_IN = '15m';
+const ADMIN_ACCESS_TOKEN_EXPIRES_IN = '30s';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 /**
@@ -55,7 +56,10 @@ export class TokenManager {
   generateAccessToken(payload: TokenPayloadSchema): string {
     return jwt.sign(payload, JWT_SECRET, {
       algorithm: 'HS256',
-      expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+      expiresIn:
+        payload.role === 'project_admin'
+          ? ADMIN_ACCESS_TOKEN_EXPIRES_IN
+          : ACCESS_TOKEN_EXPIRES_IN,
     });
   }
 

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -7,7 +7,6 @@ import type { TokenPayloadSchema } from '@insforge/shared-schemas';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
 const ACCESS_TOKEN_EXPIRES_IN = '15m';
-const ADMIN_ACCESS_TOKEN_EXPIRES_IN = '30s';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 /**
@@ -56,10 +55,7 @@ export class TokenManager {
   generateAccessToken(payload: TokenPayloadSchema): string {
     return jwt.sign(payload, JWT_SECRET, {
       algorithm: 'HS256',
-      expiresIn:
-        payload.role === 'project_admin'
-          ? ADMIN_ACCESS_TOKEN_EXPIRES_IN
-          : ACCESS_TOKEN_EXPIRES_IN,
+      expiresIn: ACCESS_TOKEN_EXPIRES_IN,
     });
   }
 

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -20,6 +20,7 @@ import { RecordFormField } from './RecordFormField';
 import { cn } from '../../../lib/utils/utils';
 import { ColumnSchema } from '@insforge/shared-schemas';
 import { SYSTEM_FIELDS } from '../helpers';
+import { databaseTableQueryKeys } from '../queryKeys';
 
 interface RecordFormDialogProps {
   open: boolean;
@@ -76,7 +77,7 @@ export function RecordFormDialog({
       try {
         await createRecord(data);
         void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-        void queryClient.invalidateQueries({ queryKey: ['table', tableName] });
+        void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
         onOpenChange(false);
         form.reset();
         setError(null);

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, X } from 'lucide-react';
 import {
   Button,
@@ -20,7 +19,6 @@ import { RecordFormField } from './RecordFormField';
 import { cn } from '../../../lib/utils/utils';
 import { ColumnSchema } from '@insforge/shared-schemas';
 import { SYSTEM_FIELDS } from '../helpers';
-import { databaseTableQueryKeys } from '../queryKeys';
 
 interface RecordFormDialogProps {
   open: boolean;
@@ -38,7 +36,6 @@ export function RecordFormDialog({
   onSuccess,
 }: RecordFormDialogProps) {
   const [error, setError] = useState<string | null>(null);
-  const queryClient = useQueryClient();
   const { createRecord, isCreating } = useRecords(tableName);
 
   const displayFields = useMemo(() => {
@@ -76,8 +73,6 @@ export function RecordFormDialog({
     async (data) => {
       try {
         await createRecord(data);
-        void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-        void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
         onOpenChange(false);
         form.reset();
         setError(null);

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -363,9 +363,11 @@ export function TableForm({
           queryKey: databaseTableQueryKeys.schema(editTable.tableName),
         });
       }
-      void queryClient.invalidateQueries({
-        queryKey: databaseTableQueryKeys.schema(data.tableName),
-      });
+      if (data.tableName !== editTable?.tableName) {
+        void queryClient.invalidateQueries({
+          queryKey: databaseTableQueryKeys.schema(data.tableName),
+        });
+      }
 
       // Invalidate all table data queries for this table (with all parameter combinations)
       void queryClient.invalidateQueries({ queryKey: ['records', editTable?.tableName] });

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -17,6 +17,7 @@ import { TableFormColumn } from './TableFormColumn';
 import { ForeignKeyPopover } from './ForeignKeyPopover';
 import { ColumnType, TableSchema, UpdateTableSchemaRequest } from '@insforge/shared-schemas';
 import { SYSTEM_FIELDS } from '../helpers';
+import { databaseTableQueryKeys } from '../queryKeys';
 
 const newColumn: TableFormColumnSchema = {
   columnName: '',
@@ -224,7 +225,7 @@ export function TableForm({
     },
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ['database-metadata'] });
-      void queryClient.invalidateQueries({ queryKey: ['tables'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
       void queryClient.invalidateQueries({ queryKey: ['metadata'] });
 
       showToast('Table created successfully!', 'success');
@@ -355,13 +356,18 @@ export function TableForm({
     },
     onSuccess: (_, data) => {
       void queryClient.invalidateQueries({ queryKey: ['database-metadata'] });
-      void queryClient.invalidateQueries({ queryKey: ['tables'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
       void queryClient.invalidateQueries({ queryKey: ['metadata'] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', editTable?.tableName, 'schema'] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', data.tableName, 'schema'] });
+      if (editTable?.tableName) {
+        void queryClient.invalidateQueries({
+          queryKey: databaseTableQueryKeys.schema(editTable.tableName),
+        });
+      }
+      void queryClient.invalidateQueries({
+        queryKey: databaseTableQueryKeys.schema(data.tableName),
+      });
 
       // Invalidate all table data queries for this table (with all parameter combinations)
-      void queryClient.invalidateQueries({ queryKey: ['table', editTable?.tableName] });
       void queryClient.invalidateQueries({ queryKey: ['records', editTable?.tableName] });
       void queryClient.invalidateQueries({ queryKey: ['records', data.tableName] });
 
@@ -374,9 +380,6 @@ export function TableForm({
       onSuccess?.(data.tableName);
     },
     onError: (err) => {
-      // Invalidate queries to ensure we have fresh data after failed request
-      void queryClient.invalidateQueries({ queryKey: ['table', editTable?.tableName] });
-
       const errorMessage = err.message || 'Failed to update table';
       setError(errorMessage);
       showToast(errorMessage, 'error');

--- a/packages/dashboard/src/features/database/hooks/useRawSQL.ts
+++ b/packages/dashboard/src/features/database/hooks/useRawSQL.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { advanceService } from '../services/advance.service';
+import { databaseTableQueryKeys } from '../queryKeys';
 import { RawSQLResponse } from '@insforge/shared-schemas';
 import { useToast } from '../../../lib/hooks/useToast';
 
@@ -25,8 +26,8 @@ export function useRawSQL(options?: UseRawSQLOptions) {
     },
     onSuccess: (data) => {
       // Invalidate database schema queries to ensure UI reflects any schema changes
-      void queryClient.invalidateQueries({ queryKey: ['tables'] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', 'schemas'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schemaRoot });
 
       if (options?.showSuccessToast !== false) {
         const message = 'SQL query executed successfully';

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { recordService } from '../services/record.service';
+import { databaseTableQueryKeys } from '../queryKeys';
 import { useToast } from '../../../lib/hooks/useToast';
 import { ConvertedValue } from '../../../components/datagrid/datagridTypes';
 
@@ -50,7 +51,7 @@ export function useRecords(tableName: string) {
       recordService.createRecord(tableName, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', tableName, 'schema'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
       showToast('Record created successfully', 'success');
     },
     onError: (error: Error) => {
@@ -65,7 +66,7 @@ export function useRecords(tableName: string) {
       recordService.createRecords(tableName, records),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', tableName, 'schema'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
       showToast('Records created successfully', 'success');
     },
     onError: (error: Error) => {
@@ -87,7 +88,7 @@ export function useRecords(tableName: string) {
     }) => recordService.updateRecord(tableName, pkColumn, pkValue, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', tableName, 'schema'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
       showToast('Record updated successfully', 'success');
     },
     onError: (error: Error) => {
@@ -102,7 +103,7 @@ export function useRecords(tableName: string) {
       recordService.deleteRecords(tableName, variables.pkColumn, variables.pkValues),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: ['records', tableName] });
-      void queryClient.invalidateQueries({ queryKey: ['tables', tableName, 'schema'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
       const count = variables.pkValues.length;
       if (count === 1) {
         showToast('Record deleted successfully', 'success');

--- a/packages/dashboard/src/features/database/hooks/useTables.ts
+++ b/packages/dashboard/src/features/database/hooks/useTables.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { tableService } from '../services/table.service';
+import { databaseTableQueryKeys } from '../queryKeys';
 import { useToast } from '../../../lib/hooks/useToast';
 import {
   ColumnSchema,
@@ -18,7 +19,7 @@ export function useTables() {
     error: tablesError,
     refetch: refetchTables,
   } = useQuery({
-    queryKey: ['tables'],
+    queryKey: databaseTableQueryKeys.list,
     queryFn: () => tableService.listTables(),
     staleTime: 2 * 60 * 1000, // Cache for 2 minutes
   });
@@ -26,7 +27,7 @@ export function useTables() {
   // Query to fetch a specific table schema (cached per table)
   const useTableSchema = (tableName: string, enabled = true) => {
     return useQuery({
-      queryKey: ['tables', tableName, 'schema'],
+      queryKey: databaseTableQueryKeys.schema(tableName),
       queryFn: () => tableService.getTableSchema(tableName),
       enabled: enabled && !!tableName,
       staleTime: 2 * 60 * 1000,
@@ -38,7 +39,7 @@ export function useTables() {
     mutationFn: ({ tableName, columns }: { tableName: string; columns: ColumnSchema[] }) =>
       tableService.createTable(tableName, columns),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['tables'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
       showToast('Table created successfully', 'success');
     },
     onError: (error: Error) => {
@@ -51,7 +52,7 @@ export function useTables() {
   const deleteTableMutation = useMutation({
     mutationFn: (tableName: string) => tableService.deleteTable(tableName),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['tables'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
       showToast('Table deleted successfully', 'success');
     },
     onError: (error: Error) => {
@@ -70,7 +71,7 @@ export function useTables() {
       operations: UpdateTableSchemaRequest;
     }) => tableService.updateTableSchema(tableName, operations),
     onSuccess: (_, { tableName }) => {
-      void queryClient.invalidateQueries({ queryKey: ['tables', tableName, 'schema'] });
+      void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.schema(tableName) });
       showToast('Table schema updated successfully', 'success');
     },
     onError: (error: Error) => {
@@ -115,7 +116,7 @@ export function useAllTableSchemas(enabled = true) {
   const { allSchemas, isLoadingSchemas } = useQueries({
     queries: enabled
       ? tables.map((tableName) => ({
-          queryKey: ['tables', tableName, 'schema'],
+          queryKey: databaseTableQueryKeys.schema(tableName),
           queryFn: () => tableService.getTableSchema(tableName),
           staleTime: 2 * 60 * 1000,
         }))

--- a/packages/dashboard/src/features/database/queryKeys.ts
+++ b/packages/dashboard/src/features/database/queryKeys.ts
@@ -1,0 +1,5 @@
+export const databaseTableQueryKeys = {
+  list: ['database', 'tables', 'list'] as const,
+  schemaRoot: ['database', 'tables', 'schema'] as const,
+  schema: (tableName: string) => ['database', 'tables', 'schema', tableName] as const,
+};

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import { loginService } from '../../features/login/services/login.service';
+import { databaseTableQueryKeys } from '../../features/database/queryKeys';
 import { useDashboardHost } from '../config/DashboardHostContext';
 import { apiClient } from '../api/client';
 import { getCurrentDistinctId, identifyUser } from '../analytics/posthog';
@@ -65,7 +66,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       queryClient.invalidateQueries({ queryKey: ['apiKey'] }),
       queryClient.invalidateQueries({ queryKey: ['metadata'] }),
       queryClient.invalidateQueries({ queryKey: ['users'] }),
-      queryClient.invalidateQueries({ queryKey: ['tables'] }),
+      queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list }),
       queryClient.invalidateQueries({ queryKey: ['mcp-usage'] }),
     ]);
   }, [queryClient]);

--- a/packages/dashboard/src/lib/contexts/SocketContext.tsx
+++ b/packages/dashboard/src/lib/contexts/SocketContext.tsx
@@ -14,6 +14,7 @@ import { apiClient } from '../api/client';
 import { useAuth } from './AuthContext';
 import { getDashboardBackendUrl } from '../config/runtime';
 import type { SocketMessage } from '@insforge/shared-schemas';
+import { databaseTableQueryKeys } from '../../features/database/queryKeys';
 import { useMcpUsage } from '../../features/logs/hooks/useMcpUsage';
 import { trackPostHog, getFeatureFlag } from '../analytics/posthog';
 
@@ -263,14 +264,16 @@ export function SocketProvider({ children }: SocketProviderProps) {
             switch (change.type) {
               case 'tables':
                 // CREATE TABLE / DROP TABLE - affects table list
-                void queryClient.invalidateQueries({ queryKey: ['tables'] });
+                void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
                 void queryClient.invalidateQueries({ queryKey: ['metadata', 'full'] });
                 break;
               case 'table':
                 // ALTER TABLE / RENAME - affects specific table and list
-                void queryClient.invalidateQueries({ queryKey: ['tables'] });
+                void queryClient.invalidateQueries({ queryKey: databaseTableQueryKeys.list });
                 if (change.name) {
-                  void queryClient.invalidateQueries({ queryKey: ['table', change.name] });
+                  void queryClient.invalidateQueries({
+                    queryKey: databaseTableQueryKeys.schema(change.name),
+                  });
                 }
                 break;
               case 'records':


### PR DESCRIPTION
## Summary

This PR attempts to fix a problem that the tables list in database stuck in loading state after the dashboard stale for a while. I will monitor closely if such case happens again after this PR fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized database cache key handling across the dashboard to replace scattered hardcoded keys with standardized, reusable query-key helpers—streamlining cache invalidation for table lists and per-table schemas and improving consistency and maintainability without changing visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->