### PR TITLE
feat(dashboard): add immediate revoke option to API key rotate dialog

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/ProjectSettingsMenuDialog.tsx
+++ b/packages/dashboard/src/features/dashboard/components/ProjectSettingsMenuDialog.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Cpu, HardDrive, Plug, RefreshCw, Settings } from 'lucide-react';
 import {
   Button,
+  Checkbox,
   CopyButton,
   ConfirmDialog,
   Input,
@@ -67,6 +68,8 @@ export default function ProjectSettingsMenuDialog({
   const [selectedInstanceType, setSelectedInstanceType] = useState<string | null>(null);
   const [isChangingInstanceType, setIsChangingInstanceType] = useState(false);
   const [isRotatingApiKey, setIsRotatingApiKey] = useState(false);
+  const [isRotateDialogOpen, setIsRotateDialogOpen] = useState(false);
+  const [immediateRevoke, setImmediateRevoke] = useState(false);
 
   const { apiKey, isLoading: isApiKeyLoading } = useApiKey();
   const { version, isLoading: isVersionLoading } = useHealth();
@@ -275,26 +278,21 @@ export default function ProjectSettingsMenuDialog({
     setIsProjectNameFocused(false);
   };
 
-  const handleRotateApiKey = async () => {
-    const confirmed = await confirm({
-      title: 'Rotate API Key',
-      description:
-        'This will generate a new API key. The current key will remain valid for 24 hours to allow for a smooth transition. This action cannot be undone.',
-      confirmText: 'Rotate Key',
-      cancelText: 'Cancel',
-      destructive: true,
-    });
+  const openRotateApiKeyDialog = () => {
+    setImmediateRevoke(false);
+    setIsRotateDialogOpen(true);
+  };
 
-    if (!confirmed) {
-      return;
-    }
-
+  const handleConfirmRotateApiKey = async () => {
+    const gracePeriodHours = immediateRevoke ? 0 : 24;
     setIsRotatingApiKey(true);
     try {
-      const result = await metadataService.rotateApiKey(24);
+      const result = await metadataService.rotateApiKey(gracePeriodHours);
       queryClient.setQueryData(['metadata', 'apiKey'], result.apiKey);
       showToast(
-        'API key rotated successfully. The old key will remain valid for 24 hours.',
+        immediateRevoke
+          ? 'API key rotated. The old key is now revoked and will fail on the next request.'
+          : 'API key rotated successfully. The old key will remain valid for 24 hours.',
         'success'
       );
     } catch {
@@ -356,6 +354,41 @@ export default function ProjectSettingsMenuDialog({
   return (
     <>
       <ConfirmDialog {...confirmDialogProps} />
+      <ConfirmDialog
+        open={isRotateDialogOpen}
+        onOpenChange={(nextOpen) => {
+          setIsRotateDialogOpen(nextOpen);
+          if (!nextOpen) {
+            setImmediateRevoke(false);
+          }
+        }}
+        title="Rotate API Key"
+        confirmText={immediateRevoke ? 'Revoke & Rotate' : 'Rotate Key'}
+        cancelText="Cancel"
+        destructive
+        isLoading={isRotatingApiKey}
+        onConfirm={handleConfirmRotateApiKey}
+        description={
+          <div className="flex flex-col gap-3">
+            <p>
+              {immediateRevoke
+                ? 'This will generate a new API key and revoke the current key immediately. Any in-flight callers still using the old key will start failing on the next request. This action cannot be undone.'
+                : 'This will generate a new API key. The current key will remain valid for 24 hours to allow for a smooth transition. This action cannot be undone.'}
+            </p>
+            <label className="flex cursor-pointer items-start gap-2">
+              <Checkbox
+                checked={immediateRevoke}
+                onCheckedChange={(checked) => setImmediateRevoke(checked === true)}
+                disabled={isRotatingApiKey}
+                className="mt-0.5"
+              />
+              <span className="text-sm leading-5 text-foreground">
+                Revoke old key immediately (use if exposed)
+              </span>
+            </label>
+          </div>
+        }
+      />
       <MenuDialog open={open} onOpenChange={onOpenChange}>
         <MenuDialogContent>
           <MenuDialogSideNav>
@@ -480,7 +513,7 @@ export default function ProjectSettingsMenuDialog({
                       </div>
                       <Button
                         variant="secondary"
-                        onClick={() => void handleRotateApiKey()}
+                        onClick={openRotateApiKeyDialog}
                         disabled={isApiKeyLoading || isRotatingApiKey}
                         className="h-8 shrink-0 rounded border-[var(--alpha-8)] bg-card px-3 text-sm font-medium"
                       >


### PR DESCRIPTION
## Summary

Fixes #1233

Dashboard "Rotate API Key" flow hardcoded a 24-hour grace period with no way to revoke immediately. Backend already supports `gracePeriodHours: 0` end-to-end — only the UI was the blocker. This PR exposes an "immediate revoke" choice in the rotate confirmation dialog.

## Manual test logs

**Backend logs confirm immediate revoke works at the validator layer:**

**Before rotate — old key valid**
{"key":"API_KEY","level":"info","message":"Secret check successful","timestamp":"2026-05-12T14:56:23.007Z"}

**Rotate with "Revoke immediately" checked — grace = 0, oldKeyExpiresAt == NOW**

{"gracePeriodKey":"API_KEY_OLD_1778597930018","level":"info","message":"API key rotated successfully","oldKeyExpiresAt":"2026-05-12T14:58:50.013Z","timestamp":"2026-05-12T14:58:50.035Z"}
{"action":"ROTATE_API_KEY","actor":"[admin@example.com](mailto:admin@example.com)","level":"info","message":"Audit log created","module":"SECRETS","timestamp":"2026-05-12T14:58:50.037Z"}

**Old key after immediate-revoke rotate — rejected**
{"key":"API_KEY","level":"warn","message":"Secret check failed - value mismatch","timestamp":"2026-05-12T14:58:52.553Z"}
{"key":"API_KEY","level":"warn","message":"Secret check failed - value mismatch","timestamp":"2026-05-12T14:58:55.266Z"}

Audit log row already distinguishes immediate vs delayed via the `gracePeriodHours` field on `ROTATE_API_KEY` (per issue acceptance criteria).

## Demo Video 

https://github.com/user-attachments/assets/dc4b05b0-7ab4-4ee8-b74b-8f4d69455a23



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Revoke immediately” option to the API key rotate dialog so teams can invalidate a leaked key right away. Meets #1233 by wiring `gracePeriodHours: 0` to the backend; default remains a 24‑hour grace period.

- **New Features**
  - Added checkbox “Revoke old key immediately” in the rotate dialog.
  - When checked, sends `gracePeriodHours = 0`, updates confirm label, and shows an immediate-revoke toast.
  - Opens a dedicated rotate dialog (replaces the single-step confirm) with clear copy for immediate vs delayed revoke.

<sup>Written for commit 6550957e61570c432fbee4aeface3b8fb2958a85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced API key rotation with a confirmation dialog featuring a two-step flow
  * Added option to immediately revoke existing API keys during the rotation process
  * Improved success messaging to reflect the selected revocation method

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1257)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->