### PR TITLE
fix(compute): hide sidebar item when no Fly token / cloud-proxy creds

### DIFF
--- a/backend/src/api/routes/metadata/index.routes.ts
+++ b/backend/src/api/routes/metadata/index.routes.ts
@@ -13,6 +13,7 @@ import type { AppMetadataSchema, ProjectIdResponse } from '@insforge/shared-sche
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { CloudDatabaseProvider } from '@/providers/database/cloud.provider.js';
+import { isComputeConfigured } from '@/services/compute/services.service.js';
 
 const router = Router();
 const authService = AuthService.getInstance();
@@ -48,6 +49,7 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
       storage,
       functions,
       aiIntegration: aiConfig,
+      compute: { enabled: isComputeConfigured() },
       version,
     };
 

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -174,6 +174,15 @@ function rewrapCloudError(error: unknown, defaultMessage: string): AppError {
   );
 }
 
+// Cheap availability probe used by the metadata route to gate the dashboard
+// sidebar. Mirrors the precedence in `selectComputeProvider` but never
+// throws — neither path configured returns false instead of an AppError.
+export function isComputeConfigured(): boolean {
+  return (
+    FlyProvider.getInstance().isConfigured() || CloudComputeProvider.getInstance().isConfigured()
+  );
+}
+
 export function selectComputeProvider(): ComputeProvider {
   // Self-host takes precedence: if FLY_API_TOKEN is set, the user has their own
   // Fly account and wants direct control. Otherwise fall through to cloud-proxy

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -1083,3 +1083,47 @@ describe('selectComputeProvider factory', () => {
     expect(() => selectComputeProvider()).toThrow(/COMPUTE_NOT_CONFIGURED|not configured/);
   });
 });
+
+describe('isComputeConfigured probe', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@/providers/compute/fly.provider.js');
+    vi.doUnmock('@/providers/compute/cloud.provider.js');
+  });
+
+  it('returns true when FLY_API_TOKEN is set', async () => {
+    vi.doMock('@/infra/config/app.config.js', () => ({
+      config: {
+        fly: { apiToken: 'tok', org: 'o', enabled: true, domain: 'd' },
+        cloud: { projectId: 'local', apiHost: '' },
+        app: { jwtSecret: 'x' },
+      },
+    }));
+    const { isComputeConfigured } = await import('@/services/compute/services.service.js');
+    expect(isComputeConfigured()).toBe(true);
+  });
+
+  it('returns true when only cloud-proxy creds are set', async () => {
+    vi.doMock('@/infra/config/app.config.js', () => ({
+      config: {
+        fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        cloud: { projectId: 'p', apiHost: 'https://x' },
+        app: { jwtSecret: 'x' },
+      },
+    }));
+    const { isComputeConfigured } = await import('@/services/compute/services.service.js');
+    expect(isComputeConfigured()).toBe(true);
+  });
+
+  it('returns false when neither path is configured (does not throw)', async () => {
+    vi.doMock('@/infra/config/app.config.js', () => ({
+      config: {
+        fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        cloud: { projectId: 'local', apiHost: '' },
+        app: { jwtSecret: 'x' },
+      },
+    }));
+    const { isComputeConfigured } = await import('@/services/compute/services.service.js');
+    expect(isComputeConfigured()).toBe(false);
+  });
+});

--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insfo
 import { ProjectSettingsMenuDialog } from '../features/dashboard/components';
 import { getFeatureFlag } from '../lib/analytics/posthog';
 import { useDashboardHost } from '../lib/config/DashboardHostContext';
+import { useMetadata } from '../lib/hooks/useMetadata';
 
 interface AppSidebarProps extends React.HTMLAttributes<HTMLElement> {
   isCollapsed: boolean;
@@ -28,11 +29,19 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
   const host = useDashboardHost();
   const isDTest = getFeatureFlag('dashboard-v4-experiment') === 'd_test';
   const isDTestCloud = isDTest && host.mode === 'cloud-hosting';
+  const { compute } = useMetadata();
+  // Treat as enabled until metadata loads to avoid a flash of the item
+  // appearing then disappearing on the first render. The metadata route is
+  // hit early in the dashboard's bootstrap so the window is small.
+  const isComputeEnabled = compute?.enabled ?? true;
 
   // Insert deployments after Model Gateway for cloud projects. Compute
   // already terminates the section, so deployments doesn't need sectionEnd.
+  // When compute is disabled (no Fly token / no cloud-proxy creds), hide
+  // the item entirely and shift sectionEnd onto the preceding item so the
+  // section divider stays correct.
   const mainMenuItems = useMemo(() => {
-    const items = dashboardStaticMenuItems.map((item) => ({ ...item }));
+    let items = dashboardStaticMenuItems.map((item) => ({ ...item }));
 
     if (isCloud) {
       const aiItemIndex = items.findIndex((item) => item.id === 'ai');
@@ -40,14 +49,24 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
 
       if (aiItemIndex >= 0) {
         items.splice(aiItemIndex + 1, 0, deploymentsItem);
-        return items;
+      } else {
+        items = [...items, deploymentsItem];
       }
+    }
 
-      return [...items, deploymentsItem];
+    if (!isComputeEnabled) {
+      const computeIndex = items.findIndex((item) => item.id === 'compute');
+      if (computeIndex >= 0) {
+        const computeItem = items[computeIndex];
+        items.splice(computeIndex, 1);
+        if (computeItem.sectionEnd && computeIndex > 0) {
+          items[computeIndex - 1] = { ...items[computeIndex - 1], sectionEnd: true };
+        }
+      }
     }
 
     return items;
-  }, [isCloud]);
+  }, [isCloud, isComputeEnabled]);
 
   // d_test + cloud-hosting prepends Install + Doc above Settings in the
   // bottom nav. Other shells just show Settings.

--- a/packages/dashboard/src/lib/hooks/useMetadata.ts
+++ b/packages/dashboard/src/lib/hooks/useMetadata.ts
@@ -24,6 +24,7 @@ export function useMetadata(options?: UseMetadataOptions) {
     auth: metadata?.auth,
     tables: metadata?.database.tables,
     storage: metadata?.storage,
+    compute: metadata?.compute,
     version: metadata?.version || 'Unknown',
     isLoading,
     error,

--- a/packages/shared-schemas/src/metadata.schema.ts
+++ b/packages/shared-schemas/src/metadata.schema.ts
@@ -48,11 +48,21 @@ export const realtimeMetadataSchema = z.object({
   permissions: realtimePermissionsResponseSchema,
 });
 
+// Compute services availability. The dashboard uses `enabled` to hide the
+// Compute sidebar item entirely when neither a Fly token (self-host) nor
+// cloud-proxy creds (PROJECT_ID + CLOUD_API_HOST + JWT_SECRET) are set —
+// rather than letting users click into a page that returns 503 on every
+// request.
+export const computeMetadataSchema = z.object({
+  enabled: z.boolean(),
+});
+
 export const appMetaDataSchema = z.object({
   auth: authMetadataSchema,
   database: databaseMetadataSchema,
   storage: storageMetadataSchema,
   aiIntegration: aiMetadataSchema.optional(),
+  compute: computeMetadataSchema.optional(),
   functions: z.array(edgeFunctionMetadataSchema),
   realtime: realtimeMetadataSchema.optional(),
   version: z.string().optional(),
@@ -65,6 +75,7 @@ export type StorageMetadataSchema = z.infer<typeof storageMetadataSchema>;
 export type EdgeFunctionMetadataSchema = z.infer<typeof edgeFunctionMetadataSchema>;
 export type AIMetadataSchema = z.infer<typeof aiMetadataSchema>;
 export type RealtimeMetadataSchema = z.infer<typeof realtimeMetadataSchema>;
+export type ComputeMetadataSchema = z.infer<typeof computeMetadataSchema>;
 export type AppMetadataSchema = z.infer<typeof appMetaDataSchema>;
 
 // Database connection schemas


### PR DESCRIPTION
## Summary

OSS users without `FLY_API_TOKEN` (or cloud-proxy creds — `PROJECT_ID` + `CLOUD_API_HOST` + `JWT_SECRET`) currently see a **Compute** item in the sidebar that links to a page returning `503 COMPUTE_NOT_CONFIGURED` on every request. The friendly empty-state we land on is informative, but the sidebar entry itself is misleading.

This mirrors the gating model the dashboard already uses for **Deployments** (only shown when `isCloud`) by surfacing compute availability through the existing `/api/metadata` response and filtering the sidebar items client-side.

- **shared-schemas**: add `compute: { enabled: boolean }` to `AppMetadataSchema`.
- **backend**: export `isComputeConfigured()` — a non-throwing probe over `FlyProvider` / `CloudComputeProvider` — and include it in the metadata route.
- **dashboard**: read `compute.enabled` via `useMetadata`; when false, drop the Compute item and shift its `sectionEnd` onto the preceding entry so the section divider stays correct.

`ComputePage`'s existing `COMPUTE_NOT_CONFIGURED` empty-state is left in place as a safety net for direct URL hits.

## Test plan
- [ ] Backend unit tests pass (`vitest tests/unit/compute/services-service.test.ts`) — including 3 new `isComputeConfigured` cases.
- [ ] Self-host without `FLY_API_TOKEN`: Compute item is absent from the sidebar; section divider lands after AI / Deployments correctly.
- [ ] Self-host with `FLY_API_TOKEN` + `FLY_ORG`: Compute item appears as before.
- [ ] Cloud-managed (PROJECT_ID + CLOUD_API_HOST + JWT_SECRET): Compute item appears as before.
- [ ] Direct nav to `/dashboard/compute` while disabled still shows the friendly "Compute services not configured" card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata endpoint now reports compute feature availability status.
  * Sidebar dynamically hides the compute menu item when compute is not configured, while maintaining proper UI layout and section organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->