### PR TITLE
fix(compute): trim setup card message to self-host path only

### DIFF
--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -201,8 +201,8 @@ export function selectComputeProvider(): ComputeProvider {
     'Compute services not configured.',
     503,
     ERROR_CODES.COMPUTE_NOT_CONFIGURED,
-    'Self-hosted: set FLY_API_TOKEN and FLY_ORG in .env. ' +
-      'Cloud: ensure PROJECT_ID, CLOUD_API_HOST, and JWT_SECRET are set (provisioned by insforge-cloud).'
+    'Set FLY_API_TOKEN and FLY_ORG in your .env, then restart the container. ' +
+      'See https://docs.insforge.dev/core-concepts/compute/architecture for setup details.'
   );
 }
 


### PR DESCRIPTION
## Summary

The `COMPUTE_NOT_CONFIGURED` setup card on `/dashboard/compute` previously told users to either set `FLY_API_TOKEN`/`FLY_ORG` **or** ensure `PROJECT_ID`/`CLOUD_API_HOST`/`JWT_SECRET` are set. The cloud-managed path is internal to InsForge Cloud — it is provisioned automatically for projects that live in our cloud and is not something an OSS self-hoster ever configures by hand. Showing both implied a choice that does not exist for them, and the link in the message pointed nowhere useful.

This PR drops the cloud half from `nextActions` and replaces it with a concrete self-host action plus a docs link:

> Set `FLY_API_TOKEN` and `FLY_ORG` in your `.env`, then restart the container. See https://docs.insforge.dev/core-concepts/compute/architecture for setup details.

The architecture docs page is being added in a separate PR so this change can ship independently.

## Test plan
- [ ] `vitest tests/unit/compute/services-service.test.ts` — `selectComputeProvider` tests still pass (regex matches the unchanged "Compute services not configured." prefix).
- [ ] Self-host with no `FLY_API_TOKEN` → `/dashboard/compute` shows the new self-host-only setup line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compute service error message to provide clearer setup instructions, including required environment variables and a documentation reference for configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->