### PR TITLE
Add more unit tests and component tests

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -89,9 +89,14 @@ jobs:
       - name: Run UI component tests
         run: npm --workspace @insforge/ui run test:component
 
-  dashboard-ui-tests:
-    name: Dashboard UI Tests
+  dashboard-e2e-tests:
+    name: Dashboard E2E Tests
     runs-on: ubuntu-latest
+    needs:
+      - dashboard-unit-tests
+      - dashboard-component-tests
+      - ui-unit-tests
+      - ui-component-tests
 
     steps:
       - name: Checkout code
@@ -109,7 +114,7 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run dashboard UI tests
+      - name: Run dashboard E2E tests
         run: npm --workspace @insforge/dashboard run test:ui
 
       - name: Upload Playwright artifacts

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -49,6 +49,46 @@ jobs:
       - name: Run dashboard component tests
         run: npm --workspace @insforge/dashboard run test:component
 
+  ui-unit-tests:
+    name: UI Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run UI unit tests
+        run: npm --workspace @insforge/ui run test:unit
+
+  ui-component-tests:
+    name: UI Component Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run UI component tests
+        run: npm --workspace @insforge/ui run test:component
+
   dashboard-ui-tests:
     name: Dashboard UI Tests
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -17029,6 +17029,12 @@
         "lucide-react": "^0.536.0",
         "tailwind-merge": "^3.3.1"
       },
+      "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "jsdom": "^29.1.1",
+        "vitest": "^4.1.6"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -17036,6 +17042,253 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwindcss": "^4.0.0"
+      }
+    },
+    "packages/ui/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ui/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/ui/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/ui/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ui/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "packages/ui/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ui/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/ui/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "shared-schemas": {

--- a/packages/dashboard/src/features/analytics/lib/__tests__/format.test.ts
+++ b/packages/dashboard/src/features/analytics/lib/__tests__/format.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  countryName,
+  flagEmoji,
+  formatDuration,
+  formatNumber,
+  formatPercent,
+  formatRelativeTime,
+  truncateId,
+  webOverviewLabel,
+  webOverviewValue,
+} from '#features/analytics/lib/format';
+
+describe('analytics format helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats country codes', () => {
+    expect(flagEmoji('us')).toBe('🇺🇸');
+    expect(flagEmoji('USA')).toBe('');
+    expect(countryName('us')).toBe('United States');
+    expect(countryName('')).toBe('');
+  });
+
+  it('formats numeric analytics values', () => {
+    expect(formatDuration(65)).toBe('1:05');
+    expect(formatDuration(3661)).toBe('1:01:01');
+    expect(formatDuration(-1)).toBe('0:00');
+    expect(formatNumber(1234567)).toBe('1,234,567');
+    expect(formatPercent(1.24, { signed: true })).toBe('+1.2%');
+    expect(formatPercent(-1.24, { signed: true })).toBe('-1.2%');
+  });
+
+  it('formats relative and compact labels', () => {
+    expect(formatRelativeTime('2026-05-17T11:58:00.000Z')).toBe('2m ago');
+    expect(truncateId('019ddbc3-272e-4567', 12)).toBe('019ddbc3-272…');
+    expect(webOverviewLabel('bounce_rate')).toBe('Bounce rate');
+    expect(webOverviewLabel('custom_key')).toBe('custom key');
+  });
+
+  it('formats web overview values by metric key', () => {
+    expect(webOverviewValue('visitors', 1234)).toBe('1,234');
+    expect(webOverviewValue('bounce_rate', 42.4)).toBe('42%');
+    expect(webOverviewValue('session_duration', 125)).toBe('2:05');
+    expect(webOverviewValue('visitors', null)).toBe('—');
+  });
+});

--- a/packages/dashboard/src/features/compute/components/__tests__/DeleteServiceDialog.test.tsx
+++ b/packages/dashboard/src/features/compute/components/__tests__/DeleteServiceDialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { DeleteServiceDialog } from '#features/compute/components/DeleteServiceDialog';
+
+describe('DeleteServiceDialog', () => {
+  it('requires typing the service name before confirming deletion', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(
+      <DeleteServiceDialog
+        open
+        onOpenChange={onOpenChange}
+        serviceName="api-worker"
+        onConfirm={onConfirm}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
+
+    await user.type(screen.getByLabelText(/Type api-worker to confirm/i), 'api-worker');
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(false);
+
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledOnce();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -1,0 +1,84 @@
+import { ColumnType, type ColumnSchema } from '@insforge/shared-schemas';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DATABASE_SCHEMA,
+  buildDatabaseSchemaSearch,
+  buildDynamicSchema,
+  getDatabaseSchemaInfo,
+  getInitialValues,
+  isInsForgeManagedDatabaseSchema,
+  parseDatabaseTableReference,
+} from '#features/database/helpers';
+
+function column(overrides: Partial<ColumnSchema>): ColumnSchema {
+  return {
+    columnName: 'name',
+    type: ColumnType.STRING,
+    isNullable: false,
+    isUnique: false,
+    defaultValue: undefined,
+    ...overrides,
+  };
+}
+
+describe('database helpers', () => {
+  it('detects InsForge-managed schemas', () => {
+    expect(isInsForgeManagedDatabaseSchema('auth')).toBe(true);
+    expect(isInsForgeManagedDatabaseSchema('public')).toBe(false);
+  });
+
+  it('builds schema query strings only for non-default schemas', () => {
+    expect(buildDatabaseSchemaSearch(DEFAULT_DATABASE_SCHEMA)).toBe('');
+    expect(buildDatabaseSchemaSearch('auth')).toBe('?schema=auth');
+  });
+
+  it('parses table references with optional schema names', () => {
+    expect(parseDatabaseTableReference('profiles')).toEqual({
+      schemaName: 'public',
+      tableName: 'profiles',
+    });
+    expect(parseDatabaseTableReference('auth.users')).toEqual({
+      schemaName: 'auth',
+      tableName: 'users',
+    });
+    expect(() => parseDatabaseTableReference('auth.')).toThrow('Invalid table reference "auth."');
+  });
+
+  it('builds initial values from editable columns', () => {
+    expect(
+      getInitialValues([
+        column({ columnName: 'id', type: ColumnType.UUID, defaultValue: 'gen_random_uuid()' }),
+        column({ columnName: 'enabled', type: ColumnType.BOOLEAN }),
+        column({ columnName: 'count', type: ColumnType.INTEGER, defaultValue: '5' }),
+        column({ columnName: 'metadata', type: ColumnType.JSON }),
+      ])
+    ).toEqual({
+      enabled: false,
+      count: 5,
+      metadata: '',
+    });
+  });
+
+  it('builds validation schemas while skipping system fields', () => {
+    const schema = buildDynamicSchema([
+      column({ columnName: 'id', type: ColumnType.UUID }),
+      column({ columnName: 'name', type: ColumnType.STRING, isNullable: false }),
+      column({ columnName: 'age', type: ColumnType.INTEGER, isNullable: true }),
+    ]);
+
+    expect(schema.safeParse({ name: 'Ada', age: null }).success).toBe(true);
+    expect(schema.safeParse({ name: '', age: 1 }).success).toBe(false);
+    expect(schema.safeParse({ id: 'ignored', name: 'Ada', age: 1 }).success).toBe(true);
+  });
+
+  it('falls back schema info for unknown schemas', () => {
+    expect(getDatabaseSchemaInfo(undefined, 'auth')).toEqual({
+      name: 'auth',
+      isProtected: true,
+    });
+    expect(getDatabaseSchemaInfo([{ name: 'custom', isProtected: false }], 'custom')).toEqual({
+      name: 'custom',
+      isProtected: false,
+    });
+  });
+});

--- a/packages/dashboard/src/features/database/components/__tests__/CreateBackupDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/CreateBackupDialog.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CreateBackupDialog } from '#features/database/components/CreateBackupDialog';
+
+describe('CreateBackupDialog', () => {
+  it('creates a backup with a trimmed name and closes on success', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(<CreateBackupDialog open onOpenChange={onOpenChange} onCreate={onCreate} />);
+
+    const input = screen.getByLabelText('Backup Name');
+    await user.clear(input);
+    await user.type(input, ' release backup ');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith('release backup');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/dashboard/src/features/database/components/__tests__/RenameBackupDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/RenameBackupDialog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { RenameBackupDialog } from '#features/database/components/RenameBackupDialog';
+
+describe('RenameBackupDialog', () => {
+  it('saves a trimmed backup name and closes on success', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(
+      <RenameBackupDialog
+        open
+        initialName="old backup"
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+      />
+    );
+
+    const input = screen.getByLabelText('Backup Name');
+    await user.clear(input);
+    await user.type(input, ' new backup ');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('new backup');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/dashboard/src/features/functions/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/functions/__tests__/helpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeHeaders } from '#features/functions/helpers';
+
+describe('normalizeHeaders', () => {
+  it('normalizes object and JSON-string headers to string records', () => {
+    expect(normalizeHeaders({ Accept: 'application/json', Retries: 2 })).toEqual({
+      Accept: 'application/json',
+      Retries: '2',
+    });
+    expect(normalizeHeaders('{"Content-Type":"application/json","Enabled":true}')).toEqual({
+      'Content-Type': 'application/json',
+      Enabled: 'true',
+    });
+  });
+
+  it('returns undefined for null, invalid JSON, and non-object inputs', () => {
+    expect(normalizeHeaders(null)).toBeUndefined();
+    expect(normalizeHeaders('not-json')).toBeUndefined();
+    expect(normalizeHeaders('"string"')).toBeUndefined();
+    expect(normalizeHeaders(42)).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
+++ b/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ChannelFormDialog } from '#features/realtime/components/ChannelFormDialog';
+
+describe('ChannelFormDialog', () => {
+  it('creates a channel and filters empty webhook URLs', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+
+    render(<ChannelFormDialog mode="create" open onOpenChange={vi.fn()} onCreate={onCreate} />);
+
+    await user.type(screen.getByLabelText('Pattern'), 'room:%');
+    await user.type(screen.getByLabelText('Description'), 'Room updates');
+    await user.click(screen.getByRole('button', { name: 'Create Channel' }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith({
+        pattern: 'room:%',
+        enabled: true,
+        description: 'Room updates',
+        webhookUrls: undefined,
+      });
+    });
+  });
+});

--- a/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
+++ b/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { ChannelFormDialog } from '#features/realtime/components/ChannelFormDialog';
+import type { RealtimeChannel } from '@insforge/shared-schemas';
 
 describe('ChannelFormDialog', () => {
   it('creates a channel and filters empty webhook URLs', async () => {
@@ -20,6 +21,56 @@ describe('ChannelFormDialog', () => {
         enabled: true,
         description: 'Room updates',
         webhookUrls: undefined,
+      });
+    });
+  });
+
+  it('saves only changed edit-mode fields', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const channel: RealtimeChannel = {
+      id: '11111111-1111-1111-1111-111111111111',
+      pattern: 'room:%',
+      description: 'Room updates',
+      enabled: true,
+      webhookUrls: ['https://old.example.com/webhook'],
+      createdAt: '2026-05-17T12:00:00.000Z',
+      updatedAt: '2026-05-17T12:00:00.000Z',
+    };
+
+    render(
+      <ChannelFormDialog
+        mode="edit"
+        open
+        channel={channel}
+        onOpenChange={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('room:%')).toBeTruthy();
+      expect(screen.getByDisplayValue('https://old.example.com/webhook')).toBeTruthy();
+    });
+
+    const description = screen.getByLabelText('Description');
+    await user.clear(description);
+    await user.type(description, 'Updated room updates');
+
+    const webhookUrl = screen.getByPlaceholderText(
+      'https://example.com/webhook'
+    ) as HTMLInputElement;
+    await user.clear(webhookUrl);
+    await user.type(webhookUrl, 'https://new.example.com/webhook');
+
+    await user.click(screen.getByRole('switch', { name: 'Enabled' }));
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(channel.id, {
+        description: 'Updated room updates',
+        enabled: false,
+        webhookUrls: ['https://new.example.com/webhook'],
       });
     });
   });

--- a/packages/dashboard/src/features/storage/components/__tests__/BucketFormDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/BucketFormDialog.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BucketFormDialog } from '#features/storage/components/BucketFormDialog';
+
+const bucketMocks = vi.hoisted(() => ({
+  createBucket: vi.fn(),
+  editBucket: vi.fn(),
+}));
+
+vi.mock('#features/storage/hooks/useBuckets', () => ({
+  useBuckets: () => ({
+    createBucket: bucketMocks.createBucket,
+    editBucket: bucketMocks.editBucket,
+    isCreatingBucket: false,
+    isEditingBucket: false,
+  }),
+}));
+
+describe('BucketFormDialog', () => {
+  afterEach(() => {
+    bucketMocks.createBucket.mockReset();
+    bucketMocks.editBucket.mockReset();
+  });
+
+  it('creates a bucket with a trimmed name and closes on success', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn();
+    bucketMocks.createBucket.mockResolvedValue(undefined);
+
+    render(
+      <BucketFormDialog open onOpenChange={onOpenChange} onSuccess={onSuccess} mode="create" />
+    );
+
+    await user.type(screen.getByPlaceholderText('Enter a name'), ' logs ');
+    await user.click(screen.getByRole('button', { name: 'Create Bucket' }));
+
+    await waitFor(() => {
+      expect(bucketMocks.createBucket).toHaveBeenCalledWith({
+        bucketName: 'logs',
+        isPublic: false,
+      });
+      expect(onSuccess).toHaveBeenCalledWith('logs');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/dashboard/src/features/storage/components/__tests__/S3AccessKeyCreateDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/S3AccessKeyCreateDialog.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { S3AccessKeyWithSecretSchema } from '@insforge/shared-schemas';
+import { describe, expect, it, vi } from 'vitest';
+import { S3AccessKeyCreateDialog } from '#features/storage/components/S3AccessKeyCreateDialog';
+
+const createdKey: S3AccessKeyWithSecretSchema = {
+  id: '00000000-0000-4000-8000-000000000001',
+  accessKeyId: 'INSFABCDEF1234567890',
+  description: 'ci uploader',
+  createdAt: '2026-05-17T00:00:00.000Z',
+  lastUsedAt: null,
+  secretAccessKey: 'a'.repeat(40),
+};
+
+describe('S3AccessKeyCreateDialog', () => {
+  it('creates a key, displays the secret, and requires acknowledgement before closing', async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn().mockResolvedValue(createdKey);
+    const onOpenChange = vi.fn();
+
+    render(
+      <S3AccessKeyCreateDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreate={onCreate}
+        isCreating={false}
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText('e.g. backup-script, ci-uploader'),
+      ' ci uploader '
+    );
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith('ci uploader');
+      expect(screen.getByText('S3 Access Key Created')).toBeTruthy();
+      expect(screen.getByDisplayValue(createdKey.accessKeyId)).toBeTruthy();
+    });
+
+    const doneButton = screen.getByRole('button', { name: 'Done' }) as HTMLButtonElement;
+    expect(doneButton.disabled).toBe(true);
+
+    await user.click(screen.getByText('I have saved the Secret Access Key in a safe place.'));
+    expect(doneButton.disabled).toBe(false);
+
+    await user.click(doneButton);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
+++ b/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
@@ -1,0 +1,77 @@
+import { ColumnType } from '@insforge/shared-schemas';
+import { describe, expect, it } from 'vitest';
+import {
+  cn,
+  compareVersions,
+  convertValueForColumn,
+  formatDate,
+  formatTime,
+  formatValueForDisplay,
+  isEmptyValue,
+} from '#lib/utils/utils';
+
+describe('cn', () => {
+  it('merges conditional classes and resolves Tailwind conflicts', () => {
+    expect(cn('px-2', undefined, 'px-4', ['text-sm'])).toBe('px-4 text-sm');
+  });
+});
+
+describe('isEmptyValue', () => {
+  it('only treats null and undefined as empty database values', () => {
+    expect(isEmptyValue(null)).toBe(true);
+    expect(isEmptyValue(undefined)).toBe(true);
+    expect(isEmptyValue('')).toBe(false);
+    expect(isEmptyValue(0)).toBe(false);
+    expect(isEmptyValue(false)).toBe(false);
+  });
+});
+
+describe('compareVersions', () => {
+  it('compares semantic versions with optional v prefix and missing segments', () => {
+    expect(compareVersions('v2.1.0', '2.0.9')).toBe(1);
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1.2.3', '1.10.0')).toBe(-1);
+  });
+});
+
+describe('formatTime', () => {
+  it('formats valid ISO timestamps and preserves invalid input', () => {
+    expect(formatTime('2026-05-17T12:30:00.000Z')).toMatch(/May 17, 2026/);
+    expect(formatTime('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats valid ISO dates and preserves invalid input', () => {
+    expect(formatDate('2026-05-17T12:30:00.000Z')).toBe('May 17, 2026');
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('formatValueForDisplay', () => {
+  it('formats common database display values by column type', () => {
+    expect(formatValueForDisplay(null)).toBe('null');
+    expect(formatValueForDisplay(true, ColumnType.BOOLEAN)).toBe('True');
+    expect(formatValueForDisplay('2026-05-17', ColumnType.DATE)).toBe('May 17, 2026');
+    expect(formatValueForDisplay({ ok: true }, ColumnType.JSON)).toBe('{"ok":true}');
+  });
+
+  it('returns Invalid JSON for malformed JSON strings', () => {
+    expect(formatValueForDisplay('{bad json', ColumnType.JSON)).toBe('Invalid JSON');
+  });
+});
+
+describe('convertValueForColumn', () => {
+  it('converts valid values and reports validation errors', () => {
+    expect(convertValueForColumn(ColumnType.INTEGER, '42')).toEqual({ success: true, value: 42 });
+    expect(convertValueForColumn(ColumnType.BOOLEAN, 'true')).toEqual({
+      success: true,
+      value: true,
+    });
+    expect(convertValueForColumn('unsupported', 'x')).toEqual({
+      success: false,
+      error: 'Unsupported column type: unsupported',
+    });
+    expect(convertValueForColumn(ColumnType.INTEGER, 'not-number').success).toBe(false);
+  });
+});

--- a/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
+++ b/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
@@ -36,14 +36,14 @@ describe('compareVersions', () => {
 
 describe('formatTime', () => {
   it('formats valid ISO timestamps and preserves invalid input', () => {
-    expect(formatTime('2026-05-17T12:30:00.000Z')).toMatch(/May 17, 2026/);
+    expect(formatTime('2026-05-17T12:30:00')).toBe('May 17, 2026, 12:30 PM');
     expect(formatTime('not-a-date')).toBe('not-a-date');
   });
 });
 
 describe('formatDate', () => {
   it('formats valid ISO dates and preserves invalid input', () => {
-    expect(formatDate('2026-05-17T12:30:00.000Z')).toBe('May 17, 2026');
+    expect(formatDate('2026-05-17T12:30:00')).toBe('May 17, 2026');
     expect(formatDate('not-a-date')).toBe('not-a-date');
   });
 });

--- a/packages/dashboard/vitest.component.config.ts
+++ b/packages/dashboard/vitest.component.config.ts
@@ -6,7 +6,9 @@ export default mergeConfig(
   sharedConfig,
   defineConfig({
     test: {
+      environment: 'jsdom',
       include: ['src/**/*.test.tsx'],
+      setupFiles: ['./src/test/setup.ts'],
     },
   })
 );

--- a/packages/dashboard/vitest.component.config.ts
+++ b/packages/dashboard/vitest.component.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   sharedConfig,
   defineConfig({
     test: {
+      name: 'component',
       environment: 'jsdom',
       include: ['src/**/*.test.tsx'],
       setupFiles: ['./src/test/setup.ts'],

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -6,7 +6,9 @@ export default mergeConfig(
   sharedConfig,
   defineConfig({
     test: {
+      environment: 'jsdom',
       include: ['src/**/*.test.{ts,tsx}'],
+      setupFiles: ['./src/test/setup.ts'],
     },
   })
 );

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -1,14 +1,7 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
-import sharedConfig from './vitest.shared.config';
-
-export default mergeConfig(
-  sharedConfig,
-  defineConfig({
-    test: {
-      environment: 'jsdom',
-      include: ['src/**/*.test.{ts,tsx}'],
-      setupFiles: ['./src/test/setup.ts'],
-    },
-  })
-);
+export default defineConfig({
+  test: {
+    projects: ['./vitest.unit.config.ts', './vitest.component.config.ts'],
+  },
+});

--- a/packages/dashboard/vitest.shared.config.ts
+++ b/packages/dashboard/vitest.shared.config.ts
@@ -21,8 +21,4 @@ export default defineConfig({
       '@insforge/ui': path.resolve(currentDir, '../ui/src'),
     },
   },
-  test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-  },
 });

--- a/packages/dashboard/vitest.unit.config.ts
+++ b/packages/dashboard/vitest.unit.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   sharedConfig,
   defineConfig({
     test: {
+      name: 'unit',
       environment: 'node',
       include: ['src/**/*.test.ts'],
     },

--- a/packages/dashboard/vitest.unit.config.ts
+++ b/packages/dashboard/vitest.unit.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   sharedConfig,
   defineConfig({
     test: {
+      environment: 'node',
       include: ['src/**/*.test.ts'],
     },
   })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && cp src/styles.css dist/styles.css",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:component": "vitest run --config vitest.component.config.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint ."
   },
@@ -72,5 +75,11 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "^4.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.6"
   }
 }

--- a/packages/ui/src/components/__tests__/Button.test.tsx
+++ b/packages/ui/src/components/__tests__/Button.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Button } from '../Button';
+import { Button } from '@insforge/ui';
 
 describe('Button', () => {
   it('renders a styled button with forwarded native attributes', () => {

--- a/packages/ui/src/components/__tests__/Button.test.tsx
+++ b/packages/ui/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../Button';
+
+describe('Button', () => {
+  it('renders a styled button with forwarded native attributes', () => {
+    render(
+      <Button type="submit" variant="secondary" size="lg" disabled className="custom-button">
+        Save
+      </Button>
+    );
+
+    const button = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    expect(button.type).toBe('submit');
+    expect(button.disabled).toBe(true);
+    expect(button.className).toContain('custom-button');
+    expect(button.className).toContain('bg-card');
+    expect(button.className).toContain('h-9');
+  });
+
+  it('renders the child element when asChild is enabled', () => {
+    render(
+      <Button asChild>
+        <a href="/docs">Docs</a>
+      </Button>
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' }) as HTMLAnchorElement;
+    expect(link.href).toContain('/docs');
+    expect(link.className).toContain('inline-flex');
+  });
+});

--- a/packages/ui/src/components/__tests__/Input.test.tsx
+++ b/packages/ui/src/components/__tests__/Input.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Input } from '../Input';
+
+describe('Input', () => {
+  it('forwards input props and change events', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<Input aria-label="Project name" placeholder="Name" onChange={onChange} />);
+
+    const input = screen.getByRole('textbox', { name: 'Project name' }) as HTMLInputElement;
+    expect(input.placeholder).toBe('Name');
+
+    await user.type(input, 'demo');
+
+    expect(input.value).toBe('demo');
+    expect(onChange).toHaveBeenCalledTimes(4);
+  });
+
+  it('supports disabled state and custom classes', () => {
+    render(<Input aria-label="Disabled input" disabled className="custom-input" />);
+
+    const input = screen.getByRole('textbox', { name: 'Disabled input' }) as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    expect(input.className).toContain('custom-input');
+  });
+});

--- a/packages/ui/src/components/__tests__/Input.test.tsx
+++ b/packages/ui/src/components/__tests__/Input.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Input } from '../Input';
+import { Input } from '@insforge/ui';
 
 describe('Input', () => {
   it('forwards input props and change events', async () => {

--- a/packages/ui/src/components/__tests__/SearchInput.test.tsx
+++ b/packages/ui/src/components/__tests__/SearchInput.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SearchInput } from '../SearchInput';
+
+describe('SearchInput', () => {
+  it('emits immediate and committed changes when debounce is disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onImmediateChange = vi.fn();
+
+    render(
+      <SearchInput
+        value=""
+        onChange={onChange}
+        onImmediateChange={onImmediateChange}
+        debounceTime={0}
+        placeholder="Search projects"
+      />
+    );
+
+    await user.type(screen.getByRole('textbox'), 'api');
+
+    expect(onImmediateChange).toHaveBeenLastCalledWith('api');
+    expect(onChange).toHaveBeenLastCalledWith('api');
+  });
+
+  it('clears the current value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onImmediateChange = vi.fn();
+
+    render(
+      <SearchInput
+        value="api"
+        onChange={onChange}
+        onImmediateChange={onImmediateChange}
+        debounceTime={0}
+      />
+    );
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('api');
+
+    await user.click(screen.getByRole('button'));
+
+    expect(input.value).toBe('');
+    expect(onImmediateChange).toHaveBeenLastCalledWith('');
+    expect(onChange).toHaveBeenLastCalledWith('');
+  });
+});

--- a/packages/ui/src/components/__tests__/SearchInput.test.tsx
+++ b/packages/ui/src/components/__tests__/SearchInput.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { SearchInput } from '../SearchInput';
+import { SearchInput } from '@insforge/ui';
 
 describe('SearchInput', () => {
   it('emits immediate and committed changes when debounce is disabled', async () => {

--- a/packages/ui/src/lib/__tests__/utils.test.ts
+++ b/packages/ui/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cn } from '../utils';
+import { cn } from '@insforge/ui';
 
 describe('cn', () => {
   it('merges conditional classes and resolves Tailwind conflicts', () => {

--- a/packages/ui/src/lib/__tests__/utils.test.ts
+++ b/packages/ui/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn', () => {
+  it('merges conditional classes and resolves Tailwind conflicts', () => {
+    expect(cn('px-2', undefined, false, ['text-sm'], 'px-4')).toBe('text-sm px-4');
+  });
+});

--- a/packages/ui/src/test/setup.ts
+++ b/packages/ui/src/test/setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -8,5 +8,5 @@
     "outDir": "dist",
     "allowImportingTsExtensions": false
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/test", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/ui/vitest.component.config.ts
+++ b/packages/ui/vitest.component.config.ts
@@ -1,10 +1,15 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
-export default defineConfig({
-  test: {
-    name: 'component',
-    environment: 'jsdom',
-    include: ['src/**/*.test.tsx'],
-    setupFiles: ['./src/test/setup.ts'],
-  },
-});
+import sharedConfig from './vitest.shared.config';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: 'component',
+      environment: 'jsdom',
+      include: ['src/**/*.test.tsx'],
+      setupFiles: ['./src/test/setup.ts'],
+    },
+  })
+);

--- a/packages/ui/vitest.component.config.ts
+++ b/packages/ui/vitest.component.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'component',
+    environment: 'jsdom',
+    include: ['src/**/*.test.tsx'],
+    setupFiles: ['./src/test/setup.ts'],
+  },
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: ['./vitest.unit.config.ts', './vitest.component.config.ts'],
+  },
+});

--- a/packages/ui/vitest.shared.config.ts
+++ b/packages/ui/vitest.shared.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@insforge/ui': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+    },
+  },
+});

--- a/packages/ui/vitest.unit.config.ts
+++ b/packages/ui/vitest.unit.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/ui/vitest.unit.config.ts
+++ b/packages/ui/vitest.unit.config.ts
@@ -1,9 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
 
-export default defineConfig({
-  test: {
-    name: 'unit',
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-  },
-});
+import sharedConfig from './vitest.shared.config';
+
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      name: 'unit',
+      environment: 'node',
+      include: ['src/**/*.test.ts'],
+    },
+  })
+);


### PR DESCRIPTION
## Summary

Add more tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit and component tests across the dashboard and `@insforge/ui` to improve coverage for analytics, helpers, dialogs, storage, realtime channels, core utils, and UI components. Split `vitest` configs per package and update CI to run separate UI tests and gate dashboard E2E on all test jobs.

- **Refactors**
  - Split `vitest` into named projects for dashboard and `@insforge/ui`: unit uses `node`; component uses `jsdom` with package-local `src/test/setup.ts`.
  - Moved `jsdom` env and `setupFiles` out of shared configs into component configs; added project names.
  - Added `@insforge/ui` test scripts and excluded tests from build; CI runs `ui-unit-tests` and `ui-component-tests`, and gates `dashboard-e2e-tests` on all unit/component jobs.

- **Dependencies**
  - `@insforge/ui` dev deps: `vitest`, `jsdom`, `@testing-library/react`, `@testing-library/user-event`.

<sup>Written for commit 6eb646051e00e393551fd913a85a30d1a08bf49c. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit and component tests for dashboard features and split vitest configs by environment
> - Adds test suites across analytics formatting helpers, database helpers, utility functions, and several dialog components (`DeleteServiceDialog`, `CreateBackupDialog`, `RenameBackupDialog`, `BucketFormDialog`, `S3AccessKeyCreateDialog`, `ChannelFormDialog`).
> - Moves `jsdom` environment and `setupFiles` config out of [vitest.shared.config.ts](https://github.com/InsForge/InsForge/pull/1289/files#diff-d47b532737d460b282b4788d1ffc42f55ec472c8d7247698950f5e6cf64d377b) into individual config files, setting unit tests to `node` environment and component/general tests to `jsdom`.
> - Behavioral Change: unit tests now run in a pure Node environment rather than jsdom; any unit test relying on browser globals will fail.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1289 opened
>
> - Restructured the vitest configuration to use a projects-based approach [b0f1e94]
> - Added name fields to vitest unit and component test configurations [b0f1e94]
> - Updated test assertions for time and date formatting utilities to use exact string matching [b0f1e94]
> - Added test infrastructure with `vitest`, `@testing-library/react`, `@testing-library/user-event`, and `jsdom` as devDependencies to the `@insforge/ui` package, configured separate `vitest.unit.config.ts` and `vitest.component.config.ts` projects using `node` and `jsdom` environments respectively, created test setup running `cleanup()` via `afterEach` hook, added `test`, `test:unit`, and `test:component` npm scripts, excluded test files from build via `tsconfig.build.json`, and integrated `ui-unit-tests` and `ui-component-tests` jobs into GitHub Actions workflow running workspace-scoped vitest commands on `ubuntu-latest` with Node.js v20 [416986c]
> - Added component tests for `Button` component verifying native attribute forwarding including `type`, `disabled`, and `className`, class application based on variant and size props, and `asChild` prop rendering child anchor elements with expected role, href, and classes [416986c]
> - Added component tests for `Input` component asserting placeholder attribute passthrough, value updates and `onChange` handler invocation per keystroke during typing, disabled state support, and custom className application [416986c]
> - Added component tests for `SearchInput` component covering immediate and committed change callbacks when `debounceTime` equals zero, and clear button functionality that resets input value and invokes callbacks with empty string [416986c]
> - Added unit test for `cn` utility function validating conditional class merging and Tailwind CSS conflict resolution, expecting output `text-sm px-4` from mixed input classes [416986c]
> - Renamed dashboard E2E tests job in CI workflow and added job dependencies [6eb6460]
> - Created shared Vitest configuration with package alias resolution [6eb6460]
> - Updated test file imports to use package alias [6eb6460]
> - Added test case for partial field updates in ChannelFormDialog [6eb6460]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ed78f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad Vitest + React Testing Library coverage for analytics formatting, database helpers, function headers, realtime channels, storage dialogs/flows, backup dialogs, delete/rename dialogs, S3 access key flow, UI components (Button, Input, SearchInput), utilities, and centralized test setup/cleanup.

* **Chores**
  * Split test configs into explicit unit/component projects, added test scripts and dev-dependencies, excluded test files from builds, and updated CI to run separate unit and component UI test jobs before E2E.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->