### PR TITLE
fix(dashboard): remove 50MB File Size Limit UI from bucket edit dialog

### DIFF
--- a/packages/dashboard/src/features/storage/components/BucketFormDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/BucketFormDialog.tsx
@@ -162,7 +162,6 @@ export function BucketFormDialog({
                 <Switch id="bucket-public" checked={isPublic} onCheckedChange={setIsPublic} />
               </div>
             </BucketFormRow>
-
           </DialogBody>
           <DialogFooter className="gap-3 p-4">
             <Button type="button" variant="secondary" onClick={handleClose} className="h-8 px-2">

--- a/packages/dashboard/src/features/storage/components/BucketFormDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/BucketFormDialog.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useBuckets } from '#features/storage/hooks/useBuckets';
-import { isInsForgeCloudProject } from '#lib/utils/utils';
-import DiscordIcon from '#assets/logos/discord.svg?react';
 import {
   Button,
   Dialog,
@@ -165,32 +163,6 @@ export function BucketFormDialog({
               </div>
             </BucketFormRow>
 
-            {/* File Size Limit - Cloud only, edit mode only */}
-            {mode === 'edit' && isInsForgeCloudProject() && (
-              <>
-                <DialogDivider />
-                <BucketFormRow
-                  label="File Size Limit"
-                  description="Default limit for cloud projects."
-                >
-                  <div className="flex w-full flex-col gap-1">
-                    <p className="text-sm leading-5 text-foreground">50MB per file</p>
-                    <p className="text-[13px] leading-[18px] text-muted-foreground">
-                      Need a higher limit? Reach out to us on{' '}
-                      <a
-                        href="https://discord.gg/DvBtaEc9Jz"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 align-middle text-primary"
-                      >
-                        <DiscordIcon className="h-3.5 w-3.5 text-primary" />
-                        <span className="text-xs font-medium leading-4 text-primary">Discord</span>
-                      </a>
-                    </p>
-                  </div>
-                </BucketFormRow>
-              </>
-            )}
           </DialogBody>
           <DialogFooter className="gap-3 p-4">
             <Button type="button" variant="secondary" onClick={handleClose} className="h-8 px-2">


### PR DESCRIPTION
## Summary
Remove the "File Size Limit" UI block from the bucket edit dialog. It displayed a hardcoded "50MB per file" value plus a Discord contact-us link — informational only, not an editable setting, and pinning the limit at a stale value in the UI.

## Changes
- Remove the conditional block (`mode === 'edit' && isInsForgeCloudProject()`) in `BucketFormDialog.tsx` that rendered the limit + Discord link.
- Drop the now-unused `isInsForgeCloudProject` and `DiscordIcon` imports.

## Test plan
- [ ] Open the bucket edit dialog as a cloud project user; confirm the file-size-limit row is gone.
- [ ] Create a new bucket; dialog renders normally with no missing dividers/spacing.
- [ ] Lint/typecheck pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded “File Size Limit” block from the bucket edit dialog to avoid showing a stale 50MB value and Discord link. Simplifies the UI by removing non-editable, cloud-only info.

- **Refactors**
  - Dropped unused `isInsForgeCloudProject` and `DiscordIcon` imports.
  - Removed a stray blank line before the `DialogBody` close (prettier).

<sup>Written for commit 08a3e17a739defe66faecef3cece44764adf625e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the File Size Limit field from the bucket form dialog, simplifying the configuration interface. The bucket name input and public bucket toggle remain functional.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1252)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->