### PR TITLE
ci(build-image): skip ECR push for pre-release tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -159,7 +159,7 @@ jobs:
   push-to-ecr:
     needs: merge-manifests
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       id-token: write
       contents: read

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -52,7 +52,15 @@ export class S3StorageProvider implements StorageProvider {
   constructor(
     private s3Bucket: string,
     private appKey: string,
-    private region: string = 'us-east-2'
+    private region: string = 'us-east-2',
+    /**
+     * When set, this provider runs in branch mode: read methods try the
+     * branch's S3 path first, then fall back to the parent's path on 404.
+     * Writes (put/delete/copy/multipart) are NEVER directed to the parent
+     * path. Injected by StorageService from the PARENT_APP_KEY env var
+     * that cloud-backend sets at branch EC2 startup.
+     */
+    private parentAppKey?: string
   ) {}
 
   initialize(): void {
@@ -92,6 +100,30 @@ export class S3StorageProvider implements StorageProvider {
     return `${this.appKey}/${bucket}/${key}`;
   }
 
+  /**
+   * Parent's S3 key path for the same bucket+key, when this provider is in
+   * branch mode. Returns null when no parent is configured (regular project).
+   */
+  private getParentS3Key(bucket: string, key: string): string | null {
+    return this.parentAppKey ? `${this.parentAppKey}/${bucket}/${key}` : null;
+  }
+
+  /**
+   * Branch fallback wrapper for read paths: try the branch's S3 key first;
+   * on a "not found" miss (provider returned null), retry with the parent's
+   * S3 key when one is configured. Errors other than NotFound propagate.
+   */
+  private async withFallback<T>(
+    branchPath: string,
+    parentPath: string | null,
+    op: (s3Key: string) => Promise<T | null>,
+  ): Promise<T | null> {
+    const primary = await op(branchPath);
+    if (primary !== null) return primary;
+    if (!parentPath) return null;
+    return op(parentPath);
+  }
+
   async putObject(bucket: string, key: string, file: Express.Multer.File): Promise<void> {
     if (!this.s3Client) {
       throw new Error('S3 client not initialized');
@@ -121,20 +153,31 @@ export class S3StorageProvider implements StorageProvider {
     if (!this.s3Client) {
       throw new Error('S3 client not initialized');
     }
+    return this.withFallback(
+      this.getS3Key(bucket, key),
+      this.getParentS3Key(bucket, key),
+      async (s3Key) => this.tryGetObject(s3Key),
+    );
+  }
+
+  private async tryGetObject(s3Key: string): Promise<Buffer | null> {
     try {
       const command = new GetObjectCommand({
         Bucket: this.s3Bucket,
-        Key: this.getS3Key(bucket, key),
+        Key: s3Key,
       });
-      const response = await this.s3Client.send(command);
+      const response = await this.s3Client!.send(command);
       const chunks: Uint8Array[] = [];
-      // Type assertion for readable stream
       const body = response.Body as AsyncIterable<Uint8Array>;
       for await (const chunk of body) {
         chunks.push(chunk);
       }
       return Buffer.concat(chunks);
-    } catch {
+    } catch (err) {
+      if (isS3NotFound(err)) return null;
+      // Match prior behaviour: any error → null. Branch fallback only kicks
+      // in for NotFound; non-404 errors are still treated as "no object" so
+      // service-layer behaviour is unchanged.
       return null;
     }
   }
@@ -249,7 +292,19 @@ export class S3StorageProvider implements StorageProvider {
       throw new Error('S3 client not initialized');
     }
 
-    const s3Key = this.getS3Key(bucket, key);
+    // In branch mode, HEAD the branch path first; if missing and a parent
+    // is configured, sign the parent's S3 path instead. The HEAD adds one
+    // round-trip but is required: we can't tell from key alone whether the
+    // object lives on the branch or fell through to parent.
+    const branchKey = this.getS3Key(bucket, key);
+    const parentKey = this.getParentS3Key(bucket, key);
+    let s3Key = branchKey;
+    if (parentKey) {
+      const branchExists = await this.tryHeadObject(branchKey);
+      if (!branchExists) {
+        s3Key = parentKey;
+      }
+    }
     // Public files get longer expiration (7 days), private files get shorter (1 hour default)
     const actualExpiresIn = isPublic ? SEVEN_DAYS_IN_SECONDS : expiresIn; // 604800 = 7 days
     const cloudFrontUrl = process.env.AWS_CLOUDFRONT_URL;
@@ -392,29 +447,58 @@ export class S3StorageProvider implements StorageProvider {
     if (!this.s3Client) {
       throw new Error('S3 client not initialized');
     }
-    const s3Key = this.getS3Key(bucket, key);
-    const resp = await this.s3Client.send(
-      new GetObjectCommand({ Bucket: this.s3Bucket, Key: s3Key, Range: opts?.range })
+    const branchKey = this.getS3Key(bucket, key);
+    const parentKey = this.getParentS3Key(bucket, key);
+    const range = opts?.range;
+    const result = await this.withFallback(
+      branchKey,
+      parentKey,
+      async (s3Key) => this.tryGetObjectStream(s3Key, range),
     );
-    if (!resp.Body) {
+    if (!result) {
+      // Preserve previous behaviour: missing object surfaces as a thrown
+      // error here (callers expect a stream, not null).
       throw new Error('GetObject returned empty body');
     }
-    return {
-      body: resp.Body as Readable,
-      size: Number(resp.ContentLength ?? 0),
-      etag: stripEtagQuotes(resp.ETag),
-      contentType: resp.ContentType,
-      lastModified: resp.LastModified ?? new Date(),
-    };
+    return result;
+  }
+
+  private async tryGetObjectStream(
+    s3Key: string,
+    range: string | undefined,
+  ): Promise<GetObjectResult | null> {
+    try {
+      const resp = await this.s3Client!.send(
+        new GetObjectCommand({ Bucket: this.s3Bucket, Key: s3Key, Range: range })
+      );
+      if (!resp.Body) return null;
+      return {
+        body: resp.Body as Readable,
+        size: Number(resp.ContentLength ?? 0),
+        etag: stripEtagQuotes(resp.ETag),
+        contentType: resp.ContentType,
+        lastModified: resp.LastModified ?? new Date(),
+      };
+    } catch (err) {
+      if (isS3NotFound(err)) return null;
+      throw err;
+    }
   }
 
   async headObject(bucket: string, key: string): Promise<ObjectMetadata | null> {
     if (!this.s3Client) {
       throw new Error('S3 client not initialized');
     }
-    const s3Key = this.getS3Key(bucket, key);
+    return this.withFallback(
+      this.getS3Key(bucket, key),
+      this.getParentS3Key(bucket, key),
+      async (s3Key) => this.tryHeadObject(s3Key),
+    );
+  }
+
+  private async tryHeadObject(s3Key: string): Promise<ObjectMetadata | null> {
     try {
-      const resp = await this.s3Client.send(
+      const resp = await this.s3Client!.send(
         new HeadObjectCommand({ Bucket: this.s3Bucket, Key: s3Key })
       );
       return {

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -29,16 +29,24 @@ export class StorageService {
   private constructor() {
     const s3Bucket = process.env.AWS_S3_BUCKET;
     const appKey = process.env.APP_KEY || 'local';
+    // PARENT_APP_KEY is set by cloud-backend at branch EC2 startup. When
+    // present, the S3 provider runs in branch mode: read paths fall back to
+    // parent's S3 prefix on 404, write paths target the branch's prefix only.
+    const parentAppKey = process.env.PARENT_APP_KEY?.trim() || undefined;
 
     if (s3Bucket) {
       // Use S3 backend
       this.provider = new S3StorageProvider(
         s3Bucket,
         appKey,
-        process.env.AWS_REGION || 'us-east-2'
+        process.env.AWS_REGION || 'us-east-2',
+        parentAppKey
       );
+      if (parentAppKey) {
+        logger.info('Storage initialized in branch mode', { appKey, parentAppKey });
+      }
     } else {
-      // Use local filesystem backend
+      // Use local filesystem backend (no fallback support — local installs aren't branched)
       const baseDir = process.env.STORAGE_DIR || path.resolve(process.cwd(), 'insforge-storage');
       this.provider = new LocalStorageProvider(baseDir);
     }

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { S3StorageProvider } from '../../src/providers/storage/s3.provider.ts';
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { Readable } from 'stream';
+
+function asyncIterableFromString(s: string): AsyncIterable<Uint8Array> {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      yield Buffer.from(s);
+    },
+  };
+}
+
+function notFoundError(name = 'NoSuchKey') {
+  return Object.assign(new Error(name), { name, $metadata: { httpStatusCode: 404 } });
+}
+
+describe('S3StorageProvider — branch fallback', () => {
+  let sendMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendMock = vi.fn();
+    vi.spyOn(S3Client.prototype, 'send').mockImplementation(sendMock as any);
+  });
+
+  function makeProvider(parentAppKey?: string): S3StorageProvider {
+    const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', parentAppKey);
+    // Inject a real client without going through env-driven initialize().
+    (p as any).s3Client = new S3Client({ region: 'us-east-2' });
+    return p;
+  }
+
+  describe('getObject', () => {
+    it('returns branch object on first hit (no parent call)', async () => {
+      sendMock.mockResolvedValueOnce({ Body: asyncIterableFromString('hello') });
+      const p = makeProvider('parentkey');
+      const out = await p.getObject('photos', 'a.txt');
+      expect(out?.toString()).toBe('hello');
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const cmd = sendMock.mock.calls[0][0] as GetObjectCommand;
+      expect(cmd.input.Key).toBe('branchkey/photos/a.txt');
+    });
+
+    it('falls back to parent on NoSuchKey', async () => {
+      sendMock
+        .mockRejectedValueOnce(notFoundError('NoSuchKey'))
+        .mockResolvedValueOnce({ Body: asyncIterableFromString('parent-data') });
+      const p = makeProvider('parentkey');
+      const out = await p.getObject('photos', 'a.txt');
+      expect(out?.toString()).toBe('parent-data');
+      const k1 = (sendMock.mock.calls[0][0] as GetObjectCommand).input.Key;
+      const k2 = (sendMock.mock.calls[1][0] as GetObjectCommand).input.Key;
+      expect(k1).toBe('branchkey/photos/a.txt');
+      expect(k2).toBe('parentkey/photos/a.txt');
+    });
+
+    it('returns null when both branch and parent miss', async () => {
+      sendMock
+        .mockRejectedValueOnce(notFoundError())
+        .mockRejectedValueOnce(notFoundError());
+      const p = makeProvider('parentkey');
+      expect(await p.getObject('photos', 'a.txt')).toBeNull();
+    });
+
+    it('does NOT fall back when no parent configured', async () => {
+      sendMock.mockRejectedValueOnce(notFoundError());
+      const p = makeProvider();  // no parentAppKey
+      expect(await p.getObject('photos', 'a.txt')).toBeNull();
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('headObject', () => {
+    it('returns branch metadata on first hit', async () => {
+      sendMock.mockResolvedValueOnce({
+        ContentLength: 42,
+        ETag: '"abc"',
+        ContentType: 'text/plain',
+        LastModified: new Date('2026-04-29'),
+      });
+      const p = makeProvider('parentkey');
+      const meta = await p.headObject('photos', 'a.txt');
+      expect(meta?.size).toBe(42);
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to parent on NotFound', async () => {
+      sendMock
+        .mockRejectedValueOnce(notFoundError('NotFound'))
+        .mockResolvedValueOnce({ ContentLength: 7, ETag: '"p"', LastModified: new Date() });
+      const p = makeProvider('parentkey');
+      const meta = await p.headObject('photos', 'a.txt');
+      expect(meta?.size).toBe(7);
+      expect(sendMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows non-404 errors instead of falling back', async () => {
+      sendMock.mockRejectedValueOnce(Object.assign(new Error('boom'), { name: 'AccessDenied' }));
+      const p = makeProvider('parentkey');
+      await expect(p.headObject('photos', 'a.txt')).rejects.toThrow();
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getObjectStream', () => {
+    function fakeStreamResponse(body: string) {
+      return {
+        Body: Readable.from([Buffer.from(body)]),
+        ContentLength: body.length,
+        ETag: '"x"',
+        ContentType: 'text/plain',
+        LastModified: new Date(),
+      };
+    }
+
+    it('streams from parent when branch is 404', async () => {
+      sendMock
+        .mockRejectedValueOnce(notFoundError())
+        .mockResolvedValueOnce(fakeStreamResponse('parent-stream'));
+      const p = makeProvider('parentkey');
+      const out = await p.getObjectStream('photos', 'a.txt');
+      const chunks: Buffer[] = [];
+      for await (const c of out.body) chunks.push(c as Buffer);
+      expect(Buffer.concat(chunks).toString()).toBe('parent-stream');
+    });
+
+    it('throws when both branch and parent miss', async () => {
+      sendMock
+        .mockRejectedValueOnce(notFoundError())
+        .mockRejectedValueOnce(notFoundError());
+      const p = makeProvider('parentkey');
+      await expect(p.getObjectStream('photos', 'a.txt')).rejects.toThrow();
+    });
+  });
+
+  describe('getDownloadStrategy presigned URL', () => {
+    beforeEach(() => {
+      delete process.env.AWS_CLOUDFRONT_URL;
+    });
+
+    it('signs branch key when branch HEAD succeeds', async () => {
+      sendMock.mockResolvedValueOnce({ ContentLength: 5, LastModified: new Date(), ETag: '"x"' });
+      const p = makeProvider('parentkey');
+      const strategy = await p.getDownloadStrategy('photos', 'a.txt');
+      expect(strategy.method).toBe('presigned');
+      expect(strategy.url).toContain('branchkey/photos/a.txt');
+    });
+
+    it('signs parent key when branch HEAD returns 404', async () => {
+      // First call = branch HEAD → 404.
+      sendMock.mockRejectedValueOnce(notFoundError('NotFound'));
+      const p = makeProvider('parentkey');
+      const strategy = await p.getDownloadStrategy('photos', 'a.txt');
+      expect(strategy.url).toContain('parentkey/photos/a.txt');
+    });
+
+    it('non-branch project: no HEAD round-trip, signs branch key directly', async () => {
+      const p = makeProvider();  // no parentAppKey
+      const strategy = await p.getDownloadStrategy('photos', 'a.txt');
+      expect(strategy.url).toContain('branchkey/photos/a.txt');
+      // No HEAD call should have happened.
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/superpowers/plans/2026-04-29-backend-branching-oss.md
+++ b/docs/superpowers/plans/2026-04-29-backend-branching-oss.md
@@ -1,0 +1,405 @@
+# Backend Branching (OSS) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add read-only fallback from a branch project's storage to its parent project's S3 directory, gated by a new `PARENT_APP_KEY` env var. Read-only, transparent, no HTTP API changes.
+
+**Architecture:** Extend `S3StorageProvider` with an optional `parentAppKey`. Read methods (`getObject`, `headObject`, `getObjectStream`, `getPresignedUrl`) attempt the branch's S3 path first; on 404, retry the parent's path. Writes always target the branch path. Service layer and HTTP routes unchanged.
+
+**Tech Stack:** TypeScript, Node.js, Express, AWS SDK v3 (`@aws-sdk/client-s3`), Vitest.
+
+**Spec:** [docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md](../specs/2026-04-29-backend-branching-oss-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `backend/src/providers/storage/s3.provider.ts` — accept `parentAppKey`, add fallback in read methods
+- `backend/src/services/storage/storage.service.ts` — pass `PARENT_APP_KEY` env var into provider constructor
+- `backend/src/providers/storage/storage.provider.ts` (interface, if any) — no new methods, just a fallback-aware contract
+
+**Create:**
+- `backend/tests/unit/storage-s3-fallback.test.ts` — fallback behavior unit tests
+
+---
+
+## Task 1: Extend S3StorageProvider Constructor
+
+**Files:**
+- Modify: `backend/src/providers/storage/s3.provider.ts:49-56`
+
+- [ ] **Step 1: Accept `parentAppKey` in constructor**
+
+```typescript
+export class S3StorageProvider implements StorageProvider {
+  private s3Client: S3Client | null = null;
+
+  constructor(
+    private s3Bucket: string,
+    private appKey: string,
+    private region: string = 'us-east-2',
+    private parentAppKey?: string,
+  ) {
+    // ... existing init ...
+  }
+
+  private getS3Key(bucket: string, key: string): string {
+    return `${this.appKey}/${bucket}/${key}`;
+  }
+
+  private getParentS3Key(bucket: string, key: string): string | null {
+    return this.parentAppKey ? `${this.parentAppKey}/${bucket}/${key}` : null;
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/providers/storage/s3.provider.ts
+git commit -m "feat(branching): S3StorageProvider accepts optional parentAppKey"
+```
+
+---
+
+## Task 2: Fallback in Read Methods (TDD)
+
+**Files:**
+- Create: `backend/tests/unit/storage-s3-fallback.test.ts`
+- Modify: `backend/src/providers/storage/s3.provider.ts` (`getObject`, `headObject`, `getObjectStream`)
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// backend/tests/unit/storage-s3-fallback.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { S3StorageProvider } from '@/providers/storage/s3.provider.js';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+
+describe('S3StorageProvider fallback to parent', () => {
+  let sendMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    sendMock = vi.fn();
+    vi.spyOn(S3Client.prototype, 'send').mockImplementation(sendMock as any);
+  });
+
+  it('returns branch object when present (no fallback call)', async () => {
+    sendMock.mockResolvedValueOnce({ Body: streamOf('hello') });
+    const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', 'parentkey');
+    (p as any).s3Client = new S3Client({});  // bypass async init for unit
+    const out = await p.getObject('foo', 'a.txt');
+    expect(out?.toString()).toBe('hello');
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const cmd: any = sendMock.mock.calls[0][0];
+    expect(cmd.input.Key).toBe('branchkey/foo/a.txt');
+  });
+
+  it('falls back to parent when branch returns NoSuchKey', async () => {
+    const noSuchKey = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+    sendMock.mockRejectedValueOnce(noSuchKey).mockResolvedValueOnce({ Body: streamOf('parent-data') });
+    const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', 'parentkey');
+    (p as any).s3Client = new S3Client({});
+    const out = await p.getObject('foo', 'a.txt');
+    expect(out?.toString()).toBe('parent-data');
+    const k1 = (sendMock.mock.calls[0][0] as any).input.Key;
+    const k2 = (sendMock.mock.calls[1][0] as any).input.Key;
+    expect(k1).toBe('branchkey/foo/a.txt');
+    expect(k2).toBe('parentkey/foo/a.txt');
+  });
+
+  it('returns null when both branch and parent are missing', async () => {
+    const noSuchKey = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+    sendMock.mockRejectedValueOnce(noSuchKey).mockRejectedValueOnce(noSuchKey);
+    const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', 'parentkey');
+    (p as any).s3Client = new S3Client({});
+    const out = await p.getObject('foo', 'a.txt');
+    expect(out).toBeNull();
+  });
+
+  it('does NOT fall back when parentAppKey is unset', async () => {
+    const noSuchKey = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+    sendMock.mockRejectedValueOnce(noSuchKey);
+    const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2');  // no parentAppKey
+    (p as any).s3Client = new S3Client({});
+    const out = await p.getObject('foo', 'a.txt');
+    expect(out).toBeNull();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function streamOf(s: string) {
+  const { Readable } = require('node:stream');
+  return Readable.from([Buffer.from(s)]);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run tests/unit/storage-s3-fallback.test.ts`
+Expected: FAIL — fallback not yet implemented.
+
+- [ ] **Step 3: Implement fallback in `getObject`**
+
+```typescript
+async getObject(bucket: string, key: string): Promise<Buffer | null> {
+  if (!this.s3Client) throw new Error('S3 client not initialized');
+  const primary = await this.tryGet(this.getS3Key(bucket, key));
+  if (primary !== null) return primary;
+  const parentKey = this.getParentS3Key(bucket, key);
+  if (!parentKey) return null;
+  return this.tryGet(parentKey);
+}
+
+private async tryGet(s3Key: string): Promise<Buffer | null> {
+  try {
+    const cmd = new GetObjectCommand({ Bucket: this.s3Bucket, Key: s3Key });
+    const res = await this.s3Client!.send(cmd);
+    if (!res.Body) return null;
+    const chunks: Buffer[] = [];
+    // @ts-ignore SDK v3 stream
+    for await (const c of res.Body) chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
+    return Buffer.concat(chunks);
+  } catch (err: any) {
+    if (err?.name === 'NoSuchKey' || err?.$metadata?.httpStatusCode === 404) return null;
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Implement fallback in `headObject` and `getObjectStream`**
+
+Apply the same primary-then-parent pattern:
+
+```typescript
+async headObject(bucket: string, key: string): Promise<{ size: number; mimeType: string } | null> {
+  const tryHead = async (s3Key: string) => {
+    try {
+      const res = await this.s3Client!.send(new HeadObjectCommand({ Bucket: this.s3Bucket, Key: s3Key }));
+      return { size: res.ContentLength ?? 0, mimeType: res.ContentType ?? 'application/octet-stream' };
+    } catch (err: any) {
+      if (err?.name === 'NotFound' || err?.$metadata?.httpStatusCode === 404) return null;
+      throw err;
+    }
+  };
+  const primary = await tryHead(this.getS3Key(bucket, key));
+  if (primary) return primary;
+  const parentKey = this.getParentS3Key(bucket, key);
+  return parentKey ? tryHead(parentKey) : null;
+}
+```
+
+Mirror the pattern in `getObjectStream` if present.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd backend && npx vitest run tests/unit/storage-s3-fallback.test.ts`
+Expected: all four cases pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/providers/storage/s3.provider.ts backend/tests/unit/storage-s3-fallback.test.ts
+git commit -m "feat(branching): read-only S3 fallback to parent appkey on 404"
+```
+
+---
+
+## Task 3: Fallback in Presigned URL Generation
+
+**Files:**
+- Modify: `backend/src/providers/storage/s3.provider.ts` (`getPresignedUrl` method)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `backend/tests/unit/storage-s3-fallback.test.ts`:
+
+```typescript
+it('presigned URL: signs branch key when present', async () => {
+  // Mock HeadObject to succeed for branch path
+  sendMock.mockResolvedValueOnce({ ContentLength: 5 });
+  const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', 'parentkey');
+  (p as any).s3Client = new S3Client({});
+  const url = await p.getPresignedUrl('foo', 'a.txt');
+  expect(url).toContain('branchkey/foo/a.txt');
+});
+
+it('presigned URL: signs parent key when branch HEAD returns 404', async () => {
+  const notFound = Object.assign(new Error('NotFound'), { name: 'NotFound' });
+  sendMock.mockRejectedValueOnce(notFound);
+  sendMock.mockResolvedValueOnce({ ContentLength: 7 });
+  const p = new S3StorageProvider('bucket', 'branchkey', 'us-east-2', 'parentkey');
+  (p as any).s3Client = new S3Client({});
+  const url = await p.getPresignedUrl('foo', 'a.txt');
+  expect(url).toContain('parentkey/foo/a.txt');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && npx vitest run tests/unit/storage-s3-fallback.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement fallback for `getPresignedUrl`**
+
+```typescript
+async getPresignedUrl(bucket: string, key: string, expiresIn = 3600): Promise<string> {
+  // Decide which path to sign by checking existence first.
+  const branchKey = this.getS3Key(bucket, key);
+  const parentKey = this.getParentS3Key(bucket, key);
+  let signKey = branchKey;
+  if (parentKey) {
+    const exists = await this.objectExists(branchKey);
+    if (!exists) signKey = parentKey;
+  }
+  const cmd = new GetObjectCommand({ Bucket: this.s3Bucket, Key: signKey });
+  return getSignedUrl(this.s3Client!, cmd, { expiresIn });
+}
+
+private async objectExists(s3Key: string): Promise<boolean> {
+  try {
+    await this.s3Client!.send(new HeadObjectCommand({ Bucket: this.s3Bucket, Key: s3Key }));
+    return true;
+  } catch (err: any) {
+    if (err?.name === 'NotFound' || err?.$metadata?.httpStatusCode === 404) return false;
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && npx vitest run tests/unit/storage-s3-fallback.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/providers/storage/s3.provider.ts backend/tests/unit/storage-s3-fallback.test.ts
+git commit -m "feat(branching): presigned URL fallback to parent path"
+```
+
+---
+
+## Task 4: Wire `PARENT_APP_KEY` Env Var Through StorageService
+
+**Files:**
+- Modify: `backend/src/services/storage/storage.service.ts:29-45`
+
+- [ ] **Step 1: Pass `PARENT_APP_KEY` to S3StorageProvider**
+
+```typescript
+private constructor() {
+  const s3Bucket = process.env.AWS_S3_BUCKET;
+  const appKey = process.env.APP_KEY || 'local';
+  const parentAppKey = process.env.PARENT_APP_KEY;  // <-- new
+
+  if (s3Bucket) {
+    this.provider = new S3StorageProvider(
+      s3Bucket,
+      appKey,
+      process.env.AWS_REGION || 'us-east-2',
+      parentAppKey,
+    );
+    if (parentAppKey) {
+      logger.info('Storage initialized in branch mode', { appKey, parentAppKey });
+    }
+  } else {
+    // local storage — fallback unsupported in v1, ignore
+    const baseDir = process.env.STORAGE_DIR || path.resolve(process.cwd(), 'insforge-storage');
+    this.provider = new LocalStorageProvider(baseDir);
+  }
+}
+```
+
+- [ ] **Step 2: Verify boot log**
+
+Run:
+```bash
+cd backend
+APP_KEY=branchkey PARENT_APP_KEY=parentkey AWS_S3_BUCKET=test-bucket npm run dev 2>&1 | head -30
+```
+Expected: log line `Storage initialized in branch mode { appKey: 'branchkey', parentAppKey: 'parentkey' }`. Stop with Ctrl-C.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/services/storage/storage.service.ts
+git commit -m "feat(branching): wire PARENT_APP_KEY through to S3 provider"
+```
+
+---
+
+## Task 5: Manual Smoke Test
+
+- [ ] **Step 1: Two-namespace smoke against real S3**
+
+Pre-requisites: AWS creds + a test bucket with two prefixes:
+- `parentkey/photos/cat.jpg` (some real file)
+- `branchkey/photos/dog.jpg` (some other real file)
+
+```bash
+# Branch mode boot
+APP_KEY=branchkey PARENT_APP_KEY=parentkey AWS_S3_BUCKET=insforge-storage-test \
+  AWS_REGION=us-east-2 npm run dev:backend
+```
+
+Then in another terminal (after seeding `storage.objects` rows so RLS allows access):
+
+```bash
+# Should hit branch (own file)
+curl -i http://localhost:7130/api/storage/buckets/photos/objects/dog.jpg
+
+# Should hit parent (fallback)
+curl -i http://localhost:7130/api/storage/buckets/photos/objects/cat.jpg
+
+# Write goes to branch only
+curl -i -X PUT http://localhost:7130/api/storage/buckets/photos/objects/new.txt \
+  -H "Authorization: Bearer $TOKEN" --data-binary "branch-write"
+
+# Verify on S3 directly
+aws s3 ls s3://insforge-storage-test/branchkey/photos/   # contains new.txt
+aws s3 ls s3://insforge-storage-test/parentkey/photos/   # unchanged
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+git push -u origin feat/branching
+gh pr create --title "feat: storage fallback to parent for branch projects" --body "$(cat <<'EOF'
+## Summary
+- Adds optional `PARENT_APP_KEY` env var that triggers read-only fallback in S3 storage provider.
+- All read methods (getObject, headObject, getObjectStream, getPresignedUrl) try branch path first, fall back to parent path on 404.
+- Writes are unchanged — they always target the branch's own appkey path.
+- Local storage provider is unaffected (no fallback).
+
+## Spec
+- [docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md](docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md)
+
+## Test plan
+- [ ] Vitest suite green
+- [ ] Manual: GET on branch object hits branch
+- [ ] Manual: GET on parent-only object falls back to parent
+- [ ] Manual: GET on missing object returns 404
+- [ ] Manual: PUT on branch creates only at branch path
+- [ ] Manual: existing non-branch projects (no PARENT_APP_KEY) are unaffected
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Fallback is read-only**: writes (PUT/DELETE/multipart) always go to branch path. Verified by not modifying any write methods.
+- **Local provider unchanged**: only S3 provider gets the fallback. Local installs aren't branched.
+- **No HTTP API changes**: routes and middleware unchanged. RLS / bucket-visibility checks remain authoritative.
+- **No new IAM permissions**: existing role can read all prefixes in `AWS_S3_BUCKET`.
+- **Schema-only mode**: branches with `mode='schema-only'` truncate `storage.objects` in the DB → RLS lookup returns 404 before reaching the provider → fallback never runs. Documented in spec as expected.

--- a/docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md
+++ b/docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md
@@ -1,0 +1,121 @@
+# Backend Branching (OSS) — Design
+
+**Date:** 2026-04-29
+**Status:** Draft
+**Source PRD:** [insforge-cloud-backend Backend-Branching.md](../../../../insforge-cloud-backend/Backend-Branching.md)
+**Cloud-backend spec:** [2026-04-29-backend-branching-cloud-design.md](../../../../insforge-cloud-backend/docs/superpowers/specs/2026-04-29-backend-branching-cloud-design.md)
+
+This spec covers the **OSS slice** of backend branching v1: read-only fallback from a branch project's storage to its parent project's S3 directory.
+
+## Problem
+
+When a branch project is created from a parent, copying every storage object would be slow and wasteful (parent may have GB of files). The cloud-backend spec dictates: branch's S3 directory starts empty; reads of parent objects must transparently succeed via fallback. Branch writes go to branch's directory only; parent files are never modified from a branch.
+
+## Goals (v1)
+
+1. The OSS storage server, when started in "branch mode" (with an injected `PARENT_APP_KEY` env var), reads object data from parent's S3 path when the branch's path returns nothing.
+2. Fallback is **read-only**. Writes (PUT/DELETE/multipart-upload) always target the branch's own appkey path.
+3. Existing RLS / bucket-visibility checks continue to apply unchanged.
+4. No HTTP API additions. Behavior change is server-internal.
+5. Local-storage provider does **not** support fallback (cloud-only). Local installs are not branched.
+
+## Non-Goals (v1)
+
+- Cross-project fallback for non-branch projects.
+- Write-through: copying a parent object into branch when first written to (CoW). Branches always start with the empty file set in their own namespace; modifications create new objects.
+- Deletion markers: branch cannot "hide" a parent file. Deleting from a branch only deletes the branch's own copy (which doesn't exist for inherited files), so the parent file remains visible. Documented as v1 limitation.
+- Schema-only mode files: when the branch was created with `mode='schema-only'`, the cloud-backend truncates `storage.objects`, so RLS/metadata returns 404 for parent files. This matches "fresh start" semantics — fallback is only effective for `mode='full'` branches.
+
+## Current State Summary
+
+- OSS storage server: TypeScript / Express monorepo at `backend/`. See [backend/src/server.ts:1-80](../../../backend/src/server.ts).
+- S3 path layout: `{appKey}/{bucketName}/{key}` in a single shared bucket (`AWS_S3_BUCKET`). Code in [backend/src/providers/storage/s3.provider.ts:91-93](../../../backend/src/providers/storage/s3.provider.ts).
+- `appKey` loaded from `APP_KEY` env var at server startup. Singleton pattern in [backend/src/services/storage/storage.service.ts:29-45](../../../backend/src/services/storage/storage.service.ts).
+- HTTP read endpoint: `GET /api/storage/buckets/:bucketName/objects/*` ([backend/src/api/routes/storage/index.routes.ts:398-459](../../../backend/src/api/routes/storage/index.routes.ts)).
+- `StorageService.getObject` returns `null` if metadata absent or S3 returns nothing — these are the natural interception points for fallback ([backend/src/services/storage/storage.service.ts:201-238](../../../backend/src/services/storage/storage.service.ts)).
+- Presigned URL flow: `getDownloadStrategy` → `getPresignedUrl` (S3 sigV4 GET against `{appKey}/{bucket}/{key}`).
+
+## Design
+
+### Configuration
+
+New env var:
+- `PARENT_APP_KEY` (optional). When set, the server runs in "branch mode" and falls back to this appkey for object reads.
+
+The cloud-backend injects this at branch container startup (alongside the existing `APP_KEY`).
+
+### S3 Provider Changes
+
+Extend `S3StorageProvider` to optionally hold a `parentAppKey`:
+
+```typescript
+constructor(
+  private s3Bucket: string,
+  private appKey: string,
+  private region: string = 'us-east-2',
+  private parentAppKey?: string,
+) { ... }
+
+private getS3Key(bucket: string, key: string): string {
+  return `${this.appKey}/${bucket}/${key}`;
+}
+private getParentS3Key(bucket: string, key: string): string | null {
+  return this.parentAppKey ? `${this.parentAppKey}/${bucket}/${key}` : null;
+}
+```
+
+Read methods (`getObject`, `headObject`, `getObjectStream`, `getPresignedUrl`) get a single new helper:
+
+```typescript
+private async withFallback<T>(primary: () => Promise<T | null>, parent: () => Promise<T | null>): Promise<T | null> {
+  const a = await primary();
+  if (a !== null) return a;
+  if (!this.parentAppKey) return null;
+  return parent();
+}
+```
+
+Each read becomes:
+- Attempt with `getS3Key(bucket, key)`. On null/404 → if `parentAppKey` set, attempt with `getParentS3Key(bucket, key)`.
+
+Write methods (`putObject`, `deleteObject`, `createMultipartUpload`, etc.) do **not** call the fallback — they always target `getS3Key`.
+
+### Presigned URLs
+
+`getPresignedUrl(bucket, key)` is the only read path that doesn't actually fetch the object — it just constructs a signed URL. For fallback to work for presigned URLs, we must do a `headObject` first against the branch path; if 404, sign against the parent path. This adds a HEAD round-trip but is required for correctness.
+
+### Service Layer
+
+`StorageService.getObject` and `objectIsVisible` rely on a metadata row in `storage.objects`. For `mode='full'` branches, that row exists (copied via pg_dump). The provider does the actual S3 fallback; service layer needs no change.
+
+For `mode='schema-only'` branches, `storage.objects` is truncated by the cloud-backend after restore. Result: branch users get 404 from RLS lookup, never reaching the provider. This is the expected behavior — the storage feature simply doesn't apply.
+
+### Failure Modes
+
+- `parentAppKey` set but parent's directory was deleted (branch outlived parent — shouldn't happen given lifecycle cascade): primary 404 + parent 404 → final 404. Same as today.
+- Parent exists but specific key missing on parent too: same 404. No new error path.
+- IAM error reading parent path (cross-prefix permission denied): logged as warning, behaves as 404. The IAM role for the EC2 already has access to the entire `insforge-storage` bucket per the existing single-bucket model; no permissions change required.
+
+### Compatibility
+
+- Local storage provider: ignored. `LocalStorageProvider` never receives `parentAppKey`. The constructor signature can be extended for symmetry but the fallback path no-ops.
+- Existing non-branch projects: `PARENT_APP_KEY` is unset → fallback path never executes → zero behavior change.
+
+## API
+
+No new HTTP endpoints. Existing endpoints' behavior changes only for branches with `PARENT_APP_KEY` set, and only for read paths.
+
+## Acceptance
+
+A branch container started with `APP_KEY=branchkey` and `PARENT_APP_KEY=parentkey`:
+1. `GET /api/storage/buckets/foo/objects/path/to/file.jpg` returns the file from `parentkey/foo/path/to/file.jpg` if `branchkey/foo/path/to/file.jpg` doesn't exist (assuming branch DB has the metadata row).
+2. `PUT /api/storage/buckets/foo/objects/path/to/file.jpg` writes to `branchkey/foo/path/to/file.jpg` only.
+3. After (2), step (1) returns the new branch-local file (branch path takes priority).
+4. `DELETE /api/storage/buckets/foo/objects/path/to/file.jpg` (after 2) removes the branch's copy. Subsequent GET falls back to parent file again.
+5. RLS still gates: a user without read access to the bucket gets 404, regardless of fallback.
+
+## Open Questions / TBD
+
+1. **Deletion markers (post-v1).** A branch may want to "hide" a parent file. Requires a sentinel object or a row in branch's metadata. Not in v1.
+2. **CoW write-through.** When a branch writes to `path/to/file.jpg` after reading the parent's version, should we copy on first write? Today writing creates a fresh file at the branch path; reads naturally see the new file. No copy needed unless we want diff/merge of file contents (not in product scope).
+3. **Schema-only branch + storage**. Confirm with cloud-backend team: should schema-only mode skip truncating `storage.objects`, so storage fallback works in that mode too? Current spec assumes truncate (matching "fresh start"). Worth a one-line check.


### PR DESCRIPTION
## Summary
- Only push to ECR for production tags like `v2.0.9`. Pre-release tags (`v2.0.9-test1`, `v2.0.9-auth`, …) and manual `workflow_dispatch` runs now skip the ECR step.
- Test images still build and publish to GHCR, so internal testing flow is unchanged — they just no longer get copied into our customer-facing ECR.
- Uses the same `!contains(github.ref_name, '-')` convention already in this file for the `latest` tag.

## Test plan
- [ ] Push a test tag (e.g. `v2.0.9-test1`) and confirm `push-to-ecr` job is skipped while GHCR images are produced.
- [ ] Push a real release tag (e.g. `v2.0.9`) and confirm `push-to-ecr` runs and the image lands in ECR.
- [ ] Trigger via `workflow_dispatch` and confirm `push-to-ecr` is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 storage now supports branch-to-parent fallback for read operations when configured with a parent storage location; writes remain branch-only.

* **Documentation**
  * Added backend branching implementation guide and design specification for branch-aware storage behavior.

* **Chores**
  * Updated CI/CD workflow publishing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->