### PR TITLE
fix(compute): use APP_KEY as Fly network name (short, validator-safe)

### DIFF
--- a/backend/src/providers/compute/cloud.provider.ts
+++ b/backend/src/providers/compute/cloud.provider.ts
@@ -86,11 +86,17 @@ export class CloudComputeProvider implements ComputeProvider {
     return text ? (JSON.parse(text) as T) : undefined;
   }
 
-  async createApp(params: { name: string; network: string; org: string }) {
-    const result = await this.call<{ appId: string; serviceId?: string }>('POST', '/apps', {
-      name: params.name,
-      network: params.network,
-    });
+  async createApp(params: { name: string; network?: string; org: string }) {
+    // Forward `network` only if the caller passed one. We keep it short
+    // (services.service.ts uses APP_KEY, ~8 chars) so Fly's network-name
+    // validator accepts it. Live e2e on prod (project 2163e1eb-…) showed
+    // the previous long `${projectId}-network` (~44 chars) 422'd as
+    // "Name not a valid network name".
+    const body: Record<string, unknown> = { name: params.name };
+    if (params.network !== undefined) {
+      body.network = params.network;
+    }
+    const result = await this.call<{ appId: string; serviceId?: string }>('POST', '/apps', body);
     return { appId: result?.appId ?? params.name };
   }
 

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -130,8 +130,15 @@ function makeFlyAppName(name: string, projectId: string): string {
   return `${truncated}-${hash}${suffix}`;
 }
 
-function makeNetwork(projectId: string): string {
-  return `${projectId}-network`;
+// Network name is sent on Fly POST /apps. Fly validates network names more
+// strictly than app names (varies by org — prod's Fly org rejected the old
+// `${projectId}-network` (~44 chars) with 422 "Name not a valid network
+// name"). APP_KEY is the project's short DNS-safe slug (~8 chars, e.g.
+// `d9byq46t`), unique per project, already used as the OSS hostname prefix.
+// Using it as the network name keeps per-project 6PN isolation AND stays
+// well under Fly's network-name validator length cap on every org.
+function makeNetwork(): string {
+  return process.env.APP_KEY || 'default-app-key';
 }
 
 // Default to Fly's own .fly.dev hostname (which Fly routes automatically for
@@ -334,7 +341,7 @@ export class ComputeServicesService {
     const row: ServiceRow = insertResult.rows[0];
     const serviceId = row.id;
     const flyAppName = makeFlyAppName(input.name, input.projectId);
-    const network = makeNetwork(input.projectId);
+    const network = makeNetwork();
     const endpointUrl = makeEndpointUrl(flyAppName);
 
     let flyMachineId: string | undefined;
@@ -414,7 +421,7 @@ export class ComputeServicesService {
       : null;
 
     const flyAppName = makeFlyAppName(input.name, input.projectId);
-    const network = makeNetwork(input.projectId);
+    const network = makeNetwork();
     const endpointUrl = makeEndpointUrl(flyAppName);
 
     // Insert row — check for duplicate name before calling Fly APIs

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -138,7 +138,14 @@ function makeFlyAppName(name: string, projectId: string): string {
 // Using it as the network name keeps per-project 6PN isolation AND stays
 // well under Fly's network-name validator length cap on every org.
 function makeNetwork(): string {
-  return process.env.APP_KEY || 'default-app-key';
+  if (!process.env.APP_KEY) {
+    throw new AppError(
+      'APP_KEY environment variable is required for compute network isolation',
+      500,
+      ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
+    );
+  }
+  return process.env.APP_KEY;
 }
 
 // Default to Fly's own .fly.dev hostname (which Fly routes automatically for

--- a/backend/tests/unit/compute/cloud-provider.test.ts
+++ b/backend/tests/unit/compute/cloud-provider.test.ts
@@ -41,6 +41,47 @@ describe('CloudComputeProvider', () => {
     expect(result.appId).toBe('ifc-proj-test');
   });
 
+  // Regression: live e2e on prod (project 2163e1eb-...) showed Fly 422
+  // "Validation failed: Name not a valid network name" because the caller
+  // (services.service.ts) used to pass `${projectId}-network` (~44 chars)
+  // which exceeded Fly's network-name validator on stricter orgs. The
+  // service now uses APP_KEY (~8 chars) — these tests pin the wire format.
+  it('createApp forwards network when caller passes a (short) value', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ appId: 'ifc-proj-test' }),
+    } as Response);
+
+    const provider = CloudComputeProvider.getInstance();
+    await provider.createApp({
+      name: 'test',
+      network: 'd9byq46t',
+      org: 'unused-in-cloud-mode',
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const sentBody = JSON.parse((call[1] as RequestInit).body as string);
+    expect(sentBody).toEqual({ name: 'test', network: 'd9byq46t' });
+  });
+
+  it('createApp omits network field when caller does not pass one', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ appId: 'ifc-proj-test' }),
+    } as Response);
+
+    const provider = CloudComputeProvider.getInstance();
+    await provider.createApp({
+      name: 'test',
+      org: 'unused-in-cloud-mode',
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const sentBody = JSON.parse((call[1] as RequestInit).body as string);
+    expect(sentBody).toEqual({ name: 'test' });
+    expect('network' in sentBody).toBe(false);
+  });
+
   it('throws COMPUTE_CLOUD_UNAVAILABLE on network error', async () => {
     fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
     const provider = CloudComputeProvider.getInstance();

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -79,6 +79,7 @@ describe('ComputeServicesService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.APP_KEY = 'testkey1';
     service = ComputeServicesService.getInstance();
     mockIsConfigured.mockReturnValue(true);
   });
@@ -159,7 +160,7 @@ describe('ComputeServicesService', () => {
       // Verify Fly calls
       expect(mockCreateApp).toHaveBeenCalledWith({
         name: 'my-api-proj-123',
-        network: 'proj-123-network',
+        network: 'testkey1',
         org: 'test-org',
       });
       expect(mockLaunchMachine).toHaveBeenCalledWith(
@@ -530,7 +531,7 @@ describe('ComputeServicesService', () => {
       // Verify Fly app created
       expect(mockCreateApp).toHaveBeenCalledWith({
         name: 'my-api-proj-123',
-        network: 'proj-123-network',
+        network: 'testkey1',
         org: 'test-org',
       });
 


### PR DESCRIPTION
## Summary

Compute service creation fails on main with Fly 422 *"Validation failed: Name not a valid network name"* whenever the project UUID starts with a digit (≈63% of UUIDs) or is on a Fly org with a stricter network-name length cap.

Reported on project `6ba14416-352c-49ca-b495-6689112fa18c` — every service-name attempt 422s because the OSS backend builds the network name as `\${projectId}-network` (~44 chars, starts with `6`).

This is **not a new fix** — it's a cherry-pick of `b9df6a2` (originally PR #1171) which already shipped the fix to the `feat/compute-services-pr1062` working branch on 2026-04-29 but was never opened back against `main`. So main has been carrying the bug for ~8 days.

## What changed

- `backend/src/services/compute/services.service.ts` — `makeNetwork()` now returns `process.env.APP_KEY` (the project's existing short DNS-safe slug, ~8 chars) instead of `\${projectId}-network`. Passes Fly's network-name validator on every org while preserving per-project 6PN isolation.
- `backend/src/providers/compute/cloud.provider.ts` — only forward `network` when set, matching cloud-backend's omit-when-undefined contract (companion fix from the same commit).
- Tests updated: `services-service.test.ts` expects APP_KEY; `cloud-provider.test.ts` adds regression coverage for forward + omit paths.
- Self-host `FlyProvider` is unchanged.

Original commit message documents live e2e on prod project `2163e1eb-…`:
- Direct cloud-backend call (no network) → 201
- OSS proxy call → 422 *"Name not a valid network name"*

## Test plan

- [ ] CI: `backend/tests/unit/compute/cloud-provider.test.ts` and `services-service.test.ts` green
- [ ] Self-hosted: create a compute service on a project whose UUID starts with a digit (e.g. the reporter's `6ba14416-…`) — should return 201
- [ ] Cloud-managed: same, with the cloud provider path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compute service creation failures by using the short `APP_KEY` as the Fly network name and only sending `network` when provided. Adds validation to throw a clear error when `APP_KEY` is missing, preventing Fly 422 “Name not a valid network name” on stricter orgs and projects with UUIDs starting with a digit.

- **Bug Fixes**
  - `services.service.ts`: `makeNetwork()` now reads `process.env.APP_KEY` and throws `AppError` (`ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED`) if unset; callers updated to use `makeNetwork()`.
  - `cloud.provider.ts`: `createApp` accepts optional `network` and omits it when undefined to match cloud-backend behavior.
  - Tests: Set `APP_KEY` in setup, expect `APP_KEY` in calls, and add coverage for forwarding vs. omitting `network`.

<sup>Written for commit 7786f498d9e80aa241abce54962383b1e660738e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App creation no longer sends a network value unless explicitly provided.
  * Deployment network name is now derived from an environment key for consistent naming.

* **Tests**
  * Added tests to verify the network field is present only when supplied.
  * Updated tests to expect environment-derived network naming in deployment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->