### PR TITLE
fix(readme): use bare URL so GitHub renders the demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@
 ## InsForge
 The all-in-one, open-source backend platform for agentic coding. InsForge gives your coding agent database, auth, storage, compute, hosting, and AI gateway to ship full-stack apps end-to-end.
 
-<p align="center">
-  <video width="100%" src="https://github.com/user-attachments/assets/345efbc6-ca63-4189-bde0-12ef3bda561b" controls></video>
-</p>
+https://github.com/user-attachments/assets/345efbc6-ca63-4189-bde0-12ef3bda561b
 
 ### How it works
 


### PR DESCRIPTION
## Summary
- The README demo clip wasn't rendering because GitHub's markdown sanitizer strips `<video>` tags from README files.
- Replaced the HTML `<video>` element with a standalone `user-attachments/assets/...` URL, which GitHub auto-embeds as a native video player.

## Test plan
- [ ] View the rendered README on the PR page and confirm the demo video plays inline.
- [ ] Confirm no other README sections were affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the README demo video by replacing the sanitized `<video>` tag with a bare GitHub user-attachments URL so GitHub auto-embeds the player. The demo now plays inline on the README page.

<sup>Written for commit d5c9e4de09df4e1b85a364554d53eebbae6e3bcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README's media section with a new asset link for the hero media content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->