### PR TITLE
INS-189: Add auto-refresh or manual refresh for disk telemetry

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -1,13 +1,5 @@
 import { useState } from 'react';
-import {
-  ArrowDownToLine,
-  ArrowUpFromLine,
-  Cpu,
-  HardDrive,
-  MemoryStick,
-  RefreshCw,
-} from 'lucide-react';
-import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { ArrowDownToLine, ArrowUpFromLine, Cpu, HardDrive, MemoryStick } from 'lucide-react';
 import { useProjectMetrics } from '#features/dashboard/hooks/useProjectMetrics';
 import type { DashboardMetricName, DashboardMetricsRange } from '#types';
 import { MetricChartCard } from './MetricChartCard';
@@ -79,68 +71,32 @@ const METRICS: MetricConfig[] = [
 
 export function ObservabilitySection() {
   const [range, setRange] = useState<DashboardMetricsRange>('1h');
-  const { data, isLoading, isUnavailable, error, refetch } = useProjectMetrics(range);
-  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
-
-  const handleRefresh = async () => {
-    setIsManualRefreshing(true);
-    try {
-      await refetch();
-    } finally {
-      setIsManualRefreshing(false);
-    }
-  };
+  const { data, isLoading, isUnavailable, error } = useProjectMetrics(range);
 
   return (
     <section className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-medium leading-7 text-foreground">Observability</h2>
-        <div className="flex items-center gap-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => void handleRefresh()}
-                  disabled={isUnavailable || isManualRefreshing}
-                  className="h-8 w-8 rounded p-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] active:bg-[var(--alpha-8)]"
-                >
-                  <RefreshCw
-                    className={
-                      isManualRefreshing
-                        ? 'h-5 w-5 animate-spin stroke-[1.5]'
-                        : 'h-5 w-5 stroke-[1.5]'
-                    }
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" align="center">
-                <p>{isManualRefreshing ? 'Refreshing...' : 'Refresh metrics'}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <div
-            role="group"
-            aria-label="Time range"
-            className="flex items-center overflow-hidden rounded border border-[var(--alpha-8)] bg-[var(--alpha-4)]"
-          >
-            {RANGES.map((value) => (
-              <button
-                key={value}
-                type="button"
-                aria-pressed={range === value}
-                onClick={() => setRange(value)}
-                className={`flex items-center px-3 py-1.5 text-sm leading-5 transition-colors ${
-                  range === value
-                    ? 'bg-toast text-foreground'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {value}
-              </button>
-            ))}
-          </div>
+        <div
+          role="group"
+          aria-label="Time range"
+          className="flex items-center overflow-hidden rounded border border-[var(--alpha-8)] bg-[var(--alpha-4)]"
+        >
+          {RANGES.map((value) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={range === value}
+              onClick={() => setRange(value)}
+              className={`flex items-center px-3 py-1.5 text-sm leading-5 transition-colors ${
+                range === value
+                  ? 'bg-toast text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {value}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react';
-import { ArrowDownToLine, ArrowUpFromLine, Cpu, HardDrive, MemoryStick } from 'lucide-react';
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Cpu,
+  HardDrive,
+  MemoryStick,
+  RefreshCw,
+} from 'lucide-react';
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
 import { useProjectMetrics } from '#features/dashboard/hooks/useProjectMetrics';
 import type { DashboardMetricName, DashboardMetricsRange } from '#types';
 import { MetricChartCard } from './MetricChartCard';
@@ -71,32 +79,68 @@ const METRICS: MetricConfig[] = [
 
 export function ObservabilitySection() {
   const [range, setRange] = useState<DashboardMetricsRange>('1h');
-  const { data, isLoading, isUnavailable, error } = useProjectMetrics(range);
+  const { data, isLoading, isUnavailable, error, refetch } = useProjectMetrics(range);
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setIsManualRefreshing(true);
+    try {
+      await refetch();
+    } finally {
+      setIsManualRefreshing(false);
+    }
+  };
 
   return (
     <section className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-medium leading-7 text-foreground">Observability</h2>
-        <div
-          role="group"
-          aria-label="Time range"
-          className="flex items-center overflow-hidden rounded border border-[var(--alpha-8)] bg-[var(--alpha-4)]"
-        >
-          {RANGES.map((value) => (
-            <button
-              key={value}
-              type="button"
-              aria-pressed={range === value}
-              onClick={() => setRange(value)}
-              className={`flex items-center px-3 py-1.5 text-sm leading-5 transition-colors ${
-                range === value
-                  ? 'bg-toast text-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {value}
-            </button>
-          ))}
+        <div className="flex items-center gap-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => void handleRefresh()}
+                  disabled={isUnavailable || isManualRefreshing}
+                  className="h-8 w-8 rounded p-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] active:bg-[var(--alpha-8)]"
+                >
+                  <RefreshCw
+                    className={
+                      isManualRefreshing
+                        ? 'h-5 w-5 animate-spin stroke-[1.5]'
+                        : 'h-5 w-5 stroke-[1.5]'
+                    }
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" align="center">
+                <p>{isManualRefreshing ? 'Refreshing...' : 'Refresh metrics'}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <div
+            role="group"
+            aria-label="Time range"
+            className="flex items-center overflow-hidden rounded border border-[var(--alpha-8)] bg-[var(--alpha-4)]"
+          >
+            {RANGES.map((value) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={range === value}
+                onClick={() => setRange(value)}
+                className={`flex items-center px-3 py-1.5 text-sm leading-5 transition-colors ${
+                  range === value
+                    ? 'bg-toast text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {value}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/packages/dashboard/src/features/dashboard/hooks/useProjectMetrics.ts
+++ b/packages/dashboard/src/features/dashboard/hooks/useProjectMetrics.ts
@@ -7,10 +7,8 @@ export const PROJECT_METRICS_QUERY_KEY = 'project-metrics';
 export interface UseProjectMetricsResult {
   data?: DashboardMetricsResponse;
   isLoading: boolean;
-  isFetching: boolean;
   isUnavailable: boolean;
   error: Error | null;
-  refetch: () => Promise<void>;
 }
 
 export function useProjectMetrics(range: DashboardMetricsRange): UseProjectMetricsResult {
@@ -36,11 +34,7 @@ export function useProjectMetrics(range: DashboardMetricsRange): UseProjectMetri
   return {
     data: query.data,
     isLoading: query.isLoading && !!fetcher,
-    isFetching: query.isFetching && !!fetcher,
     isUnavailable,
     error: isUnavailable ? null : (query.error as Error | null),
-    refetch: async () => {
-      await query.refetch();
-    },
   };
 }

--- a/packages/dashboard/src/features/dashboard/hooks/useProjectMetrics.ts
+++ b/packages/dashboard/src/features/dashboard/hooks/useProjectMetrics.ts
@@ -7,8 +7,10 @@ export const PROJECT_METRICS_QUERY_KEY = 'project-metrics';
 export interface UseProjectMetricsResult {
   data?: DashboardMetricsResponse;
   isLoading: boolean;
+  isFetching: boolean;
   isUnavailable: boolean;
   error: Error | null;
+  refetch: () => Promise<void>;
 }
 
 export function useProjectMetrics(range: DashboardMetricsRange): UseProjectMetricsResult {
@@ -25,7 +27,8 @@ export function useProjectMetrics(range: DashboardMetricsRange): UseProjectMetri
     },
     enabled: !!fetcher,
     retry: false,
-    staleTime: 60 * 1000,
+    staleTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
   });
 
   const isUnavailable = !fetcher || query.error?.message === 'METRICS_UNAVAILABLE';
@@ -33,7 +36,11 @@ export function useProjectMetrics(range: DashboardMetricsRange): UseProjectMetri
   return {
     data: query.data,
     isLoading: query.isLoading && !!fetcher,
+    isFetching: query.isFetching && !!fetcher,
     isUnavailable,
     error: isUnavailable ? null : (query.error as Error | null),
+    refetch: async () => {
+      await query.refetch();
+    },
   };
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 30s auto-refresh for Observability metrics and reduce cache staleness to 30s to keep data fresh. Remove the manual refresh button; `useProjectMetrics` now polls in the background via `refetchInterval`.

<sup>Written for commit 2af6e0aadca7cd77afb2cedcd6f79b7a960d8a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-refresh and manual refresh button to observability metrics
> - `useProjectMetrics` now refetches metrics every 30 seconds and reduces `staleTime` from 60s to 30s; it also exposes `isFetching` and a `refetch` function to callers.
> - `ObservabilitySection` adds a refresh button in the header that triggers an immediate refetch, shows a spinning icon while in progress, and is disabled when metrics are unavailable or a refresh is already running.
> - Behavioral Change: metrics now generate a network request every 30 seconds instead of only on mount or manual navigation.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1268 opened
>
> - Removed `refetch` function and `isFetching` boolean from the `UseProjectMetricsResult` type and return value of the `useProjectMetrics` hook in the `dashboard` package [2af6e0a]
> - Removed manual refresh functionality from the `ObservabilitySection` component at the `/dashboard` route [2af6e0a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4306904.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dashboard metrics refresh rate for more timely data updates in the project dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1268)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->