### PR TITLE
INS-156 Avoid fetching missing OAuth provider configs

### DIFF
--- a/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
@@ -45,6 +45,8 @@ interface OAuthConfigDialogProps {
   onSuccess?: () => void;
 }
 
+export type OAuthDialogMode = OAuthConfigDialogProps['mode'];
+
 export function OAuthConfigDialog({
   provider,
   mode,
@@ -318,10 +320,10 @@ export function OAuthConfigDialog({
               </Button>
               <Button type="button" onClick={handleSubmit} disabled={isDisabled()} className="w-30">
                 {saving
-                  ? providerConfig
+                  ? mode === 'edit'
                     ? 'Updating...'
                     : 'Adding...'
-                  : providerConfig
+                  : mode === 'edit'
                     ? 'Update'
                     : 'Add Provider'}
               </Button>

--- a/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
@@ -39,6 +39,7 @@ const getCallbackUrl = (provider?: string) => {
 
 interface OAuthConfigDialogProps {
   provider?: OAuthProviderInfo;
+  mode: 'create' | 'edit';
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: () => void;
@@ -46,12 +47,13 @@ interface OAuthConfigDialogProps {
 
 export function OAuthConfigDialog({
   provider,
+  mode,
   isOpen,
   onClose,
   onSuccess,
 }: OAuthConfigDialogProps) {
   const { providerConfig, createConfig, updateConfig, isCreating, isUpdating, isLoadingProvider } =
-    useOAuthConfig(provider?.id);
+    useOAuthConfig(mode === 'edit' ? provider?.id : null);
 
   const form = useForm<OAuthConfigSchema & { clientSecret?: string }>({
     resolver: zodResolver(oAuthConfigSchema.extend({ clientSecret: z.string().optional() })),
@@ -93,24 +95,29 @@ export function OAuthConfigDialog({
 
   // Load OAuth configuration after fetching
   useEffect(() => {
-    if (isOpen && provider && !isLoadingProvider) {
-      if (providerConfig) {
-        form.reset({
-          provider: provider.id,
-          clientId: providerConfig.clientId || '',
-          clientSecret: providerConfig.clientSecret || '',
-          useSharedKey: providerConfig.useSharedKey || false,
-        });
-      } else {
-        form.reset({
-          provider: provider.id,
-          clientId: '',
-          clientSecret: '',
-          useSharedKey: isSharedKeysAvailable,
-        });
-      }
+    if (!isOpen || !provider) {
+      return;
     }
-  }, [form, isLoadingProvider, isOpen, isSharedKeysAvailable, provider, providerConfig]);
+
+    if (mode === 'create') {
+      form.reset({
+        provider: provider.id,
+        clientId: '',
+        clientSecret: '',
+        useSharedKey: isSharedKeysAvailable,
+      });
+      return;
+    }
+
+    if (!isLoadingProvider && providerConfig) {
+      form.reset({
+        provider: provider.id,
+        clientId: providerConfig.clientId || '',
+        clientSecret: providerConfig.clientSecret || '',
+        useSharedKey: providerConfig.useSharedKey || false,
+      });
+    }
+  }, [form, isLoadingProvider, isOpen, isSharedKeysAvailable, mode, provider, providerConfig]);
 
   const handleSubmitData = (data: OAuthConfigSchema & { clientSecret?: string }) => {
     if (!provider) {
@@ -118,7 +125,11 @@ export function OAuthConfigDialog({
     }
 
     try {
-      if (providerConfig) {
+      if (mode === 'edit') {
+        if (!providerConfig) {
+          return;
+        }
+
         // Update existing config
         updateConfig({
           provider: provider.id,
@@ -164,8 +175,10 @@ export function OAuthConfigDialog({
     }
 
     // In update mode, require dirty state
-    if (providerConfig && !isDirty) {
-      return true;
+    if (mode === 'edit') {
+      if (!providerConfig || !isDirty) {
+        return true;
+      }
     }
 
     // If using shared keys, always allow (no credential validation needed)

--- a/packages/dashboard/src/features/auth/components/index.ts
+++ b/packages/dashboard/src/features/auth/components/index.ts
@@ -1,4 +1,4 @@
-export { OAuthConfigDialog } from './OAuthConfigDialog';
+export { OAuthConfigDialog, type OAuthDialogMode } from './OAuthConfigDialog';
 export { CustomOAuthConfigDialog } from './CustomOAuthConfigDialog';
 export { AuthSettingsMenuDialog } from './AuthSettingsMenuDialog';
 export { OAuthEmptyState } from './OAuthEmptyState';

--- a/packages/dashboard/src/features/auth/hooks/useOAuthConfig.ts
+++ b/packages/dashboard/src/features/auth/hooks/useOAuthConfig.ts
@@ -25,24 +25,17 @@ export function useOAuthConfig(selectedProvider?: OAuthProvidersSchema | null) {
     queryFn: () => oAuthConfigService.getAllConfigs(),
   });
 
-  const shouldFetchProviderConfig =
-    !!selectedProvider &&
-    (configs?.data?.some((config) => config.provider === selectedProvider) ?? false);
-
   // Query to fetch specific provider config
   const {
-    data: fetchedProviderConfig,
+    data: providerConfig,
     isLoading: isLoadingProvider,
-    error: fetchedProviderError,
+    error: providerError,
     refetch: refetchProvider,
   } = useQuery<OAuthConfigSchema & { clientSecret?: string }>({
     queryKey: ['oauth-config', selectedProvider],
     queryFn: () => oAuthConfigService.getConfigByProvider(selectedProvider ?? ''),
-    enabled: shouldFetchProviderConfig,
+    enabled: !!selectedProvider,
   });
-
-  const providerConfig = shouldFetchProviderConfig ? fetchedProviderConfig : undefined;
-  const providerError = shouldFetchProviderConfig ? fetchedProviderError : null;
 
   // Mutation to create OAuth configuration
   const createConfigMutation = useMutation({

--- a/packages/dashboard/src/features/auth/hooks/useOAuthConfig.ts
+++ b/packages/dashboard/src/features/auth/hooks/useOAuthConfig.ts
@@ -25,17 +25,24 @@ export function useOAuthConfig(selectedProvider?: OAuthProvidersSchema | null) {
     queryFn: () => oAuthConfigService.getAllConfigs(),
   });
 
+  const shouldFetchProviderConfig =
+    !!selectedProvider &&
+    (configs?.data?.some((config) => config.provider === selectedProvider) ?? false);
+
   // Query to fetch specific provider config
   const {
-    data: providerConfig,
+    data: fetchedProviderConfig,
     isLoading: isLoadingProvider,
-    error: providerError,
+    error: fetchedProviderError,
     refetch: refetchProvider,
   } = useQuery<OAuthConfigSchema & { clientSecret?: string }>({
     queryKey: ['oauth-config', selectedProvider],
     queryFn: () => oAuthConfigService.getConfigByProvider(selectedProvider ?? ''),
-    enabled: !!selectedProvider,
+    enabled: shouldFetchProviderConfig,
   });
+
+  const providerConfig = shouldFetchProviderConfig ? fetchedProviderConfig : undefined;
+  const providerError = shouldFetchProviderConfig ? fetchedProviderError : null;
 
   // Mutation to create OAuth configuration
   const createConfigMutation = useMutation({

--- a/packages/dashboard/src/features/auth/pages/AuthMethodsPage.tsx
+++ b/packages/dashboard/src/features/auth/pages/AuthMethodsPage.tsx
@@ -1,6 +1,10 @@
 import { useState, useCallback, useMemo } from 'react';
 import { MoreHorizontal, Plus, Trash2, Pencil, Mail, ChevronDown, KeyRound } from 'lucide-react';
-import { OAuthConfigDialog, CustomOAuthConfigDialog } from '#features/auth/components';
+import {
+  OAuthConfigDialog,
+  CustomOAuthConfigDialog,
+  type OAuthDialogMode,
+} from '#features/auth/components';
 import { useOAuthConfig } from '#features/auth/hooks/useOAuthConfig';
 import { useCustomOAuthConfig } from '#features/auth/hooks/useCustomOAuthConfig';
 import { useConfirm } from '#lib/hooks/useConfirm';
@@ -16,8 +20,6 @@ import {
 } from '@insforge/ui';
 import type { OAuthProvidersSchema, CustomOAuthConfigSchema } from '@insforge/shared-schemas';
 import { oauthProviders, type OAuthProviderInfo } from '#features/auth/helpers';
-
-type OAuthDialogMode = 'create' | 'edit';
 
 export default function AuthMethodsPage() {
   const [selectedProvider, setSelectedProvider] = useState<OAuthProviderInfo>();

--- a/packages/dashboard/src/features/auth/pages/AuthMethodsPage.tsx
+++ b/packages/dashboard/src/features/auth/pages/AuthMethodsPage.tsx
@@ -17,8 +17,11 @@ import {
 import type { OAuthProvidersSchema, CustomOAuthConfigSchema } from '@insforge/shared-schemas';
 import { oauthProviders, type OAuthProviderInfo } from '#features/auth/helpers';
 
+type OAuthDialogMode = 'create' | 'edit';
+
 export default function AuthMethodsPage() {
   const [selectedProvider, setSelectedProvider] = useState<OAuthProviderInfo>();
+  const [oauthDialogMode, setOAuthDialogMode] = useState<OAuthDialogMode>('create');
   const [selectedCustomProvider, setSelectedCustomProvider] = useState<CustomOAuthConfigSchema>();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isCustomDialogOpen, setIsCustomDialogOpen] = useState(false);
@@ -37,8 +40,9 @@ export default function AuthMethodsPage() {
     refetchConfigs: refetchCustomConfigs,
   } = useCustomOAuthConfig();
 
-  const handleConfigureProvider = (provider: OAuthProviderInfo) => {
+  const handleConfigureProvider = (provider: OAuthProviderInfo, mode: OAuthDialogMode) => {
     setSelectedProvider(provider);
+    setOAuthDialogMode(mode);
     setIsDialogOpen(true);
   };
 
@@ -73,6 +77,7 @@ export default function AuthMethodsPage() {
   const handleCloseDialog = () => {
     setIsDialogOpen(false);
     setSelectedProvider(undefined);
+    setOAuthDialogMode('create');
   };
 
   const handleOpenCustomDialog = (config?: CustomOAuthConfigSchema) => {
@@ -140,7 +145,7 @@ export default function AuthMethodsPage() {
                 {availableProviders.map((provider) => (
                   <DropdownMenuItem
                     key={provider.id}
-                    onClick={() => handleConfigureProvider(provider)}
+                    onClick={() => handleConfigureProvider(provider, 'create')}
                     className="cursor-pointer gap-1 px-1.5 py-1.5"
                   >
                     <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -227,7 +232,7 @@ export default function AuthMethodsPage() {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-40 p-1.5">
                     <DropdownMenuItem
-                      onClick={() => handleConfigureProvider(provider)}
+                      onClick={() => handleConfigureProvider(provider, 'edit')}
                       className="cursor-pointer gap-2"
                     >
                       <Pencil className="h-5 w-5" />
@@ -299,6 +304,7 @@ export default function AuthMethodsPage() {
 
       <OAuthConfigDialog
         provider={selectedProvider}
+        mode={oauthDialogMode}
         isOpen={isDialogOpen}
         onClose={handleCloseDialog}
         onSuccess={handleSuccess}


### PR DESCRIPTION
## Summary

Fix a loading state bug in dashboard add Oauth dialog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth configuration dialog now supports distinct "create" and "edit" modes: creating a new provider starts with a reset/blank form while editing preloads the existing provider.
  * Edit mode requires an existing configuration and disables saving until changes are made.
  * Provider actions in the UI now open the dialog in the appropriate mode (create or edit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->