### PR TITLE
bump version to v2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary

Patch bump `2.1.3 → 2.1.4`. Touches `package.json` + `package-lock.json` only, same convention as #1247 and prior bumps.

## What's queued for `v2.1.4`

Open PRs likely to land in this patch window:

- #1248 — `fix(dashboard)`: show `compute deploy` instead of nonexistent `compute create`
- #1242 — `fix(functions)`: support Deno-native ESM imports in self-hosted runtime
- #1239 — `docs(quickstart)`: convert numbered list to Steps component
- #1232 — `fix`: repair the broken & compressed 'Create Table' button
- #1231 — `fix(security)`: nosniff + attachment for XSS-active types on storage GET, bump axios 1.15.0 -> 1.16.0 (13 CVEs)
- #1230 — `feat(auth)`: configurable email verification & password reset token expiry
- ...plus whatever else lands before tag-cut

Tag `v2.1.4` can be cut after this lands.

## Test plan

- [ ] `package.json` and `package-lock.json` both show `2.1.4`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump version to v2.1.4 to prepare the next patch release. Updates `package.json` and `package-lock.json` only, no code changes.

<sup>Written for commit 2d2c0b76b2947a096c9cfebda301384ae7504089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.1.4

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->