### PR TITLE
Guard deployment env vars routes from id collisions

### DIFF
--- a/backend/src/api/routes/deployments/index.routes.ts
+++ b/backend/src/api/routes/deployments/index.routes.ts
@@ -23,6 +23,15 @@ const uuidParamSchema = z.string().uuid();
 // Mount sub-routers first to avoid conflicts with parameterized routes
 router.use('/env-vars', envVarsRouter);
 
+function parseDeploymentId(id: string): string {
+  const validationResult = uuidParamSchema.safeParse(id);
+  if (!validationResult.success) {
+    throw new AppError('Invalid deployment ID', 400, ERROR_CODES.INVALID_INPUT);
+  }
+
+  return validationResult.data;
+}
+
 /**
  * Create a new deployment record with WAITING status
  * Returns presigned upload info for the legacy source zip flow
@@ -144,7 +153,7 @@ router.post(
   verifyAdmin,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = parseDeploymentId(req.params.id);
 
       const validationResult = startDeploymentRequestSchema.safeParse(req.body);
       if (!validationResult.success) {
@@ -368,7 +377,7 @@ router.delete(
  */
 router.get('/:id', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const { id } = req.params;
+    const id = parseDeploymentId(req.params.id);
 
     const deployment = await deploymentService.getDeploymentById(id);
 
@@ -391,7 +400,7 @@ router.post(
   verifyAdmin,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = parseDeploymentId(req.params.id);
 
       const deployment = await deploymentService.syncDeploymentById(id);
 
@@ -415,7 +424,7 @@ router.post(
   verifyAdmin,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = parseDeploymentId(req.params.id);
 
       await deploymentService.cancelDeploymentById(id);
 

--- a/backend/tests/unit/deployments-routes.test.ts
+++ b/backend/tests/unit/deployments-routes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('deployments route wiring', () => {
+  const deploymentsRouteSource = readFileSync(
+    resolve(__dirname, '../../src/api/routes/deployments/index.routes.ts'),
+    'utf-8'
+  );
+
+  it('mounts env-vars before parameterized deployment routes', () => {
+    const envVarsMountIndex = deploymentsRouteSource.indexOf(
+      "router.use('/env-vars', envVarsRouter);"
+    );
+    const deploymentIdRouteIndex = deploymentsRouteSource.indexOf("router.get('/:id'");
+
+    expect(envVarsMountIndex).toBeGreaterThan(-1);
+    expect(deploymentIdRouteIndex).toBeGreaterThan(-1);
+    expect(envVarsMountIndex).toBeLessThan(deploymentIdRouteIndex);
+  });
+
+  it('validates deployment ids before service calls on parameterized routes', () => {
+    expect(deploymentsRouteSource).toContain('function parseDeploymentId(id: string): string');
+    expect(deploymentsRouteSource).toContain(
+      "throw new AppError('Invalid deployment ID', 400, ERROR_CODES.INVALID_INPUT);"
+    );
+    expect(deploymentsRouteSource).toContain('const id = parseDeploymentId(req.params.id);');
+    expect(deploymentsRouteSource).toMatch(
+      /router\.get\('\/:id'[\s\S]*const id = parseDeploymentId\(req\.params\.id\);[\s\S]*deploymentService\.getDeploymentById\(id\)/
+    );
+    expect(deploymentsRouteSource).toMatch(
+      /router\.post\(\s*'\/:id\/sync'[\s\S]*const id = parseDeploymentId\(req\.params\.id\);[\s\S]*deploymentService\.syncDeploymentById\(id\)/
+    );
+    expect(deploymentsRouteSource).toMatch(
+      /router\.post\(\s*'\/:id\/cancel'[\s\S]*const id = parseDeploymentId\(req\.params\.id\);[\s\S]*deploymentService\.cancelDeploymentById\(id\)/
+    );
+    expect(deploymentsRouteSource).toMatch(
+      /router\.post\(\s*'\/:id\/start'[\s\S]*const id = parseDeploymentId\(req\.params\.id\);[\s\S]*deploymentService\.startDeployment\(id, validationResult\.data\)/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- guard deployment `/:id` routes with explicit UUID validation
- add regression coverage for `/env-vars` route wiring and id validation

## Root cause
The broken behavior reproduced on the published `ghcr.io/insforge/insforge-oss:v1.5.0` image was caused by stale runtime code, not by self-host configuration.

In that image, `GET /api/deployments/env-vars` was handled as if `env-vars` were a deployment id, which triggered a UUID/database parse failure instead of the intended deployment-service configuration check.

This change adds route-level regression coverage and hardens deployment id handlers so invalid ids fail with `400 INVALID_INPUT` before reaching service/database code.

## Before
On the official `v1.5.0` deployment image in a live self-hosted stack:
- `GET /api/deployments/env-vars` returned `500`
- backend log showed: `invalid input syntax for type uuid: "env-vars"`
- backend log showed: `Failed to get deployment by ID`

## After
On a fresh image built from this branch and tested in the same live deployment:
- `GET /api/deployments/env-vars` returns `503`
- response body: `Deployment service is not configured. Please set VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID environment variables.`
- no UUID parse failure appears in logs
- `/api/health` remains healthy

## Tests
- `npm test -- --run tests/unit/deployments-routes.test.ts`
- `npm test -- --run tests/unit/database-schema-routes.test.ts tests/unit/payments-routes.test.ts`

## Validation
- Built local image from this branch and tested it in-place against an existing Docker Compose deployment.
- Confirmed the failing admin endpoint changed from `500` to the expected `503` behavior.
