### PR TITLE
fix(compute): prepend `n-` to Fly network name (digit-leading APP_KEYs)

### DIFF
--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -130,13 +130,13 @@ function makeFlyAppName(name: string, projectId: string): string {
   return `${truncated}-${hash}${suffix}`;
 }
 
-// Network name is sent on Fly POST /apps. Fly validates network names more
-// strictly than app names (varies by org — prod's Fly org rejected the old
-// `${projectId}-network` (~44 chars) with 422 "Name not a valid network
-// name"). APP_KEY is the project's short DNS-safe slug (~8 chars, e.g.
-// `d9byq46t`), unique per project, already used as the OSS hostname prefix.
-// Using it as the network name keeps per-project 6PN isolation AND stays
-// well under Fly's network-name validator length cap on every org.
+// Network name is sent on Fly POST /apps. Fly's documented rule: "Network
+// names can have letters, numbers, and dashes, but must start with a letter."
+// The old `${projectId}-network` failed for the ~63% of projects whose UUID
+// begins with a hex digit; using bare APP_KEY still failed for the ~30% of
+// keys generateAppKey() produces digit-leading. The static `n-` prefix
+// guarantees a letter-leading name for every project, and APP_KEY's
+// per-project uniqueness still preserves 6PN isolation.
 function makeNetwork(): string {
   if (!process.env.APP_KEY) {
     throw new AppError(
@@ -145,7 +145,7 @@ function makeNetwork(): string {
       ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
     );
   }
-  return process.env.APP_KEY;
+  return `n-${process.env.APP_KEY}`;
 }
 
 // Default to Fly's own .fly.dev hostname (which Fly routes automatically for

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -160,7 +160,7 @@ describe('ComputeServicesService', () => {
       // Verify Fly calls
       expect(mockCreateApp).toHaveBeenCalledWith({
         name: 'my-api-proj-123',
-        network: 'testkey1',
+        network: 'n-testkey1',
         org: 'test-org',
       });
       expect(mockLaunchMachine).toHaveBeenCalledWith(
@@ -531,7 +531,7 @@ describe('ComputeServicesService', () => {
       // Verify Fly app created
       expect(mockCreateApp).toHaveBeenCalledWith({
         name: 'my-api-proj-123',
-        network: 'testkey1',
+        network: 'n-testkey1',
         org: 'test-org',
       });
 


### PR DESCRIPTION
## Summary

Follow-up to #1224. After that PR set the Fly network to bare `process.env.APP_KEY`, projects whose APP_KEY starts with a digit (~30% of `generateAppKey()` output) still get **422 Validation failed: Name not a valid network name**.

## Why ~30%

`generateAppKey()` uses the charset `abcdefghijkmnpqrstuvwxyz23456789` (24 letters + 8 digits), guarantees ≥1 letter and ≥1 digit, then Fisher-Yates shuffles. After shuffling, the first character is a digit roughly 3/8 of the time — e.g. `8mlfa9q2`. Fly's [documented rule](https://fly.io/docs/networking/custom-private-networks/) is unambiguous: *"Network names can have letters, numbers, and dashes, but must start with a letter."*

## Fix

Always prepend the static `n-` prefix in `makeNetwork()`:

```ts
return `n-${process.env.APP_KEY}`;
```

- Letter-leading for every project, no conditional, no surprises.
- Result is ~10 chars total, well under any Fly limit.
- APP_KEY's per-project uniqueness still preserves 6PN isolation.

## Tradeoff worth noting

Projects that already created a Fly app on bare `${APP_KEY}` between #1224 merging and this fix landing will, on their **next** compute service, land on a different network (`n-${APP_KEY}` vs `${APP_KEY}`). Existing apps stay healthy, but old + new apps in the same project can't reach each other over 6PN. With the current 1-app-per-project pattern this is invisible; multi-app projects on bare-APP_KEY networks would need recreation.

## Test plan

- [x] Existing `services-service.test.ts` updated — both `network: 'testkey1'` assertions → `network: 'n-testkey1'`. All 31 tests green locally.
- [ ] Live e2e on a project with digit-leading APP_KEY — verify Fly POST /apps now 201s.
- [ ] Spot-check a project with letter-leading APP_KEY — verify Fly accepts `n-<key>` (it should; the prefix is universally valid).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced network naming convention for compute service and app creation to ensure identifiers follow proper naming standards, preventing potential creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->