### PR TITLE
fix(compute): enable scale-to-zero on Fly machines

### DIFF
--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -165,6 +165,29 @@ export class FlyProvider implements ComputeProvider {
     await this.request(`/apps/${appId}`, { method: 'DELETE' });
   }
 
+  // Single source of truth for the per-machine service block. Both launch
+  // and update need to send the same shape, including the autostop fields:
+  // without them Fly defaults to never stopping and machines run 24/7 even
+  // when idle.
+  private serviceConfig(internalPort: number) {
+    return {
+      ports: [
+        { port: 443, handlers: ['tls', 'http'] },
+        { port: 80, handlers: ['http'] },
+      ],
+      internal_port: internalPort,
+      protocol: 'tcp',
+      // Scale-to-zero defaults. Fly stops the machine when traffic is idle
+      // and wakes it on the next incoming request. `min_machines_running: 0`
+      // is required for full scale-to-zero (any value >0 keeps that many
+      // warm). `stop` (vs `suspend`) fully releases the machine — cheaper
+      // for compute that isn't sensitive to ~1s cold-start latency.
+      auto_stop_machines: 'stop',
+      auto_start_machines: true,
+      min_machines_running: 0,
+    };
+  }
+
   async launchMachine(params: {
     appId: string;
     image: string;
@@ -182,16 +205,7 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [
-            {
-              ports: [
-                { port: 443, handlers: ['tls', 'http'] },
-                { port: 80, handlers: ['http'] },
-              ],
-              internal_port: params.port,
-              protocol: 'tcp',
-            },
-          ],
+          services: [this.serviceConfig(params.port)],
         },
         region: params.region,
       }),
@@ -216,16 +230,7 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [
-            {
-              ports: [
-                { port: 443, handlers: ['tls', 'http'] },
-                { port: 80, handlers: ['http'] },
-              ],
-              internal_port: params.port,
-              protocol: 'tcp',
-            },
-          ],
+          services: [this.serviceConfig(params.port)],
         },
       }),
     });

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -169,6 +169,12 @@ export class FlyProvider implements ComputeProvider {
   // and update need to send the same shape, including the autostop fields:
   // without them Fly defaults to never stopping and machines run 24/7 even
   // when idle.
+  //
+  // Field names are the **Machines API** spelling (`autostart` / `autostop`),
+  // NOT fly.toml's longer `auto_start_machines` / `auto_stop_machines`. The
+  // Machines API silently ignores unknown fields, so getting these wrong
+  // looks like it works but leaves machines always-on. Source of truth:
+  // https://docs.machines.dev/spec/openapi3.json — fly.MachineService.
   private serviceConfig(internalPort: number) {
     return {
       ports: [
@@ -182,8 +188,8 @@ export class FlyProvider implements ComputeProvider {
       // is required for full scale-to-zero (any value >0 keeps that many
       // warm). `stop` (vs `suspend`) fully releases the machine — cheaper
       // for compute that isn't sensitive to ~1s cold-start latency.
-      auto_stop_machines: 'stop',
-      auto_start_machines: true,
+      autostop: 'stop',
+      autostart: true,
       min_machines_running: 0,
     };
   }

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -4,6 +4,16 @@ import type { ComputeProvider } from './compute.provider.js';
 
 const FLY_API_BASE = 'https://api.machines.dev/v1';
 
+// Fly Machines API field names for the autostop/autostart block on a
+// service. Kept narrow on purpose: extend when we expose CLI overrides.
+// `autostop` accepts `"off" | "stop" | "suspend"` per fly.MachineService
+// in https://docs.machines.dev/spec/openapi3.json.
+type ScaleOptions = {
+  autostop: 'off' | 'stop' | 'suspend';
+  autostart: boolean;
+  min_machines_running: number;
+};
+
 export class FlyProvider implements ComputeProvider {
   private static instance: FlyProvider;
 
@@ -165,6 +175,18 @@ export class FlyProvider implements ComputeProvider {
     await this.request(`/apps/${appId}`, { method: 'DELETE' });
   }
 
+  // Scale-to-zero is v1's only mode — see compute-deploy.md in the skill
+  // for the rationale. Callers don't pass autostop overrides today. When
+  // we do want to expose `--autostop` / `--min-machines` CLI flags later,
+  // this is the one spot to plumb them through: extend `ScaleOptions` and
+  // pass it from launchMachine/updateMachine. The defaults stay correct
+  // regardless of how callers evolve.
+  private static readonly SCALE_TO_ZERO: ScaleOptions = {
+    autostop: 'stop',
+    autostart: true,
+    min_machines_running: 0,
+  };
+
   // Single source of truth for the per-machine service block. Both launch
   // and update need to send the same shape, including the autostop fields:
   // without them Fly defaults to never stopping and machines run 24/7 even
@@ -175,7 +197,7 @@ export class FlyProvider implements ComputeProvider {
   // Machines API silently ignores unknown fields, so getting these wrong
   // looks like it works but leaves machines always-on. Source of truth:
   // https://docs.machines.dev/spec/openapi3.json — fly.MachineService.
-  private serviceConfig(internalPort: number) {
+  private serviceConfig(internalPort: number, scale: ScaleOptions = FlyProvider.SCALE_TO_ZERO) {
     return {
       ports: [
         { port: 443, handlers: ['tls', 'http'] },
@@ -183,14 +205,13 @@ export class FlyProvider implements ComputeProvider {
       ],
       internal_port: internalPort,
       protocol: 'tcp',
-      // Scale-to-zero defaults. Fly stops the machine when traffic is idle
-      // and wakes it on the next incoming request. `min_machines_running: 0`
-      // is required for full scale-to-zero (any value >0 keeps that many
-      // warm). `stop` (vs `suspend`) fully releases the machine — cheaper
-      // for compute that isn't sensitive to ~1s cold-start latency.
-      autostop: 'stop',
-      autostart: true,
-      min_machines_running: 0,
+      // Scale config. `stop` (vs `suspend`) fully releases the machine —
+      // cheaper for compute that isn't sensitive to ~1s cold-start latency.
+      // `min_machines_running: 0` is required for full scale-to-zero (any
+      // value > 0 keeps that many warm).
+      autostop: scale.autostop,
+      autostart: scale.autostart,
+      min_machines_running: scale.min_machines_running,
     };
   }
 

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -171,6 +171,10 @@ describe('FlyProvider', () => {
         { port: 443, handlers: ['tls', 'http'] },
         { port: 80, handlers: ['http'] },
       ]);
+      // Scale-to-zero defaults — without these Fly keeps the machine warm 24/7.
+      expect(body.config.services[0].auto_stop_machines).toBe('stop');
+      expect(body.config.services[0].auto_start_machines).toBe(true);
+      expect(body.config.services[0].min_machines_running).toBe(0);
       expect(body.region).toBe('iad');
     });
   });

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -172,8 +172,13 @@ describe('FlyProvider', () => {
         { port: 80, handlers: ['http'] },
       ]);
       // Scale-to-zero defaults — without these Fly keeps the machine warm 24/7.
-      expect(body.config.services[0].auto_stop_machines).toBe('stop');
-      expect(body.config.services[0].auto_start_machines).toBe(true);
+      // Note: the Machines API uses the short field names (`autostop`/`autostart`),
+      // NOT fly.toml's `auto_stop_machines`/`auto_start_machines`. The API
+      // silently ignores unknown fields, so the wrong names look healthy at
+      // request time but leave the machine always-on. Schema reference:
+      // https://docs.machines.dev/spec/openapi3.json (fly.MachineService).
+      expect(body.config.services[0].autostop).toBe('stop');
+      expect(body.config.services[0].autostart).toBe(true);
       expect(body.config.services[0].min_machines_running).toBe(0);
       expect(body.region).toBe('iad');
     });


### PR DESCRIPTION
## Summary

Compute services on Fly were running 24/7 even when idle — the machine config sent on `POST /apps/:app/machines` had no autostop fields, so Fly (correctly) kept every machine warm forever.

## How I found it

Inspected the live Fly org. Every machine I checked has been `started` since the day it was deployed (~13 days continuous, no idle stops):

```
nginx-b0e42c30-...        state: started   created 2026-04-29
qr-api-b0e42c30-...       state: started   created 2026-04-29
python-demo-b0e42c30-...  state: started   created 2026-04-29
figlet-api-b0e42c30-...   state: started   created 2026-04-29
```

Pulling one machine's config back via the API:

```json
{
  "services": [{
    "ports": [...],
    "internal_port": 80,
    "protocol": "tcp"
  }]
}
```

No `auto_stop_machines`, no `auto_start_machines`, no `min_machines_running`. Per [Fly's docs](https://fly.io/docs/launch/autostop-autostart/) the default when these are absent is "do nothing" — the machine never stops on idle.

## Fix

In `backend/src/providers/compute/fly.provider.ts`, extract the per-machine `services` block into a single `serviceConfig()` helper (so launch + update can't drift) and add three fields:

```ts
auto_stop_machines: 'stop'    // fully stop on idle (vs 'suspend')
auto_start_machines: true     // wake on next incoming request
min_machines_running: 0       // allow zero warm replicas
```

### Why `stop` and not `suspend`

`suspend` is faster wake-up (~100ms vs ~1s) but more expensive. Compute services here aren't latency-sensitive enough to justify the cost — `stop` is the right default for a "deploy a container, pay for usage" product. If anyone needs always-on or fast-suspend, we can expose this as a per-service knob later.

### Backward compat

**Existing already-deployed machines won't pick up the new config until they're redeployed** (an `updateMachine` call) or until the config is applied via Fly CLI on the existing machine. Operators with running 24/7 machines should redeploy each service (or the worst-case is they keep paying until next redeploy).

## Test plan

- [x] Added unit test that asserts `auto_stop_machines: 'stop'`, `auto_start_machines: true`, `min_machines_running: 0` are present in `launchMachine`'s body — `tests/unit/compute/fly-provider.test.ts`
- [x] Existing `fly-provider.test.ts` suite still passes (10/10)
- [ ] Deploy a fresh compute service after merge. Confirm:
  - `flyctl machines list -a <app>` shows it goes from `started` to `stopped` after the idle window
  - Hitting the endpoint URL wakes the machine, response succeeds (with ~1s cold start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable scale-to-zero for Fly Machines by sending the correct Machines API `autostop`/`autostart` settings in the service config. Idle machines now stop and wake on request, reducing always-on costs. Existing machines stay unchanged until redeploy.

- **Bug Fixes**
  - Use Machines API fields via a shared `serviceConfig()` for both launch and update: `autostop: 'stop'`, `autostart: true`, `min_machines_running: 0`.
  - Add a regression test asserting `autostop`/`autostart` names to avoid silently ignored fly.toml-style fields.

- **Refactors**
  - Extract `ScaleOptions` and `SCALE_TO_ZERO`; `serviceConfig(port, scale?)` accepts optional overrides for future flags without changing current behavior.

<sup>Written for commit 981e52c9a3b1c63007564bdc03281ec2ba7b801e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compute machines now support scale-to-zero behavior: idle machines will auto-stop, auto-start is enabled, and minimum running machines can be zero—reducing costs for inactive workloads.

* **Tests**
  * Unit tests updated to verify the scale-to-zero behavior is applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->