### PR TITLE
feat(ai): surface embedding quick starts

### DIFF
--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -5,9 +5,47 @@ import GeminiIcon from '#assets/logos/gemini.svg?react';
 export type CodeTab = 'sdk' | 'python' | 'http';
 export type QuickStartMode = 'text' | 'image' | 'video' | 'embedding';
 export type ModelModalityFilter = string;
+type OverviewQuickStartKind = 'chat' | 'embedding';
+
+export const OVERVIEW_QUICK_START_MODELS = [
+  {
+    id: 'openai/gpt-5.5',
+    label: 'OpenAI',
+    icon: OpenAIIcon,
+    kind: 'chat',
+  },
+  {
+    id: 'anthropic/claude-sonnet-4.6',
+    label: 'Anthropic',
+    icon: ClaudeIcon,
+    kind: 'chat',
+  },
+  {
+    id: 'google/gemini-2.5-pro',
+    label: 'Gemini',
+    icon: GeminiIcon,
+    kind: 'chat',
+  },
+  {
+    id: 'openai/text-embedding-3-small',
+    label: 'Embeddings',
+    icon: OpenAIIcon,
+    kind: 'embedding',
+  },
+] as const;
+
+function getOverviewQuickStartKind(modelId: string): OverviewQuickStartKind {
+  return OVERVIEW_QUICK_START_MODELS.find((model) => model.id === modelId)?.kind ?? 'chat';
+}
+
+export function getOverviewQuickStartMode(
+  modelId: string
+): Extract<QuickStartMode, 'text' | 'embedding'> {
+  return getOverviewQuickStartKind(modelId) === 'embedding' ? 'embedding' : 'text';
+}
 
 export function getOverviewCodeSnippets(modelId: string): Record<CodeTab, string> {
-  if (modelId.includes('embedding')) {
+  if (getOverviewQuickStartKind(modelId) === 'embedding') {
     return {
       sdk: `import OpenAI from 'openai';
 
@@ -94,29 +132,6 @@ export const CODE_TAB_LANGUAGE: Record<CodeTab, 'javascript' | 'python'> = {
   http: 'python',
 };
 
-export const OVERVIEW_QUICK_START_MODELS = [
-  {
-    id: 'openai/gpt-5.5',
-    label: 'OpenAI',
-    icon: OpenAIIcon,
-  },
-  {
-    id: 'anthropic/claude-sonnet-4.6',
-    label: 'Anthropic',
-    icon: ClaudeIcon,
-  },
-  {
-    id: 'google/gemini-2.5-pro',
-    label: 'Gemini',
-    icon: GeminiIcon,
-  },
-  {
-    id: 'openai/text-embedding-3-small',
-    label: 'Embeddings',
-    icon: OpenAIIcon,
-  },
-] as const;
-
 export const MODEL_MODALITY_FILTERS: { id: ModelModalityFilter; label: string }[] = [
   { id: 'all', label: 'All' },
   { id: 'text', label: 'Text' },
@@ -132,6 +147,12 @@ export const QUICK_START_MODES: { value: QuickStartMode; label: string }[] = [
   { value: 'video', label: 'Video Generation' },
   { value: 'embedding', label: 'Embeddings' },
 ];
+
+const QUICK_START_MODE_VALUES = new Set<string>(QUICK_START_MODES.map(({ value }) => value));
+
+export function isQuickStartMode(value: string | null): value is QuickStartMode {
+  return value !== null && QUICK_START_MODE_VALUES.has(value);
+}
 
 export const PROMPT_CARD_COPY: Record<QuickStartMode, string> = {
   text: 'Copy this prompt for your agent to generate text through the OpenRouter model gateway.',

--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -234,16 +234,21 @@ const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
 });
 
-const response = await openai.embeddings.create({
-  model: '${model}',
-  input: [
-    'InsForge gives coding agents database, auth, storage, and functions.',
-    'Use embeddings to power semantic search over product documentation.',
-  ],
-});
+try {
+  const response = await openai.embeddings.create({
+    model: '${model}',
+    input: [
+      'InsForge gives coding agents database, auth, storage, and functions.',
+      'Use embeddings to power semantic search over product documentation.',
+    ],
+  });
 
-for (const item of response.data) {
-  console.log({ index: item.index, dimensions: item.embedding.length });
+  for (const item of response.data) {
+    console.log({ index: item.index, dimensions: item.embedding.length });
+  }
+} catch (error) {
+  console.error('Failed to generate embeddings:', error);
+  process.exitCode = 1;
 }`;
   }
 

--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -3,10 +3,46 @@ import ClaudeIcon from '#assets/logos/claude_code.svg?react';
 import GeminiIcon from '#assets/logos/gemini.svg?react';
 
 export type CodeTab = 'sdk' | 'python' | 'http';
-export type QuickStartMode = 'text' | 'image' | 'video';
+export type QuickStartMode = 'text' | 'image' | 'video' | 'embedding';
 export type ModelModalityFilter = string;
 
 export function getOverviewCodeSnippets(modelId: string): Record<CodeTab, string> {
+  if (modelId.includes('embedding')) {
+    return {
+      sdk: `import OpenAI from 'openai';
+
+const openai = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const response = await openai.embeddings.create({
+  model: '${modelId}',
+  input: 'InsForge gives coding agents a complete backend.',
+});
+
+console.log(response.data[0].embedding.length);`,
+      python: `from openai import OpenAI
+import os
+
+client = OpenAI(
+    base_url="https://openrouter.ai/api/v1",
+    api_key=os.environ["OPENROUTER_API_KEY"],
+)
+
+response = client.embeddings.create(
+    model="${modelId}",
+    input="InsForge gives coding agents a complete backend.",
+)
+
+print(len(response.data[0].embedding))`,
+      http: `curl https://openrouter.ai/api/v1/embeddings \\
+  -H "Authorization: Bearer $OPENROUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model":"${modelId}","input":"InsForge gives coding agents a complete backend."}'`,
+    };
+  }
+
   return {
     sdk: `import OpenAI from 'openai';
 
@@ -74,6 +110,11 @@ export const OVERVIEW_QUICK_START_MODELS = [
     label: 'Gemini',
     icon: GeminiIcon,
   },
+  {
+    id: 'openai/text-embedding-3-small',
+    label: 'Embeddings',
+    icon: OpenAIIcon,
+  },
 ] as const;
 
 export const MODEL_MODALITY_FILTERS: { id: ModelModalityFilter; label: string }[] = [
@@ -82,19 +123,22 @@ export const MODEL_MODALITY_FILTERS: { id: ModelModalityFilter; label: string }[
   { id: 'image', label: 'Image' },
   { id: 'audio', label: 'Audio' },
   { id: 'video', label: 'Video' },
-  { id: 'embeddings', label: 'Embed' },
+  { id: 'embeddings', label: 'Embeddings' },
 ];
 
 export const QUICK_START_MODES: { value: QuickStartMode; label: string }[] = [
   { value: 'text', label: 'Text Generation' },
   { value: 'image', label: 'Image Generation' },
   { value: 'video', label: 'Video Generation' },
+  { value: 'embedding', label: 'Embeddings' },
 ];
 
 export const PROMPT_CARD_COPY: Record<QuickStartMode, string> = {
   text: 'Copy this prompt for your agent to generate text through the OpenRouter model gateway.',
   image: 'Copy this prompt for your agent to generate images through the OpenRouter model gateway.',
   video: 'Copy this prompt for your agent to generate videos through the OpenRouter model gateway.',
+  embedding:
+    'Copy this prompt for your agent to generate embeddings through the OpenRouter model gateway.',
 };
 
 export const QUICK_START_COPY: Record<
@@ -118,6 +162,12 @@ export const QUICK_START_COPY: Record<
     description: 'Submit an asynchronous video generation job and poll until it completes.',
     model: 'google/veo-3.1',
     installCommand: 'npm install dotenv\nnpm install --save-dev @types/node tsx typescript',
+  },
+  embedding: {
+    projectName: 'ai-embedding-demo',
+    description: 'Generate text embeddings for vector search or RAG workflows.',
+    model: 'openai/text-embedding-3-small',
+    installCommand: 'npm install openai dotenv\nnpm install --save-dev @types/node tsx typescript',
   },
 };
 
@@ -175,6 +225,28 @@ while (result.status !== 'completed' && result.status !== 'failed') {
 console.log(result);`;
   }
 
+  if (mode === 'embedding') {
+    return `import OpenAI from 'openai';
+import 'dotenv/config';
+
+const openai = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const response = await openai.embeddings.create({
+  model: '${model}',
+  input: [
+    'InsForge gives coding agents database, auth, storage, and functions.',
+    'Use embeddings to power semantic search over product documentation.',
+  ],
+});
+
+for (const item of response.data) {
+  console.log({ index: item.index, dimensions: item.embedding.length });
+}`;
+  }
+
   return `import OpenAI from 'openai';
 import 'dotenv/config';
 
@@ -200,6 +272,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
     image: 'an image generation feature that sends a user prompt and renders the returned image',
     video:
       'a video generation feature that submits a prompt, polls the job status, and renders the completed video',
+    embedding:
+      'an embeddings feature that converts text into vectors and stores or displays vector dimensions',
   };
   const apiCopy: Record<QuickStartMode, string> = {
     text: 'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1.',
@@ -207,6 +281,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
       "Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1 and request modalities ['image', 'text'].",
     video:
       'Use fetch with the OpenRouter video endpoint at https://openrouter.ai/api/v1/videos; do not install or use the OpenAI SDK for video.',
+    embedding:
+      'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1 and call embeddings.create().',
   };
 
   return [

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -23,6 +23,7 @@ import {
   CODE_TAB_LANGUAGE,
   OVERVIEW_QUICK_START_MODELS,
   getOverviewCodeSnippets,
+  getOverviewQuickStartMode,
   type CodeTab,
 } from '#features/ai/constants';
 
@@ -492,6 +493,11 @@ export default function AIOverviewPage() {
   } = useAIModelCredits();
   const shouldShowModelCredits = host.mode === 'cloud-hosting' && !!host.onRequestModelCredits;
   const codeSnippets = useMemo(() => getOverviewCodeSnippets(selectedModelId), [selectedModelId]);
+  const quickStartMode = getOverviewQuickStartMode(selectedModelId);
+  const quickStartPath =
+    quickStartMode === 'embedding'
+      ? '/dashboard/ai/quick-start?mode=embedding'
+      : '/dashboard/ai/quick-start';
 
   const totals = useMemo(
     () => ({
@@ -551,7 +557,7 @@ export default function AIOverviewPage() {
                 size="sm"
                 className="h-8 bg-[#68e5a2] px-4 text-black hover:bg-[#68e5a2]/90"
               >
-                <Link to="/dashboard/ai/quick-start">Quick Start</Link>
+                <Link to={quickStartPath}>Quick Start</Link>
               </Button>
             </div>
           </div>

--- a/packages/dashboard/src/features/ai/pages/AIQuickStartPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIQuickStartPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button, CopyButton, Tab, Tabs } from '@insforge/ui';
 import { CodeEditor } from '#components';
 import { useOpenRouterKey } from '#features/ai/hooks/useOpenRouterKey';
@@ -9,6 +10,7 @@ import {
   QUICK_START_MODES,
   getQuickStartPrompt,
   getQuickStartScript,
+  isQuickStartMode,
   type QuickStartMode,
 } from '#features/ai/constants';
 
@@ -224,7 +226,9 @@ function StepItem({ step, isLast }: { step: QuickStartStep; isLast: boolean }) {
 }
 
 export default function AIQuickStartPage() {
-  const [mode, setMode] = useState<QuickStartMode>('text');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const modeParam = searchParams.get('mode');
+  const mode: QuickStartMode = isQuickStartMode(modeParam) ? modeParam : 'text';
   const { data: openRouterKey, isLoading: isOpenRouterKeyLoading } = useOpenRouterKey();
   const copy = QUICK_START_COPY[mode];
   const quickStartPrompt = useMemo(() => getQuickStartPrompt(mode), [mode]);
@@ -236,6 +240,21 @@ export default function AIQuickStartPage() {
   const copiedEnvLine = copiedOpenRouterKey
     ? `OPENROUTER_API_KEY=${copiedOpenRouterKey}`
     : displayedEnvLine;
+
+  const handleModeChange = (value: string) => {
+    if (!isQuickStartMode(value)) {
+      return;
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+    if (value === 'text') {
+      nextSearchParams.delete('mode');
+    } else {
+      nextSearchParams.set('mode', value);
+    }
+
+    setSearchParams(nextSearchParams, { replace: true });
+  };
 
   const steps: QuickStartStep[] = [
     {
@@ -297,11 +316,7 @@ export default function AIQuickStartPage() {
       <div className="mx-auto flex w-full max-w-[1024px] flex-col gap-6 px-10 pb-12 pt-10">
         <h1 className="text-2xl font-medium leading-8 text-foreground">Quick Start</h1>
 
-        <Tabs
-          value={mode}
-          onValueChange={(value) => setMode(value as QuickStartMode)}
-          className="h-8 w-full"
-        >
+        <Tabs value={mode} onValueChange={handleModeChange} className="h-8 w-full">
           {QUICK_START_MODES.map((item) => (
             <Tab key={item.value} value={item.value} className="h-8 flex-1">
               {item.label}


### PR DESCRIPTION
## Summary

- Adds an Embeddings quick-start mode that calls `openai.embeddings.create()` through the OpenRouter model gateway.
- Adds an embeddings model shortcut to the AI overview snippets and switches that card to the `/embeddings` examples when selected.
- Renames the model modality filter label from `Embed` to `Embeddings` for discoverability.

Closes #1147

## How did you test this change?

- `npx prettier --write packages/dashboard/src/features/ai/constants.ts`
- `npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard`
- `npm run typecheck --workspace @insforge/dashboard`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Embeddings quick start with SDK, Python, and HTTP examples via the OpenRouter gateway, improves discoverability in the dashboard, and adds error handling. Fulfills Linear #1147 by surfacing embedding quick starts and clarifying the modality filter.

- **New Features**
  - Added `embedding` quick-start mode with scripts, prompts, and copy; uses `openai.embeddings.create()`.
  - Overview snippets detect embedding models and render embedding-specific code (including `curl` to `/embeddings`).
  - Added Embeddings model shortcut (`openai/text-embedding-3-small`) that routes to `/embeddings` examples; modality filter label now "Embeddings".

- **Bug Fixes**
  - Wrapped the embedding quick-start script in try/catch and set a non-zero exit code on failure to prevent silent errors.
  - Preserves quick-start mode via a `mode` URL param and deep-links from the Overview (e.g., `?mode=embedding`) so refresh/navigation keeps context.

<sup>Written for commit 44edce0f087a09ef2255b2290aec1ac286bfd870. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1285?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add embedding quick start mode to AI dashboard with URL-based mode persistence
> - Adds an 'Embeddings' tab to the AI quick start page, with dedicated copy, a default model (`openai/text-embedding-3-small`), and a generated script that calls `embeddings.create` instead of chat completions.
> - Extends the overview page so that selecting an embeddings model navigates to `/dashboard/ai/quick-start?mode=embedding` via `getOverviewQuickStartMode`.
> - Replaces local React state in `AIQuickStartPage` with URL search params (`useSearchParams`), enabling deep-linking and browser back/forward navigation; defaults to `text` when the param is absent or invalid.
> - Adds `getOverviewCodeSnippets` support for embeddings-specific SDK, Python, and HTTP snippets in the overview.
> - Renames the modality filter label from 'Embed' to 'Embeddings' for consistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44edce0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Embeddings mode to AI quick-start guides with SDK/Python/curl examples showing embedding creation and vector dimensions.
  * OpenAI embeddings model added to models list and filters; new embeddings demo project with install/setup instructions.
  * Quick Start link and page now route and persist the selected mode via URL, enabling direct linking to Embeddings quick-start.
* **Documentation**
  * UI copy and prompt guidance updated to include embeddings-specific instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->