### PR TITLE
[Bug FIx] Relax write permission on given tables

### DIFF
--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -9,17 +9,13 @@ let initialized = false;
 // These are the documented managed tables where developers are expected to add
 // app-specific runtime rows through raw SQL.
 const MANAGED_SCHEMA_WRITE_TABLE_EXCEPTIONS = new Set(
-  [
-    'realtime.channels',
-  ].map((tableName) => tableName.toLowerCase())
+  ['realtime.channels'].map((tableName) => tableName.toLowerCase())
 );
 
 // These are the documented managed tables where developers are expected to add
 // business-logic triggers, but not broad table writes.
 const MANAGED_SCHEMA_TRIGGER_TABLE_EXCEPTIONS = new Set(
-  ['payments.payment_history', 'payments.subscriptions'].map((tableName) =>
-    tableName.toLowerCase()
-  )
+  ['payments.payment_history', 'payments.subscriptions'].map((tableName) => tableName.toLowerCase())
 );
 
 // These are the documented managed tables where developers are expected to
@@ -520,16 +516,10 @@ export function checkManagedSchemaWriteOperations(
             relation.tableName &&
             ((removeType === 'OBJECT_TRIGGER' &&
               (isManagedSchemaWriteTableException(relation.schemaName, relation.tableName) ||
-                isManagedSchemaTriggerTableException(
-                  relation.schemaName,
-                  relation.tableName
-                ))) ||
+                isManagedSchemaTriggerTableException(relation.schemaName, relation.tableName))) ||
               (removeType === 'OBJECT_POLICY' &&
                 (isManagedSchemaWriteTableException(relation.schemaName, relation.tableName) ||
-                  isManagedSchemaRlsTableException(
-                    relation.schemaName,
-                    relation.tableName
-                  ))))
+                  isManagedSchemaRlsTableException(relation.schemaName, relation.tableName))))
           ) {
             continue;
           }

--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -7,17 +7,38 @@ import logger from './logger.js';
 let initialized = false;
 
 // These are the documented managed tables where developers are expected to add
-// app-specific RLS, triggers, or runtime rows through raw SQL.
+// app-specific runtime rows through raw SQL.
 const MANAGED_SCHEMA_WRITE_TABLE_EXCEPTIONS = new Set(
   [
+    'realtime.channels',
+  ].map((tableName) => tableName.toLowerCase())
+);
+
+// These are the documented managed tables where developers are expected to add
+// business-logic triggers, but not broad table writes.
+const MANAGED_SCHEMA_TRIGGER_TABLE_EXCEPTIONS = new Set(
+  ['payments.payment_history', 'payments.subscriptions'].map((tableName) =>
+    tableName.toLowerCase()
+  )
+);
+
+// These are the documented managed tables where developers are expected to
+// enable/manage RLS and policies, but not perform broad writes.
+const MANAGED_SCHEMA_RLS_TABLE_EXCEPTIONS = new Set(
+  [
+    'storage.objects',
     'payments.checkout_sessions',
     'payments.customer_portal_sessions',
-    'payments.payment_history',
-    'payments.subscriptions',
-    'realtime.channels',
     'realtime.messages',
   ].map((tableName) => tableName.toLowerCase())
 );
+
+const ALLOWED_RLS_ALTER_TABLE_SUBTYPES = new Set([
+  'AT_EnableRowSecurity',
+  'AT_DisableRowSecurity',
+  'AT_ForceRowSecurity',
+  'AT_NoForceRowSecurity',
+]);
 
 /**
  * Initialize the SQL parser WASM module.
@@ -339,6 +360,53 @@ function isManagedSchemaWriteTableException(
   );
 }
 
+function isManagedSchemaTriggerTableException(
+  schemaName: string | null,
+  tableName: string | null
+): boolean {
+  if (!schemaName || !tableName) {
+    return false;
+  }
+
+  return MANAGED_SCHEMA_TRIGGER_TABLE_EXCEPTIONS.has(
+    `${schemaName.toLowerCase()}.${tableName.toLowerCase()}`
+  );
+}
+
+function isManagedSchemaRlsTableException(
+  schemaName: string | null,
+  tableName: string | null
+): boolean {
+  if (!schemaName || !tableName) {
+    return false;
+  }
+
+  return MANAGED_SCHEMA_RLS_TABLE_EXCEPTIONS.has(
+    `${schemaName.toLowerCase()}.${tableName.toLowerCase()}`
+  );
+}
+
+function isManagedSchemaRlsAlterTableException(
+  data: Record<string, unknown>,
+  schemaName: string | null,
+  tableName: string | null
+): boolean {
+  if (!isManagedSchemaRlsTableException(schemaName, tableName)) {
+    return false;
+  }
+
+  const commands = (data.cmds as Array<Record<string, unknown>>) ?? [];
+  if (commands.length === 0) {
+    return false;
+  }
+
+  return commands.every((command) => {
+    const alterTableCmd = command.AlterTableCmd as Record<string, unknown> | undefined;
+    const subtype = alterTableCmd?.subtype as string | undefined;
+    return subtype ? ALLOWED_RLS_ALTER_TABLE_SUBTYPES.has(subtype) : false;
+  });
+}
+
 function getDropManagedRelation(
   removeType: string,
   obj: Record<string, unknown>
@@ -421,7 +489,8 @@ export function checkManagedSchemaWriteOperations(
         const relationTableName = getRelationName(relation);
         if (
           relationSchema &&
-          !isManagedSchemaWriteTableException(relationSchema, relationTableName)
+          !isManagedSchemaWriteTableException(relationSchema, relationTableName) &&
+          !isManagedSchemaTriggerTableException(relationSchema, relationTableName)
         ) {
           return buildManagedSchemaWriteError(relationSchema);
         }
@@ -449,7 +518,18 @@ export function checkManagedSchemaWriteOperations(
             relation &&
             relation.schemaName &&
             relation.tableName &&
-            isManagedSchemaWriteTableException(relation.schemaName, relation.tableName)
+            ((removeType === 'OBJECT_TRIGGER' &&
+              (isManagedSchemaWriteTableException(relation.schemaName, relation.tableName) ||
+                isManagedSchemaTriggerTableException(
+                  relation.schemaName,
+                  relation.tableName
+                ))) ||
+              (removeType === 'OBJECT_POLICY' &&
+                (isManagedSchemaWriteTableException(relation.schemaName, relation.tableName) ||
+                  isManagedSchemaRlsTableException(
+                    relation.schemaName,
+                    relation.tableName
+                  ))))
           ) {
             continue;
           }
@@ -464,7 +544,7 @@ export function checkManagedSchemaWriteOperations(
         }
       }
 
-      if (stmtType === 'CreateStmt' || stmtType === 'IndexStmt' || stmtType === 'RenameStmt') {
+      if (stmtType === 'CreateStmt' || stmtType === 'IndexStmt') {
         const relation = data.relation as Record<string, unknown> | undefined;
         const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
         const tableName = getRelationName(relation);
@@ -473,11 +553,23 @@ export function checkManagedSchemaWriteOperations(
         }
       }
 
+      if (stmtType === 'RenameStmt') {
+        const relation = data.relation as Record<string, unknown> | undefined;
+        const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
+        if (schemaName) {
+          return buildManagedSchemaWriteError(schemaName);
+        }
+      }
+
       if (stmtType === 'AlterTableStmt') {
         const relation = data.relation as Record<string, unknown> | undefined;
         const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
         const tableName = getRelationName(relation);
-        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
+        if (
+          schemaName &&
+          !isManagedSchemaWriteTableException(schemaName, tableName) &&
+          !isManagedSchemaRlsAlterTableException(data, schemaName, tableName)
+        ) {
           return buildManagedSchemaWriteError(schemaName);
         }
       }
@@ -495,7 +587,11 @@ export function checkManagedSchemaWriteOperations(
         const relation = data.table as Record<string, unknown> | undefined;
         const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
         const tableName = getRelationName(relation);
-        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
+        if (
+          schemaName &&
+          !isManagedSchemaWriteTableException(schemaName, tableName) &&
+          !isManagedSchemaRlsTableException(schemaName, tableName)
+        ) {
           return buildManagedSchemaWriteError(schemaName);
         }
       }

--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -6,6 +6,19 @@ import logger from './logger.js';
 
 let initialized = false;
 
+// These are the documented managed tables where developers are expected to add
+// app-specific RLS, triggers, or runtime rows through raw SQL.
+const MANAGED_SCHEMA_WRITE_TABLE_EXCEPTIONS = new Set(
+  [
+    'payments.checkout_sessions',
+    'payments.customer_portal_sessions',
+    'payments.payment_history',
+    'payments.subscriptions',
+    'realtime.channels',
+    'realtime.messages',
+  ].map((tableName) => tableName.toLowerCase())
+);
+
 /**
  * Initialize the SQL parser WASM module.
  * Must be called and awaited before using analyzeQuery().
@@ -126,6 +139,25 @@ function getSchemaName(relation: Record<string, unknown> | undefined): string | 
   return null;
 }
 
+function getRelationName(relation: Record<string, unknown> | undefined): string | null {
+  if (!relation) {
+    return null;
+  }
+
+  if (relation.relname) {
+    return relation.relname as string;
+  }
+
+  if (relation.RangeVar) {
+    const rangeVar = relation.RangeVar as Record<string, unknown>;
+    if (rangeVar.relname) {
+      return rangeVar.relname as string;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Check if a query contains dangerous operations on the auth schema
  * Returns an error message if blocked, null if allowed
@@ -237,8 +269,18 @@ function getSchemaFromNameList(items: Array<Record<string, unknown>>): string | 
   if (items.length < 1) {
     return null;
   }
-  const first = items[0];
-  return ((first.String as Record<string, unknown> | undefined)?.sval as string) ?? null;
+  return getStringNodeValue(items[0]);
+}
+
+function getTableFromNameList(items: Array<Record<string, unknown>>): string | null {
+  if (items.length < 2) {
+    return null;
+  }
+  return getStringNodeValue(items[1]);
+}
+
+function getStringNodeValue(item: Record<string, unknown> | undefined): string | null {
+  return ((item?.String as Record<string, unknown> | undefined)?.sval as string) ?? null;
 }
 
 function getDropObjectSchema(obj: Record<string, unknown>): string | null {
@@ -282,6 +324,40 @@ function getProtectedSchema(
 
 function buildManagedSchemaWriteError(schemaName: string): string {
   return `Write operations on ${schemaName} schema are not allowed. InsForge-managed schemas are protected in the dashboard.`;
+}
+
+function isManagedSchemaWriteTableException(
+  schemaName: string | null,
+  tableName: string | null
+): boolean {
+  if (!schemaName || !tableName) {
+    return false;
+  }
+
+  return MANAGED_SCHEMA_WRITE_TABLE_EXCEPTIONS.has(
+    `${schemaName.toLowerCase()}.${tableName.toLowerCase()}`
+  );
+}
+
+function getDropManagedRelation(
+  removeType: string,
+  obj: Record<string, unknown>
+): { schemaName: string | null; tableName: string | null } | null {
+  if (removeType !== 'OBJECT_POLICY' && removeType !== 'OBJECT_TRIGGER') {
+    return null;
+  }
+
+  const items =
+    ((obj.List as Record<string, unknown> | undefined)?.items as Array<Record<string, unknown>>) ??
+    [];
+  if (items.length < 2) {
+    return null;
+  }
+
+  return {
+    schemaName: getSchemaFromNameList(items),
+    tableName: getTableFromNameList(items),
+  };
 }
 
 export function checkManagedSchemaWriteOperations(
@@ -342,7 +418,11 @@ export function checkManagedSchemaWriteOperations(
       if (stmtType === 'CreateTrigStmt') {
         const relation = data.relation as Record<string, unknown> | undefined;
         const relationSchema = getProtectedSchema(getSchemaName(relation), protectedSchemas);
-        if (relationSchema) {
+        const relationTableName = getRelationName(relation);
+        if (
+          relationSchema &&
+          !isManagedSchemaWriteTableException(relationSchema, relationTableName)
+        ) {
           return buildManagedSchemaWriteError(relationSchema);
         }
 
@@ -357,9 +437,20 @@ export function checkManagedSchemaWriteOperations(
       }
 
       if (stmtType === 'DropStmt') {
+        const removeType = (data.removeType as string) ?? '';
         const objects = (data.objects as Array<unknown>) ?? [];
         for (const obj of objects) {
           if (typeof obj !== 'object' || obj === null) {
+            continue;
+          }
+
+          const relation = getDropManagedRelation(removeType, obj as Record<string, unknown>);
+          if (
+            relation &&
+            relation.schemaName &&
+            relation.tableName &&
+            isManagedSchemaWriteTableException(relation.schemaName, relation.tableName)
+          ) {
             continue;
           }
 
@@ -373,18 +464,29 @@ export function checkManagedSchemaWriteOperations(
         }
       }
 
-      if (
-        stmtType === 'CreateStmt' ||
-        stmtType === 'AlterTableStmt' ||
-        stmtType === 'IndexStmt' ||
-        stmtType === 'InsertStmt' ||
-        stmtType === 'UpdateStmt' ||
-        stmtType === 'DeleteStmt' ||
-        stmtType === 'RenameStmt'
-      ) {
+      if (stmtType === 'CreateStmt' || stmtType === 'IndexStmt' || stmtType === 'RenameStmt') {
         const relation = data.relation as Record<string, unknown> | undefined;
         const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
-        if (schemaName) {
+        const tableName = getRelationName(relation);
+        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
+          return buildManagedSchemaWriteError(schemaName);
+        }
+      }
+
+      if (stmtType === 'AlterTableStmt') {
+        const relation = data.relation as Record<string, unknown> | undefined;
+        const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
+        const tableName = getRelationName(relation);
+        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
+          return buildManagedSchemaWriteError(schemaName);
+        }
+      }
+
+      if (stmtType === 'InsertStmt' || stmtType === 'UpdateStmt' || stmtType === 'DeleteStmt') {
+        const relation = data.relation as Record<string, unknown> | undefined;
+        const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
+        const tableName = getRelationName(relation);
+        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
           return buildManagedSchemaWriteError(schemaName);
         }
       }
@@ -392,7 +494,8 @@ export function checkManagedSchemaWriteOperations(
       if (stmtType === 'CreatePolicyStmt' || stmtType === 'AlterPolicyStmt') {
         const relation = data.table as Record<string, unknown> | undefined;
         const schemaName = getProtectedSchema(getSchemaName(relation), protectedSchemas);
-        if (schemaName) {
+        const tableName = getRelationName(relation);
+        if (schemaName && !isManagedSchemaWriteTableException(schemaName, tableName)) {
           return buildManagedSchemaWriteError(schemaName);
         }
       }

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -418,10 +418,60 @@ describe('DatabaseAdvanceService - sanitizeQuery', () => {
   });
 
   describe('other managed schema blocking', () => {
+    test('allows storage RLS setup', () => {
+      const alterQuery = 'ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY';
+      expect(() => service.sanitizeQuery(alterQuery)).not.toThrow();
+
+      const query =
+        'CREATE POLICY storage_owner_select ON storage.objects FOR SELECT TO authenticated USING (true)';
+      expect(() => service.sanitizeQuery(query)).not.toThrow();
+    });
+
+    test('allows payments session RLS setup', () => {
+      const queries = [
+        'ALTER TABLE payments.checkout_sessions ENABLE ROW LEVEL SECURITY',
+        'ALTER TABLE payments.customer_portal_sessions FORCE ROW LEVEL SECURITY',
+        `CREATE POLICY checkout_subject_guard
+         ON payments.checkout_sessions
+         FOR INSERT TO authenticated
+         WITH CHECK (subject_type = 'team')`,
+      ];
+
+      queries.forEach((query) => {
+        expect(() => service.sanitizeQuery(query)).not.toThrow();
+      });
+    });
+
     test('blocks INSERT on storage schema', () => {
       const query = "INSERT INTO storage.objects (name) VALUES ('avatar.png')";
       expect(() => service.sanitizeQuery(query)).toThrow(AppError);
       expect(() => service.sanitizeQuery(query)).toThrow(/storage schema/i);
+    });
+
+    test('blocks broad writes on payments session tables', () => {
+      const queries = [
+        `INSERT INTO payments.checkout_sessions
+         (environment, mode, success_url, cancel_url)
+         VALUES ('test', 'payment', 'https://example.com/success', 'https://example.com/cancel')`,
+        'ALTER TABLE payments.checkout_sessions ADD COLUMN internal_note TEXT',
+      ];
+
+      queries.forEach((query) => {
+        expect(() => service.sanitizeQuery(query)).toThrow(AppError);
+        expect(() => service.sanitizeQuery(query)).toThrow(/payments schema/i);
+      });
+    });
+
+    test('blocks renames on managed extension tables', () => {
+      const queries = [
+        'ALTER TABLE realtime.channels RENAME TO realtime_channels_v2',
+        'ALTER TABLE realtime.channels RENAME COLUMN description TO details',
+      ];
+
+      queries.forEach((query) => {
+        expect(() => service.sanitizeQuery(query)).toThrow(AppError);
+        expect(() => service.sanitizeQuery(query)).toThrow(/realtime schema/i);
+      });
     });
 
     test('blocks CREATE INDEX on storage schema', () => {

--- a/backend/tests/unit/sql-parser.test.ts
+++ b/backend/tests/unit/sql-parser.test.ts
@@ -275,9 +275,20 @@ describe('checkManagedSchemaWriteOperations', () => {
       checkManagedSchemaWriteOperations('ALTER TABLE realtime.channels ENABLE ROW LEVEL SECURITY')
     ).toBeNull();
     expect(
+      checkManagedSchemaWriteOperations('ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY')
+    ).toBeNull();
+    expect(
       checkManagedSchemaWriteOperations(
         'ALTER TABLE payments.checkout_sessions ENABLE ROW LEVEL SECURITY'
       )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE payments.customer_portal_sessions FORCE ROW LEVEL SECURITY'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations('ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY')
     ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
@@ -286,12 +297,42 @@ describe('checkManagedSchemaWriteOperations', () => {
     ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
+        'DROP POLICY checkout_subject_guard ON payments.checkout_sessions'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'DROP POLICY IF EXISTS portal_subject_guard ON payments.customer_portal_sessions'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
         "CREATE POLICY publish_guard ON realtime.messages FOR INSERT TO authenticated WITH CHECK (channel_name LIKE 'chat:%')"
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'CREATE POLICY storage_owner_select ON storage.objects FOR SELECT TO authenticated USING (true)'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'DROP POLICY IF EXISTS storage_owner_select ON storage.objects'
       )
     ).toBeNull();
   });
 
   it('allows documented writes on exempted managed tables', () => {
+    expect(
+      checkManagedSchemaWriteOperations(
+        "INSERT INTO realtime.channels (pattern, description, enabled) VALUES ('orders', 'Order events', true)"
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        "UPDATE realtime.channels SET enabled = false WHERE pattern = 'orders'"
+      )
+    ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
         'CREATE TRIGGER fulfill_paid_order AFTER INSERT ON payments.payment_history FOR EACH ROW EXECUTE FUNCTION public.fulfill_paid_order()'
@@ -307,16 +348,44 @@ describe('checkManagedSchemaWriteOperations', () => {
         'CREATE TRIGGER sync_team_billing_status AFTER INSERT ON payments.subscriptions FOR EACH ROW EXECUTE FUNCTION public.sync_team_billing_status()'
       )
     ).toBeNull();
+  });
+
+  it('blocks broad writes on RLS-only and trigger-only managed tables', () => {
     expect(
       checkManagedSchemaWriteOperations(
         "INSERT INTO payments.checkout_sessions (environment, mode, success_url, cancel_url) VALUES ('test', 'payment', 'https://example.com/success', 'https://example.com/cancel')"
       )
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
         'ALTER TABLE payments.checkout_sessions ADD COLUMN internal_note TEXT'
       )
-    ).toBeNull();
+    ).not.toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY, ADD COLUMN owner_note TEXT'
+      )
+    ).not.toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE realtime.channels RENAME TO realtime_channels_v2'
+      )
+    ).not.toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE realtime.channels RENAME COLUMN description TO details'
+      )
+    ).not.toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        "INSERT INTO realtime.messages (event_name, channel_name, payload) VALUES ('new_message', 'chat:1', '{}'::jsonb)"
+      )
+    ).not.toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        "UPDATE payments.subscriptions SET status = 'canceled' WHERE id = 'sub_123'"
+      )
+    ).not.toBeNull();
   });
 
   it('allows SELECT on managed schemas', () => {

--- a/backend/tests/unit/sql-parser.test.ts
+++ b/backend/tests/unit/sql-parser.test.ts
@@ -272,9 +272,7 @@ describe('checkManagedSchemaWriteOperations', () => {
 
   it('allows RLS changes on documented managed tables', () => {
     expect(
-      checkManagedSchemaWriteOperations(
-        'ALTER TABLE realtime.channels ENABLE ROW LEVEL SECURITY'
-      )
+      checkManagedSchemaWriteOperations('ALTER TABLE realtime.channels ENABLE ROW LEVEL SECURITY')
     ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
@@ -283,12 +281,12 @@ describe('checkManagedSchemaWriteOperations', () => {
     ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
-        'CREATE POLICY checkout_subject_guard ON payments.checkout_sessions FOR INSERT TO authenticated WITH CHECK (subject_type = \'team\')'
+        "CREATE POLICY checkout_subject_guard ON payments.checkout_sessions FOR INSERT TO authenticated WITH CHECK (subject_type = 'team')"
       )
     ).toBeNull();
     expect(
       checkManagedSchemaWriteOperations(
-        'CREATE POLICY publish_guard ON realtime.messages FOR INSERT TO authenticated WITH CHECK (channel_name LIKE \'chat:%\')'
+        "CREATE POLICY publish_guard ON realtime.messages FOR INSERT TO authenticated WITH CHECK (channel_name LIKE 'chat:%')"
       )
     ).toBeNull();
   });

--- a/backend/tests/unit/sql-parser.test.ts
+++ b/backend/tests/unit/sql-parser.test.ts
@@ -254,6 +254,73 @@ describe('checkManagedSchemaWriteOperations', () => {
     ).not.toBeNull();
   });
 
+  it('allows realtime channel management through raw SQL', () => {
+    expect(
+      checkManagedSchemaWriteOperations(
+        "INSERT INTO realtime.channels (pattern, description, enabled) VALUES ('orders', 'Order events', true)"
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        "UPDATE realtime.channels SET enabled = false WHERE pattern = 'orders'"
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations("DELETE FROM realtime.channels WHERE pattern = 'orders'")
+    ).toBeNull();
+  });
+
+  it('allows RLS changes on documented managed tables', () => {
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE realtime.channels ENABLE ROW LEVEL SECURITY'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE payments.checkout_sessions ENABLE ROW LEVEL SECURITY'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'CREATE POLICY checkout_subject_guard ON payments.checkout_sessions FOR INSERT TO authenticated WITH CHECK (subject_type = \'team\')'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'CREATE POLICY publish_guard ON realtime.messages FOR INSERT TO authenticated WITH CHECK (channel_name LIKE \'chat:%\')'
+      )
+    ).toBeNull();
+  });
+
+  it('allows documented writes on exempted managed tables', () => {
+    expect(
+      checkManagedSchemaWriteOperations(
+        'CREATE TRIGGER fulfill_paid_order AFTER INSERT ON payments.payment_history FOR EACH ROW EXECUTE FUNCTION public.fulfill_paid_order()'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'DROP TRIGGER IF EXISTS fulfill_paid_order ON payments.payment_history'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'CREATE TRIGGER sync_team_billing_status AFTER INSERT ON payments.subscriptions FOR EACH ROW EXECUTE FUNCTION public.sync_team_billing_status()'
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        "INSERT INTO payments.checkout_sessions (environment, mode, success_url, cancel_url) VALUES ('test', 'payment', 'https://example.com/success', 'https://example.com/cancel')"
+      )
+    ).toBeNull();
+    expect(
+      checkManagedSchemaWriteOperations(
+        'ALTER TABLE payments.checkout_sessions ADD COLUMN internal_note TEXT'
+      )
+    ).toBeNull();
+  });
+
   it('allows SELECT on managed schemas', () => {
     expect(checkManagedSchemaWriteOperations('SELECT * FROM auth.users')).toBeNull();
     expect(checkManagedSchemaWriteOperations('SELECT * FROM storage.objects')).toBeNull();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",


### PR DESCRIPTION
## Summary

Relax write permission on realtime & payments & storage schemas, so necessary sql-based configurations are no longer blocked.

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced protection for managed database schemas that blocks unauthorized write operations (creates/edits/deletes/triggers/policies/functions/extensions) with explicit, documented exceptions for certain tables.
  * Added a SQL parser utility to split and sanitize SQL input into individual statements with error handling.

* **Tests**
  * Added comprehensive tests covering schema write validation, realtime channel management, RLS/policy changes, and managed-extension write/rename protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->