### PR TITLE
docs(readme): fix repo URL case to InsForge/InsForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <p>
     <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-orange.svg" alt="License"></a>
     <a href="https://www.npmjs.com/package/@insforge/sdk"><img src="https://img.shields.io/npm/dt/@insforge/sdk?color=blue&label=downloads" alt="Downloads"></a>
-    <a href="https://github.com/InsForge/insforge/graphs/contributors"><img src="https://img.shields.io/github/contributors/InsForge/insforge?color=green" alt="Contributors"></a>
+    <a href="https://github.com/InsForge/InsForge/graphs/contributors"><img src="https://img.shields.io/github/contributors/InsForge/InsForge?color=green" alt="Contributors"></a>
     <a href="https://insforge.dev"><img src="https://img.shields.io/badge/Visit-InsForge.dev-181818?logoColor=white&labelColor=555555&logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMjQwIiBoZWlnaHQ9IjI0MCIgdmlld0JveD0iMCAwIDI0MCAyNDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTI2LjExODQgMTAxLjZDMjMuMjkzOSA5OC43ODMzIDIzLjI5MzkgOTQuMjE2NiAyNi4xMTg0IDkxLjRMOTcuNzE2NyAyMEwyMDAgMjBMNzcuMjYgMTQyLjRDNzQuNDM1NSAxNDUuMjE3IDY5Ljg1NjIgMTQ1LjIxNyA2Ny4wMzE3IDE0Mi40TDI2LjExODQgMTAxLjZaIiBmaWxsPSJ3aGl0ZSIvPjxwYXRoIGQ9Ik0xNTUuMjUxIDc3LjM3NUwyMDAgMTIyVjIyNEwxMDQuMTA5IDEyOC4zNzVMMTU1LjI1MSA3Ny4zNzVaIiBmaWxsPSJ3aGl0ZSIvPjwvc3ZnPgo=" alt="Visit InsForge.dev"></a>
     <a href="https://gitcgr.com/InsForge/InsForge">
       <img src="https://gitcgr.com/badge/InsForge/InsForge.svg" alt="gitcgr" />
@@ -125,7 +125,7 @@ You can run InsForge locally using Docker Compose. This will start a local InsFo
 Or run from source:
 ```bash
 # Run with Docker
-git clone https://github.com/insforge/insforge.git
+git clone https://github.com/InsForge/InsForge.git
 cd insforge
 cp .env.example .env
 docker compose -f docker-compose.prod.yml up
@@ -214,7 +214,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=InsForge/insforge&type=Date)](https://www.star-history.com/#InsForge/insforge&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=InsForge/InsForge&type=Date)](https://www.star-history.com/#InsForge/InsForge&Date)
 
 ## Badges
 


### PR DESCRIPTION
## Summary

GitHub repository URLs are case-sensitive. This PR fixes 4 instances of incorrect casing:

| Location | Before | After |
|----------|--------|-------|
| Contributors badge | `InsForge/insforge` | `InsForge/InsForge` |
| Clone URL | `insforge/insforge` | `InsForge/InsForge` |
| Star history | `InsForge/insforge` | `InsForge/InsForge` |

## Test plan

- [ ] Verify contributors badge loads correctly
- [ ] Verify star history chart loads correctly
- [ ] Verify clone URL works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README repository URLs to use the correct case `InsForge/InsForge`. This ensures the contributors badge, clone command, and star history chart load correctly.

<sup>Written for commit 6985bb11d60378bcc6461d6b51fb1664578c2e78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation with corrected organization name formatting in links and setup instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1241)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->