### PR TITLE
feat(config): make global rate limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@
 # -----------------------------------------------------------------------------
 PORT=7130
 
+# Global Express request rate limit per IP per 15 minutes.
+# Keep the default in production. Local dev/E2E can raise this, for example 1000000.
+GLOBAL_RATE_LIMIT_MAX=3000
+
 # -----------------------------------------------------------------------------
 # PostgreSQL Configuration
 # -----------------------------------------------------------------------------

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -48,6 +48,16 @@ if (fs.existsSync(envPath)) {
   dotenv.config();
 }
 
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export async function createApp() {
   // Initialize database first
   const dbManager = DatabaseManager.getInstance();
@@ -71,7 +81,7 @@ export async function createApp() {
 
   const limiter = rateLimit({
     windowMs: 15 * 60 * 1000,
-    max: 3000,
+    max: parsePositiveIntegerEnv('GLOBAL_RATE_LIMIT_MAX', 3000),
     message: 'Too many requests from this IP',
     skip: (req) => req.path === '/api/health',
   });

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -6,6 +6,10 @@ POSTGRES_DB=insforge
 API_BASE_URL=http://localhost:7130
 VITE_API_BASE_URL=http://localhost:7130
 
+# Global Express request rate limit per IP per 15 minutes.
+# Keep 3000 in production; local dev/E2E can raise this, for example 1000000.
+GLOBAL_RATE_LIMIT_MAX=3000
+
 # Authentication
 JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
 ADMIN_EMAIL=admin@example.com

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,6 +67,7 @@ services:
       - PORT=7130
       - PROJECT_ROOT=/app
       - API_BASE_URL=${API_BASE_URL:-}
+      - GLOBAL_RATE_LIMIT_MAX=${GLOBAL_RATE_LIMIT_MAX:-3000}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - PROJECT_ROOT=/app
       - API_BASE_URL=${API_BASE_URL:-}
       - VITE_API_BASE_URL=${VITE_API_BASE_URL:-}
+      - GLOBAL_RATE_LIMIT_MAX=${GLOBAL_RATE_LIMIT_MAX:-3000}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}


### PR DESCRIPTION
## Summary
- Adds `GLOBAL_RATE_LIMIT_MAX` so self-hosted deployments can configure the global Express IP limiter without patching built output.
- Keeps the production-safe default at 3000 requests per IP per 15 minutes when unset.
- Documents the setting in Docker env examples and passes it through both compose files.

## Test plan
- Ran `npm run build` in `backend/`.
- Rebuilt the local Docker image and verified `X-RateLimit-Limit: 1000000` with the local dev override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting configuration is now externally configurable via environment variable, with a default limit of 3000 requests per IP over a 15-minute window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->