### PR TITLE
fix: repair the broken & compressed 'Create Table' button

### DIFF
--- a/packages/dashboard/src/features/database/components/TablesEmptyState.tsx
+++ b/packages/dashboard/src/features/database/components/TablesEmptyState.tsx
@@ -18,9 +18,9 @@ export function TablesEmptyState({
     <div className="flex h-full w-full justify-center overflow-y-auto bg-[rgb(var(--semantic-1))]">
       <div className="mx-auto flex w-full max-w-[1024px] flex-col gap-6 px-4 pb-10 pt-8 sm:px-6 sm:pt-10 lg:px-10">
         <h2 className="text-2xl font-medium leading-8 text-foreground">Create Your First Table</h2>
-        <Button className="h-8 w-fit gap-0 rounded px-1.5" onClick={onCreateTable}>
+        <Button className="h-9 min-h-9 w-fit gap-1 rounded px-3 py-2" onClick={onCreateTable}>
           <Plus className="h-5 w-5" />
-          <span className="px-1 text-sm font-medium leading-5">Create Table</span>
+          <span className="text-sm font-medium">Create Table</span>
         </Button>
         <div className="flex flex-col gap-3">
           <p className="text-sm leading-6 text-muted-foreground">or choose a template to start</p>


### PR DESCRIPTION
## Summary

Fixed the compressed **Create Table** button in the database empty state.

The button was rendering too narrow, causing the icon and label to appear squeezed. This update restores proper spacing so the button looks consistent and remains readable.

## Before

The **Create Table** button appeared compressed and visually broken.

<img width="1356" height="269" alt="Compressed Create Table button before fix" src="https://github.com/user-attachments/assets/4fc57df0-3561-4eb4-a86e-c4b3ca4aa0b2" />

## After

The button now renders with proper width, spacing, and readable text.

<img width="1349" height="509" alt="Create Table button after fix" src="https://github.com/user-attachments/assets/a1489bf8-9a90-4ef3-9eac-cf8b1e62b9e1" />

## Testing

- Ran `npm.cmd run typecheck` in `packages/dashboard`
- Verified the fix locally on `/dashboard/database/tables`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the compressed Create Table button in the database empty state. Updated button height, min-height, gap, and padding, and removed extra label padding so the icon and text render clearly and match our standard button size.

<sup>Written for commit bf402ed4e61f9f0780662a88e6a25386520a909e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Create Table" button styling in the database interface for improved visual consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->