### PR TITLE
feat(deployments): expose customSlug in admin metadata for config-as-code

### DIFF
--- a/backend/src/api/routes/metadata/index.routes.ts
+++ b/backend/src/api/routes/metadata/index.routes.ts
@@ -39,7 +39,7 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
       storageService.getMetadata(),
       aiConfigService.getMetadata(),
       functionService.getMetadata(),
-      deploymentService.getMetadata(),
+      deploymentService.getConfigMetadata(),
     ]);
 
     // Get version from package.json or default
@@ -52,10 +52,10 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
       functions,
       aiIntegration: aiConfig,
       // Deployments slice is omitted entirely on self-hosted backends
-      // (deploymentService.getMetadata returns undefined). Cloud projects
-      // see { customSlug: string | null }. The CLI capability probe
-      // depends on this presence/absence signal to gate [deployments]
-      // TOML sections.
+      // (deploymentService.getConfigMetadata returns undefined). Cloud
+      // projects see { customSlug: string | null }. The CLI capability
+      // probe depends on this presence/absence signal to gate
+      // [deployments] TOML sections.
       ...(deployments ? { deployments } : {}),
       version,
     };

--- a/backend/src/api/routes/metadata/index.routes.ts
+++ b/backend/src/api/routes/metadata/index.routes.ts
@@ -5,6 +5,7 @@ import { StorageService } from '@/services/storage/storage.service.js';
 import { AIConfigService } from '@/services/ai/ai-config.service.js';
 import { FunctionService } from '@/services/functions/function.service.js';
 import { RealtimeChannelService } from '@/services/realtime/realtime-channel.service.js';
+import { DeploymentService } from '@/services/deployments/deployment.service.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { successResponse } from '@/utils/response.js';
 import { ERROR_CODES } from '@/types/error-constants.js';
@@ -22,6 +23,7 @@ const realtimeChannelService = RealtimeChannelService.getInstance();
 const dbManager = DatabaseManager.getInstance();
 const dbAdvanceService = DatabaseAdvanceService.getInstance();
 const aiConfigService = AIConfigService.getInstance();
+const deploymentService = DeploymentService.getInstance();
 
 router.use(verifyAdmin);
 
@@ -31,12 +33,13 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
     // Gather metadata from all modules
 
     // Fetch all metadata in parallel for better performance
-    const [auth, database, storage, aiConfig, functions] = await Promise.all([
+    const [auth, database, storage, aiConfig, functions, deployments] = await Promise.all([
       authService.getMetadata(),
       dbManager.getMetadata(),
       storageService.getMetadata(),
       aiConfigService.getMetadata(),
       functionService.getMetadata(),
+      deploymentService.getMetadata(),
     ]);
 
     // Get version from package.json or default
@@ -48,6 +51,12 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
       storage,
       functions,
       aiIntegration: aiConfig,
+      // Deployments slice is omitted entirely on self-hosted backends
+      // (deploymentService.getMetadata returns undefined). Cloud projects
+      // see { customSlug: string | null }. The CLI capability probe
+      // depends on this presence/absence signal to gate [deployments]
+      // TOML sections.
+      ...(deployments ? { deployments } : {}),
       version,
     };
 

--- a/backend/src/services/deployments/deployment.service.ts
+++ b/backend/src/services/deployments/deployment.service.ts
@@ -113,8 +113,19 @@ export class DeploymentService {
     if (!isCloudEnvironment()) {
       return undefined;
     }
-    const customSlug = await this.vercelProvider.getSlug();
-    return { customSlug };
+    try {
+      const customSlug = await this.vercelProvider.getSlug();
+      return { customSlug };
+    } catch (error) {
+      // Cloud slug lookup hits CLOUD_API_HOST + Vercel; transient failures
+      // here must not take down the whole /api/metadata response. Surface
+      // the slice with a null slug so the CLI still sees the cloud signal
+      // (it'll just skip the [deployments] section as if no slug is set).
+      logger.warn('deployments.customSlug lookup failed; reporting null slug', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { customSlug: null };
+    }
   }
 
   private isReservedHostedDomain(domain: string): boolean {

--- a/backend/src/services/deployments/deployment.service.ts
+++ b/backend/src/services/deployments/deployment.service.ts
@@ -109,7 +109,7 @@ export class DeploymentService {
    *
    * `customSlug: null` means cloud + slug not set (project uses default URL).
    */
-  async getMetadata(): Promise<DeploymentsMetadataSchema | undefined> {
+  async getConfigMetadata(): Promise<DeploymentsMetadataSchema | undefined> {
     if (!isCloudEnvironment()) {
       return undefined;
     }

--- a/backend/src/services/deployments/deployment.service.ts
+++ b/backend/src/services/deployments/deployment.service.ts
@@ -31,6 +31,7 @@ import type {
   ListCustomDomainsResponse,
   AddCustomDomainResponse,
   VerifyCustomDomainResponse,
+  DeploymentsMetadataSchema,
 } from '@insforge/shared-schemas';
 
 export type {
@@ -95,6 +96,25 @@ export class DeploymentService {
       this.pool = DatabaseManager.getInstance().getPool();
     }
     return this.pool;
+  }
+
+  /**
+   * Deployments slice for admin /api/metadata (gated behind verifyAdmin).
+   *
+   * Cloud-only: returns `undefined` in self-hosted backends so the metadata
+   * route omits the slice entirely. The CLI's capability probe uses
+   * presence/absence to gate `[deployments]` TOML sections — self-host
+   * users naturally skip features they can't use, without ever issuing a
+   * PUT to the cloud-only slug endpoint.
+   *
+   * `customSlug: null` means cloud + slug not set (project uses default URL).
+   */
+  async getMetadata(): Promise<DeploymentsMetadataSchema | undefined> {
+    if (!isCloudEnvironment()) {
+      return undefined;
+    }
+    const customSlug = await this.vercelProvider.getSlug();
+    return { customSlug };
   }
 
   private isReservedHostedDomain(domain: string): boolean {

--- a/packages/shared-schemas/src/metadata.schema.ts
+++ b/packages/shared-schemas/src/metadata.schema.ts
@@ -52,6 +52,19 @@ export const realtimeMetadataSchema = z.object({
   permissions: realtimePermissionsResponseSchema,
 });
 
+/**
+ * Deployments slice for the admin metadata response. Cloud-only: this slice
+ * is omitted entirely in self-hosted backends (where custom slugs are not
+ * available). The CLI's capability probe uses presence/absence of this slice
+ * to decide whether to apply `[deployments]` TOML sections.
+ *
+ * `customSlug: null` means cloud + slug not set (project uses default URL).
+ * Absent slice means self-host (feature doesn't exist).
+ */
+export const deploymentsMetadataSchema = z.object({
+  customSlug: z.string().nullable(),
+});
+
 export const appMetaDataSchema = z.object({
   auth: authMetadataSchema,
   database: databaseMetadataSchema,
@@ -59,6 +72,7 @@ export const appMetaDataSchema = z.object({
   aiIntegration: aiMetadataSchema.optional(),
   functions: z.array(edgeFunctionMetadataSchema),
   realtime: realtimeMetadataSchema.optional(),
+  deployments: deploymentsMetadataSchema.optional(),
   version: z.string().optional(),
 });
 
@@ -69,6 +83,7 @@ export type StorageMetadataSchema = z.infer<typeof storageMetadataSchema>;
 export type EdgeFunctionMetadataSchema = z.infer<typeof edgeFunctionMetadataSchema>;
 export type AIMetadataSchema = z.infer<typeof aiMetadataSchema>;
 export type RealtimeMetadataSchema = z.infer<typeof realtimeMetadataSchema>;
+export type DeploymentsMetadataSchema = z.infer<typeof deploymentsMetadataSchema>;
 export type AppMetadataSchema = z.infer<typeof appMetaDataSchema>;
 
 // Database connection schemas


### PR DESCRIPTION
## Summary

Step 1 of 2 for declarative deployment subdomain (\`*.insforge.site\`) via \`insforge.toml\`. Adds the \`deployments\` slice to admin \`/api/metadata\` so the CLI's capability probe knows whether the connected backend supports the feature.

This is **the same pattern** as #1258 (SMTP) and the merged #1216 (allowedRedirectUrls). Cloud-only feature → cloud-only metadata slice → CLI naturally skips on self-host.

## Shape

\`\`\`ts
deployments: { customSlug: string | null }
\`\`\`

- Cloud + slug set: \`{ customSlug: \"myapp\" }\`
- Cloud + no slug: \`{ customSlug: null }\`
- Self-host: field **omitted entirely** (the capability signal)

## Why cloud-only

\`DeploymentService.updateSlug()\` already throws \`503 Custom slugs are only available in cloud environment\` for self-hosters. Mirroring that in metadata means the CLI gates on presence/absence and skips with the upgrade message — no need for self-host users to see fields they can't touch.

## Changes

- **\`packages/shared-schemas/src/metadata.schema.ts\`**: new \`deploymentsMetadataSchema\`; \`appMetaDataSchema.deployments\` made optional
- **\`backend/src/services/deployments/deployment.service.ts\`**: new \`getMetadata()\` — returns \`undefined\` on self-host, otherwise \`{ customSlug: <slug or null> }\`
- **\`backend/src/api/routes/metadata/index.routes.ts\`**: aggregate the new slice in parallel with the others; spread conditionally so absent on self-host

## Followup

InsForge/CLI follow-up PR (separate) will add \`[deployments] subdomain = \"...\"\` to \`insforge.toml\` and wire up \`config apply\` to PUT \`/api/deployments/slug\`. Holding that until this lands and the existing SMTP PRs (#1258 / CLI#123) finish review — keeps the merge order linear.

## Test plan

- [x] \`npm run build\` (both shared-schemas + backend) — clean
- [x] \`npm run lint\` — clean
- [ ] After merge: hit \`GET /api/metadata\` on a cloud project, confirm \`deployments\` slice present
- [ ] After merge: hit \`GET /api/metadata\` on a self-hosted backend, confirm \`deployments\` slice **absent**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `deployments` slice to admin `/api/metadata` to expose `customSlug` for declarative subdomain management (`*.insforge.site`) via config-as-code. Cloud-only; self-hosted backends omit the slice so the CLI can detect support and skip `[deployments]` in `insforge.toml`.

- **New Features**
  - Schema updates in `@insforge/shared-schemas`: optional `deployments` slice `{ customSlug: string | null }` (omitted on self-host).
  - `DeploymentService.getConfigMetadata()` returns `{ customSlug }` in cloud or `undefined` otherwise; admin `/api/metadata` includes `deployments` only when present.

- **Bug Fixes**
  - Renamed to `getConfigMetadata` to avoid colliding with the existing `getMetadata()` used by `GET /api/deployments/metadata`.
  - Fail-soft slug lookup: on cloud fetch errors, return `{ customSlug: null }` and keep `/api/metadata` responsive.

<sup>Written for commit fff11b36c20393623e48698181c2431f6491583d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin metadata now includes optional deployment info (cloud-only custom slug). Cloud instances expose a deployments slice with customSlug (null if lookup fails); self-hosted instances omit the field. Schema updated so the new deployments metadata is optional and backward-compatible for non-cloud environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1259)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->