### PR TITLE
bump version to v2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary

Patch bump `2.1.2 → 2.1.3`. Touches `package.json` + `package-lock.json` only, following the convention used by prior version bumps (e.g. 7d809c07, a1e093cc).

## What's in this patch since `v2.1.2`

- `fix(migrations)`: make `038_create-compute-services` idempotent (#1246)
- `fix(auth)`: replace bespoke wildcard matching with glob-based redirect URL whitelist (#1235)
- `feat(auth)`: add disable new user signups toggle (#1244)
- `security`: two-tier sandbox isolation for serverless functions (#1137)
- `fix(compute)`: prepend `n-` to Fly network name so digit-leading APP_KEYs pass validator (#1228)
- Misc docs cleanups (#1236, #1237, #1240, #1241) and project-restoring-page removal (#1229)

Tag `v2.1.3` can be cut after this lands.

## Test plan

- [ ] `package.json` and `package-lock.json` both show `2.1.3`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to 2.1.3. Updates `package.json` and `package-lock.json` only to release recent auth, compute, and migration changes.

- **New Features**
  - Disable new user signups toggle.
  - Two-tier sandbox isolation for serverless functions.

- **Bug Fixes**
  - Make `038_create-compute-services` migration idempotent.
  - Use glob-based redirect URL whitelist in auth.
  - Prefix Fly network name with `n-` to allow digit-leading `APP_KEY`s.

<sup>Written for commit a1e29e51797303a01c321d2369af51245286168b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.1.3.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1247)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->