### PR TITLE
docs(partnership): remove emoji from feature lists

### DIFF
--- a/docs/partnership.mdx
+++ b/docs/partnership.mdx
@@ -73,22 +73,22 @@ InsForge provides two partnership models that enable seamless integration of our
 In co-branded mode, developers explicitly know they are InsForge platform users (linked through the same email address). After logging into the InsForge platform, developers have full management rights for projects created through partners and need to pay according to InsForge's billing plans.
 
 Partner platforms can:
-- ✅ Sync user accounts (name, email) with InsForge
-- ✅ Sync projects to InsForge
-- ✅ Query project connection information to leverage the completed backend capabilities.
+- Sync user accounts (name, email) with InsForge
+- Sync projects to InsForge
+- Query project connection information to leverage the completed backend capabilities.
 
 ### White-Label Features
 In white-label mode, developers are not aware of InsForge's existence and cannot see partner-created projects on the InsForge platform.
 
 Partner platforms can:
-- ✅ Create embedded projects
-- ✅ Query project metadata to leverage the completed backend capabilities.
-- ✅ Pause projects
-- ✅ Restore projects
-- ✅ Delete projects
-- ✅ Get project's authorization token for access
-- ✅ Get project's usage
-- ✅ Get aggregated usage across all partnership projects (for billing)
+- Create embedded projects
+- Query project metadata to leverage the completed backend capabilities.
+- Pause projects
+- Restore projects
+- Delete projects
+- Get project's authorization token for access
+- Get project's usage
+- Get aggregated usage across all partnership projects (for billing)
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

- Removes ✅ emoji from 11 bullet points in `docs/partnership.mdx`
- Plain markdown bullets already read as a checklist without emoji

Addresses item 1 from #1121:
> **`docs/partnership.mdx:76-91`** — 16 bullets begin with ✅ emoji. Strip the emoji; plain bullets already read as a checklist.

## Test plan

- [ ] Verify partnership page renders correctly in docs preview

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the ✅ emoji from 11 bullets in `docs/partnership.mdx` to follow the docs style guide; plain bullets already read as a checklist. Satisfies item 1 of #1121 for the partnership page.

<sup>Written for commit 342c8bd14c99f67311d0f27bde4f760ab7d6b172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated partnership documentation formatting for improved readability of Co-Branded and White-Label feature lists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1236)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->