### PR TITLE
chore(d_test): drop DTestViewBroadcaster postMessage

### DIFF
--- a/packages/dashboard/src/layout/AppLayout.tsx
+++ b/packages/dashboard/src/layout/AppLayout.tsx
@@ -55,23 +55,6 @@ function ConnectOverlayBridge({ hostMode, onOpenDialog }: ConnectOverlayBridgePr
   return null;
 }
 
-function DTestViewBroadcaster() {
-  const { pathname } = useLocation();
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || window.parent === window) {
-      return;
-    }
-    if (getFeatureFlag('dashboard-v4-experiment') !== 'd_test') {
-      return;
-    }
-    const view = pathname === '/dashboard/install' ? 'install' : 'dashboard';
-    window.parent.postMessage({ type: 'D_TEST_VIEW_CHANGED', view }, '*');
-  }, [pathname]);
-
-  return null;
-}
-
 function getEmbeddedDashboardRoute(path: string): string | null {
   if (path.startsWith('/dashboard')) {
     return path;
@@ -121,7 +104,6 @@ export default function AppLayout({ children }: LayoutProps) {
     <ThemeProvider forcedTheme={forcedTheme}>
       <ConnectDialogProvider value={openConnectDialog}>
         <ConnectOverlayBridge hostMode={host.mode} onOpenDialog={openConnectDialog} />
-        <DTestViewBroadcaster />
         <DTestConnectTip />
         <div
           className={cn(


### PR DESCRIPTION
The cross-window D_TEST_VIEW_CHANGED contract was used solely to disable insforge-cloud's Install button while the dashboard was on /dashboard/install. We no longer want that disable behavior, so stop emitting the message. Cloud side keeps the listener as harmless dead code (state stays null, button stays enabled).

## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
Test manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal cross-window messaging logic from the dashboard layout component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->