### PR TITLE
feat(dashboard): surface sub-minute interval form in ScheduleFormDialog

### DIFF
--- a/backend/src/infra/database/migrations/036_schedules-http-timeout.sql
+++ b/backend/src/infra/database/migrations/036_schedules-http-timeout.sql
@@ -1,0 +1,88 @@
+-- Migration 036: Bound execute_job's HTTP timeout
+--
+-- Sets a per-call timeout (30s end-to-end, 5s connect) on the synchronous
+-- http() invocation inside schedules.execute_job() so a hung downstream
+-- target cannot pin a pg_cron worker indefinitely.
+--
+-- This is the only safety guardrail needed once sub-minute cadence
+-- ("N seconds" interval syntax) is exposed: the existing pgsql-http stack
+-- handles 2-second cadence cleanly (POC verified) so long as a slow
+-- target can't accumulate workers. The 30s cap ensures even a wedged
+-- target frees its worker before the next cron tick at minute cadence,
+-- and limits pool pressure at sub-minute cadence to a small constant.
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION.
+
+CREATE OR REPLACE FUNCTION schedules.execute_job(p_job_id UUID)
+RETURNS void AS $$
+DECLARE
+  v_job RECORD;
+  v_http_request http_request;
+  v_http_response http_response;
+  v_success BOOLEAN;
+  v_status INT;
+  v_body TEXT;
+  v_decrypted_headers JSONB;
+  v_final_body JSONB;
+  v_start_time TIMESTAMP := clock_timestamp();
+  v_end_time TIMESTAMP;
+  v_duration_ms BIGINT;
+  v_error_message TEXT;
+BEGIN
+  -- Bound the per-call HTTP timeout. http_set_curlopt is per-session;
+  -- pg_cron may reuse a session across ticks but the values are stable so
+  -- repeated calls are harmless.
+  PERFORM http_set_curlopt('CURLOPT_TIMEOUT_MS', '30000');
+  PERFORM http_set_curlopt('CURLOPT_CONNECTTIMEOUT_MS', '5000');
+
+  SELECT
+    j.id,
+    j.name,
+    j.function_url,
+    j.http_method,
+    j.body,
+    j.encrypted_headers
+  INTO v_job
+  FROM schedules.jobs AS j
+  WHERE j.id = p_job_id;
+
+  IF NOT FOUND THEN
+    PERFORM schedules.log_job_execution(p_job_id, 'unknown', FALSE, 404, 0, 'Job not found');
+    RETURN;
+  END IF;
+
+  BEGIN
+    -- Decrypt headers
+    v_decrypted_headers := schedules.decrypt_headers(v_job.encrypted_headers);
+
+    -- Build the final request body
+    v_final_body := COALESCE(v_job.body, '{}'::JSONB);
+
+    -- Construct HTTP request
+    v_http_request := (
+      v_job.http_method::http_method,
+      v_job.function_url,
+      schedules.build_http_headers(v_decrypted_headers),
+      'application/json',
+      v_final_body::TEXT
+    );
+    v_start_time := clock_timestamp();
+    -- Execute HTTP call (synchronous; bounded by curl timeouts set above)
+    v_http_response := http(v_http_request);
+    v_end_time := clock_timestamp();
+    v_duration_ms := EXTRACT(EPOCH FROM (v_end_time - v_start_time)) * 1000;
+    v_status := v_http_response.status;
+    v_body := v_http_response.content;
+    v_success := v_status BETWEEN 200 AND 299;
+
+    -- Log execution
+    v_error_message := CASE WHEN v_success THEN 'Success' ELSE 'HTTP ' || v_status END;
+    PERFORM schedules.log_job_execution(v_job.id, v_job.name, v_success, v_status, v_duration_ms, v_error_message);
+
+  EXCEPTION WHEN OTHERS THEN
+    v_end_time := clock_timestamp();
+    v_duration_ms := EXTRACT(EPOCH FROM (v_end_time - v_start_time)) * 1000;
+    PERFORM schedules.log_job_execution(v_job.id, v_job.name, FALSE, 500, v_duration_ms, SQLERRM);
+  END;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/src/services/schedules/schedule.service.ts
+++ b/backend/src/services/schedules/schedule.service.ts
@@ -31,21 +31,43 @@ export class ScheduleService {
   }
 
   /**
-   * Validate that the cron expression is exactly 5 fields (minute, hour, day, month, day-of-week).
-   * pg_cron does not support 6-field expressions with seconds.
+   * Match pg_cron's sub-minute interval syntax: "<n> seconds|minutes|hours" (pg_cron >= 1.5).
+   * Captures: [1] = numeric value, [2] = unit (seconds|second|minutes|minute|hours|hour).
+   */
+  private static readonly INTERVAL_RE = /^\s*(\d+)\s+(seconds?|minutes?|hours?)\s*$/i;
+
+  /**
+   * Validate that the cron expression is either a 5-field cron expression or a pg_cron
+   * interval expression (e.g. "2 seconds", "30 seconds", "5 minutes").
+   * 6-field cron-with-seconds (Quartz/Spring style) is NOT supported by pg_cron.
    */
   private validateCronExpression(cronSchedule: string): void {
-    const fields = cronSchedule.trim().split(/\s+/);
+    const trimmed = cronSchedule.trim();
+
+    const interval = trimmed.match(ScheduleService.INTERVAL_RE);
+    if (interval) {
+      const n = Number(interval[1]);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new AppError(
+          'Interval value must be a positive integer (e.g., "2 seconds", "30 seconds").',
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+      return;
+    }
+
+    const fields = trimmed.split(/\s+/);
     if (fields.length !== 5) {
       throw new AppError(
-        `Cron expression must be exactly 5 fields (minute, hour, day, month, day-of-week). Got ${fields.length} fields. Example: "*/5 * * * *" for every 5 minutes.`,
+        `Cron expression must be exactly 5 fields (minute, hour, day, month, day-of-week) or an interval like "2 seconds". Got ${fields.length} fields. Examples: "*/5 * * * *" for every 5 minutes, "30 seconds" for every 30 seconds.`,
         400,
         ERROR_CODES.INVALID_INPUT
       );
     }
 
     try {
-      CronExpressionParser.parse(cronSchedule, { strict: false });
+      CronExpressionParser.parse(trimmed, { strict: false });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new AppError(`Invalid cron expression: ${msg}`, 400, ERROR_CODES.INVALID_INPUT);
@@ -73,6 +95,19 @@ export class ScheduleService {
 
       if (updatedAt && updatedAt > after) {
         after = updatedAt;
+      }
+
+      // Interval syntax (pg_cron >= 1.5) — cron-parser cannot parse this.
+      const interval = schedule.cronSchedule.trim().match(ScheduleService.INTERVAL_RE);
+      if (interval) {
+        const n = Number(interval[1]);
+        const unit = interval[2].toLowerCase();
+        const multMs = unit.startsWith('hour')
+          ? 3_600_000
+          : unit.startsWith('minute')
+            ? 60_000
+            : 1_000;
+        return new Date(after.getTime() + n * multMs).toISOString();
       }
 
       const cronExpression = CronExpressionParser.parse(schedule.cronSchedule, {

--- a/backend/tests/unit/schedule.service.sub-minute-cadence.test.ts
+++ b/backend/tests/unit/schedule.service.sub-minute-cadence.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const servicePath = path.resolve(
+  currentDir,
+  '../../src/services/schedules/schedule.service.ts'
+);
+const sharedSchemaPath = path.resolve(
+  currentDir,
+  '../../../packages/shared-schemas/src/schedules-api.schema.ts'
+);
+
+describe('Sub-minute cadence support: validator', () => {
+  const serviceSrc = fs.readFileSync(servicePath, 'utf8');
+  const sharedSrc = fs.readFileSync(sharedSchemaPath, 'utf8');
+
+  it('service defines an INTERVAL_RE that accepts seconds/minutes/hours', () => {
+    // Must declare an INTERVAL_RE (or equivalent) constant
+    expect(serviceSrc).toMatch(/INTERVAL_RE\s*=\s*\//);
+    // The regex alternation must contain (seconds?|minutes?|hours?)
+    expect(serviceSrc).toMatch(/\(seconds\?\|minutes\?\|hours\?\)/);
+    // And be case-insensitive (i flag)
+    expect(serviceSrc).toMatch(/INTERVAL_RE[\s\S]*?\/i\b/);
+  });
+
+  it('service validateCronExpression takes the interval branch first', () => {
+    // The validator should match the interval regex and early-return before falling to 5-field check.
+    // Sequence: validateCronExpression(...) -> ... -> INTERVAL_RE -> ... -> return; -> ... -> fields.length
+    expect(serviceSrc).toMatch(
+      /validateCronExpression\b[\s\S]+?INTERVAL_RE[\s\S]+?return\s*;[\s\S]+?fields\.length/
+    );
+  });
+
+  it('service validator error message mentions both 5-field cron and interval examples', () => {
+    expect(serviceSrc).toMatch(/seconds/i);
+    expect(serviceSrc).toMatch(/\* \* \* \* \*|5 fields/);
+  });
+
+  it('service computeNextRunForSchedule has an interval branch using INTERVAL_RE', () => {
+    expect(serviceSrc).toMatch(
+      /computeNextRunForSchedule\b[\s\S]+?INTERVAL_RE[\s\S]+?getTime\(\)/
+    );
+  });
+
+  it('service interval next-run handles seconds, minutes, and hours multipliers', () => {
+    // 1_000 (sec), 60_000 (min), 3_600_000 (hour) — accept underscores or plain digits
+    expect(serviceSrc).toMatch(/3[_]?600[_]?000/);
+    expect(serviceSrc).toMatch(/60[_]?000/);
+    expect(serviceSrc).toMatch(/\b1[_]?000\b/);
+  });
+
+  it('shared-schemas cron validator accepts the interval form (2-part strings)', () => {
+    // The refine() must accept "2 seconds" etc. — i.e., it must mention the interval pattern
+    // or accept length === 2 with a units check.
+    expect(sharedSrc).toMatch(/seconds\?\s*\|\s*minutes\?\s*\|\s*hours\?/i);
+  });
+
+  it('shared-schemas error message mentions interval form', () => {
+    expect(sharedSrc).toMatch(/seconds|interval/i);
+  });
+});
+
+// Behavioural sanity checks on the regex shape. These don't import the service
+// (which needs DatabaseManager); instead, re-derive the same pattern and assert
+// it accepts the inputs we care about and rejects the ones we don't.
+describe('Sub-minute cadence regex behaviour', () => {
+  const INTERVAL_RE = /^\s*(\d+)\s+(seconds?|minutes?|hours?)\s*$/i;
+
+  it.each([
+    ['1 second', '1', 'second'],
+    ['2 seconds', '2', 'seconds'],
+    ['30 seconds', '30', 'seconds'],
+    ['90 seconds', '90', 'seconds'],
+    ['1 minute', '1', 'minute'],
+    ['5 minutes', '5', 'minutes'],
+    ['1 hour', '1', 'hour'],
+    ['12 hours', '12', 'hours'],
+    [' 30 SECONDS ', '30', 'SECONDS'],
+  ])('accepts %j as interval', (input, n, unit) => {
+    const m = input.match(INTERVAL_RE);
+    expect(m).not.toBeNull();
+    expect(m?.[1]).toBe(n);
+    expect(m?.[2]).toBe(unit);
+  });
+
+  it.each([
+    '* * * * *',
+    '*/5 * * * *',
+    '0 9 * * 1-5',
+    '',
+    'foo bar',
+    '2',
+    '2 days',
+    '2 weeks',
+    '2.5 seconds',
+    '-1 seconds',
+    '* * * * * *',
+  ])('rejects %j as interval', (input) => {
+    expect(input.match(INTERVAL_RE)).toBeNull();
+  });
+});
+

--- a/backend/tests/unit/schedules-http-timeout-migration.test.ts
+++ b/backend/tests/unit/schedules-http-timeout-migration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDir,
+  '../../src/infra/database/migrations/036_schedules-http-timeout.sql'
+);
+
+describe('036_schedules-http-timeout migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  // ── idempotency ─────────────────────────────────────────────────────
+  it('uses CREATE OR REPLACE FUNCTION (idempotent re-run)', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION schedules\.execute_job\(p_job_id UUID\)/i);
+  });
+
+  it('does not drop or rename anything', () => {
+    expect(sql).not.toMatch(/DROP FUNCTION/i);
+    expect(sql).not.toMatch(/DROP TABLE/i);
+    expect(sql).not.toMatch(/ALTER TABLE[\s\S]*?RENAME TO/i);
+  });
+
+  it('contains no top-level transaction control', () => {
+    const outsideDoBlocks = sql.replace(/DO\s*\$\$[\s\S]*?\$\$/g, '');
+    expect(outsideDoBlocks).not.toMatch(/^\s*BEGIN\s*;/im);
+    expect(outsideDoBlocks).not.toMatch(/^\s*COMMIT\s*;/im);
+    expect(outsideDoBlocks).not.toMatch(/^\s*ROLLBACK\s*;/im);
+  });
+
+  // ── HTTP timeouts are configured ─────────────────────────────────────
+  it('sets CURLOPT_TIMEOUT_MS to 30000 (30s end-to-end timeout)', () => {
+    expect(sql).toMatch(
+      /http_set_curlopt\(\s*'CURLOPT_TIMEOUT_MS'\s*,\s*'30000'\s*\)/i
+    );
+  });
+
+  it('sets CURLOPT_CONNECTTIMEOUT_MS to 5000 (5s connect timeout)', () => {
+    expect(sql).toMatch(
+      /http_set_curlopt\(\s*'CURLOPT_CONNECTTIMEOUT_MS'\s*,\s*'5000'\s*\)/i
+    );
+  });
+
+  it('timeouts are set BEFORE the http() call inside execute_job', () => {
+    // The two PERFORM http_set_curlopt calls must appear textually before the
+    // line that invokes http(v_http_request).
+    const setIdx = sql.search(/http_set_curlopt/i);
+    const httpIdx = sql.search(/v_http_response\s*:=\s*http\(/i);
+    expect(setIdx).toBeGreaterThan(0);
+    expect(httpIdx).toBeGreaterThan(setIdx);
+  });
+
+  // ── still uses the existing http extension (not pg_net) ──────────────
+  it('does NOT introduce pg_net (we are intentionally staying with sync http)', () => {
+    expect(sql).not.toMatch(/pg_net/i);
+    expect(sql).not.toMatch(/net\.http_post/i);
+    expect(sql).not.toMatch(/net\.http_get/i);
+    expect(sql).not.toMatch(/net\._http_response/i);
+  });
+
+  it('still calls the http extension synchronously', () => {
+    expect(sql).toMatch(/v_http_response\s*:=\s*http\s*\(\s*v_http_request\s*\)/i);
+  });
+
+  // ── preserves the existing exception path ────────────────────────────
+  it('preserves the EXCEPTION WHEN OTHERS log path with status 500', () => {
+    expect(sql).toMatch(/EXCEPTION\s+WHEN OTHERS THEN[\s\S]*?log_job_execution[\s\S]*?500/i);
+  });
+
+  // ── ordering ─────────────────────────────────────────────────────────
+  it('runs after migration 021 (schedules schema)', () => {
+    const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    const idx036 = migrations.findIndex((f) => f === '036_schedules-http-timeout.sql');
+    const idx021 = migrations.findIndex((f) => f === '021_create-schedules-schema.sql');
+    expect(idx021).toBeGreaterThanOrEqual(0);
+    expect(idx036).toBeGreaterThan(idx021);
+  });
+});

--- a/packages/dashboard/src/features/functions/components/ScheduleFormDialog.tsx
+++ b/packages/dashboard/src/features/functions/components/ScheduleFormDialog.tsx
@@ -227,9 +227,25 @@ export function ScheduleFormDialog({
                   <input
                     {...form.register('cronSchedule')}
                     className="w-full px-3 py-2 rounded border bg-white dark:bg-neutral-800 border-zinc-200 dark:border-neutral-700 text-sm text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500"
-                    placeholder="E.g., */5 * * * *"
+                    placeholder='E.g. "*/5 * * * *" or "30 seconds"'
                   />
+                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                    5-field cron (e.g. <code>*/5 * * * *</code>) or interval form for sub-minute
+                    cadence (e.g. <code>30 seconds</code>, <code>5 minutes</code>).
+                  </p>
                   <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                    <button
+                      type="button"
+                      className="px-3 py-2 rounded-lg bg-zinc-100 text-zinc-900 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 dark:bg-neutral-800 dark:text-zinc-100 dark:hover:bg-neutral-700 text-sm transition-colors text-left"
+                      onClick={() => {
+                        form.setValue('cronSchedule', '30 seconds', {
+                          shouldDirty: true,
+                          shouldValidate: true,
+                        });
+                      }}
+                    >
+                      Every 30 seconds
+                    </button>
                     <button
                       type="button"
                       className="px-3 py-2 rounded-lg bg-zinc-100 text-zinc-900 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 dark:bg-neutral-800 dark:text-zinc-100 dark:hover:bg-neutral-700 text-sm transition-colors text-left"

--- a/packages/shared-schemas/src/schedules-api.schema.ts
+++ b/packages/shared-schemas/src/schedules-api.schema.ts
@@ -1,12 +1,23 @@
 import { z } from 'zod';
 import { scheduleSchema, scheduleLogSchema } from './schedules.schema.js';
 
+// Accept either:
+//   - 5-field cron expression (e.g. "*/5 * * * *", "0 9 * * 1-5")
+//   - pg_cron interval form for sub-minute cadence (e.g. "2 seconds", "30 seconds", "5 minutes")
+const intervalRegex = /^\s*\d+\s+(seconds?|minutes?|hours?)\s*$/i;
+
 const cronScheduleSchema = z.string().refine(
   (value) => {
-    const parts = value.split(' ');
+    if (intervalRegex.test(value)) {
+      return true;
+    }
+    const parts = value.trim().split(/\s+/);
     return parts.length === 5 || parts.length === 6;
   },
-  { message: 'Invalid cron schedule format. Use 5 or 6 parts (e.g., "* * * * *").' }
+  {
+    message:
+      'Invalid cron schedule. Use 5-field cron (e.g., "* * * * *") or interval form (e.g., "2 seconds", "30 seconds", "5 minutes").',
+  }
 );
 
 /**


### PR DESCRIPTION
## Summary

Updates the schedule create/edit dialog so the new sub-minute interval form added in #1159 is discoverable from the UI.

- Placeholder now shows both formats: `*/5 * * * *` or `30 seconds`
- A one-line caption under the input documents the two accepted shapes
- New **Every 30 seconds** quick-pick (placed first so it's the most visible new capability)
- Existing four cron quick-picks unchanged

No state, validation, or display logic touched — purely visual/copy. Form submission already validates against `@insforge/shared-schemas`'s `cronScheduleSchema`, which #1159 updated to accept the interval form.

## Stacked on #1159

This PR includes the 5 commits from `feat/schedules-pg-net` (backend + shared-schemas + sub-minute support). **#1159 must merge first** — once it does, GitHub will collapse this PR's diff to just the single dashboard commit.

The single net-new commit on this branch is:

```
7fecabc1 feat(dashboard): surface sub-minute interval form in ScheduleFormDialog
```

## What changed

| Path | Change |
|---|---|
| `packages/dashboard/src/features/functions/components/ScheduleFormDialog.tsx` | Placeholder + caption + 5th quick-pick button (`30 seconds`) |

## Why nothing breaks

- Form resolver still uses the same Zod schema — once #1159 lands, the schema accepts both 5-field cron and `"N seconds|minutes|hours"`.
- Existing cron strings in stored schedules continue to render unchanged (the form is read-only-display from `initialValues.cronSchedule` for edits).
- No new dependencies. No new components. No re-rendering hot paths touched.

## Test plan

- [x] `npx turbo run lint typecheck build --filter=@insforge/dashboard` — 5/5 successful
- [ ] In a dev session, open the schedule create dialog: confirm placeholder reads `E.g. "*/5 * * * *" or "30 seconds"`, the caption appears below the input, and clicking **Every 30 seconds** populates the field with `30 seconds`.
- [ ] After #1159 lands, submit the form with `30 seconds` and confirm the schedule is created (currently blocked by shared-schemas validator until #1159 merges).
- [ ] Visual regression: check the existing four quick-pick buttons still align in the 2-column grid and don't wrap awkwardly with the new fifth button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for sub-minute schedule intervals (e.g., "30 seconds", "5 minutes", "1 hour") alongside traditional cron expressions
- Added "Every 30 seconds" preset to the schedule creation dialog
- Implemented asynchronous HTTP request execution for scheduled jobs

## Documentation
- Enhanced cron schedule input documentation to show both interval and cron syntax examples

## Tests
- Added unit tests for schedule interval validation and database migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->