### PR TITLE
fix(smtp): save Custom SMTP settings when disabling

### DIFF
--- a/backend/src/services/email/smtp-config.service.ts
+++ b/backend/src/services/email/smtp-config.service.ts
@@ -227,11 +227,12 @@ export class SmtpConfigService {
         passwordEncrypted = EncryptionManager.encrypt(input.password);
       }
 
-      if (input.host) {
-        await this.validateSmtpHost(input.host, input.port);
-      }
-
+      // Only validate host/port when enabling — when disabling, the user is
+      // turning SMTP off and the values aren't going to be used.
       if (input.enabled) {
+        if (input.host) {
+          await this.validateSmtpHost(input.host, input.port);
+        }
         await this.verifySmtpConnection(input, existingRow.password_encrypted);
       }
 

--- a/backend/tests/unit/smtp-schemas.test.ts
+++ b/backend/tests/unit/smtp-schemas.test.ts
@@ -118,6 +118,27 @@ describe('SMTP Config Request Schema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts disabled config with empty connection fields', () => {
+    // Regression: disabling custom SMTP should not require filling in host/username/etc.
+    const result = upsertSmtpConfigRequestSchema.safeParse({
+      enabled: false,
+      host: '',
+      port: 587,
+      username: '',
+      senderEmail: '',
+      senderName: '',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts disabled config with only enabled and port', () => {
+    const result = upsertSmtpConfigRequestSchema.safeParse({
+      enabled: false,
+      port: 587,
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('Email Template Request Schema', () => {

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -370,18 +370,54 @@ export const getPublicAuthConfigResponseSchema = z.object({
 /**
  * PUT /api/auth/smtp-config - Upsert SMTP configuration
  */
-export const upsertSmtpConfigRequestSchema = z.object({
-  enabled: z.boolean(),
-  host: z.string().min(1, 'SMTP host is required'),
-  port: z.union([z.literal(25), z.literal(465), z.literal(587), z.literal(2525)], {
-    errorMap: () => ({ message: 'Port must be one of: 25, 465, 587, 2525' }),
-  }),
-  username: z.string().min(1, 'SMTP username is required'),
-  password: z.string().min(1, 'SMTP password is required').optional(),
-  senderEmail: z.string().email('Invalid sender email'),
-  senderName: z.string().min(1, 'Sender name is required'),
-  minIntervalSeconds: z.number().int().min(0).default(60),
-});
+export const upsertSmtpConfigRequestSchema = z
+  .object({
+    enabled: z.boolean(),
+    host: z.string().default(''),
+    port: z.union([z.literal(25), z.literal(465), z.literal(587), z.literal(2525)], {
+      errorMap: () => ({ message: 'Port must be one of: 25, 465, 587, 2525' }),
+    }),
+    username: z.string().default(''),
+    password: z.string().min(1, 'SMTP password is required').optional(),
+    senderEmail: z.string().default(''),
+    senderName: z.string().default(''),
+    minIntervalSeconds: z.number().int().min(0).default(60),
+  })
+  .superRefine((data, ctx) => {
+    // When disabling custom SMTP, allow saving without filling in connection fields —
+    // the user is opting out, so those values are irrelevant.
+    if (!data.enabled) {
+      return;
+    }
+    if (data.host.length < 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['host'],
+        message: 'SMTP host is required',
+      });
+    }
+    if (data.username.length < 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['username'],
+        message: 'SMTP username is required',
+      });
+    }
+    if (!z.string().email().safeParse(data.senderEmail).success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['senderEmail'],
+        message: 'Invalid sender email',
+      });
+    }
+    if (data.senderName.length < 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['senderName'],
+        message: 'Sender name is required',
+      });
+    }
+  });
 
 /**
  * Response for GET /api/auth/smtp-config


### PR DESCRIPTION
## Summary

Fixes the bug where **clicking Save changes on Authentication → Custom SMTP after toggling Enable Custom SMTP off does nothing** — the toggle stays on after refresh and the row in `email.config` keeps `enabled = true`.

Two root causes, both gated behind `enabled === true` after this PR:

1. **Schema (`packages/shared-schemas/src/auth-api.schema.ts`)** — `upsertSmtpConfigRequestSchema` required `host`, `username`, `senderEmail`, and `senderName` to be non-empty unconditionally. When the toggle is off those fields are hidden, so any field-level error (e.g. invalid `senderEmail`) fails react-hook-form's `handleSubmit` silently — the Save button looks broken. Now those checks live inside a `superRefine` that early-returns when `enabled` is `false`.

2. **Backend (`backend/src/services/email/smtp-config.service.ts`)** — `validateSmtpHost` (DNS resolution + SSRF blocklist) and `verifySmtpConnection` ran even when the request payload had `enabled: false`. A flaky DNS lookup or a saved host whose A records moved into a private range would 400 the disable request. Both now only run when `enabled === true`.

Disable behavior is preserved (no DELETE): the row keeps host / username / sender / encrypted password — re-enabling later restores them without re-entry.

## Test plan

- [x] `npx vitest run tests/unit/smtp-schemas.test.ts` — 18 pass (added 2 regression tests covering disabled-with-empty-fields and disabled-minimal-payload)
- [x] `npx vitest run tests/unit/smtp-link-validation.test.ts` — still green
- [ ] Manual: Auth → Custom SMTP → toggle off → Save changes → refresh → toggle stays off, Email Templates copy flips to "Enable custom SMTP above to customize email templates"
- [ ] Manual: Toggle off → Save → toggle back on → connection fields are still populated from the saved config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Streamlined SMTP configuration validation to occur only when enabling the service, eliminating unnecessary checks during disablement.
  * Enhanced configuration flexibility with sensible default values for optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->