### PR TITLE
feat(auth): expose smtpConfig in admin metadata for config-as-code

### DIFF
--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -19,6 +19,7 @@ import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import { CustomOAuthConfigService } from '@/services/auth/custom-oauth-config.service.js';
 import { AuthConfigService } from './auth-config.service.js';
 import { AuthOTPService, OTPPurpose, OTPType } from './auth-otp.service.js';
+import { SmtpConfigService } from '@/services/email/smtp-config.service.js';
 import { GoogleOAuthProvider } from '@/providers/oauth/google.provider.js';
 import { GitHubOAuthProvider } from '@/providers/oauth/github.provider.js';
 import { DiscordOAuthProvider } from '@/providers/oauth/discord.provider.js';
@@ -941,20 +942,36 @@ export class AuthService {
 
   /**
    * Admin auth metadata for /api/metadata (gated behind verifyAdmin).
-   * Includes allowedRedirectUrls so the CLI can render insforge.toml.
+   * Includes allowedRedirectUrls and smtpConfig so the CLI can render
+   * insforge.toml and probe backend capability for declarative config.
+   *
+   * smtpConfig.hasPassword is the only credential signal — the actual
+   * password is never returned by the SmtpConfigService.
    */
   async getMetadata(): Promise<AuthMetadataSchema> {
     const authConfigService = AuthConfigService.getInstance();
     const oAuthConfigService = OAuthConfigService.getInstance();
     const customOAuthConfigService = CustomOAuthConfigService.getInstance();
-    const [oAuthProviders, customOAuthConfigs, authConfig] = await Promise.all([
+    const smtpConfigService = SmtpConfigService.getInstance();
+    const [oAuthProviders, customOAuthConfigs, authConfig, smtpConfig] = await Promise.all([
       oAuthConfigService.getConfiguredProviders(),
       customOAuthConfigService.listConfigs(),
       authConfigService.getAuthConfig(),
+      smtpConfigService.getSmtpConfig(),
     ]);
     return {
       oAuthProviders,
       customOAuthProviders: customOAuthConfigs.map((config) => config.key),
+      smtpConfig: {
+        enabled: smtpConfig.enabled,
+        host: smtpConfig.host,
+        port: smtpConfig.port,
+        username: smtpConfig.username,
+        hasPassword: smtpConfig.hasPassword,
+        senderEmail: smtpConfig.senderEmail,
+        senderName: smtpConfig.senderName,
+        minIntervalSeconds: smtpConfig.minIntervalSeconds,
+      },
       requireEmailVerification: authConfig.requireEmailVerification,
       passwordMinLength: authConfig.passwordMinLength,
       requireNumber: authConfig.requireNumber,

--- a/backend/tests/unit/smtp-schemas.test.ts
+++ b/backend/tests/unit/smtp-schemas.test.ts
@@ -4,6 +4,9 @@ import {
   updateEmailTemplateRequestSchema,
   smtpConfigSchema,
   emailTemplateSchema,
+  authConfigAdminResponseSchema,
+  getPublicAuthConfigResponseSchema,
+  adminSmtpMetadataSchema,
 } from '@insforge/shared-schemas';
 
 describe('SMTP Config Request Schema', () => {
@@ -211,5 +214,104 @@ describe('Email Template Schema', () => {
       updatedAt: '2026-01-01T00:00:00Z',
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('SMTP in admin/public metadata response', () => {
+  // The admin metadata response is what /api/metadata returns (admin-gated).
+  // It MUST include smtpConfig so the CLI can probe backend capability before
+  // applying TOML changes. The public response (unauthenticated) MUST NOT
+  // include it — SMTP host can leak internal infrastructure.
+
+  const adminSmtpSlice = {
+    enabled: true,
+    host: 'smtp.gmail.com',
+    port: 465,
+    username: 'user@gmail.com',
+    hasPassword: true,
+    senderEmail: 'noreply@myapp.com',
+    senderName: 'My App',
+    minIntervalSeconds: 60,
+  };
+
+  const baseAdminResponse = {
+    oAuthProviders: [],
+    customOAuthProviders: [],
+    smtpConfig: adminSmtpSlice,
+    requireEmailVerification: false,
+    passwordMinLength: 8,
+    requireNumber: false,
+    requireLowercase: false,
+    requireUppercase: false,
+    requireSpecialChar: false,
+    verifyEmailMethod: 'code' as const,
+    resetPasswordMethod: 'code' as const,
+    allowedRedirectUrls: [],
+    disableSignup: false,
+  };
+
+  it('admin response includes smtpConfig with hasPassword', () => {
+    const result = authConfigAdminResponseSchema.safeParse(baseAdminResponse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.smtpConfig.hasPassword).toBe(true);
+      expect(result.data.smtpConfig.host).toBe('smtp.gmail.com');
+    }
+  });
+
+  it('admin smtp slice has no id / createdAt / updatedAt (rendering metadata)', () => {
+    const withRowMetadata = {
+      ...adminSmtpSlice,
+      id: '00000000-0000-0000-0000-000000000001',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    // Strict parse: extra keys should be stripped, not error. We verify the
+    // parsed output doesn't carry them through (zod strips unknown keys by default).
+    const result = adminSmtpMetadataSchema.safeParse(withRowMetadata);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('id' in result.data).toBe(false);
+      expect('createdAt' in result.data).toBe(false);
+      expect('updatedAt' in result.data).toBe(false);
+    }
+  });
+
+  it('admin smtp slice does NOT include a password field', () => {
+    // The shape only carries hasPassword; the actual credential never crosses
+    // the wire. If someone tries to add a `password` field, it must be stripped
+    // and definitely not present in the type.
+    const withPassword = {
+      ...adminSmtpSlice,
+      password: 'literal-secret-that-should-never-leak',
+    };
+    const result = adminSmtpMetadataSchema.safeParse(withPassword);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('password' in result.data).toBe(false);
+    }
+  });
+
+  it('public response omits smtpConfig (admin-only — host can leak internal infra)', () => {
+    const publicShape: Record<string, unknown> = { ...baseAdminResponse };
+    delete publicShape.smtpConfig;
+    delete publicShape.allowedRedirectUrls;
+    const result = getPublicAuthConfigResponseSchema.safeParse(publicShape);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('smtpConfig' in result.data).toBe(false);
+      expect('allowedRedirectUrls' in result.data).toBe(false);
+    }
+  });
+
+  it('public response still parses when smtpConfig is mistakenly included (strips it)', () => {
+    // Belt-and-suspenders: even if a future code change accidentally sends
+    // smtpConfig through the public route, zod's default strip behavior drops
+    // it from the parsed output.
+    const result = getPublicAuthConfigResponseSchema.safeParse(baseAdminResponse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('smtpConfig' in result.data).toBe(false);
+    }
   });
 });

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -359,9 +359,21 @@ export const getAuthConfigResponseSchema = authConfigSchema;
  * call in `getPublicAuthConfigResponseSchema`. This way the safer default
  * (admin-only) is what you get if you forget to think about it.
  */
+/**
+ * SMTP slice for the admin metadata response. Excludes id/createdAt/updatedAt
+ * (rendering metadata, not the row); password is never exposed — hasPassword
+ * is the only signal admins get about credential presence.
+ */
+export const adminSmtpMetadataSchema = smtpConfigSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
 export const authConfigAdminResponseSchema = z.object({
   oAuthProviders: z.array(oAuthProvidersSchema),
   customOAuthProviders: z.array(customOAuthKeySchema),
+  smtpConfig: adminSmtpMetadataSchema,
   ...authConfigSchema.omit({
     id: true,
     updatedAt: true,
@@ -372,10 +384,13 @@ export const authConfigAdminResponseSchema = z.object({
 /**
  * Response for GET /api/auth/public-config — admin response minus
  * admin-only fields. This route is unauthenticated, so anything sensitive
- * MUST be omitted here.
+ * MUST be omitted here. SMTP host can leak internal infrastructure
+ * (e.g. internal corp mail server), so the entire smtpConfig slice is
+ * admin-only.
  */
 export const getPublicAuthConfigResponseSchema = authConfigAdminResponseSchema.omit({
   allowedRedirectUrls: true,
+  smtpConfig: true,
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Wire `smtpConfig` into the admin metadata response so the CLI's `config apply` capability probe can detect whether the backend supports declarative SMTP management. Step 1 of 3 for SMTP config-as-code (backend → CLI → skills).

## Why

The CLI hits `/api/metadata` before issuing PUTs to decide which TOML sections the connected backend can accept. Today, that response covers `auth.config` fields (allowedRedirectUrls, passwordMinLength, etc.) but **not** `smtpConfig` — so the CLI can't gate `[email.smtp]` writes against backend version, which would mean silent drops on older backends.

## Changes

- **Schema:** Add `adminSmtpMetadataSchema` (smtpConfigSchema minus `id`/`createdAt`/`updatedAt` — rendering metadata, not the row). Include it in `authConfigAdminResponseSchema`. `hasPassword: boolean` is the only credential signal; the actual password is never in `SmtpConfigSchema` (the service returns it masked) and therefore never crosses the wire.
- **Public split:** `getPublicAuthConfigResponseSchema` omits `smtpConfig` — SMTP host can leak internal infrastructure (corp mail server, etc.). Same admin-only pattern as `allowedRedirectUrls`.
- **Service:** Wire `SmtpConfigService.getSmtpConfig()` into `AuthService.getMetadata()`. Returns the `EMPTY_CONFIG` shape when no SMTP row exists, so the capability probe always sees the field (signals "backend supports SMTP").
- **Tests:** 5 new unit tests pin the admin/public split — admin carries `hasPassword`, strips row metadata, strips any stray `password` field; public omits the whole slice even if mistakenly included.

## Out of scope

- CLI `[email.smtp]` schema + `env()` validator wiring (next PR)
- Skill docs for SMTP TOML (after CLI ships)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test -- --run tests/unit/smtp-schemas.test.ts` — 23/23 pass (18 pre-existing + 5 new)
- [ ] After merge: hit `GET /api/metadata` against a project, confirm `smtpConfig` slice appears with `hasPassword: false` on a fresh project
- [ ] After merge: hit `GET /api/auth/public-config`, confirm `smtpConfig` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `smtpConfig` in the admin `/api/metadata` response so the CLI can detect SMTP config-as-code support, while keeping it out of the public config. Adds schema updates, service wiring, and tests to enforce the admin/public split.

- **New Features**
  - Added `adminSmtpMetadataSchema` and included it in `authConfigAdminResponseSchema` in `@insforge/shared-schemas` (no ids/timestamps; exposes `hasPassword` only).
  - Updated `AuthService.getMetadata()` to include `smtpConfig` via `SmtpConfigService`, returning an empty shape when no row exists.
  - Ensured `getPublicAuthConfigResponseSchema` omits `smtpConfig` to avoid leaking SMTP host details.
  - Added unit tests to pin the admin/public split and password masking.

<sup>Written for commit 74ef9e2598c598bb8caa5e491b85a1b6c5fe6f3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin authentication metadata now includes SMTP configuration details, exposing enabled status, server information, sender settings, and timing parameters.
  * SMTP configuration data is restricted to authenticated admin responses; public authentication endpoints exclude this information for security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1258)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->