### PR TITLE
fix(functions): support Deno-native ESM imports

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -171,7 +171,7 @@ services:
         echo 'Downloading Deno dependencies...' &&
         deno cache functions/server.ts &&
         echo 'Starting Deno server on port 7133...' &&
-        deno run --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js functions/server.ts
+        deno run --unstable-worker-options --allow-net --allow-env --allow-import --allow-read=./functions/worker-template.js functions/server.ts
       "
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
         echo 'Downloading Deno dependencies...' &&
         deno cache functions/server.ts &&
         echo 'Starting Deno server on port 7133...' &&
-        deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --unstable-worker-options --watch functions/server.ts
+        deno run --allow-net --allow-env --allow-import --allow-read=./functions/worker-template.js --unstable-worker-options --watch functions/server.ts
       "
     restart: unless-stopped
     security_opt:

--- a/functions/examples/README.md
+++ b/functions/examples/README.md
@@ -6,6 +6,7 @@ This folder contains **example serverless (edge) functions** you can deploy to I
 
 - `demo-hello-world.js`: public function (GET/POST) with CORS + secret example (`HELLO_PREFIX`)
 - `demo-whoami.js`: authenticated function (GET) that returns the current user
+- `demo-zod-esm.ts`: Deno-native `export default` function with a top-level `npm:zod` import
 
 ## Deploy
 

--- a/functions/examples/demo-zod-esm.ts
+++ b/functions/examples/demo-zod-esm.ts
@@ -1,0 +1,20 @@
+import { z } from 'npm:zod';
+
+/**
+ * Demo: Deno-native ESM function with an npm import.
+ *
+ * Deploy this code as a function body to validate that the self-hosted runtime
+ * supports top-level imports and `export default` handlers.
+ */
+export default async function (request: Request) {
+  const BodySchema = z.object({
+    name: z.string().trim().min(1).default('World'),
+  });
+
+  const body = BodySchema.parse(await request.json().catch(() => ({})));
+
+  return new Response(JSON.stringify({ message: `Hello, ${body.name}!` }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -175,7 +175,8 @@ async function executeInWorker(code: string, request: Request): Promise<Response
           run: false,
           ffi: false,
           sys: false,
-          import: false,
+          // Deno-native functions may import npm:, jsr:, data:, or remote modules.
+          import: true,
           hrtime: false,
         },
       },

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -60,6 +60,78 @@ const { createClient } = await import('npm:@insforge/sdk');
 const { encodeBase64, decodeBase64 } =
   await import('https://deno.land/std@0.224.0/encoding/base64.ts');
 
+const MODULE_CONTEXT_KEY = '__INSFORGE_FUNCTION_CONTEXT__';
+
+function isModuleSource(code) {
+  return /^\s*(import|export)\s/m.test(code);
+}
+
+function toDataModuleUrl(source) {
+  const bytes = new TextEncoder().encode(source);
+  return `data:application/typescript;base64,${encodeBase64(bytes)}`;
+}
+
+async function loadEsmFunction(code, context) {
+  const previousContext = globalThis[MODULE_CONTEXT_KEY];
+  globalThis[MODULE_CONTEXT_KEY] = context;
+
+  try {
+    const moduleSource = `const { createClient, Deno, encodeBase64, decodeBase64 } = globalThis.${MODULE_CONTEXT_KEY};\n${code}`;
+    const userModule = await import(toDataModuleUrl(moduleSource));
+    const functionHandler = userModule.default ?? userModule.handler;
+
+    if (typeof functionHandler !== 'function') {
+      throw new Error('No function exported. Expected: export default async function(req) { ... }');
+    }
+
+    return functionHandler;
+  } finally {
+    if (previousContext === undefined) {
+      delete globalThis[MODULE_CONTEXT_KEY];
+    } else {
+      globalThis[MODULE_CONTEXT_KEY] = previousContext;
+    }
+  }
+}
+
+function loadScriptFunction(code, context) {
+  /**
+   * FUNCTION WRAPPING:
+   * Injecting mocks into the user function execution scope.
+   * We pass mockDeno instead of the real Deno global.
+   */
+  const wrapper = new Function(
+    'exports',
+    'module',
+    'createClient',
+    'Deno',
+    'encodeBase64',
+    'decodeBase64',
+    code
+  );
+  const exports = {};
+  const module = { exports };
+
+  // Execute the wrapper, passing mockDeno as the Deno global
+  wrapper(
+    exports,
+    module,
+    context.createClient,
+    context.Deno,
+    context.encodeBase64,
+    context.decodeBase64
+  );
+
+  // Get the exported function
+  const functionHandler = module.exports || exports.default || exports;
+
+  if (typeof functionHandler !== 'function') {
+    throw new Error('No function exported. Expected: module.exports = async function(req) { ... }');
+  }
+
+  return functionHandler;
+}
+
 // Handle the single message with code, request data, and secrets
 self.onmessage = async (e) => {
   const { code, requestData, secrets = {} } = e.data;
@@ -90,34 +162,16 @@ self.onmessage = async (e) => {
       },
     };
 
-    /**
-     * FUNCTION WRAPPING:
-     * Injecting mocks into the user function execution scope.
-     * We pass mockDeno instead of the real Deno global.
-     */
-    const wrapper = new Function(
-      'exports',
-      'module',
-      'createClient',
-      'Deno',
-      'encodeBase64',
-      'decodeBase64',
-      code
-    );
-    const exports = {};
-    const module = { exports };
+    const context = {
+      createClient,
+      Deno: mockDeno,
+      encodeBase64,
+      decodeBase64,
+    };
 
-    // Execute the wrapper, passing mockDeno as the Deno global
-    wrapper(exports, module, createClient, mockDeno, encodeBase64, decodeBase64);
-
-    // Get the exported function
-    const functionHandler = module.exports || exports.default || exports;
-
-    if (typeof functionHandler !== 'function') {
-      throw new Error(
-        'No function exported. Expected: module.exports = async function(req) { ... }'
-      );
-    }
+    const functionHandler = isModuleSource(code)
+      ? await loadEsmFunction(code, context)
+      : loadScriptFunction(code, context);
 
     // Create Request object from data
     const request = new Request(requestData.url, {

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -11,14 +11,19 @@
 // We polyfill Deno.env and process.env BEFORE any imports using Top-Level Await.
 // This prevents libraries (like 'debug') from triggering 'NotCapable' errors
 // when using a strict native whitelist (env: false).
+const MODULE_CONTEXT_KEY = '__INSFORGE_FUNCTION_CONTEXT__';
 const sterileEnv = {
   NODE_ENV: 'production',
 };
 
+function getActiveFunctionContext() {
+  return globalThis[MODULE_CONTEXT_KEY];
+}
+
 try {
   // Shadow Deno.env with a pure JS implementation
   const mockDenoEnv = {
-    get: (key) => sterileEnv[key] ?? undefined,
+    get: (key) => getActiveFunctionContext()?.secrets?.[key] ?? sterileEnv[key] ?? undefined,
     set: () => {
       throw new Error('Deno.env.set is disabled');
     },
@@ -26,7 +31,7 @@ try {
       throw new Error('Deno.env.delete is disabled');
     },
     toObject: () => ({ ...sterileEnv }),
-    has: (key) => key in sterileEnv,
+    has: (key) => key in sterileEnv || key in (getActiveFunctionContext()?.secrets ?? {}),
   };
 
   // Replace global Deno.env
@@ -60,8 +65,6 @@ const { createClient } = await import('npm:@insforge/sdk');
 const { encodeBase64, decodeBase64 } =
   await import('https://deno.land/std@0.224.0/encoding/base64.ts');
 
-const MODULE_CONTEXT_KEY = '__INSFORGE_FUNCTION_CONTEXT__';
-
 function isModuleSource(code) {
   return /^\s*(import|export)\s/m.test(code);
 }
@@ -71,26 +74,68 @@ function toDataModuleUrl(source) {
   return `data:application/typescript;base64,${encodeBase64(bytes)}`;
 }
 
-async function loadEsmFunction(code, context) {
+function installModuleGlobals(context) {
+  const names = ['createClient', 'encodeBase64', 'decodeBase64'];
+  const previousDescriptors = new Map(
+    names.map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)])
+  );
+
+  for (const name of names) {
+    Object.defineProperty(globalThis, name, {
+      value: context[name],
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  return () => {
+    for (const name of names) {
+      const previousDescriptor = previousDescriptors.get(name);
+      if (previousDescriptor) {
+        Object.defineProperty(globalThis, name, previousDescriptor);
+      } else {
+        delete globalThis[name];
+      }
+    }
+  };
+}
+
+function installModuleContext(context) {
   const previousContext = globalThis[MODULE_CONTEXT_KEY];
   globalThis[MODULE_CONTEXT_KEY] = context;
+  const restoreModuleGlobals = installModuleGlobals(context);
+
+  return () => {
+    restoreModuleGlobals();
+    if (previousContext === undefined) {
+      delete globalThis[MODULE_CONTEXT_KEY];
+    } else {
+      globalThis[MODULE_CONTEXT_KEY] = previousContext;
+    }
+  };
+}
+
+async function loadEsmFunction(code, context) {
+  const restoreModuleContext = installModuleContext(context);
 
   try {
-    const moduleSource = `const { createClient, Deno, encodeBase64, decodeBase64 } = globalThis.${MODULE_CONTEXT_KEY};\n${code}`;
-    const userModule = await import(toDataModuleUrl(moduleSource));
+    const userModule = await import(toDataModuleUrl(code));
     const functionHandler = userModule.default ?? userModule.handler;
 
     if (typeof functionHandler !== 'function') {
       throw new Error('No function exported. Expected: export default async function(req) { ... }');
     }
 
-    return functionHandler;
+    return async (...args) => {
+      const restoreExecutionContext = installModuleContext(context);
+      try {
+        return await functionHandler(...args);
+      } finally {
+        restoreExecutionContext();
+      }
+    };
   } finally {
-    if (previousContext === undefined) {
-      delete globalThis[MODULE_CONTEXT_KEY];
-    } else {
-      globalThis[MODULE_CONTEXT_KEY] = previousContext;
-    }
+    restoreModuleContext();
   }
 }
 
@@ -167,6 +212,7 @@ self.onmessage = async (e) => {
       Deno: mockDeno,
       encodeBase64,
       decodeBase64,
+      secrets,
     };
 
     const functionHandler = isModuleSource(code)

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -11,19 +11,60 @@
 // We polyfill Deno.env and process.env BEFORE any imports using Top-Level Await.
 // This prevents libraries (like 'debug') from triggering 'NotCapable' errors
 // when using a strict native whitelist (env: false).
-const MODULE_CONTEXT_KEY = '__INSFORGE_FUNCTION_CONTEXT__';
 const sterileEnv = {
   NODE_ENV: 'production',
 };
+let activeSecretAccessors;
 
-function getActiveFunctionContext() {
-  return globalThis[MODULE_CONTEXT_KEY];
+function getActiveSecret(key) {
+  return activeSecretAccessors?.get(key);
+}
+
+function hasActiveSecret(key) {
+  return activeSecretAccessors?.has(key) ?? false;
+}
+
+function createProcessEnv(secretAccessors) {
+  return new Proxy(
+    {},
+    {
+      get: (_target, key) => {
+        if (typeof key !== 'string') {
+          return undefined;
+        }
+        return secretAccessors.get(key) ?? sterileEnv[key];
+      },
+      has: (_target, key) =>
+        typeof key === 'string' && (key in sterileEnv || secretAccessors.has(key)),
+      ownKeys: () => Reflect.ownKeys(sterileEnv),
+      getOwnPropertyDescriptor: (_target, key) => {
+        if (typeof key !== 'string') {
+          return undefined;
+        }
+        const value = key in sterileEnv ? sterileEnv[key] : secretAccessors.get(key);
+        return value === undefined
+          ? undefined
+          : {
+              configurable: true,
+              enumerable: key in sterileEnv,
+              value,
+              writable: false,
+            };
+      },
+      set: () => {
+        throw new Error('process.env mutation is disabled');
+      },
+      deleteProperty: () => {
+        throw new Error('process.env deletion is disabled');
+      },
+    }
+  );
 }
 
 try {
   // Shadow Deno.env with a pure JS implementation
   const mockDenoEnv = {
-    get: (key) => getActiveFunctionContext()?.secrets?.[key] ?? sterileEnv[key] ?? undefined,
+    get: (key) => getActiveSecret(key) ?? sterileEnv[key] ?? undefined,
     set: () => {
       throw new Error('Deno.env.set is disabled');
     },
@@ -31,7 +72,7 @@ try {
       throw new Error('Deno.env.delete is disabled');
     },
     toObject: () => ({ ...sterileEnv }),
-    has: (key) => key in sterileEnv || key in (getActiveFunctionContext()?.secrets ?? {}),
+    has: (key) => key in sterileEnv || hasActiveSecret(key),
   };
 
   // Replace global Deno.env
@@ -101,17 +142,20 @@ function installModuleGlobals(context) {
 }
 
 function installModuleContext(context) {
-  const previousContext = globalThis[MODULE_CONTEXT_KEY];
-  globalThis[MODULE_CONTEXT_KEY] = context;
-  const restoreModuleGlobals = installModuleGlobals(context);
+  const { secretAccessors, ...publicContext } = context;
+  const previousSecretAccessors = activeSecretAccessors;
+  const previousProcessEnv = globalThis.process?.env;
+
+  activeSecretAccessors = secretAccessors;
+  if (!globalThis.process) globalThis.process = {};
+  globalThis.process.env = createProcessEnv(secretAccessors);
+
+  const restoreModuleGlobals = installModuleGlobals(publicContext);
 
   return () => {
     restoreModuleGlobals();
-    if (previousContext === undefined) {
-      delete globalThis[MODULE_CONTEXT_KEY];
-    } else {
-      globalThis[MODULE_CONTEXT_KEY] = previousContext;
-    }
+    activeSecretAccessors = previousSecretAccessors;
+    globalThis.process.env = previousProcessEnv ?? { ...sterileEnv };
   };
 }
 
@@ -140,41 +184,56 @@ async function loadEsmFunction(code, context) {
 }
 
 function loadScriptFunction(code, context) {
+  const restoreLoadContext = installModuleContext(context);
+
   /**
    * FUNCTION WRAPPING:
    * Injecting mocks into the user function execution scope.
    * We pass mockDeno instead of the real Deno global.
    */
-  const wrapper = new Function(
-    'exports',
-    'module',
-    'createClient',
-    'Deno',
-    'encodeBase64',
-    'decodeBase64',
-    code
-  );
-  const exports = {};
-  const module = { exports };
+  try {
+    const wrapper = new Function(
+      'exports',
+      'module',
+      'createClient',
+      'Deno',
+      'encodeBase64',
+      'decodeBase64',
+      code
+    );
+    const exports = {};
+    const module = { exports };
 
-  // Execute the wrapper, passing mockDeno as the Deno global
-  wrapper(
-    exports,
-    module,
-    context.createClient,
-    context.Deno,
-    context.encodeBase64,
-    context.decodeBase64
-  );
+    // Execute the wrapper, passing mockDeno as the Deno global
+    wrapper(
+      exports,
+      module,
+      context.createClient,
+      context.Deno,
+      context.encodeBase64,
+      context.decodeBase64
+    );
 
-  // Get the exported function
-  const functionHandler = module.exports || exports.default || exports;
+    // Get the exported function
+    const functionHandler = module.exports || exports.default || exports;
 
-  if (typeof functionHandler !== 'function') {
-    throw new Error('No function exported. Expected: module.exports = async function(req) { ... }');
+    if (typeof functionHandler !== 'function') {
+      throw new Error(
+        'No function exported. Expected: module.exports = async function(req) { ... }'
+      );
+    }
+
+    return async (...args) => {
+      const restoreExecutionContext = installModuleContext(context);
+      try {
+        return await functionHandler(...args);
+      } finally {
+        restoreExecutionContext();
+      }
+    };
+  } finally {
+    restoreLoadContext();
   }
-
-  return functionHandler;
 }
 
 // Handle the single message with code, request data, and secrets
@@ -206,13 +265,17 @@ self.onmessage = async (e) => {
         throw new Error('Deno.Command is natively disabled');
       },
     };
+    const secretAccessors = {
+      get: (key) => secrets[key] ?? undefined,
+      has: (key) => Object.prototype.hasOwnProperty.call(secrets, key),
+    };
 
     const context = {
       createClient,
       Deno: mockDeno,
       encodeBase64,
       decodeBase64,
-      secrets,
+      secretAccessors,
     };
 
     const functionHandler = isModuleSource(code)


### PR DESCRIPTION
## Summary

- Loads function bodies with top-level `import` or `export` as Deno TypeScript data modules, so documented `export default` functions can run in self-hosted mode.
- Keeps the legacy `module.exports` execution path intact for existing functions.
- Preserves the sandboxed worker permissions for env/read/write/run while enabling import permission for Deno-native npm/jsr/remote imports.
- Adds a `demo-zod-esm.ts` example that validates top-level `npm:zod` imports.

Closes #1146

## How did you test this change?

- Installed a temporary Deno binary and ran a worker-template smoke test with `import { z } from 'npm:zod'` plus `export default`, returning `{"message":"Hello, InsForge!"}`.
- Ran a second worker-template smoke test for the existing `module.exports` path, returning `{"message":"Hello, legacy!"}`.
- `npx prettier --check docker-compose.yml docker-compose.prod.yml functions/worker-template.js functions/server.ts functions/examples/demo-zod-esm.ts functions/examples/README.md`
- `docker compose config >/tmp/insforge-compose-dev.yml`
- `docker compose -f docker-compose.prod.yml config >/tmp/insforge-compose-prod.yml`
- `/tmp/deno_install/bin/deno check functions/examples/demo-zod-esm.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Deno-native ESM imports in self-hosted functions while keeping the legacy CommonJS path. Enables import permissions and isolates per-invocation secrets so they never leak to the global scope.

- **New Features**
  - Detects ESM (`import`/`export`) and loads code as a TypeScript data module; supports `export default`.
  - Enables module imports in the sandbox (`import: true`) and adds `--allow-import` to `docker-compose.yml` and `docker-compose.prod.yml`.
  - Exposes request-scoped secrets via `Deno.env.get/has` and `process.env` (read-only) during invocation.
  - Adds `functions/examples/demo-zod-esm.ts` using `npm:zod`.

- **Bug Fixes**
  - Scopes ESM globals and execution context per invocation and restores them after execution to prevent helper redeclarations and secret leakage.

<sup>Written for commit ffd74bbc4c9011b470056957be359797bfc130dd. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1286?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support Deno-native ESM imports in edge functions worker
> - Adds ESM detection via `isModuleSource` in [worker-template.js](https://github.com/InsForge/InsForge/pull/1286/files#diff-5b15d90fa8b813623248c82a78beb07550e9132da22b19301aeb63579a8629a6); functions using `import`/`export` syntax are loaded as ES modules via a `data:` URL instead of wrapped in a `Function` constructor.
> - Adds `loadEsmFunction` to handle `export default` or named `handler` exports, supporting top-level `npm:`, `jsr:`, and remote module imports.
> - Enables `deno.permissions.import` in [server.ts](https://github.com/InsForge/InsForge/pull/1286/files#diff-5a371eb7251cca8026249e2af0a755af5c06f18c7093664f9d7cb3331dd93378) and adds `--allow-import` to Deno commands in both compose files.
> - Exposes secrets via a read-only `Deno.env` and `process.env` proxy backed by per-execution secret accessors, with writes/deletes still throwing.
> - Adds [demo-zod-esm.ts](https://github.com/InsForge/InsForge/pull/1286/files#diff-a29f87f2b8cf3286788e7fc9b565b9c1dc0ae3569c418599eb3c8c0c47c0c99e) as a reference example using a top-level `npm:zod` import.
> - Behavioral Change: worker now allows module imports by default; previously all imports were blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffd74bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edge functions now support both ES module-style and script-style user code and allow runtime importing of external packages.
  * Per-request secret and environment context is available during function execution.

* **Documentation**
  * Added an example showing JSON request validation and a friendly "Hello, <name>!" response using an imported validator.

* **Chores**
  * Adjusted container start-up configuration for production and development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->