### PR TITLE
feat(metadata): expose auth.allowed_redirect_urls for config-as-code MVP

### DIFF
--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -229,7 +229,7 @@ router.get(
 // GET /api/auth/public-config - Get all public authentication configuration (public endpoint)
 router.get('/public-config', async (_req: Request, res: Response, next: NextFunction) => {
   try {
-    const response: GetPublicAuthConfigResponse = await authService.getMetadata();
+    const response: GetPublicAuthConfigResponse = await authService.getPublicMetadata();
 
     successResponse(res, response);
   } catch (error) {

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -939,18 +939,18 @@ export class AuthService {
       customOAuthConfigService.listConfigs(),
       authConfigService.getAuthConfig(),
     ]);
-    const {
-      id: _id,
-      createdAt: _c,
-      updatedAt: _u,
-      allowedRedirectUrls,
-      ...configFields
-    } = authConfig;
     return {
       oAuthProviders,
       customOAuthProviders: customOAuthConfigs.map((config) => config.key),
-      ...configFields,
-      allowedRedirectUrls: allowedRedirectUrls ?? [],
+      requireEmailVerification: authConfig.requireEmailVerification,
+      passwordMinLength: authConfig.passwordMinLength,
+      requireNumber: authConfig.requireNumber,
+      requireLowercase: authConfig.requireLowercase,
+      requireUppercase: authConfig.requireUppercase,
+      requireSpecialChar: authConfig.requireSpecialChar,
+      verifyEmailMethod: authConfig.verifyEmailMethod,
+      resetPasswordMethod: authConfig.resetPasswordMethod,
+      allowedRedirectUrls: authConfig.allowedRedirectUrls ?? [],
     };
   }
 

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -908,15 +908,25 @@ export class AuthService {
     const authConfigService = AuthConfigService.getInstance();
     const oAuthConfigService = OAuthConfigService.getInstance();
     const customOAuthConfigService = CustomOAuthConfigService.getInstance();
-    const [oAuthProviders, customOAuthConfigs, authConfigs] = await Promise.all([
+    const [oAuthProviders, customOAuthConfigs, authConfig] = await Promise.all([
       oAuthConfigService.getConfiguredProviders(),
       customOAuthConfigService.listConfigs(),
-      authConfigService.getPublicAuthConfig(),
+      // Use the admin-scoped reader so allowedRedirectUrls is included.
+      // The metadata endpoint is already gated behind verifyAdmin.
+      authConfigService.getAuthConfig(),
     ]);
+    const {
+      id: _id,
+      createdAt: _c,
+      updatedAt: _u,
+      allowedRedirectUrls,
+      ...configFields
+    } = authConfig;
     return {
       oAuthProviders,
       customOAuthProviders: customOAuthConfigs.map((config) => config.key),
-      ...authConfigs,
+      ...configFields,
+      allowedRedirectUrls: allowedRedirectUrls ?? [],
     };
   }
 

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -13,6 +13,7 @@ import type {
   CreateAdminSessionResponse,
   AuthMetadataSchema,
   OAuthProvidersSchema,
+  GetPublicAuthConfigResponse,
 } from '@insforge/shared-schemas';
 import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import { CustomOAuthConfigService } from '@/services/auth/custom-oauth-config.service.js';
@@ -904,6 +905,31 @@ export class AuthService {
     }
   }
 
+  /**
+   * Public auth metadata for the unauthenticated /api/auth/public-config route.
+   * Reads via getPublicAuthConfig(), which intentionally omits allowedRedirectUrls
+   * and other admin-only fields.
+   */
+  async getPublicMetadata(): Promise<GetPublicAuthConfigResponse> {
+    const authConfigService = AuthConfigService.getInstance();
+    const oAuthConfigService = OAuthConfigService.getInstance();
+    const customOAuthConfigService = CustomOAuthConfigService.getInstance();
+    const [oAuthProviders, customOAuthConfigs, authConfig] = await Promise.all([
+      oAuthConfigService.getConfiguredProviders(),
+      customOAuthConfigService.listConfigs(),
+      authConfigService.getPublicAuthConfig(),
+    ]);
+    return {
+      oAuthProviders,
+      customOAuthProviders: customOAuthConfigs.map((config) => config.key),
+      ...authConfig,
+    };
+  }
+
+  /**
+   * Admin auth metadata for /api/metadata (gated behind verifyAdmin).
+   * Includes allowedRedirectUrls so the CLI can render insforge.toml.
+   */
   async getMetadata(): Promise<AuthMetadataSchema> {
     const authConfigService = AuthConfigService.getInstance();
     const oAuthConfigService = OAuthConfigService.getInstance();
@@ -911,8 +937,6 @@ export class AuthService {
     const [oAuthProviders, customOAuthConfigs, authConfig] = await Promise.all([
       oAuthConfigService.getConfiguredProviders(),
       customOAuthConfigService.listConfigs(),
-      // Use the admin-scoped reader so allowedRedirectUrls is included.
-      // The metadata endpoint is already gated behind verifyAdmin.
       authConfigService.getAuthConfig(),
     ]);
     const {

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -349,18 +349,33 @@ export const updateAuthConfigRequestSchema = authConfigSchema
 export const getAuthConfigResponseSchema = authConfigSchema;
 
 /**
- * Response for GET /api/auth/public-config - Unified public auth configuration endpoint
- * Combines OAuth providers and email auth configuration
+ * Admin auth response — the full shape including admin-only fields. This is
+ * the canonical source; the public response is derived from this by omitting
+ * sensitive fields below. Re-exported as `authMetadataSchema` from
+ * metadata.schema.ts for the admin-gated /api/metadata route.
+ *
+ * CONVENTION: new admin-only fields land in `authConfigSchema` and appear
+ * here automatically. To expose a field publicly, REMOVE it from the .omit()
+ * call in `getPublicAuthConfigResponseSchema`. This way the safer default
+ * (admin-only) is what you get if you forget to think about it.
  */
-export const getPublicAuthConfigResponseSchema = z.object({
+export const authConfigAdminResponseSchema = z.object({
   oAuthProviders: z.array(oAuthProvidersSchema),
   customOAuthProviders: z.array(customOAuthKeySchema),
   ...authConfigSchema.omit({
     id: true,
     updatedAt: true,
     createdAt: true,
-    allowedRedirectUrls: true,
   }).shape,
+});
+
+/**
+ * Response for GET /api/auth/public-config — admin response minus
+ * admin-only fields. This route is unauthenticated, so anything sensitive
+ * MUST be omitted here.
+ */
+export const getPublicAuthConfigResponseSchema = authConfigAdminResponseSchema.omit({
+  allowedRedirectUrls: true,
 });
 
 // ============================================================================

--- a/packages/shared-schemas/src/metadata.schema.ts
+++ b/packages/shared-schemas/src/metadata.schema.ts
@@ -2,14 +2,13 @@ import { z } from 'zod';
 import { storageBucketSchema } from './storage.schema.js';
 import { realtimeChannelSchema } from './realtime.schema.js';
 import { realtimePermissionsResponseSchema } from './realtime-api.schema.js';
-import { getPublicAuthConfigResponseSchema } from './auth-api.schema.js';
+import { authConfigAdminResponseSchema } from './auth-api.schema.js';
 
-export const authMetadataSchema = getPublicAuthConfigResponseSchema.extend({
-  // Surfaced for config-as-code (insforge.toml) round-tripping.
-  // Hidden from the public auth-config response by design, but admin metadata
-  // — which already requires verifyAdmin — exposes it for the CLI to render.
-  allowedRedirectUrls: z.array(z.string()).default([]),
-});
+// Admin metadata for /api/metadata/auth (gated behind verifyAdmin). Identical
+// shape to the canonical admin auth response — public response in
+// auth-api.schema.ts is derived from the same source by omitting sensitive
+// fields, so they can't drift.
+export const authMetadataSchema = authConfigAdminResponseSchema;
 
 export const databaseMetadataSchema = z.object({
   tables: z.array(

--- a/packages/shared-schemas/src/metadata.schema.ts
+++ b/packages/shared-schemas/src/metadata.schema.ts
@@ -4,7 +4,12 @@ import { realtimeChannelSchema } from './realtime.schema.js';
 import { realtimePermissionsResponseSchema } from './realtime-api.schema.js';
 import { getPublicAuthConfigResponseSchema } from './auth-api.schema.js';
 
-export const authMetadataSchema = getPublicAuthConfigResponseSchema;
+export const authMetadataSchema = getPublicAuthConfigResponseSchema.extend({
+  // Surfaced for config-as-code (insforge.toml) round-tripping.
+  // Hidden from the public auth-config response by design, but admin metadata
+  // — which already requires verifyAdmin — exposes it for the CLI to render.
+  allowedRedirectUrls: z.array(z.string()).default([]),
+});
 
 export const databaseMetadataSchema = z.object({
   tables: z.array(


### PR DESCRIPTION
**Companion to:** `InsForge/CLI` PR (CLI half — three new `insforge config` commands that talk to this metadata endpoint)

## What

Single additive change to `/api/metadata`: include `auth.allowedRedirectUrls` in the response. This is the read source for `insforge config export` (the CLI's first config-as-code command).

## Why

The first piece of the `insforge.toml` MVP. Agents need to read the current redirect URL list to render `insforge.toml` and to compute diffs before applying changes. The public auth-config response intentionally excludes this field, but the metadata endpoint is already gated behind `verifyAdmin`, so it's the right home.

The full design is in `spec-toml-mvp.md` and `proposal-insforge-config-toml.md`. Short version: TOML at repo root holds intent; CLI orchestrates; metadata is the single read source; existing per-service endpoints handle writes. No new server endpoints, no new write paths.

## What this PR does

- Extends `authMetadataSchema` in `@insforge/shared-schemas` with `allowedRedirectUrls: z.array(z.string()).default([])`
- Updates `AuthService.getMetadata()` to read via the admin-scoped `getAuthConfig()` (instead of `getPublicAuthConfig()` which deliberately omits the field), strips `id`/`createdAt`/`updatedAt`, and emits `allowedRedirectUrls` (defaulted to `[]` when null/undefined)
- Type-clean (`npx tsc --noEmit` passes for the auth.service.ts file)

## What this PR does NOT do

- No new endpoints
- No write path changes (`PUT /api/auth/config` already accepts `allowedRedirectUrls` and is what the CLI's `insforge config apply` will use)
- No matrix-fill (SMTP, OAuth providers, deployments, etc. — those are follow-up ships, each ~half a day)

## Test plan

- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Schema rebuild succeeds (`npm run build` in `packages/shared-schemas`)
- [x] Mock backend smoke-test: `GET /api/metadata` returns `auth.allowedRedirectUrls` correctly; CLI's `insforge config export` renders it as TOML; `apply` writes back via `PUT /api/auth/config` and re-export confirms idempotence
- [ ] Live E2E against `docker compose up` instance (deferred — manual; see CLI PR's smoke test for the same loop against a mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `auth.allowedRedirectUrls` in `/api/metadata` for the `insforge.toml` config-as-code MVP. Keep `/api/auth/public-config` unchanged and public-safe.

- **New Features**
  - Introduced canonical `authConfigAdminResponseSchema` in `@insforge/shared-schemas`; `authMetadataSchema` aliases it. Public response is now derived via `.omit({ allowedRedirectUrls })` for safer defaults.
  - `AuthService.getMetadata()` reads via admin `getAuthConfig()` and returns `allowedRedirectUrls` (defaults to `[]` if null/undefined); response fields are built explicitly.

- **Bug Fixes**
  - Split into `getPublicMetadata()` (uses `getPublicAuthConfig()`, no `allowedRedirectUrls`) for `/api/auth/public-config`, and `getMetadata()` for `/api/metadata` gated by `verifyAdmin`; route now calls `getPublicMetadata()` to prevent leaks.

<sup>Written for commit ba23619501a8b04eefe9b777e2cea58ac2a8e360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public auth metadata endpoint now serves a dedicated, non-sensitive auth config (OAuth providers and custom provider keys) for unauthenticated access.

* **Updates**
  * Admin metadata now derives from a full admin auth schema; public responses omit sensitive fields.
  * Admin metadata explicitly includes allowed redirect URLs with a sensible empty-array default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->