### PR TITLE
fix(migrations): make 038_create-compute-services idempotent

### DIFF
--- a/backend/src/infra/database/migrations/038_create-compute-services.sql
+++ b/backend/src/infra/database/migrations/038_create-compute-services.sql
@@ -1,7 +1,7 @@
 -- Compute Services: deploy Docker containers, get URLs (Fly.io)
 CREATE SCHEMA IF NOT EXISTS compute;
 
-CREATE TABLE compute.services (
+CREATE TABLE IF NOT EXISTS compute.services (
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   project_id          TEXT NOT NULL,
   name                TEXT NOT NULL,
@@ -25,9 +25,10 @@ CREATE TABLE compute.services (
   UNIQUE (project_id, name)
 );
 
-CREATE INDEX idx_compute_services_project ON compute.services(project_id);
-CREATE INDEX idx_compute_services_status ON compute.services(status);
+CREATE INDEX IF NOT EXISTS idx_compute_services_project ON compute.services(project_id);
+CREATE INDEX IF NOT EXISTS idx_compute_services_status ON compute.services(status);
 
+DROP TRIGGER IF EXISTS update_compute_services_updated_at ON compute.services;
 CREATE TRIGGER update_compute_services_updated_at
   BEFORE UPDATE ON compute.services
   FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();


### PR DESCRIPTION
## Summary

Make `038_create-compute-services.sql` idempotent so InsForge can boot on environments where `compute.services` already exists from an earlier-numbered run of this same migration.

## What was happening

User report: backend container failing to start with:

```
error: relation "services" already exists
> Rolling back attempted migration ...
npm error Lifecycle script `migrate:up` failed with error
```

This migration was renumbered several times during review:

```
2d1b4e5a fix(compute): renumber compute migration 036 → 038
d249ddc0 fix(compute): renumber compute migration 036 → 038
fb19b4c4 fix(compute): renumber compute migration 036 → 038
f6b53df7 fix(compute): renumber 038 → 039
1d8a63d4 fix(migrations): use 038 for compute, revert schedules to 037
a4ff5385 feat: compute services (#1062)
```

Environments that ran it under an earlier name end up with `compute.services` in the DB but no matching row in `system.migrations`, so `node-pg-migrate` sees an unrun migration and re-issues the `CREATE TABLE` — which fails (`42P07`) and rolls the whole `migrate:up` step back, preventing the backend from starting.

## The fix

Aligns with the pattern already used in `021_create-schedules-schema.sql` and `039_create-payments-schema.sql`:

- `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`
- `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`
- `CREATE TRIGGER` → `DROP TRIGGER IF EXISTS ... ; CREATE TRIGGER ...` (PG < 14 has no `CREATE TRIGGER IF NOT EXISTS`; drop-then-create is the repo's convention)

`CREATE SCHEMA IF NOT EXISTS compute;` was already idempotent — no change there.

## Impact

- **Fresh DBs:** identical behavior, just runs the `CREATE`s once.
- **DBs that already have `compute.services`** (from a renumbered prior run): migration completes, marks 038 as run, backend boots.

## Test plan

- [ ] Apply on a fresh DB: `compute.services` is created, indexes + trigger present
- [ ] Apply on a DB that already has `compute.services`: migration completes without error
- [ ] Re-run migrations on a DB that already ran 038: no-op, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `038_create-compute-services.sql` idempotent so environments with an existing `compute.services` table no longer fail on boot. Fresh DBs behave the same; renumbered environments now pass cleanly.

- **Bug Fixes**
  - `CREATE TABLE IF NOT EXISTS compute.services`
  - `CREATE INDEX IF NOT EXISTS` for project and status indexes
  - `DROP TRIGGER IF EXISTS ...; CREATE TRIGGER update_compute_services_updated_at`
  - Keeps `CREATE SCHEMA IF NOT EXISTS compute` unchanged

<sup>Written for commit 0ef88c9b77dd2a8fd242750c908f4658f7447a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced database migration robustness to ensure consistent and reliable deployments across multiple runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1246)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->