### PR TITLE
ci(build-image): skip ECR push for pre-release tags

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -159,7 +159,7 @@ jobs:
   push-to-ecr:
     needs: merge-manifests
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
> Supersedes #1173 (closed; original branch was force-pushed but the PR head did not auto-sync).

## Summary
- Only push to ECR for production tags like `v2.0.9`. Pre-release tags (`v2.0.9-test1`, `v2.0.9-auth`, …) and manual `workflow_dispatch` runs now skip the ECR step.
- Test images still build and publish to GHCR, so internal testing flow is unchanged — they just no longer get copied into our customer-facing ECR.
- Uses the same `!contains(github.ref_name, '-')` convention already in this file for the `latest` tag in `merge-manifests`.

## Test plan
- [ ] Push a test tag (e.g. `v2.0.9-test1`) and confirm `push-to-ecr` job is skipped while GHCR images are produced.
- [ ] Push a real release tag (e.g. `v2.0.9`) and confirm `push-to-ecr` runs and the image lands in ECR.
- [ ] Trigger via `workflow_dispatch` and confirm `push-to-ecr` is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)