### PR TITLE
docs(storage): add Warning callouts to deprecated endpoints

### DIFF
--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -153,6 +153,8 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/objects/
 
 ## Upload Object (Deprecated)
 
+<Warning>This endpoint is deprecated. Use the [Upload Object with upload strategy](#upload-object-with-upload-strategy) workflow instead.</Warning>
+
 Upload a file to a bucket with a specific key.
 
 ```
@@ -194,6 +196,8 @@ curl -X PUT "https://your-app.insforge.app/api/storage/buckets/avatars/objects/u
 ---
 
 ## Upload with Auto-Generated Key (Deprecated)
+
+<Warning>This endpoint is deprecated. Use the [Upload Object with upload strategy](#upload-object-with-upload-strategy) workflow instead.</Warning>
 
 Upload a file with an auto-generated unique key.
 
@@ -287,6 +291,8 @@ Download the file from the returned URL, using the appropriate method.
 ---
 
 ## Download Object (Deprecated)
+
+<Warning>This endpoint is deprecated. Use the [Download Object with download strategy](#download-object-with-download-strategy) workflow instead.</Warning>
 
 Download a file from a bucket.
 


### PR DESCRIPTION
## Summary

Adds `<Warning>` callouts to three deprecated REST API sections in `docs/sdks/rest/storage.mdx`:

- **Upload Object (Deprecated)** → links to Upload Object with upload strategy
- **Upload with Auto-Generated Key (Deprecated)** → links to Upload Object with upload strategy
- **Download Object (Deprecated)** → links to Download Object with download strategy

This makes the deprecation machine-readable and helps users find the recommended replacement.

Addresses item 3 from #1121.

## Test plan

- [ ] Verify `<Warning>` callouts render correctly in docs preview
- [ ] Verify anchor links to replacement sections work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Warning callouts to three deprecated storage REST endpoints and linked to the recommended strategy-based workflows. Improves deprecation visibility and guides users to upload/download strategies; addresses item 3 in #1121.

<sup>Written for commit ea9c29c367da5e7b947ba1b94ee0f370f9b47499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation warnings for three REST endpoints: Upload Object, Upload with Auto-Generated Key, and Download Object.
  * Updated documentation to direct users to migrate to the newer upload and download strategy workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1238)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->