### PR TITLE
fix: validate realtime database roles before SET LOCAL ROLE

### DIFF
--- a/backend/src/services/realtime/realtime-auth.service.ts
+++ b/backend/src/services/realtime/realtime-auth.service.ts
@@ -2,6 +2,7 @@ import { Pool, PoolClient } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import logger from '@/utils/logger.js';
 import { RoleSchema } from '@insforge/shared-schemas';
+import { getSafeDatabaseRole } from '@/utils/database-role.js';
 
 /**
  * Handles channel authorization by checking RLS policies on the messages table.
@@ -49,12 +50,13 @@ export class RealtimeAuthService {
     userId: string | undefined,
     role: RoleSchema
   ): Promise<boolean> {
+    const safeRole = getSafeDatabaseRole(role);
     const client = await this.getPool().connect();
     try {
       // Begin transaction to ensure settings persist across queries
       await client.query('BEGIN');
       // Switch to specified role to enforce RLS policies
-      await client.query(`SET LOCAL ROLE ${role}`);
+      await client.query(`SET LOCAL ROLE ${safeRole}`);
       await this.setUserContext(client, userId, channelName);
 
       // Test SELECT permission via RLS on channels table

--- a/backend/src/services/realtime/realtime-message.service.ts
+++ b/backend/src/services/realtime/realtime-message.service.ts
@@ -4,6 +4,7 @@ import logger from '@/utils/logger.js';
 import type { RealtimeMessage, RoleSchema } from '@insforge/shared-schemas';
 import { RealtimeChannelService } from './realtime-channel.service.js';
 import { RealtimeAuthService } from './realtime-auth.service.js';
+import { getSafeDatabaseRole } from '@/utils/database-role.js';
 
 export class RealtimeMessageService {
   private static instance: RealtimeMessageService;
@@ -48,6 +49,7 @@ export class RealtimeMessageService {
     // Get channel info
     const channelService = RealtimeChannelService.getInstance();
     const channel = await channelService.getByName(channelName);
+    const safeRole = getSafeDatabaseRole(userRole);
 
     if (!channel) {
       logger.debug('Channel not found for message insert', { channelName });
@@ -61,7 +63,7 @@ export class RealtimeMessageService {
       await client.query('BEGIN');
 
       // Switch to specified role to enforce RLS policies
-      await client.query(`SET LOCAL ROLE ${userRole}`);
+      await client.query(`SET LOCAL ROLE ${safeRole}`);
 
       // Set user context for RLS policy evaluation
       const authService = RealtimeAuthService.getInstance();

--- a/backend/src/utils/database-role.ts
+++ b/backend/src/utils/database-role.ts
@@ -1,0 +1,13 @@
+import { AppError } from '@/api/middlewares/error.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import type { RoleSchema } from '@insforge/shared-schemas';
+
+const ALLOWED_DATABASE_ROLES = new Set<RoleSchema>(['anon', 'authenticated', 'project_admin']);
+
+export function getSafeDatabaseRole(role: RoleSchema): RoleSchema {
+  if (ALLOWED_DATABASE_ROLES.has(role)) {
+    return role;
+  }
+
+  throw new AppError('Invalid database role', 400, ERROR_CODES.INVALID_INPUT);
+}

--- a/docs/realtime-role-sql-injection-fix.md
+++ b/docs/realtime-role-sql-injection-fix.md
@@ -1,0 +1,45 @@
+# Realtime Role SQL Injection Fix
+
+## Summary
+
+This change hardens realtime role switching by validating the database role against a strict allowlist before executing `SET LOCAL ROLE`.
+
+## Problem
+
+The realtime authorization and message publishing services previously built this SQL dynamically:
+
+```ts
+await client.query(`SET LOCAL ROLE ${role}`);
+```
+
+That pattern is unsafe because it interpolates a runtime value directly into SQL.
+
+## Why this matters
+
+`SET LOCAL ROLE` expects a SQL identifier, not a normal value placeholder. That means the usual `$1` parameter binding pattern is not applicable here.
+
+Because of that, the safe approach is:
+
+1. Validate the role at runtime.
+2. Allow only known database roles.
+3. Use the validated value in the SQL statement.
+
+## Fix
+
+A shared helper now enforces an allowlist of supported database roles:
+
+- `anon`
+- `authenticated`
+- `project_admin`
+
+Both realtime services now call that helper before executing `SET LOCAL ROLE`.
+
+## Files changed
+
+- `backend/src/utils/database-role.ts`
+- `backend/src/services/realtime/realtime-auth.service.ts`
+- `backend/src/services/realtime/realtime-message.service.ts`
+
+## Security outcome
+
+This removes the SQL injection risk from realtime role switching while preserving the intended RLS-based authorization behavior.


### PR DESCRIPTION
## Summary

This PR fixes a SQL injection risk in realtime role switching.

## Changes

- add a shared helper to validate allowed database roles
- update realtime auth service to use a validated role before `SET LOCAL ROLE`
- update realtime message service to use a validated role before `SET LOCAL ROLE`
- add documentation describing the issue and the fix

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test:backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened realtime services by validating database roles against an allowlist before role switching, eliminating SQL-injection risk while preserving RLS-based access checks.

* **Documentation**
  * Added guidance describing the hardening approach for realtime role handling and the validation requirements for authorization and messaging flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->