### PR TITLE
fix(compute): add --port 80 to nginx example in services empty state

### DIFF
--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -284,7 +284,7 @@ export default function ComputePage() {
                       Use the button above, the CLI:
                     </p>
                     <code className="block px-3 py-2 bg-muted text-foreground rounded text-xs font-mono break-all">
-                      npx @insforge/cli compute deploy --name my-api --image nginx:alpine
+                      npx @insforge/cli compute deploy --name my-api --image nginx:alpine --port 80
                     </code>
                   </div>
                   <div>


### PR DESCRIPTION
## Summary
- Adds `--port 80` to the nginx example shown on the Compute services empty state
- Without it, the default `--port 8080` doesn't match nginx's listen port — users copy the command, get a "running" service, and find the endpoint unreachable with no signal as to why
- Pairs with [CLI #116](https://github.com/InsForge/CLI/pull/116) which prints `Port: <n>` in the deploy/update success output

## Before
```
npx @insforge/cli compute deploy --name my-api --image nginx:alpine
```
Endpoint returns no response (nginx listens on 80, Fly proxy routes to 8080).

## After
```
npx @insforge/cli compute deploy --name my-api --image nginx:alpine --port 80
```
Endpoint serves the nginx welcome page.

## Test plan
- [ ] Open the Compute page with no services deployed
- [ ] Copy the command from the empty-state code block
- [ ] Run it; confirm the resulting endpoint serves the nginx welcome page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--port 80` to the nginx deploy example in the Compute services empty state so copied commands create a reachable service. This fixes the default port mismatch (`8080` vs nginx’s `80`).

<sup>Written for commit a1d87b3af406b8c7a4fec80f406334ee2ae16c3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * The compute deployment command example now includes an explicit port argument, providing a more complete reference for users deploying compute resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->