### PR TITLE
INS-188: Clarify disk telemetry with absolute values and thresholds

### DIFF
--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -20,6 +20,8 @@ const VALID_METRIC_NAMES: readonly DashboardMetricName[] = [
   'cpu_usage',
   'memory_usage',
   'disk_usage',
+  'disk_used',
+  'disk_total',
   'network_in',
   'network_out',
 ] as const;

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -9,7 +9,12 @@ export interface MetricChartCardProps {
   rangeSeconds: number;
   formatValue: (value: number) => string;
   isLoading?: boolean;
+  /** Value (in data units) at which the threshold dashed line is drawn. */
   threshold?: number;
+  /** Fixed y-axis domain [min, max]. Defaults to [0, 100] when threshold is set, else auto-fits to data. */
+  fixedDomain?: [number, number];
+  /** Formatter for axis labels (threshold + zero). Defaults to `${v}%`. */
+  formatAxisLabel?: (value: number) => string;
 }
 
 const SPARKLINE_WIDTH = 434;
@@ -100,16 +105,15 @@ export function MetricChartCard({
   formatValue,
   isLoading,
   threshold,
+  fixedDomain,
+  formatAxisLabel,
 }: MetricChartCardProps) {
+  const effectiveDomain =
+    fixedDomain ?? (threshold !== undefined ? FIXED_PERCENT_DOMAIN : undefined);
   const aggregates = useMemo(() => aggregateMetricSeries(data), [data]);
   const sparkline = useMemo(
-    () =>
-      buildSparkline(
-        data,
-        rangeSeconds,
-        threshold !== undefined ? FIXED_PERCENT_DOMAIN : undefined
-      ),
-    [data, rangeSeconds, threshold]
+    () => buildSparkline(data, rangeSeconds, effectiveDomain),
+    [data, rangeSeconds, effectiveDomain]
   );
   const gradientId = useId();
   const xAxisTicks = useMemo(() => {
@@ -154,7 +158,12 @@ export function MetricChartCard({
   const hoverTopPct = hover ? (hover.y / SPARKLINE_HEIGHT) * 100 : 0;
   const tooltipTranslateX = hoverLeftPct < 15 ? '0%' : hoverLeftPct > 85 ? '-100%' : '-50%';
 
-  const thresholdOffsetPct = threshold !== undefined ? 100 - threshold : 0;
+  const [domainMin, domainMax] = effectiveDomain ?? [0, 100];
+  const domainRange = domainMax - domainMin || 1;
+  const thresholdOffsetPct =
+    threshold !== undefined ? 100 - ((threshold - domainMin) / domainRange) * 100 : 0;
+  const renderAxisLabel = (value: number) =>
+    formatAxisLabel ? formatAxisLabel(value) : `${value}%`;
   const gradientTransitionHalfWidth = 8;
   const gradientTransitionStart = Math.max(
     0,
@@ -263,10 +272,10 @@ export function MetricChartCard({
                       className="pointer-events-none absolute left-0 -translate-y-1/2 text-xs leading-4 text-muted-foreground"
                       style={{ top: `${thresholdOffsetPct}%` }}
                     >
-                      {threshold}%
+                      {renderAxisLabel(threshold)}
                     </span>
                     <span className="pointer-events-none absolute bottom-0 left-0 text-xs leading-4 text-muted-foreground">
-                      0%
+                      {renderAxisLabel(domainMin)}
                     </span>
                   </>
                 )}

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -32,6 +32,7 @@ const BYTES_PER_SEC = (value: number) => {
   }
   return `${v.toFixed(1)} ${units[i]}`;
 };
+const BYTES_TO_GIB = (value: number) => `${(value / 1024 ** 3).toFixed(1)} GiB`;
 
 const METRICS: MetricConfig[] = [
   {
@@ -49,13 +50,6 @@ const METRICS: MetricConfig[] = [
     threshold: 85,
   },
   {
-    metric: 'disk_usage',
-    title: 'Disk Usage',
-    icon: <HardDrive className="h-5 w-5" />,
-    format: PERCENT,
-    threshold: 90,
-  },
-  {
     metric: 'network_in',
     title: 'Network In',
     icon: <ArrowDownToLine className="h-5 w-5" />,
@@ -68,6 +62,9 @@ const METRICS: MetricConfig[] = [
     format: BYTES_PER_SEC,
   },
 ];
+
+// Disk card slot in the grid (after CPU + Memory, before Network).
+const DISK_GRID_INDEX = 2;
 
 export function ObservabilitySection() {
   const [range, setRange] = useState<DashboardMetricsRange>('1h');
@@ -110,21 +107,46 @@ export function ObservabilitySection() {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          {METRICS.map((config) => {
-            const series = data?.metrics.find((m) => m.metric === config.metric);
-            return (
+          {(() => {
+            const cards = METRICS.map((config) => {
+              const series = data?.metrics.find((m) => m.metric === config.metric);
+              return (
+                <MetricChartCard
+                  key={config.metric}
+                  title={config.title}
+                  icon={config.icon}
+                  data={series?.data ?? []}
+                  rangeSeconds={RANGE_SECONDS[range]}
+                  formatValue={config.format}
+                  isLoading={isLoading}
+                  threshold={config.threshold}
+                />
+              );
+            });
+
+            const diskUsed = data?.metrics.find((m) => m.metric === 'disk_used');
+            const diskTotal = data?.metrics.find((m) => m.metric === 'disk_total');
+            const totalBytes =
+              [...(diskTotal?.data ?? [])].reverse().find((p) => Number.isFinite(p.value))?.value ??
+              null;
+            cards.splice(
+              DISK_GRID_INDEX,
+              0,
               <MetricChartCard
-                key={config.metric}
-                title={config.title}
-                icon={config.icon}
-                data={series?.data ?? []}
+                key="disk_used"
+                title="Disk Usage"
+                icon={<HardDrive className="h-5 w-5" />}
+                data={diskUsed?.data ?? []}
                 rangeSeconds={RANGE_SECONDS[range]}
-                formatValue={config.format}
+                formatValue={BYTES_TO_GIB}
                 isLoading={isLoading}
-                threshold={config.threshold}
+                threshold={totalBytes !== null ? 0.9 * totalBytes : undefined}
+                fixedDomain={totalBytes !== null ? [0, totalBytes] : undefined}
+                formatAxisLabel={BYTES_TO_GIB}
               />
             );
-          })}
+            return cards;
+          })()}
         </div>
       )}
     </section>

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ArrowDownToLine, ArrowUpFromLine, Cpu, HardDrive, MemoryStick } from 'lucide-react';
 import { useProjectMetrics } from '#features/dashboard/hooks/useProjectMetrics';
 import type { DashboardMetricName, DashboardMetricsRange } from '#types';
@@ -70,6 +70,23 @@ export function ObservabilitySection() {
   const [range, setRange] = useState<DashboardMetricsRange>('1h');
   const { data, isLoading, isUnavailable, error } = useProjectMetrics(range);
 
+  // Memoize disk card derivations so the [0, totalBytes] domain array reference
+  // is stable across renders — otherwise MetricChartCard's sparkline useMemo
+  // re-runs every parent render.
+  const diskCardProps = useMemo(() => {
+    const diskUsedData = data?.metrics.find((m) => m.metric === 'disk_used')?.data ?? [];
+    const diskTotalData = data?.metrics.find((m) => m.metric === 'disk_total')?.data ?? [];
+    const totalBytes =
+      [...diskTotalData].reverse().find((p) => Number.isFinite(p.value))?.value ?? null;
+    return {
+      data: diskUsedData,
+      threshold: totalBytes !== null ? 0.9 * totalBytes : undefined,
+      fixedDomain: (totalBytes !== null ? [0, totalBytes] : undefined) as
+        | [number, number]
+        | undefined,
+    };
+  }, [data]);
+
   return (
     <section className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
@@ -124,11 +141,6 @@ export function ObservabilitySection() {
               );
             });
 
-            const diskUsed = data?.metrics.find((m) => m.metric === 'disk_used');
-            const diskTotal = data?.metrics.find((m) => m.metric === 'disk_total');
-            const totalBytes =
-              [...(diskTotal?.data ?? [])].reverse().find((p) => Number.isFinite(p.value))?.value ??
-              null;
             cards.splice(
               DISK_GRID_INDEX,
               0,
@@ -136,12 +148,12 @@ export function ObservabilitySection() {
                 key="disk_used"
                 title="Disk Usage"
                 icon={<HardDrive className="h-5 w-5" />}
-                data={diskUsed?.data ?? []}
+                data={diskCardProps.data}
                 rangeSeconds={RANGE_SECONDS[range]}
                 formatValue={BYTES_TO_GIB}
                 isLoading={isLoading}
-                threshold={totalBytes !== null ? 0.9 * totalBytes : undefined}
-                fixedDomain={totalBytes !== null ? [0, totalBytes] : undefined}
+                threshold={diskCardProps.threshold}
+                fixedDomain={diskCardProps.fixedDomain}
                 formatAxisLabel={BYTES_TO_GIB}
               />
             );

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -32,7 +32,19 @@ const BYTES_PER_SEC = (value: number) => {
   }
   return `${v.toFixed(1)} ${units[i]}`;
 };
-const BYTES_TO_GIB = (value: number) => `${(value / 1024 ** 3).toFixed(1)} GiB`;
+const BYTES_SIZE = (value: number) => {
+  if (value === 0) {
+    return '0 bytes';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let v = value;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+};
 
 const METRICS: MetricConfig[] = [
   {
@@ -150,11 +162,11 @@ export function ObservabilitySection() {
                 icon={<HardDrive className="h-5 w-5" />}
                 data={diskCardProps.data}
                 rangeSeconds={RANGE_SECONDS[range]}
-                formatValue={BYTES_TO_GIB}
+                formatValue={BYTES_SIZE}
                 isLoading={isLoading}
                 threshold={diskCardProps.threshold}
                 fixedDomain={diskCardProps.fixedDomain}
-                formatAxisLabel={BYTES_TO_GIB}
+                formatAxisLabel={BYTES_SIZE}
               />
             );
             return cards;

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -66,6 +66,8 @@ export type DashboardMetricName =
   | 'cpu_usage'
   | 'memory_usage'
   | 'disk_usage'
+  | 'disk_used'
+  | 'disk_total'
   | 'network_in'
   | 'network_out';
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show disk usage as absolute bytes with auto-scaling units (B/KB/MB/GB/TB) instead of percent. Fix the y-axis to real capacity so thresholds reflect actual bytes; aligns with INS-188.

- **New Features**
  - Replace percent-based Disk card with a bytes-based card using `disk_used` and `disk_total`, inserted after CPU/Memory.
  - Auto-scale values and axis labels using B/KB/MB/GB/TB; set threshold to 90% of the latest finite `disk_total`. If total is missing, auto-scale the y-axis.
  - Extend `MetricChartCard` with `fixedDomain` and `formatAxisLabel`; threshold and labels respect the provided domain, and the bottom label shows the domain min.

- **Bug Fixes**
  - Allow `disk_used` and `disk_total` through the cloud-hosting bridge by adding them to `VALID_METRIC_NAMES`.

<sup>Written for commit 79cefc985e881ac25ad9188efff9e42242edc34c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace disk usage percentage metric with absolute byte values and a 90% threshold in the Disk Usage chart
> - Removes the `disk_usage` percentage metric and replaces it with `disk_used` and `disk_total` byte metrics, adding both to `DashboardMetricName` and `VALID_METRIC_NAMES`.
> - The Disk Usage card in [`ObservabilitySection.tsx`](https://github.com/InsForge/InsForge/pull/1273/files#diff-4d4de4387f9c09a7f1ba64970502fcff25a504fc213a5153d41e8347edd15ba2) now renders a fixed `[0, total]` domain with a threshold at 90% of total bytes, and formats all labels using a new `BYTES_SIZE` formatter (e.g. `1.2 GB`).
> - [`MetricChartCard`](https://github.com/InsForge/InsForge/pull/1273/files#diff-6c59402e5bdc7fe1aae45ecea455773b19caa4d2fe4a692e6a0ed7ccd27dedd6) gains `fixedDomain` and `formatAxisLabel` props; threshold line and gradient positions are now computed relative to the provided domain instead of assuming a 0–100% scale.
> - Behavioral Change: any caller previously relying on `disk_usage` as a percentage will no longer see that metric; disk data now comes from raw byte values derived at render time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79cefc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable y-axis scaling and custom axis-label formatting for metric charts.
  * Disk usage metrics added with automatic byte→human-readable unit conversion.

* **Refactor**
  * Improved threshold positioning and gradient mapping for more accurate visuals.
  * Disk usage card is now computed and inserted into the metrics grid for more reliable layout and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1273)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->