### PR TITLE
feat(dev): add Mailpit local email capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,10 @@ UI_PORT=7132
 # Deno serverless runtime
 DENO_PORT=7133
 
+# Local email capture (Docker Compose defaults auth emails to Mailpit)
+MAILPIT_SMTP_PORT=1025
+MAILPIT_UI_PORT=7134
+
 # API Base URLs - Update if running on different host/port
 API_BASE_URL=http://localhost:7130
 VITE_API_BASE_URL=http://localhost:7130
@@ -159,6 +163,19 @@ LOGS_DIR=
 # OpenRouter API - Get your API key from https://openrouter.ai/keys
 # Used for AI-powered features and model gateway
 OPENROUTER_API_KEY=
+
+# -----------------------------------------------------------------------------
+# Email Delivery (Optional)
+# -----------------------------------------------------------------------------
+# Leave SMTP_HOST empty in Docker Compose to capture local auth emails in Mailpit.
+# Mailpit UI is available at http://localhost:7134 by default.
+SMTP_HOST=
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_SENDER_EMAIL=noreply@insforge.local
+SMTP_SENDER_NAME=InsForge
+SMTP_MIN_INTERVAL_SECONDS=0
 
 # -----------------------------------------------------------------------------
 # Stripe Payments Configuration (Optional)

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "migrate:redo": "npm run migrate:bootstrap && node-pg-migrate redo --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:up:local": "dotenv -e ../.env -- npm run migrate:bootstrap && dotenv -e ../.env -- node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down:local": "dotenv -e ../.env -- node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
-    "seed:run": "tsx src/scripts/seed-backend.ts",
+    "seed:run": "dotenv -e ../.env -- tsx src/scripts/seed-backend.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "migrate:redo": "npm run migrate:bootstrap && node-pg-migrate redo --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:up:local": "dotenv -e ../.env -- npm run migrate:bootstrap && dotenv -e ../.env -- node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down:local": "dotenv -e ../.env -- node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
+    "seed:run": "tsx src/scripts/seed-backend.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/backend/src/providers/email/smtp.provider.ts
+++ b/backend/src/providers/email/smtp.provider.ts
@@ -32,11 +32,16 @@ export class SmtpEmailProvider implements EmailProvider {
   }
 
   private createTransporter(config: RawSmtpConfig) {
+    const auth =
+      config.username || config.password
+        ? { user: config.username, pass: config.password }
+        : undefined;
+
     return nodemailer.createTransport({
       host: config.host,
       port: config.port,
       secure: config.port === 465,
-      auth: { user: config.username, pass: config.password },
+      auth,
       connectionTimeout: 10000,
     });
   }

--- a/backend/src/scripts/seed-backend.ts
+++ b/backend/src/scripts/seed-backend.ts
@@ -1,0 +1,22 @@
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { seedBackend } from '@/utils/seed.js';
+import logger from '@/utils/logger.js';
+
+async function main(): Promise<void> {
+  const databaseManager = DatabaseManager.getInstance();
+  await databaseManager.initialize();
+
+  try {
+    await seedBackend();
+  } finally {
+    await databaseManager.close();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Failed to seed backend', {
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+  process.exitCode = 1;
+});

--- a/backend/src/services/email/smtp-config.service.ts
+++ b/backend/src/services/email/smtp-config.service.ts
@@ -129,6 +129,10 @@ function hasStoredSmtpConfig(row: Record<string, unknown>): boolean {
   );
 }
 
+function shouldUseEnvironmentSmtpConfig(row: Record<string, unknown>): boolean {
+  return !row.enabled && !hasStoredSmtpConfig(row);
+}
+
 const EMPTY_CONFIG: SmtpConfigSchema = {
   id: '00000000-0000-0000-0000-000000000000',
   enabled: false,
@@ -236,7 +240,7 @@ export class SmtpConfigService {
       }
 
       const row = result.rows[0];
-      if (!row.enabled && !hasStoredSmtpConfig(row)) {
+      if (shouldUseEnvironmentSmtpConfig(row)) {
         const envConfig = this.getEnvironmentSmtpConfig();
         if (envConfig) {
           return toSmtpConfigSchemaFromRaw(envConfig);
@@ -269,7 +273,10 @@ export class SmtpConfigService {
 
       const row = result.rows[0];
       if (!row.enabled) {
-        return hasStoredSmtpConfig(row) ? null : this.getEnvironmentSmtpConfig();
+        // Delivery is intentionally stricter than settings reads: if a user
+        // explicitly disabled a stored SMTP config, do not silently send via the
+        // environment fallback. Only empty bootstrap rows may fall back to env.
+        return shouldUseEnvironmentSmtpConfig(row) ? this.getEnvironmentSmtpConfig() : null;
       }
 
       const password = this.getDecryptedPassword(row.password_encrypted);

--- a/backend/src/services/email/smtp-config.service.ts
+++ b/backend/src/services/email/smtp-config.service.ts
@@ -88,6 +88,47 @@ function toSmtpConfigSchema(row: Record<string, unknown>): SmtpConfigSchema {
   };
 }
 
+function toSmtpConfigSchemaFromRaw(config: RawSmtpConfig): SmtpConfigSchema {
+  const now = new Date().toISOString();
+  return {
+    id: config.id,
+    enabled: config.enabled,
+    host: config.host,
+    port: config.port,
+    username: config.username,
+    hasPassword: !!config.password,
+    senderEmail: config.senderEmail,
+    senderName: config.senderName,
+    minIntervalSeconds: config.minIntervalSeconds,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInteger(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function hasStoredSmtpConfig(row: Record<string, unknown>): boolean {
+  return Boolean(
+    row.host || row.username || row.password_encrypted || row.senderEmail || row.senderName
+  );
+}
+
 const EMPTY_CONFIG: SmtpConfigSchema = {
   id: '00000000-0000-0000-0000-000000000000',
   enabled: false,
@@ -156,6 +197,25 @@ export class SmtpConfigService {
     }
   }
 
+  private getEnvironmentSmtpConfig(): RawSmtpConfig | null {
+    const host = process.env.SMTP_HOST?.trim();
+    if (!host) {
+      return null;
+    }
+
+    return {
+      id: 'env-smtp',
+      enabled: true,
+      host,
+      port: parsePositiveInteger(process.env.SMTP_PORT, 587),
+      username: process.env.SMTP_USERNAME ?? '',
+      password: process.env.SMTP_PASSWORD ?? '',
+      senderEmail: process.env.SMTP_SENDER_EMAIL || process.env.ADMIN_EMAIL || 'admin@example.com',
+      senderName: process.env.SMTP_SENDER_NAME || 'InsForge',
+      minIntervalSeconds: parseNonNegativeInteger(process.env.SMTP_MIN_INTERVAL_SECONDS, 60),
+    };
+  }
+
   // -------------------------------------------------------------------------
   // Reads
   // -------------------------------------------------------------------------
@@ -166,11 +226,33 @@ export class SmtpConfigService {
         `SELECT ${SMTP_CONFIG_COLUMNS} FROM email.config LIMIT 1`
       );
       if (!result.rows.length) {
+        const envConfig = this.getEnvironmentSmtpConfig();
+        if (envConfig) {
+          return toSmtpConfigSchemaFromRaw(envConfig);
+        }
+
         const now = new Date().toISOString();
         return { ...EMPTY_CONFIG, createdAt: now, updatedAt: now };
       }
+
+      const row = result.rows[0];
+      if (!row.enabled && !hasStoredSmtpConfig(row)) {
+        const envConfig = this.getEnvironmentSmtpConfig();
+        if (envConfig) {
+          return toSmtpConfigSchemaFromRaw(envConfig);
+        }
+      }
+
       return toSmtpConfigSchema(result.rows[0]);
     } catch (error) {
+      const envConfig = this.getEnvironmentSmtpConfig();
+      if (envConfig) {
+        logger.warn('Failed to read SMTP config from database, using environment SMTP config', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return toSmtpConfigSchemaFromRaw(envConfig);
+      }
+
       logger.error('Failed to get SMTP config', { error });
       throw new AppError('Failed to get SMTP configuration', 500, ERROR_CODES.INTERNAL_ERROR);
     }
@@ -182,12 +264,12 @@ export class SmtpConfigService {
         `SELECT ${SMTP_CONFIG_COLUMNS} FROM email.config LIMIT 1`
       );
       if (!result.rows.length) {
-        return null;
+        return this.getEnvironmentSmtpConfig();
       }
 
       const row = result.rows[0];
       if (!row.enabled) {
-        return null;
+        return hasStoredSmtpConfig(row) ? null : this.getEnvironmentSmtpConfig();
       }
 
       const password = this.getDecryptedPassword(row.password_encrypted);
@@ -209,7 +291,7 @@ export class SmtpConfigService {
       };
     } catch (error) {
       logger.error('Failed to get raw SMTP config', { error });
-      return null;
+      return this.getEnvironmentSmtpConfig();
     }
   }
 

--- a/backend/src/services/email/smtp-config.service.ts
+++ b/backend/src/services/email/smtp-config.service.ts
@@ -456,21 +456,14 @@ export class SmtpConfigService {
     existingPasswordEncrypted: string
   ): Promise<void> {
     const password = input.password ?? this.getDecryptedPassword(existingPasswordEncrypted) ?? '';
-
-    if (!password) {
-      throw new AppError(
-        'SMTP password is required when enabling SMTP',
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
-    }
+    const auth = input.username || password ? { user: input.username, pass: password } : undefined;
 
     try {
       const transporter = nodemailer.createTransport({
         host: input.host,
         port: input.port,
         secure: input.port === 465,
-        auth: { user: input.username, pass: password },
+        auth,
         connectionTimeout: 10000,
       });
       await transporter.verify();

--- a/backend/tests/unit/smtp-config-env.test.ts
+++ b/backend/tests/unit/smtp-config-env.test.ts
@@ -115,4 +115,23 @@ describe('SmtpConfigService environment fallback', () => {
 
     await expect(SmtpConfigService.getInstance().getRawSmtpConfig()).resolves.toBeNull();
   });
+
+  it('still shows a user-disabled stored config in settings reads', async () => {
+    process.env.SMTP_HOST = 'mailpit';
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          ...emptyConfigRow,
+          host: 'smtp.example.com',
+          senderEmail: 'noreply@example.com',
+        },
+      ],
+    });
+
+    await expect(SmtpConfigService.getInstance().getSmtpConfig()).resolves.toMatchObject({
+      enabled: false,
+      host: 'smtp.example.com',
+      senderEmail: 'noreply@example.com',
+    });
+  });
 });

--- a/backend/tests/unit/smtp-config-env.test.ts
+++ b/backend/tests/unit/smtp-config-env.test.ts
@@ -1,16 +1,43 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockQuery } = vi.hoisted(() => ({
-  mockQuery: vi.fn(),
-}));
+const {
+  mockQuery,
+  mockConnect,
+  mockClientQuery,
+  mockClientRelease,
+  createTransportMock,
+  verifyMock,
+} = vi.hoisted(() => {
+  const verifyMock = vi.fn().mockResolvedValue(true);
+  const closeMock = vi.fn();
+  return {
+    mockQuery: vi.fn(),
+    mockConnect: vi.fn(),
+    mockClientQuery: vi.fn(),
+    mockClientRelease: vi.fn(),
+    verifyMock,
+    closeMock,
+    createTransportMock: vi.fn().mockReturnValue({
+      verify: verifyMock,
+      close: closeMock,
+    }),
+  };
+});
 
 vi.mock('../../src/infra/database/database.manager', () => ({
   DatabaseManager: {
     getInstance: () => ({
       getPool: () => ({
         query: mockQuery,
+        connect: mockConnect,
       }),
     }),
+  },
+}));
+
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: createTransportMock,
   },
 }));
 
@@ -43,6 +70,12 @@ describe('SmtpConfigService environment fallback', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (SmtpConfigService as unknown as { instance?: SmtpConfigService }).instance = undefined;
+    mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockClientRelease,
+    });
+    verifyMock.mockResolvedValue(true);
     process.env = { ...oldEnv };
     delete process.env.SMTP_HOST;
     delete process.env.SMTP_PORT;
@@ -99,6 +132,78 @@ describe('SmtpConfigService environment fallback', () => {
       senderName: 'InsForge',
       minIntervalSeconds: 60,
     });
+  });
+
+  it('falls back to environment SMTP config when the raw DB config read fails', async () => {
+    process.env.SMTP_HOST = 'mailpit';
+    process.env.SMTP_PORT = '1025';
+    process.env.SMTP_SENDER_EMAIL = 'noreply@insforge.local';
+    mockQuery.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(SmtpConfigService.getInstance().getRawSmtpConfig()).resolves.toEqual({
+      id: 'env-smtp',
+      enabled: true,
+      host: 'mailpit',
+      port: 1025,
+      username: '',
+      password: '',
+      senderEmail: 'noreply@insforge.local',
+      senderName: 'InsForge',
+      minIntervalSeconds: 60,
+    });
+  });
+
+  it('allows saving an enabled SMTP config without auth credentials', async () => {
+    mockClientQuery.mockImplementation((query: string) => {
+      if (query === 'BEGIN' || query === 'COMMIT') {
+        return Promise.resolve({ rows: [] });
+      }
+      if (query.includes('SELECT id, password_encrypted')) {
+        return Promise.resolve({ rows: [{ id: 'config-id', password_encrypted: '' }] });
+      }
+      if (query.includes('UPDATE email.config')) {
+        return Promise.resolve({
+          rows: [
+            {
+              ...emptyConfigRow,
+              enabled: true,
+              host: '8.8.8.8',
+              port: 587,
+              senderEmail: 'noreply@example.com',
+              senderName: 'InsForge',
+              minIntervalSeconds: 60,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(
+      SmtpConfigService.getInstance().upsertSmtpConfig({
+        enabled: true,
+        host: '8.8.8.8',
+        port: 587,
+        username: '',
+        password: '',
+        senderEmail: 'noreply@example.com',
+        senderName: 'InsForge',
+        minIntervalSeconds: 60,
+      })
+    ).resolves.toMatchObject({
+      enabled: true,
+      host: '8.8.8.8',
+      hasPassword: false,
+    });
+
+    expect(createTransportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: '8.8.8.8',
+        port: 587,
+        auth: undefined,
+      })
+    );
+    expect(verifyMock).toHaveBeenCalled();
   });
 
   it('does not override a user-disabled stored SMTP config', async () => {

--- a/backend/tests/unit/smtp-config-env.test.ts
+++ b/backend/tests/unit/smtp-config-env.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({
+        query: mockQuery,
+      }),
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { SmtpConfigService } from '../../src/services/email/smtp-config.service';
+
+const emptyConfigRow = {
+  id: 'config-id',
+  enabled: false,
+  host: '',
+  port: 465,
+  username: '',
+  password_encrypted: '',
+  senderEmail: '',
+  senderName: '',
+  minIntervalSeconds: 60,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+describe('SmtpConfigService environment fallback', () => {
+  const oldEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...oldEnv };
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_PORT;
+    delete process.env.SMTP_USERNAME;
+    delete process.env.SMTP_PASSWORD;
+    delete process.env.SMTP_SENDER_EMAIL;
+    delete process.env.SMTP_SENDER_NAME;
+    delete process.env.SMTP_MIN_INTERVAL_SECONDS;
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+  });
+
+  it('uses SMTP_* environment variables when the stored config is empty and disabled', async () => {
+    process.env.SMTP_HOST = 'mailpit';
+    process.env.SMTP_PORT = '1025';
+    process.env.SMTP_SENDER_EMAIL = 'noreply@insforge.local';
+    process.env.SMTP_SENDER_NAME = 'InsForge Local';
+    process.env.SMTP_MIN_INTERVAL_SECONDS = '0';
+    mockQuery.mockResolvedValueOnce({ rows: [emptyConfigRow] });
+
+    const config = await SmtpConfigService.getInstance().getRawSmtpConfig();
+
+    expect(config).toEqual({
+      id: 'env-smtp',
+      enabled: true,
+      host: 'mailpit',
+      port: 1025,
+      username: '',
+      password: '',
+      senderEmail: 'noreply@insforge.local',
+      senderName: 'InsForge Local',
+      minIntervalSeconds: 0,
+    });
+  });
+
+  it('exposes the active environment SMTP config to settings reads', async () => {
+    process.env.SMTP_HOST = 'mailpit';
+    process.env.SMTP_PORT = '1025';
+    process.env.SMTP_SENDER_EMAIL = 'noreply@insforge.local';
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const config = await SmtpConfigService.getInstance().getSmtpConfig();
+
+    expect(config).toMatchObject({
+      id: 'env-smtp',
+      enabled: true,
+      host: 'mailpit',
+      port: 1025,
+      username: '',
+      hasPassword: false,
+      senderEmail: 'noreply@insforge.local',
+      senderName: 'InsForge',
+      minIntervalSeconds: 60,
+    });
+  });
+
+  it('does not override a user-disabled stored SMTP config', async () => {
+    process.env.SMTP_HOST = 'mailpit';
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          ...emptyConfigRow,
+          host: 'smtp.example.com',
+          senderEmail: 'noreply@example.com',
+        },
+      ],
+    });
+
+    await expect(SmtpConfigService.getInstance().getRawSmtpConfig()).resolves.toBeNull();
+  });
+});

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -10,6 +10,8 @@ POSTGREST_PORT=5430
 APP_PORT=7130
 AUTH_PORT=7131
 DENO_PORT=7133
+MAILPIT_SMTP_PORT=1025
+MAILPIT_UI_PORT=7134
 
 API_BASE_URL=http://localhost:7130
 VITE_API_BASE_URL=http://localhost:7130
@@ -28,6 +30,15 @@ WORKER_TIMEOUT_MS=60000
 # OpenRouter Configuration
 # Get your API key from https://openrouter.ai/keys
 OPENROUTER_API_KEY=
+
+# Local email capture: leave SMTP_HOST empty to use Mailpit in docker compose
+SMTP_HOST=
+SMTP_PORT=1025
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_SENDER_EMAIL=noreply@insforge.local
+SMTP_SENDER_NAME=InsForge
+SMTP_MIN_INTERVAL_SECONDS=0
 
 # Stripe Payments Configuration (Optional)
 # Get your secret keys from https://dashboard.stripe.com/apikeys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,14 @@ services:
       - CLOUD_API_HOST=${CLOUD_API_HOST:-}
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Local email capture (defaults to Mailpit for docker compose dev)
+      - SMTP_HOST=${SMTP_HOST:-mailpit}
+      - SMTP_PORT=${SMTP_PORT:-1025}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_SENDER_EMAIL=${SMTP_SENDER_EMAIL:-noreply@insforge.local}
+      - SMTP_SENDER_NAME=${SMTP_SENDER_NAME:-InsForge}
+      - SMTP_MIN_INTERVAL_SECONDS=${SMTP_MIN_INTERVAL_SECONDS:-0}
       # Stripe Payments Configuration
       - STRIPE_TEST_SECRET_KEY=${STRIPE_TEST_SECRET_KEY:-}
       - STRIPE_LIVE_SECRET_KEY=${STRIPE_LIVE_SECRET_KEY:-}
@@ -163,6 +171,18 @@ services:
       - storage-data:/insforge-storage
     command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - insforge-network
+
+  # Local email capture for auth verification, password reset, and magic-link flows
+  mailpit:
+    image: axllent/mailpit:v1.30.0
+    restart: unless-stopped
+    ports:
+      - "${MAILPIT_SMTP_PORT:-1025}:1025"
+      - "${MAILPIT_UI_PORT:-7134}:8025"
     security_opt:
       - no-new-privileges:true
     networks:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "turbo run test",
     "test:backend": "cd backend && npm test",
     "test:e2e": "cd backend && npm run test:e2e",
+    "db:reset": "./scripts/db-reset.sh",
     "lint": "turbo run lint",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "turbo run test",
     "test:backend": "cd backend && npm test",
     "test:e2e": "cd backend && npm run test:e2e",
-    "db:reset": "./scripts/db-reset.sh",
+    "db:reset": "node ./scripts/db-reset.mjs",
     "lint": "turbo run lint",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/scripts/db-reset.mjs
+++ b/scripts/db-reset.mjs
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const backendDir = join(rootDir, 'backend');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function run(command, args, options = {}) {
+  const { allowFailure = false, capture = false, cwd = rootDir } = options;
+  const result = spawnSync(command, args, {
+    cwd,
+    env: process.env,
+    encoding: 'utf8',
+    stdio: capture ? 'pipe' : 'inherit',
+  });
+
+  if (result.error && !allowFailure) {
+    throw result.error;
+  }
+
+  if ((result.status ?? 1) !== 0 && !allowFailure) {
+    const printable = [command, ...args].join(' ');
+    throw new Error(`Command failed (${result.status}): ${printable}`);
+  }
+
+  return result;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getProjectName() {
+  if (process.env.COMPOSE_PROJECT_NAME) {
+    return process.env.COMPOSE_PROJECT_NAME;
+  }
+
+  return basename(rootDir)
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '');
+}
+
+async function waitForPostgres() {
+  const user = process.env.POSTGRES_USER || 'postgres';
+  const database = process.env.POSTGRES_DB || 'insforge';
+  const maxAttempts = 30;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = run(
+      'docker',
+      ['compose', 'exec', '-T', 'postgres', 'pg_isready', '-U', user, '-d', database],
+      { allowFailure: true, capture: true }
+    );
+
+    if (result.status === 0) {
+      console.log('Postgres is ready.');
+      return;
+    }
+
+    if (attempt === maxAttempts) {
+      const stderr = result.stderr?.trim();
+      throw new Error(
+        `Postgres did not become ready after ${maxAttempts} attempts${stderr ? `: ${stderr}` : '.'}`
+      );
+    }
+
+    console.log(`Waiting for Postgres to become ready (${attempt}/${maxAttempts})...`);
+    await sleep(2000);
+  }
+}
+
+const projectName = getProjectName();
+
+console.log('Stopping services that depend on Postgres...');
+run('docker', ['compose', 'stop', 'insforge', 'postgrest', 'deno', 'postgres'], {
+  allowFailure: true,
+  capture: true,
+});
+run('docker', ['compose', 'rm', '-f', '-s', 'postgres'], {
+  allowFailure: true,
+  capture: true,
+});
+
+const volumes = run(
+  'docker',
+  [
+    'volume',
+    'ls',
+    '-q',
+    '--filter',
+    `label=com.docker.compose.project=${projectName}`,
+    '--filter',
+    'label=com.docker.compose.volume=postgres-data',
+  ],
+  { capture: true }
+).stdout.trim();
+const postgresVolume = volumes.split('\n').find(Boolean);
+
+if (postgresVolume) {
+  console.log(`Removing Postgres volume: ${postgresVolume}`);
+  run('docker', ['volume', 'rm', postgresVolume]);
+} else {
+  console.log('No existing Postgres volume found.');
+}
+
+console.log('Starting Postgres and PostgREST...');
+run('docker', ['compose', 'up', '-d', 'postgres', 'postgrest']);
+
+await waitForPostgres();
+
+console.log('Running migrations and seed data...');
+run(npmCommand, ['run', 'migrate:up:local'], { cwd: backendDir });
+run(npmCommand, ['run', 'seed:run'], { cwd: backendDir });
+
+console.log('Database reset complete.');

--- a/scripts/db-reset.mjs
+++ b/scripts/db-reset.mjs
@@ -1,3 +1,4 @@
+/* global process, setTimeout, console */
 import { spawnSync } from 'node:child_process';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+project_name="${COMPOSE_PROJECT_NAME:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]//g')}"
+
+echo 'Stopping services that depend on Postgres...'
+docker compose stop insforge postgrest deno postgres >/dev/null 2>&1 || true
+docker compose rm -f -s postgres >/dev/null 2>&1 || true
+
+postgres_volume="$({
+  docker volume ls -q \
+    --filter "label=com.docker.compose.project=${project_name}" \
+    --filter 'label=com.docker.compose.volume=postgres-data' \
+    | head -n 1
+} || true)"
+
+if [[ -n "$postgres_volume" ]]; then
+  echo "Removing Postgres volume: ${postgres_volume}"
+  docker volume rm "$postgres_volume" >/dev/null
+else
+  echo 'No existing Postgres volume found.'
+fi
+
+echo 'Starting Postgres and PostgREST...'
+docker compose up -d postgres postgrest
+
+echo 'Running migrations and seed data...'
+cd backend
+npm run migrate:up
+npm run seed:run
+
+echo 'Database reset complete.'

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -2,33 +2,4 @@
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-
-project_name="${COMPOSE_PROJECT_NAME:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9_-]//g')}"
-
-echo 'Stopping services that depend on Postgres...'
-docker compose stop insforge postgrest deno postgres >/dev/null 2>&1 || true
-docker compose rm -f -s postgres >/dev/null 2>&1 || true
-
-postgres_volume="$({
-  docker volume ls -q \
-    --filter "label=com.docker.compose.project=${project_name}" \
-    --filter 'label=com.docker.compose.volume=postgres-data' \
-    | head -n 1
-} || true)"
-
-if [[ -n "$postgres_volume" ]]; then
-  echo "Removing Postgres volume: ${postgres_volume}"
-  docker volume rm "$postgres_volume" >/dev/null
-else
-  echo 'No existing Postgres volume found.'
-fi
-
-echo 'Starting Postgres and PostgREST...'
-docker compose up -d postgres postgrest
-
-echo 'Running migrations and seed data...'
-cd backend
-npm run migrate:up
-npm run seed:run
-
-echo 'Database reset complete.'
+exec node scripts/db-reset.mjs


### PR DESCRIPTION
## Summary

- Adds Mailpit to the dev Docker Compose stack with the web UI on `http://localhost:7134` and SMTP on `1025`.
- Defaults Docker Compose SMTP env vars to Mailpit when no stored SMTP config exists, while preserving user-disabled stored SMTP configs.
- Adds `npm run db:reset`, backed by `scripts/db-reset.sh`, to recreate only the Postgres volume, run migrations, and run backend seeding.
- Adds unit coverage for the SMTP env fallback and documents the new local email env vars.

Addresses the P0 local email capture and db reset pieces of #1129.

## How did you test this change?

- `npm run test --workspace insforge-backend -- tests/unit/smtp-config-env.test.ts`
- `npm run test --workspace insforge-backend -- tests/unit/email.test.ts`
- `npm run typecheck --workspace insforge-backend`
- `npx eslint backend/src/providers/email/smtp.provider.ts backend/src/services/email/smtp-config.service.ts backend/src/scripts/seed-backend.ts backend/tests/unit/smtp-config-env.test.ts`
- `docker compose config >/tmp/insforge-compose-config.yml`
- `bash -n scripts/db-reset.sh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mailpit to the dev Docker stack for local email capture and a fast DB reset command. SMTP now falls back to env-based Mailpit settings when no usable stored config exists and supports auth-free verify/send; addresses #1129.

- New Features
  - Mailpit in `docker-compose.yml` with UI at http://localhost:7134 and SMTP on 1025; `SMTP_*` defaults point to Mailpit; `.env.example` files updated.
  - SMTP config falls back to env when no DB record exists, the stored config is a disabled empty bootstrap row, or on DB read errors; preserves user-disabled configs; verification and delivery skip auth when no username/password are set; unit tests added for the settings vs delivery split.
  - `npm run db:reset` recreates only the Postgres volume, restarts services, waits for Postgres readiness, runs migrations, then seeds via backend `seed:run`.

- Migration
  - Leave `SMTP_HOST` empty in Docker Compose to use Mailpit; run `docker compose up` and open http://localhost:7134 to view captured emails.
  - Use `npm run db:reset` to rebuild the local DB state.

<sup>Written for commit 3c0b5fdda1a7163029906a1c3e3bd15341c08f8e. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Mailpit local email capture and environment-based SMTP fallback
> - Adds a [Mailpit](https://github.com/axllent/mailpit) service to [docker-compose.yml](https://github.com/InsForge/InsForge/pull/1287/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3), exposing SMTP on port 1025 and a web UI on port 8025, with the app container pre-configured to use it.
> - Updates `SmtpConfigService` to fall back to `SMTP_*` environment variables when no DB config exists, the stored config is a disabled bootstrap row, or the DB is unreachable.
> - Removes the unconditional SMTP auth requirement in `SmtpConfigService.verifySmtpConnection` and `SmtpEmailProvider.createTransporter` so no-auth servers (like Mailpit) work correctly.
> - Adds a `db:reset` developer utility ([scripts/db-reset.mjs](https://github.com/InsForge/InsForge/pull/1287/files#diff-26762cb60fdab1fcbc32cc2c9800912ac67aa933bb2ca7e182948ba9f10658a5)) that tears down and recreates the local Postgres container, runs migrations, and reseeds data.
> - Behavioral Change: when no SMTP config is stored in the DB, emails will now be sent using env-var config rather than silently skipped; a user-disabled stored config still suppresses delivery.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c0b5fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SMTP email delivery support with optional authentication and send-throttling
  * Local email capture for development (Mailpit) with web UI and SMTP endpoints

* **Chores**
  * Database seeding and reset utilities added (scripts and npm shortcuts)
  * Environment templates and compose defaults updated with email/SMTP settings
  * Docker Compose now includes a Mailpit service

* **Tests**
  * Unit tests added to verify SMTP config fallback and env-based behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->