### PR TITLE
feat(database): add advisor scan

### DIFF
--- a/backend/src/api/routes/advisor/index.routes.ts
+++ b/backend/src/api/routes/advisor/index.routes.ts
@@ -1,0 +1,22 @@
+import { Router, Response, NextFunction } from 'express';
+import { AuthRequest, verifyAdmin } from '@/api/middlewares/auth.js';
+import { AdvisorService } from '@/services/advisor/advisor.service.js';
+import { successResponse } from '@/utils/response.js';
+import logger from '@/utils/logger.js';
+
+export const advisorRouter = Router();
+const advisorService = AdvisorService.getInstance();
+
+advisorRouter.post(
+  '/scan',
+  verifyAdmin,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const result = await advisorService.scan();
+      successResponse(res, result);
+    } catch (error: unknown) {
+      logger.warn('Advisor scan error:', error);
+      next(error);
+    }
+  }
+);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -40,6 +40,7 @@ import packageJson from '../../package.json';
 import { schedulesRouter } from '@/api/routes/schedules/index.routes.js';
 import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { posthogRouter } from '@/api/routes/posthog/index.routes.js';
+import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -219,6 +220,7 @@ export async function createApp() {
   apiRouter.use('/payments', paymentsRouter);
   apiRouter.use('/compute/services', servicesRouter);
   apiRouter.use('/integrations/posthog', posthogRouter);
+  apiRouter.use('/advisor', advisorRouter);
 
   // Mount all API routes under /api prefix
   app.use('/api', apiRouter);

--- a/backend/src/services/advisor/advisor.service.ts
+++ b/backend/src/services/advisor/advisor.service.ts
@@ -112,11 +112,17 @@ async function queryRows<T extends QueryResultRow>(
   return result.rows;
 }
 
-async function relationExists(db: Pool | PoolClient, relationName: string): Promise<boolean> {
+async function extensionExists(db: Pool | PoolClient, extensionName: string): Promise<boolean> {
   const rows = await queryRows<{ exists: boolean }>(
     db,
-    'SELECT to_regclass($1) IS NOT NULL AS "exists"',
-    [relationName]
+    `
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_extension
+        WHERE extname = $1
+      ) AS "exists"
+    `,
+    [extensionName]
   );
   return rows[0]?.exists === true;
 }
@@ -432,7 +438,7 @@ async function scanUnusedIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
 }
 
 async function scanSlowQuery(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
-  if (!(await relationExists(ctx.db, 'pg_stat_statements'))) {
+  if (!(await extensionExists(ctx.db, 'pg_stat_statements'))) {
     return [];
   }
 

--- a/backend/src/services/advisor/advisor.service.ts
+++ b/backend/src/services/advisor/advisor.service.ts
@@ -1,0 +1,1187 @@
+import type { Pool, QueryResultRow } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { AppError } from '@/api/middlewares/error.js';
+import type {
+  AdvisorCategory,
+  AdvisorFinding,
+  AdvisorRuleId,
+  AdvisorRuleSummary,
+  AdvisorScanResponse,
+  AdvisorSeverity,
+} from '@insforge/shared-schemas';
+
+interface AdvisorContext {
+  pool: Pool;
+}
+
+interface AdvisorRule extends AdvisorRuleSummary {
+  run: (ctx: AdvisorContext) => Promise<AdvisorFinding[]>;
+}
+
+interface BaseFindingInput {
+  ruleId: AdvisorRuleId;
+  category: AdvisorCategory;
+  severity: AdvisorSeverity;
+  title: string;
+  message: string;
+  schemaName?: string;
+  tableName?: string;
+  objectName?: string;
+  detail?: Record<string, unknown>;
+  remediation: string;
+}
+
+interface NamedObjectRow extends QueryResultRow {
+  schema_name: string;
+  table_name?: string;
+  object_name?: string;
+}
+
+const INTERNAL_SCHEMAS = [
+  'pg_catalog',
+  'information_schema',
+  'auth',
+  'storage',
+  'realtime',
+  'system',
+];
+const USER_SCHEMA_FILTER = `
+  n.nspname <> ALL($1::text[])
+  AND n.nspname NOT LIKE 'pg_%'
+`;
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+function safeNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function safeStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => safeString(item));
+  }
+  if (typeof value === 'string') {
+    return value.replace(/[{}]/g, '').split(',').filter(Boolean);
+  }
+  return [];
+}
+
+function makeFinding(input: BaseFindingInput): AdvisorFinding {
+  const stableParts = [
+    input.ruleId,
+    input.schemaName,
+    input.tableName,
+    input.objectName,
+    input.message,
+  ].filter(Boolean);
+
+  return {
+    id: stableParts.join(':'),
+    ...input,
+  };
+}
+
+async function queryRows<T extends QueryResultRow>(
+  pool: Pool,
+  sql: string,
+  params: unknown[] = []
+): Promise<T[]> {
+  const result = await pool.query<T>(sql, params);
+  return result.rows;
+}
+
+async function relationExists(pool: Pool, relationName: string): Promise<boolean> {
+  const rows = await queryRows<{ exists: boolean }>(
+    pool,
+    'SELECT to_regclass($1) IS NOT NULL AS "exists"',
+    [relationName]
+  );
+  return rows[0]?.exists === true;
+}
+
+async function scanRlsDisabled(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<NamedObjectRow & { table_name: string }>(
+    ctx.pool,
+    `
+      /* advisor:rls-disabled */
+      SELECT n.nspname AS schema_name, c.relname AS table_name
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'r'
+        AND ${USER_SCHEMA_FILTER}
+        AND c.relname NOT LIKE '\\_%' ESCAPE '\\'
+        AND c.relrowsecurity = false
+      ORDER BY n.nspname, c.relname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'rls-disabled',
+      category: 'security',
+      severity: 'critical',
+      title: 'RLS is disabled',
+      message: `${row.schema_name}.${row.table_name} does not have row-level security enabled.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      remediation: 'Enable RLS and add policies that match the expected application access paths.',
+    })
+  );
+}
+
+async function scanRlsPermissive(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & { table_name: string; object_name: string; cmd: string; roles: string[] }
+  >(
+    ctx.pool,
+    `
+      /* advisor:rls-permissive */
+      SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        p.polname AS object_name,
+        p.polcmd AS cmd,
+        CASE
+          WHEN p.polroles = '{0}'::oid[] THEN ARRAY['public']::text[]
+          ELSE COALESCE(array_agg(r.rolname ORDER BY r.rolname) FILTER (WHERE r.rolname IS NOT NULL), ARRAY[]::text[])
+        END AS roles
+      FROM pg_policy p
+      JOIN pg_class c ON c.oid = p.polrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      LEFT JOIN LATERAL unnest(p.polroles) AS role_oid ON true
+      LEFT JOIN pg_roles r ON r.oid = role_oid
+      WHERE ${USER_SCHEMA_FILTER}
+        AND p.polpermissive = true
+      GROUP BY n.nspname, c.relname, p.polname, p.polcmd, p.polroles
+      ORDER BY n.nspname, c.relname, p.polname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'rls-permissive',
+      category: 'security',
+      severity: 'warning',
+      title: 'Permissive RLS policy',
+      message: `${row.schema_name}.${row.table_name} policy "${row.object_name}" is permissive for ${safeStringArray(row.roles).join(', ') || 'configured roles'}.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      objectName: row.object_name,
+      detail: { command: row.cmd, roles: safeStringArray(row.roles) },
+      remediation:
+        'Review permissive policies and convert broad access paths to restrictive policies where possible.',
+    })
+  );
+}
+
+async function scanRlsNoPolicy(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<NamedObjectRow & { table_name: string }>(
+    ctx.pool,
+    `
+      /* advisor:rls-no-policy */
+      SELECT n.nspname AS schema_name, c.relname AS table_name
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'r'
+        AND ${USER_SCHEMA_FILTER}
+        AND c.relrowsecurity = true
+        AND NOT EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+      ORDER BY n.nspname, c.relname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'rls-no-policy',
+      category: 'security',
+      severity: 'critical',
+      title: 'RLS has no policies',
+      message: `${row.schema_name}.${row.table_name} has RLS enabled but no policies, so client access is likely broken or incomplete.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      remediation:
+        'Add SELECT/INSERT/UPDATE/DELETE policies for the roles that should access this table.',
+    })
+  );
+}
+
+async function scanDangerousFunction(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & { object_name: string; argument_types: string; callable_roles: string[] }
+  >(
+    ctx.pool,
+    `
+      /* advisor:dangerous-function */
+      WITH callable_roles AS (
+        SELECT oid, rolname
+        FROM pg_roles
+        WHERE rolname IN ('anon', 'authenticated')
+      )
+      SELECT
+        n.nspname AS schema_name,
+        p.proname AS object_name,
+        pg_get_function_identity_arguments(p.oid) AS argument_types,
+        array_agg(cr.rolname ORDER BY cr.rolname) AS callable_roles
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      JOIN callable_roles cr ON has_function_privilege(cr.oid, p.oid, 'EXECUTE')
+      WHERE ${USER_SCHEMA_FILTER}
+        AND p.prosecdef = true
+      GROUP BY n.nspname, p.proname, p.oid
+      ORDER BY n.nspname, p.proname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'dangerous-function',
+      category: 'security',
+      severity: 'critical',
+      title: 'Callable SECURITY DEFINER function',
+      message: `${row.schema_name}.${row.object_name} is SECURITY DEFINER and executable by ${safeStringArray(row.callable_roles).join(', ')}.`,
+      schemaName: row.schema_name,
+      objectName: row.object_name,
+      detail: {
+        arguments: row.argument_types,
+        roles: safeStringArray(row.callable_roles),
+      },
+      remediation:
+        'Revoke EXECUTE from anon/authenticated or replace SECURITY DEFINER with a safer access pattern.',
+    })
+  );
+}
+
+async function scanRlsSelectOnly(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & { table_name: string; select_policy_count: number }
+  >(
+    ctx.pool,
+    `
+      /* advisor:rls-select-only */
+      SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        count(*) FILTER (WHERE p.polcmd = 'r')::int AS select_policy_count
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_policy p ON p.polrelid = c.oid
+      WHERE c.relkind = 'r'
+        AND c.relrowsecurity = true
+        AND ${USER_SCHEMA_FILTER}
+      GROUP BY n.nspname, c.relname, c.oid
+      HAVING count(*) FILTER (WHERE p.polcmd = 'r') > 0
+        AND count(*) FILTER (WHERE p.polcmd IN ('a', 'w', 'd', '*')) = 0
+      ORDER BY n.nspname, c.relname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'rls-select-only',
+      category: 'security',
+      severity: 'warning',
+      title: 'RLS only allows SELECT',
+      message: `${row.schema_name}.${row.table_name} has SELECT policies but no mutation policies.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      detail: { selectPolicyCount: safeNumber(row.select_policy_count) },
+      remediation:
+        'Add INSERT, UPDATE, or DELETE policies if clients are expected to mutate this table.',
+    })
+  );
+}
+
+async function scanMissingFkIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & {
+      table_name: string;
+      object_name: string;
+      columns: string[];
+      referenced_table: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:missing-fk-index */
+      SELECT
+        n.nspname AS schema_name,
+        child.relname AS table_name,
+        con.conname AS object_name,
+        array_agg(att.attname ORDER BY key_ord.ordinality) AS columns,
+        parent_ns.nspname || '.' || parent.relname AS referenced_table
+      FROM pg_constraint con
+      JOIN pg_class child ON child.oid = con.conrelid
+      JOIN pg_namespace n ON n.oid = child.relnamespace
+      JOIN pg_class parent ON parent.oid = con.confrelid
+      JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+      JOIN unnest(con.conkey) WITH ORDINALITY AS key_ord(attnum, ordinality) ON true
+      JOIN pg_attribute att ON att.attrelid = child.oid AND att.attnum = key_ord.attnum
+      WHERE con.contype = 'f'
+        AND ${USER_SCHEMA_FILTER}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM pg_index idx
+          WHERE idx.indrelid = child.oid
+            AND idx.indisvalid = true
+            AND (
+              SELECT array_agg(index_key.attnum ORDER BY index_key.ordinality)
+              FROM unnest(idx.indkey) WITH ORDINALITY AS index_key(attnum, ordinality)
+              WHERE index_key.ordinality <= cardinality(con.conkey)
+            ) = con.conkey
+        )
+      GROUP BY n.nspname, child.relname, con.conname, parent_ns.nspname, parent.relname
+      ORDER BY n.nspname, child.relname, con.conname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'missing-fk-index',
+      category: 'performance',
+      severity: 'warning',
+      title: 'Foreign key is not indexed',
+      message: `${row.schema_name}.${row.table_name} foreign key "${row.object_name}" is missing an index on (${safeStringArray(row.columns).join(', ')}).`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      objectName: row.object_name,
+      detail: {
+        columns: safeStringArray(row.columns),
+        referencedTable: row.referenced_table,
+      },
+      remediation: 'Create an index on the referencing foreign-key column set.',
+    })
+  );
+}
+
+async function scanUnusedIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & {
+      table_name: string;
+      object_name: string;
+      index_size_bytes: string;
+      idx_scan: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:unused-index */
+      SELECT
+        sui.schemaname AS schema_name,
+        sui.relname AS table_name,
+        sui.indexrelname AS object_name,
+        sui.idx_scan,
+        pg_relation_size(sui.indexrelid)::text AS index_size_bytes
+      FROM pg_stat_user_indexes sui
+      JOIN pg_index idx ON idx.indexrelid = sui.indexrelid
+      WHERE sui.idx_scan = 0
+        AND idx.indisprimary = false
+        AND idx.indisunique = false
+        AND sui.schemaname <> ALL($1::text[])
+      ORDER BY pg_relation_size(sui.indexrelid) DESC, sui.schemaname, sui.relname, sui.indexrelname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'unused-index',
+      category: 'performance',
+      severity: 'info',
+      title: 'Unused index',
+      message: `${row.schema_name}.${row.table_name} index "${row.object_name}" has not been scanned since stats were reset.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      objectName: row.object_name,
+      detail: {
+        indexSizeBytes: safeNumber(row.index_size_bytes),
+        indexScans: safeNumber(row.idx_scan),
+      },
+      remediation:
+        'Confirm the index is not needed, then drop it to reduce write overhead and storage.',
+    })
+  );
+}
+
+async function scanSlowQuery(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  if (!(await relationExists(ctx.pool, 'pg_stat_statements'))) {
+    return [];
+  }
+
+  const rows = await queryRows<
+    QueryResultRow & { object_name: string; mean_exec_time: string; calls: string; query: string }
+  >(
+    ctx.pool,
+    `
+      /* advisor:slow-query */
+      SELECT
+        queryid::text AS object_name,
+        mean_exec_time::text,
+        calls::text,
+        left(regexp_replace(query, '\\s+', ' ', 'g'), 500) AS query
+      FROM pg_stat_statements
+      WHERE mean_exec_time > 1000
+        AND calls > 0
+      ORDER BY mean_exec_time DESC
+      LIMIT 50
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'slow-query',
+      category: 'performance',
+      severity: 'warning',
+      title: 'Slow query',
+      message: `Query ${row.object_name} averages ${Math.round(safeNumber(row.mean_exec_time))} ms.`,
+      objectName: row.object_name,
+      detail: {
+        meanExecTimeMs: safeNumber(row.mean_exec_time),
+        calls: safeNumber(row.calls),
+        query: row.query,
+      },
+      remediation: 'Inspect the query plan, add selective indexes, or rewrite the query.',
+    })
+  );
+}
+
+async function scanConnectionHigh(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & { used_connections: string; max_connections: string; usage_ratio: string }
+  >(
+    ctx.pool,
+    `
+      /* advisor:connection-high */
+      WITH limits AS (
+        SELECT setting::numeric AS max_connections
+        FROM pg_settings
+        WHERE name = 'max_connections'
+      ),
+      used AS (
+        SELECT count(*)::numeric AS used_connections
+        FROM pg_stat_activity
+      )
+      SELECT
+        used_connections::text,
+        max_connections::text,
+        (used_connections / NULLIF(max_connections, 0))::text AS usage_ratio
+      FROM used, limits
+      WHERE used_connections / NULLIF(max_connections, 0) >= 0.80
+        AND used_connections / NULLIF(max_connections, 0) < 0.95
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'connection-high',
+      category: 'performance',
+      severity: 'warning',
+      title: 'High connection usage',
+      message: `Postgres is using ${safeNumber(row.used_connections)} of ${safeNumber(row.max_connections)} available connections.`,
+      detail: {
+        usedConnections: safeNumber(row.used_connections),
+        maxConnections: safeNumber(row.max_connections),
+        usageRatio: safeNumber(row.usage_ratio),
+      },
+      remediation:
+        'Reduce idle clients, add pooling, or raise max_connections if the host can support it.',
+    })
+  );
+}
+
+async function scanConnectionCritical(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & { used_connections: string; max_connections: string; usage_ratio: string }
+  >(
+    ctx.pool,
+    `
+      /* advisor:connection-critical */
+      WITH limits AS (
+        SELECT setting::numeric AS max_connections
+        FROM pg_settings
+        WHERE name = 'max_connections'
+      ),
+      used AS (
+        SELECT count(*)::numeric AS used_connections
+        FROM pg_stat_activity
+      )
+      SELECT
+        used_connections::text,
+        max_connections::text,
+        (used_connections / NULLIF(max_connections, 0))::text AS usage_ratio
+      FROM used, limits
+      WHERE used_connections / NULLIF(max_connections, 0) >= 0.95
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'connection-critical',
+      category: 'performance',
+      severity: 'critical',
+      title: 'Critical connection usage',
+      message: `Postgres is using ${safeNumber(row.used_connections)} of ${safeNumber(row.max_connections)} available connections.`,
+      detail: {
+        usedConnections: safeNumber(row.used_connections),
+        maxConnections: safeNumber(row.max_connections),
+        usageRatio: safeNumber(row.usage_ratio),
+      },
+      remediation:
+        'Free connections immediately, fix connection leaks, and route clients through a pooler.',
+    })
+  );
+}
+
+async function scanIdleInTransaction(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & {
+      object_name: string;
+      duration_seconds: string;
+      application_name: string;
+      query: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:idle-in-transaction */
+      SELECT
+        pid::text AS object_name,
+        extract(epoch FROM (now() - xact_start))::text AS duration_seconds,
+        COALESCE(application_name, '') AS application_name,
+        left(regexp_replace(query, '\\s+', ' ', 'g'), 500) AS query
+      FROM pg_stat_activity
+      WHERE state = 'idle in transaction'
+        AND xact_start IS NOT NULL
+        AND now() - xact_start > interval '5 minutes'
+      ORDER BY xact_start
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'idle-in-transaction',
+      category: 'performance',
+      severity: 'warning',
+      title: 'Idle transaction',
+      message: `Session ${row.object_name} has been idle in transaction for ${Math.round(safeNumber(row.duration_seconds))} seconds.`,
+      objectName: row.object_name,
+      detail: {
+        durationSeconds: safeNumber(row.duration_seconds),
+        applicationName: row.application_name,
+        query: row.query,
+      },
+      remediation:
+        'Commit or roll back idle transactions and fix clients that leave transactions open.',
+    })
+  );
+}
+
+async function scanLowCacheHitRatio(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & {
+      datname: string;
+      cache_hit_ratio: string;
+      blks_read: string;
+      blks_hit: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:low-cache-hit-ratio */
+      SELECT
+        datname,
+        (blks_hit::numeric / NULLIF(blks_hit + blks_read, 0))::text AS cache_hit_ratio,
+        blks_read::text,
+        blks_hit::text
+      FROM pg_stat_database
+      WHERE datname = current_database()
+        AND (blks_hit + blks_read) > 0
+        AND blks_hit::numeric / NULLIF(blks_hit + blks_read, 0) < 0.99
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'low-cache-hit-ratio',
+      category: 'performance',
+      severity: 'warning',
+      title: 'Low cache hit ratio',
+      message: `${row.datname} cache hit ratio is ${(safeNumber(row.cache_hit_ratio) * 100).toFixed(2)}%.`,
+      detail: {
+        database: row.datname,
+        cacheHitRatio: safeNumber(row.cache_hit_ratio),
+        blocksRead: safeNumber(row.blks_read),
+        blocksHit: safeNumber(row.blks_hit),
+      },
+      remediation:
+        'Inspect working-set size, missing indexes, and memory settings such as shared_buffers.',
+    })
+  );
+}
+
+async function scanLongRunningQuery(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & {
+      object_name: string;
+      duration_seconds: string;
+      application_name: string;
+      query: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:long-running-query */
+      SELECT
+        pid::text AS object_name,
+        extract(epoch FROM (now() - query_start))::text AS duration_seconds,
+        COALESCE(application_name, '') AS application_name,
+        left(regexp_replace(query, '\\s+', ' ', 'g'), 500) AS query
+      FROM pg_stat_activity
+      WHERE state = 'active'
+        AND query_start IS NOT NULL
+        AND now() - query_start > interval '5 minutes'
+        AND pid <> pg_backend_pid()
+      ORDER BY query_start
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'long-running-query',
+      category: 'performance',
+      severity: 'warning',
+      title: 'Long-running query',
+      message: `Session ${row.object_name} has been running for ${Math.round(safeNumber(row.duration_seconds))} seconds.`,
+      objectName: row.object_name,
+      detail: {
+        durationSeconds: safeNumber(row.duration_seconds),
+        applicationName: row.application_name,
+        query: row.query,
+      },
+      remediation: 'Inspect or cancel the query, then add indexes or rewrite the slow path.',
+    })
+  );
+}
+
+async function scanRlsPolicyPerf(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & { table_name: string; object_name: string; expression: string }
+  >(
+    ctx.pool,
+    `
+      /* advisor:rls-policy-perf */
+      SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        p.polname AS object_name,
+        concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) AS expression
+      FROM pg_policy p
+      JOIN pg_class c ON c.oid = p.polrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE ${USER_SCHEMA_FILTER}
+        AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ~* 'auth\\.uid\\s*\\(\\s*\\)'
+        AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) !~* '\\(\\s*select\\s+auth\\.uid\\s*\\(\\s*\\)'
+      ORDER BY n.nspname, c.relname, p.polname
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'rls-policy-perf',
+      category: 'performance',
+      severity: 'info',
+      title: 'RLS policy calls auth.uid() per row',
+      message: `${row.schema_name}.${row.table_name} policy "${row.object_name}" calls auth.uid() directly.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      objectName: row.object_name,
+      detail: { expression: row.expression },
+      remediation:
+        'Wrap auth.uid() as (select auth.uid()) so PostgreSQL can init-plan the value once.',
+    })
+  );
+}
+
+async function scanMissingRlsIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & { table_name: string; object_name: string; expression: string }
+  >(
+    ctx.pool,
+    `
+      /* advisor:missing-rls-index */
+      WITH policy_columns AS (
+        SELECT DISTINCT
+          n.nspname AS schema_name,
+          c.relname AS table_name,
+          c.oid AS table_oid,
+          a.attnum,
+          a.attname AS object_name,
+          concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) AS expression
+        FROM pg_policy p
+        JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_attribute a ON a.attrelid = c.oid
+        WHERE c.relrowsecurity = true
+          AND ${USER_SCHEMA_FILTER}
+          AND a.attnum > 0
+          AND a.attisdropped = false
+          AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ~* 'auth\\.uid\\s*\\(\\s*\\)'
+          AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ILIKE '%' || a.attname || '%'
+      )
+      SELECT schema_name, table_name, object_name, expression
+      FROM policy_columns pc
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM pg_index idx
+        WHERE idx.indrelid = pc.table_oid
+          AND idx.indisvalid = true
+          AND pc.attnum = ANY(idx.indkey::smallint[])
+      )
+      ORDER BY schema_name, table_name, object_name
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'missing-rls-index',
+      category: 'performance',
+      severity: 'warning',
+      title: 'RLS policy column is not indexed',
+      message: `${row.schema_name}.${row.table_name} policy references "${row.object_name}" without an index.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      objectName: row.object_name,
+      detail: { expression: row.expression },
+      remediation: 'Add an index on the column used by the RLS policy predicate.',
+    })
+  );
+}
+
+async function scanDeadTuples(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & {
+      table_name: string;
+      n_dead_tup: string;
+      n_live_tup: string;
+      dead_tuple_ratio: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:dead-tuples */
+      SELECT
+        schemaname AS schema_name,
+        relname AS table_name,
+        n_dead_tup::text,
+        n_live_tup::text,
+        (n_dead_tup::numeric / NULLIF(n_live_tup + n_dead_tup, 0))::text AS dead_tuple_ratio
+      FROM pg_stat_user_tables
+      WHERE schemaname <> ALL($1::text[])
+        AND n_dead_tup > 1000
+        AND n_dead_tup::numeric / NULLIF(n_live_tup + n_dead_tup, 0) > 0.20
+      ORDER BY n_dead_tup DESC
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'dead-tuples',
+      category: 'health',
+      severity: 'warning',
+      title: 'High dead tuple count',
+      message: `${row.schema_name}.${row.table_name} has ${safeNumber(row.n_dead_tup)} dead tuples.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      detail: {
+        deadTuples: safeNumber(row.n_dead_tup),
+        liveTuples: safeNumber(row.n_live_tup),
+        deadTupleRatio: safeNumber(row.dead_tuple_ratio),
+      },
+      remediation: 'Check autovacuum, long transactions, and table churn; run VACUUM if needed.',
+    })
+  );
+}
+
+async function scanStaleStatistics(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & {
+      table_name: string;
+      n_mod_since_analyze: string;
+      last_analyze: string | null;
+      last_autoanalyze: string | null;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:stale-statistics */
+      SELECT
+        schemaname AS schema_name,
+        relname AS table_name,
+        n_mod_since_analyze::text,
+        last_analyze::text,
+        last_autoanalyze::text
+      FROM pg_stat_user_tables
+      WHERE schemaname <> ALL($1::text[])
+        AND n_mod_since_analyze > 1000
+        AND (
+          greatest(COALESCE(last_analyze, 'epoch'::timestamp), COALESCE(last_autoanalyze, 'epoch'::timestamp)) < now() - interval '7 days'
+        )
+      ORDER BY n_mod_since_analyze DESC
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'stale-statistics',
+      category: 'health',
+      severity: 'warning',
+      title: 'Stale table statistics',
+      message: `${row.schema_name}.${row.table_name} has ${safeNumber(row.n_mod_since_analyze)} changes since the last analyze.`,
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      detail: {
+        rowsModifiedSinceAnalyze: safeNumber(row.n_mod_since_analyze),
+        lastAnalyze: row.last_analyze,
+        lastAutoAnalyze: row.last_autoanalyze,
+      },
+      remediation: 'Run ANALYZE or tune autovacuum analyze thresholds for this table.',
+    })
+  );
+}
+
+async function scanSequenceExhaustion(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    NamedObjectRow & {
+      object_name: string;
+      last_value: string;
+      max_value: string;
+      percent_used: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:sequence-exhaustion */
+      SELECT
+        schemaname AS schema_name,
+        sequencename AS object_name,
+        last_value::text,
+        max_value::text,
+        (last_value::numeric / NULLIF(max_value::numeric, 0))::text AS percent_used
+      FROM pg_sequences
+      WHERE schemaname <> ALL($1::text[])
+        AND last_value IS NOT NULL
+        AND max_value IS NOT NULL
+        AND last_value::numeric / NULLIF(max_value::numeric, 0) >= 0.80
+      ORDER BY last_value::numeric / NULLIF(max_value::numeric, 0) DESC
+    `,
+    [INTERNAL_SCHEMAS]
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'sequence-exhaustion',
+      category: 'health',
+      severity: safeNumber(row.percent_used) >= 0.95 ? 'critical' : 'warning',
+      title: 'Sequence nearing exhaustion',
+      message: `${row.schema_name}.${row.object_name} has used ${(safeNumber(row.percent_used) * 100).toFixed(2)}% of its range.`,
+      schemaName: row.schema_name,
+      objectName: row.object_name,
+      detail: {
+        lastValue: safeNumber(row.last_value),
+        maxValue: safeNumber(row.max_value),
+        percentUsed: safeNumber(row.percent_used),
+      },
+      remediation:
+        'Move the owning column to bigint, increase sequence max value, or cycle only if duplicates are impossible.',
+    })
+  );
+}
+
+async function scanAutovacuumBlocked(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
+  const rows = await queryRows<
+    QueryResultRow & {
+      object_name: string;
+      duration_seconds: string;
+      wait_event: string;
+      query: string;
+    }
+  >(
+    ctx.pool,
+    `
+      /* advisor:autovacuum-blocked */
+      SELECT
+        pid::text AS object_name,
+        extract(epoch FROM (now() - COALESCE(query_start, xact_start, backend_start)))::text AS duration_seconds,
+        COALESCE(wait_event, '') AS wait_event,
+        left(regexp_replace(query, '\\s+', ' ', 'g'), 500) AS query
+      FROM pg_stat_activity
+      WHERE query ILIKE 'autovacuum:%'
+        AND wait_event_type = 'Lock'
+      ORDER BY COALESCE(query_start, xact_start, backend_start)
+    `
+  );
+
+  return rows.map((row) =>
+    makeFinding({
+      ruleId: 'autovacuum-blocked',
+      category: 'health',
+      severity: 'critical',
+      title: 'Autovacuum is blocked',
+      message: `Autovacuum worker ${row.object_name} is waiting on ${row.wait_event || 'a lock'}.`,
+      objectName: row.object_name,
+      detail: {
+        durationSeconds: safeNumber(row.duration_seconds),
+        waitEvent: row.wait_event,
+        query: row.query,
+      },
+      remediation: 'Find and resolve the blocking transaction so autovacuum can clean the table.',
+    })
+  );
+}
+
+export const ADVISOR_RULES: AdvisorRule[] = [
+  {
+    ruleId: 'rls-disabled',
+    category: 'security',
+    severity: 'critical',
+    title: 'RLS is disabled',
+    description: 'Finds user tables that do not have row-level security enabled.',
+    run: scanRlsDisabled,
+  },
+  {
+    ruleId: 'rls-permissive',
+    category: 'security',
+    severity: 'warning',
+    title: 'Permissive RLS policy',
+    description:
+      'Finds permissive RLS policies that may broaden access when combined with other policies.',
+    run: scanRlsPermissive,
+  },
+  {
+    ruleId: 'rls-no-policy',
+    category: 'security',
+    severity: 'critical',
+    title: 'RLS has no policies',
+    description: 'Finds RLS-enabled tables that have no policies.',
+    run: scanRlsNoPolicy,
+  },
+  {
+    ruleId: 'dangerous-function',
+    category: 'security',
+    severity: 'critical',
+    title: 'Callable SECURITY DEFINER function',
+    description: 'Finds SECURITY DEFINER functions executable by anon or authenticated roles.',
+    run: scanDangerousFunction,
+  },
+  {
+    ruleId: 'rls-select-only',
+    category: 'security',
+    severity: 'warning',
+    title: 'RLS only allows SELECT',
+    description: 'Finds RLS-enabled tables with SELECT policies but no mutation policies.',
+    run: scanRlsSelectOnly,
+  },
+  {
+    ruleId: 'missing-fk-index',
+    category: 'performance',
+    severity: 'warning',
+    title: 'Foreign key is not indexed',
+    description: 'Finds foreign keys whose referencing columns are not covered by a leading index.',
+    run: scanMissingFkIndex,
+  },
+  {
+    ruleId: 'unused-index',
+    category: 'performance',
+    severity: 'info',
+    title: 'Unused index',
+    description: 'Finds non-primary, non-unique indexes with zero scans since stats reset.',
+    run: scanUnusedIndex,
+  },
+  {
+    ruleId: 'slow-query',
+    category: 'performance',
+    severity: 'warning',
+    title: 'Slow query',
+    description: 'Finds pg_stat_statements entries with mean execution time above one second.',
+    run: scanSlowQuery,
+  },
+  {
+    ruleId: 'connection-high',
+    category: 'performance',
+    severity: 'warning',
+    title: 'High connection usage',
+    description: 'Finds connection usage at or above 80 percent of max_connections.',
+    run: scanConnectionHigh,
+  },
+  {
+    ruleId: 'connection-critical',
+    category: 'performance',
+    severity: 'critical',
+    title: 'Critical connection usage',
+    description: 'Finds connection usage at or above 95 percent of max_connections.',
+    run: scanConnectionCritical,
+  },
+  {
+    ruleId: 'idle-in-transaction',
+    category: 'performance',
+    severity: 'warning',
+    title: 'Idle transaction',
+    description: 'Finds sessions idle in transaction for more than five minutes.',
+    run: scanIdleInTransaction,
+  },
+  {
+    ruleId: 'low-cache-hit-ratio',
+    category: 'performance',
+    severity: 'warning',
+    title: 'Low cache hit ratio',
+    description: 'Finds databases with cache hit ratio below 99 percent.',
+    run: scanLowCacheHitRatio,
+  },
+  {
+    ruleId: 'long-running-query',
+    category: 'performance',
+    severity: 'warning',
+    title: 'Long-running query',
+    description: 'Finds active queries running for more than five minutes.',
+    run: scanLongRunningQuery,
+  },
+  {
+    ruleId: 'rls-policy-perf',
+    category: 'performance',
+    severity: 'info',
+    title: 'RLS policy calls auth.uid() per row',
+    description:
+      'Finds RLS policies that call auth.uid() directly instead of as an init-plan SELECT.',
+    run: scanRlsPolicyPerf,
+  },
+  {
+    ruleId: 'missing-rls-index',
+    category: 'performance',
+    severity: 'warning',
+    title: 'RLS policy column is not indexed',
+    description: 'Finds RLS policy predicates that reference auth.uid() columns without indexes.',
+    run: scanMissingRlsIndex,
+  },
+  {
+    ruleId: 'dead-tuples',
+    category: 'health',
+    severity: 'warning',
+    title: 'High dead tuple count',
+    description: 'Finds user tables with high dead tuple counts and ratios.',
+    run: scanDeadTuples,
+  },
+  {
+    ruleId: 'stale-statistics',
+    category: 'health',
+    severity: 'warning',
+    title: 'Stale table statistics',
+    description: 'Finds tables with many changes since an old or missing analyze.',
+    run: scanStaleStatistics,
+  },
+  {
+    ruleId: 'sequence-exhaustion',
+    category: 'health',
+    severity: 'warning',
+    title: 'Sequence nearing exhaustion',
+    description: 'Finds sequences that have consumed at least 80 percent of their range.',
+    run: scanSequenceExhaustion,
+  },
+  {
+    ruleId: 'autovacuum-blocked',
+    category: 'health',
+    severity: 'critical',
+    title: 'Autovacuum is blocked',
+    description: 'Finds autovacuum workers blocked on locks.',
+    run: scanAutovacuumBlocked,
+  },
+];
+
+function summarize(findings: AdvisorFinding[]): AdvisorScanResponse['summary'] {
+  return findings.reduce<AdvisorScanResponse['summary']>(
+    (summary, finding) => {
+      summary[finding.category] += 1;
+      summary[finding.severity] += 1;
+      return summary;
+    },
+    {
+      security: 0,
+      performance: 0,
+      health: 0,
+      critical: 0,
+      warning: 0,
+      info: 0,
+    }
+  );
+}
+
+export class AdvisorService {
+  private static instance: AdvisorService;
+  private dbManager = DatabaseManager.getInstance();
+  private scanInProgress = false;
+
+  private constructor() {}
+
+  public static getInstance(): AdvisorService {
+    if (!AdvisorService.instance) {
+      AdvisorService.instance = new AdvisorService();
+    }
+    return AdvisorService.instance;
+  }
+
+  async scan(): Promise<AdvisorScanResponse> {
+    if (this.scanInProgress) {
+      throw new AppError(
+        'An advisor scan is already running. Wait for it to finish and try again.',
+        409,
+        'ADVISOR_SCAN_IN_PROGRESS'
+      );
+    }
+
+    this.scanInProgress = true;
+    const startedAt = Date.now();
+    const scannedAt = new Date().toISOString();
+
+    try {
+      const ctx: AdvisorContext = { pool: this.dbManager.getPool() };
+      const findingsByRule = await Promise.all(ADVISOR_RULES.map((rule) => rule.run(ctx)));
+      const findings = findingsByRule.flat();
+
+      return {
+        scannedAt,
+        durationMs: Date.now() - startedAt,
+        findingCount: findings.length,
+        summary: summarize(findings),
+        rules: ADVISOR_RULES.map(({ ruleId, category, severity, title, description }) => ({
+          ruleId,
+          category,
+          severity,
+          title,
+          description,
+        })),
+        findings,
+      };
+    } finally {
+      this.scanInProgress = false;
+    }
+  }
+}

--- a/backend/src/services/advisor/advisor.service.ts
+++ b/backend/src/services/advisor/advisor.service.ts
@@ -1,4 +1,4 @@
-import type { Pool, QueryResultRow } from 'pg';
+import type { Pool, PoolClient, QueryResultRow } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/api/middlewares/error.js';
 import type {
@@ -11,7 +11,7 @@ import type {
 } from '@insforge/shared-schemas';
 
 interface AdvisorContext {
-  pool: Pool;
+  db: Pool | PoolClient;
 }
 
 interface AdvisorRule extends AdvisorRuleSummary {
@@ -27,6 +27,7 @@ interface BaseFindingInput {
   schemaName?: string;
   tableName?: string;
   objectName?: string;
+  stableIdPart?: string;
   detail?: Record<string, unknown>;
   remediation: string;
 }
@@ -83,27 +84,37 @@ function makeFinding(input: BaseFindingInput): AdvisorFinding {
     input.schemaName,
     input.tableName,
     input.objectName,
+    input.stableIdPart,
     input.message,
   ].filter(Boolean);
 
   return {
     id: stableParts.join(':'),
-    ...input,
+    ruleId: input.ruleId,
+    category: input.category,
+    severity: input.severity,
+    title: input.title,
+    message: input.message,
+    schemaName: input.schemaName,
+    tableName: input.tableName,
+    objectName: input.objectName,
+    detail: input.detail,
+    remediation: input.remediation,
   };
 }
 
 async function queryRows<T extends QueryResultRow>(
-  pool: Pool,
+  db: Pool | PoolClient,
   sql: string,
   params: unknown[] = []
 ): Promise<T[]> {
-  const result = await pool.query<T>(sql, params);
+  const result = await db.query<T>(sql, params);
   return result.rows;
 }
 
-async function relationExists(pool: Pool, relationName: string): Promise<boolean> {
+async function relationExists(db: Pool | PoolClient, relationName: string): Promise<boolean> {
   const rows = await queryRows<{ exists: boolean }>(
-    pool,
+    db,
     'SELECT to_regclass($1) IS NOT NULL AS "exists"',
     [relationName]
   );
@@ -112,7 +123,7 @@ async function relationExists(pool: Pool, relationName: string): Promise<boolean
 
 async function scanRlsDisabled(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
   const rows = await queryRows<NamedObjectRow & { table_name: string }>(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:rls-disabled */
       SELECT n.nspname AS schema_name, c.relname AS table_name
@@ -145,7 +156,7 @@ async function scanRlsPermissive(ctx: AdvisorContext): Promise<AdvisorFinding[]>
   const rows = await queryRows<
     NamedObjectRow & { table_name: string; object_name: string; cmd: string; roles: string[] }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:rls-permissive */
       SELECT
@@ -189,7 +200,7 @@ async function scanRlsPermissive(ctx: AdvisorContext): Promise<AdvisorFinding[]>
 
 async function scanRlsNoPolicy(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
   const rows = await queryRows<NamedObjectRow & { table_name: string }>(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:rls-no-policy */
       SELECT n.nspname AS schema_name, c.relname AS table_name
@@ -223,7 +234,7 @@ async function scanDangerousFunction(ctx: AdvisorContext): Promise<AdvisorFindin
   const rows = await queryRows<
     NamedObjectRow & { object_name: string; argument_types: string; callable_roles: string[] }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:dangerous-function */
       WITH callable_roles AS (
@@ -256,6 +267,7 @@ async function scanDangerousFunction(ctx: AdvisorContext): Promise<AdvisorFindin
       message: `${row.schema_name}.${row.object_name} is SECURITY DEFINER and executable by ${safeStringArray(row.callable_roles).join(', ')}.`,
       schemaName: row.schema_name,
       objectName: row.object_name,
+      stableIdPart: row.argument_types,
       detail: {
         arguments: row.argument_types,
         roles: safeStringArray(row.callable_roles),
@@ -270,7 +282,7 @@ async function scanRlsSelectOnly(ctx: AdvisorContext): Promise<AdvisorFinding[]>
   const rows = await queryRows<
     NamedObjectRow & { table_name: string; select_policy_count: number }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:rls-select-only */
       SELECT
@@ -316,7 +328,7 @@ async function scanMissingFkIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]
       referenced_table: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:missing-fk-index */
       SELECT
@@ -379,7 +391,7 @@ async function scanUnusedIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
       idx_scan: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:unused-index */
       SELECT
@@ -420,14 +432,14 @@ async function scanUnusedIndex(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
 }
 
 async function scanSlowQuery(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
-  if (!(await relationExists(ctx.pool, 'pg_stat_statements'))) {
+  if (!(await relationExists(ctx.db, 'pg_stat_statements'))) {
     return [];
   }
 
   const rows = await queryRows<
     QueryResultRow & { object_name: string; mean_exec_time: string; calls: string; query: string }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:slow-query */
       SELECT
@@ -438,6 +450,7 @@ async function scanSlowQuery(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
       FROM pg_stat_statements
       WHERE mean_exec_time > 1000
         AND calls > 0
+        AND dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
       ORDER BY mean_exec_time DESC
       LIMIT 50
     `
@@ -465,7 +478,7 @@ async function scanConnectionHigh(ctx: AdvisorContext): Promise<AdvisorFinding[]
   const rows = await queryRows<
     QueryResultRow & { used_connections: string; max_connections: string; usage_ratio: string }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:connection-high */
       WITH limits AS (
@@ -476,6 +489,8 @@ async function scanConnectionHigh(ctx: AdvisorContext): Promise<AdvisorFinding[]
       used AS (
         SELECT count(*)::numeric AS used_connections
         FROM pg_stat_activity
+        WHERE backend_type = 'client backend'
+          AND pid <> pg_backend_pid()
       )
       SELECT
         used_connections::text,
@@ -509,7 +524,7 @@ async function scanConnectionCritical(ctx: AdvisorContext): Promise<AdvisorFindi
   const rows = await queryRows<
     QueryResultRow & { used_connections: string; max_connections: string; usage_ratio: string }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:connection-critical */
       WITH limits AS (
@@ -520,6 +535,8 @@ async function scanConnectionCritical(ctx: AdvisorContext): Promise<AdvisorFindi
       used AS (
         SELECT count(*)::numeric AS used_connections
         FROM pg_stat_activity
+        WHERE backend_type = 'client backend'
+          AND pid <> pg_backend_pid()
       )
       SELECT
         used_connections::text,
@@ -557,7 +574,7 @@ async function scanIdleInTransaction(ctx: AdvisorContext): Promise<AdvisorFindin
       query: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:idle-in-transaction */
       SELECT
@@ -601,7 +618,7 @@ async function scanLowCacheHitRatio(ctx: AdvisorContext): Promise<AdvisorFinding
       blks_hit: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:low-cache-hit-ratio */
       SELECT
@@ -644,7 +661,7 @@ async function scanLongRunningQuery(ctx: AdvisorContext): Promise<AdvisorFinding
       query: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:long-running-query */
       SELECT
@@ -683,7 +700,7 @@ async function scanRlsPolicyPerf(ctx: AdvisorContext): Promise<AdvisorFinding[]>
   const rows = await queryRows<
     NamedObjectRow & { table_name: string; object_name: string; expression: string }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:rls-policy-perf */
       SELECT
@@ -723,7 +740,7 @@ async function scanMissingRlsIndex(ctx: AdvisorContext): Promise<AdvisorFinding[
   const rows = await queryRows<
     NamedObjectRow & { table_name: string; object_name: string; expression: string }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:missing-rls-index */
       WITH policy_columns AS (
@@ -743,7 +760,7 @@ async function scanMissingRlsIndex(ctx: AdvisorContext): Promise<AdvisorFinding[
           AND a.attnum > 0
           AND a.attisdropped = false
           AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ~* 'auth\\.uid\\s*\\(\\s*\\)'
-          AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ILIKE '%' || a.attname || '%'
+          AND concat_ws(' ', pg_get_expr(p.polqual, p.polrelid), pg_get_expr(p.polwithcheck, p.polrelid)) ~* ('\\m' || a.attname || '\\M')
       )
       SELECT schema_name, table_name, object_name, expression
       FROM policy_columns pc
@@ -784,7 +801,7 @@ async function scanDeadTuples(ctx: AdvisorContext): Promise<AdvisorFinding[]> {
       dead_tuple_ratio: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:dead-tuples */
       SELECT
@@ -830,7 +847,7 @@ async function scanStaleStatistics(ctx: AdvisorContext): Promise<AdvisorFinding[
       last_autoanalyze: string | null;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:stale-statistics */
       SELECT
@@ -874,25 +891,54 @@ async function scanSequenceExhaustion(ctx: AdvisorContext): Promise<AdvisorFindi
     NamedObjectRow & {
       object_name: string;
       last_value: string;
+      start_value: string;
+      min_value: string;
       max_value: string;
+      increment_by: string;
       percent_used: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:sequence-exhaustion */
       SELECT
         schemaname AS schema_name,
         sequencename AS object_name,
         last_value::text,
+        start_value::text,
+        min_value::text,
         max_value::text,
-        (last_value::numeric / NULLIF(max_value::numeric, 0))::text AS percent_used
+        increment_by::text,
+        CASE
+          WHEN increment_by > 0 THEN
+            (last_value::numeric - start_value::numeric)
+              / NULLIF(max_value::numeric - start_value::numeric, 0)
+          ELSE
+            (start_value::numeric - last_value::numeric)
+              / NULLIF(start_value::numeric - min_value::numeric, 0)
+        END::text AS percent_used
       FROM pg_sequences
       WHERE schemaname <> ALL($1::text[])
         AND last_value IS NOT NULL
-        AND max_value IS NOT NULL
-        AND last_value::numeric / NULLIF(max_value::numeric, 0) >= 0.80
-      ORDER BY last_value::numeric / NULLIF(max_value::numeric, 0) DESC
+        AND (
+          CASE
+            WHEN increment_by > 0 THEN
+              (last_value::numeric - start_value::numeric)
+                / NULLIF(max_value::numeric - start_value::numeric, 0)
+            ELSE
+              (start_value::numeric - last_value::numeric)
+                / NULLIF(start_value::numeric - min_value::numeric, 0)
+          END
+        ) >= 0.80
+      ORDER BY
+        CASE
+          WHEN increment_by > 0 THEN
+            (last_value::numeric - start_value::numeric)
+              / NULLIF(max_value::numeric - start_value::numeric, 0)
+          ELSE
+            (start_value::numeric - last_value::numeric)
+              / NULLIF(start_value::numeric - min_value::numeric, 0)
+        END DESC
     `,
     [INTERNAL_SCHEMAS]
   );
@@ -908,7 +954,10 @@ async function scanSequenceExhaustion(ctx: AdvisorContext): Promise<AdvisorFindi
       objectName: row.object_name,
       detail: {
         lastValue: safeNumber(row.last_value),
+        startValue: safeNumber(row.start_value),
+        minValue: safeNumber(row.min_value),
         maxValue: safeNumber(row.max_value),
+        incrementBy: safeNumber(row.increment_by),
         percentUsed: safeNumber(row.percent_used),
       },
       remediation:
@@ -926,7 +975,7 @@ async function scanAutovacuumBlocked(ctx: AdvisorContext): Promise<AdvisorFindin
       query: string;
     }
   >(
-    ctx.pool,
+    ctx.db,
     `
       /* advisor:autovacuum-blocked */
       SELECT
@@ -1162,24 +1211,35 @@ export class AdvisorService {
     const scannedAt = new Date().toISOString();
 
     try {
-      const ctx: AdvisorContext = { pool: this.dbManager.getPool() };
-      const findingsByRule = await Promise.all(ADVISOR_RULES.map((rule) => rule.run(ctx)));
-      const findings = findingsByRule.flat();
+      const client = await this.dbManager.getPool().connect();
 
-      return {
-        scannedAt,
-        durationMs: Date.now() - startedAt,
-        findingCount: findings.length,
-        summary: summarize(findings),
-        rules: ADVISOR_RULES.map(({ ruleId, category, severity, title, description }) => ({
-          ruleId,
-          category,
-          severity,
-          title,
-          description,
-        })),
-        findings,
-      };
+      try {
+        const ctx: AdvisorContext = { db: client };
+        const findingsByRule: AdvisorFinding[][] = [];
+
+        for (const rule of ADVISOR_RULES) {
+          findingsByRule.push(await rule.run(ctx));
+        }
+
+        const findings = findingsByRule.flat();
+
+        return {
+          scannedAt,
+          durationMs: Date.now() - startedAt,
+          findingCount: findings.length,
+          summary: summarize(findings),
+          rules: ADVISOR_RULES.map(({ ruleId, category, severity, title, description }) => ({
+            ruleId,
+            category,
+            severity,
+            title,
+            description,
+          })),
+          findings,
+        };
+      } finally {
+        client.release();
+      }
     } finally {
       this.scanInProgress = false;
     }

--- a/backend/tests/unit/advisor.service.test.ts
+++ b/backend/tests/unit/advisor.service.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pool } from 'pg';
+import type { AdvisorRuleId } from '@insforge/shared-schemas';
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({ getPool: () => mockPool }),
+  },
+}));
+
+let mockPool: Pool;
+let rowsByRule: Partial<Record<AdvisorRuleId, unknown[]>>;
+let pgStatStatementsExists = false;
+let holdRlsDisabledQuery: (() => void) | null = null;
+
+const expectedRuleIds: AdvisorRuleId[] = [
+  'rls-disabled',
+  'rls-permissive',
+  'rls-no-policy',
+  'dangerous-function',
+  'rls-select-only',
+  'missing-fk-index',
+  'unused-index',
+  'slow-query',
+  'connection-high',
+  'connection-critical',
+  'idle-in-transaction',
+  'low-cache-hit-ratio',
+  'long-running-query',
+  'rls-policy-perf',
+  'missing-rls-index',
+  'dead-tuples',
+  'stale-statistics',
+  'sequence-exhaustion',
+  'autovacuum-blocked',
+];
+
+const sampleRowsByRule: Record<AdvisorRuleId, unknown[]> = {
+  'rls-disabled': [{ schema_name: 'public', table_name: 'profiles' }],
+  'rls-permissive': [
+    {
+      schema_name: 'public',
+      table_name: 'profiles',
+      object_name: 'profiles_select',
+      cmd: 'r',
+      roles: ['authenticated'],
+    },
+  ],
+  'rls-no-policy': [{ schema_name: 'public', table_name: 'orders' }],
+  'dangerous-function': [
+    {
+      schema_name: 'public',
+      object_name: 'admin_escalate',
+      argument_types: 'user_id uuid',
+      callable_roles: ['authenticated'],
+    },
+  ],
+  'rls-select-only': [
+    { schema_name: 'public', table_name: 'messages', select_policy_count: 1 },
+  ],
+  'missing-fk-index': [
+    {
+      schema_name: 'public',
+      table_name: 'comments',
+      object_name: 'comments_post_id_fkey',
+      columns: ['post_id'],
+      referenced_table: 'public.posts',
+    },
+  ],
+  'unused-index': [
+    {
+      schema_name: 'public',
+      table_name: 'events',
+      object_name: 'events_unused_idx',
+      index_size_bytes: '8192',
+      idx_scan: '0',
+    },
+  ],
+  'slow-query': [
+    {
+      object_name: '42',
+      mean_exec_time: '1250',
+      calls: '3',
+      query: 'select pg_sleep(2)',
+    },
+  ],
+  'connection-high': [{ used_connections: '80', max_connections: '100', usage_ratio: '0.8' }],
+  'connection-critical': [
+    { used_connections: '96', max_connections: '100', usage_ratio: '0.96' },
+  ],
+  'idle-in-transaction': [
+    {
+      object_name: '101',
+      duration_seconds: '400',
+      application_name: 'psql',
+      query: 'select 1',
+    },
+  ],
+  'low-cache-hit-ratio': [
+    { datname: 'insforge', cache_hit_ratio: '0.95', blks_read: '50', blks_hit: '950' },
+  ],
+  'long-running-query': [
+    {
+      object_name: '202',
+      duration_seconds: '500',
+      application_name: 'api',
+      query: 'select slow()',
+    },
+  ],
+  'rls-policy-perf': [
+    {
+      schema_name: 'public',
+      table_name: 'profiles',
+      object_name: 'profiles_owner',
+      expression: 'user_id = auth.uid()',
+    },
+  ],
+  'missing-rls-index': [
+    {
+      schema_name: 'public',
+      table_name: 'profiles',
+      object_name: 'user_id',
+      expression: 'user_id = auth.uid()',
+    },
+  ],
+  'dead-tuples': [
+    {
+      schema_name: 'public',
+      table_name: 'events',
+      n_dead_tup: '5000',
+      n_live_tup: '10000',
+      dead_tuple_ratio: '0.333',
+    },
+  ],
+  'stale-statistics': [
+    {
+      schema_name: 'public',
+      table_name: 'events',
+      n_mod_since_analyze: '4000',
+      last_analyze: null,
+      last_autoanalyze: null,
+    },
+  ],
+  'sequence-exhaustion': [
+    {
+      schema_name: 'public',
+      object_name: 'events_id_seq',
+      last_value: '90',
+      max_value: '100',
+      percent_used: '0.9',
+    },
+  ],
+  'autovacuum-blocked': [
+    {
+      object_name: '303',
+      duration_seconds: '600',
+      wait_event: 'relation',
+      query: 'autovacuum: VACUUM public.events',
+    },
+  ],
+};
+
+function findRuleMarker(sql: string): AdvisorRuleId | null {
+  for (const ruleId of expectedRuleIds) {
+    if (sql.includes(`advisor:${ruleId}`)) {
+      return ruleId;
+    }
+  }
+  return null;
+}
+
+function makeMockPool(): Pool {
+  return {
+    query: vi.fn(async (sqlInput: string) => {
+      const sql = String(sqlInput);
+
+      if (sql.includes('SELECT to_regclass($1) IS NOT NULL')) {
+        return { rows: [{ exists: pgStatStatementsExists }], rowCount: 1 };
+      }
+
+      const ruleId = findRuleMarker(sql);
+      if (ruleId === 'rls-disabled' && holdRlsDisabledQuery) {
+        await new Promise<void>((resolve) => {
+          holdRlsDisabledQuery = resolve;
+        });
+      }
+
+      if (!ruleId) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      const rows = rowsByRule[ruleId] ?? [];
+      return { rows, rowCount: rows.length };
+    }),
+  } as unknown as Pool;
+}
+
+async function loadService() {
+  vi.resetModules();
+  const module = await import('@/services/advisor/advisor.service.js');
+  return module.AdvisorService.getInstance();
+}
+
+describe('AdvisorService', () => {
+  beforeEach(() => {
+    rowsByRule = {};
+    pgStatStatementsExists = false;
+    holdRlsDisabledQuery = null;
+    mockPool = makeMockPool();
+  });
+
+  it('registers the 19 advisor rules from the issue', async () => {
+    const { ADVISOR_RULES } = await import('@/services/advisor/advisor.service.js');
+    expect(ADVISOR_RULES.map((rule) => rule.ruleId)).toEqual(expectedRuleIds);
+  });
+
+  it.each(expectedRuleIds)('returns a finding for %s when the catalog query matches', async (ruleId) => {
+    rowsByRule = { [ruleId]: sampleRowsByRule[ruleId] };
+    pgStatStatementsExists = ruleId === 'slow-query';
+    const service = await loadService();
+
+    const result = await service.scan();
+
+    expect(result.findings.map((finding) => finding.ruleId)).toEqual([ruleId]);
+    expect(result.findingCount).toBe(1);
+    expect(result.rules).toHaveLength(19);
+  });
+
+  it('returns an empty scan when no rules match', async () => {
+    const service = await loadService();
+
+    const result = await service.scan();
+
+    expect(result.findingCount).toBe(0);
+    expect(result.findings).toEqual([]);
+    expect(result.summary).toEqual({
+      security: 0,
+      performance: 0,
+      health: 0,
+      critical: 0,
+      warning: 0,
+      info: 0,
+    });
+  });
+
+  it('rejects overlapping scans with an in-memory lock', async () => {
+    rowsByRule = { 'rls-disabled': sampleRowsByRule['rls-disabled'] };
+    holdRlsDisabledQuery = () => {};
+    const service = await loadService();
+
+    const firstScan = service.scan();
+    await expect(service.scan()).rejects.toThrow(/already running/);
+
+    holdRlsDisabledQuery?.();
+    await expect(firstScan).resolves.toMatchObject({ findingCount: 1 });
+  });
+});

--- a/backend/tests/unit/advisor.service.test.ts
+++ b/backend/tests/unit/advisor.service.test.ts
@@ -174,7 +174,7 @@ async function handleQuery(sqlInput: string) {
   const sql = String(sqlInput);
   executedSql.push(sql);
 
-  if (sql.includes('SELECT to_regclass($1) IS NOT NULL')) {
+  if (sql.includes('FROM pg_extension')) {
     return { rows: [{ exists: pgStatStatementsExists }], rowCount: 1 };
   }
 
@@ -279,7 +279,9 @@ describe('AdvisorService', () => {
 
     await service.scan();
 
+    const extensionSql = executedSql.find((sql) => sql.includes('FROM pg_extension')) ?? '';
     const slowQuerySql = executedSql.find((sql) => sql.includes('advisor:slow-query')) ?? '';
+    expect(extensionSql).toContain('WHERE extname = $1');
     expect(slowQuerySql).toContain(
       'dbid = (SELECT oid FROM pg_database WHERE datname = current_database())'
     );

--- a/backend/tests/unit/advisor.service.test.ts
+++ b/backend/tests/unit/advisor.service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Pool } from 'pg';
+import type { Pool, PoolClient } from 'pg';
 import type { AdvisorRuleId } from '@insforge/shared-schemas';
 
 vi.mock('@/infra/database/database.manager.js', () => ({
@@ -9,9 +9,11 @@ vi.mock('@/infra/database/database.manager.js', () => ({
 }));
 
 let mockPool: Pool;
+let mockClient: PoolClient;
 let rowsByRule: Partial<Record<AdvisorRuleId, unknown[]>>;
 let pgStatStatementsExists = false;
 let holdRlsDisabledQuery: (() => void) | null = null;
+let executedSql: string[];
 
 const expectedRuleIds: AdvisorRuleId[] = [
   'rls-disabled',
@@ -55,9 +57,7 @@ const sampleRowsByRule: Record<AdvisorRuleId, unknown[]> = {
       callable_roles: ['authenticated'],
     },
   ],
-  'rls-select-only': [
-    { schema_name: 'public', table_name: 'messages', select_policy_count: 1 },
-  ],
+  'rls-select-only': [{ schema_name: 'public', table_name: 'messages', select_policy_count: 1 }],
   'missing-fk-index': [
     {
       schema_name: 'public',
@@ -85,9 +85,7 @@ const sampleRowsByRule: Record<AdvisorRuleId, unknown[]> = {
     },
   ],
   'connection-high': [{ used_connections: '80', max_connections: '100', usage_ratio: '0.8' }],
-  'connection-critical': [
-    { used_connections: '96', max_connections: '100', usage_ratio: '0.96' },
-  ],
+  'connection-critical': [{ used_connections: '96', max_connections: '100', usage_ratio: '0.96' }],
   'idle-in-transaction': [
     {
       object_name: '101',
@@ -146,7 +144,10 @@ const sampleRowsByRule: Record<AdvisorRuleId, unknown[]> = {
       schema_name: 'public',
       object_name: 'events_id_seq',
       last_value: '90',
+      start_value: '1',
+      min_value: '1',
       max_value: '100',
+      increment_by: '1',
       percent_used: '0.9',
     },
   ],
@@ -169,29 +170,40 @@ function findRuleMarker(sql: string): AdvisorRuleId | null {
   return null;
 }
 
+async function handleQuery(sqlInput: string) {
+  const sql = String(sqlInput);
+  executedSql.push(sql);
+
+  if (sql.includes('SELECT to_regclass($1) IS NOT NULL')) {
+    return { rows: [{ exists: pgStatStatementsExists }], rowCount: 1 };
+  }
+
+  const ruleId = findRuleMarker(sql);
+  if (ruleId === 'rls-disabled' && holdRlsDisabledQuery) {
+    await new Promise<void>((resolve) => {
+      holdRlsDisabledQuery = resolve;
+    });
+  }
+
+  if (!ruleId) {
+    return { rows: [], rowCount: 0 };
+  }
+
+  const rows = rowsByRule[ruleId] ?? [];
+  return { rows, rowCount: rows.length };
+}
+
+function makeMockClient(): PoolClient {
+  return {
+    query: vi.fn(handleQuery),
+    release: vi.fn(),
+  } as unknown as PoolClient;
+}
+
 function makeMockPool(): Pool {
   return {
-    query: vi.fn(async (sqlInput: string) => {
-      const sql = String(sqlInput);
-
-      if (sql.includes('SELECT to_regclass($1) IS NOT NULL')) {
-        return { rows: [{ exists: pgStatStatementsExists }], rowCount: 1 };
-      }
-
-      const ruleId = findRuleMarker(sql);
-      if (ruleId === 'rls-disabled' && holdRlsDisabledQuery) {
-        await new Promise<void>((resolve) => {
-          holdRlsDisabledQuery = resolve;
-        });
-      }
-
-      if (!ruleId) {
-        return { rows: [], rowCount: 0 };
-      }
-
-      const rows = rowsByRule[ruleId] ?? [];
-      return { rows, rowCount: rows.length };
-    }),
+    connect: vi.fn(async () => mockClient),
+    query: vi.fn(handleQuery),
   } as unknown as Pool;
 }
 
@@ -206,6 +218,8 @@ describe('AdvisorService', () => {
     rowsByRule = {};
     pgStatStatementsExists = false;
     holdRlsDisabledQuery = null;
+    executedSql = [];
+    mockClient = makeMockClient();
     mockPool = makeMockPool();
   });
 
@@ -214,17 +228,20 @@ describe('AdvisorService', () => {
     expect(ADVISOR_RULES.map((rule) => rule.ruleId)).toEqual(expectedRuleIds);
   });
 
-  it.each(expectedRuleIds)('returns a finding for %s when the catalog query matches', async (ruleId) => {
-    rowsByRule = { [ruleId]: sampleRowsByRule[ruleId] };
-    pgStatStatementsExists = ruleId === 'slow-query';
-    const service = await loadService();
+  it.each(expectedRuleIds)(
+    'returns a finding for %s when the catalog query matches',
+    async (ruleId) => {
+      rowsByRule = { [ruleId]: sampleRowsByRule[ruleId] };
+      pgStatStatementsExists = ruleId === 'slow-query';
+      const service = await loadService();
 
-    const result = await service.scan();
+      const result = await service.scan();
 
-    expect(result.findings.map((finding) => finding.ruleId)).toEqual([ruleId]);
-    expect(result.findingCount).toBe(1);
-    expect(result.rules).toHaveLength(19);
-  });
+      expect(result.findings.map((finding) => finding.ruleId)).toEqual([ruleId]);
+      expect(result.findingCount).toBe(1);
+      expect(result.rules).toHaveLength(19);
+    }
+  );
 
   it('returns an empty scan when no rules match', async () => {
     const service = await loadService();
@@ -253,5 +270,83 @@ describe('AdvisorService', () => {
 
     holdRlsDisabledQuery?.();
     await expect(firstScan).resolves.toMatchObject({ findingCount: 1 });
+  });
+
+  it('scopes slow-query to the current database', async () => {
+    rowsByRule = { 'slow-query': sampleRowsByRule['slow-query'] };
+    pgStatStatementsExists = true;
+    const service = await loadService();
+
+    await service.scan();
+
+    const slowQuerySql = executedSql.find((sql) => sql.includes('advisor:slow-query')) ?? '';
+    expect(slowQuerySql).toContain(
+      'dbid = (SELECT oid FROM pg_database WHERE datname = current_database())'
+    );
+  });
+
+  it('counts only other client backends for connection pressure rules', async () => {
+    rowsByRule = {
+      'connection-high': sampleRowsByRule['connection-high'],
+      'connection-critical': sampleRowsByRule['connection-critical'],
+    };
+    const service = await loadService();
+
+    await service.scan();
+
+    for (const ruleId of ['connection-high', 'connection-critical']) {
+      const sql = executedSql.find((query) => query.includes(`advisor:${ruleId}`)) ?? '';
+      expect(sql).toContain("backend_type = 'client backend'");
+      expect(sql).toContain('pid <> pg_backend_pid()');
+    }
+  });
+
+  it('uses whole-identifier matching for missing RLS index detection', async () => {
+    rowsByRule = { 'missing-rls-index': sampleRowsByRule['missing-rls-index'] };
+    const service = await loadService();
+
+    await service.scan();
+
+    const sql = executedSql.find((query) => query.includes('advisor:missing-rls-index')) ?? '';
+    expect(sql).toContain("~* ('\\m' || a.attname || '\\M')");
+    expect(sql).not.toContain("ILIKE '%' || a.attname || '%'");
+  });
+
+  it('gives overloaded dangerous functions distinct finding IDs', async () => {
+    rowsByRule = {
+      'dangerous-function': [
+        sampleRowsByRule['dangerous-function'][0],
+        {
+          schema_name: 'public',
+          object_name: 'admin_escalate',
+          argument_types: 'email text',
+          callable_roles: ['authenticated'],
+        },
+      ],
+    };
+    const service = await loadService();
+
+    const result = await service.scan();
+
+    expect(new Set(result.findings.map((finding) => finding.id)).size).toBe(2);
+  });
+
+  it('uses sequence bounds and increment direction for sequence exhaustion', async () => {
+    rowsByRule = { 'sequence-exhaustion': sampleRowsByRule['sequence-exhaustion'] };
+    const service = await loadService();
+
+    const result = await service.scan();
+
+    const sql = executedSql.find((query) => query.includes('advisor:sequence-exhaustion')) ?? '';
+    expect(sql).toContain('increment_by > 0');
+    expect(sql).toContain('max_value::numeric - start_value::numeric');
+    expect(sql).toContain('start_value::numeric - min_value::numeric');
+    expect(result.findings[0]?.detail).toMatchObject({
+      startValue: 1,
+      minValue: 1,
+      maxValue: 100,
+      incrementBy: 1,
+      percentUsed: 0.9,
+    });
   });
 });

--- a/docs/core-concepts/database/advisors.mdx
+++ b/docs/core-concepts/database/advisors.mdx
@@ -1,0 +1,91 @@
+---
+title: Database Advisors
+description: Security, performance, and health checks for self-hosted Postgres projects
+---
+
+## Overview
+
+Database Advisors scan the project's PostgreSQL database and return read-only findings for common security, performance, and health risks. The scan is on-demand and stateless: InsForge does not store advisor history or dismissals in the open-source version.
+
+Use the dashboard page at **Database -> Advisors** or call the admin API directly:
+
+```bash
+curl -X POST http://localhost:7130/api/advisor/scan \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Only one scan can run at a time in a backend process. If a scan is already running, the API returns `409`.
+
+## Response
+
+The scan returns the rules that were evaluated, summary counts, and findings:
+
+```json
+{
+  "scannedAt": "2026-05-16T08:15:00.000Z",
+  "durationMs": 124,
+  "findingCount": 1,
+  "summary": {
+    "security": 1,
+    "performance": 0,
+    "health": 0,
+    "critical": 1,
+    "warning": 0,
+    "info": 0
+  },
+  "rules": [],
+  "findings": [
+    {
+      "id": "rls-disabled:public:profiles:public.profiles does not have row-level security enabled.",
+      "ruleId": "rls-disabled",
+      "category": "security",
+      "severity": "critical",
+      "title": "RLS is disabled",
+      "message": "public.profiles does not have row-level security enabled.",
+      "schemaName": "public",
+      "tableName": "profiles",
+      "remediation": "Enable RLS and add policies that match the expected application access paths."
+    }
+  ]
+}
+```
+
+## Security rules
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| `rls-disabled` | Critical | User tables where row-level security is disabled. |
+| `rls-permissive` | Warning | Permissive RLS policies that may broaden access when combined with other policies. |
+| `rls-no-policy` | Critical | RLS-enabled tables that do not have any policies. |
+| `dangerous-function` | Critical | `SECURITY DEFINER` functions executable by `anon` or `authenticated`. |
+| `rls-select-only` | Warning | RLS-enabled tables with SELECT policies but no INSERT, UPDATE, or DELETE policies. |
+
+## Performance rules
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| `missing-fk-index` | Warning | Foreign keys whose referencing columns are not covered by a leading index. |
+| `unused-index` | Info | Non-primary, non-unique indexes with zero scans since Postgres statistics were reset. |
+| `slow-query` | Warning | `pg_stat_statements` queries with mean execution time greater than one second. If `pg_stat_statements` is unavailable, this rule returns no findings. |
+| `connection-high` | Warning | Connection usage at or above 80 percent and below 95 percent of `max_connections`. |
+| `connection-critical` | Critical | Connection usage at or above 95 percent of `max_connections`. |
+| `idle-in-transaction` | Warning | Sessions idle in transaction for more than five minutes. |
+| `low-cache-hit-ratio` | Warning | Current database cache hit ratio below 99 percent. |
+| `long-running-query` | Warning | Active queries running for more than five minutes. |
+| `rls-policy-perf` | Info | RLS policies that call `auth.uid()` directly instead of wrapping it as `(select auth.uid())`. |
+| `missing-rls-index` | Warning | RLS policy predicates that compare `auth.uid()` against unindexed table columns. |
+
+## Health rules
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| `dead-tuples` | Warning | User tables with more than 1,000 dead tuples and a dead tuple ratio above 20 percent. |
+| `stale-statistics` | Warning | User tables with more than 1,000 changes since an analyze older than seven days. |
+| `sequence-exhaustion` | Warning or critical | Sequences that have used at least 80 percent of their range. Findings become critical at 95 percent. |
+| `autovacuum-blocked` | Critical | Autovacuum workers waiting on locks. |
+
+## Notes
+
+The open-source advisor intentionally excludes cloud host metrics such as CPU, disk, and memory because self-hosted deployments do not have a shared CloudWatch source.
+
+The MCP server source is not part of this repository. Agents can still call `POST /api/advisor/scan` with admin credentials until the external `@insforge/mcp` package exposes an `advisor.scan` tool.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,6 +41,7 @@
                 "pages": [
                   "core-concepts/database/architecture",
                   "core-concepts/database/migrations",
+                  "core-concepts/database/advisors",
                   "core-concepts/database/branching",
                   "core-concepts/database/pgvector"
                 ]
@@ -208,6 +209,10 @@
           {
             "group": "Records",
             "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/records.yaml"
+          },
+          {
+            "group": "Advisor",
+            "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/advisor.yaml"
           },
           {
             "group": "Storage",

--- a/openapi/advisor.yaml
+++ b/openapi/advisor.yaml
@@ -1,0 +1,207 @@
+openapi: 3.0.3
+info:
+  title: Insforge Advisor API
+  version: 1.0.0
+
+paths:
+  /api/advisor/scan:
+    post:
+      summary: Run Database Advisor scan
+      description: Runs read-only security, performance, and health advisor rules against the project PostgreSQL database.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      responses:
+        '200':
+          description: Advisor scan completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorScanResponse'
+        '401':
+          description: Missing or invalid admin credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A scan is already running
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: ADVISOR_SCAN_IN_PROGRESS
+                message: An advisor scan is already running. Wait for it to finish and try again.
+                statusCode: 409
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  schemas:
+    AdvisorScanResponse:
+      type: object
+      required:
+        - scannedAt
+        - durationMs
+        - findingCount
+        - summary
+        - rules
+        - findings
+      properties:
+        scannedAt:
+          type: string
+          format: date-time
+        durationMs:
+          type: integer
+          minimum: 0
+        findingCount:
+          type: integer
+          minimum: 0
+        summary:
+          type: object
+          required:
+            - security
+            - performance
+            - health
+            - critical
+            - warning
+            - info
+          properties:
+            security:
+              type: integer
+              minimum: 0
+            performance:
+              type: integer
+              minimum: 0
+            health:
+              type: integer
+              minimum: 0
+            critical:
+              type: integer
+              minimum: 0
+            warning:
+              type: integer
+              minimum: 0
+            info:
+              type: integer
+              minimum: 0
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdvisorRule'
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdvisorFinding'
+
+    AdvisorRule:
+      type: object
+      required:
+        - ruleId
+        - category
+        - severity
+        - title
+        - description
+      properties:
+        ruleId:
+          $ref: '#/components/schemas/AdvisorRuleId'
+        category:
+          $ref: '#/components/schemas/AdvisorCategory'
+        severity:
+          $ref: '#/components/schemas/AdvisorSeverity'
+        title:
+          type: string
+        description:
+          type: string
+
+    AdvisorFinding:
+      type: object
+      required:
+        - id
+        - ruleId
+        - category
+        - severity
+        - title
+        - message
+        - remediation
+      properties:
+        id:
+          type: string
+        ruleId:
+          $ref: '#/components/schemas/AdvisorRuleId'
+        category:
+          $ref: '#/components/schemas/AdvisorCategory'
+        severity:
+          $ref: '#/components/schemas/AdvisorSeverity'
+        title:
+          type: string
+        message:
+          type: string
+        schemaName:
+          type: string
+        tableName:
+          type: string
+        objectName:
+          type: string
+        detail:
+          type: object
+          additionalProperties: true
+        remediation:
+          type: string
+
+    AdvisorRuleId:
+      type: string
+      enum:
+        - rls-disabled
+        - rls-permissive
+        - rls-no-policy
+        - dangerous-function
+        - rls-select-only
+        - missing-fk-index
+        - unused-index
+        - slow-query
+        - connection-high
+        - connection-critical
+        - idle-in-transaction
+        - low-cache-hit-ratio
+        - long-running-query
+        - rls-policy-perf
+        - missing-rls-index
+        - dead-tuples
+        - stale-statistics
+        - sequence-exhaustion
+        - autovacuum-blocked
+
+    AdvisorCategory:
+      type: string
+      enum: [security, performance, health]
+
+    AdvisorSeverity:
+      type: string
+      enum: [critical, warning, info]
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        statusCode:
+          type: integer
+        nextActions:
+          type: string

--- a/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
@@ -43,6 +43,11 @@ const DATABASE_STUDIO_SIDEBAR_BASE_ITEMS: Array<{
     sectionEnd: true,
   },
   {
+    id: 'advisors',
+    label: 'Advisors',
+    href: '/dashboard/database/advisors',
+  },
+  {
     id: 'migrations',
     label: 'Migrations',
     href: '/dashboard/database/migrations',

--- a/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
+++ b/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { databaseService } from '#features/database/services/database.service';
+
+export function useAdvisorScan() {
+  return useMutation({
+    mutationKey: ['database', 'advisor', 'scan'],
+    mutationFn: () => databaseService.runAdvisorScan(),
+  });
+}

--- a/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
@@ -122,13 +122,14 @@ function AdvisorContent({
 
   return (
     <div className="min-h-0 flex-1 overflow-auto">
-      <div className="grid grid-cols-2 gap-3 border-b border-[var(--alpha-8)] bg-[rgb(var(--semantic-1))] p-4 md:grid-cols-6">
+      <div className="grid grid-cols-2 gap-3 border-b border-[var(--alpha-8)] bg-[rgb(var(--semantic-1))] p-4 md:grid-cols-4 xl:grid-cols-7">
         <SummaryTile label="Findings" value={result.findingCount} tone="default" />
         <SummaryTile label="Critical" value={result.summary.critical} tone="critical" />
         <SummaryTile label="Warnings" value={result.summary.warning} tone="warning" />
         <SummaryTile label="Info" value={result.summary.info} tone="info" />
         <SummaryTile label="Security" value={result.summary.security} tone="default" />
         <SummaryTile label="Performance" value={result.summary.performance} tone="default" />
+        <SummaryTile label="Health" value={result.summary.health} tone="default" />
       </div>
 
       <div className="flex flex-wrap items-center gap-2 border-b border-[var(--alpha-8)] bg-[rgb(var(--semantic-0))] px-4 py-3">

--- a/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, RefreshCw, ShieldCheck } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '@insforge/ui';
+import { EmptyState, TableHeader } from '#components';
+import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
+import { useAdvisorScan } from '#features/database/hooks/useAdvisorScan';
+import { cn } from '#lib/utils/utils';
+import type {
+  AdvisorCategory,
+  AdvisorFinding,
+  AdvisorScanResponse,
+} from '@insforge/shared-schemas';
+
+type CategoryFilter = 'all' | AdvisorCategory;
+
+const CATEGORY_FILTERS: Array<{ id: CategoryFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'security', label: 'Security' },
+  { id: 'performance', label: 'Performance' },
+  { id: 'health', label: 'Health' },
+];
+
+function severityClass(severity: AdvisorFinding['severity']) {
+  if (severity === 'critical') {
+    return 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300';
+  }
+  if (severity === 'warning') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+  }
+  return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300';
+}
+
+function categoryClass(category: AdvisorCategory) {
+  if (category === 'security') {
+    return 'border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300';
+  }
+  if (category === 'performance') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+  }
+  return 'border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-300';
+}
+
+function Badge({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-6 items-center rounded border px-2 text-xs font-medium leading-none',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function SummaryTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: 'critical' | 'warning' | 'info' | 'default';
+}) {
+  const toneClass =
+    tone === 'critical'
+      ? 'text-red-600 dark:text-red-300'
+      : tone === 'warning'
+        ? 'text-amber-600 dark:text-amber-300'
+        : tone === 'info'
+          ? 'text-sky-600 dark:text-sky-300'
+          : 'text-foreground';
+
+  return (
+    <div className="min-w-0 rounded border border-border bg-[rgb(var(--semantic-0))] px-3 py-2">
+      <div className={cn('text-lg font-semibold leading-7', toneClass)}>{value}</div>
+      <div className="truncate text-xs leading-4 text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function FindingRow({ finding }: { finding: AdvisorFinding }) {
+  const objectLabel = [finding.schemaName, finding.tableName, finding.objectName]
+    .filter(Boolean)
+    .join(' / ');
+
+  return (
+    <div className="border-b border-[var(--alpha-8)] px-4 py-3 last:border-b-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <Badge className={severityClass(finding.severity)}>{finding.severity}</Badge>
+        <Badge className={categoryClass(finding.category)}>{finding.category}</Badge>
+        <span className="truncate text-sm font-medium leading-5 text-foreground">
+          {finding.title}
+        </span>
+      </div>
+      <p className="mt-2 text-sm leading-5 text-muted-foreground">{finding.message}</p>
+      <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-xs leading-4 text-muted-foreground">
+        <span className="font-mono">{finding.ruleId}</span>
+        {objectLabel && <span className="truncate">{objectLabel}</span>}
+      </div>
+      <p className="mt-2 text-sm leading-5 text-foreground">{finding.remediation}</p>
+    </div>
+  );
+}
+
+function AdvisorContent({
+  result,
+  activeCategory,
+  onCategoryChange,
+}: {
+  result: AdvisorScanResponse;
+  activeCategory: CategoryFilter;
+  onCategoryChange: (category: CategoryFilter) => void;
+}) {
+  const findings = useMemo(() => {
+    if (activeCategory === 'all') {
+      return result.findings;
+    }
+    return result.findings.filter((finding) => finding.category === activeCategory);
+  }, [activeCategory, result.findings]);
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <div className="grid grid-cols-2 gap-3 border-b border-[var(--alpha-8)] bg-[rgb(var(--semantic-1))] p-4 md:grid-cols-6">
+        <SummaryTile label="Findings" value={result.findingCount} tone="default" />
+        <SummaryTile label="Critical" value={result.summary.critical} tone="critical" />
+        <SummaryTile label="Warnings" value={result.summary.warning} tone="warning" />
+        <SummaryTile label="Info" value={result.summary.info} tone="info" />
+        <SummaryTile label="Security" value={result.summary.security} tone="default" />
+        <SummaryTile label="Performance" value={result.summary.performance} tone="default" />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 border-b border-[var(--alpha-8)] bg-[rgb(var(--semantic-0))] px-4 py-3">
+        {CATEGORY_FILTERS.map((filter) => (
+          <Button
+            key={filter.id}
+            variant={activeCategory === filter.id ? 'primary' : 'outline'}
+            size="sm"
+            className="h-8 rounded"
+            onClick={() => onCategoryChange(filter.id)}
+          >
+            {filter.label}
+          </Button>
+        ))}
+        <span className="ml-auto text-xs leading-4 text-muted-foreground">
+          Scanned {new Date(result.scannedAt).toLocaleString()}
+        </span>
+      </div>
+
+      {findings.length === 0 ? (
+        <div className="flex min-h-[320px] items-center justify-center">
+          <EmptyState
+            title="No advisor findings"
+            description={
+              activeCategory === 'all'
+                ? 'All enabled advisor rules passed.'
+                : `No ${activeCategory} findings in the latest scan.`
+            }
+          />
+        </div>
+      ) : (
+        <div className="bg-[rgb(var(--semantic-0))]">
+          {findings.map((finding) => (
+            <FindingRow key={finding.id} finding={finding} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AdvisorsPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [activeCategory, setActiveCategory] = useState<CategoryFilter>('all');
+  const advisorScan = useAdvisorScan();
+  const result = advisorScan.data;
+  const isScanning = advisorScan.isPending;
+
+  const runScan = () => {
+    setActiveCategory('all');
+    advisorScan.mutate();
+  };
+
+  const rightActions = (
+    <Button className="h-8 rounded gap-2" onClick={runScan} disabled={isScanning}>
+      <RefreshCw className={cn('h-4 w-4', isScanning && 'animate-spin')} />
+      {isScanning ? 'Scanning' : 'Run scan now'}
+    </Button>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 overflow-hidden bg-[rgb(var(--semantic-1))]">
+      <DatabaseStudioSidebarPanel
+        onBack={() =>
+          void navigate(
+            {
+              pathname: '/dashboard/database/tables',
+              search: location.search,
+            },
+            { state: { slideFromStudio: true } }
+          )
+        }
+      />
+      <div className="min-w-0 flex-1 flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
+        <TableHeader
+          title="Database Advisors"
+          showDividerAfterTitle
+          leftSlot={
+            result ? (
+              <div className="flex items-center gap-2 text-xs leading-4 text-muted-foreground">
+                {result.findingCount === 0 ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                ) : (
+                  <AlertTriangle className="h-4 w-4 text-amber-500" />
+                )}
+                {result.durationMs} ms
+              </div>
+            ) : undefined
+          }
+          rightActions={rightActions}
+          showSearch={false}
+        />
+
+        {advisorScan.error ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <EmptyState
+              title="Advisor scan failed"
+              description={
+                advisorScan.error instanceof Error ? advisorScan.error.message : 'An error occurred'
+              }
+            />
+          </div>
+        ) : result ? (
+          <AdvisorContent
+            result={result}
+            activeCategory={activeCategory}
+            onCategoryChange={setActiveCategory}
+          />
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <div className="flex max-w-md flex-col items-center gap-4 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded border border-border bg-[rgb(var(--semantic-0))]">
+                <ShieldCheck className="h-6 w-6 text-muted-foreground" />
+              </div>
+              <EmptyState
+                title={isScanning ? 'Scanning database...' : 'No advisor scan yet'}
+                description={
+                  isScanning
+                    ? 'Checking security, performance, and health rules.'
+                    : 'Run a scan to review the current database state.'
+                }
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/database/services/database.service.ts
+++ b/packages/dashboard/src/features/database/services/database.service.ts
@@ -6,6 +6,7 @@ import type {
   DatabasePoliciesResponse,
   DatabaseSchemasResponse,
   DatabaseTriggersResponse,
+  AdvisorScanResponse,
 } from '@insforge/shared-schemas';
 
 export class DatabaseService {
@@ -62,6 +63,17 @@ export class DatabaseService {
   ): Promise<DatabaseTriggersResponse> {
     return apiClient.request(`/database/triggers${buildDatabaseSchemaSearch(schemaName)}`, {
       method: 'GET',
+      headers: apiClient.withAccessToken({}),
+    });
+  }
+
+  /**
+   * Run the database advisor scan.
+   * Requires admin privileges.
+   */
+  async runAdvisorScan(): Promise<AdvisorScanResponse> {
+    return apiClient.request('/advisor/scan', {
+      method: 'POST',
       headers: apiClient.withAccessToken({}),
     });
   }

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -15,6 +15,7 @@ import DashboardPage from '#features/dashboard/pages/DashboardPage';
 import DTestDashboardPage from '#features/dashboard/pages/DTestDashboardPage';
 import DTestInstallPage from '#features/dashboard/pages/DTestInstallPage';
 import DatabaseLayout from '#features/database/components/DatabaseLayout';
+import AdvisorsPage from '#features/database/pages/AdvisorsPage';
 import SQLEditorLayout from '#features/database/components/SQLEditorLayout';
 import BackupsPage from '#features/database/pages/BackupsPage';
 import DatabaseFunctionsPage from '#features/database/pages/FunctionsPage';
@@ -88,6 +89,7 @@ function AuthenticatedRoutes() {
           <Route path="functions" element={<DatabaseFunctionsPage />} />
           <Route path="triggers" element={<TriggersPage />} />
           <Route path="policies" element={<PoliciesPage />} />
+          <Route path="advisors" element={<AdvisorsPage />} />
           <Route path="sql-editor" element={<Navigate to="/dashboard/sql-editor" replace />} />
           <Route path="templates" element={<TemplatesPage />} />
           <Route path="migrations" element={<MigrationsPage />} />

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -403,6 +403,69 @@ export const databaseMigrationsResponseSchema = z.object({
   migrations: z.array(migrationSchema),
 });
 
+export const advisorRuleIdSchema = z.enum([
+  'rls-disabled',
+  'rls-permissive',
+  'rls-no-policy',
+  'dangerous-function',
+  'rls-select-only',
+  'missing-fk-index',
+  'unused-index',
+  'slow-query',
+  'connection-high',
+  'connection-critical',
+  'idle-in-transaction',
+  'low-cache-hit-ratio',
+  'long-running-query',
+  'rls-policy-perf',
+  'missing-rls-index',
+  'dead-tuples',
+  'stale-statistics',
+  'sequence-exhaustion',
+  'autovacuum-blocked',
+]);
+
+export const advisorCategorySchema = z.enum(['security', 'performance', 'health']);
+export const advisorSeveritySchema = z.enum(['critical', 'warning', 'info']);
+
+export const advisorFindingSchema = z.object({
+  id: z.string(),
+  ruleId: advisorRuleIdSchema,
+  category: advisorCategorySchema,
+  severity: advisorSeveritySchema,
+  title: z.string(),
+  message: z.string(),
+  schemaName: z.string().optional(),
+  tableName: z.string().optional(),
+  objectName: z.string().optional(),
+  detail: z.record(z.string(), z.unknown()).optional(),
+  remediation: z.string(),
+});
+
+export const advisorRuleSummarySchema = z.object({
+  ruleId: advisorRuleIdSchema,
+  category: advisorCategorySchema,
+  severity: advisorSeveritySchema,
+  title: z.string(),
+  description: z.string(),
+});
+
+export const advisorScanResponseSchema = z.object({
+  scannedAt: z.string(),
+  durationMs: z.number().int().min(0),
+  findingCount: z.number().int().min(0),
+  summary: z.object({
+    security: z.number().int().min(0),
+    performance: z.number().int().min(0),
+    health: z.number().int().min(0),
+    critical: z.number().int().min(0),
+    warning: z.number().int().min(0),
+    info: z.number().int().min(0),
+  }),
+  rules: z.array(advisorRuleSummarySchema),
+  findings: z.array(advisorFindingSchema),
+});
+
 // Database Metadata Response Types
 export type DatabaseFunctionsResponse = z.infer<typeof databaseFunctionsResponseSchema>;
 export type DatabaseSchemasResponse = z.infer<typeof databaseSchemasResponseSchema>;
@@ -410,3 +473,9 @@ export type DatabaseIndexesResponse = z.infer<typeof databaseIndexesResponseSche
 export type DatabasePoliciesResponse = z.infer<typeof databasePoliciesResponseSchema>;
 export type DatabaseTriggersResponse = z.infer<typeof databaseTriggersResponseSchema>;
 export type DatabaseMigrationsResponse = z.infer<typeof databaseMigrationsResponseSchema>;
+export type AdvisorRuleId = z.infer<typeof advisorRuleIdSchema>;
+export type AdvisorCategory = z.infer<typeof advisorCategorySchema>;
+export type AdvisorSeverity = z.infer<typeof advisorSeveritySchema>;
+export type AdvisorFinding = z.infer<typeof advisorFindingSchema>;
+export type AdvisorRuleSummary = z.infer<typeof advisorRuleSummarySchema>;
+export type AdvisorScanResponse = z.infer<typeof advisorScanResponseSchema>;


### PR DESCRIPTION
## Linked Issue

Closes #1271

## Description

Adds a self-hosted Database Advisor for InsForge OSS.

This PR exposes `POST /api/advisor/scan` behind admin auth. The endpoint runs 19 Postgres advisor rules across security, performance, and health categories, then returns stateless JSON findings.

It also adds a Database > Advisors dashboard page where admins can run a scan manually, view summary counts, filter by category, and inspect severity-tagged findings.

This keeps the first OSS version intentionally stateless: no scan history, dismissals, scheduled scans, or persistence tables. The issue listed those as open design questions, so this PR focuses on the on-demand advisor path.

Note: I could not wire the `advisor.scan` MCP tool in this repo because the MCP server source does not appear to be present here. I found references to the external `@insforge/mcp` package, but not the tool registration source. The REST endpoint is available for agents to call directly until the MCP package exposes `advisor.scan`.

## What Changed

- Added shared advisor schemas/types for scan responses and rule metadata.
- Added `AdvisorService` with the 19 requested rules:
  - Security: `rls-disabled`, `rls-permissive`, `rls-no-policy`, `dangerous-function`, `rls-select-only`
  - Performance: `missing-fk-index`, `unused-index`, `slow-query`, `connection-high`, `connection-critical`, `idle-in-transaction`, `low-cache-hit-ratio`, `long-running-query`, `rls-policy-perf`, `missing-rls-index`
  - Health: `dead-tuples`, `stale-statistics`, `sequence-exhaustion`, `autovacuum-blocked`
- Added `POST /api/advisor/scan` with admin auth.
- Added an in-memory scan lock so only one advisor scan runs at a time.
- Added dashboard service/hook/page for Database Advisors.
- Added sidebar route under Database.
- Added docs page listing every rule and what it checks.
- Added OpenAPI spec for the advisor scan endpoint.
- Added unit coverage for all 19 rules.

## Implementation Notes

The scan is read-only and stateless. It queries Postgres catalog/stat views and returns findings directly to the caller.

Cloud-only host metric rules for CPU, disk, and memory are intentionally not included because OSS does not have an equivalent CloudWatch source.

During local manual validation, the first live scan exposed an ambiguous `indexrelid` reference in the `unused-index` rule. I fixed that by qualifying the `pg_stat_user_indexes` columns and reran advisor tests/typecheck successfully.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Tests
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor

## Test Coverage

Automated validation:

- `cd backend && npm run typecheck` passed.
- `cd backend && npm test -- advisor.service.test.ts` passed.
- `cd backend && npm test` passed.
- `cd backend && npm run build` passed.
- `cd packages/shared-schemas && npm run typecheck` passed.
- `cd packages/shared-schemas && npm run build` passed.
- `cd packages/dashboard && npm run typecheck` passed.
- `cd packages/dashboard && npm run build` passed.
- `cd frontend && npm run build` passed.

Scoped lint passed:

`npx eslint backend/src/api/routes/advisor/index.routes.ts backend/src/services/advisor/advisor.service.ts backend/tests/unit/advisor.service.test.ts packages/dashboard/src/features/database/hooks/useAdvisorScan.ts packages/dashboard/src/features/database/pages/AdvisorsPage.tsx`

Results:
- Backend typecheck passed.
- Advisor unit tests passed: 22 tests.
- Full backend test suite passed.
- Backend build passed.
- Shared schemas typecheck/build passed.
- Dashboard typecheck/build passed.
- Frontend build passed.
- Scoped ESLint on advisor-related files passed.

## Manual Validation

Started the local stack with `docker compose up -d`.

Waited for `Backend API service listening on port 7130`.

Called the advisor endpoint with the local admin API key:

`curl.exe -X POST http://127.0.0.1:7130/api/advisor/scan -H "x-api-key: ik_your-api-key-here-32-chars-minimum"`

Confirmed:
- Endpoint returned `200 OK`.
- Default local schema returned advisor findings.
- Response included all 19 rule definitions.
- Response included summary counts by category and severity.

Opened `http://localhost:7131/dashboard/database/advisors`.

Confirmed:
- Database Advisors page renders.
- Run scan button works.
- Summary cards render.
- Severity badges render.
- Category badges render.
- Category filters work for All, Security, Performance, and Health.
- Findings render with rule id, schema/table/object context, and remediation text.

Seeded validation objects through SQL Editor and reran the scan.

Confirmed the advisor detected seeded findings, including `missing-fk-index` for `public.advisor_child`.

The scan count increased after seeding, then the seeded objects were cleaned up.

Cleanup SQL used:

`DROP FUNCTION IF EXISTS advisor_dangerous();`

`DROP TABLE IF EXISTS advisor_child, advisor_parent, advisor_no_policy, advisor_rls_disabled CASCADE;`

## Known Local Validation Notes

Full repo lint is noisy in this Windows checkout because many existing files report CRLF Prettier errors. I ran scoped ESLint against the advisor-related files instead.

Root Turbo typecheck/build can be blocked on Windows by the existing `packages/ui` build script using Unix `cp`. I did not modify that package because it is unrelated to this issue.

## Scope Decisions

This PR does not add:
- Advisor scan persistence/history.
- Finding dismissals.
- Scheduled scans.
- Cloud CPU/disk/memory rules.
- MCP tool registration, because the MCP server source is not present in this repo.

Those are called out separately so maintainers can decide whether they should be follow-up work or handled in another package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hosted Database Advisor with an admin API and a dashboard to run on-demand, read-only Postgres checks and return stateless findings. Implements 19 security, performance, and health rules with summary counts and severity tags, addressing the OSS scope in #1271.

- **New Features**
  - API: `POST /api/advisor/scan` behind admin auth (Bearer or `X-API-Key`); stateless scan with a single-scan in-memory lock returning 409 `ADVISOR_SCAN_IN_PROGRESS`; OpenAPI at `openapi/advisor.yaml`.
  - Rules: 19 checks (e.g., RLS gaps, missing FK indexes, slow/long-running queries, connection pressure, autovacuum blocks, dead tuples, sequence exhaustion).
  - Dashboard: Database → Advisors page to run a scan, view counts, filter by category, and inspect findings with severity/category badges, scan time, and duration.
  - Schemas/Docs/Tests: Added advisor types to `@insforge/shared-schemas`, docs at `docs/core-concepts/database/advisors.mdx`, and unit coverage for all rules.

- **Bug Fixes**
  - Scoped slow-query checks to the current DB and return no findings if `pg_stat_statements` is unavailable.
  - Count only other client backends for connection usage rules.
  - Use whole-identifier matching for RLS index detection and generate distinct IDs for overloaded SECURITY DEFINER functions.
  - Make the `pg_stat_statements` extension check schema-agnostic by querying `pg_extension` by name only.

<sup>Written for commit 32cb4f1c305a9f7b60822ed78bf4e506a4bf0655. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database advisor scan with 19 rules across security, performance, and health categories
> - Adds [`AdvisorService`](https://github.com/InsForge/InsForge/pull/1282/files#diff-a7b55f31bf784c0e87e28a79bf33f0e936dc895115d3fd605c78c2236eb67c8a) with 19 scan rules: security rules (RLS disabled/no policy/permissive, dangerous SECURITY DEFINER functions), performance rules (missing FK indexes, unused indexes, slow queries, high connections, idle transactions, low cache hit ratio), and health rules (dead tuples, stale statistics, sequence exhaustion, autovacuum blocked).
> - Exposes a `POST /api/advisor/scan` endpoint in [`index.routes.ts`](https://github.com/InsForge/InsForge/pull/1282/files#diff-6fc85aa5b4cbb1ae194ba7c66b70a0a4eb876ecb2573cc0bf14081d0d5303747) restricted to admins; concurrent scan attempts return 409 via an in-memory lock.
> - Adds an [`AdvisorsPage`](https://github.com/InsForge/InsForge/pull/1282/files#diff-b652621741e879778f77e4ae535bcc1e0620a5f4c86f3718862622ccd10c7857) in the dashboard with category filters, severity badges, summary tiles, and remediation text, reachable at `/dashboard/database/advisors` via a new sidebar link.
> - Adds shared Zod schemas and TypeScript types for `AdvisorFinding`, `AdvisorRuleSummary`, and `AdvisorScanResponse` in [`database-api.schema.ts`](https://github.com/InsForge/InsForge/pull/1282/files#diff-b36b10da732a6923ba4ff08476bd3df82a78720ab4015b38906da55567b904ff), plus an OpenAPI spec in [`openapi/advisor.yaml`](https://github.com/InsForge/InsForge/pull/1282/files#diff-5510bcc974be873fff15db618ba113deea5e52b010771a2806e03f0dd55c15d3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32cb4f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database Advisors: on-demand PostgreSQL scans (security, performance, health) with a “Run scan now” action in the dashboard, categorized findings, severity badges, filtering, summary/duration, and remediation guidance. Admin API endpoint to trigger scans; only one scan runs at a time (409 on overlap).

* **Documentation**
  * Added full Database Advisors docs, examples, and an OpenAPI spec describing scan request/response shapes.

* **Tests**
  * Expanded unit tests covering rule registration, scan results, SQL scoping, and concurrency behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->