### PR TITLE
docs: align Email SDK title

### DIFF
--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -1,5 +1,5 @@
 ---
-title: Emails SDK Reference
+title: Email SDK Reference
 description: Send custom transactional emails with the InsForge SDK
 ---
 


### PR DESCRIPTION
## Summary
- Rename the TypeScript email SDK page title from `Emails SDK Reference` to `Email SDK Reference`
- Align the page title with the docs nav group and the email architecture page

## Verification
- `git diff --check`
- `npx --yes prettier@3.6.2 --check docs/sdks/typescript/email.mdx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the TypeScript Email SDK docs page title to "Email SDK Reference" (from "Emails SDK Reference") to match the docs nav and the email architecture page.

<sup>Written for commit 765ed60898fb548d41b83e8b7f1a7ab0333ff512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the page title in the TypeScript Email SDK Reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->