### PR TITLE
UI/UX: Accessibility: Focus rings removed with !important flags

### DIFF
--- a/packages/dashboard/src/components/radix/Textarea.tsx
+++ b/packages/dashboard/src/components/radix/Textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'tex
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus:border-black dark:focus:border-neutral-500 focus:outline-none! focus:ring-0! focus:ring-offset-0! disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus:border-black dark:focus:border-neutral-500 disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Problem

In Textarea and TextCellEditor components, focus rings are explicitly removed with !important flags (focus:outline-none!, focus:ring-0!, focus:ring-offset-0!). This removes visible focus indicators which are critical for keyboard navigation accessibility.

**Severity**: `high`
**File**: `packages/dashboard/src/components/radix/Textarea.tsx`

## Solution

Replace !important focus removal with custom focus styles that maintain visibility: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'

## Changes

- `packages/dashboard/src/components/radix/Textarea.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore visible focus indicators for keyboard users by removing `!important` focus suppression in the dashboard Textarea. Fixes a high-severity accessibility issue that hid focus rings.

- **Bug Fixes**
  - In `packages/dashboard/src/components/radix/Textarea.tsx`, replaced `focus:outline-none! focus:ring-0! focus:ring-offset-0!` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to keep a clear, accessible focus state.

<sup>Written for commit af10fa033e27da3acadb4ac9357bdbb9fedd54a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Textarea component's focus state styling to provide improved visual feedback when users interact with text input areas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1254)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->