### PR TITLE
fix: add pg_cron retention policy for schedules.job_logs (#1162)

### DIFF
--- a/backend/src/api/routes/schedules/index.routes.ts
+++ b/backend/src/api/routes/schedules/index.routes.ts
@@ -4,7 +4,12 @@ import { ScheduleService } from '@/services/schedules/schedule.service.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/api/middlewares/error.js';
 import { ERROR_CODES } from '@/types/error-constants.js';
-import { createScheduleRequestSchema, updateScheduleRequestSchema } from '@insforge/shared-schemas';
+import {
+  createScheduleRequestSchema,
+  updateScheduleRequestSchema,
+  getSchedulesConfigResponseSchema,
+  updateSchedulesConfigRequestSchema,
+} from '@insforge/shared-schemas';
 
 const router = Router();
 const scheduleService = ScheduleService.getInstance();
@@ -131,6 +136,48 @@ router.delete('/:id', async (req: AuthRequest, res: Response, next: NextFunction
     const { id } = req.params;
     await scheduleService.deleteSchedule(id);
     successResponse(res, { message: 'Schedule deleted successfully.' });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ============================================================================
+// Config Routes
+// ============================================================================
+
+/**
+ * GET /api/schedules/config
+ * Get schedules config (retention days)
+ */
+router.get('/config', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const config = getSchedulesConfigResponseSchema.parse({
+      retentionDays: await scheduleService.getRetentionDays(),
+    });
+    successResponse(res, config);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * PATCH /api/schedules/config
+ * Update schedules config (retention days)
+ */
+router.patch('/config', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const validation = updateSchedulesConfigRequestSchema.safeParse(req.body);
+    if (!validation.success) {
+      throw new AppError(
+        validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    const { retentionDays } = validation.data;
+    await scheduleService.updateRetentionDays(retentionDays);
+    successResponse(res, { message: 'Schedules config updated successfully' });
   } catch (error) {
     next(error);
   }

--- a/backend/src/infra/database/migrations/041_job-logs-retention.sql
+++ b/backend/src/infra/database/migrations/041_job-logs-retention.sql
@@ -3,32 +3,109 @@
 -- schedules.job_logs grows unbounded — every schedule fire inserts a row and
 -- nothing ever deletes them.  A 2-second schedule accumulates ~15.8 M rows
 -- (~3.3 GB) per year.  This migration adds a pg_cron job that runs hourly to
--- delete rows older than 7 days.
+-- delete rows older than the configured retention period.
 --
--- The retention interval (7 days) is long enough for ops to debug failures but
--- short enough to bound the table.  Could be made configurable later.
+-- The retention interval is configurable through the dashboard via schedules.config.
+-- Default is 7 days if not configured.
 --
 -- Dependencies: pg_cron (already enabled in migration 021)
 
 -- ============================================================================
--- RETENTION CRON JOB
+-- CONFIGURATION TABLE
 -- ============================================================================
+CREATE TABLE IF NOT EXISTS schedules.config (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  retention_days INTEGER DEFAULT 7 CHECK (retention_days IS NULL OR retention_days > 0),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
 
--- Remove any previously-scheduled job with the same name (idempotent re-run).
--- cron.unschedule is a no-op when the job doesn't exist, but we guard with an
--- explicit check so the migration is safe even if the cron job name changes.
+-- Ensure only one row exists (singleton pattern)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_schedules_config_singleton ON schedules.config ((1));
+
+-- Trigger for updated_at
+DROP TRIGGER IF EXISTS update_schedules_config_updated_at ON schedules.config;
+CREATE TRIGGER update_schedules_config_updated_at
+  BEFORE UPDATE ON schedules.config
+  FOR EACH ROW
+  EXECUTE FUNCTION system.update_updated_at();
+
+-- ============================================================================
+-- CLEANUP FUNCTION
+-- ============================================================================
+-- Deletes job_logs older than the configured retention period.
+-- Default retention is 7 days if not set in schedules.config.
+
+CREATE OR REPLACE FUNCTION schedules.cleanup_job_logs(p_batch_size INT DEFAULT 1000)
+RETURNS INT AS $$
+DECLARE
+  v_retention_days INT;
+  v_cutoff TIMESTAMPTZ;
+  v_deleted_count INT := 0;
+  v_total_deleted INT := 0;
+BEGIN
+  -- Get retention days from schedules.config
+  SELECT retention_days INTO v_retention_days
+  FROM schedules.config LIMIT 1;
+  
+  -- Handle "Never" (e.g. NULL or < 0)
+  IF v_retention_days IS NULL OR v_retention_days < 0 THEN
+    RETURN 0;
+  END IF;
+  
+  -- Calculate cutoff time
+  v_cutoff := NOW() - (v_retention_days || ' days')::INTERVAL;
+  
+  LOOP
+    WITH deleted AS (
+      DELETE FROM schedules.job_logs
+      WHERE id IN (
+        SELECT id FROM schedules.job_logs
+        WHERE executed_at < v_cutoff
+        ORDER BY executed_at ASC
+        LIMIT p_batch_size
+      )
+      RETURNING id
+    )
+    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+    
+    v_total_deleted := v_total_deleted + v_deleted_count;
+    
+    -- Exit loop if no rows deleted or batch not full
+    EXIT WHEN v_deleted_count < p_batch_size;
+  END LOOP;
+  
+  RETURN v_total_deleted;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'schedules.cleanup_job_logs failed: %', SQLERRM;
+  RETURN v_total_deleted;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Revoke execute from public, only superuser/backend can call this
+REVOKE ALL ON FUNCTION schedules.cleanup_job_logs FROM PUBLIC;
+
+-- ============================================================================
+-- SEED CONFIGURATION
+-- ============================================================================
+-- Insert default retention period (7 days)
+
+INSERT INTO schedules.config (retention_days)
+SELECT 7
+WHERE NOT EXISTS (SELECT 1 FROM schedules.config);
+
+-- ============================================================================
+-- SCHEDULE CLEANUP
+-- ============================================================================
+-- Schedule the cleanup function to run hourly using pg_cron.
+
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedules-job-logs-retention') THEN
-    PERFORM cron.unschedule(
-      (SELECT jobid FROM cron.job WHERE jobname = 'schedules-job-logs-retention')
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedules-job-logs-retention') THEN
+    PERFORM cron.schedule(
+      'schedules-job-logs-retention',
+      '0 * * * *',  -- hourly at minute 0
+      'SELECT schedules.cleanup_job_logs()'
     );
   END IF;
-END;
-$$;
-
-SELECT cron.schedule(
-  'schedules-job-logs-retention',
-  '0 * * * *',  -- hourly at minute 0
-  $$DELETE FROM schedules.job_logs WHERE executed_at < now() - interval '7 days'$$
-);
+END $$;

--- a/backend/src/infra/database/migrations/041_job-logs-retention.sql
+++ b/backend/src/infra/database/migrations/041_job-logs-retention.sql
@@ -1,0 +1,34 @@
+-- Migration 041: Add retention policy for schedules.job_logs
+--
+-- schedules.job_logs grows unbounded — every schedule fire inserts a row and
+-- nothing ever deletes them.  A 2-second schedule accumulates ~15.8 M rows
+-- (~3.3 GB) per year.  This migration adds a pg_cron job that runs hourly to
+-- delete rows older than 7 days.
+--
+-- The retention interval (7 days) is long enough for ops to debug failures but
+-- short enough to bound the table.  Could be made configurable later.
+--
+-- Dependencies: pg_cron (already enabled in migration 021)
+
+-- ============================================================================
+-- RETENTION CRON JOB
+-- ============================================================================
+
+-- Remove any previously-scheduled job with the same name (idempotent re-run).
+-- cron.unschedule is a no-op when the job doesn't exist, but we guard with an
+-- explicit check so the migration is safe even if the cron job name changes.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'schedules-job-logs-retention') THEN
+    PERFORM cron.unschedule(
+      (SELECT jobid FROM cron.job WHERE jobname = 'schedules-job-logs-retention')
+    );
+  END IF;
+END;
+$$;
+
+SELECT cron.schedule(
+  'schedules-job-logs-retention',
+  '0 * * * *',  -- hourly at minute 0
+  $$DELETE FROM schedules.job_logs WHERE executed_at < now() - interval '7 days'$$
+);

--- a/backend/src/services/schedules/schedule.service.ts
+++ b/backend/src/services/schedules/schedule.service.ts
@@ -480,4 +480,44 @@ export class ScheduleService {
       throw error;
     }
   }
+
+  // ============================================================================
+  // Config Methods
+  // ============================================================================
+
+  async getRetentionDays(): Promise<number | null> {
+    try {
+      const result = await this.dbManager.query(
+        'SELECT retention_days as "retentionDays" FROM schedules.config LIMIT 1'
+      );
+      return result.rows.length === 0 ? null : result.rows[0].retentionDays;
+    } catch (error) {
+      logger.error('Error getting schedules retention config:', { error });
+      throw error;
+    }
+  }
+
+  async updateRetentionDays(retentionDays: number | null): Promise<void> {
+    try {
+      // Check if config row exists
+      const existing = await this.dbManager.query('SELECT 1 FROM schedules.config LIMIT 1');
+
+      if (existing.rows.length === 0) {
+        await this.dbManager.query(
+          'INSERT INTO schedules.config (retention_days) VALUES ($1)',
+          [retentionDays]
+        );
+      } else {
+        await this.dbManager.query(
+          'UPDATE schedules.config SET retention_days = $1, updated_at = NOW()',
+          [retentionDays]
+        );
+      }
+
+      logger.info('Schedules retention config updated', { retentionDays });
+    } catch (error) {
+      logger.error('Error updating schedules retention config:', { error });
+      throw error;
+    }
+  }
 }

--- a/backend/tests/unit/job-logs-retention-migration.test.ts
+++ b/backend/tests/unit/job-logs-retention-migration.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationFile = '041_job-logs-retention.sql';
+const migrationPath = path.resolve(
+  currentDir,
+  `../../src/infra/database/migrations/${migrationFile}`
+);
+
+describe('job-logs-retention migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  // ── idempotency ─────────────────────────────────────────────────────
+  it('unschedules any existing cron job before re-scheduling (idempotent)', () => {
+    expect(sql).toMatch(/cron\.unschedule/i);
+    expect(sql).toMatch(/schedules-job-logs-retention/i);
+  });
+
+  it('does not drop or rename anything destructive', () => {
+    expect(sql).not.toMatch(/DROP TABLE/i);
+    expect(sql).not.toMatch(/DROP SCHEMA/i);
+    expect(sql).not.toMatch(/ALTER TABLE[\s\S]*?RENAME TO/i);
+  });
+
+  it('contains no top-level transaction control', () => {
+    const outsideDoBlocks = sql.replace(/DO\s*\$\$[\s\S]*?\$\$/g, '');
+    expect(outsideDoBlocks).not.toMatch(/^\s*BEGIN\s*;/im);
+    expect(outsideDoBlocks).not.toMatch(/^\s*COMMIT\s*;/im);
+    expect(outsideDoBlocks).not.toMatch(/^\s*ROLLBACK\s*;/im);
+  });
+
+  // ── retention configuration ─────────────────────────────────────────
+  it('schedules a pg_cron job named schedules-job-logs-retention', () => {
+    expect(sql).toMatch(/cron\.schedule\(/i);
+    expect(sql).toMatch(/'schedules-job-logs-retention'/);
+  });
+
+  it('runs hourly (every hour at minute 0)', () => {
+    expect(sql).toMatch(/'0 \* \* \* \*'/);
+  });
+
+  it('deletes rows older than 7 days', () => {
+    expect(sql).toMatch(/DELETE FROM schedules\.job_logs/i);
+    expect(sql).toMatch(/7 days/i);
+  });
+
+  it('filters on executed_at column', () => {
+    expect(sql).toMatch(/executed_at\s*<\s*now\(\)\s*-\s*interval/i);
+  });
+
+  // ── ordering ─────────────────────────────────────────────────────────
+  it('runs after migration 021 (schedules schema)', () => {
+    const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    const idx041 = migrations.findIndex((f) => f === migrationFile);
+    const idx021 = migrations.findIndex((f) => f === '021_create-schedules-schema.sql');
+    expect(idx021).toBeGreaterThanOrEqual(0);
+    expect(idx041).toBeGreaterThan(idx021);
+  });
+});

--- a/backend/tests/unit/job-logs-retention-migration.test.ts
+++ b/backend/tests/unit/job-logs-retention-migration.test.ts
@@ -17,7 +17,32 @@ describe('job-logs-retention migration', () => {
     expect(fs.existsSync(migrationPath)).toBe(true);
   });
 
-  // ── idempotency ─────────────────────────────────────────────────────
+  // ── config table ──────────────────────────────────────────────────
+  it('creates a schedules.config table for retention settings', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS schedules\.config/i);
+    expect(sql).toMatch(/retention_days/i);
+  });
+
+  it('uses singleton pattern for config table', () => {
+    expect(sql).toMatch(/idx_schedules_config_singleton/i);
+  });
+
+  // ── cleanup function ──────────────────────────────────────────────
+  it('creates a cleanup function that reads from config', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION schedules\.cleanup_job_logs/i);
+    expect(sql).toMatch(/SELECT retention_days INTO v_retention_days/i);
+    expect(sql).toMatch(/FROM schedules\.config/i);
+  });
+
+  it('handles "Never" retention (NULL config)', () => {
+    expect(sql).toMatch(/v_retention_days IS NULL/i);
+  });
+
+  it('deletes in batches to prevent performance impact', () => {
+    expect(sql).toMatch(/p_batch_size/i);
+  });
+
+  // ── idempotency ───────────────────────────────────────────────────
   it('unschedules any existing cron job before re-scheduling (idempotent)', () => {
     expect(sql).toMatch(/cron\.unschedule/i);
     expect(sql).toMatch(/schedules-job-logs-retention/i);
@@ -36,7 +61,7 @@ describe('job-logs-retention migration', () => {
     expect(outsideDoBlocks).not.toMatch(/^\s*ROLLBACK\s*;/im);
   });
 
-  // ── retention configuration ─────────────────────────────────────────
+  // ── schedule configuration ────────────────────────────────────────
   it('schedules a pg_cron job named schedules-job-logs-retention', () => {
     expect(sql).toMatch(/cron\.schedule\(/i);
     expect(sql).toMatch(/'schedules-job-logs-retention'/);
@@ -46,16 +71,11 @@ describe('job-logs-retention migration', () => {
     expect(sql).toMatch(/'0 \* \* \* \*'/);
   });
 
-  it('deletes rows older than 7 days', () => {
-    expect(sql).toMatch(/DELETE FROM schedules\.job_logs/i);
-    expect(sql).toMatch(/7 days/i);
+  it('calls the cleanup function', () => {
+    expect(sql).toMatch(/SELECT schedules\.cleanup_job_logs\(\)/i);
   });
 
-  it('filters on executed_at column', () => {
-    expect(sql).toMatch(/executed_at\s*<\s*now\(\)\s*-\s*interval/i);
-  });
-
-  // ── ordering ─────────────────────────────────────────────────────────
+  // ── ordering ─────────────────────────────────────────────────────
   it('runs after migration 021 (schedules schema)', () => {
     const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
     const migrations = fs

--- a/packages/dashboard/src/features/functions/components/SchedulesSettingsMenuDialog.tsx
+++ b/packages/dashboard/src/features/functions/components/SchedulesSettingsMenuDialog.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react';
+import { Settings } from 'lucide-react';
+import {
+  Button,
+  MenuDialog,
+  MenuDialogBody,
+  MenuDialogCloseButton,
+  MenuDialogContent,
+  MenuDialogFooter,
+  MenuDialogHeader,
+  MenuDialogMain,
+  MenuDialogNav,
+  MenuDialogNavItem,
+  MenuDialogNavList,
+  MenuDialogSideNav,
+  MenuDialogSideNavHeader,
+  MenuDialogSideNavTitle,
+  MenuDialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@insforge/ui';
+import { useSchedulesConfig } from '#features/functions/hooks/useSchedulesConfig';
+
+interface SchedulesSettingsMenuDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type RetentionOption = string;
+
+interface SettingRowProps {
+  label: string;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+function SettingRow({ label, description, children }: SettingRowProps) {
+  return (
+    <div className="flex w-full items-start gap-6">
+      <div className="w-[260px] shrink-0">
+        <div className="py-1.5">
+          <p className="text-sm leading-5 text-foreground">{label}</p>
+        </div>
+        {description && (
+          <div className="pt-1 pb-2 text-[13px] leading-[18px] text-muted-foreground">
+            {description}
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function toRetentionOption(retentionDays: number | null): RetentionOption {
+  return retentionDays === null ? 'never' : String(retentionDays);
+}
+
+export function SchedulesSettingsMenuDialog({
+  open,
+  onOpenChange,
+}: SchedulesSettingsMenuDialogProps) {
+  const [retentionDays, setRetentionDays] = useState<RetentionOption | null>(null);
+  const [initialRetentionDays, setInitialRetentionDays] = useState<RetentionOption | null>(null);
+  const { config, isLoading, isUpdating, error, updateConfig } = useSchedulesConfig();
+
+  useEffect(() => {
+    if (!open) {
+      setRetentionDays(null);
+      setInitialRetentionDays(null);
+      return;
+    }
+
+    if (!config) {
+      return;
+    }
+
+    const nextRetentionDays = toRetentionOption(config.retentionDays);
+    setRetentionDays(nextRetentionDays);
+    setInitialRetentionDays(nextRetentionDays);
+  }, [config, open]);
+
+  const isLoaded = retentionDays !== null && initialRetentionDays !== null;
+  const hasChanges = isLoaded && retentionDays !== initialRetentionDays;
+  const canClose = !isUpdating;
+  const isSelectDisabled = !isLoaded || isLoading || isUpdating;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!canClose) {
+      return;
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleSave = async () => {
+    if (!isLoaded || !hasChanges) {
+      return;
+    }
+
+    try {
+      await updateConfig({
+        retentionDays: retentionDays === 'never' ? null : Number(retentionDays),
+      });
+      onOpenChange(false);
+    } catch {
+      // The mutation hook already handles error toasts; swallow here to avoid an unhandled rejection.
+    }
+  };
+
+  return (
+    <MenuDialog open={open} onOpenChange={handleOpenChange}>
+      <MenuDialogContent>
+        <MenuDialogSideNav>
+          <MenuDialogSideNavHeader>
+            <MenuDialogSideNavTitle>Schedules Settings</MenuDialogSideNavTitle>
+          </MenuDialogSideNavHeader>
+          <MenuDialogNav>
+            <MenuDialogNavList>
+              <MenuDialogNavItem icon={<Settings className="h-5 w-5" />} active={true}>
+                General
+              </MenuDialogNavItem>
+            </MenuDialogNavList>
+          </MenuDialogNav>
+        </MenuDialogSideNav>
+
+        <MenuDialogMain>
+          <MenuDialogHeader>
+            <MenuDialogTitle>General</MenuDialogTitle>
+            <MenuDialogCloseButton className="ml-auto" />
+          </MenuDialogHeader>
+
+          {!isLoaded ? (
+            <MenuDialogBody>
+              <div className="flex min-h-[92px] items-center justify-center text-sm text-muted-foreground">
+                {isLoading && !error ? 'Loading configuration...' : 'Unable to load configuration.'}
+              </div>
+            </MenuDialogBody>
+          ) : (
+            <>
+              <MenuDialogBody>
+                <SettingRow
+                  label="Log Retention"
+                  description="How long execution logs are kept before cleanup. Set to Never to disable automatic cleanup."
+                >
+                  <div className="flex justify-end">
+                    <Select
+                      value={retentionDays ?? undefined}
+                      onValueChange={setRetentionDays}
+                      disabled={isSelectDisabled}
+                    >
+                      <SelectTrigger id="retention-days" className="h-9 w-[180px] max-w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="7">7 days</SelectItem>
+                        <SelectItem value="14">14 days</SelectItem>
+                        <SelectItem value="30">30 days</SelectItem>
+                        <SelectItem value="90">90 days</SelectItem>
+                        <SelectItem value="never">Never</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </SettingRow>
+              </MenuDialogBody>
+
+              <MenuDialogFooter>
+                {hasChanges && (
+                  <>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => handleOpenChange(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => void handleSave()}
+                      disabled={!isLoaded || isUpdating || !hasChanges}
+                    >
+                      {isUpdating ? 'Saving...' : 'Save Changes'}
+                    </Button>
+                  </>
+                )}
+              </MenuDialogFooter>
+            </>
+          )}
+        </MenuDialogMain>
+      </MenuDialogContent>
+    </MenuDialog>
+  );
+}

--- a/packages/dashboard/src/features/functions/hooks/useSchedulesConfig.ts
+++ b/packages/dashboard/src/features/functions/hooks/useSchedulesConfig.ts
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback } from 'react';
+import { toast } from 'sonner';
+
+interface SchedulesConfig {
+  retentionDays: number | null;
+}
+
+export function useSchedulesConfig() {
+  const [config, setConfig] = useState<SchedulesConfig | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await fetch('/api/schedules/config', {
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch schedules config');
+      }
+      const data = await response.json();
+      setConfig(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchConfig();
+  }, [fetchConfig]);
+
+  const updateConfig = useCallback(
+    async (updates: Partial<SchedulesConfig>) => {
+      try {
+        setIsUpdating(true);
+        const response = await fetch('/api/schedules/config', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(updates),
+        });
+        if (!response.ok) {
+          throw new Error('Failed to update schedules config');
+        }
+        toast.success('Schedules config updated');
+        await fetchConfig();
+      } catch (err) {
+        toast.error('Failed to update schedules config');
+        throw err;
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [fetchConfig]
+  );
+
+  return { config, isLoading, isUpdating, error, updateConfig };
+}

--- a/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
-import { ArrowLeft, CirclePlus } from 'lucide-react';
+import { ArrowLeft, CirclePlus, Settings } from 'lucide-react';
 import { useSchedules } from '#features/functions/hooks/useSchedules';
 import {
   Button,
@@ -17,6 +17,7 @@ import ScheduleRow from '#features/functions/components/ScheduleRow';
 import ScheduleLogs from '#features/functions/components/ScheduleLogs';
 import { Alert, AlertDescription } from '#components/radix/Alert';
 import ScheduleEmptyState from '#features/functions/components/ScheduleEmptyState';
+import { SchedulesSettingsMenuDialog } from '#features/functions/components/SchedulesSettingsMenuDialog';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import RefreshIcon from '#assets/icons/refresh.svg?react';
 
@@ -25,6 +26,7 @@ const PAGE_SIZE = 50;
 export default function SchedulesPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -236,6 +238,23 @@ export default function SchedulesPage() {
               <CirclePlus className="h-6 w-6 stroke-[1.5] text-primary" />
               <span className="px-1 text-sm font-medium leading-5">Add Schedule</span>
             </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setSettingsOpen(true)}
+                    className="h-8 w-8 rounded p-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] active:bg-[var(--alpha-8)]"
+                  >
+                    <Settings className="h-5 w-5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="center">
+                  <p>Schedules Settings</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         }
         searchValue={searchQuery}
@@ -367,6 +386,11 @@ export default function SchedulesPage() {
       )}
 
       <ConfirmDialog {...confirmDialogProps} />
+
+      <SchedulesSettingsMenuDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+      />
     </div>
   );
 }

--- a/packages/shared-schemas/src/schedules-api.schema.ts
+++ b/packages/shared-schemas/src/schedules-api.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { scheduleSchema, scheduleLogSchema } from './schedules.schema.js';
+import { scheduleSchema, scheduleLogSchema, schedulesConfigSchema } from './schedules.schema.js';
 
 // Accept either:
 //   - 5-field cron expression (e.g. "*/5 * * * *", "0 9 * * 1-5")
@@ -117,3 +117,13 @@ export type GetScheduleResponse = z.infer<typeof getScheduleResponseSchema>;
 export type ExecutionLogResponse = z.infer<typeof executionLogResponseSchema>;
 export type ListExecutionLogsResponse = z.infer<typeof listExecutionLogsResponseSchema>;
 export type DeleteScheduleResponse = z.infer<typeof deleteScheduleResponseSchema>;
+
+// ============================================================================
+// Config Schemas
+// ============================================================================
+
+export const getSchedulesConfigResponseSchema = schedulesConfigSchema;
+export const updateSchedulesConfigRequestSchema = schedulesConfigSchema;
+
+export type GetSchedulesConfigResponse = z.infer<typeof getSchedulesConfigResponseSchema>;
+export type UpdateSchedulesConfigRequest = z.infer<typeof updateSchedulesConfigRequestSchema>;

--- a/packages/shared-schemas/src/schedules.schema.ts
+++ b/packages/shared-schemas/src/schedules.schema.ts
@@ -38,3 +38,13 @@ export const scheduleLogSchema = z.object({
 
 export type ScheduleSchema = z.infer<typeof scheduleSchema>;
 export type ScheduleLogSchema = z.infer<typeof scheduleLogSchema>;
+
+// ============================================================================
+// Config Schema
+// ============================================================================
+
+export const schedulesConfigSchema = z.object({
+  retentionDays: z.number().int().positive().nullable(),
+});
+
+export type SchedulesConfig = z.infer<typeof schedulesConfigSchema>;


### PR DESCRIPTION
## Problem

`schedules.job_logs` has no automatic cleanup. Every schedule fire writes one row, and rows live forever. A 2-second schedule accumulates ~15.8M rows (~3.3 GB) per year (see #1162 for measurements).

## Solution

Add migration `041_job-logs-retention.sql` that schedules a `pg_cron` job named `schedules-job-logs-retention` running **hourly** to delete rows older than **7 days**.

## Key properties

- **Idempotent**: unschedules any existing `schedules-job-logs-retention` job before re-creating (safe for re-runs)
- **7-day retention**: long enough for ops to debug failures, short enough to bound the table
- **No destructive changes**: no DROP TABLE, no schema changes, no function modifications

## Files changed

- `backend/src/infra/database/migrations/041_job-logs-retention.sql` — New migration
- `backend/tests/unit/job-logs-retention-migration.test.ts` — Unit test (9 assertions)

## Tests

All 9 unit tests pass (idempotency, retention interval, column filter, ordering, etc).

Closes #1162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Job logs older than 7 days are now automatically cleaned up on an hourly basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->