### PR TITLE
fix(dashboard): drop stray divider between Deployments and Compute

### DIFF
--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -29,19 +29,16 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
   const isDTest = getFeatureFlag('dashboard-v4-experiment') === 'd_test';
   const isDTestCloud = isDTest && host.mode === 'cloud-hosting';
 
-  // Insert deployments at the end of section 2 for cloud projects.
+  // Insert deployments after Model Gateway for cloud projects. Compute
+  // already terminates the section, so deployments doesn't need sectionEnd.
   const mainMenuItems = useMemo(() => {
     const items = dashboardStaticMenuItems.map((item) => ({ ...item }));
 
     if (isCloud) {
       const aiItemIndex = items.findIndex((item) => item.id === 'ai');
-      const deploymentsItem: DashboardPrimaryMenuItem = {
-        ...dashboardDeploymentsMenuItem,
-        sectionEnd: true,
-      };
+      const deploymentsItem: DashboardPrimaryMenuItem = { ...dashboardDeploymentsMenuItem };
 
       if (aiItemIndex >= 0) {
-        items[aiItemIndex] = { ...items[aiItemIndex], sectionEnd: false };
         items.splice(aiItemIndex + 1, 0, deploymentsItem);
         return items;
       }


### PR DESCRIPTION
## Summary
- Cloud sidebar was rendering an extra divider between **Deployments** and **Compute** because `AppSidebar` still hardcoded `sectionEnd: true` on the dynamically-inserted Deployments item.
- Compute (a static item with `sectionEnd: true`) already terminates that section, so Deployments doesn't need it.

## Before / After
- **Before:** … Model Gateway, Deployments, ─divider─, Compute, ─divider─, Logs
- **After:**  … Model Gateway, Deployments, Compute, ─divider─, Logs

## Test plan
- [ ] Cloud project sidebar: only one divider, sitting after Compute
- [ ] Self-hosted sidebar unchanged (no Deployments injection path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar menu item positioning for cloud projects, ensuring the deployments menu appears in the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->