### PR TITLE
fix(security): harden CORS configuration to prevent authenticated CSRF

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,7 +24,7 @@ import { s3GatewayRouter } from '@/api/routes/s3-gateway/index.routes.js';
 import { paymentsRouter } from '@/api/routes/payments/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
-import { isCloudEnvironment } from '@/utils/environment.js';
+import { isCloudEnvironment, isDevelopment, getApiBaseUrl } from '@/utils/environment.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
 import fetch from 'node-fetch';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
@@ -89,11 +89,76 @@ export async function createApp() {
     skip: shouldSkipGlobalRateLimit,
   });
 
-  // Basic middleware
+  /**
+   * CORS origin validation.
+   *
+   * Previously `origin: true` reflected every requesting Origin, which combined
+   * with `credentials: true` created an authenticated CSRF vulnerability
+   * (issue #1243).
+   *
+   * The new logic:
+   *  1. Reads an optional CORS_ORIGIN env var (comma-separated whitelist).
+   *  2. If not set, derives a sensible default from API_BASE_URL.
+   *  3. In development mode the built-in Vite dev server origin
+   *     (http://localhost:5173) is also accepted.
+   *  4. Requests with no Origin header (curl, server-to-server) are allowed.
+   *  5. Requests whose Origin matches the whitelist receive a reflected
+   *     `Access-Control-Allow-Origin` + `Access-Control-Allow-Credentials: true`.
+   *  6. All other origins are rejected (CORS preflight returns 415).
+   */
+  const allowedOrigins = (() => {
+    const origins: string[] = [];
+
+    // Explicitly configured whitelist
+    if (process.env.CORS_ORIGIN) {
+      origins.push(
+        ...process.env.CORS_ORIGIN
+          .split(',')
+          .map((o) => o.trim())
+          .filter(Boolean)
+      );
+    }
+
+    // Always include the API base URL origin
+    try {
+      const apiBase = new URL(getApiBaseUrl());
+      const apiOrigin = apiBase.origin;
+      if (!origins.includes(apiOrigin)) {
+        origins.push(apiOrigin);
+      }
+    } catch {
+      // ignore invalid URL
+    }
+
+    // In development, also allow the Vite dev server
+    if (isDevelopment()) {
+      const viteOrigin = 'http://localhost:5173';
+      if (!origins.includes(viteOrigin)) {
+        origins.push(viteOrigin);
+      }
+    }
+
+    return origins;
+  })();
+
+  logger.info('CORS allowed origins', { origins: allowedOrigins });
+
   app.use(
     cors({
-      origin: true, // Allow all origins (matches Better Auth's trustedOrigins: ['*'])
-      credentials: true, // Allow cookies/credentials
+      origin: (requestOrigin, callback) => {
+        // Requests without an Origin header (server-to-server, curl, etc.)
+        if (!requestOrigin) {
+          return callback(null, true);
+        }
+
+        if (allowedOrigins.includes(requestOrigin)) {
+          return callback(null, true);
+        }
+
+        logger.warn('CORS: blocked origin', { origin: requestOrigin });
+        return callback(new Error('CORS origin not allowed'), false);
+      },
+      credentials: true,
       exposedHeaders: ['Content-Range', 'Preference-Applied'],
     })
   );

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -112,10 +112,7 @@ export async function createApp() {
     // Explicitly configured whitelist
     if (process.env.CORS_ORIGIN) {
       origins.push(
-        ...process.env.CORS_ORIGIN
-          .split(',')
-          .map((o) => o.trim())
-          .filter(Boolean)
+        ...process.env.CORS_ORIGIN.split(',').map((o) => o.trim()).filter(Boolean)
       );
     }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -112,7 +112,9 @@ export async function createApp() {
     // Explicitly configured whitelist
     if (process.env.CORS_ORIGIN) {
       origins.push(
-        ...process.env.CORS_ORIGIN.split(',').map((o) => o.trim()).filter(Boolean)
+        ...process.env.CORS_ORIGIN.split(',')
+          .map((o) => o.trim())
+          .filter(Boolean)
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1243

Hardens the CORS middleware in `backend/src/server.ts` to prevent an authenticated CSRF vulnerability caused by `origin: true` combined with `credentials: true`.

## The Vulnerability

The previous configuration:

```ts
cors({
  origin: true,       // reflects ANY Origin header
  credentials: true,  // allows session cookies
})
```

This combination allowed **any website on the internet** to make authenticated cross-site requests on behalf of a logged-in InsForge user. An attacker-controlled page could call `/api/auth/me`, `/api/database/*`, `/api/storage/*`, etc. using the victim's session cookie — a textbook CSRF bypass of the Same-Origin Policy.

### Reproduction (before fix):
```bash
curl -v -H "Origin: https://malicious-site.com" http://localhost:7130/auth/me
# Response includes:
# Access-Control-Allow-Origin: https://malicious-site.com
# Access-Control-Allow-Credentials: true
```

## The Fix

Replaced `origin: true` with a whitelist-based validation function:

```ts
cors({
  origin: (requestOrigin, callback) => {
    if (!requestOrigin) return callback(null, true);  // server-to-server
    if (allowedOrigins.includes(requestOrigin)) return callback(null, true);
    logger.warn('CORS: blocked origin', { origin: requestOrigin });
    return callback(new Error('CORS origin not allowed'), false);
  },
  credentials: true,
})
```

### Whitelist sources (in priority order):
1. **`CORS_ORIGIN` env var** — comma-separated list of explicitly allowed origins (e.g., `CORS_ORIGIN=https://app.example.com,https://admin.example.com`)
2. **`API_BASE_URL` origin** — always included as a fallback (defaults to `http://localhost:7130`)
3. **Vite dev server** — `http://localhost:5173` is automatically allowed in development mode (`NODE_ENV=development`)

### After fix:
```bash
curl -v -H "Origin: https://malicious-site.com" http://localhost:7130/auth/me
# Response: CORS error, origin blocked
# Log: WARN CORS: blocked origin { origin: "https://malicious-site.com" }
```

## Backward Compatibility

This is a **non-breaking change** for standard deployments:

| Deployment | Behavior |
|---|---|
| **Self-hosted (default)** | `http://localhost:7130` is auto-allowed. Works out of the box. |
| **Self-hosted (custom domain)** | Set `CORS_ORIGIN=https://yourdomain.com` in `.env` |
| **Cloud** | `API_BASE_URL` origin is auto-allowed |
| **Development** | Both `localhost:7130` and `localhost:5173` are allowed |
| **Server-to-server** | Requests without `Origin` header are allowed (same as before) |

## What's NOT changed

- The function proxy endpoint (`/functions/:slug`) still uses `Access-Control-Allow-Origin: *` — this is correct because it does NOT use credentials
- All existing API behavior is preserved for whitelisted origins

## Files Changed

- `backend/src/server.ts` — CORS middleware configuration (lines 92-164)

## Testing

- [x] Verified the fix addresses the exact reproduction steps from issue #1243
- [x] Confirmed `http://localhost:7130` is auto-allowed for self-hosted
- [x] Confirmed `http://localhost:5173` is auto-allowed in dev mode
- [x] Confirmed server-to-server requests (no Origin header) still work
- [x] Confirmed function proxy endpoint is unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened CORS in `backend/src/server.ts` to prevent authenticated CSRF by replacing `origin: true` with an explicit allowlist while keeping credentials enabled. Only approved origins can make authenticated browser requests; others are blocked and logged.

- **Bug Fixes**
  - Replaced `origin: true` with an allowlist validator.
  - Allowlist sources: `CORS_ORIGIN` (comma‑separated), `API_BASE_URL` origin, plus `http://localhost:5173` in development.
  - Requests without `Origin` are allowed; blocked origins are logged at WARN. Allowed origins are logged at INFO on startup.
  - `/functions/:slug` remains `*` without credentials and is unaffected.
  - Applied Prettier formatting in CORS parsing.

- **Migration**
  - If using a custom domain, set `CORS_ORIGIN=https://yourdomain.com` in the environment.

<sup>Written for commit adc76f7b950f68c4bd9e0134cc684327bef970ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden CORS configuration in `createApp` to block unauthenticated cross-origin requests
> - Replaces permissive CORS wildcard with an explicit origin allowlist built from the `CORS_ORIGIN` env var, the origin derived from `getApiBaseUrl()`, and `http://localhost:5173` in development.
> - Requests without an `Origin` header are still allowed; requests from unlisted origins are rejected with a CORS error.
> - `credentials: true` and `exposedHeaders` are unchanged.
> - Behavioral Change: any cross-origin client not covered by the allowlist will now receive a CORS error instead of a permissive response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adc76f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched server CORS handling to an explicit origin allowlist.
  * Always includes the API base origin and permits the local dev origin in development.
  * Requests without an Origin header are allowed; requests with an Origin are validated against the allowlist.
  * Cross-origin requests that are allowed include credentials; blocked origins are logged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1261)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->