### PR TITLE
add database advisor for self-hosted projects

### DIFF
--- a/backend/src/api/routes/advisor/index.routes.ts
+++ b/backend/src/api/routes/advisor/index.routes.ts
@@ -1,10 +1,69 @@
 import { Router, Response, NextFunction } from 'express';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { AppError } from '@/api/middlewares/error.js';
 import { AdvisorService } from '@/services/advisor/advisor.service.js';
+import type { AdvisorCategory, AdvisorIssuesQuery, AdvisorSeverity } from '@/lib/advisor/types.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
 import { successResponse } from '@/utils/response.js';
 
 const router = Router();
 const advisorService = AdvisorService.getInstance();
+const advisorCategories = new Set<AdvisorCategory>(['security', 'performance', 'health']);
+const advisorSeverities = new Set<AdvisorSeverity>(['critical', 'warning', 'info']);
+const DEFAULT_ISSUE_LIMIT = 50;
+const MAX_ISSUE_LIMIT = 100;
+
+function parseSingleQueryValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    return typeof value[0] === 'string' ? value[0] : undefined;
+  }
+  return typeof value === 'string' ? value : undefined;
+}
+
+function parseIssueListQuery(req: AuthRequest): AdvisorIssuesQuery {
+  const category = parseSingleQueryValue(req.query.category);
+  const severity = parseSingleQueryValue(req.query.severity);
+  const limitValue = parseSingleQueryValue(req.query.limit);
+  const offsetValue = parseSingleQueryValue(req.query.offset);
+  const limit = limitValue ? Number.parseInt(limitValue, 10) : DEFAULT_ISSUE_LIMIT;
+  const offset = offsetValue ? Number.parseInt(offsetValue, 10) : 0;
+
+  if (category && !advisorCategories.has(category as AdvisorCategory)) {
+    throw new AppError('Invalid advisor category', 400, ERROR_CODES.INVALID_INPUT);
+  }
+  if (severity && !advisorSeverities.has(severity as AdvisorSeverity)) {
+    throw new AppError('Invalid advisor severity', 400, ERROR_CODES.INVALID_INPUT);
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_ISSUE_LIMIT) {
+    throw new AppError('Invalid advisor issue limit', 400, ERROR_CODES.INVALID_INPUT);
+  }
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new AppError('Invalid advisor issue offset', 400, ERROR_CODES.INVALID_INPUT);
+  }
+
+  return {
+    category: category as AdvisorCategory | undefined,
+    severity: severity as AdvisorSeverity | undefined,
+    limit,
+    offset,
+  };
+}
+
+router.get('/latest', verifyAdmin, (_req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    successResponse(res, advisorService.getLatestScan());
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+router.get('/issues', verifyAdmin, (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    successResponse(res, advisorService.listIssues(parseIssueListQuery(req)));
+  } catch (error: unknown) {
+    next(error);
+  }
+});
 
 router.post('/scan', verifyAdmin, async (_req: AuthRequest, res: Response, next: NextFunction) => {
   try {

--- a/backend/src/api/routes/advisor/index.routes.ts
+++ b/backend/src/api/routes/advisor/index.routes.ts
@@ -1,0 +1,16 @@
+import { Router, Response, NextFunction } from 'express';
+import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { successResponse } from '@/utils/response.js';
+
+export const advisorRouter = Router();
+
+advisorRouter.post('/scan', verifyAdmin, (_req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    successResponse(res, {
+      status: 'not_implemented',
+      message: 'Advisor scan endpoint is registered. Scan logic is not implemented yet.',
+    });
+  } catch (error: unknown) {
+    next(error);
+  }
+});

--- a/backend/src/api/routes/advisor/index.routes.ts
+++ b/backend/src/api/routes/advisor/index.routes.ts
@@ -1,16 +1,18 @@
 import { Router, Response, NextFunction } from 'express';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { AdvisorService } from '@/services/advisor/advisor.service.js';
 import { successResponse } from '@/utils/response.js';
 
-export const advisorRouter = Router();
+const router = Router();
+const advisorService = AdvisorService.getInstance();
 
-advisorRouter.post('/scan', verifyAdmin, (_req: AuthRequest, res: Response, next: NextFunction) => {
+router.post('/scan', verifyAdmin, async (_req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    successResponse(res, {
-      status: 'not_implemented',
-      message: 'Advisor scan endpoint is registered. Scan logic is not implemented yet.',
-    });
+    const scanResult = await advisorService.runScan();
+    successResponse(res, scanResult);
   } catch (error: unknown) {
     next(error);
   }
 });
+
+export { router as advisorRouter };

--- a/backend/src/api/routes/docs/index.routes.ts
+++ b/backend/src/api/routes/docs/index.routes.ts
@@ -103,6 +103,7 @@ const LEGACY_DOCS_MAP: Record<DocTypeSchema, string> = {
   'ai-integration-sdk': 'sdks/typescript/ai.mdx',
   'real-time': 'agent-docs/real-time.md',
   deployment: 'agent-docs/deployment.md',
+  advisor: 'agent-docs/advisor.md',
 };
 
 // SDK documentation map for GET /api/docs/:docFeature/:docLanguage endpoint

--- a/backend/src/lib/advisor/rules/health/autovacuum-blocked.ts
+++ b/backend/src/lib/advisor/rules/health/autovacuum-blocked.ts
@@ -1,0 +1,50 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    coalesce(lock_relation.relation_name, format('pid %s', a.pid)) AS affected_object,
+    format(
+      'Autovacuum worker %s is waiting on %s.',
+      a.pid,
+      coalesce(a.wait_event, 'a lock')
+    ) AS detail,
+    'Find and resolve the blocking session so autovacuum can complete.' AS recommendation,
+    jsonb_build_object(
+      'pid', a.pid,
+      'query', a.query,
+      'wait_event_type', a.wait_event_type,
+      'wait_event', a.wait_event,
+      'relation', lock_relation.relation_name,
+      'state', a.state
+    ) AS metadata
+  FROM pg_catalog.pg_stat_activity a
+  LEFT JOIN LATERAL (
+    SELECT l.relation::regclass::text AS relation_name
+    FROM pg_catalog.pg_locks l
+    WHERE l.pid = a.pid
+      AND l.relation IS NOT NULL
+    ORDER BY l.granted ASC
+    LIMIT 1
+  ) lock_relation ON true
+  WHERE a.query ILIKE 'autovacuum:%'
+    AND (
+      a.wait_event_type = 'Lock'
+      OR EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_locks blocked_lock
+        WHERE blocked_lock.pid = a.pid
+          AND NOT blocked_lock.granted
+      )
+    )
+  ORDER BY a.query_start ASC NULLS LAST
+`;
+
+export const autovacuumBlockedRule: AdvisorRule = {
+  id: 'autovacuum-blocked',
+  category: 'health',
+  severity: 'critical',
+  title: 'Autovacuum Blocked',
+  description: 'Detects autovacuum workers blocked while trying to maintain a table.',
+  run: (executor) => runSqlRule(autovacuumBlockedRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/health/dead-tuples.ts
+++ b/backend/src/lib/advisor/rules/health/dead-tuples.ts
@@ -1,0 +1,36 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I', schemaname, relname) AS affected_object,
+    format(
+      'Table %I.%I has %s dead tuples, about %s%% of tracked tuples.',
+      schemaname,
+      relname,
+      n_dead_tup,
+      round((n_dead_tup::numeric / greatest(n_live_tup + n_dead_tup, 1)) * 100, 2)
+    ) AS detail,
+    'Run VACUUM or tune autovacuum settings if this table frequently accumulates dead tuples.' AS recommendation,
+    jsonb_build_object(
+      'schema', schemaname,
+      'table', relname,
+      'n_live_tup', n_live_tup,
+      'n_dead_tup', n_dead_tup,
+      'dead_tuple_ratio', n_dead_tup::numeric / greatest(n_live_tup + n_dead_tup, 1)
+    ) AS metadata
+  FROM pg_catalog.pg_stat_user_tables
+  WHERE schemaname = 'public'
+    AND n_dead_tup > 1000
+    AND n_dead_tup::numeric / greatest(n_live_tup + n_dead_tup, 1) > 0.20
+  ORDER BY n_dead_tup DESC
+`;
+
+export const deadTuplesRule: AdvisorRule = {
+  id: 'dead-tuples',
+  category: 'health',
+  severity: 'warning',
+  title: 'High Dead Tuples',
+  description: 'Detects tables with high dead tuple counts that may need vacuuming.',
+  run: (executor) => runSqlRule(deadTuplesRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/health/sequence-exhaustion.ts
+++ b/backend/src/lib/advisor/rules/health/sequence-exhaustion.ts
@@ -1,0 +1,50 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH sequence_usage AS (
+    SELECT
+      schemaname,
+      sequencename,
+      last_value,
+      min_value,
+      max_value,
+      CASE
+        WHEN last_value IS NULL OR max_value = min_value THEN NULL
+        ELSE (last_value - min_value)::numeric / nullif((max_value - min_value)::numeric, 0)
+      END AS used_ratio
+    FROM pg_catalog.pg_sequences
+    WHERE schemaname = 'public'
+      AND increment_by > 0
+      AND NOT cycle
+  )
+  SELECT
+    format('%I.%I', schemaname, sequencename) AS affected_object,
+    format(
+      'Sequence %I.%I is %s%% used.',
+      schemaname,
+      sequencename,
+      round(used_ratio * 100, 2)
+    ) AS detail,
+    'Increase the sequence type/range, reset ownership strategy, or migrate the column before the sequence is exhausted.' AS recommendation,
+    jsonb_build_object(
+      'schema', schemaname,
+      'sequence', sequencename,
+      'last_value', last_value,
+      'min_value', min_value,
+      'max_value', max_value,
+      'used_ratio', used_ratio
+    ) AS metadata
+  FROM sequence_usage
+  WHERE used_ratio > 0.90
+  ORDER BY used_ratio DESC
+`;
+
+export const sequenceExhaustionRule: AdvisorRule = {
+  id: 'sequence-exhaustion',
+  category: 'health',
+  severity: 'critical',
+  title: 'Sequence Exhaustion',
+  description: 'Detects sequences that have used more than 90 percent of their available range.',
+  run: (executor) => runSqlRule(sequenceExhaustionRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/health/stale-statistics.ts
+++ b/backend/src/lib/advisor/rules/health/stale-statistics.ts
@@ -1,0 +1,47 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH table_stats AS (
+    SELECT
+      schemaname,
+      relname,
+      n_live_tup,
+      CASE
+        WHEN last_analyze IS NULL THEN last_autoanalyze
+        WHEN last_autoanalyze IS NULL THEN last_analyze
+        ELSE greatest(last_analyze, last_autoanalyze)
+      END AS last_analyzed
+    FROM pg_catalog.pg_stat_user_tables
+    WHERE schemaname = 'public'
+  )
+  SELECT
+    format('%I.%I', schemaname, relname) AS affected_object,
+    CASE
+      WHEN last_analyzed IS NULL THEN format('Table %I.%I has rows but has never been analyzed.', schemaname, relname)
+      ELSE format('Table %I.%I statistics were last analyzed at %s.', schemaname, relname, last_analyzed)
+    END AS detail,
+    'Run ANALYZE or verify autovacuum analyze settings so the planner has fresh statistics.' AS recommendation,
+    jsonb_build_object(
+      'schema', schemaname,
+      'table', relname,
+      'n_live_tup', n_live_tup,
+      'last_analyzed', last_analyzed
+    ) AS metadata
+  FROM table_stats
+  WHERE n_live_tup > 0
+    AND (
+      last_analyzed IS NULL
+      OR last_analyzed < now() - interval '7 days'
+    )
+  ORDER BY last_analyzed NULLS FIRST, schemaname, relname
+`;
+
+export const staleStatisticsRule: AdvisorRule = {
+  id: 'stale-statistics',
+  category: 'health',
+  severity: 'info',
+  title: 'Stale Statistics',
+  description: 'Detects tables whose planner statistics are older than seven days.',
+  run: (executor) => runSqlRule(staleStatisticsRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/helpers.ts
+++ b/backend/src/lib/advisor/rules/helpers.ts
@@ -7,7 +7,8 @@ import type {
 } from '@/lib/advisor/types.js';
 
 export function mapRuleRows(rule: AdvisorRule, rows: AdvisorRuleResultRow[]): AdvisorFinding[] {
-  return rows.map((row) => ({
+  return rows.map((row, index) => ({
+    id: `${rule.id}:${row.affected_object}:${index}`,
     ruleId: rule.id,
     category: rule.category,
     severity: rule.severity,

--- a/backend/src/lib/advisor/rules/helpers.ts
+++ b/backend/src/lib/advisor/rules/helpers.ts
@@ -1,0 +1,46 @@
+import { hasPgErrorCode } from '@/utils/errors.js';
+import type {
+  AdvisorFinding,
+  AdvisorQueryExecutor,
+  AdvisorRule,
+  AdvisorRuleResultRow,
+} from '@/lib/advisor/types.js';
+
+export function mapRuleRows(rule: AdvisorRule, rows: AdvisorRuleResultRow[]): AdvisorFinding[] {
+  return rows.map((row) => ({
+    ruleId: rule.id,
+    category: rule.category,
+    severity: rule.severity,
+    title: rule.title,
+    description: rule.description,
+    detail: row.detail,
+    recommendation: row.recommendation,
+    affectedObject: row.affected_object,
+    metadata: row.metadata ?? {},
+  }));
+}
+
+export async function runSqlRule(
+  rule: AdvisorRule,
+  executor: AdvisorQueryExecutor,
+  sql: string
+): Promise<AdvisorFinding[]> {
+  const result = await executor.query<AdvisorRuleResultRow>(sql);
+  return mapRuleRows(rule, result.rows);
+}
+
+export async function runOptionalPgStatStatementsRule(
+  rule: AdvisorRule,
+  executor: AdvisorQueryExecutor,
+  sql: string
+): Promise<AdvisorFinding[]> {
+  try {
+    return await runSqlRule(rule, executor, sql);
+  } catch (error: unknown) {
+    if (hasPgErrorCode(error, '42P01') || hasPgErrorCode(error, '42703')) {
+      return [];
+    }
+
+    throw error;
+  }
+}

--- a/backend/src/lib/advisor/rules/index.ts
+++ b/backend/src/lib/advisor/rules/index.ts
@@ -1,0 +1,42 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { autovacuumBlockedRule } from './health/autovacuum-blocked.js';
+import { deadTuplesRule } from './health/dead-tuples.js';
+import { sequenceExhaustionRule } from './health/sequence-exhaustion.js';
+import { staleStatisticsRule } from './health/stale-statistics.js';
+import { connectionCriticalRule } from './performance/connection-critical.js';
+import { connectionHighRule } from './performance/connection-high.js';
+import { idleInTransactionRule } from './performance/idle-in-transaction.js';
+import { longRunningQueryRule } from './performance/long-running-query.js';
+import { lowCacheHitRatioRule } from './performance/low-cache-hit-ratio.js';
+import { missingFkIndexRule } from './performance/missing-fk-index.js';
+import { missingRlsIndexRule } from './performance/missing-rls-index.js';
+import { rlsPolicyPerfRule } from './performance/rls-policy-perf.js';
+import { slowQueryRule } from './performance/slow-query.js';
+import { unusedIndexRule } from './performance/unused-index.js';
+import { dangerousFunctionRule } from './security/dangerous-function.js';
+import { rlsDisabledRule } from './security/rls-disabled.js';
+import { rlsNoPolicyRule } from './security/rls-no-policy.js';
+import { rlsPermissiveRule } from './security/rls-permissive.js';
+import { rlsSelectOnlyRule } from './security/rls-select-only.js';
+
+export const advisorRules: AdvisorRule[] = [
+  rlsDisabledRule,
+  rlsPermissiveRule,
+  rlsNoPolicyRule,
+  dangerousFunctionRule,
+  rlsSelectOnlyRule,
+  missingFkIndexRule,
+  unusedIndexRule,
+  slowQueryRule,
+  connectionHighRule,
+  connectionCriticalRule,
+  idleInTransactionRule,
+  lowCacheHitRatioRule,
+  longRunningQueryRule,
+  rlsPolicyPerfRule,
+  missingRlsIndexRule,
+  deadTuplesRule,
+  staleStatisticsRule,
+  sequenceExhaustionRule,
+  autovacuumBlockedRule,
+];

--- a/backend/src/lib/advisor/rules/performance/connection-critical.ts
+++ b/backend/src/lib/advisor/rules/performance/connection-critical.ts
@@ -1,0 +1,36 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH usage AS (
+    SELECT
+      count(*)::numeric AS used_connections,
+      current_setting('max_connections')::numeric AS max_connections
+    FROM pg_catalog.pg_stat_activity
+  )
+  SELECT
+    current_database() AS affected_object,
+    format(
+      'Connection usage is critical at %s%% (%s of %s connections).',
+      round((used_connections / nullif(max_connections, 0)) * 100, 2),
+      used_connections,
+      max_connections
+    ) AS detail,
+    'Immediately reduce open connections or increase pool limits before new clients are rejected.' AS recommendation,
+    jsonb_build_object(
+      'used_connections', used_connections,
+      'max_connections', max_connections,
+      'usage_ratio', used_connections / nullif(max_connections, 0)
+    ) AS metadata
+  FROM usage
+  WHERE used_connections / nullif(max_connections, 0) >= 0.95
+`;
+
+export const connectionCriticalRule: AdvisorRule = {
+  id: 'connection-critical',
+  category: 'performance',
+  severity: 'critical',
+  title: 'Connection Usage Critical',
+  description: 'Detects database connection usage above 95 percent.',
+  run: (executor) => runSqlRule(connectionCriticalRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/connection-high.ts
+++ b/backend/src/lib/advisor/rules/performance/connection-high.ts
@@ -1,0 +1,37 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH usage AS (
+    SELECT
+      count(*)::numeric AS used_connections,
+      current_setting('max_connections')::numeric AS max_connections
+    FROM pg_catalog.pg_stat_activity
+  )
+  SELECT
+    current_database() AS affected_object,
+    format(
+      'Connection usage is at %s%% (%s of %s connections).',
+      round((used_connections / nullif(max_connections, 0)) * 100, 2),
+      used_connections,
+      max_connections
+    ) AS detail,
+    'Investigate connection pooling and close idle clients before the database reaches its connection limit.' AS recommendation,
+    jsonb_build_object(
+      'used_connections', used_connections,
+      'max_connections', max_connections,
+      'usage_ratio', used_connections / nullif(max_connections, 0)
+    ) AS metadata
+  FROM usage
+  WHERE used_connections / nullif(max_connections, 0) >= 0.80
+    AND used_connections / nullif(max_connections, 0) < 0.95
+`;
+
+export const connectionHighRule: AdvisorRule = {
+  id: 'connection-high',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Connection Usage High',
+  description: 'Detects database connection usage above 80 percent.',
+  run: (executor) => runSqlRule(connectionHighRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/idle-in-transaction.ts
+++ b/backend/src/lib/advisor/rules/performance/idle-in-transaction.ts
@@ -1,0 +1,35 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('pid %s', pid) AS affected_object,
+    format(
+      'Session %s has been idle in transaction for %s.',
+      pid,
+      now() - state_change
+    ) AS detail,
+    'Find the client holding the transaction open and commit, rollback, or terminate it.' AS recommendation,
+    jsonb_build_object(
+      'pid', pid,
+      'usename', usename,
+      'application_name', application_name,
+      'client_addr', client_addr,
+      'state_change', state_change,
+      'query', query
+    ) AS metadata
+  FROM pg_catalog.pg_stat_activity
+  WHERE state = 'idle in transaction'
+    AND now() - state_change > interval '5 minutes'
+    AND pid <> pg_backend_pid()
+  ORDER BY state_change ASC
+`;
+
+export const idleInTransactionRule: AdvisorRule = {
+  id: 'idle-in-transaction',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Idle In Transaction',
+  description: 'Detects sessions stuck idle inside an open transaction.',
+  run: (executor) => runSqlRule(idleInTransactionRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/long-running-query.ts
+++ b/backend/src/lib/advisor/rules/performance/long-running-query.ts
@@ -1,0 +1,38 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('pid %s', pid) AS affected_object,
+    format(
+      'Query in session %s has been running for %s.',
+      pid,
+      now() - query_start
+    ) AS detail,
+    'Inspect the query plan and consider cancelling the query if it is blocking production work.' AS recommendation,
+    jsonb_build_object(
+      'pid', pid,
+      'usename', usename,
+      'application_name', application_name,
+      'client_addr', client_addr,
+      'query_start', query_start,
+      'wait_event_type', wait_event_type,
+      'wait_event', wait_event,
+      'query', query
+    ) AS metadata
+  FROM pg_catalog.pg_stat_activity
+  WHERE state = 'active'
+    AND query_start IS NOT NULL
+    AND now() - query_start > interval '5 minutes'
+    AND pid <> pg_backend_pid()
+  ORDER BY query_start ASC
+`;
+
+export const longRunningQueryRule: AdvisorRule = {
+  id: 'long-running-query',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Long Running Query',
+  description: 'Detects active queries running longer than five minutes.',
+  run: (executor) => runSqlRule(longRunningQueryRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/low-cache-hit-ratio.ts
+++ b/backend/src/lib/advisor/rules/performance/low-cache-hit-ratio.ts
@@ -1,0 +1,32 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    datname AS affected_object,
+    format(
+      'Database %I has buffer cache hit ratio of %s%%.',
+      datname,
+      round((blks_hit::numeric / nullif(blks_hit + blks_read, 0)) * 100, 2)
+    ) AS detail,
+    'Investigate frequently read tables and indexes. Consider query/index changes or more memory if the workload is expected.' AS recommendation,
+    jsonb_build_object(
+      'database', datname,
+      'blks_hit', blks_hit,
+      'blks_read', blks_read,
+      'cache_hit_ratio', blks_hit::numeric / nullif(blks_hit + blks_read, 0)
+    ) AS metadata
+  FROM pg_catalog.pg_stat_database
+  WHERE datname = current_database()
+    AND blks_hit + blks_read > 0
+    AND blks_hit::numeric / nullif(blks_hit + blks_read, 0) < 0.90
+`;
+
+export const lowCacheHitRatioRule: AdvisorRule = {
+  id: 'low-cache-hit-ratio',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Low Cache Hit Ratio',
+  description: 'Detects databases with buffer cache hit ratio below 90 percent.',
+  run: (executor) => runSqlRule(lowCacheHitRatioRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/missing-fk-index.ts
+++ b/backend/src/lib/advisor/rules/performance/missing-fk-index.ts
@@ -1,0 +1,58 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH foreign_keys AS (
+    SELECT
+      n.nspname AS schema_name,
+      cl.relname AS table_name,
+      cl.oid AS table_oid,
+      ct.conname AS fkey_name,
+      ct.conkey AS col_attnums
+    FROM pg_catalog.pg_constraint ct
+    JOIN pg_catalog.pg_class cl
+      ON ct.conrelid = cl.oid
+    JOIN pg_catalog.pg_namespace n
+      ON n.oid = cl.relnamespace
+    LEFT JOIN pg_catalog.pg_depend dep
+      ON dep.objid = cl.oid
+      AND dep.deptype = 'e'
+    WHERE ct.contype = 'f'
+      AND n.nspname = 'public'
+      AND dep.objid IS NULL
+  ),
+  valid_indexes AS (
+    SELECT
+      pi.indrelid AS table_oid,
+      pi.indexrelid,
+      string_to_array(pi.indkey::text, ' ')::smallint[] AS col_attnums
+    FROM pg_catalog.pg_index pi
+    WHERE pi.indisvalid
+  )
+  SELECT
+    format('%I.%I', fk.schema_name, fk.table_name) AS affected_object,
+    format('Table %I.%I has foreign key %I without a covering index.', fk.schema_name, fk.table_name, fk.fkey_name) AS detail,
+    'Create an index whose leading columns match the foreign key columns.' AS recommendation,
+    jsonb_build_object(
+      'schema', fk.schema_name,
+      'table', fk.table_name,
+      'foreign_key', fk.fkey_name,
+      'column_attnums', fk.col_attnums
+    ) AS metadata
+  FROM foreign_keys fk
+  LEFT JOIN valid_indexes idx
+    ON idx.table_oid = fk.table_oid
+    AND fk.col_attnums = idx.col_attnums[1:array_length(fk.col_attnums, 1)]
+  WHERE idx.indexrelid IS NULL
+  ORDER BY fk.schema_name, fk.table_name, fk.fkey_name
+`;
+
+export const missingFkIndexRule: AdvisorRule = {
+  id: 'missing-fk-index',
+  category: 'performance',
+  severity: 'info',
+  title: 'Missing Foreign Key Index',
+  description:
+    'Foreign key columns should have a covering index for joins and deletes on referenced rows.',
+  run: (executor) => runSqlRule(missingFkIndexRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/missing-rls-index.ts
+++ b/backend/src/lib/advisor/rules/performance/missing-rls-index.ts
@@ -1,0 +1,76 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH policy_columns AS (
+    SELECT DISTINCT
+      n.nspname AS schema_name,
+      c.relname AS table_name,
+      c.oid AS table_oid,
+      a.attname AS column_name,
+      a.attnum AS column_attnum,
+      p.polname AS policy_name
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c
+      ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n
+      ON n.oid = c.relnamespace
+    JOIN pg_catalog.pg_policies pgp
+      ON pgp.schemaname = n.nspname
+      AND pgp.tablename = c.relname
+      AND pgp.policyname = p.polname
+    JOIN pg_catalog.pg_attribute a
+      ON a.attrelid = c.oid
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+    LEFT JOIN pg_catalog.pg_depend dep
+      ON dep.objid = c.oid
+      AND dep.deptype = 'e'
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+      AND dep.objid IS NULL
+      AND (
+        coalesce(pgp.qual, '') LIKE '%auth.uid()%'
+        OR coalesce(pgp.with_check, '') LIKE '%auth.uid()%'
+      )
+      AND (
+        lower(coalesce(pgp.qual, '')) LIKE '%' || lower(a.attname) || '%'
+        OR lower(coalesce(pgp.with_check, '')) LIKE '%' || lower(a.attname) || '%'
+      )
+  )
+  SELECT
+    format('%I.%I.%I', pc.schema_name, pc.table_name, pc.column_name) AS affected_object,
+    format(
+      'RLS policy %I on table %I.%I filters on column %I but no index covers that column.',
+      pc.policy_name,
+      pc.schema_name,
+      pc.table_name,
+      pc.column_name
+    ) AS detail,
+    'Create an index on the policy filter column to avoid full table scans during RLS checks.' AS recommendation,
+    jsonb_build_object(
+      'schema', pc.schema_name,
+      'table', pc.table_name,
+      'column', pc.column_name,
+      'policy', pc.policy_name
+    ) AS metadata
+  FROM policy_columns pc
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_index i
+    WHERE i.indrelid = pc.table_oid
+      AND i.indisvalid
+      AND pc.column_attnum = ANY(string_to_array(i.indkey::text, ' ')::smallint[])
+  )
+  ORDER BY pc.schema_name, pc.table_name, pc.column_name, pc.policy_name
+`;
+
+export const missingRlsIndexRule: AdvisorRule = {
+  id: 'missing-rls-index',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Missing RLS Index',
+  description: 'Detects RLS policy filter columns that do not have an index.',
+  run: (executor) => runSqlRule(missingRlsIndexRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/rls-policy-perf.ts
+++ b/backend/src/lib/advisor/rules/performance/rls-policy-perf.ts
@@ -1,0 +1,65 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH policies AS (
+    SELECT
+      n.nspname AS schema_name,
+      c.relname AS table_name,
+      p.polname AS policy_name,
+      pgp.qual,
+      pgp.with_check
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c
+      ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n
+      ON n.oid = c.relnamespace
+    JOIN pg_catalog.pg_policies pgp
+      ON pgp.schemaname = n.nspname
+      AND pgp.tablename = c.relname
+      AND pgp.policyname = p.polname
+    LEFT JOIN pg_catalog.pg_depend dep
+      ON dep.objid = c.oid
+      AND dep.deptype = 'e'
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+      AND dep.objid IS NULL
+  )
+  SELECT
+    format('%I.%I.%I', schema_name, table_name, policy_name) AS affected_object,
+    format(
+      'Policy %I on table %I.%I calls auth.uid() directly, which can be evaluated per row.',
+      policy_name,
+      schema_name,
+      table_name
+    ) AS detail,
+    'Wrap auth.uid() in a scalar subquery, for example (SELECT auth.uid()), so PostgreSQL can evaluate it once per statement.' AS recommendation,
+    jsonb_build_object(
+      'schema', schema_name,
+      'table', table_name,
+      'policy', policy_name,
+      'using', qual,
+      'with_check', with_check
+    ) AS metadata
+  FROM policies
+  WHERE (
+      coalesce(qual, '') LIKE '%auth.uid()%'
+      AND lower(coalesce(qual, '')) NOT LIKE '%select auth.uid()%'
+    )
+    OR (
+      coalesce(with_check, '') LIKE '%auth.uid()%'
+      AND lower(coalesce(with_check, '')) NOT LIKE '%select auth.uid()%'
+    )
+  ORDER BY schema_name, table_name, policy_name
+`;
+
+export const rlsPolicyPerfRule: AdvisorRule = {
+  id: 'rls-policy-perf',
+  category: 'performance',
+  severity: 'warning',
+  title: 'RLS Policy Auth Function Per Row',
+  description:
+    'Detects RLS policies that call auth.uid() directly instead of wrapping it in SELECT.',
+  run: (executor) => runSqlRule(rlsPolicyPerfRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/slow-query.ts
+++ b/backend/src/lib/advisor/rules/performance/slow-query.ts
@@ -1,0 +1,28 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runOptionalPgStatStatementsRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    left(regexp_replace(query, '\\s+', ' ', 'g'), 160) AS affected_object,
+    format('Query has mean execution time of %s ms across %s calls.', round(mean_exec_time::numeric, 2), calls) AS detail,
+    'Inspect the query plan and add indexes or rewrite the query if needed.' AS recommendation,
+    jsonb_build_object(
+      'query', query,
+      'calls', calls,
+      'mean_exec_time_ms', mean_exec_time,
+      'total_exec_time_ms', total_exec_time
+    ) AS metadata
+  FROM pg_stat_statements
+  WHERE mean_exec_time > 1000
+  ORDER BY mean_exec_time DESC
+  LIMIT 50
+`;
+
+export const slowQueryRule: AdvisorRule = {
+  id: 'slow-query',
+  category: 'performance',
+  severity: 'warning',
+  title: 'Slow Query',
+  description: 'Detects queries whose mean execution time is greater than one second.',
+  run: (executor) => runOptionalPgStatStatementsRule(slowQueryRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/performance/unused-index.ts
+++ b/backend/src/lib/advisor/rules/performance/unused-index.ts
@@ -1,0 +1,36 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I.%I', psui.schemaname, psui.relname, psui.indexrelname) AS affected_object,
+    format('Index %I on table %I.%I has never been used.', psui.indexrelname, psui.schemaname, psui.relname) AS detail,
+    'Review whether this index is still needed. Drop it if it is not used by expected workloads.' AS recommendation,
+    jsonb_build_object(
+      'schema', psui.schemaname,
+      'table', psui.relname,
+      'index', psui.indexrelname,
+      'idx_scan', psui.idx_scan
+    ) AS metadata
+  FROM pg_catalog.pg_stat_user_indexes psui
+  JOIN pg_catalog.pg_index pi
+    ON pi.indexrelid = psui.indexrelid
+  LEFT JOIN pg_catalog.pg_depend dep
+    ON dep.objid = psui.relid
+    AND dep.deptype = 'e'
+  WHERE psui.schemaname = 'public'
+    AND psui.idx_scan = 0
+    AND NOT pi.indisunique
+    AND NOT pi.indisprimary
+    AND dep.objid IS NULL
+  ORDER BY psui.schemaname, psui.relname, psui.indexrelname
+`;
+
+export const unusedIndexRule: AdvisorRule = {
+  id: 'unused-index',
+  category: 'performance',
+  severity: 'info',
+  title: 'Unused Index',
+  description: 'Detects non-primary, non-unique indexes that have never been scanned.',
+  run: (executor) => runSqlRule(unusedIndexRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/security/dangerous-function.ts
+++ b/backend/src/lib/advisor/rules/security/dangerous-function.ts
@@ -1,0 +1,43 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I(%s)', n.nspname, p.proname, pg_catalog.pg_get_function_identity_arguments(p.oid)) AS affected_object,
+    format(
+      'Function %I.%I(%s) does not set search_path, so it uses the caller/session search path.',
+      n.nspname,
+      p.proname,
+      pg_catalog.pg_get_function_identity_arguments(p.oid)
+    ) AS detail,
+    'Set a fixed search_path on the function, for example ALTER FUNCTION ... SET search_path = public, pg_temp.' AS recommendation,
+    jsonb_build_object(
+      'schema', n.nspname,
+      'function', p.proname,
+      'arguments', pg_catalog.pg_get_function_identity_arguments(p.oid),
+      'security_definer', p.prosecdef
+    ) AS metadata
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n
+    ON n.oid = p.pronamespace
+  LEFT JOIN pg_catalog.pg_depend dep
+    ON dep.objid = p.oid
+    AND dep.deptype = 'e'
+  WHERE n.nspname = 'public'
+    AND dep.objid IS NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(coalesce(p.proconfig, '{}')) AS config
+      WHERE config LIKE 'search_path=%'
+    )
+  ORDER BY n.nspname, p.proname, pg_catalog.pg_get_function_identity_arguments(p.oid)
+`;
+
+export const dangerousFunctionRule: AdvisorRule = {
+  id: 'dangerous-function',
+  category: 'security',
+  severity: 'warning',
+  title: 'Function Search Path Mutable',
+  description: 'Functions should set an explicit search_path to avoid search path hijacking risks.',
+  run: (executor) => runSqlRule(dangerousFunctionRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/security/rls-disabled.ts
+++ b/backend/src/lib/advisor/rules/security/rls-disabled.ts
@@ -1,0 +1,34 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I', n.nspname, c.relname) AS affected_object,
+    format('Table %I.%I is in the public schema but row level security is not enabled.', n.nspname, c.relname) AS detail,
+    'Enable row level security and add policies that match the intended access model.' AS recommendation,
+    jsonb_build_object(
+      'schema', n.nspname,
+      'table', c.relname,
+      'relrowsecurity', c.relrowsecurity
+    ) AS metadata
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n
+    ON n.oid = c.relnamespace
+  LEFT JOIN pg_catalog.pg_depend dep
+    ON dep.objid = c.oid
+    AND dep.deptype = 'e'
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND NOT c.relrowsecurity
+    AND dep.objid IS NULL
+  ORDER BY n.nspname, c.relname
+`;
+
+export const rlsDisabledRule: AdvisorRule = {
+  id: 'rls-disabled',
+  category: 'security',
+  severity: 'critical',
+  title: 'RLS Disabled',
+  description: 'Tables in the public schema should have row level security enabled.',
+  run: (executor) => runSqlRule(rlsDisabledRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/security/rls-no-policy.ts
+++ b/backend/src/lib/advisor/rules/security/rls-no-policy.ts
@@ -1,0 +1,36 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I', n.nspname, c.relname) AS affected_object,
+    format('Table %I.%I has RLS enabled but no policies are defined.', n.nspname, c.relname) AS detail,
+    'Create explicit SELECT, INSERT, UPDATE, and DELETE policies for the roles that should access this table.' AS recommendation,
+    jsonb_build_object(
+      'schema', n.nspname,
+      'table', c.relname
+    ) AS metadata
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n
+    ON n.oid = c.relnamespace
+  LEFT JOIN pg_catalog.pg_policy p
+    ON p.polrelid = c.oid
+  LEFT JOIN pg_catalog.pg_depend dep
+    ON dep.objid = c.oid
+    AND dep.deptype = 'e'
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relrowsecurity
+    AND p.oid IS NULL
+    AND dep.objid IS NULL
+  ORDER BY n.nspname, c.relname
+`;
+
+export const rlsNoPolicyRule: AdvisorRule = {
+  id: 'rls-no-policy',
+  category: 'security',
+  severity: 'warning',
+  title: 'RLS Enabled With No Policies',
+  description: 'Tables with RLS enabled but no policies are inaccessible to non-bypass roles.',
+  run: (executor) => runSqlRule(rlsNoPolicyRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/security/rls-permissive.ts
+++ b/backend/src/lib/advisor/rules/security/rls-permissive.ts
@@ -1,0 +1,76 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  WITH expanded_policies AS (
+    SELECT
+      n.nspname AS schema_name,
+      c.relname AS table_name,
+      p.polname AS policy_name,
+      CASE
+        WHEN role_oid = 0 THEN 'public'
+        ELSE role_oid::regrole::text
+      END AS role_name,
+      action_name
+    FROM pg_catalog.pg_policy p
+    JOIN pg_catalog.pg_class c
+      ON c.oid = p.polrelid
+    JOIN pg_catalog.pg_namespace n
+      ON n.oid = c.relnamespace
+    CROSS JOIN LATERAL unnest(
+      CASE
+        WHEN p.polroles = ARRAY[0::oid] THEN ARRAY[0::oid]
+        ELSE p.polroles
+      END
+    ) AS policy_roles(role_oid)
+    CROSS JOIN LATERAL unnest(
+      CASE p.polcmd
+        WHEN 'r' THEN ARRAY['SELECT']
+        WHEN 'a' THEN ARRAY['INSERT']
+        WHEN 'w' THEN ARRAY['UPDATE']
+        WHEN 'd' THEN ARRAY['DELETE']
+        WHEN '*' THEN ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+        ELSE ARRAY['UNKNOWN']
+      END
+    ) AS policy_actions(action_name)
+    LEFT JOIN pg_catalog.pg_depend dep
+      ON dep.objid = c.oid
+      AND dep.deptype = 'e'
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+      AND p.polpermissive
+      AND dep.objid IS NULL
+  )
+  SELECT
+    format('%I.%I', schema_name, table_name) AS affected_object,
+    format(
+      'Table %I.%I has multiple permissive RLS policies for role %s and action %s: %s.',
+      schema_name,
+      table_name,
+      role_name,
+      action_name,
+      array_to_string(array_agg(policy_name ORDER BY policy_name), ', ')
+    ) AS detail,
+    'Merge overlapping permissive policies or convert one of them to a restrictive policy so each role/action has one clear access path.' AS recommendation,
+    jsonb_build_object(
+      'schema', schema_name,
+      'table', table_name,
+      'role', role_name,
+      'action', action_name,
+      'policies', array_agg(policy_name ORDER BY policy_name)
+    ) AS metadata
+  FROM expanded_policies
+  GROUP BY schema_name, table_name, role_name, action_name
+  HAVING count(*) > 1
+  ORDER BY schema_name, table_name, role_name, action_name
+`;
+
+export const rlsPermissiveRule: AdvisorRule = {
+  id: 'rls-permissive',
+  category: 'security',
+  severity: 'warning',
+  title: 'Multiple Permissive RLS Policies',
+  description: 'Detects tables with multiple permissive policies for the same role and action.',
+  run: (executor) => runSqlRule(rlsPermissiveRule, executor, sql),
+};

--- a/backend/src/lib/advisor/rules/security/rls-select-only.ts
+++ b/backend/src/lib/advisor/rules/security/rls-select-only.ts
@@ -1,0 +1,42 @@
+import type { AdvisorRule } from '@/lib/advisor/types.js';
+import { runSqlRule } from '../helpers.js';
+
+const sql = `
+  SELECT
+    format('%I.%I', n.nspname, c.relname) AS affected_object,
+    format(
+      'Table %I.%I has RLS policies defined but RLS is not enabled. Policies: %s.',
+      n.nspname,
+      c.relname,
+      array_to_string(array_agg(p.polname ORDER BY p.polname), ', ')
+    ) AS detail,
+    'Enable RLS on the table so the defined policies are actually enforced.' AS recommendation,
+    jsonb_build_object(
+      'schema', n.nspname,
+      'table', c.relname,
+      'policies', array_agg(p.polname ORDER BY p.polname)
+    ) AS metadata
+  FROM pg_catalog.pg_policy p
+  JOIN pg_catalog.pg_class c
+    ON c.oid = p.polrelid
+  JOIN pg_catalog.pg_namespace n
+    ON n.oid = c.relnamespace
+  LEFT JOIN pg_catalog.pg_depend dep
+    ON dep.objid = c.oid
+    AND dep.deptype = 'e'
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND NOT c.relrowsecurity
+    AND dep.objid IS NULL
+  GROUP BY n.nspname, c.relname
+  ORDER BY n.nspname, c.relname
+`;
+
+export const rlsSelectOnlyRule: AdvisorRule = {
+  id: 'rls-select-only',
+  category: 'security',
+  severity: 'critical',
+  title: 'RLS Policies Not Enforced',
+  description: 'Detects tables with RLS policies defined while RLS is disabled on the table.',
+  run: (executor) => runSqlRule(rlsSelectOnlyRule, executor, sql),
+};

--- a/backend/src/lib/advisor/types.ts
+++ b/backend/src/lib/advisor/types.ts
@@ -12,6 +12,7 @@ export interface AdvisorQueryExecutor {
 }
 
 export interface AdvisorFinding {
+  id: string;
   ruleId: string;
   category: AdvisorCategory;
   severity: AdvisorSeverity;
@@ -59,4 +60,16 @@ export interface AdvisorScanResult {
   summary: AdvisorScanSummary;
   findings: AdvisorFinding[];
   errors: AdvisorScanRuleError[];
+}
+
+export interface AdvisorIssuesQuery {
+  category?: AdvisorCategory;
+  severity?: AdvisorSeverity;
+  limit: number;
+  offset: number;
+}
+
+export interface AdvisorIssuesResponse {
+  issues: AdvisorFinding[];
+  total: number;
 }

--- a/backend/src/lib/advisor/types.ts
+++ b/backend/src/lib/advisor/types.ts
@@ -1,0 +1,62 @@
+import type { QueryResultRow } from 'pg';
+
+export type AdvisorCategory = 'security' | 'performance' | 'health';
+
+export type AdvisorSeverity = 'critical' | 'warning' | 'info';
+
+export interface AdvisorQueryExecutor {
+  query<T extends QueryResultRow = QueryResultRow>(
+    text: string,
+    values?: readonly unknown[]
+  ): Promise<{ rows: T[] }>;
+}
+
+export interface AdvisorFinding {
+  ruleId: string;
+  category: AdvisorCategory;
+  severity: AdvisorSeverity;
+  title: string;
+  description: string;
+  detail: string;
+  recommendation: string;
+  affectedObject: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface AdvisorRule {
+  id: string;
+  category: AdvisorCategory;
+  severity: AdvisorSeverity;
+  title: string;
+  description: string;
+  run: (executor: AdvisorQueryExecutor) => Promise<AdvisorFinding[]>;
+}
+
+export interface AdvisorRuleResultRow extends QueryResultRow {
+  affected_object: string;
+  detail: string;
+  recommendation: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AdvisorScanSummary {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+}
+
+export interface AdvisorScanRuleError {
+  ruleId: string;
+  message: string;
+}
+
+export interface AdvisorScanResult {
+  scanId: string;
+  status: 'completed' | 'completed_with_errors';
+  scanType: 'manual';
+  scannedAt: string;
+  summary: AdvisorScanSummary;
+  findings: AdvisorFinding[];
+  errors: AdvisorScanRuleError[];
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -22,6 +22,7 @@ import { deploymentsRouter } from '@/api/routes/deployments/index.routes.js';
 import { webhooksRouter } from '@/api/routes/webhooks/index.routes.js';
 import { s3GatewayRouter } from '@/api/routes/s3-gateway/index.routes.js';
 import { paymentsRouter } from '@/api/routes/payments/index.routes.js';
+import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
@@ -217,6 +218,7 @@ export async function createApp() {
   apiRouter.use('/deployments', deploymentsRouter);
   apiRouter.use('/schedules', schedulesRouter);
   apiRouter.use('/payments', paymentsRouter);
+  apiRouter.use('/advisor', advisorRouter);
   apiRouter.use('/compute/services', servicesRouter);
   apiRouter.use('/integrations/posthog', posthogRouter);
 

--- a/backend/src/services/advisor/advisor.service.ts
+++ b/backend/src/services/advisor/advisor.service.ts
@@ -2,13 +2,20 @@ import { randomUUID } from 'crypto';
 import { AppError } from '@/api/middlewares/error.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { advisorRules } from '@/lib/advisor/rules/index.js';
-import type { AdvisorFinding, AdvisorScanResult, AdvisorScanSummary } from '@/lib/advisor/types.js';
+import type {
+  AdvisorFinding,
+  AdvisorIssuesQuery,
+  AdvisorIssuesResponse,
+  AdvisorScanResult,
+  AdvisorScanSummary,
+} from '@/lib/advisor/types.js';
 import { ERROR_CODES } from '@/types/error-constants.js';
 import logger from '@/utils/logger.js';
 
 export class AdvisorService {
   private static instance: AdvisorService;
   private isScanRunning = false;
+  private latestScanResult: AdvisorScanResult | null = null;
 
   static getInstance(): AdvisorService {
     if (!AdvisorService.instance) {
@@ -47,7 +54,7 @@ export class AdvisorService {
         }
       }
 
-      return {
+      const result: AdvisorScanResult = {
         scanId,
         status: errors.length > 0 ? 'completed_with_errors' : 'completed',
         scanType: 'manual',
@@ -56,9 +63,34 @@ export class AdvisorService {
         findings,
         errors,
       };
+
+      this.latestScanResult = result;
+      return result;
     } finally {
       this.isScanRunning = false;
     }
+  }
+
+  getLatestScan(): AdvisorScanResult | null {
+    return this.latestScanResult;
+  }
+
+  listIssues(query: AdvisorIssuesQuery): AdvisorIssuesResponse {
+    const findings = this.latestScanResult?.findings ?? [];
+    const filtered = findings.filter((finding) => {
+      if (query.category && finding.category !== query.category) {
+        return false;
+      }
+      if (query.severity && finding.severity !== query.severity) {
+        return false;
+      }
+      return true;
+    });
+
+    return {
+      issues: filtered.slice(query.offset, query.offset + query.limit),
+      total: filtered.length,
+    };
   }
 
   private buildSummary(findings: AdvisorFinding[]): AdvisorScanSummary {

--- a/backend/src/services/advisor/advisor.service.ts
+++ b/backend/src/services/advisor/advisor.service.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'crypto';
+import { AppError } from '@/api/middlewares/error.js';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { advisorRules } from '@/lib/advisor/rules/index.js';
+import type { AdvisorFinding, AdvisorScanResult, AdvisorScanSummary } from '@/lib/advisor/types.js';
+import { ERROR_CODES } from '@/types/error-constants.js';
+import logger from '@/utils/logger.js';
+
+export class AdvisorService {
+  private static instance: AdvisorService;
+  private isScanRunning = false;
+
+  static getInstance(): AdvisorService {
+    if (!AdvisorService.instance) {
+      AdvisorService.instance = new AdvisorService();
+    }
+
+    return AdvisorService.instance;
+  }
+
+  async runScan(): Promise<AdvisorScanResult> {
+    if (this.isScanRunning) {
+      throw new AppError('Advisor scan already running', 409, ERROR_CODES.TOO_MANY_REQUESTS);
+    }
+
+    this.isScanRunning = true;
+    const scanId = randomUUID();
+    const scannedAt = new Date().toISOString();
+    const pool = DatabaseManager.getInstance().getPool();
+    const findings: AdvisorFinding[] = [];
+    const errors: AdvisorScanResult['errors'] = [];
+
+    try {
+      for (const rule of advisorRules) {
+        try {
+          findings.push(...(await rule.run(pool)));
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : 'Unknown advisor rule error';
+          logger.warn('Advisor rule failed', {
+            ruleId: rule.id,
+            error: message,
+          });
+          errors.push({
+            ruleId: rule.id,
+            message,
+          });
+        }
+      }
+
+      return {
+        scanId,
+        status: errors.length > 0 ? 'completed_with_errors' : 'completed',
+        scanType: 'manual',
+        scannedAt,
+        summary: this.buildSummary(findings),
+        findings,
+        errors,
+      };
+    } finally {
+      this.isScanRunning = false;
+    }
+  }
+
+  private buildSummary(findings: AdvisorFinding[]): AdvisorScanSummary {
+    return findings.reduce<AdvisorScanSummary>(
+      (summary, finding) => {
+        summary.total += 1;
+        summary[finding.severity] += 1;
+        return summary;
+      },
+      {
+        total: 0,
+        critical: 0,
+        warning: 0,
+        info: 0,
+      }
+    );
+  }
+}

--- a/backend/tests/unit/advisor-routes.test.ts
+++ b/backend/tests/unit/advisor-routes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+import { advisorRouter } from '../../src/api/routes/advisor/index.routes.js';
+
+interface ExpressRouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{
+      handle: {
+        name?: string;
+      };
+    }>;
+  };
+}
+
+function getRoute(path: string, method: string) {
+  const stack = (advisorRouter as unknown as { stack: ExpressRouteLayer[] }).stack;
+  return stack
+    .map((layer) => layer.route)
+    .find((route) => route?.path === path && route.methods[method]);
+}
+
+describe('advisor route wiring', () => {
+  it('registers admin-only scan, latest, and issue routes', () => {
+    for (const [path, method] of [
+      ['/scan', 'post'],
+      ['/latest', 'get'],
+      ['/issues', 'get'],
+    ] as const) {
+      const route = getRoute(path, method);
+
+      expect(route).toBeDefined();
+      expect(route?.stack.some((layer) => layer.handle.name === 'verifyAdmin')).toBe(true);
+    }
+  });
+});

--- a/backend/tests/unit/advisor-rules.test.ts
+++ b/backend/tests/unit/advisor-rules.test.ts
@@ -1,5 +1,165 @@
 import { describe, expect, it } from 'vitest';
+import type { QueryResultRow } from 'pg';
+import type {
+  AdvisorQueryExecutor,
+  AdvisorRule,
+  AdvisorRuleResultRow,
+} from '../../src/lib/advisor/types.js';
 import { advisorRules } from '../../src/lib/advisor/rules/index.js';
+
+function makeExecutor(rows: AdvisorRuleResultRow[]) {
+  const calls: Array<{ sql: string; values?: readonly unknown[] }> = [];
+  const executor: AdvisorQueryExecutor = {
+    query: async <T extends QueryResultRow = QueryResultRow>(
+      sql: string,
+      values?: readonly unknown[]
+    ) => {
+      calls.push({ sql, values });
+      return { rows: rows as unknown as T[] };
+    },
+  };
+
+  return { executor, calls };
+}
+
+function makeThrowingExecutor(error: unknown): AdvisorQueryExecutor {
+  return {
+    query: async () => {
+      throw error;
+    },
+  };
+}
+
+function makePgError(code: string) {
+  return Object.assign(new Error(`Postgres error ${code}`), { code });
+}
+
+function getRule(ruleId: string): AdvisorRule {
+  const rule = advisorRules.find((candidate) => candidate.id === ruleId);
+
+  if (!rule) {
+    throw new Error(`Missing advisor rule ${ruleId}`);
+  }
+
+  return rule;
+}
+
+const seededRowsByRuleId: Record<string, AdvisorRuleResultRow> = {
+  'rls-disabled': {
+    affected_object: 'public.customers',
+    detail: 'Table public.customers is in the public schema but RLS is not enabled.',
+    recommendation: 'Enable RLS and add access policies.',
+    metadata: { schema: 'public', table: 'customers' },
+  },
+  'rls-permissive': {
+    affected_object: 'public.orders/authenticated/SELECT',
+    detail: 'Table public.orders has multiple permissive SELECT policies.',
+    recommendation: 'Merge duplicate permissive policies.',
+    metadata: { schema: 'public', table: 'orders', role: 'authenticated' },
+  },
+  'rls-no-policy': {
+    affected_object: 'public.invoices',
+    detail: 'Table public.invoices has RLS enabled but no policies exist.',
+    recommendation: 'Add at least one RLS policy.',
+    metadata: { schema: 'public', table: 'invoices' },
+  },
+  'dangerous-function': {
+    affected_object: 'public.recalculate_total',
+    detail: 'Function public.recalculate_total has a mutable search_path.',
+    recommendation: 'Set an explicit search_path on the function.',
+    metadata: { schema: 'public', function: 'recalculate_total' },
+  },
+  'rls-select-only': {
+    affected_object: 'public.profiles',
+    detail: 'Table public.profiles has RLS policies defined but RLS is not enabled.',
+    recommendation: 'Enable RLS so the defined policies are enforced.',
+    metadata: { schema: 'public', table: 'profiles' },
+  },
+  'missing-fk-index': {
+    affected_object: 'public.orders.customer_id',
+    detail: 'Foreign key orders_customer_id_fkey does not have a covering index.',
+    recommendation: 'Create an index on customer_id.',
+    metadata: { schema: 'public', table: 'orders', constraint: 'orders_customer_id_fkey' },
+  },
+  'unused-index': {
+    affected_object: 'public.orders.idx_orders_unused',
+    detail: 'Index idx_orders_unused has never been scanned.',
+    recommendation: 'Drop the index if it is not needed.',
+    metadata: { schema: 'public', table: 'orders', index: 'idx_orders_unused' },
+  },
+  'slow-query': {
+    affected_object: 'select * from public.orders',
+    detail: 'Query has mean execution time over one second.',
+    recommendation: 'Inspect the query plan.',
+    metadata: { calls: 12, mean_exec_time_ms: 1200 },
+  },
+  'connection-high': {
+    affected_object: 'postgres connections',
+    detail: 'Connection usage is above 80 percent.',
+    recommendation: 'Reduce open connections or raise max_connections.',
+    metadata: { used_connections: 82, max_connections: 100 },
+  },
+  'connection-critical': {
+    affected_object: 'postgres connections',
+    detail: 'Connection usage is above 95 percent.',
+    recommendation: 'Immediately reduce open connections.',
+    metadata: { used_connections: 97, max_connections: 100 },
+  },
+  'idle-in-transaction': {
+    affected_object: 'pid 1234',
+    detail: 'Session 1234 is idle in transaction.',
+    recommendation: 'Close or terminate the idle transaction.',
+    metadata: { pid: 1234, state: 'idle in transaction' },
+  },
+  'low-cache-hit-ratio': {
+    affected_object: 'database cache',
+    detail: 'Cache hit ratio is below 90 percent.',
+    recommendation: 'Review memory and query patterns.',
+    metadata: { cache_hit_ratio: 0.85 },
+  },
+  'long-running-query': {
+    affected_object: 'pid 4321',
+    detail: 'Query has been running longer than five minutes.',
+    recommendation: 'Review or terminate the query.',
+    metadata: { pid: 4321, duration_seconds: 360 },
+  },
+  'rls-policy-perf': {
+    affected_object: 'public.orders.orders_select_own',
+    detail: 'Policy calls auth.uid() per row without a SELECT wrapper.',
+    recommendation: 'Wrap auth.uid() as (select auth.uid()).',
+    metadata: { schema: 'public', table: 'orders', policy: 'orders_select_own' },
+  },
+  'missing-rls-index': {
+    affected_object: 'public.orders.user_id',
+    detail: 'RLS policy filters on user_id without an index.',
+    recommendation: 'Create an index on user_id.',
+    metadata: { schema: 'public', table: 'orders', column: 'user_id' },
+  },
+  'dead-tuples': {
+    affected_object: 'public.events',
+    detail: 'Table public.events has too many dead tuples.',
+    recommendation: 'Run VACUUM or tune autovacuum.',
+    metadata: { schema: 'public', table: 'events', dead_tuple_ratio: 0.3 },
+  },
+  'stale-statistics': {
+    affected_object: 'public.events',
+    detail: 'Table public.events has stale statistics.',
+    recommendation: 'Run ANALYZE or check autovacuum analyze settings.',
+    metadata: { schema: 'public', table: 'events', last_analyze: null },
+  },
+  'sequence-exhaustion': {
+    affected_object: 'public.events_id_seq',
+    detail: 'Sequence public.events_id_seq is more than 90 percent used.',
+    recommendation: 'Increase the sequence range.',
+    metadata: { schema: 'public', sequence: 'events_id_seq', used_ratio: 0.92 },
+  },
+  'autovacuum-blocked': {
+    affected_object: 'public.events',
+    detail: 'Autovacuum is blocked on table public.events.',
+    recommendation: 'Resolve blocking sessions so autovacuum can finish.',
+    metadata: { schema: 'public', table: 'events', blocker_pid: 100 },
+  },
+};
 
 describe('advisor rule registry', () => {
   it('registers the expected 19 advisor rules in issue order', () => {
@@ -48,5 +208,53 @@ describe('advisor rule registry', () => {
       ['sequence-exhaustion', 'health'],
       ['autovacuum-blocked', 'health'],
     ]);
+  });
+});
+
+describe('advisor rules', () => {
+  it.each(advisorRules)('$id maps seeded database rows into advisor findings', async (rule) => {
+    const row = seededRowsByRuleId[rule.id];
+    const { executor, calls } = makeExecutor([row]);
+
+    const findings = await rule.run(executor);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.sql).toMatch(/\bselect\b/i);
+    expect(findings).toEqual([
+      {
+        id: `${rule.id}:${row.affected_object}:0`,
+        ruleId: rule.id,
+        category: rule.category,
+        severity: rule.severity,
+        title: rule.title,
+        description: rule.description,
+        detail: row.detail,
+        recommendation: row.recommendation,
+        affectedObject: row.affected_object,
+        metadata: row.metadata,
+      },
+    ]);
+  });
+
+  it.each(advisorRules)('$id returns no findings when the query returns no rows', async (rule) => {
+    const { executor, calls } = makeExecutor([]);
+
+    await expect(rule.run(executor)).resolves.toEqual([]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('treats missing pg_stat_statements as no slow-query findings', async () => {
+    const rule = getRule('slow-query');
+
+    await expect(rule.run(makeThrowingExecutor(makePgError('42P01')))).resolves.toEqual([]);
+    await expect(rule.run(makeThrowingExecutor(makePgError('42703')))).resolves.toEqual([]);
+  });
+
+  it('rethrows unexpected slow-query errors', async () => {
+    const rule = getRule('slow-query');
+
+    await expect(rule.run(makeThrowingExecutor(makePgError('XX000')))).rejects.toThrow(
+      'Postgres error XX000'
+    );
   });
 });

--- a/backend/tests/unit/advisor-rules.test.ts
+++ b/backend/tests/unit/advisor-rules.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { advisorRules } from '../../src/lib/advisor/rules/index.js';
+
+describe('advisor rule registry', () => {
+  it('registers the expected 19 advisor rules in issue order', () => {
+    expect(advisorRules.map((rule) => rule.id)).toEqual([
+      'rls-disabled',
+      'rls-permissive',
+      'rls-no-policy',
+      'dangerous-function',
+      'rls-select-only',
+      'missing-fk-index',
+      'unused-index',
+      'slow-query',
+      'connection-high',
+      'connection-critical',
+      'idle-in-transaction',
+      'low-cache-hit-ratio',
+      'long-running-query',
+      'rls-policy-perf',
+      'missing-rls-index',
+      'dead-tuples',
+      'stale-statistics',
+      'sequence-exhaustion',
+      'autovacuum-blocked',
+    ]);
+  });
+
+  it('assigns each rule to the expected advisor category', () => {
+    expect(advisorRules.map((rule) => [rule.id, rule.category])).toEqual([
+      ['rls-disabled', 'security'],
+      ['rls-permissive', 'security'],
+      ['rls-no-policy', 'security'],
+      ['dangerous-function', 'security'],
+      ['rls-select-only', 'security'],
+      ['missing-fk-index', 'performance'],
+      ['unused-index', 'performance'],
+      ['slow-query', 'performance'],
+      ['connection-high', 'performance'],
+      ['connection-critical', 'performance'],
+      ['idle-in-transaction', 'performance'],
+      ['low-cache-hit-ratio', 'performance'],
+      ['long-running-query', 'performance'],
+      ['rls-policy-perf', 'performance'],
+      ['missing-rls-index', 'performance'],
+      ['dead-tuples', 'health'],
+      ['stale-statistics', 'health'],
+      ['sequence-exhaustion', 'health'],
+      ['autovacuum-blocked', 'health'],
+    ]);
+  });
+});

--- a/backend/tests/unit/advisor.service.test.ts
+++ b/backend/tests/unit/advisor.service.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AdvisorCategory,
+  AdvisorFinding,
+  AdvisorQueryExecutor,
+  AdvisorRule,
+  AdvisorScanResult,
+  AdvisorSeverity,
+} from '../../src/lib/advisor/types.js';
+
+const { mockAdvisorRules, mockLogger, mockPool } = vi.hoisted(() => ({
+  mockAdvisorRules: [] as AdvisorRule[],
+  mockLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  mockPool: {
+    query: vi.fn(),
+  } as unknown as AdvisorQueryExecutor,
+}));
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => mockPool),
+    })),
+  },
+}));
+
+vi.mock('@/lib/advisor/rules/index.js', () => ({
+  advisorRules: mockAdvisorRules,
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: mockLogger,
+}));
+
+import { AdvisorService } from '../../src/services/advisor/advisor.service.js';
+
+function makeFinding(
+  ruleId: string,
+  severity: AdvisorSeverity,
+  category: AdvisorCategory = 'security'
+): AdvisorFinding {
+  return {
+    id: `${ruleId}:public.orders:0`,
+    ruleId,
+    category,
+    severity,
+    title: `${ruleId} title`,
+    description: `${ruleId} description`,
+    detail: `${ruleId} detail`,
+    recommendation: `${ruleId} recommendation`,
+    affectedObject: 'public.orders',
+    metadata: { ruleId },
+  };
+}
+
+function makeRule(
+  id: string,
+  severity: AdvisorSeverity,
+  findings: AdvisorFinding[],
+  category: AdvisorCategory = 'security'
+): AdvisorRule {
+  return {
+    id,
+    category,
+    severity,
+    title: `${id} title`,
+    description: `${id} description`,
+    run: vi.fn(async () => findings),
+  };
+}
+
+function makeFailingRule(id: string, error: Error): AdvisorRule {
+  return {
+    id,
+    category: 'performance',
+    severity: 'warning',
+    title: `${id} title`,
+    description: `${id} description`,
+    run: vi.fn(async () => {
+      throw error;
+    }),
+  };
+}
+
+describe('AdvisorService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdvisorRules.length = 0;
+    const serviceState = AdvisorService.getInstance() as unknown as {
+      isScanRunning: boolean;
+      latestScanResult: AdvisorScanResult | null;
+    };
+    serviceState.isScanRunning = false;
+    serviceState.latestScanResult = null;
+  });
+
+  it('runs all advisor rules and summarizes returned findings', async () => {
+    const criticalFinding = makeFinding('critical-rule', 'critical');
+    const warningFinding = makeFinding('warning-rule', 'warning', 'performance');
+    const infoFinding = makeFinding('info-rule', 'info', 'health');
+    const criticalRule = makeRule('critical-rule', 'critical', [criticalFinding]);
+    const warningRule = makeRule('warning-rule', 'warning', [warningFinding], 'performance');
+    const infoRule = makeRule('info-rule', 'info', [infoFinding], 'health');
+    mockAdvisorRules.push(criticalRule, warningRule, infoRule);
+
+    const result = await AdvisorService.getInstance().runScan();
+
+    expect(criticalRule.run).toHaveBeenCalledWith(mockPool);
+    expect(warningRule.run).toHaveBeenCalledWith(mockPool);
+    expect(infoRule.run).toHaveBeenCalledWith(mockPool);
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        scanType: 'manual',
+        summary: {
+          total: 3,
+          critical: 1,
+          warning: 1,
+          info: 1,
+        },
+        findings: [criticalFinding, warningFinding, infoFinding],
+        errors: [],
+      })
+    );
+    expect(result.scanId).toEqual(expect.any(String));
+    expect(result.scannedAt).toEqual(expect.any(String));
+    expect(AdvisorService.getInstance().getLatestScan()).toBe(result);
+  });
+
+  it('continues scanning when one rule fails and reports the rule error', async () => {
+    const finding = makeFinding('ok-rule', 'info', 'health');
+    const okRule = makeRule('ok-rule', 'info', [finding], 'health');
+    const failingRule = makeFailingRule('bad-rule', new Error('query failed'));
+    mockAdvisorRules.push(okRule, failingRule);
+
+    const result = await AdvisorService.getInstance().runScan();
+
+    expect(result.status).toBe('completed_with_errors');
+    expect(result.findings).toEqual([finding]);
+    expect(result.summary).toEqual({
+      total: 1,
+      critical: 0,
+      warning: 0,
+      info: 1,
+    });
+    expect(result.errors).toEqual([{ ruleId: 'bad-rule', message: 'query failed' }]);
+    expect(mockLogger.warn).toHaveBeenCalledWith('Advisor rule failed', {
+      ruleId: 'bad-rule',
+      error: 'query failed',
+    });
+  });
+
+  it('rejects a second scan while another scan is running', async () => {
+    let resolveScan!: (findings: AdvisorFinding[]) => void;
+    const pendingScan = new Promise<AdvisorFinding[]>((resolve) => {
+      resolveScan = resolve;
+    });
+    const slowRule: AdvisorRule = {
+      id: 'slow-rule',
+      category: 'performance',
+      severity: 'warning',
+      title: 'slow-rule title',
+      description: 'slow-rule description',
+      run: vi.fn(() => pendingScan),
+    };
+    mockAdvisorRules.push(slowRule);
+
+    const firstScan = AdvisorService.getInstance().runScan();
+
+    await expect(AdvisorService.getInstance().runScan()).rejects.toMatchObject({
+      message: 'Advisor scan already running',
+      statusCode: 409,
+    });
+
+    resolveScan([]);
+    await expect(firstScan).resolves.toEqual(
+      expect.objectContaining({
+        status: 'completed',
+        findings: [],
+        errors: [],
+      })
+    );
+  });
+
+  it('filters latest advisor issues by category and severity with pagination', async () => {
+    const criticalFinding = makeFinding('critical-rule', 'critical', 'security');
+    const warningFinding = makeFinding('warning-rule', 'warning', 'performance');
+    const secondWarningFinding = {
+      ...makeFinding('second-warning-rule', 'warning', 'performance'),
+      id: 'second-warning-rule:public.orders:0',
+    };
+    mockAdvisorRules.push(
+      makeRule('critical-rule', 'critical', [criticalFinding], 'security'),
+      makeRule('warning-rule', 'warning', [warningFinding], 'performance'),
+      makeRule('second-warning-rule', 'warning', [secondWarningFinding], 'performance')
+    );
+
+    await AdvisorService.getInstance().runScan();
+
+    expect(
+      AdvisorService.getInstance().listIssues({
+        category: 'performance',
+        severity: 'warning',
+        limit: 1,
+        offset: 1,
+      })
+    ).toEqual({
+      issues: [secondWarningFinding],
+      total: 2,
+    });
+  });
+
+  it('returns an empty issue list before the first scan', () => {
+    expect(
+      AdvisorService.getInstance().listIssues({
+        limit: 50,
+        offset: 0,
+      })
+    ).toEqual({
+      issues: [],
+      total: 0,
+    });
+  });
+});

--- a/docs/agent-docs/advisor.md
+++ b/docs/agent-docs/advisor.md
@@ -1,0 +1,48 @@
+# Database Advisor - Agent Documentation
+
+Run the database advisor after schema migrations or policy changes to catch common security, performance, and health regressions.
+
+## MCP Tool
+
+Use the `advisor.scan` MCP tool when it is available. It should run the same backend scan as:
+
+```http
+POST /api/advisor/scan
+```
+
+The tool returns a scan result with `summary`, `findings`, and `errors`.
+
+## REST Fallback
+
+If the MCP tool is not available in the current client, call the admin API directly:
+
+```bash
+curl -X POST "$INSFORGE_URL/api/advisor/scan" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+Fetch the last result without starting a new scan:
+
+```http
+GET /api/advisor/latest
+```
+
+Fetch filtered findings from the latest scan:
+
+```http
+GET /api/advisor/issues?category=security&severity=critical
+```
+
+## Agent Workflow
+
+1. Apply the database migration or SQL change.
+2. Run `advisor.scan`.
+3. Review `findings`.
+4. Fix critical security findings before continuing.
+5. Re-run the scan after fixes.
+
+## Rule Categories
+
+- Security: RLS, dangerous functions, and policy coverage.
+- Performance: foreign key indexes, slow queries, connection pressure, cache ratio, long-running queries, and RLS policy performance.
+- Health: dead tuples, stale statistics, sequence exhaustion, and blocked autovacuum.

--- a/docs/core-concepts/database/advisors.mdx
+++ b/docs/core-concepts/database/advisors.mdx
@@ -1,0 +1,108 @@
+---
+title: Database Advisors
+description: Scan Postgres for security, performance, and health findings
+---
+
+## Overview
+
+Database Advisors run read-only checks against the project Postgres database and return actionable findings for security, performance, and health. Self-hosted projects can run the scan on demand from the dashboard or by calling the admin API.
+
+## Run A Scan
+
+The dashboard exposes Advisors under **Database**. Click **Run scan now** to execute the rules and render the latest result.
+
+Admins can also call the API directly:
+
+```bash
+curl -X POST "$INSFORGE_URL/api/advisor/scan" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+The endpoint allows one scan at a time in the current backend process. If another scan is already running, the API returns `409`.
+
+## API Surface
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/advisor/scan` | Runs all advisor rules and returns the scan result. |
+| `GET /api/advisor/latest` | Returns the latest in-memory scan result, or `null` before the first scan. |
+| `GET /api/advisor/issues` | Returns findings from the latest scan, filtered by `category`, `severity`, `limit`, and `offset`. |
+
+All advisor endpoints require admin authentication.
+
+## Result Shape
+
+```json
+{
+  "scanId": "7f8f0d9a-7d46-4b50-9896-3c28f64de612",
+  "status": "completed",
+  "scanType": "manual",
+  "scannedAt": "2026-05-17T08:00:00.000Z",
+  "summary": {
+    "total": 2,
+    "critical": 1,
+    "warning": 1,
+    "info": 0
+  },
+  "findings": [
+    {
+      "id": "rls-disabled:public.customers:0",
+      "ruleId": "rls-disabled",
+      "category": "security",
+      "severity": "critical",
+      "title": "RLS Disabled",
+      "description": "Tables in the public schema should have row level security enabled.",
+      "detail": "Table public.customers is in the public schema but row level security is not enabled.",
+      "recommendation": "Enable row level security and add policies that match the intended access model.",
+      "affectedObject": "public.customers",
+      "metadata": {
+        "schema": "public",
+        "table": "customers"
+      }
+    }
+  ],
+  "errors": []
+}
+```
+
+If one rule fails, the scan continues and returns `completed_with_errors` with the failed rule IDs in `errors`.
+
+## Rules
+
+### Security
+
+| Rule | What it checks |
+| --- | --- |
+| `rls-disabled` | Tables in the `public` schema where row level security is not enabled. |
+| `rls-permissive` | Multiple permissive RLS policies for the same table, role, and command. |
+| `rls-no-policy` | Tables with RLS enabled but no policies. |
+| `dangerous-function` | Functions in `public` that do not pin `search_path`. |
+| `rls-select-only` | Tables with RLS policies defined while RLS is not enabled. |
+
+### Performance
+
+| Rule | What it checks |
+| --- | --- |
+| `missing-fk-index` | Foreign keys without a covering index on the referencing columns. |
+| `unused-index` | Non-primary, non-unique indexes that have never been scanned. |
+| `slow-query` | `pg_stat_statements` queries with mean execution time greater than one second. |
+| `connection-high` | Postgres connection usage above 80 percent. |
+| `connection-critical` | Postgres connection usage above 95 percent. |
+| `idle-in-transaction` | Sessions stuck in `idle in transaction`. |
+| `low-cache-hit-ratio` | Buffer cache hit ratio below 90 percent. |
+| `long-running-query` | Active queries running longer than five minutes. |
+| `rls-policy-perf` | RLS policies that call `auth.uid()` per row instead of using a `select` wrapper. |
+| `missing-rls-index` | RLS policy filter columns without an index. |
+
+### Health
+
+| Rule | What it checks |
+| --- | --- |
+| `dead-tuples` | Tables with a high dead tuple ratio and enough dead rows to need vacuum attention. |
+| `stale-statistics` | Tables that have not been analyzed in more than seven days. |
+| `sequence-exhaustion` | Non-cycling public sequences that have used more than 90 percent of their range. |
+| `autovacuum-blocked` | Autovacuum workers blocked by another session. |
+
+## Cloud-Only Host Metrics
+
+Cloud-only CPU, disk, and memory advisor rules depend on host metrics from CloudWatch. Self-hosted projects do not have a common host-metric source, so those rules are not included in the OSS advisor scan.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,7 @@
                 "group": "Database",
                 "pages": [
                   "core-concepts/database/architecture",
+                  "core-concepts/database/advisors",
                   "core-concepts/database/migrations",
                   "core-concepts/database/branching",
                   "core-concepts/database/pgvector"
@@ -244,6 +245,10 @@
           {
             "group": "Metadata",
             "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/metadata.yaml"
+          },
+          {
+            "group": "Advisor",
+            "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/advisor.yaml"
           },
           {
             "group": "Health",

--- a/docs/insforge-instructions-sdk.md
+++ b/docs/insforge-instructions-sdk.md
@@ -76,6 +76,7 @@ Available documentation types:
 - `"ai-integration-sdk"` - AI integration with the provisioned OpenRouter key and OpenAI SDK
 - `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
 - `"deployment"` - Deploy frontend applications via MCP tool
+- `"advisor"` - Run database advisor scans after migrations
 
 These documentations are mostly for TypeScript SDK. For other languages, you can also use `fetch-sdk-docs` mcp tool to get specific documentation.
 
@@ -114,6 +115,7 @@ Available languages:
 - Database schema management (`run-raw-sql`, `get-table-schema`)
 - Storage bucket creation (`create-bucket`, `list-buckets`, `delete-bucket`)
 - Serverless function deployment (`create-function`, `update-function`, `delete-function`)
+- Database advisor scan (`advisor.scan`) - Run security, performance, and health checks after schema changes
 - Frontend deployment (`create-deployment`) - Deploy frontend apps to InsForge hosting
 
 ## Important Notes

--- a/openapi/advisor.yaml
+++ b/openapi/advisor.yaml
@@ -1,0 +1,251 @@
+openapi: 3.0.3
+info:
+  title: Insforge Advisor API
+  version: 1.0.0
+
+paths:
+  /api/advisor/scan:
+    post:
+      summary: Run database advisor scan
+      description: Runs all database advisor rules. Only one scan can run at a time in the current backend process.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Advisor scan result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorScanResult'
+        '401':
+          description: Missing or invalid admin token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Advisor scan already running
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/advisor/latest:
+    get:
+      summary: Get latest advisor scan
+      description: Returns the latest in-memory advisor scan result, or null before the first scan.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Latest advisor scan result
+          content:
+            application/json:
+              schema:
+                nullable: true
+                allOf:
+                  - $ref: '#/components/schemas/AdvisorScanResult'
+        '401':
+          description: Missing or invalid admin token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/advisor/issues:
+    get:
+      summary: List latest advisor findings
+      description: Returns findings from the latest advisor scan with optional category and severity filters.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: category
+          in: query
+          schema:
+            $ref: '#/components/schemas/AdvisorCategory'
+        - name: severity
+          in: query
+          schema:
+            $ref: '#/components/schemas/AdvisorSeverity'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Advisor findings from the latest scan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisorIssuesResponse'
+        '400':
+          description: Invalid filter or pagination value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid admin token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    AdvisorCategory:
+      type: string
+      enum: [security, performance, health]
+
+    AdvisorSeverity:
+      type: string
+      enum: [critical, warning, info]
+
+    AdvisorScanSummary:
+      type: object
+      required:
+        - total
+        - critical
+        - warning
+        - info
+      properties:
+        total:
+          type: integer
+        critical:
+          type: integer
+        warning:
+          type: integer
+        info:
+          type: integer
+
+    AdvisorFinding:
+      type: object
+      required:
+        - id
+        - ruleId
+        - category
+        - severity
+        - title
+        - description
+        - detail
+        - recommendation
+        - affectedObject
+        - metadata
+      properties:
+        id:
+          type: string
+        ruleId:
+          type: string
+        category:
+          $ref: '#/components/schemas/AdvisorCategory'
+        severity:
+          $ref: '#/components/schemas/AdvisorSeverity'
+        title:
+          type: string
+        description:
+          type: string
+        detail:
+          type: string
+        recommendation:
+          type: string
+        affectedObject:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+
+    AdvisorScanRuleError:
+      type: object
+      required:
+        - ruleId
+        - message
+      properties:
+        ruleId:
+          type: string
+        message:
+          type: string
+
+    AdvisorScanResult:
+      type: object
+      required:
+        - scanId
+        - status
+        - scanType
+        - scannedAt
+        - summary
+        - findings
+        - errors
+      properties:
+        scanId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [completed, completed_with_errors]
+        scanType:
+          type: string
+          enum: [manual]
+        scannedAt:
+          type: string
+          format: date-time
+        summary:
+          $ref: '#/components/schemas/AdvisorScanSummary'
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdvisorFinding'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdvisorScanRuleError'
+
+    AdvisorIssuesResponse:
+      type: object
+      required:
+        - issues
+        - total
+      properties:
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdvisorFinding'
+        total:
+          type: integer
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+          example: INVALID_INPUT
+        message:
+          type: string
+        statusCode:
+          type: integer
+        nextActions:
+          type: string

--- a/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
@@ -43,6 +43,11 @@ const DATABASE_STUDIO_SIDEBAR_BASE_ITEMS: Array<{
     sectionEnd: true,
   },
   {
+    id: 'advisors',
+    label: 'Advisors',
+    href: '/dashboard/database/advisors',
+  },
+  {
     id: 'migrations',
     label: 'Migrations',
     href: '/dashboard/database/migrations',

--- a/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
+++ b/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  advisorService,
+  type AdvisorScanResult,
+} from '#features/database/services/advisor.service';
+import { useToast } from '#lib/hooks/useToast';
+
+export function useAdvisorScan() {
+  const { showToast } = useToast();
+
+  const mutation = useMutation<AdvisorScanResult, Error>({
+    mutationFn: () => advisorService.runScan(),
+    onSuccess: (result) => {
+      if (result.errors.length > 0) {
+        showToast('Advisor scan completed with some rule errors', 'warn');
+        return;
+      }
+
+      showToast('Advisor scan completed', 'success');
+    },
+    onError: (error) => {
+      showToast(error.message || 'Advisor scan failed', 'error');
+    },
+  });
+
+  return {
+    runScan: mutation.mutate,
+    runScanAsync: mutation.mutateAsync,
+    isScanning: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    result: mutation.data,
+    error: mutation.error,
+    reset: mutation.reset,
+  };
+}

--- a/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
+++ b/packages/dashboard/src/features/database/hooks/useAdvisorScan.ts
@@ -1,16 +1,30 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   advisorService,
   type AdvisorScanResult,
 } from '#features/database/services/advisor.service';
 import { useToast } from '#lib/hooks/useToast';
 
+const ADVISOR_LATEST_QUERY_KEY = ['database', 'advisor', 'latest'] as const;
+
+export function useAdvisorLatestScan() {
+  return useQuery<AdvisorScanResult | null, Error>({
+    queryKey: ADVISOR_LATEST_QUERY_KEY,
+    queryFn: () => advisorService.getLatestScan(),
+    retry: false,
+    staleTime: 60 * 1000,
+  });
+}
+
 export function useAdvisorScan() {
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation<AdvisorScanResult, Error>({
     mutationFn: () => advisorService.runScan(),
     onSuccess: (result) => {
+      void queryClient.invalidateQueries({ queryKey: ADVISOR_LATEST_QUERY_KEY });
+
       if (result.errors.length > 0) {
         showToast('Advisor scan completed with some rule errors', 'warn');
         return;

--- a/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
@@ -1,9 +1,22 @@
-import { AlertTriangle, CheckCircle2, Loader2, Scan } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Loader2, Scan, AlertCircle, Copy, Check } from 'lucide-react';
 import { Button } from '@insforge/ui';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
-import { useAdvisorScan } from '#features/database/hooks/useAdvisorScan';
-import type { AdvisorFinding, AdvisorSeverity } from '#features/database/services/advisor.service';
+import { useAdvisorLatestScan, useAdvisorScan } from '#features/database/hooks/useAdvisorScan';
+import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
+import type {
+  AdvisorCategory,
+  AdvisorFinding,
+  AdvisorSeverity,
+} from '#features/database/services/advisor.service';
+
+const categoryFilters: Array<{ value: AdvisorCategory | 'all'; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'security', label: 'Security' },
+  { value: 'performance', label: 'Performance' },
+  { value: 'health', label: 'Health' },
+];
 
 function formatScanTime(value: string) {
   return new Intl.DateTimeFormat(undefined, {
@@ -15,11 +28,11 @@ function formatScanTime(value: string) {
 function getSeverityClass(severity: AdvisorSeverity) {
   switch (severity) {
     case 'critical':
-      return 'border-red-500/30 bg-red-500/10 text-red-500';
+      return 'border-red-600 bg-red-600 text-white';
     case 'warning':
-      return 'border-yellow-500/30 bg-yellow-500/10 text-yellow-500';
+      return 'border-amber-400 bg-amber-400 text-amber-950';
     case 'info':
-      return 'border-blue-500/30 bg-blue-500/10 text-blue-500';
+      return 'border-blue-600 bg-blue-600 text-white';
   }
 }
 
@@ -27,13 +40,220 @@ function formatCategory(value: AdvisorFinding['category']) {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+function getMetadataString(finding: AdvisorFinding, key: string): string | null {
+  const value = finding.metadata?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function getMetadataNumber(finding: AdvisorFinding, key: string): number | null {
+  const value = finding.metadata?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getMetadataStringArray(finding: AdvisorFinding, key: string): string[] {
+  const value = finding.metadata?.[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function createIndexName(parts: string[]): string {
+  return parts
+    .join('_')
+    .replace(/[^a-zA-Z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 60);
+}
+
+function getAffectedTable(
+  finding: AdvisorFinding
+): { schemaName: string; tableName: string } | null {
+  const tableName = getMetadataString(finding, 'table');
+  if (tableName) {
+    return {
+      schemaName: getMetadataString(finding, 'schema') ?? DEFAULT_DATABASE_SCHEMA,
+      tableName,
+    };
+  }
+
+  if (!finding.affectedObject) {
+    return null;
+  }
+
+  const parts = finding.affectedObject.split('.');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [schemaName, parsedTableName] = parts;
+  if (!schemaName || !parsedTableName || parsedTableName.includes('(')) {
+    return null;
+  }
+
+  return { schemaName, tableName: parsedTableName };
+}
+
+function getFriendlyDescription(finding: AdvisorFinding): string {
+  switch (finding.ruleId) {
+    case 'rls-select-only':
+      return 'This table has security policies written but RLS is switched off. The policies exist, but PostgreSQL is ignoring them, so rows can be exposed.';
+    case 'rls-disabled':
+      return 'This public table does not have row-level security enabled. Without RLS, table access depends only on broad database permissions.';
+    case 'rls-no-policy':
+      return 'RLS is enabled on this table, but no policies exist yet. Normal application users may be blocked until you define who can read or write rows.';
+    case 'dangerous-function':
+      return 'This function does not lock its search path. A caller-controlled search path can make the function resolve the wrong object at runtime.';
+    case 'rls-permissive':
+      return 'This table has more than one permissive policy for the same role and action. PostgreSQL has to evaluate overlapping policies, and the access model becomes harder to reason about.';
+    case 'missing-fk-index':
+      return 'This foreign key is missing a matching index. Updates or deletes on the referenced table can become slow as data grows.';
+    case 'unused-index':
+      return 'This index has not been used by recorded queries. It may be adding write overhead without helping reads.';
+    case 'slow-query':
+      return 'This query is averaging more than one second. It is worth checking the query plan and indexes before it becomes a user-facing bottleneck.';
+    case 'connection-high':
+      return 'Database connection usage is above the warning threshold. New requests may start queueing if usage keeps rising.';
+    case 'connection-critical':
+      return 'Database connection usage is near the maximum. The app can start failing new database requests.';
+    case 'idle-in-transaction':
+      return 'A client opened a transaction and then stopped doing work. This can hold locks and prevent cleanup.';
+    case 'low-cache-hit-ratio':
+      return 'Postgres is reading too much from disk instead of memory cache. Queries may feel slower than expected.';
+    case 'long-running-query':
+      return 'A query has been running for more than five minutes. It may be blocked, inefficient, or affecting other work.';
+    case 'rls-policy-perf':
+      return 'This RLS policy calls auth.uid() directly for each row. Wrapping it in a SELECT lets Postgres evaluate it once per statement.';
+    case 'missing-rls-index':
+      return 'This RLS policy filters by a column that is not indexed. User queries can turn into full table scans.';
+    case 'dead-tuples':
+      return 'This table has many dead rows waiting for cleanup. Vacuuming can recover space and improve query planning.';
+    case 'stale-statistics':
+      return 'The planner statistics for this table are old. Postgres may choose poor query plans until the table is analyzed.';
+    case 'sequence-exhaustion':
+      return 'This sequence is close to running out of available values. Inserts using it can fail once it is exhausted.';
+    case 'autovacuum-blocked':
+      return 'Autovacuum is blocked while trying to maintain a table. Cleanup cannot finish until the blocking session is resolved.';
+    default:
+      return finding.description;
+  }
+}
+
+function getSqlRemediation(finding: AdvisorFinding): string | null {
+  const affectedTable = getAffectedTable(finding);
+  const qualifiedTable = affectedTable
+    ? `${quoteIdentifier(affectedTable.schemaName)}.${quoteIdentifier(affectedTable.tableName)}`
+    : null;
+
+  switch (finding.ruleId) {
+    case 'rls-disabled':
+    case 'rls-select-only':
+      return qualifiedTable ? `ALTER TABLE ${qualifiedTable} ENABLE ROW LEVEL SECURITY;` : null;
+    case 'rls-no-policy':
+      return qualifiedTable
+        ? `CREATE POLICY "allow_owner_access" ON ${qualifiedTable} FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);`
+        : null;
+    case 'dangerous-function': {
+      const schemaName = getMetadataString(finding, 'schema') ?? DEFAULT_DATABASE_SCHEMA;
+      const functionName = getMetadataString(finding, 'function');
+      const argumentsList = getMetadataString(finding, 'arguments') ?? '';
+      return functionName
+        ? `ALTER FUNCTION ${quoteIdentifier(schemaName)}.${quoteIdentifier(functionName)}(${argumentsList}) SET search_path = public, pg_temp;`
+        : null;
+    }
+    case 'rls-permissive': {
+      const policies = getMetadataStringArray(finding, 'policies');
+      const policyToDrop = policies[1] ?? policies[0] ?? 'duplicate_policy_name';
+      return qualifiedTable
+        ? `DROP POLICY ${quoteIdentifier(policyToDrop)} ON ${qualifiedTable};`
+        : null;
+    }
+    case 'unused-index': {
+      const schemaName = getMetadataString(finding, 'schema') ?? DEFAULT_DATABASE_SCHEMA;
+      const indexName = getMetadataString(finding, 'index');
+      return indexName
+        ? `DROP INDEX CONCURRENTLY IF EXISTS ${quoteIdentifier(schemaName)}.${quoteIdentifier(indexName)};`
+        : null;
+    }
+    case 'missing-rls-index': {
+      const columnName = getMetadataString(finding, 'column');
+      if (!qualifiedTable || !affectedTable || !columnName) {
+        return null;
+      }
+
+      const indexName = createIndexName(['idx', affectedTable.tableName, columnName, 'rls']);
+      return `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${quoteIdentifier(indexName)} ON ${qualifiedTable} (${quoteIdentifier(columnName)});`;
+    }
+    case 'dead-tuples':
+      return qualifiedTable ? `VACUUM (ANALYZE) ${qualifiedTable};` : null;
+    case 'stale-statistics':
+      return qualifiedTable ? `ANALYZE ${qualifiedTable};` : null;
+    case 'long-running-query': {
+      const pid = getMetadataNumber(finding, 'pid');
+      return pid ? `SELECT pg_cancel_backend(${pid});` : null;
+    }
+    case 'idle-in-transaction': {
+      const pid = getMetadataNumber(finding, 'pid');
+      return pid ? `SELECT pg_terminate_backend(${pid});` : null;
+    }
+    default:
+      return null;
+  }
+}
+
 export default function AdvisorsPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { runScan, isScanning, result, error } = useAdvisorScan();
+  const [categoryFilter, setCategoryFilter] = useState<AdvisorCategory | 'all'>('all');
+  const [copiedFindingId, setCopiedFindingId] = useState<string | null>(null);
+  const { data: latestResult, isLoading: isLatestLoading } = useAdvisorLatestScan();
+  const { runScan, isScanning, result: scanResult, error } = useAdvisorScan();
+  const result = scanResult ?? latestResult;
+  const filteredFindings = useMemo(() => {
+    if (!result) {
+      return [];
+    }
+
+    if (categoryFilter === 'all') {
+      return result.findings;
+    }
+
+    return result.findings.filter((finding) => finding.category === categoryFilter);
+  }, [categoryFilter, result]);
 
   const handleRunScan = () => {
     runScan();
+  };
+
+  const handleCopySql = (findingId: string, sql: string) => {
+    void navigator.clipboard.writeText(sql).then(() => {
+      setCopiedFindingId(findingId);
+      window.setTimeout(() => setCopiedFindingId(null), 1400);
+    });
+  };
+
+  const handleAffectedObjectClick = (finding: AdvisorFinding) => {
+    const affectedTable = getAffectedTable(finding);
+    if (!affectedTable) {
+      return;
+    }
+
+    const nextSearchParams = new URLSearchParams();
+    if (affectedTable.schemaName !== DEFAULT_DATABASE_SCHEMA) {
+      nextSearchParams.set('schema', affectedTable.schemaName);
+    }
+    nextSearchParams.set('table', affectedTable.tableName);
+
+    void navigate({
+      pathname: '/dashboard/database/tables',
+      search: `?${nextSearchParams.toString()}`,
+    });
   };
 
   return (
@@ -71,7 +291,7 @@ export default function AdvisorsPage() {
             {isScanning ? (
               <div className="flex min-h-10 items-center gap-2 rounded border border-border bg-[rgb(var(--semantic-1))] px-4 py-2 text-sm font-medium text-foreground">
                 <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                Scanning database...
+                Scanning your database...
               </div>
             ) : (
               <Button className="gap-2" onClick={handleRunScan}>
@@ -82,122 +302,209 @@ export default function AdvisorsPage() {
           </div>
 
           {result ? (
-            <div className="rounded border border-border bg-[rgb(var(--semantic-2))] p-5">
-              <div className="flex flex-col gap-4">
-                <div className="flex items-start gap-3">
-                  {result.errors.length > 0 ? (
-                    <AlertTriangle className="mt-0.5 h-5 w-5 text-yellow-500" />
-                  ) : (
-                    <CheckCircle2 className="mt-0.5 h-5 w-5 text-green-500" />
-                  )}
-                  <div className="min-w-0">
-                    <h2 className="text-base font-medium leading-6 text-foreground">
-                      Scan finished
-                    </h2>
-                    <p className="text-sm leading-6 text-muted-foreground">
+            <div className="rounded-lg border border-border bg-[rgb(var(--semantic-2))] p-6 shadow-sm">
+              <div className="flex flex-col gap-6">
+                <div className="flex items-start gap-4">
+                  <div
+                    className={`flex rounded-full p-2.5 ${result.errors.length > 0 ? 'bg-yellow-500/10' : 'bg-green-500/10'}`}
+                  >
+                    {result.errors.length > 0 ? (
+                      <AlertTriangle className="h-6 w-6 text-yellow-500" />
+                    ) : (
+                      <CheckCircle2 className="h-6 w-6 text-green-500" />
+                    )}
+                  </div>
+                  <div className="min-w-0 pt-0.5">
+                    <h2 className="text-lg font-semibold text-foreground">Scan finished</h2>
+                    <p className="text-sm text-muted-foreground">
                       {formatScanTime(result.scannedAt)}
                     </p>
                   </div>
                 </div>
 
-                <div className="grid gap-3 sm:grid-cols-4">
-                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
-                    <p className="text-xs leading-4 text-muted-foreground">Total findings</p>
-                    <p className="text-2xl font-medium leading-8 text-foreground">
+                <div className="grid gap-4 sm:grid-cols-4">
+                  <div className="rounded-lg border border-border bg-[rgb(var(--semantic-1))] p-4 shadow-sm">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Total</p>
+                    <p className="mt-1 text-2xl font-semibold text-foreground">
                       {result.summary.total}
                     </p>
                   </div>
-                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
-                    <p className="text-xs leading-4 text-muted-foreground">Critical</p>
-                    <p className="text-2xl font-medium leading-8 text-red-500">
+                  <div className="rounded-lg border border-border bg-[rgb(var(--semantic-1))] p-4 shadow-sm">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Critical</p>
+                    <p className="mt-1 text-2xl font-semibold text-red-500">
                       {result.summary.critical}
                     </p>
                   </div>
-                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
-                    <p className="text-xs leading-4 text-muted-foreground">Warnings</p>
-                    <p className="text-2xl font-medium leading-8 text-yellow-500">
+                  <div className="rounded-lg border border-border bg-[rgb(var(--semantic-1))] p-4 shadow-sm">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Warnings</p>
+                    <p className="mt-1 text-2xl font-semibold text-yellow-500">
                       {result.summary.warning}
                     </p>
                   </div>
-                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
-                    <p className="text-xs leading-4 text-muted-foreground">Info</p>
-                    <p className="text-2xl font-medium leading-8 text-blue-500">
+                  <div className="rounded-lg border border-border bg-[rgb(var(--semantic-1))] p-4 shadow-sm">
+                    <p className="text-xs font-medium uppercase text-muted-foreground">Info</p>
+                    <p className="mt-1 text-2xl font-semibold text-blue-500">
                       {result.summary.info}
                     </p>
                   </div>
                 </div>
 
                 {result.errors.length > 0 ? (
-                  <div className="rounded border border-yellow-500/30 bg-yellow-500/10 p-3">
-                    <p className="text-sm font-medium leading-5 text-foreground">
-                      {result.errors.length} rule error{result.errors.length === 1 ? '' : 's'}
-                    </p>
-                    <p className="text-sm leading-6 text-muted-foreground">
-                      Some advisor rules could not complete. Check backend logs for full details.
-                    </p>
+                  <div className="relative w-full rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4 shadow-sm dark:border-yellow-500/20">
+                    <AlertTriangle className="absolute left-4 top-4 h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+                    <div className="pl-8">
+                      <h3 className="mb-1 text-sm font-semibold leading-none text-yellow-600 dark:text-yellow-400">
+                        {result.errors.length} rule error{result.errors.length === 1 ? '' : 's'}
+                      </h3>
+                      <div className="text-sm text-yellow-700/90 dark:text-yellow-400/90">
+                        Some advisor rules could not complete. Check backend logs for full details.
+                      </div>
+                    </div>
                   </div>
                 ) : null}
 
-                <div className="flex flex-col gap-3">
-                  <h2 className="text-base font-medium leading-6 text-foreground">Scan results</h2>
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <h2 className="text-lg font-semibold text-foreground">Scan results</h2>
+                    <div className="flex flex-wrap gap-1 rounded border border-border bg-[rgb(var(--semantic-1))] p-1">
+                      {categoryFilters.map((filter) => {
+                        const isActive = categoryFilter === filter.value;
+                        const count = result
+                          ? filter.value === 'all'
+                            ? result.findings.length
+                            : result.findings.filter((f) => f.category === filter.value).length
+                          : 0;
 
-                  {result.findings.length === 0 ? (
-                    <div className="rounded border border-green-500/30 bg-green-500/10 p-4">
-                      <p className="text-sm font-medium leading-5 text-foreground">
-                        No advisor findings
-                      </p>
-                      <p className="text-sm leading-6 text-muted-foreground">
-                        The scan did not find security, performance, or health issues.
+                        return (
+                          <button
+                            key={filter.value}
+                            type="button"
+                            onClick={() => setCategoryFilter(filter.value)}
+                            className={`relative cursor-pointer rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                              isActive
+                                ? 'bg-primary text-primary-foreground'
+                                : 'text-muted-foreground hover:bg-[rgb(var(--semantic-2))] hover:text-foreground'
+                            }`}
+                          >
+                            {filter.label}
+                            {count > 0 ? (
+                              <span className="absolute -right-1.5 -top-1.5 flex min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 py-0.5 text-[10px] font-bold leading-none text-white shadow-sm ring-2 ring-[rgb(var(--semantic-1))]">
+                                {count}
+                              </span>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {filteredFindings.length === 0 ? (
+                    <div className="flex w-full flex-col items-center justify-center rounded-lg border border-green-500/30 bg-green-500/10 px-6 py-10 text-center shadow-sm dark:border-green-500/20">
+                      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-600 text-white">
+                        <CheckCircle2 className="h-6 w-6" />
+                      </div>
+                      <p className="text-base font-base leading-6 text-green-700 dark:text-green-400">
+                        {categoryFilter === 'all'
+                          ? 'The latest scan did not find security, performance, or health issues.'
+                          : `No ${categoryFilter} issues were found in the latest scan.`}
                       </p>
                     </div>
+                  ) : isScanning ? (
+                    <div className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-[rgb(var(--semantic-1))] px-6 py-10 text-sm font-medium text-foreground shadow-sm">
+                      <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                      Scanning your database...
+                    </div>
                   ) : (
-                    <div className="flex flex-col gap-3">
-                      {result.findings.map((finding) => (
-                        <div
-                          key={finding.id}
-                          className="rounded border border-border bg-[rgb(var(--semantic-1))] p-4"
-                        >
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                            <div className="min-w-0">
-                              <div className="flex flex-wrap items-center gap-2">
-                                <h3 className="text-sm font-medium leading-5 text-foreground">
-                                  {finding.title}
-                                </h3>
-                                <span
-                                  className={`rounded border px-2 py-0.5 text-xs font-medium leading-4 ${getSeverityClass(
-                                    finding.severity
-                                  )}`}
-                                >
-                                  {finding.severity}
-                                </span>
-                                <span className="rounded border border-border bg-[rgb(var(--semantic-2))] px-2 py-0.5 text-xs font-medium leading-4 text-muted-foreground">
-                                  {formatCategory(finding.category)}
-                                </span>
+                    <div className="flex flex-col gap-4">
+                      {filteredFindings.map((finding) => {
+                        const sqlRemediation = getSqlRemediation(finding);
+                        const affectedTable = getAffectedTable(finding);
+
+                        return (
+                          <div
+                            key={finding.id}
+                            className="rounded-lg border border-border bg-[rgb(var(--semantic-1))] p-5 shadow-sm transition-shadow hover:shadow-md"
+                          >
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                              <div className="min-w-0 flex-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <h3 className="text-sm font-medium leading-5 text-foreground">
+                                    {finding.title}
+                                  </h3>
+                                  <span
+                                    className={`rounded border px-2 py-0.5 text-xs font-semibold leading-4 ${getSeverityClass(
+                                      finding.severity
+                                    )}`}
+                                  >
+                                    {finding.severity}
+                                  </span>
+                                  <span className="rounded border border-border bg-[rgb(var(--semantic-2))] px-2 py-0.5 text-xs font-medium leading-4 text-muted-foreground">
+                                    {formatCategory(finding.category)}
+                                  </span>
+                                </div>
+
+                                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                                  {getFriendlyDescription(finding)}
+                                </p>
+
+                                {finding.affectedObject ? (
+                                  <div className="mt-3 flex flex-wrap items-center gap-2 text-xs leading-5">
+                                    <span className="font-medium text-muted-foreground">
+                                      Affected
+                                    </span>
+                                    {affectedTable ? (
+                                      <button
+                                        type="button"
+                                        onClick={() => handleAffectedObjectClick(finding)}
+                                        className="max-w-full cursor-pointer break-all rounded border border-primary/30 bg-primary/10 px-2 py-1 font-mono font-medium text-primary transition-colors hover:border-primary hover:bg-primary/15"
+                                      >
+                                        {finding.affectedObject}
+                                      </button>
+                                    ) : (
+                                      <span className="max-w-full break-all rounded border border-primary/30 bg-primary/10 px-2 py-1 font-mono font-medium text-primary">
+                                        {finding.affectedObject}
+                                      </span>
+                                    )}
+                                  </div>
+                                ) : null}
+
+                                {sqlRemediation ? (
+                                  <div className="mt-4 overflow-hidden rounded border border-border bg-[rgb(var(--semantic-2))]">
+                                    <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+                                      <span className="text-xs font-medium uppercase text-muted-foreground">
+                                        Remediation SQL
+                                      </span>
+                                      <button
+                                        type="button"
+                                        onClick={() => handleCopySql(finding.id, sqlRemediation)}
+                                        className="flex  cursor-pointer items-center gap-1 rounded border border-border bg-[rgb(var(--semantic-1))] px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-[rgb(var(--semantic-3))]"
+                                      >
+                                        {copiedFindingId === finding.id ? (
+                                          <Check className="h-3.5 w-3.5 text-green-500" />
+                                        ) : (
+                                          <Copy className="h-3.5 w-3.5" />
+                                        )}
+                                        {copiedFindingId === finding.id ? 'Copied' : 'Copy'}
+                                      </button>
+                                    </div>
+                                    <pre className="overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-xs leading-5 text-foreground">
+                                      {sqlRemediation}
+                                    </pre>
+                                  </div>
+                                ) : finding.recommendation ? (
+                                  <p className="mt-3 text-sm leading-6 text-foreground">
+                                    {finding.recommendation}
+                                  </p>
+                                ) : null}
                               </div>
 
-                              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                                {finding.description}
-                              </p>
-
-                              {finding.affectedObject ? (
-                                <p className="mt-2 break-all text-xs leading-5 text-muted-foreground">
-                                  Affected: {finding.affectedObject}
-                                </p>
-                              ) : null}
-
-                              {finding.recommendation ? (
-                                <p className="mt-2 text-sm leading-6 text-foreground">
-                                  {finding.recommendation}
-                                </p>
-                              ) : null}
+                              <span className="shrink-0 rounded bg-[rgb(var(--semantic-2))] px-2 py-1 font-mono text-xs leading-4 text-muted-foreground">
+                                {finding.ruleId}
+                              </span>
                             </div>
-
-                            <span className="shrink-0 rounded bg-[rgb(var(--semantic-2))] px-2 py-1 font-mono text-xs leading-4 text-muted-foreground">
-                              {finding.ruleId}
-                            </span>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   )}
                 </div>
@@ -205,10 +512,29 @@ export default function AdvisorsPage() {
             </div>
           ) : null}
 
+          {!result && isScanning ? (
+            <div className="flex items-center gap-3 rounded border border-border bg-[rgb(var(--semantic-2))] px-4 py-3 text-sm font-medium text-foreground shadow-sm">
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+              Scanning your database...
+            </div>
+          ) : null}
+
+          {!result && isLatestLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading latest advisor scan...
+            </div>
+          ) : null}
+
           {error ? (
-            <div className="rounded border border-red-500/30 bg-red-500/10 p-4">
-              <p className="text-sm font-medium leading-5 text-foreground">Scan failed</p>
-              <p className="text-sm leading-6 text-muted-foreground">{error.message}</p>
+            <div className="relative w-full rounded-lg border border-red-500/30 bg-red-500/10 p-4 shadow-sm dark:border-red-500/20">
+              <AlertCircle className="absolute left-4 top-4 h-5 w-5 text-red-600 dark:text-red-400" />
+              <div className="pl-8">
+                <h3 className="mb-1 text-sm font-semibold leading-none text-red-600 dark:text-red-400">
+                  Scan failed
+                </h3>
+                <div className="text-sm text-red-700/90 dark:text-red-400/90">{error.message}</div>
+              </div>
             </div>
           ) : null}
         </div>

--- a/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
@@ -1,0 +1,55 @@
+import { Scan } from 'lucide-react';
+import { Button } from '@insforge/ui';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
+
+export default function AdvisorsPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleRunScan = () => {
+    return undefined;
+  };
+
+  return (
+    <div className="flex h-full min-h-0 overflow-hidden bg-[rgb(var(--semantic-1))]">
+      <DatabaseStudioSidebarPanel
+        onBack={() =>
+          void navigate(
+            {
+              pathname: '/dashboard/database/tables',
+              search: location.search,
+            },
+            { state: { slideFromStudio: true } }
+          )
+        }
+      />
+      <div className="min-w-0 flex-1 overflow-auto bg-[rgb(var(--semantic-1))]">
+        <div className="mx-auto flex w-full max-w-[1024px] flex-col gap-6 px-4 pb-10 pt-8 sm:px-6 sm:pt-10 lg:px-10">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-2xl font-medium leading-8 text-foreground">Database Advisors</h1>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              Scan the database for security, performance, and health recommendations.
+            </p>
+          </div>
+
+          <div className="flex min-h-[220px] flex-col items-start justify-center gap-5 rounded border border-border bg-[rgb(var(--semantic-2))] px-6 py-8">
+            <div className="flex h-12 w-12 items-center justify-center rounded bg-primary/10 text-primary">
+              <Scan className="h-6 w-6" />
+            </div>
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-medium leading-7 text-foreground">Run advisor scan</h2>
+              <p className="max-w-xl text-sm leading-6 text-muted-foreground">
+                Check row-level security, indexes, slow queries, and database health signals.
+              </p>
+            </div>
+            <Button className="gap-2" onClick={handleRunScan}>
+              <Scan className="h-4 w-4" />
+              Run scan now
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/AdvisorsPage.tsx
@@ -1,14 +1,39 @@
-import { Scan } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, Scan } from 'lucide-react';
 import { Button } from '@insforge/ui';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
+import { useAdvisorScan } from '#features/database/hooks/useAdvisorScan';
+import type { AdvisorFinding, AdvisorSeverity } from '#features/database/services/advisor.service';
+
+function formatScanTime(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function getSeverityClass(severity: AdvisorSeverity) {
+  switch (severity) {
+    case 'critical':
+      return 'border-red-500/30 bg-red-500/10 text-red-500';
+    case 'warning':
+      return 'border-yellow-500/30 bg-yellow-500/10 text-yellow-500';
+    case 'info':
+      return 'border-blue-500/30 bg-blue-500/10 text-blue-500';
+  }
+}
+
+function formatCategory(value: AdvisorFinding['category']) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
 
 export default function AdvisorsPage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { runScan, isScanning, result, error } = useAdvisorScan();
 
   const handleRunScan = () => {
-    return undefined;
+    runScan();
   };
 
   return (
@@ -43,11 +68,149 @@ export default function AdvisorsPage() {
                 Check row-level security, indexes, slow queries, and database health signals.
               </p>
             </div>
-            <Button className="gap-2" onClick={handleRunScan}>
-              <Scan className="h-4 w-4" />
-              Run scan now
-            </Button>
+            {isScanning ? (
+              <div className="flex min-h-10 items-center gap-2 rounded border border-border bg-[rgb(var(--semantic-1))] px-4 py-2 text-sm font-medium text-foreground">
+                <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                Scanning database...
+              </div>
+            ) : (
+              <Button className="gap-2" onClick={handleRunScan}>
+                <Scan className="h-4 w-4" />
+                Run scan now
+              </Button>
+            )}
           </div>
+
+          {result ? (
+            <div className="rounded border border-border bg-[rgb(var(--semantic-2))] p-5">
+              <div className="flex flex-col gap-4">
+                <div className="flex items-start gap-3">
+                  {result.errors.length > 0 ? (
+                    <AlertTriangle className="mt-0.5 h-5 w-5 text-yellow-500" />
+                  ) : (
+                    <CheckCircle2 className="mt-0.5 h-5 w-5 text-green-500" />
+                  )}
+                  <div className="min-w-0">
+                    <h2 className="text-base font-medium leading-6 text-foreground">
+                      Scan finished
+                    </h2>
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      {formatScanTime(result.scannedAt)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-4">
+                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
+                    <p className="text-xs leading-4 text-muted-foreground">Total findings</p>
+                    <p className="text-2xl font-medium leading-8 text-foreground">
+                      {result.summary.total}
+                    </p>
+                  </div>
+                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
+                    <p className="text-xs leading-4 text-muted-foreground">Critical</p>
+                    <p className="text-2xl font-medium leading-8 text-red-500">
+                      {result.summary.critical}
+                    </p>
+                  </div>
+                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
+                    <p className="text-xs leading-4 text-muted-foreground">Warnings</p>
+                    <p className="text-2xl font-medium leading-8 text-yellow-500">
+                      {result.summary.warning}
+                    </p>
+                  </div>
+                  <div className="rounded border border-border bg-[rgb(var(--semantic-1))] p-3">
+                    <p className="text-xs leading-4 text-muted-foreground">Info</p>
+                    <p className="text-2xl font-medium leading-8 text-blue-500">
+                      {result.summary.info}
+                    </p>
+                  </div>
+                </div>
+
+                {result.errors.length > 0 ? (
+                  <div className="rounded border border-yellow-500/30 bg-yellow-500/10 p-3">
+                    <p className="text-sm font-medium leading-5 text-foreground">
+                      {result.errors.length} rule error{result.errors.length === 1 ? '' : 's'}
+                    </p>
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      Some advisor rules could not complete. Check backend logs for full details.
+                    </p>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-3">
+                  <h2 className="text-base font-medium leading-6 text-foreground">Scan results</h2>
+
+                  {result.findings.length === 0 ? (
+                    <div className="rounded border border-green-500/30 bg-green-500/10 p-4">
+                      <p className="text-sm font-medium leading-5 text-foreground">
+                        No advisor findings
+                      </p>
+                      <p className="text-sm leading-6 text-muted-foreground">
+                        The scan did not find security, performance, or health issues.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-3">
+                      {result.findings.map((finding) => (
+                        <div
+                          key={finding.id}
+                          className="rounded border border-border bg-[rgb(var(--semantic-1))] p-4"
+                        >
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h3 className="text-sm font-medium leading-5 text-foreground">
+                                  {finding.title}
+                                </h3>
+                                <span
+                                  className={`rounded border px-2 py-0.5 text-xs font-medium leading-4 ${getSeverityClass(
+                                    finding.severity
+                                  )}`}
+                                >
+                                  {finding.severity}
+                                </span>
+                                <span className="rounded border border-border bg-[rgb(var(--semantic-2))] px-2 py-0.5 text-xs font-medium leading-4 text-muted-foreground">
+                                  {formatCategory(finding.category)}
+                                </span>
+                              </div>
+
+                              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                                {finding.description}
+                              </p>
+
+                              {finding.affectedObject ? (
+                                <p className="mt-2 break-all text-xs leading-5 text-muted-foreground">
+                                  Affected: {finding.affectedObject}
+                                </p>
+                              ) : null}
+
+                              {finding.recommendation ? (
+                                <p className="mt-2 text-sm leading-6 text-foreground">
+                                  {finding.recommendation}
+                                </p>
+                              ) : null}
+                            </div>
+
+                            <span className="shrink-0 rounded bg-[rgb(var(--semantic-2))] px-2 py-1 font-mono text-xs leading-4 text-muted-foreground">
+                              {finding.ruleId}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="rounded border border-red-500/30 bg-red-500/10 p-4">
+              <p className="text-sm font-medium leading-5 text-foreground">Scan failed</p>
+              <p className="text-sm leading-6 text-muted-foreground">{error.message}</p>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/dashboard/src/features/database/services/advisor.service.ts
+++ b/packages/dashboard/src/features/database/services/advisor.service.ts
@@ -1,0 +1,51 @@
+import { apiClient } from '#lib/api/client';
+
+export type AdvisorScanStatus = 'completed' | 'completed_with_errors' | 'failed';
+export type AdvisorScanType = 'manual' | 'scheduled';
+export type AdvisorSeverity = 'critical' | 'warning' | 'info';
+export type AdvisorCategory = 'security' | 'performance' | 'health';
+
+export interface AdvisorFinding {
+  id: string;
+  ruleId: string;
+  title: string;
+  description: string;
+  severity: AdvisorSeverity;
+  category: AdvisorCategory;
+  affectedObject?: string;
+  recommendation?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AdvisorScanRuleError {
+  ruleId: string;
+  message: string;
+}
+
+export interface AdvisorScanResult {
+  scanId: string;
+  status: AdvisorScanStatus;
+  scanType: AdvisorScanType;
+  scannedAt: string;
+  summary: {
+    total: number;
+    critical: number;
+    warning: number;
+    info: number;
+  };
+  findings: AdvisorFinding[];
+  errors: AdvisorScanRuleError[];
+}
+
+class AdvisorService {
+  runScan(): Promise<AdvisorScanResult> {
+    return apiClient.request('/advisor/scan', {
+      method: 'POST',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+    });
+  }
+}
+
+export const advisorService = new AdvisorService();

--- a/packages/dashboard/src/features/database/services/advisor.service.ts
+++ b/packages/dashboard/src/features/database/services/advisor.service.ts
@@ -38,6 +38,34 @@ export interface AdvisorScanResult {
 }
 
 class AdvisorService {
+  getLatestScan(): Promise<AdvisorScanResult | null> {
+    return apiClient.request('/advisor/latest');
+  }
+
+  listIssues(params: {
+    category?: AdvisorCategory;
+    severity?: AdvisorSeverity;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ issues: AdvisorFinding[]; total: number }> {
+    const searchParams = new URLSearchParams();
+    if (params.category) {
+      searchParams.set('category', params.category);
+    }
+    if (params.severity) {
+      searchParams.set('severity', params.severity);
+    }
+    if (params.limit !== undefined) {
+      searchParams.set('limit', String(params.limit));
+    }
+    if (params.offset !== undefined) {
+      searchParams.set('offset', String(params.offset));
+    }
+
+    const query = searchParams.toString();
+    return apiClient.request(`/advisor/issues${query ? `?${query}` : ''}`);
+  }
+
   runScan(): Promise<AdvisorScanResult> {
     return apiClient.request('/advisor/scan', {
       method: 'POST',

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -17,6 +17,7 @@ import DTestInstallPage from '#features/dashboard/pages/DTestInstallPage';
 import DatabaseLayout from '#features/database/components/DatabaseLayout';
 import SQLEditorLayout from '#features/database/components/SQLEditorLayout';
 import BackupsPage from '#features/database/pages/BackupsPage';
+import AdvisorsPage from '#features/database/pages/AdvisorsPage';
 import DatabaseFunctionsPage from '#features/database/pages/FunctionsPage';
 import IndexesPage from '#features/database/pages/IndexesPage';
 import MigrationsPage from '#features/database/pages/MigrationsPage';
@@ -92,6 +93,7 @@ function AuthenticatedRoutes() {
           <Route path="templates" element={<TemplatesPage />} />
           <Route path="migrations" element={<MigrationsPage />} />
           <Route path="backups" element={<BackupsPage />} />
+          <Route path="advisors" element={<AdvisorsPage />} />
         </Route>
         <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>
           <Route index element={<SQLEditorPage />} />

--- a/packages/shared-schemas/src/docs.schema.ts
+++ b/packages/shared-schemas/src/docs.schema.ts
@@ -48,6 +48,7 @@ export const docTypeSchema = z
     'ai-integration-sdk',
     'real-time',
     'deployment',
+    'advisor',
   ])
   .describe(
     `
@@ -59,7 +60,8 @@ export const docTypeSchema = z
       "auth-sdk" (direct SDK methods for custom auth flows),
       "ai-integration-sdk" (AI features),
       "real-time" (real-time pub/sub through WebSockets),
-      "deployment" (deploy frontend applications via MCP tool)
+      "deployment" (deploy frontend applications via MCP tool),
+      "advisor" (run database advisor scans after migrations)
     `
   );
 


### PR DESCRIPTION
Closes #1271

## Summary

This PR adds Database Advisor support to the open-source/self-hosted InsForge repository.

It introduces an admin-only advisor scanning API, advisor rule execution layer, dashboard UI, and documentation so self-hosted users can scan their Postgres database for security, performance, and health issues.

## What Changed

### Backend

* Added `POST /api/advisor/scan` to execute advisor scans and return findings as JSON.
* Added advisor latest/issues endpoints for dashboard consumption.
* Added an in-memory scan lock to ensure only one advisor scan can run at a time.

### Advisor Rules

Added 19 advisor rules across the following categories:

#### Security

* RLS disabled
* Permissive RLS policies
* Missing RLS policies
* Unsafe function `search_path`
* Policies not enforced

#### Performance

* Missing foreign key indexes
* Unused indexes
* Slow queries
* High connection usage
* Idle transactions
* Low cache hit ratio
* Long-running queries
* RLS policy performance issues
* Missing RLS indexes

#### Health

* Dead tuples
* Stale statistics
* Sequence exhaustion
* Blocked autovacuum

### Dashboard

Added a Database Advisors dashboard page with:

* Run Scan button
* Loading states
* Severity badges
* Category filters
* Finding cards
* Clickable affected table chips
* Copyable remediation SQL where safe to generate

### Documentation & API

* Added documentation describing all advisor rules and their checks.
* Added OpenAPI coverage for advisor endpoints.

## Verification

To verify that all security rules triggered correctly, I seeded the database with intentional security misconfigurations:

* A table without RLS enabled (`test_no_rls`)
* A table with multiple permissive policies (`test_permissive`)
* A table with RLS enabled but no policies (`test_no_policy`)
* A table with policies defined but RLS disabled (`test_rls_select_only`)
* A function without an explicit `search_path` (`test_dangerous`)

The advisor scan correctly detected all issues with the expected severity levels, categories, and remediation SQL.



https://github.com/user-attachments/assets/e441d619-5444-4188-8cdb-6b889284626d




## Design Decisions

* The OSS implementation is currently stateless/in-memory:

  * Latest scan results are stored in memory only.
  * Scan history and dismissals are intentionally excluded from this PR.
* Scans are currently on-demand only.

  * Scheduled scans can be added in a future iteration.
* CloudWatch-based CPU, disk, and memory checks are excluded because self-hosted OSS deployments do not share a common CloudWatch metadata source.
* Advisor rule logic is implemented directly in the backend advisor layer for this initial OSS release.
* The public repository did not appear to include the private cloud `services/advisor/` implementation, so the rules were implemented directly from the issue requirements and PostgreSQL catalog/stat views.

## Tests

* Added test coverage for all 19 advisor rules.
* Added route tests covering:

  * Admin authentication
  * Scan response behavior
  * Latest scan results
  * Issue filtering
  * Scan lock behavior
* Added service tests for:

  * Summary generation
  * Failed rule handling

## Validation

Passed:

* `cd backend && npm test`
* `cd backend && npm run build`
* `cd packages/dashboard && npm run typecheck`
* Dashboard ESLint
* Shared schema lint/typecheck/build
* Docs schema validation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hosted Database Advisor with an admin-only scan API, 19 rules, and a dashboard page to surface security, performance, and health findings. Implements the self-hosted Advisor requested in #1271.

- **New Features**
  - Backend: `POST /api/advisor/scan`, `GET /api/advisor/latest`, `GET /api/advisor/issues` with a single-scan lock and JSON findings/summary/errors.
  - Rules: 19 checks across security, performance, and health (e.g., RLS gaps, missing/unused indexes, slow/long-running queries, dead tuples, blocked autovacuum).
  - Dashboard: New Advisors page with Run Scan button, loading states, severity badges, category filters, finding cards, table chips, and copyable remediation SQL.
  - Docs & API: Added docs for rules and usage, OpenAPI spec at `openapi/advisor.yaml`, and docs routing updates.
  - Tests: Unit tests for routes, rules, and service; type checks/builds pass.
  - Initial scope: Stateless/in-memory latest result, on-demand scans only (no history/dismissals/scheduling).

<sup>Written for commit d74e6b106d8d5666b76e89d0951a4b23215ad3f4. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1288?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database advisor feature for self-hosted projects
> - Adds a backend `AdvisorService` that runs a configurable set of SQL-based rules against the connected Postgres database, returning categorized findings (security, performance, health) with severity levels and metadata.
> - Implements 18 advisor rules covering RLS gaps, dangerous functions, connection saturation, slow queries, dead tuples, sequence exhaustion, and more.
> - Exposes three admin-only API endpoints (`POST /api/advisor/scan`, `GET /api/advisor/latest`, `GET /api/advisor/issues`) with pagination and category/severity filtering.
> - Adds a Dashboard `AdvisorsPage` at `/dashboard/database/advisors` with scan triggering, finding display, remediation SQL copy, and category filtering; adds an `Advisors` entry to the database sidebar.
> - Behavioral Change: scans are blocked from running concurrently — a second `POST /scan` while one is running returns 409.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d74e6b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Database Advisor system with read-only PostgreSQL health, security, and performance checks
  * Added admin API endpoints to run scans, retrieve latest results, and filter findings by category/severity
  * Created Dashboard UI page to execute scans and view detailed findings with remediation recommendations
  * Implemented 19 advisor rules detecting issues like disabled RLS, missing indexes, slow queries, and connection limits

* **Documentation**
  * Added comprehensive Database Advisor guides and API reference documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->