### PR TITLE
docs(compute): add architecture page; trim setup card to self-host only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,7 @@ DENO_SUBHOSTING_ORG_ID=
 
 # ─── Compute Services (Fly.io) ──────────────────────────────────────────────
 # Deploy Docker containers with persistent URLs.
+# Full setup + architecture: https://docs.insforge.dev/core-concepts/compute/architecture
 #
 # Setup — both FLY_API_TOKEN and FLY_ORG are required. FLY_ORG must be YOUR
 # Fly org slug; leaving it blank or as "insforge" will fail with an opaque

--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ graph TB
     SL --> ST[Storage]
     SL --> EF[Edge Functions]
     SL --> MG[Model Gateway]
+    SL --> CP[Compute]
     SL --> DEP[Deployment]
 
     classDef bar fill:#0b0f14,stroke:#30363d,stroke-width:1px,color:#ffffff
     classDef card fill:#161b22,stroke:#30363d,stroke-width:1px,color:#ffffff
 
     class AG,SL bar
-    class AUTH,DB,ST,EF,MG,DEP card
+    class AUTH,DB,ST,EF,MG,CP,DEP card
 
     style TOP fill:transparent,stroke:transparent
     style MID fill:transparent,stroke:transparent
@@ -91,6 +92,7 @@ graph TB
 - **Storage**: S3 compatible file storage
 - **Model Gateway**: OpenAI compatible API across multiple LLM providers
 - **Edge Functions**: Serverless code running on the edge
+- **Compute** (experimental): Long-running container services on Fly.io with public URLs ([docs](https://docs.insforge.dev/core-concepts/compute/architecture))
 - **Site Deployment**: Site build and deployment
 
 

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -201,8 +201,8 @@ export function selectComputeProvider(): ComputeProvider {
     'Compute services not configured.',
     503,
     ERROR_CODES.COMPUTE_NOT_CONFIGURED,
-    'Self-hosted: set FLY_API_TOKEN and FLY_ORG in .env. ' +
-      'Cloud: ensure PROJECT_ID, CLOUD_API_HOST, and JWT_SECRET are set (provisioned by insforge-cloud).'
+    'Set FLY_API_TOKEN and FLY_ORG in your .env, then restart the container. ' +
+      'See https://docs.insforge.dev/core-concepts/compute/architecture for setup details.'
   );
 }
 

--- a/docs/core-concepts/compute/architecture.mdx
+++ b/docs/core-concepts/compute/architecture.mdx
@@ -1,0 +1,235 @@
+---
+title: Compute Architecture
+description: Deploy long-running container services with public URLs, backed by Fly.io machines
+---
+
+## Overview
+
+Compute lets you deploy a Docker image as a long-running service from your InsForge backend, get a public HTTPS URL, and manage its lifecycle (start/stop/restart, env vars, image updates) from the dashboard or the CLI. Each service runs as a single [Fly.io machine](https://fly.io/docs/machines/) provisioned by InsForge.
+
+This is **not** a serverless platform — services are always-on Fly machines (with optional auto-stop on idle). For event-driven, short-lived code, use [Edge Functions](/core-concepts/functions/architecture) instead.
+
+## Self-Hosted vs Cloud-Managed
+
+Compute supports two execution modes. The OSS distribution selects the mode at startup based on which environment variables are set; you do not pick one in the dashboard.
+
+| Mode | Who owns the Fly account | Trigger | Where billing lands |
+|------|-------------------------|---------|---------------------|
+| **Self-hosted** | You | `FLY_API_TOKEN` + `FLY_ORG` are set | Your Fly.io account |
+| **Cloud-managed** | InsForge Cloud | `PROJECT_ID` + `CLOUD_API_HOST` + `JWT_SECRET` are set (provisioned automatically by InsForge Cloud — operators don't set these by hand) | Your InsForge Cloud invoice |
+
+If you are running OSS InsForge yourself, you are in **self-hosted** mode. The cloud-managed path is what InsForge Cloud uses internally to proxy compute calls through the cloud control plane on behalf of customers — it is not something a self-hoster opts into.
+
+If neither set of variables is configured, the `/api/compute/services` endpoint returns `503 COMPUTE_NOT_CONFIGURED` and the dashboard's Compute page renders a setup card.
+
+## Setting Up Self-Hosted Compute
+
+### 1. Create a Fly account and org
+
+If you do not already have one:
+
+1. Sign up at [fly.io](https://fly.io).
+2. Install the [`flyctl` CLI](https://fly.io/docs/flyctl/install/) (only needed once, for token creation and listing orgs).
+3. Run `fly orgs list` and pick the org slug you want compute services to live under (typically `personal` for individual accounts).
+
+### 2. Mint an API token
+
+Compute talks to the [Fly Machines REST API](https://docs.machines.dev/) directly. Create an org-scoped deploy token:
+
+```bash
+fly tokens create org -o <your-org-slug>
+```
+
+Copy the resulting `FlyV1 fm2_…` string.
+
+### 3. Configure the InsForge backend
+
+Add to your `.env`:
+
+```bash
+FLY_API_TOKEN=FlyV1 fm2_lJ…    # the token from step 2 — keep the FlyV1 prefix
+FLY_ORG=personal                # or your org slug from step 1
+```
+
+Optional:
+
+```bash
+COMPUTE_DOMAIN=compute.example.com   # custom domain for service endpoints (defaults to fly.dev)
+```
+
+Restart the backend container so the new env is picked up. The Compute item appears in the dashboard sidebar once the metadata route reports the feature as configured.
+
+### 4. Verify
+
+```bash
+curl -H "Authorization: Bearer <admin-token>" \
+     http://localhost:7130/api/compute/services
+# → []   (empty array on first run, not 503)
+```
+
+## Deploying a Service
+
+### From the CLI
+
+The OSS [InsForge CLI](https://github.com/InsForge/CLI) is the recommended path — it handles image push, env var encryption, and polling for `running` status.
+
+```bash
+insforge compute deploy \
+  --name my-api \
+  --image nginx:alpine \
+  --port 80 \
+  --cpu shared-1x \
+  --memory 256 \
+  --region iad
+```
+
+To deploy from local source instead of a pre-built image, drop the `--image` flag and point `--dockerfile` at a Dockerfile; the CLI will run a Fly remote build and push the resulting image to `registry.fly.io`.
+
+### From the dashboard
+
+The **Compute** page exposes the same deploy flow as a dialog: name, image URL, port, CPU profile, memory, region, and env vars.
+
+### Service lifecycle states
+
+| Status | Meaning |
+|--------|---------|
+| `creating` | DB row inserted, Fly app being created |
+| `deploying` | Fly app exists; machine launch in progress |
+| `running` | Machine is up and serving traffic |
+| `stopped` | User stopped the machine; row + Fly app retained |
+| `failed` | A deploy step errored; check `compute events <id>` |
+| `destroying` | Delete in progress |
+| `destroyed` | Row deleted; Fly app destroyed |
+
+`compute events <id>` returns Fly machine lifecycle events (start/stop/exit/restart). Container stdout/stderr streaming is roadmap work — see the [feature gap notes](#limitations) below.
+
+## Architecture
+
+```mermaid
+graph TB
+    Dashboard[InsForge Dashboard] --> API[/api/compute/services/]
+    CLI[InsForge CLI] --> API
+    API --> SVC[ComputeServicesService]
+    SVC --> DB[(compute.services<br/>PostgreSQL)]
+    SVC --> Provider{Provider Selection}
+    Provider -->|self-hosted| Fly[FlyProvider<br/>api.machines.dev REST]
+    Provider -->|cloud-managed| Cloud[CloudComputeProvider<br/>JWT-signed RPC to InsForge Cloud]
+    Cloud --> CloudBackend[InsForge Cloud Backend]
+    CloudBackend --> Fly2[api.machines.dev REST]
+
+    style Dashboard fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style CLI fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style API fill:#166534,stroke:#22c55e,color:#dcfce7
+    style SVC fill:#166534,stroke:#22c55e,color:#dcfce7
+    style DB fill:#0e7490,stroke:#06b6d4,color:#cffafe
+    style Provider fill:#475569,stroke:#94a3b8,color:#e2e8f0
+    style Fly fill:#c2410c,stroke:#fb923c,color:#fed7aa
+    style Cloud fill:#6b21a8,stroke:#a855f7,color:#f3e8ff
+    style CloudBackend fill:#6b21a8,stroke:#a855f7,color:#f3e8ff
+    style Fly2 fill:#c2410c,stroke:#fb923c,color:#fed7aa
+```
+
+### Provider selection
+
+`selectComputeProvider()` runs once when `ComputeServicesService` is first instantiated and never changes for the lifetime of the process:
+
+1. **Fly takes precedence.** If `FLY_API_TOKEN` is set, the self-hosted path is selected. A missing or empty `FLY_ORG` is logged as a warning at this point — Fly's API will reject requests without a valid org slug.
+2. **Cloud fallback.** Otherwise, if `PROJECT_ID` (≠ `local`), `CLOUD_API_HOST`, and `JWT_SECRET` are all set, the cloud-proxy path is selected.
+3. **Neither.** Throws `503 COMPUTE_NOT_CONFIGURED`.
+
+### App naming
+
+Fly apps are named `<service-name>-<projectId>` (truncated to 60 chars with a SHA-256 suffix when the combined length would overflow). The endpoint URL defaults to `https://<app-name>.fly.dev` unless `COMPUTE_DOMAIN` is set.
+
+### Env var storage
+
+Env vars set on a service are encrypted at rest using `EncryptionManager` (AES-256-GCM, key derived from `ENCRYPTION_KEY` or `JWT_SECRET`) and stored in `compute.services.env_vars_encrypted`. They are forwarded to the Fly machine as plaintext at launch time only; the dashboard's GET path never returns env values, only the keys. Partial updates are supported via `envVarsPatch: { set, unset }` so rotating one secret does not require re-stating the other six.
+
+## Database Schema
+
+```sql
+CREATE SCHEMA IF NOT EXISTS compute;
+
+CREATE TABLE compute.services (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  image_url TEXT NOT NULL,
+  port INT NOT NULL,
+  cpu TEXT NOT NULL,           -- 'shared-1x' | 'shared-2x' | 'performance-1x' | …
+  memory INT NOT NULL,         -- MB
+  region TEXT NOT NULL,        -- Fly region code (e.g. 'iad', 'sjc')
+  fly_app_id TEXT,
+  fly_machine_id TEXT,
+  status TEXT NOT NULL,
+  endpoint_url TEXT,
+  env_vars_encrypted TEXT,     -- AES-256-GCM ciphertext
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (project_id, name)
+);
+```
+
+Migration: `038_create-compute-services.sql`.
+
+## API Endpoints
+
+All endpoints require the project admin token.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/compute/services` | List services in the current project |
+| GET | `/api/compute/services/:id` | Get one service (excludes env values) |
+| POST | `/api/compute/services` | Create + launch a service in one call |
+| POST | `/api/compute/services/deploy` | Create the Fly app without launching a machine (CLI uses this when running `flyctl remote build`) |
+| POST | `/api/compute/services/:id/deploy-token` | Issue a short-lived Fly deploy token (cloud-managed only) |
+| PATCH | `/api/compute/services/:id` | Update image, port, env, etc. Mutually exclusive: `envVars` (replace) vs `envVarsPatch` (set/unset) |
+| POST | `/api/compute/services/:id/start` | Start a stopped machine |
+| POST | `/api/compute/services/:id/stop` | Stop the machine; row + Fly app retained |
+| DELETE | `/api/compute/services/:id` | Destroy the machine, app, and DB row. Returns an audit snapshot. |
+| GET | `/api/compute/services/:id/events` | Fly machine lifecycle events (`start`/`stop`/`exit`/`restart`); not stdout/stderr |
+
+## Environment Variables
+
+| Variable | Required for self-host | Description |
+|----------|----------------------|-------------|
+| `FLY_API_TOKEN` | yes | Org-scoped deploy token (`FlyV1 fm2_…`). Mint with `fly tokens create org`. |
+| `FLY_ORG` | yes | Fly org slug, e.g. `personal`. Get with `fly orgs list`. |
+| `COMPUTE_DOMAIN` | no | Custom domain for endpoint URLs. Defaults to `fly.dev`. |
+| `ENCRYPTION_KEY` | recommended | AES-256-GCM key for env-var encryption. Falls back to `JWT_SECRET` — **rotating `JWT_SECRET` without a dedicated `ENCRYPTION_KEY` corrupts all stored env vars.** |
+
+The cloud-managed path uses a different set of variables (`PROJECT_ID`, `CLOUD_API_HOST`, `JWT_SECRET`) — operators on InsForge Cloud have these provisioned automatically and do not need to set them by hand.
+
+## Limitations
+
+<CardGroup cols={2}>
+  <Card title="No container logs yet" icon="terminal">
+    `compute events` returns Fly machine lifecycle events (start/stop/exit). Streaming container stdout/stderr is roadmap work and will reuse the now-vacated `compute logs` command name when it ships.
+  </Card>
+
+  <Card title="Single machine per service" icon="server">
+    Each service runs as exactly one Fly machine. Multi-region replicas, autoscale, and process groups are not yet exposed.
+  </Card>
+
+  <Card title="Cron and one-shot tasks" icon="clock">
+    The current API only models long-running services. Scheduled tasks and one-shot jobs are tracked separately on the `feat/compute` branch and not yet in main.
+  </Card>
+
+  <Card title="No BYOK in the dashboard" icon="key">
+    `FLY_API_TOKEN` is read from the environment only. There is no in-dashboard token entry form (unlike Model Gateway BYOK).
+  </Card>
+</CardGroup>
+
+## Troubleshooting
+
+### "Compute services not configured"
+
+The metadata route reports `compute.enabled = false`. Either `FLY_API_TOKEN` is empty or `FLY_ORG` is empty (a missing org slug logs a warning at provider-selection time but the feature still appears off because Fly will reject every request). Set both, restart the container.
+
+### `unauthorized` from Fly
+
+The token does not match the org. `FLY_ORG` must be the slug shown by `fly orgs list`, not a display name.
+
+### Service stuck in `creating`
+
+Check `/api/compute/services/:id/events` for the Fly machine's last lifecycle event. The most common cause is an image that fails to pull (private registry without `imagePullSecrets`) or a port mismatch between the container's `EXPOSE` and the `--port` flag.

--- a/docs/core-concepts/compute/infrastructure.mdx
+++ b/docs/core-concepts/compute/infrastructure.mdx
@@ -1,0 +1,392 @@
+---
+title: Compute Infrastructure
+description: How the Compute service layer talks to Fly.io — provider abstraction, deploy lifecycle, race handling, and rollback semantics
+---
+
+This page is the deep dive for operators and contributors. For "what is Compute and how do I turn it on," start with the [architecture overview](/core-concepts/compute/architecture).
+
+## Provider Abstraction
+
+The compute system has a single integration point — the [`ComputeProvider`](https://github.com/InsForge/InsForge/blob/main/backend/src/providers/compute/compute.provider.ts) interface — and two implementations.
+
+```ts
+interface ComputeProvider {
+  isConfigured(): boolean;
+  createApp(p: { name; network; org }): Promise<{ appId }>;
+  destroyApp(appId): Promise<void>;
+  launchMachine(p: LaunchMachineParams): Promise<{ machineId }>;
+  updateMachine(p: UpdateMachineParams): Promise<void>;
+  stopMachine(appId, machineId): Promise<void>;
+  startMachine(appId, machineId): Promise<void>;
+  destroyMachine(appId, machineId): Promise<void>;
+  listMachines(appId): Promise<MachineSummary[]>;
+  getMachineStatus(appId, machineId): Promise<{ state }>;
+  getEvents(appId, machineId, opts?): Promise<ComputeEvent[]>;
+  waitForState(appId, machineId, targetStates, timeoutMs?): Promise<string>;
+}
+```
+
+`selectComputeProvider()` runs **once** at the time `ComputeServicesService` is first instantiated. The chosen provider lives on a `private readonly` field for the lifetime of the process — switching modes requires a backend restart.
+
+```mermaid
+flowchart TD
+    Start[ComputeServicesService.getInstance] --> Select[selectComputeProvider]
+    Select --> FlyCheck{FLY_API_TOKEN set?}
+    FlyCheck -->|yes| FlyProv[FlyProvider]
+    FlyCheck -->|no| CloudCheck{PROJECT_ID ≠ 'local'<br/>+ CLOUD_API_HOST<br/>+ JWT_SECRET}
+    CloudCheck -->|all set| CloudProv[CloudComputeProvider]
+    CloudCheck -->|missing| Throw[throw 503 COMPUTE_NOT_CONFIGURED]
+
+    style FlyProv fill:#c2410c,stroke:#fb923c,color:#fed7aa
+    style CloudProv fill:#6b21a8,stroke:#a855f7,color:#f3e8ff
+    style Throw fill:#7f1d1d,stroke:#ef4444,color:#fecaca
+```
+
+A missing `FLY_ORG` while `FLY_API_TOKEN` is set still chooses `FlyProvider` but emits a startup warning — the next API call to Fly will return `401 unauthorized` because Fly cannot tell which org to act in.
+
+## FlyProvider: REST Contract
+
+`FlyProvider` talks directly to the [Fly Machines REST API](https://docs.machines.dev/) at `https://api.machines.dev/v1`. The `Authorization: Bearer <FLY_API_TOKEN>` header carries an org-scoped deploy token (`FlyV1 fm2_…`).
+
+### Create app + IP allocation
+
+`POST /v1/apps` only creates the app shell. To make the app reachable on the public internet, two IPs must be allocated separately (Fly does not auto-allocate on app create):
+
+```mermaid
+sequenceDiagram
+    participant Svc as ComputeServicesService
+    participant Fly as FlyProvider
+    participant API as api.machines.dev
+    participant GQL as api.fly.io/graphql
+
+    Svc->>Fly: createApp({name, network, org})
+    Fly->>API: POST /v1/apps
+    API-->>Fly: 201 Created
+    loop allocateOneIp(shared_v4)
+      Fly->>GQL: allocateIpAddress mutation
+      GQL-->>Fly: ipAddress: null (race)
+      Fly->>GQL: app(name) { sharedIpAddress }
+      GQL-->>Fly: sharedIpAddress: "1.2.3.4"
+    end
+    loop allocateOneIp(v6)
+      Fly->>GQL: allocateIpAddress mutation
+      GQL-->>Fly: ipAddress: { address: "2a09:..." }
+    end
+    Fly-->>Svc: { appId }
+```
+
+Two non-obvious mechanics live in this path:
+
+| Mechanic | Why |
+|----------|-----|
+| **Retry loop in `allocateOneIp`** | When called immediately after `POST /apps`, Fly's GraphQL returns `{ipAddress: null}` with no `errors` field — the response looks successful but no allocation happened. Five attempts with linear backoff (1s, 2s, 3s, 4s, 5s) catch the eventual write through Fly's internal store. |
+| **`shared_v4` follow-up query** | Shared IPv4 is an org-level address; Fly returns `null` from the mutation and instead flips a flag on the app. The provider verifies via a separate `app(name) { sharedIpAddress }` query before declaring success. Without this the app would be marked IPv6-only and IPv4-only clients would `NXDOMAIN` the `.fly.dev` URL. |
+
+### Launch + update machines
+
+`POST /v1/apps/{app}/machines` launches a machine; the body wraps a [Fly machine config](https://docs.machines.dev/#tag/Apps/operation/Machines_create) with three opinions InsForge bakes in:
+
+```json
+{
+  "config": {
+    "image": "<image url>",
+    "guest": { "cpu_kind": "shared|performance", "cpus": <N>, "memory_mb": <MB> },
+    "env": { ... },
+    "services": [{
+      "ports": [
+        { "port": 443, "handlers": ["tls", "http"] },
+        { "port": 80,  "handlers": ["http"] }
+      ],
+      "internal_port": <user-port>,
+      "protocol": "tcp"
+    }]
+  },
+  "region": "iad"
+}
+```
+
+- **Always TCP, always 80 + 443.** The user picks `internal_port`; Fly terminates TLS at 443 and serves a `301`-style redirect from 80. UDP / non-HTTP services are not yet exposed.
+- **No restart policy override.** Default Fly behavior (auto-restart on crash) applies.
+- **No volumes.** Stateless services only; persistent storage is roadmap work.
+
+`POST /v1/apps/{app}/machines/{id}` (yes, POST not PATCH) updates the same shape. `updateMachine` is used for in-place image / port / env / CPU / memory changes; the machine restarts but keeps its `machine_id` and IP. Region cannot change in-place — that constraint is enforced at the service layer (see [updateService](#updateservice)).
+
+### CPU tier parsing
+
+`mapCpuTier` parses Fly's `<kind>-<N>x` pattern with a single regex:
+
+```ts
+const m = /^(shared|performance)-([1-9]\d*)x$/.exec(cpu);
+if (!m) return { cpu_kind: 'shared', cpus: 1, memory_mb: memory };
+return { cpu_kind: m[1], cpus: parseInt(m[2], 10), memory_mb: memory };
+```
+
+There is no hardcoded allow-list. Fly is the source of truth for which sizes exist; an unsupported combination returns a clean Fly 4xx at machine-create time. A typo in the input (e.g. `shared-1` without the `x`) silently falls back to `shared-1x` rather than crashing the deploy.
+
+### Destroying machines
+
+`DELETE /v1/apps/{app}/machines/{id}?force=true` is used unconditionally. Without `force=true` Fly returns `412 failed_precondition` for any running machine, which would 502 the caller's delete and leave the Fly app + DB row orphaned. The force flag costs nothing for already-stopped machines.
+
+### Events ≠ logs
+
+`getEvents` returns Fly's machine **lifecycle** events from `GET /v1/apps/{app}/machines/{id}/events` — `start`, `stop`, `exit`, `restart`. The provider folds Fly's structured event into a flat `[<source>] <type>: <status>` string. **Container stdout/stderr is a separate Fly NATS log stream and is not yet integrated.** `compute logs` was renamed to `compute events` in the CLI to reflect this distinction; the `logs` command name is reserved for the future container-log integration.
+
+## CloudComputeProvider: JWT-Signed RPC
+
+When InsForge runs as a cloud-managed customer project, the OSS instance does not hold a Fly token. Instead it proxies every compute call through the InsForge cloud control plane.
+
+```mermaid
+sequenceDiagram
+    participant OSS as OSS backend
+    participant Cloud as InsForge Cloud
+    participant Fly as api.machines.dev
+
+    OSS->>OSS: signToken (HS256, sub=projectId, exp=10m)
+    OSS->>Cloud: POST /projects/v1/{projectId}/compute/* <br/>header: sign=<jwt>
+    Cloud->>Cloud: verify JWT (expects projectId match)
+    Cloud->>Fly: forward with cloud's FLY_API_TOKEN
+    Fly-->>Cloud: response
+    Cloud-->>OSS: response (passthrough)
+```
+
+| Detail | Value |
+|--------|-------|
+| **Sign algorithm** | HS256 with `JWT_SECRET` |
+| **Claims** | `{ sub: PROJECT_ID }`, 10-minute expiry |
+| **Header** | `sign: <jwt>` (not `Authorization`) |
+| **Timeout** | 60s per call (was 15s — caused false-positive `COMPUTE_CLOUD_UNAVAILABLE` and orphaned Fly resources during slow `launchMachine` calls; bump to 60s covered the 15–25s tail) |
+| **Error mapping** | Network failure → `503 COMPUTE_CLOUD_UNAVAILABLE`. Non-2xx HTTP from cloud → `COMPUTE_PROVIDER_ERROR` with the cloud's status passed through. `signToken` failure → surfaces `COMPUTE_NOT_CONFIGURED` (config-level, not network-level). |
+
+### Deploy token issuance
+
+The cloud-managed path has one method that does not exist on `FlyProvider`: `issueDeployToken`. The CLI uses it so `compute deploy` can run `flyctl` (for the remote-build push to `registry.fly.io`) without the user holding their own `FLY_API_TOKEN`.
+
+```
+POST /projects/v1/{projectId}/compute/apps/{appId}/deploy-token
+→ { token: "FlyV1 fm2_...", expirySeconds: 1200 }
+```
+
+The cloud mints the token using its own org-scoped `FLY_API_TOKEN`. Token is scoped to **one app** and expires in 20 minutes. Self-hosters do not need this endpoint — they already have a Fly token in `.env`.
+
+The previous implementation shelled out to `flyctl tokens attenuate` inside the cloud's container; it now uses Fly's native `POST /v1/apps/{app}/deploy_token` REST endpoint instead, dropping a 10 MB binary dependency and ~50ms of subprocess startup latency per call.
+
+## Service-Layer Orchestration
+
+`ComputeServicesService` sits between the HTTP routes and the provider. Every method follows a "DB write → provider call → DB write" sandwich, with rollback on partial failure.
+
+### App naming + network isolation
+
+Fly app names are project-scoped:
+
+```ts
+makeFlyAppName(serviceName, projectId)
+// → "<serviceName>-<projectId>", or
+// → "<truncated-name>-<6-char-sha256>-<projectId>" if combined > 60 chars
+```
+
+The network is `<projectId>-network` — every service in the same project shares one Fly private network, but services across projects are isolated.
+
+The endpoint URL defaults to `https://<flyAppName>.fly.dev` and falls through to `https://<flyAppName>.<COMPUTE_DOMAIN>` when set. We deliberately **don't** synthesize a vanity domain at the dashboard level — operators who haven't set up `COMPUTE_DOMAIN` get a URL that actually resolves instead of a misleading one.
+
+### `createService` — image-mode immediate launch
+
+The simple path: image already exists in a registry, launch in one shot.
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant DB
+    participant Fly as Provider
+    API->>DB: INSERT row, status='creating'
+    Note over DB: 23505 dup → 409<br/>COMPUTE_SERVICE_ALREADY_EXISTS
+    DB-->>API: row
+    API->>Fly: createApp
+    API->>Fly: launchMachine
+    API->>DB: UPDATE fly_app_id, fly_machine_id,<br/>endpoint_url, status='running'
+    DB-->>API: row → return
+```
+
+If `createApp` or `launchMachine` throws, the catch block destroys whatever Fly resources got created (machine first, then app) and flips status to `failed`. The DB row is **kept** so the operator can see the failure in the dashboard; the Fly side is cleaned up to stop billing.
+
+### `prepareForDeploy` + `updateService` — source-mode (Path A)
+
+When the user runs `insforge compute deploy` against a Dockerfile, the CLI cannot know the final image URL until `flyctl deploy --build-only --push` finishes the remote build. The flow is:
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant API
+    participant DB
+    participant Fly as Provider
+
+    CLI->>API: POST /compute/services/deploy
+    API->>DB: INSERT, status='deploying',<br/>fly_app_id=<name>, fly_machine_id=NULL
+    API->>Fly: createApp (idempotent on 422 'already exists')
+    API-->>CLI: { id, flyAppId, ... }
+
+    CLI->>API: POST /compute/services/<id>/deploy-token (cloud-only)
+    API-->>CLI: { token: 'FlyV1 fm2_...' }
+
+    CLI->>CLI: flyctl deploy --build-only --push<br/>→ registry.fly.io/&lt;app&gt;:&lt;sha&gt;
+
+    CLI->>API: PATCH /compute/services/&lt;id&gt; { imageUrl }
+    API->>Fly: launchMachine (Path A — first launch)
+    API->>DB: UPDATE fly_machine_id, status='running'<br/>WHERE id=$1 AND fly_machine_id IS NULL
+    Note over DB: optimistic lock<br/>(see launch-race below)
+```
+
+`prepareForDeploy` tolerates "app already exists" (422) so the CLI can retry safely after a transient network blip. Other failures (including IP allocation timeout) destroy the partially-created Fly app and the DB row.
+
+### Launch-race optimistic lock
+
+A subtle case in `updateService`: when the CLI double-clicks the deploy button or retries on a flaky network, two concurrent `PATCH` calls can race past the "no machine yet" check, both call `launchMachine`, and both end up holding a freshly-created Fly machine. Without a guard, the second writer would silently overwrite `fly_machine_id` and the first machine would orphan.
+
+The fix is an optimistic lock at the final UPDATE:
+
+```sql
+UPDATE compute.services
+SET fly_machine_id = $N, status = 'running', endpoint_url = $M, ...
+WHERE id = $X AND fly_machine_id IS NULL
+RETURNING *;
+```
+
+If `RETURNING *` is empty, the loser knows it lost the race. It then calls `destroyMachine` on the orphan it just created and re-fetches the row to return the winner's state. Best-effort: even if the destroy itself fails, returning the current row is still correct because the winning machine is healthy.
+
+### `updateService` — in-place updates
+
+Once a machine exists (`fly_machine_id IS NOT NULL`), updates fan out by field type:
+
+| Field | Effect |
+|-------|--------|
+| `imageUrl` / `port` / `cpu` / `memory` / `envVars` | `updateMachine` on Fly **first**, then DB write. Ordering matters: a Fly failure must not leave the DB ahead of reality. |
+| `region` | `400 COMPUTE_REGION_CHANGE_NOT_SUPPORTED` if the machine already exists. Region is persisted only on first deploy because Fly cannot move machines in-place. |
+| `envVarsPatch` | Resolved to a full `envVars` map at the start of `updateService` (decrypt current + apply set/unset), then everything else flows through unchanged. The CLI sends a sparse patch; the storage layer keeps writing one full encrypted blob. |
+
+`envVars` and `envVarsPatch` are mutually exclusive — enforced at both the route schema and the service layer.
+
+### `deleteService` + audit snapshot
+
+Delete is destructive and irreversible at the Fly side, so the response includes an `auditSnapshot` containing the row state at delete time, **including the still-encrypted env-vars blob**. The route writes this snapshot into the audit log so a future restore path can re-deploy the same service with the same secrets without ever exposing them in plaintext to the audit reader.
+
+```mermaid
+flowchart LR
+    A[DELETE /services/:id] --> B[SELECT row]
+    B --> C[UPDATE status='destroying']
+    C --> D[destroyMachine<br/>404 → continue]
+    D --> E[destroyApp<br/>404 → continue]
+    E --> F[DELETE row]
+    F --> G[return snapshot]
+    D -.failure.-> X[UPDATE status='failed']
+    E -.failure.-> X
+    X --> Y[502 COMPUTE_SERVICE_DELETE_FAILED]
+```
+
+404s are treated as success — if the Fly resource is already gone (out-of-band cleanup, partial previous delete), the DB row still drops cleanly. Any other Fly error aborts and pins the row at `failed` so the operator can investigate.
+
+## Env-Var Encryption
+
+Env vars set on a service are encrypted at rest in `compute.services.env_vars_encrypted`:
+
+| Property | Value |
+|----------|-------|
+| **Algorithm** | AES-256-GCM |
+| **Key** | `sha256(ENCRYPTION_KEY)` (preferred) or `sha256(JWT_SECRET)` (fallback, with startup warning) |
+| **Storage format** | `<iv-hex>:<authTag-hex>:<ciphertext-hex>` — single TEXT column |
+| **GET path** | Returns key names only, never plaintext values |
+| **Forward to Fly** | Decrypted at `launchMachine`/`updateMachine` time and passed in the machine config; lives in Fly's machine state from then on |
+
+<Warning>
+**Rotating `JWT_SECRET` without setting a dedicated `ENCRYPTION_KEY` corrupts every stored env-vars blob across the database** — not just compute. `JWT_SECRET` is used by auth tokens, function secrets, and (as fallback) the encryption manager. If you must rotate it, set `ENCRYPTION_KEY` to a separate value first and redeploy, then rotate `JWT_SECRET`.
+</Warning>
+
+## Status State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> creating: POST /services
+    [*] --> deploying: POST /services/deploy
+    creating --> running: launchMachine ok
+    creating --> failed: createApp/launchMachine error
+    deploying --> running: PATCH with imageUrl (Path A)
+    deploying --> failed: launchMachine error
+    running --> stopped: POST /:id/stop
+    stopped --> running: POST /:id/start
+    running --> running: PATCH (in-place update)
+    running --> destroying: DELETE /:id
+    stopped --> destroying: DELETE /:id
+    failed --> destroying: DELETE /:id
+    destroying --> [*]: row deleted
+    destroying --> failed: Fly destroy error<br/>(non-404)
+```
+
+CHECK constraint enforces the set: `status IN ('creating', 'deploying', 'running', 'stopped', 'failed', 'destroying')`. The terminal `destroyed` state from the SDK schema is not stored — it's the absence of a row.
+
+## Database Schema
+
+```sql
+CREATE SCHEMA IF NOT EXISTS compute;
+
+CREATE TABLE compute.services (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id          TEXT NOT NULL,
+  name                TEXT NOT NULL,
+  image_url           TEXT NOT NULL,
+  port                INT  NOT NULL DEFAULT 8080 CHECK (port BETWEEN 1 AND 65535),
+  cpu                 TEXT NOT NULL DEFAULT 'shared-1x',
+  memory              INT  NOT NULL DEFAULT 512,
+  env_vars_encrypted  TEXT,
+  region              TEXT NOT NULL DEFAULT 'iad',
+  fly_app_id          TEXT,
+  fly_machine_id      TEXT,
+  status              TEXT NOT NULL DEFAULT 'creating'
+                      CHECK (status IN ('creating','deploying','running','stopped','failed','destroying')),
+  endpoint_url        TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (project_id, name)
+);
+
+CREATE INDEX idx_compute_services_project ON compute.services(project_id);
+CREATE INDEX idx_compute_services_status  ON compute.services(status);
+
+CREATE TRIGGER update_compute_services_updated_at
+  BEFORE UPDATE ON compute.services
+  FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
+```
+
+Migration: `038_create-compute-services.sql`. The `(project_id, name)` uniqueness is what surfaces as `409 COMPUTE_SERVICE_ALREADY_EXISTS` when the INSERT trips Postgres error code `23505`.
+
+## Failure Modes
+
+| Symptom | Likely cause | Where to look |
+|---------|--------------|---------------|
+| `503 COMPUTE_NOT_CONFIGURED` on every call | Neither Fly nor cloud creds set | `selectComputeProvider` log line at startup |
+| `401 unauthorized` from Fly | `FLY_ORG` is empty or wrong slug | Startup warning from `selectComputeProvider`; verify with `fly orgs list` |
+| Service stuck in `creating` | `createApp` succeeded but `launchMachine` is blocked on the image pull | `getEvents` returns Fly's last lifecycle event; private registries need `imagePullSecrets` config (not yet exposed) |
+| Service stuck in `deploying` | CLI never followed up with the PATCH (build failed before push, network blip) | `services.status` + absence of `fly_machine_id`; CLI logs |
+| `COMPUTE_CLOUD_UNAVAILABLE` (cloud-managed only) | Cloud control plane unreachable, or call took longer than 60s | OSS backend logs for the AbortSignal timeout; cloud backend health |
+| `COMPUTE_REGION_CHANGE_NOT_SUPPORTED` | PATCH tried to change `region` after the machine exists | Delete + redeploy in the new region |
+| Orphaned Fly app under your org | Pre-rollback bug (≤ v2.1.0) where `prepareForDeploy` IP-allocation failure left the app behind | Fixed in fb3e3a19 — recent failures should self-clean |
+
+## Observability
+
+| Source | What to look at |
+|--------|-----------------|
+| Backend logs | Every `compute service deployed/stopped/started/deleted` line includes `serviceId`, `flyAppName`, and (where applicable) `machineId`. Failures log `error` with the original Fly response body. |
+| `compute.services` table | Snapshot of every service's last-known state. `status='failed'` rows are not auto-cleaned — operators decide whether to retry or delete. |
+| `audit_logs` table | One entry per CREATE / UPDATE / DELETE / STOP / START. `envVarsPatch` audit entries log only the **set/unset key names**, never values. DELETE audit entries embed the `auditSnapshot` (with encrypted env blob). |
+| `getEvents` API | Fly machine lifecycle from the last 100 events, surfaced via `compute events <id>`. |
+
+## Comparison: Self-Hosted vs Cloud-Managed
+
+| Aspect | Self-hosted (`FlyProvider`) | Cloud-managed (`CloudComputeProvider`) |
+|--------|-----------------------------|----------------------------------------|
+| **Fly account** | Yours | InsForge's |
+| **Fly token storage** | `FLY_API_TOKEN` in your `.env` | Cloud's secret store, never reaches OSS |
+| **Networking** | Direct HTTPS to `api.machines.dev` | HTTPS to InsForge cloud, proxied to Fly |
+| **Latency overhead** | One round trip | Two round trips (OSS → cloud → Fly) |
+| **Deploy token endpoint** | Not needed (CLI uses your `FLY_API_TOKEN`) | `POST /:id/deploy-token` mints 20-min app-scoped tokens |
+| **Billing** | Your Fly invoice | Your InsForge Cloud invoice |
+| **IP allocation** | Done by OSS provider directly via Fly GraphQL | Done by cloud backend |
+| **Per-call timeout** | Fly's own (no AbortSignal) | 60s AbortSignal in OSS |
+| **Failure surface** | `Fly API error (xxx): <body>` | `COMPUTE_PROVIDER_ERROR` (cloud passthrough) or `COMPUTE_CLOUD_UNAVAILABLE` (network) |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,7 +92,8 @@
               {
                 "group": "Compute (Experimental)",
                 "pages": [
-                  "core-concepts/compute/architecture"
+                  "core-concepts/compute/architecture",
+                  "core-concepts/compute/infrastructure"
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,6 +88,12 @@
                 "pages": [
                   "core-concepts/deployments/architecture"
                 ]
+              },
+              {
+                "group": "Compute (Experimental)",
+                "pages": [
+                  "core-concepts/compute/architecture"
+                ]
               }
             ]
           },


### PR DESCRIPTION
## Summary

The Compute setup card on `/dashboard/compute` previously instructed users to either set `FLY_API_TOKEN`/`FLY_ORG` **or** `PROJECT_ID`/`CLOUD_API_HOST`/`JWT_SECRET`. But the cloud-managed path is internal to InsForge Cloud — it is provisioned automatically when a customer's project lives in our cloud and is not something an OSS self-hoster ever sets by hand. Showing both options implied a choice that does not exist for them, and the link in the message pointed nowhere.

This PR:

1. **Trims the `nextActions`** on `COMPUTE_NOT_CONFIGURED` to: _"Set `FLY_API_TOKEN` and `FLY_ORG` in your `.env`, then restart the container. See <docs URL> for setup details."_
2. **Adds `docs/core-concepts/compute/architecture.mdx`** covering:
   - the self-host vs cloud-managed split (and which one OSS users are in),
   - step-by-step Fly setup (mint token, set env, restart),
   - architecture diagrams (provider selection, request flow),
   - env-var encryption + `ENCRYPTION_KEY` rotation hazard,
   - DB schema, full API surface, all relevant env vars,
   - current limitations (no container logs yet, single machine per service, no in-dashboard BYOK),
   - common troubleshooting paths.
3. **Adds `docs/core-concepts/compute/infrastructure.mdx`** — operator/contributor deep-dive on the FlyProvider REST contract (IP allocation race + retry, force-destroy, machine events ≠ container logs), CloudComputeProvider JWT-signed RPC (60s timeout, deploy-token contract), `ComputeServicesService` orchestration (createService rollback, prepareForDeploy + Path-A optimistic lock, audit-snapshot deletes), env-var encryption with the `JWT_SECRET` rotation hazard, status state machine, schema, and known failure modes.
4. **Registers both pages** in `docs.json` under Core Concepts → Compute (Experimental).

## Documentation

Repo docs synced with the new compute pages:

| File | Change |
|------|--------|
| `docs/core-concepts/compute/architecture.mdx` | **New** — user-facing architecture + setup guide |
| `docs/core-concepts/compute/infrastructure.mdx` | **New** — operator/contributor infra deep-dive |
| `docs/docs.json` | Both pages registered under Core Concepts → Compute (Experimental) |
| `README.md` | Added Compute to the architecture mermaid diagram and Core Products list (with link to architecture page) |
| `.env.example` | Added link to architecture docs in the Compute Services section header |

`AGENTS.md`, `CLAUDE_PLUGIN.md`, `CONTRIBUTING.md`, `CHANGELOG.md` were reviewed and intentionally left unchanged — none currently cover per-product surfaces, and CHANGELOG is auto-generated on release.

## Test plan
- [ ] `vitest tests/unit/compute/services-service.test.ts` — `selectComputeProvider` tests still pass (regex matches the unchanged "Compute services not configured." prefix).
- [ ] Self-host with no `FLY_API_TOKEN` → `/dashboard/compute` shows the new self-host-only setup line + docs link.
- [ ] Mintlify build picks up the new pages (preview after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Compute Architecture and Infrastructure docs covering setup, deployment flow, API reference, operational guidance, limitations, and troubleshooting.
  * Exposed the new Compute docs in the Core Concepts navigation.

* **Bug Fixes**
  * Clarified compute configuration error message with step-by-step setup guidance and a link to the new documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
