### PR TITLE
fix(dashboard): hide observability and backend advisor in self-hosting

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
@@ -10,6 +10,7 @@ import { isInsForgeCloudProject } from '../../../../lib/utils/utils';
 import { useMcpUsage } from '../../../logs/hooks/useMcpUsage';
 import { useAdvisorLatest } from '../../hooks/useAdvisor';
 import { useLastBackup } from '../../hooks/useLastBackup';
+import { useIsCloudHostingMode } from '../../../../lib/config/DashboardHostContext';
 import CloudDoneIcon from '../../../../assets/icons/cloud_done.svg?react';
 import CriticalIcon from '../../../../assets/icons/severity_critical.svg?react';
 import { DashboardPromptStepper } from './DashboardPromptStepper';
@@ -45,6 +46,7 @@ const STATUS_BADGE_CLASS =
 export function DTestConnectedDashboard() {
   const navigate = useNavigate();
   const isCloudProject = isInsForgeCloudProject();
+  const isCloudHostingMode = useIsCloudHostingMode();
   const {
     metadata,
     tables,
@@ -174,8 +176,12 @@ export function DTestConnectedDashboard() {
         </div>
 
         <DashboardPromptStepper />
-        <ObservabilitySection />
-        <BackendAdvisorSection />
+        {isCloudHostingMode && (
+          <>
+            <ObservabilitySection />
+            <BackendAdvisorSection />
+          </>
+        )}
       </div>
     </main>
   );

--- a/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
@@ -540,8 +540,12 @@ export default function DashboardPage() {
   }
 
   return (
-    <main className="h-full min-h-0 min-w-0 overflow-y-auto bg-semantic-0">
-      <div className="flex min-w-0 flex-col lg:flex-row">
+    <main
+      className={`h-full min-h-0 min-w-0 overflow-y-auto bg-semantic-0${isCloudHostingMode ? '' : ' lg:overflow-hidden'}`}
+    >
+      <div
+        className={`flex min-w-0 flex-col lg:flex-row${isCloudHostingMode ? '' : ' min-h-full lg:h-full lg:min-h-0'}`}
+      >
         <section className="insforge-dashboard-home-sidebar min-w-0 shrink-0 border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
           <div className="mx-auto flex w-full max-w-[400px] flex-col gap-12">
             <div className="flex flex-col gap-12">
@@ -663,10 +667,12 @@ export default function DashboardPage() {
           </div>
         </section>
       </div>
-      <div className="flex flex-col gap-12 px-10 py-10">
-        <ObservabilitySection />
-        <BackendAdvisorSection />
-      </div>
+      {isCloudHostingMode && (
+        <div className="flex flex-col gap-12 px-10 py-10">
+          <ObservabilitySection />
+          <BackendAdvisorSection />
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Both sections rely on cloud-hosting, the self-hosting shell does not provide

## How did you test this change?

<!-- Describe how you tested this PR -->
Test Manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observability and Backend Advisor dashboard sections now conditionally render based on the hosting environment type, appearing exclusively in cloud hosting mode to deliver an experience optimized for your deployment configuration.

* **Style**
  * Dashboard layout responsiveness improved with refined overflow handling and explicit sizing constraints, enhancing visual presentation and rendering optimization across different screen types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->