### PR TITLE
fix(dashboard): show `compute deploy` instead of nonexistent `compute create`

### DIFF
--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -284,7 +284,7 @@ export default function ComputePage() {
                       Use the button above, the CLI:
                     </p>
                     <code className="block px-3 py-2 bg-muted text-foreground rounded text-xs font-mono break-all">
-                      npx @insforge/cli compute create --name my-api --image nginx:alpine
+                      npx @insforge/cli compute deploy --name my-api --image nginx:alpine
                     </code>
                   </div>
                   <div>


### PR DESCRIPTION
## Summary

The Compute empty-state on the dashboard showcases the CLI command users should run, but it pointed at a subcommand that doesn't exist:

```
npx @insforge/cli compute create --name my-api --image nginx:alpine
```

The CLI's compute namespace only has `deploy`, `delete`, `events`, `get`, `list`, `start`, `stop`, `update` (see `CLI/src/commands/compute/`). Copy-pasting the snippet lands users on `error: unknown command 'create'` from Commander.

Updates the snippet to the actual subcommand: `compute deploy`.

## Where

`packages/dashboard/src/features/compute/pages/ComputePage.tsx:287`

Other strings on the page that say "Create Service" (the button label, the dialog title) are fine — those are UI verbs, not CLI commands. Only the literal command-line snippet was wrong.

## Test plan

- [ ] Visit the Compute page in the dashboard with zero services. Confirm the showcased command is now `compute deploy ...`.
- [ ] Run the showcased command verbatim against an OSS backend — it parses cleanly (any error now comes from the actual deploy path, not Commander).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Compute page empty-state to show the correct CLI snippet using `compute deploy` with `@insforge/cli` instead of the nonexistent `compute create`, avoiding “unknown command” errors when users copy-paste.

<sup>Written for commit 784367ea3df52490a746630dc9ffd3e31efbbb5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example CLI command displayed in the compute service creation guide to reflect the current deployment syntax.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1248)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->