### PR TITLE
UI/UX: Accessibility: Focus rings removed in cell editor

### DIFF
--- a/packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx
+++ b/packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx
@@ -29,7 +29,7 @@ export function TextCellEditor({ value, onValueChange, onCancel, className }: Te
       onKeyDown={handleKeyDown}
       onBlur={handleSave}
       className={cn(
-        'w-full border-none outline-none bg-white dark:bg-neutral-800 focus:border-0! focus:ring-0! focus:ring-offset-0! focus:outline-none!',
+        'w-full border-none bg-white dark:bg-neutral-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
         className
       )}
       autoFocus


### PR DESCRIPTION
## Problem

TextCellEditor removes all focus indicators with !important flags, making keyboard navigation difficult for users.

**Severity**: `high`
**File**: `packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx`

## Solution

Add visible focus styles instead of removing them: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary'

## Changes

- `packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores visible focus rings in the data grid `TextCellEditor`, replacing `!important` overrides that hid focus. Improves keyboard navigation and accessibility.

<sup>Written for commit bd98f2f37f4b9e8ba2e31bf9cff916cb116726a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated focus ring styling for the text input editor in the data grid component to provide more consistent visual feedback when editing cells.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->