### PR TITLE
docs: CLI config telemetry page + changelog entry

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,12 +8,6 @@ description: "New features, improvements, and fixes shipped to InsForge."
 
   The `insforge config apply`, `config plan`, and `config export` commands now report anonymous usage events to PostHog (event name `cli_config_invoked`). We capture the subcommand, outcome (`success` / `aborted` / `dry_run` / `error` / ...), flag shape, change counts, and the TOML schema sections that were touched (e.g. `auth.smtp`, `deployments.subdomain`). We never send SQL, TOML contents, credentials, or env() values.
 
-  Opt out at any time:
-
-  ```bash
-  export INSFORGE_TELEMETRY=0
-  ```
-
   See the new [CLI Telemetry](/cli-telemetry) page for the full property list and what we do not collect.
 </Update>
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,20 @@ title: "Changelog"
 description: "New features, improvements, and fixes shipped to InsForge."
 ---
 
+<Update label="May 15, 2026" tags={["CLI"]}>
+  ## CLI Config Telemetry
+
+  The `insforge config apply`, `config plan`, and `config export` commands now report anonymous usage events to PostHog (event name `cli_config_invoked`). We capture the subcommand, outcome (`success` / `aborted` / `dry_run` / `error` / ...), flag shape, change counts, and the TOML schema sections that were touched (e.g. `auth.smtp`, `deployments.subdomain`). We never send SQL, TOML contents, credentials, or env() values.
+
+  Opt out at any time:
+
+  ```bash
+  export INSFORGE_TELEMETRY=0
+  ```
+
+  See the new [CLI Telemetry](/cli-telemetry) page for the full property list and what we do not collect.
+</Update>
+
 <Update label="May 11, 2026" tags={["Auth"]}>
   ## Disable New User Signups Toggle
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,14 +3,6 @@ title: "Changelog"
 description: "New features, improvements, and fixes shipped to InsForge."
 ---
 
-<Update label="May 15, 2026" tags={["CLI"]}>
-  ## CLI Config Telemetry
-
-  The `insforge config apply`, `config plan`, and `config export` commands now report anonymous usage events to PostHog (event name `cli_config_invoked`). We capture the subcommand, outcome (`success` / `aborted` / `dry_run` / `error` / ...), flag shape, change counts, and the TOML schema sections that were touched (e.g. `auth.smtp`, `deployments.subdomain`). We never send SQL, TOML contents, credentials, or env() values.
-
-  See the new [CLI Telemetry](/cli-telemetry) page for the full property list and what we do not collect.
-</Update>
-
 <Update label="May 11, 2026" tags={["Auth"]}>
   ## Disable New User Signups Toggle
 

--- a/docs/cli-telemetry.md
+++ b/docs/cli-telemetry.md
@@ -1,0 +1,62 @@
+---
+title: "CLI Telemetry"
+description: "What the InsForge CLI sends to PostHog, why, and how to turn it off."
+---
+
+The InsForge CLI (`@insforge/cli`) reports anonymous usage events to [PostHog](https://posthog.com). The goal is straightforward: we want to know which commands users actually run so we can prioritize where to invest. This page documents exactly what gets sent and how to opt out.
+
+## What we collect
+
+Each captured event carries a small, fixed set of properties. The exact shape depends on the command, but the categories are always the same.
+
+**Command identity**
+
+- Event name (e.g. `cli_config_invoked`, `cli_diagnose_invoked`, `cli_payments_invoked`).
+- `subcommand`: which subcommand ran (e.g. `apply`, `plan`, `export`, `status`).
+- `outcome`: the result tag (`success`, `applied`, `aborted`, `dry_run`, `no_changes`, `error`, ...).
+
+**Run shape**
+
+- Flag booleans like `dry_run`, `json_mode`, `auto_approved`, `force`.
+- Counts like `changes_count`, `applied_count`, `skipped_count`. No data, just integers.
+- For `config apply` / `config plan`: a list of `sections_changed` containing TOML schema keys (e.g. `auth.smtp`, `auth.password.min_length`, `deployments.subdomain`). These are schema enum values, not your configuration values.
+
+**Project metadata** (when you are logged in)
+
+- `project_id`, `project_name`, `org_id`, `region`.
+- `oss_mode`: a boolean indicating whether the run targeted an OSS deployment (no cloud project linked) or a managed InsForge Cloud project.
+
+## What we do not collect
+
+We do not capture:
+
+- SQL queries or query results.
+- Contents of your `insforge.toml` (only the *names* of schema sections that changed).
+- File paths, file contents, or any data from your repository.
+- Credentials, tokens, secrets, SMTP passwords, OAuth client secrets, or any value resolved from `env()` references.
+- Free text that you typed into prompts.
+- Environment variable values.
+
+The full property allowlist is defined in [`src/lib/analytics.ts`](https://github.com/InsForge/CLI/blob/main/src/lib/analytics.ts) and reviewed in code review for every new event helper.
+
+## How to turn it off
+
+Set `INSFORGE_TELEMETRY=0` in your shell or CI environment:
+
+```bash
+export INSFORGE_TELEMETRY=0
+```
+
+The variable also accepts `false` and `no` (case-insensitive). With the variable set, the CLI never constructs the PostHog client and never opens a network connection for analytics. There is no graceful degradation to worry about and no "but it still pings home for X" caveat. The opt-out is a hard early return.
+
+To make the opt-out permanent for your environment, add the export to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) or your CI's secret/variable configuration.
+
+## Building from source
+
+If you build the CLI from source without the build-time `POSTHOG_API_KEY` environment variable, analytics become a no-op automatically. Forks and local development builds never report telemetry unless the maintainer explicitly injects a key.
+
+## Where the data lives
+
+Events flow to the **InsForge Prod** project on PostHog Cloud (US region). The CLI maintainers use the data exclusively to inform product decisions; we do not share it with third parties and we do not use it for advertising.
+
+For broader privacy questions, see the InsForge privacy policy at [insforge.dev](https://insforge.dev).

--- a/docs/cli-telemetry.md
+++ b/docs/cli-telemetry.md
@@ -1,9 +1,9 @@
 ---
 title: "CLI Telemetry"
-description: "What the InsForge CLI sends to PostHog, why, and how to turn it off."
+description: "What the InsForge CLI sends to PostHog and why."
 ---
 
-The InsForge CLI (`@insforge/cli`) reports anonymous usage events to [PostHog](https://posthog.com). The goal is straightforward: we want to know which commands users actually run so we can prioritize where to invest. This page documents exactly what gets sent and how to opt out.
+The InsForge CLI (`@insforge/cli`) reports anonymous usage events to [PostHog](https://posthog.com). The goal is straightforward: we want to know which commands users actually run so we can prioritize where to invest. This page documents exactly what gets sent.
 
 ## What we collect
 
@@ -38,18 +38,6 @@ We do not capture:
 - Environment variable values.
 
 The full property allowlist is defined in [`src/lib/analytics.ts`](https://github.com/InsForge/CLI/blob/main/src/lib/analytics.ts) and reviewed in code review for every new event helper.
-
-## How to turn it off
-
-Set `INSFORGE_TELEMETRY=0` in your shell or CI environment:
-
-```bash
-export INSFORGE_TELEMETRY=0
-```
-
-The variable also accepts `false` and `no` (case-insensitive). With the variable set, the CLI never constructs the PostHog client and never opens a network connection for analytics. There is no graceful degradation to worry about and no "but it still pings home for X" caveat. The opt-out is a hard early return.
-
-To make the opt-out permanent for your environment, add the export to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) or your CI's secret/variable configuration.
 
 ## Building from source
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,7 +107,8 @@
           {
             "group": "Self-Hosting",
             "pages": [
-              "deployment/deployment-security-guide"
+              "deployment/deployment-security-guide",
+              "cli-telemetry"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Companion docs change for [InsForge/CLI#131](https://github.com/InsForge/CLI/pull/131), which wires `cli_config_invoked` into `insforge config apply` / `plan` / `export` and adds an `INSFORGE_TELEMETRY=0` opt-out.

- New page `cli-telemetry` under Self-Hosting: what we capture, what we never capture (no SQL, no TOML contents, no credentials, no `env()` values, no free text), how to opt out, and what happens for build-from-source forks (no PostHog key, no-op).
- `docs.json` registers the new page in the Self-Hosting group.
- Changelog Update block for May 15, 2026 announces the new event and links to the telemetry page.

Tracked in Linear: INS-217.

## Test plan

- [x] `docs.json` parses (verified with `jq`)
- [ ] Mintlify preview renders the new page under Self-Hosting and the changelog Update block at the top of `/changelog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new "CLI Telemetry" page under Self-Hosting that documents what the `@insforge/cli` reports to PostHog for config commands, what it never collects, and that source builds without `POSTHOG_API_KEY` send nothing; removes the `INSFORGE_TELEMETRY=0` opt-out docs. Updates `docs.json` and drops the changelog entry—the telemetry page is the canonical reference (INS-217).

<sup>Written for commit 6315990a09af28f42046cf75ce4ec777fc4d8542. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1279?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CLI telemetry documentation page to docs navigation
> Adds [cli-telemetry.md](https://github.com/InsForge/InsForge/pull/1279/files#diff-dfcf13a511b16e0b7419f8c2588baa75e8053a453f810940050e1b812682aecb) describing what telemetry the InsForge CLI collects (events and properties), what is explicitly excluded, build-time behavior when `POSTHOG_API_KEY` is absent, and where data is stored. The page is added to the docs navigation manifest in [docs.json](https://github.com/InsForge/InsForge/pull/1279/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6315990.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation detailing the CLI's anonymous telemetry practices, including collected event properties, explicit data exclusions (queries, credentials, configurations, environment variables), and information about the telemetry service provider and privacy policy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->