### PR TITLE
feat(compute): wire OSS provider for Path A source-deploy

### DIFF
--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -632,7 +632,8 @@ export class ComputeServicesService {
       }
     } else if (data.imageUrl && existing.flyAppId && !existing.flyMachineId) {
       // Path A: prepareForDeploy created the app + DB row but no machine.
-      // CLI has now docker-pushed the image and is telling us to launch.
+      // CLI has now built+pushed the image (via flyctl remote builder, or
+      // pre-built --image URL) and is telling us to launch the machine.
       const existingRow = await this.getPool().query(
         `SELECT env_vars_encrypted FROM compute.services WHERE id = $1`,
         [id]

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -630,6 +630,58 @@ export class ComputeServicesService {
           ERROR_CODES.COMPUTE_SERVICE_DEPLOY_FAILED
         );
       }
+    } else if (data.imageUrl && existing.flyAppId && !existing.flyMachineId) {
+      // Path A: prepareForDeploy created the app + DB row but no machine.
+      // CLI has now docker-pushed the image and is telling us to launch.
+      const existingRow = await this.getPool().query(
+        `SELECT env_vars_encrypted FROM compute.services WHERE id = $1`,
+        [id]
+      );
+      const existingEnvVarsEncrypted: string | null =
+        existingRow.rows[0]?.env_vars_encrypted ?? null;
+      const envVars = data.envVars ?? this.decryptEnvVars(existingEnvVarsEncrypted);
+      try {
+        const { machineId } = await this.getCompute().launchMachine({
+          appId: existing.flyAppId,
+          image: data.imageUrl,
+          port: data.port ?? existing.port,
+          cpu: data.cpu ?? existing.cpu,
+          memory: data.memory ?? existing.memory,
+          envVars,
+          region: data.region ?? existing.region,
+        });
+        // Persist machine id + flip status alongside the field updates below.
+        updates.push(`fly_machine_id = $${paramIdx++}`);
+        values.push(machineId);
+        updates.push(`status = $${paramIdx++}`);
+        values.push('running');
+        updates.push(`endpoint_url = $${paramIdx++}`);
+        values.push(makeEndpointUrl(existing.flyAppId));
+        logger.info('Compute service machine launched (Path A)', { id, machineId });
+      } catch (error) {
+        logger.error('Failed to launch machine on Fly (Path A)', { id, error });
+        if (error instanceof AppError) {
+          let parsed: { code?: string; error?: string; nextActions?: string[] } | undefined;
+          try {
+            parsed = JSON.parse(error.message);
+          } catch {
+            parsed = undefined;
+          }
+          throw new AppError(
+            parsed?.error ?? error.message,
+            error.statusCode,
+            (parsed?.code as keyof typeof ERROR_CODES & string) ??
+              error.code ??
+              ERROR_CODES.COMPUTE_SERVICE_DEPLOY_FAILED,
+            parsed?.nextActions?.join('; ')
+          );
+        }
+        throw new AppError(
+          error instanceof Error ? error.message : 'Compute service operation failed',
+          502,
+          ERROR_CODES.COMPUTE_SERVICE_DEPLOY_FAILED
+        );
+      }
     }
 
     // Fly accepted the update (or no Fly update was needed) — now commit to DB


### PR DESCRIPTION
## Summary

Wires the OSS compute provider for the **Path A** (CLI-side Docker build + push) source-deploy architecture. Stacks on top of #1062.

The headline change is the new `else if` branch in `updateService` — when the cloud has already created the Fly app (via `prepareForDeploy`) but no machine exists yet, and the CLI is now sending an `imageUrl` (because it just docker-pushed), call `launchMachine` to bring the machine up. Previously this case fell through to a no-op.

End-to-end POC validated against staging: app create → deploy-token mint → docker build/login/push → PATCH-launch → HTTPS probe → REDEPLOY → second probe. All 7 steps green.

### Companion PRs
- **CLI** (`compute deploy <dir>` source mode): https://github.com/InsForge/CLI/pull/87
- **Cloud backend** (attenuator + per-app deploy token): https://github.com/InsForge/insforge-cloud-backend/pull/475

### Commits
- `2694ab4e feat(compute): launch machine on first PATCH for Path A` ← **the load-bearing change**
- `7434ba9f`, `f3a201d1`, `b1d3cea5` — prettier/lint
- `83bef787 feat(compute): updateService accepts sourceKey for redeploy` ← Path B leftover; safe to leave (the field is just optional passthrough), or trim in a follow-up
- `f03475ef feat(compute): OSS proxy for /build-creds + sourceKey passthrough` ← Path B leftover; the cloud-side `/build-creds` endpoint was removed in favor of `/deploy-token`. Proxy code is dead but harmless. Candidate for a follow-up cleanup commit.

## Test plan

- [x] OSS proxy unit tests pass (`npm test`)
- [x] Lint + prettier clean
- [x] End-to-end POC against staging (project provider → cloud) — `poc-oss-patch-launch.mjs`, all 7 steps green
- [x] First-launch path: PATCH with `imageUrl` on a service with `flyAppId` but no `flyMachineId` triggers `launchMachine`
- [x] Redeploy path: PATCH with new `imageUrl` on a service with both `flyAppId` and `flyMachineId` triggers `updateMachine`
- [ ] Reviewer: confirm the dead `/build-creds` proxy + `sourceKey` field can land as-is (cloud no longer accepts them, OSS just won't forward anything useful) or should be stripped before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)