### PR TITLE
feat(dashboard): inline copied feedback on backend advisor copy buttons

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
@@ -1,4 +1,5 @@
-import { ChevronDown, ChevronUp, Copy } from 'lucide-react';
+import { useState } from 'react';
+import { Check, ChevronDown, ChevronUp, Copy } from 'lucide-react';
 import type { DashboardAdvisorIssue } from '../../../../types';
 import { useToast } from '../../../../lib/hooks/useToast';
 import { formatRemediationPrompt } from './remediationPrompt';
@@ -26,6 +27,7 @@ const SEVERITY_TONE = {
 
 export function AdvisoryItem({ issue, expanded, onToggle }: AdvisoryItemProps) {
   const { showToast } = useToast();
+  const [copied, setCopied] = useState(false);
   const Icon = SEVERITY_ICON[issue.severity];
 
   const handleCopyRemediation = async () => {
@@ -34,15 +36,17 @@ export function AdvisoryItem({ issue, expanded, onToggle }: AdvisoryItemProps) {
     }
     try {
       await navigator.clipboard.writeText(formatRemediationPrompt(issue));
-      showToast('Remediation copied', 'success');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch {
       showToast('Failed to copy remediation', 'error');
     }
   };
 
-  const copyButtonVisibility = expanded
-    ? 'opacity-100'
-    : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100';
+  const copyButtonVisibility =
+    expanded || copied
+      ? 'opacity-100'
+      : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100';
 
   return (
     <div className="group border-b border-[var(--alpha-8)] transition-colors last:border-b-0 hover:bg-[var(--alpha-8)]">
@@ -80,8 +84,8 @@ export function AdvisoryItem({ issue, expanded, onToggle }: AdvisoryItemProps) {
                 }}
                 className={`flex items-center gap-1 rounded border border-[var(--alpha-8)] bg-card px-1 py-1 text-sm leading-5 text-foreground transition-opacity hover:bg-[var(--alpha-4)] ${copyButtonVisibility}`}
               >
-                <Copy className="h-5 w-5" />
-                <span className="px-1">Copy Remediation</span>
+                {copied ? <Check className="h-5 w-5" /> : <Copy className="h-5 w-5" />}
+                <span className="px-1">{copied ? 'Copied' : 'Copy Remediation'}</span>
               </button>
             )}
             <span

--- a/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
@@ -43,10 +43,9 @@ export function AdvisoryItem({ issue, expanded, onToggle }: AdvisoryItemProps) {
     }
   };
 
-  const copyButtonVisibility =
-    expanded || copied
-      ? 'opacity-100'
-      : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100';
+  const copyButtonVisibility = expanded
+    ? 'opacity-100'
+    : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100';
 
   return (
     <div className="group border-b border-[var(--alpha-8)] transition-colors last:border-b-0 hover:bg-[var(--alpha-8)]">

--- a/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Copy, Loader2, RotateCw } from 'lucide-react';
+import { Check, Copy, Loader2, RotateCw } from 'lucide-react';
 import {
   useAdvisorCategoryCounts,
   useAdvisorIssues,
@@ -102,6 +102,7 @@ export function BackendAdvisorSection() {
   const queryClient = useQueryClient();
 
   const [isScanning, setIsScanning] = useState(false);
+  const [copiedAll, setCopiedAll] = useState(false);
   const baselineScanIdRef = useRef<string | undefined>(undefined);
   const pollStartRef = useRef<number | null>(null);
   const refetchLatest = latest.refetch;
@@ -238,10 +239,8 @@ export function BackendAdvisorSection() {
         return;
       }
       await navigator.clipboard.writeText(formatRemediationPromptBatch(actionable));
-      showToast(
-        `Copied ${actionable.length} remediation${actionable.length === 1 ? '' : 's'}`,
-        'success'
-      );
+      setCopiedAll(true);
+      setTimeout(() => setCopiedAll(false), 2000);
     } catch {
       showToast('Failed to copy remediations', 'error');
     }
@@ -281,8 +280,8 @@ export function BackendAdvisorSection() {
             onClick={() => void handleCopyAll()}
             className={ADVISOR_BUTTON_CLASS}
           >
-            <Copy className="h-4 w-4" />
-            <span>Copy All</span>
+            {copiedAll ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            <span>{copiedAll ? 'Copied' : 'Copy All'}</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->
Replace the success toast with an in-button state swap (Copy icon → Check icon, label → "Copied") that resets after 2s. Each AdvisoryItem holds its own copied state so other rows are unaffected.

## How did you test this change?

<!-- Describe how you tested this PR -->
Test manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remediation copy buttons now show an inline "Copied" confirmation with a check icon for 2 seconds after successful copying, replacing success toasts with contextual feedback.
  * "Copy All" button uses the same inline confirmation behavior for consistency when copying multiple remediations; error notifications remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->