### PR TITLE
fix(dashboard): smart-paste KEY=VALUE for function secrets

### DIFF
--- a/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
@@ -1,13 +1,15 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Button, ConfirmDialog, Input } from '@insforge/ui';
 import { Skeleton, TableHeader } from '../../../components';
 import { SecretRow } from '../components/SecretRow';
 import SecretEmptyState from '../components/SecretEmptyState';
 import { useSecrets } from '../hooks/useSecrets';
+import { parseEnvAssignment } from '../utils/secretPaste';
 
 export default function SecretsPage() {
   const [newSecretKey, setNewSecretKey] = useState('');
   const [newSecretValue, setNewSecretValue] = useState('');
+  const valueInputRef = useRef<HTMLInputElement>(null);
 
   const {
     filteredSecrets,
@@ -25,6 +27,21 @@ export default function SecretsPage() {
       setNewSecretKey('');
       setNewSecretValue('');
     }
+  };
+
+  const handleSmartPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData('text');
+    const parsed = parseEnvAssignment(pasted);
+    if (!parsed) {
+      return;
+    }
+
+    e.preventDefault();
+    setNewSecretKey(parsed.key);
+    setNewSecretValue(parsed.value);
+
+    // Give React a tick to commit the value before focusing.
+    queueMicrotask(() => valueInputRef.current?.focus());
   };
 
   return (
@@ -53,6 +70,7 @@ export default function SecretsPage() {
                   placeholder="e.g CLIENT_KEY"
                   value={newSecretKey}
                   onChange={(e) => setNewSecretKey(e.target.value)}
+                  onPaste={handleSmartPaste}
                 />
               </div>
               <div className="flex-1">
@@ -62,6 +80,8 @@ export default function SecretsPage() {
                   type="text"
                   value={newSecretValue}
                   onChange={(e) => setNewSecretValue(e.target.value)}
+                  onPaste={handleSmartPaste}
+                  ref={valueInputRef}
                 />
               </div>
               <Button

--- a/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
@@ -5,6 +5,7 @@ import { SecretRow } from '../components/SecretRow';
 import SecretEmptyState from '../components/SecretEmptyState';
 import { useSecrets } from '../hooks/useSecrets';
 import { parseEnvAssignment } from '../utils/secretPaste';
+import { useSmartPaste } from '../../../lib/hooks/useSmartPaste';
 
 export default function SecretsPage() {
   const [newSecretKey, setNewSecretKey] = useState('');
@@ -29,20 +30,14 @@ export default function SecretsPage() {
     }
   };
 
-  const handleSmartPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
-    const pasted = e.clipboardData.getData('text');
-    const parsed = parseEnvAssignment(pasted);
-    if (!parsed) {
-      return;
-    }
-
-    e.preventDefault();
-    setNewSecretKey(parsed.key);
-    setNewSecretValue(parsed.value);
-
-    // Give React a tick to commit the value before focusing.
-    queueMicrotask(() => valueInputRef.current?.focus());
-  };
+  const handleSmartPaste = useSmartPaste({
+    parse: parseEnvAssignment,
+    onParsed: ({ key, value }) => {
+      setNewSecretKey(key);
+      setNewSecretValue(value);
+    },
+    focusRef: valueInputRef,
+  });
 
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">

--- a/packages/dashboard/src/features/functions/utils/secretPaste.ts
+++ b/packages/dashboard/src/features/functions/utils/secretPaste.ts
@@ -1,0 +1,33 @@
+export function parseEnvAssignment(input: string): { key: string; value: string } | null {
+  const text = input.replace(/\r\n/g, '\n').trim();
+  if (!text.includes('=')) {
+    return null;
+  }
+
+  // Minimum viable behavior: if multiple lines are pasted, use the first non-empty line.
+  const firstLine = text
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine || !firstLine.includes('=')) {
+    return null;
+  }
+
+  const eqIndex = firstLine.indexOf('=');
+  const key = firstLine.slice(0, eqIndex).trim();
+  let value = firstLine.slice(eqIndex + 1).trim();
+
+  if (!key || !value) {
+    return null;
+  }
+
+  // Strip outer matching quotes only.
+  if (
+    (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+    (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+  ) {
+    value = value.slice(1, -1);
+  }
+
+  return { key, value };
+}

--- a/packages/dashboard/src/lib/hooks/useSmartPaste.ts
+++ b/packages/dashboard/src/lib/hooks/useSmartPaste.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+
+export function useSmartPaste<TParsed>({
+  parse,
+  onParsed,
+  focusRef,
+}: {
+  parse: (text: string) => TParsed | null;
+  onParsed: (parsed: TParsed) => void;
+  focusRef?: React.RefObject<HTMLElement | null>;
+}) {
+  return useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const pasted = e.clipboardData.getData('text');
+      const parsed = parse(pasted);
+      if (!parsed) {
+        return;
+      }
+
+      e.preventDefault();
+      onParsed(parsed);
+
+      if (focusRef?.current) {
+        queueMicrotask(() => focusRef.current?.focus());
+      }
+    },
+    [focusRef, onParsed, parse]
+  );
+}


### PR DESCRIPTION
## Summary
- Adds smart-paste handling for `KEY=VALUE` in Functions → Secrets.
- Strips outer quotes from pasted values and focuses the value field.

### Demo Video
https://github.com/user-attachments/assets/8ec790b8-1ebc-4eb5-9042-19247349f0eb
 

Fixes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart paste for secrets: Pasting environment-style KEY=VALUE into either field now auto-extracts and populates both key and value, trimming quotes and normalizing line endings.
  * After a successful paste, focus moves to the value input to streamline editing; unparsable paste content is ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->