### PR TITLE
docs(agents): surface built-in email service so agents stop scaffolding SMTP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Backend-as-a-service (BaaS) platform providing:
 - **Storage**: File upload/download
 - **AI**: Chat completions and image generation (OpenAI-compatible)
 - **Functions**: Serverless function deployment
+- **Email**: Send transactional email via `insforge.emails.send()`. **No SMTP / Resend / SendGrid setup required — a default cloud email provider works out of the box.** Only configure custom SMTP if the user explicitly wants their own sender domain. Do NOT install or scaffold third-party email packages by default.
 
 ## Installation
 

--- a/docs/insforge-instructions-sdk.md
+++ b/docs/insforge-instructions-sdk.md
@@ -74,6 +74,7 @@ Available documentation types:
 - `"storage-sdk"` - File storage operations
 - `"functions-sdk"` - Serverless functions invocation
 - `"ai-integration-sdk"` - AI chat and image generation
+- `"email-sdk"` - Send transactional email. **No SMTP / Resend / SendGrid setup required — a default cloud email provider works out of the box.** Only configure custom SMTP if the user explicitly wants their own sender domain.
 - `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
 - `"deployment"` - Deploy frontend applications via MCP tool
 
@@ -90,6 +91,7 @@ Available feature types:
 - auth - User authentication
 - ai - AI chat and image generation
 - realtime - Real-time pub/sub (database + client events) via WebSockets
+- email - Transactional email (default cloud provider — no SMTP setup required)
 
 Available languages:
 - typescript - JavaScript/TypeScript SDK
@@ -106,6 +108,7 @@ Available languages:
 - Storage operations (upload, download files)
 - AI operations (chat, image generation)
 - Serverless function invocation
+- **Email** — use `insforge.emails.send()` from the SDK. Do NOT scaffold `nodemailer`, `resend`, `sendgrid`, or any other third-party email package by default. The built-in service works without any SMTP env vars; the default cloud provider handles delivery automatically. Configure custom SMTP only when the user explicitly asks for their own sender domain.
 
 ### Use MCP Tools for Infrastructure:
 

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -7,6 +7,10 @@ description: Send custom transactional emails with the InsForge SDK
   **Private Preview** — This feature is currently in private preview. APIs and behavior may change.
 </Warning>
 
+<Note>
+  **No SMTP setup required.** InsForge ships a default cloud email provider — `insforge.emails.send()` works out of the box, no Resend / SendGrid / nodemailer / `SMTP_HOST` env vars needed. Configure [Custom SMTP](/core-concepts/email/custom-smtp) only when you want to send from your own sender domain.
+</Note>
+
 import Installation from '/snippets/sdk-installation.mdx';
 
 <Installation />

--- a/docs/sdks/typescript/overview.mdx
+++ b/docs/sdks/typescript/overview.mdx
@@ -30,6 +30,7 @@ const insforge = createClient({
 - **Functions** - Invoke serverless edge functions
 - **AI** - Chat completions and image generation
 - **Realtime** - WebSocket-based pub/sub messaging
+- **Email (Private Preview)** - Send transactional email. **Works out of the box with no SMTP configuration** — InsForge ships a default cloud email provider. Only set up custom SMTP (Resend, SendGrid, etc.) if you want to send from your own sender domain.
 - **Payments (Private Preview)** - Stripe Checkout and Billing Portal sessions
 
 ## SDK Reference
@@ -52,6 +53,9 @@ const insforge = createClient({
   </Card>
   <Card title="Realtime" icon="signal-stream" href="/sdks/typescript/realtime">
     WebSocket pub/sub messaging
+  </Card>
+  <Card title="Email (Private Preview)" icon="envelope" href="/sdks/typescript/email">
+    Send transactional email — no SMTP setup required
   </Card>
   <Card title="Payments (Private Preview)" icon="credit-card" href="/sdks/typescript/payments">
     Stripe Checkout and Billing Portal sessions


### PR DESCRIPTION
Closing — wrong repo. The agent skill content lives in `InsForge/insforge-skills`. Reopening there. Original body preserved below for context.

---

## Problem

Agents building on InsForge frequently scaffold third-party email packages (`nodemailer`, `resend`, `sendgrid`) and ask users for SMTP env vars, even though InsForge ships a **default cloud email provider** that works out of the box.

**Production evidence** (scan on 2026-05-13): **17+ user projects** had `RESEND_API_KEY` set as a secret.