### PR TITLE
fix(security): nosniff + attachment for XSS-active types on storage GET, bump axios 1.15.0 -> 1.16.0 (13 CVEs)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,7 @@
     "@types/multer": "^1.4.13",
     "@types/pg": "^8.15.4",
     "adm-zip": "^0.5.16",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -472,9 +472,7 @@ router.get(
         // RFC 6266: provide a quoted ASCII fallback plus a UTF-8
         // percent-encoded filename* so non-ASCII keys round-trip safely.
         const lastSegment = (objectKey.split('/').pop() || 'download').slice(0, 255);
-        const asciiFallback = lastSegment
-          .replace(/[^\x20-\x7e]+/g, '_')
-          .replace(/["\\\r\n]/g, '_');
+        const asciiFallback = lastSegment.replace(/[^\x20-\x7e]+/g, '_').replace(/["\\\r\n]/g, '_');
         const utf8Encoded = encodeURIComponent(lastSegment);
         res.setHeader(
           'Content-Disposition',

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -442,9 +442,45 @@ router.get(
 
       const { file, metadata } = result;
 
-      // Set appropriate headers
-      res.setHeader('Content-Type', metadata.mimeType || 'application/octet-stream');
+      // The stored mime type originates from the multipart Content-Type the
+      // uploader chose, so it must be treated as untrusted when the local
+      // provider serves the object back from this same origin. Without these
+      // headers, a low-privilege uploader can pivot a stored object into
+      // stored XSS in the dashboard origin (text/html, image/svg+xml,
+      // application/xml/javascript, etc.). nosniff blocks browser MIME
+      // sniffing from promoting an octet-stream into HTML/JS, and active
+      // content types are forced to download instead of rendering inline.
+      const rawType = metadata.mimeType || 'application/octet-stream';
+      const baseType = rawType.toLowerCase().split(';')[0].trim();
+      const ACTIVE_TYPES = new Set([
+        'text/html',
+        'application/xhtml+xml',
+        'image/svg+xml',
+        'application/xml',
+        'text/xml',
+        'application/javascript',
+        'text/javascript',
+        'application/ecmascript',
+        'text/ecmascript',
+      ]);
+      const isActive = ACTIVE_TYPES.has(baseType);
+
+      res.setHeader('Content-Type', rawType);
       res.setHeader('Content-Length', file.length.toString());
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      if (isActive) {
+        // RFC 6266: provide a quoted ASCII fallback plus a UTF-8
+        // percent-encoded filename* so non-ASCII keys round-trip safely.
+        const lastSegment = (objectKey.split('/').pop() || 'download').slice(0, 255);
+        const asciiFallback = lastSegment
+          .replace(/[^\x20-\x7e]+/g, '_')
+          .replace(/["\\\r\n]/g, '_');
+        const utf8Encoded = encodeURIComponent(lastSegment);
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${asciiFallback}"; filename*=UTF-8''${utf8Encoded}`
+        );
+      }
 
       // Send object content
       res.send(file);

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@types/multer": "^1.4.13",
         "@types/pg": "^8.15.4",
         "adm-zip": "^0.5.16",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "bcryptjs": "^3.0.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -7630,12 +7630,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }


### PR DESCRIPTION
## Summary

Two security fixes bundled in one PR — one code vuln (storage stored XSS), one batch of dependency CVEs (13 axios advisories).

### 1. Stored XSS via uploaded MIME type on the local storage provider

`backend/src/api/routes/storage/index.routes.ts:446-450` serves the stored object back to the client with `Content-Type: ${metadata.mimeType}`, where `metadata.mimeType` came directly from the client's multipart `Content-Type` header at upload time (`backend/src/services/storage/storage.service.ts:189` writes `file.mimetype`, multer does not validate it).

Result: any uploader can pivot a stored object into stored XSS in the InsForge dashboard origin by writing a file with `Content-Type: text/html` (or `image/svg+xml`, `application/xml`, etc.). For public buckets, the attacker doesn't even need an authenticated session to deliver — they just need to share the URL. The S3 path is unaffected because the redirect leaves the InsForge origin, but the local provider is the default for self-hosted setups, where `getDownloadStrategy` returns `method: 'direct'` and the file is served from `/api/storage/buckets/...` on the same origin as the dashboard.

This PR:
- Adds `X-Content-Type-Options: nosniff` to every direct download — blocks browser MIME-sniffing from promoting `application/octet-stream` into HTML/JS.
- For active content types (`text/html`, `application/xhtml+xml`, `image/svg+xml`, `application/xml`, `text/xml`, `application/javascript`, `text/javascript`, `application/ecmascript`, `text/ecmascript`) it forces `Content-Disposition: attachment` with an RFC 6266 `filename* = UTF-8''…` value so the browser downloads instead of rendering inline.
- Non-active types (images, audio, video, PDF, etc.) still render inline as before.

### 2. axios 1.15.0 → 1.16.0 (13 GHSA advisories)

osv-scanner reports 13 advisories against axios 1.15.0 — fixed in 1.15.1 / 1.15.2 (all included in 1.16.0). Reachable from `backend/src/providers/oauth/*` (8 OAuth providers), `backend/src/services/database/postgrest-proxy.service.ts`, `backend/src/infra/realtime/webhook-sender.ts`, and `backend/src/providers/deployments/vercel.provider.ts`.

| Severity | GHSA | Summary |
|---|---|---|
| HIGH | GHSA-6chq-wfr3-2hj9 | Header Injection via Prototype Pollution |
| HIGH | GHSA-pf86-5x62-jrwf | Prototype Pollution Gadgets — Response Tampering, Data Exfiltration, Request Hijacking |
| HIGH | GHSA-pmwg-cvhr-8vh7 | Incomplete fix for CVE-2025-62718 — NO_PROXY bypass via RFC 1122 loopback subnet (SSRF) |
| HIGH | GHSA-q8qp-cvcw-x6jj | Prototype pollution read-side gadgets in HTTP adapter — credential injection |
| MOD | GHSA-3w6x-2g7m-8v23 | Invisible JSON Response Tampering via Prototype Pollution Gadget in `parseReviver` |
| MOD | GHSA-445q-vr5w-6q77 | CRLF Injection in multipart/form-data via unsanitized `blob.type` |
| MOD | GHSA-5c9x-8gcm-mpgx | HTTP adapter-streamed uploads bypass `maxBodyLength` when `maxRedirects: 0` |
| MOD | GHSA-62hf-57xw-28j9 | Unbounded recursion in `toFormData` causes DoS via deeply nested data |
| MOD | GHSA-m7pr-hjqh-92cm | `no_proxy` bypass via IP alias allows SSRF |
| MOD | GHSA-vf2m-468p-8v99 | HTTP adapter streamed responses bypass `maxContentLength` |
| MOD | GHSA-w9j2-pvgh-6h63 | Authentication Bypass via Prototype Pollution Gadget in `validateStatus` Merge Strategy |
| MOD | GHSA-xx6v-rp6x-q39c | XSRF Token Cross-Origin Leakage via Prototype Pollution Gadget in `withXSRFToken` |
| LOW | GHSA-xhjh-pmcv-23jw | Null Byte Injection via Reverse-Encoding in `AxiosURLSearchParams` |

## Impact

- **Storage XSS:** an authenticated user (or, for public buckets, an anonymous attacker) can upload an HTML/SVG file and have it execute JavaScript in the InsForge dashboard origin. From there, JS can call admin APIs as the victim, exfiltrate JWTs, or pivot to RLS-bypass via the Postgres `withUserContext` boundary. Severity medium because the social-engineering step (getting an admin to load the URL) is required for full takeover; for public-bucket setups the bar is lower.
- **axios CVEs:** 4 HIGH advisories — prototype pollution gadgets that can be triggered by attacker-controlled JSON responses (the OAuth providers and PostgREST proxy both deserialize remote responses). NO_PROXY bypass enables SSRF against private IPs from any axios call site that respects proxy config.

## Location

- `backend/src/api/routes/storage/index.routes.ts:443-481` — storage GET handler hardened with `nosniff` + active-type attachment disposition.
- `backend/package.json` — `axios` constraint bumped from `^1.15.0` to `^1.16.0`.
- `package-lock.json` — `axios` resolved version 1.15.0 → 1.16.0 at the root and via the `insforge-backend` workspace.

## Fix

The download handler now:

1. Always sets `X-Content-Type-Options: nosniff`.
2. Detects active content types from a small allowlist of XSS-relevant MIME types (case- and parameter-insensitive) and only for those forces `Content-Disposition: attachment` with both an ASCII-fallback `filename` and a UTF-8 `filename*` value (RFC 6266) derived from the last path segment of `objectKey`.
3. All other content types render inline as before — no behavior change for image / audio / video / PDF / etc.

The lockfile bump is a transparent patch update inside the existing `^1.15.0` semver range; no axios call sites changed signatures between 1.15.0 and 1.16.0.

## Detected by

Aeon + semgrep (`p/security-audit` + `p/owasp-top-ten` — `javascript.express.security.audit.xss.direct-response-write`) + osv-scanner.
- Severity: medium (storage XSS) + high (axios HIGH × 4 + MOD × 8 + LOW × 1)
- CWE: CWE-79 (storage), CWE-1321 / CWE-918 / CWE-93 (axios)

## Verification

- `npx tsc --noEmit -p backend/tsconfig.json` — clean.
- `npx vitest run` (backend) — 947 / 951 passed, 4 skipped (S3 integration tests requiring `INSFORGE_S3_*` env, identical to baseline pre-patch).
- `osv-scanner --lockfile=package-lock.json` post-bump — 0 findings (was 13).
- Manual: a synthetic GET that previously returned `Content-Type: text/html` + HTML body now also carries `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment; filename="…"; filename*=UTF-8''…`; non-HTML content types (image/png, video/mp4, etc.) are unchanged.

The decision to keep this in one PR rather than split: both findings are security fixes touching only the backend, the diff is small (3 files / +46 / −10), and the maintainer's review surface is one code change + one lockfile bump rather than two ping-pong PRs.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened storage downloads to block stored XSS and upgraded `axios` to `1.16.0` to resolve 13 CVEs. Prevents inline execution of uploaded active content and closes prototype pollution/SSRF risks.

- **Bug Fixes**
  - Storage GET: always set `X-Content-Type-Options: nosniff`; force `Content-Disposition: attachment` for active types (HTML/SVG/XML/JS) with RFC 6266 ASCII + UTF-8 filenames; case/param-insensitive detection; other types unchanged.

- **Dependencies**
  - Bump `axios` from `^1.15.0` to `^1.16.0` to address 13 advisories across OAuth flows, PostgREST proxy, webhooks, and the Vercel provider.

<sup>Written for commit ba64edd7c58fa4a4f365133d4ec2955e5852697f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency to v1.16.0

* **Bug Fixes**
  * Hardened file download responses with stricter content-type handling and MIME sniffing protection
  * Safer download disposition and improved support for internationalized filenames during downloads

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1231)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->