### PR TITLE
feat(auth): queue email delivery jobs

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -36,6 +36,7 @@ import { seedBackend } from '@/utils/seed.js';
 import logger from '@/utils/logger.js';
 import { initSqlParser } from '@/utils/sql-parser.js';
 import { FunctionService } from '@/services/functions/function.service.js';
+import { JobQueue } from '@/services/job-queue.service.js';
 import packageJson from '../../package.json';
 import { schedulesRouter } from '@/api/routes/schedules/index.routes.js';
 import { servicesRouter } from '@/api/routes/compute/services.routes.js';
@@ -356,6 +357,14 @@ void initializeServer();
 
 async function cleanup() {
   logger.info('Shutting down gracefully...');
+
+  try {
+    await JobQueue.drainExisting(5_000);
+  } catch (error) {
+    logger.error('Error draining JobQueue', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   try {
     const realtimeManager = RealtimeManager.getInstance();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import type { Server } from 'http';
 import authRouter from '@/api/routes/auth/index.routes.js';
 import databaseRouter from '@/api/routes/database/index.routes.js';
 import { storageRouter } from '@/api/routes/storage/index.routes.js';
@@ -43,6 +44,7 @@ import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+let httpServer: Server | undefined;
 
 function shouldSkipGlobalRateLimit(req: Request): boolean {
   if (req.path === '/api/health') {
@@ -328,6 +330,7 @@ async function initializeServer() {
     const server = app.listen(PORT, () => {
       logger.info(`Backend API service listening on port ${PORT}`);
     });
+    httpServer = server;
 
     // Initialize Socket.IO service
     const socketService = SocketManager.getInstance();
@@ -355,8 +358,41 @@ async function initializeServer() {
 
 void initializeServer();
 
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 async function cleanup() {
   logger.info('Shutting down gracefully...');
+
+  try {
+    const socketService = SocketManager.getInstance();
+    socketService.close();
+  } catch (error) {
+    logger.error('Error closing SocketManager', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    if (httpServer) {
+      logger.info('Stopping HTTP server before draining background jobs...');
+      await closeServer(httpServer);
+      httpServer = undefined;
+    }
+  } catch (error) {
+    logger.error('Error closing HTTP server', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   try {
     await JobQueue.drainExisting(5_000);
@@ -371,15 +407,6 @@ async function cleanup() {
     await realtimeManager.close();
   } catch (error) {
     logger.error('Error closing RealtimeManager', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  try {
-    const socketService = SocketManager.getInstance();
-    socketService.close();
-  } catch (error) {
-    logger.error('Error closing SocketManager', {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/backend/src/services/auth/auth-otp.service.ts
+++ b/backend/src/services/auth/auth-otp.service.ts
@@ -160,6 +160,33 @@ export class AuthOTPService {
   }
 
   /**
+   * Delete an active email OTP for a purpose.
+   *
+   * Background auth-email jobs use this when delivery permanently fails so the
+   * database does not retain a code or link token that was never successfully
+   * delivered to the user.
+   */
+  async deleteEmailOTP(email: string, purpose: OTPPurpose, expiresAt?: Date): Promise<void> {
+    try {
+      if (expiresAt) {
+        await this.getPool().query(
+          'DELETE FROM auth.email_otps WHERE email = $1 AND purpose = $2 AND expires_at = $3',
+          [email, purpose, expiresAt]
+        );
+      } else {
+        await this.getPool().query(
+          'DELETE FROM auth.email_otps WHERE email = $1 AND purpose = $2',
+          [email, purpose]
+        );
+      }
+      logger.info('Deleted undelivered email verification token', { purpose });
+    } catch (error) {
+      logger.error('Failed to delete email verification token', { error, purpose });
+      throw new AppError('Failed to delete verification token', 500, ERROR_CODES.INTERNAL_ERROR);
+    }
+  }
+
+  /**
    * Verify a numeric OTP code (6 digits)
    * Looks up by email and verifies the bcrypt-hashed code
    *

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -50,6 +50,13 @@ import {
   type VerifyEmailResponse,
 } from '@insforge/shared-schemas';
 
+interface AuthEmailTemplateVariables {
+  variables: Record<string, string>;
+  expiresAt: Date;
+}
+
+type AuthEmailTemplateVariablesFactory = () => Promise<AuthEmailTemplateVariables>;
+
 /**
  * Simplified JWT-based auth service
  * Handles all authentication operations including OAuth
@@ -123,29 +130,44 @@ export class AuthService {
   }
 
   /**
-   * Queue provider delivery after the OTP/token has been created.
+   * Queue auth email delivery and create the OTP/token inside the job.
    *
-   * Keeping token generation synchronous preserves existing auth semantics and
-   * user-enumeration protections, while moving the slow SMTP/provider call off
-   * the request path with retries.
+   * This avoids creating an active auth token before a non-durable in-memory job
+   * is accepted for execution. If delivery permanently fails after retries, the
+   * job cleanup deletes the current token for that email/purpose so users are
+   * not left with an undelivered code or link.
    */
   private enqueueEmailTemplateDelivery(
     email: string,
     name: string,
     template: EmailTemplate,
-    variables: Record<string, string>
+    purpose: OTPPurpose,
+    createVariables: AuthEmailTemplateVariablesFactory
   ): void {
+    let preparedVariables: Record<string, string> | undefined;
+    let preparedExpiresAt: Date | undefined;
+
     const jobId = JobQueue.getInstance().enqueue(
       'email',
-      { email, template },
+      { email, template, purpose },
       async () => {
         const emailService = EmailService.getInstance();
-        await emailService.sendWithTemplate(email, name, template, variables);
+        if (!preparedVariables) {
+          const prepared = await createVariables();
+          preparedVariables = prepared.variables;
+          preparedExpiresAt = prepared.expiresAt;
+        }
+        await emailService.sendWithTemplate(email, name, template, preparedVariables);
       },
       {
         priority: 'high',
         maxAttempts: 3,
         retryDelayMs: 1_000,
+        onPermanentFailure: async () => {
+          if (preparedExpiresAt) {
+            await AuthOTPService.getInstance().deleteEmailOTP(email, purpose, preparedExpiresAt);
+          }
+        },
       }
     );
 
@@ -352,18 +374,21 @@ export class AuthService {
       return;
     }
 
-    // Create numeric OTP code using the OTP service
-    const otpService = AuthOTPService.getInstance();
-    const { otp: code } = await otpService.createEmailOTP(
-      email,
-      OTPPurpose.VERIFY_EMAIL,
-      OTPType.NUMERIC_CODE
-    );
-
     const userName = dbUser.profile?.name || 'User';
-    this.enqueueEmailTemplateDelivery(email, userName, 'email-verification-code', {
-      token: code,
-    });
+    this.enqueueEmailTemplateDelivery(
+      email,
+      userName,
+      'email-verification-code',
+      OTPPurpose.VERIFY_EMAIL,
+      async () => {
+        const { otp: code, expiresAt } = await AuthOTPService.getInstance().createEmailOTP(
+          email,
+          OTPPurpose.VERIFY_EMAIL,
+          OTPType.NUMERIC_CODE
+        );
+        return { variables: { token: code }, expiresAt };
+      }
+    );
   }
 
   /**
@@ -383,21 +408,26 @@ export class AuthService {
       return;
     }
 
-    // Create long cryptographic token for clickable verification link
-    const otpService = AuthOTPService.getInstance();
-    const { otp: token } = await otpService.createEmailOTP(
-      email,
-      OTPPurpose.VERIFY_EMAIL,
-      OTPType.HASH_TOKEN,
-      { redirectTo }
-    );
-
-    const linkUrl = this.buildEmailLink('/api/auth/email/verify-link', token);
-
     const userName = dbUser.profile?.name || 'User';
-    this.enqueueEmailTemplateDelivery(email, userName, 'email-verification-link', {
-      link: linkUrl,
-    });
+    this.enqueueEmailTemplateDelivery(
+      email,
+      userName,
+      'email-verification-link',
+      OTPPurpose.VERIFY_EMAIL,
+      async () => {
+        const { otp: token, expiresAt } = await AuthOTPService.getInstance().createEmailOTP(
+          email,
+          OTPPurpose.VERIFY_EMAIL,
+          OTPType.HASH_TOKEN,
+          { redirectTo }
+        );
+
+        return {
+          variables: { link: this.buildEmailLink('/api/auth/email/verify-link', token) },
+          expiresAt,
+        };
+      }
+    );
   }
 
   /**
@@ -537,18 +567,21 @@ export class AuthService {
       return;
     }
 
-    // Create numeric OTP code using the OTP service
-    const otpService = AuthOTPService.getInstance();
-    const { otp: code } = await otpService.createEmailOTP(
-      email,
-      OTPPurpose.RESET_PASSWORD,
-      OTPType.NUMERIC_CODE
-    );
-
     const userName = dbUser.profile?.name || 'User';
-    this.enqueueEmailTemplateDelivery(email, userName, 'reset-password-code', {
-      token: code,
-    });
+    this.enqueueEmailTemplateDelivery(
+      email,
+      userName,
+      'reset-password-code',
+      OTPPurpose.RESET_PASSWORD,
+      async () => {
+        const { otp: code, expiresAt } = await AuthOTPService.getInstance().createEmailOTP(
+          email,
+          OTPPurpose.RESET_PASSWORD,
+          OTPType.NUMERIC_CODE
+        );
+        return { variables: { token: code }, expiresAt };
+      }
+    );
   }
 
   /**
@@ -567,21 +600,26 @@ export class AuthService {
       return;
     }
 
-    // Create long cryptographic token for clickable reset link
-    const otpService = AuthOTPService.getInstance();
-    const { otp: token } = await otpService.createEmailOTP(
-      email,
-      OTPPurpose.RESET_PASSWORD,
-      OTPType.HASH_TOKEN,
-      { redirectTo }
-    );
-
-    const linkUrl = this.buildEmailLink('/api/auth/email/reset-password-link', token);
-
     const userName = dbUser.profile?.name || 'User';
-    this.enqueueEmailTemplateDelivery(email, userName, 'reset-password-link', {
-      link: linkUrl,
-    });
+    this.enqueueEmailTemplateDelivery(
+      email,
+      userName,
+      'reset-password-link',
+      OTPPurpose.RESET_PASSWORD,
+      async () => {
+        const { otp: token, expiresAt } = await AuthOTPService.getInstance().createEmailOTP(
+          email,
+          OTPPurpose.RESET_PASSWORD,
+          OTPType.HASH_TOKEN,
+          { redirectTo }
+        );
+
+        return {
+          variables: { link: this.buildEmailLink('/api/auth/email/reset-password-link', token) },
+          expiresAt,
+        };
+      }
+    );
   }
 
   /**

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -149,9 +149,8 @@ export class AuthService {
       }
     );
 
-    logger.info('Queued auth email delivery', {
+    logger.debug('Queued auth email delivery', {
       jobId,
-      email,
       template,
     });
   }

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -32,9 +32,11 @@ import {
 import { ADMIN_ID } from '@/utils/constants.js';
 import { AppError } from '@/utils/errors.js';
 import { EmailService } from '@/services/email/email.service.js';
+import { JobQueue } from '@/services/job-queue.service.js';
 import { XOAuthProvider } from '@/providers/oauth/x.provider.js';
 import { AppleOAuthProvider } from '@/providers/oauth/apple.provider.js';
 import { getApiBaseUrl } from '@/utils/environment.js';
+import type { EmailTemplate } from '@/types/email.js';
 import {
   ERROR_CODES,
   type AuthMetadataSchema,
@@ -118,6 +120,40 @@ export class AuthService {
     const url = new URL(pathname, getApiBaseUrl());
     url.searchParams.set('token', token);
     return url.toString();
+  }
+
+  /**
+   * Queue provider delivery after the OTP/token has been created.
+   *
+   * Keeping token generation synchronous preserves existing auth semantics and
+   * user-enumeration protections, while moving the slow SMTP/provider call off
+   * the request path with retries.
+   */
+  private enqueueEmailTemplateDelivery(
+    email: string,
+    name: string,
+    template: EmailTemplate,
+    variables: Record<string, string>
+  ): void {
+    const jobId = JobQueue.getInstance().enqueue(
+      'email',
+      { email, template },
+      async () => {
+        const emailService = EmailService.getInstance();
+        await emailService.sendWithTemplate(email, name, template, variables);
+      },
+      {
+        priority: 'high',
+        maxAttempts: 3,
+        retryDelayMs: 1_000,
+      }
+    );
+
+    logger.info('Queued auth email delivery', {
+      jobId,
+      email,
+      template,
+    });
   }
 
   /**
@@ -325,10 +361,8 @@ export class AuthService {
       OTPType.NUMERIC_CODE
     );
 
-    // Send email with verification code
-    const emailService = EmailService.getInstance();
     const userName = dbUser.profile?.name || 'User';
-    await emailService.sendWithTemplate(email, userName, 'email-verification-code', {
+    this.enqueueEmailTemplateDelivery(email, userName, 'email-verification-code', {
       token: code,
     });
   }
@@ -361,10 +395,8 @@ export class AuthService {
 
     const linkUrl = this.buildEmailLink('/api/auth/email/verify-link', token);
 
-    // Send email with verification link
-    const emailService = EmailService.getInstance();
     const userName = dbUser.profile?.name || 'User';
-    await emailService.sendWithTemplate(email, userName, 'email-verification-link', {
+    this.enqueueEmailTemplateDelivery(email, userName, 'email-verification-link', {
       link: linkUrl,
     });
   }
@@ -514,10 +546,8 @@ export class AuthService {
       OTPType.NUMERIC_CODE
     );
 
-    // Send email with reset password code
-    const emailService = EmailService.getInstance();
     const userName = dbUser.profile?.name || 'User';
-    await emailService.sendWithTemplate(email, userName, 'reset-password-code', {
+    this.enqueueEmailTemplateDelivery(email, userName, 'reset-password-code', {
       token: code,
     });
   }
@@ -549,10 +579,8 @@ export class AuthService {
 
     const linkUrl = this.buildEmailLink('/api/auth/email/reset-password-link', token);
 
-    // Send email with password reset link
-    const emailService = EmailService.getInstance();
     const userName = dbUser.profile?.name || 'User';
-    await emailService.sendWithTemplate(email, userName, 'reset-password-link', {
+    this.enqueueEmailTemplateDelivery(email, userName, 'reset-password-link', {
       link: linkUrl,
     });
   }

--- a/backend/src/services/job-queue.service.ts
+++ b/backend/src/services/job-queue.service.ts
@@ -9,6 +9,7 @@ export interface EnqueueJobOptions {
   maxAttempts?: number;
   retryDelayMs?: number;
   retryBackoffMultiplier?: number;
+  onPermanentFailure?: (error: Error) => Promise<void> | void;
 }
 
 export interface JobSnapshot<TPayload = unknown> {
@@ -32,6 +33,7 @@ interface QueuedJob<TPayload = unknown> extends JobSnapshot<TPayload> {
   handler: JobHandler;
   retryDelayMs: number;
   retryBackoffMultiplier: number;
+  onPermanentFailure?: (error: Error) => Promise<void> | void;
   sequence: number;
 }
 
@@ -101,6 +103,7 @@ export class JobQueue {
       maxAttempts: Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS),
       retryDelayMs: Math.max(0, options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS),
       retryBackoffMultiplier: Math.max(1, options.retryBackoffMultiplier ?? 2),
+      onPermanentFailure: options.onPermanentFailure,
       createdAt: now,
       updatedAt: now,
       runAt: now,
@@ -280,6 +283,18 @@ export class JobQueue {
           error: message,
         });
       } else {
+        if (job.onPermanentFailure) {
+          try {
+            await job.onPermanentFailure(error instanceof Error ? error : new Error(message));
+          } catch (cleanupError) {
+            logger.error('Background job permanent-failure cleanup failed', {
+              jobId: job.id,
+              type: job.type,
+              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            });
+          }
+        }
+
         job.status = 'failed';
         this.recordHistory(job);
         logger.error('Background job failed permanently', {
@@ -300,6 +315,7 @@ export class JobQueue {
       handler: _handler,
       retryDelayMs: _retryDelayMs,
       retryBackoffMultiplier: _retryBackoffMultiplier,
+      onPermanentFailure: _onPermanentFailure,
       sequence: _sequence,
       payload: _payload,
       ...snapshot

--- a/backend/src/services/job-queue.service.ts
+++ b/backend/src/services/job-queue.service.ts
@@ -14,7 +14,7 @@ export interface EnqueueJobOptions {
 export interface JobSnapshot<TPayload = unknown> {
   id: string;
   type: string;
-  payload: TPayload;
+  payload?: TPayload;
   priority: JobPriority;
   status: JobStatus;
   attempts: number;
@@ -28,6 +28,7 @@ export interface JobSnapshot<TPayload = unknown> {
 type JobHandler = () => Promise<void> | void;
 
 interface QueuedJob<TPayload = unknown> extends JobSnapshot<TPayload> {
+  payload: TPayload;
   handler: JobHandler;
   retryDelayMs: number;
   retryBackoffMultiplier: number;
@@ -54,11 +55,14 @@ export class JobQueue {
   private running = 0;
   private sequence = 0;
   private processScheduled = false;
+  private delayedProcessTimer: NodeJS.Timeout | undefined;
+  private delayedProcessAt: number | undefined;
 
-  private constructor(
-    concurrency = readPositiveInteger(process.env.JOB_QUEUE_CONCURRENCY, DEFAULT_CONCURRENCY)
-  ) {
-    this.concurrency = concurrency;
+  private constructor(concurrency?: number) {
+    this.concurrency =
+      concurrency === undefined
+        ? readPositiveInteger(process.env.JOB_QUEUE_CONCURRENCY, DEFAULT_CONCURRENCY)
+        : normalizePositiveInteger(concurrency, DEFAULT_CONCURRENCY);
   }
 
   public static getInstance(options?: { concurrency?: number }): JobQueue {
@@ -71,6 +75,12 @@ export class JobQueue {
   public static resetForTests(): void {
     JobQueue.instance?.clear();
     JobQueue.instance = undefined;
+  }
+
+  public static async drainExisting(timeoutMs = 5_000): Promise<void> {
+    if (JobQueue.instance) {
+      await JobQueue.instance.drain(timeoutMs);
+    }
   }
 
   public enqueue<TPayload>(
@@ -133,7 +143,12 @@ export class JobQueue {
   public async drain(timeoutMs = 5_000): Promise<void> {
     const start = Date.now();
 
-    while (this.queue.length > 0 || this.running > 0 || this.processScheduled) {
+    while (
+      this.queue.length > 0 ||
+      this.running > 0 ||
+      this.processScheduled ||
+      this.delayedProcessTimer
+    ) {
       if (Date.now() - start > timeoutMs) {
         throw new Error('Timed out waiting for background job queue to drain');
       }
@@ -142,9 +157,14 @@ export class JobQueue {
   }
 
   public clear(): void {
+    if (this.delayedProcessTimer) {
+      clearTimeout(this.delayedProcessTimer);
+      this.delayedProcessTimer = undefined;
+      this.delayedProcessAt = undefined;
+    }
+
     this.queue = [];
     this.history = [];
-    this.running = 0;
     this.sequence = 0;
     this.processScheduled = false;
   }
@@ -163,8 +183,22 @@ export class JobQueue {
       return;
     }
 
-    const timer = setTimeout(() => this.process(), delayMs);
-    timer.unref?.();
+    const runAt = Date.now() + delayMs;
+    if (this.delayedProcessAt !== undefined && this.delayedProcessAt <= runAt) {
+      return;
+    }
+
+    if (this.delayedProcessTimer) {
+      clearTimeout(this.delayedProcessTimer);
+    }
+
+    this.delayedProcessAt = runAt;
+    this.delayedProcessTimer = setTimeout(() => {
+      this.delayedProcessTimer = undefined;
+      this.delayedProcessAt = undefined;
+      this.process();
+    }, delayMs);
+    this.delayedProcessTimer.unref?.();
   }
 
   private process(): void {
@@ -267,6 +301,7 @@ export class JobQueue {
       retryDelayMs: _retryDelayMs,
       retryBackoffMultiplier: _retryBackoffMultiplier,
       sequence: _sequence,
+      payload: _payload,
       ...snapshot
     } = job;
     this.history.push(snapshot);
@@ -305,5 +340,9 @@ function readPositiveInteger(rawValue: string | undefined, fallback: number): nu
   }
 
   const parsed = Number(rawValue);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+  return normalizePositiveInteger(parsed, fallback);
+}
+
+function normalizePositiveInteger(value: number, fallback: number): number {
+  return Number.isInteger(value) && value > 0 ? value : fallback;
 }

--- a/backend/src/services/job-queue.service.ts
+++ b/backend/src/services/job-queue.service.ts
@@ -1,0 +1,309 @@
+import crypto from 'crypto';
+import logger from '@/utils/logger.js';
+
+export type JobPriority = 'high' | 'normal' | 'low';
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'retrying';
+
+export interface EnqueueJobOptions {
+  priority?: JobPriority;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  retryBackoffMultiplier?: number;
+}
+
+export interface JobSnapshot<TPayload = unknown> {
+  id: string;
+  type: string;
+  payload: TPayload;
+  priority: JobPriority;
+  status: JobStatus;
+  attempts: number;
+  maxAttempts: number;
+  createdAt: Date;
+  updatedAt: Date;
+  runAt: Date;
+  lastError?: string;
+}
+
+type JobHandler = () => Promise<void> | void;
+
+interface QueuedJob<TPayload = unknown> extends JobSnapshot<TPayload> {
+  handler: JobHandler;
+  retryDelayMs: number;
+  retryBackoffMultiplier: number;
+  sequence: number;
+}
+
+const PRIORITY_RANK: Record<JobPriority, number> = {
+  high: 0,
+  normal: 1,
+  low: 2,
+};
+
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_CONCURRENCY = 2;
+const MAX_HISTORY = 100;
+
+export class JobQueue {
+  private static instance: JobQueue | undefined;
+
+  private readonly concurrency: number;
+  private queue: QueuedJob[] = [];
+  private history: JobSnapshot[] = [];
+  private running = 0;
+  private sequence = 0;
+  private processScheduled = false;
+
+  private constructor(
+    concurrency = readPositiveInteger(process.env.JOB_QUEUE_CONCURRENCY, DEFAULT_CONCURRENCY)
+  ) {
+    this.concurrency = concurrency;
+  }
+
+  public static getInstance(options?: { concurrency?: number }): JobQueue {
+    if (!JobQueue.instance) {
+      JobQueue.instance = new JobQueue(options?.concurrency);
+    }
+    return JobQueue.instance;
+  }
+
+  public static resetForTests(): void {
+    JobQueue.instance?.clear();
+    JobQueue.instance = undefined;
+  }
+
+  public enqueue<TPayload>(
+    type: string,
+    payload: TPayload,
+    handler: JobHandler,
+    options: EnqueueJobOptions = {}
+  ): string {
+    const now = new Date();
+    const job: QueuedJob<TPayload> = {
+      id: crypto.randomUUID(),
+      type,
+      payload,
+      handler,
+      priority: options.priority ?? 'normal',
+      status: 'queued',
+      attempts: 0,
+      maxAttempts: Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS),
+      retryDelayMs: Math.max(0, options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS),
+      retryBackoffMultiplier: Math.max(1, options.retryBackoffMultiplier ?? 2),
+      createdAt: now,
+      updatedAt: now,
+      runAt: now,
+      sequence: this.sequence++,
+    };
+
+    this.queue.push(job);
+    logger.debug('Background job queued', {
+      jobId: job.id,
+      type: job.type,
+      priority: job.priority,
+      maxAttempts: job.maxAttempts,
+    });
+    this.scheduleProcess();
+
+    return job.id;
+  }
+
+  public getStats(): {
+    queued: number;
+    running: number;
+    completed: number;
+    failed: number;
+    retrying: number;
+  } {
+    const queued = this.queue.filter((job) => job.status === 'queued').length;
+    const retrying = this.queue.filter((job) => job.status === 'retrying').length;
+    const completed = this.history.filter((job) => job.status === 'completed').length;
+    const failed = this.history.filter((job) => job.status === 'failed').length;
+
+    return {
+      queued,
+      running: this.running,
+      completed,
+      failed,
+      retrying,
+    };
+  }
+
+  public async drain(timeoutMs = 5_000): Promise<void> {
+    const start = Date.now();
+
+    while (this.queue.length > 0 || this.running > 0 || this.processScheduled) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error('Timed out waiting for background job queue to drain');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  public clear(): void {
+    this.queue = [];
+    this.history = [];
+    this.running = 0;
+    this.sequence = 0;
+    this.processScheduled = false;
+  }
+
+  private scheduleProcess(delayMs = 0): void {
+    if (delayMs <= 0) {
+      if (this.processScheduled) {
+        return;
+      }
+
+      this.processScheduled = true;
+      queueMicrotask(() => {
+        this.processScheduled = false;
+        this.process();
+      });
+      return;
+    }
+
+    const timer = setTimeout(() => this.process(), delayMs);
+    timer.unref?.();
+  }
+
+  private process(): void {
+    const now = Date.now();
+
+    while (this.running < this.concurrency) {
+      const nextJobIndex = this.getNextRunnableJobIndex(now);
+      if (nextJobIndex === -1) {
+        break;
+      }
+
+      const [job] = this.queue.splice(nextJobIndex, 1);
+      void this.run(job);
+    }
+
+    const nextRunAt = this.queue.reduce<number | null>((earliest, job) => {
+      const runAt = job.runAt.getTime();
+      return earliest === null || runAt < earliest ? runAt : earliest;
+    }, null);
+
+    if (nextRunAt !== null && nextRunAt > Date.now()) {
+      this.scheduleProcess(nextRunAt - Date.now());
+    }
+  }
+
+  private getNextRunnableJobIndex(now: number): number {
+    let bestIndex = -1;
+
+    for (let index = 0; index < this.queue.length; index += 1) {
+      const job = this.queue[index];
+      if (job.runAt.getTime() > now) {
+        continue;
+      }
+
+      if (bestIndex === -1 || compareJobs(job, this.queue[bestIndex]) < 0) {
+        bestIndex = index;
+      }
+    }
+
+    return bestIndex;
+  }
+
+  private async run(job: QueuedJob): Promise<void> {
+    this.running += 1;
+    job.status = 'running';
+    job.attempts += 1;
+    job.updatedAt = new Date();
+
+    try {
+      await job.handler();
+      job.status = 'completed';
+      job.updatedAt = new Date();
+      this.recordHistory(job);
+      logger.debug('Background job completed', {
+        jobId: job.id,
+        type: job.type,
+        attempts: job.attempts,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      job.lastError = message;
+      job.updatedAt = new Date();
+
+      if (job.attempts < job.maxAttempts) {
+        job.status = 'retrying';
+        const retryDelayMs = calculateRetryDelay(
+          job.retryDelayMs,
+          job.retryBackoffMultiplier,
+          job.attempts
+        );
+        job.runAt = new Date(Date.now() + retryDelayMs);
+        this.queue.push(job);
+        logger.warn('Background job failed, retrying', {
+          jobId: job.id,
+          type: job.type,
+          attempts: job.attempts,
+          maxAttempts: job.maxAttempts,
+          retryDelayMs,
+          error: message,
+        });
+      } else {
+        job.status = 'failed';
+        this.recordHistory(job);
+        logger.error('Background job failed permanently', {
+          jobId: job.id,
+          type: job.type,
+          attempts: job.attempts,
+          error: message,
+        });
+      }
+    } finally {
+      this.running -= 1;
+      this.process();
+    }
+  }
+
+  private recordHistory(job: QueuedJob): void {
+    const {
+      handler: _handler,
+      retryDelayMs: _retryDelayMs,
+      retryBackoffMultiplier: _retryBackoffMultiplier,
+      sequence: _sequence,
+      ...snapshot
+    } = job;
+    this.history.push(snapshot);
+
+    if (this.history.length > MAX_HISTORY) {
+      this.history.splice(0, this.history.length - MAX_HISTORY);
+    }
+  }
+}
+
+function compareJobs(left: QueuedJob, right: QueuedJob): number {
+  const priorityDelta = PRIORITY_RANK[left.priority] - PRIORITY_RANK[right.priority];
+  if (priorityDelta !== 0) {
+    return priorityDelta;
+  }
+
+  const runAtDelta = left.runAt.getTime() - right.runAt.getTime();
+  if (runAtDelta !== 0) {
+    return runAtDelta;
+  }
+
+  return left.sequence - right.sequence;
+}
+
+function calculateRetryDelay(
+  baseDelayMs: number,
+  multiplier: number,
+  attemptsCompleted: number
+): number {
+  return Math.round(baseDelayMs * multiplier ** Math.max(0, attemptsCompleted - 1));
+}
+
+function readPositiveInteger(rawValue: string | undefined, fallback: number): number {
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number(rawValue);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/backend/tests/unit/job-queue.service.test.ts
+++ b/backend/tests/unit/job-queue.service.test.ts
@@ -94,7 +94,7 @@ describe('JobQueue', () => {
       },
       {
         maxAttempts: 2,
-        retryDelayMs: 1,
+        retryDelayMs: 0,
       }
     );
 

--- a/backend/tests/unit/job-queue.service.test.ts
+++ b/backend/tests/unit/job-queue.service.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JobQueue } from '../../src/services/job-queue.service';
+
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('JobQueue', () => {
+  beforeEach(() => {
+    JobQueue.resetForTests();
+  });
+
+  afterEach(() => {
+    JobQueue.resetForTests();
+  });
+
+  it('runs jobs asynchronously after enqueue returns', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+    const calls: string[] = [];
+
+    queue.enqueue('email', { email: 'user@example.com' }, () => {
+      calls.push('sent');
+    });
+
+    expect(calls).toEqual([]);
+
+    await queue.drain();
+
+    expect(calls).toEqual(['sent']);
+    expect(queue.getStats()).toMatchObject({
+      queued: 0,
+      running: 0,
+      completed: 1,
+      failed: 0,
+    });
+  });
+
+  it('processes higher priority jobs first', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+    const calls: string[] = [];
+
+    queue.enqueue('low-priority', {}, () => calls.push('low'), { priority: 'low' });
+    queue.enqueue('high-priority', {}, () => calls.push('high'), { priority: 'high' });
+    queue.enqueue('normal-priority', {}, () => calls.push('normal'), { priority: 'normal' });
+
+    await queue.drain();
+
+    expect(calls).toEqual(['high', 'normal', 'low']);
+  });
+
+  it('retries failed jobs with backoff until they succeed', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+    let attempts = 0;
+
+    queue.enqueue(
+      'email',
+      { email: 'user@example.com' },
+      () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error('SMTP temporarily unavailable');
+        }
+      },
+      {
+        maxAttempts: 3,
+        retryDelayMs: 1,
+      }
+    );
+
+    await queue.drain();
+
+    expect(attempts).toBe(3);
+    expect(queue.getStats()).toMatchObject({
+      queued: 0,
+      running: 0,
+      completed: 1,
+      failed: 0,
+    });
+  });
+
+  it('records permanently failed jobs after max attempts', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+
+    queue.enqueue(
+      'email',
+      { email: 'user@example.com' },
+      () => {
+        throw new Error('SMTP down');
+      },
+      {
+        maxAttempts: 2,
+        retryDelayMs: 1,
+      }
+    );
+
+    await queue.drain();
+
+    expect(queue.getStats()).toMatchObject({
+      queued: 0,
+      running: 0,
+      completed: 0,
+      failed: 1,
+    });
+  });
+});

--- a/backend/tests/unit/job-queue.service.test.ts
+++ b/backend/tests/unit/job-queue.service.test.ts
@@ -108,6 +108,36 @@ describe('JobQueue', () => {
     });
   });
 
+  it('runs permanent-failure cleanup after retry attempts are exhausted', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+    const cleanup = vi.fn();
+
+    queue.enqueue(
+      'email',
+      { email: 'user@example.com' },
+      () => {
+        throw new Error('SMTP down');
+      },
+      {
+        maxAttempts: 2,
+        retryDelayMs: 0,
+        onPermanentFailure: cleanup,
+      }
+    );
+
+    await queue.drain();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanup.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(cleanup.mock.calls[0][0]).toMatchObject({ message: 'SMTP down' });
+    expect(queue.getStats()).toMatchObject({
+      queued: 0,
+      running: 0,
+      completed: 0,
+      failed: 1,
+    });
+  });
+
   it('falls back to default concurrency when an explicit value is invalid', async () => {
     const queue = JobQueue.getInstance({ concurrency: 0 });
     const calls: string[] = [];

--- a/backend/tests/unit/job-queue.service.test.ts
+++ b/backend/tests/unit/job-queue.service.test.ts
@@ -107,4 +107,27 @@ describe('JobQueue', () => {
       failed: 1,
     });
   });
+
+  it('falls back to default concurrency when an explicit value is invalid', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 0 });
+    const calls: string[] = [];
+
+    queue.enqueue('email', {}, () => calls.push('sent'));
+
+    await queue.drain();
+
+    expect(calls).toEqual(['sent']);
+  });
+
+  it('does not retain job payloads in completed history', async () => {
+    const queue = JobQueue.getInstance({ concurrency: 1 });
+
+    queue.enqueue('email', { email: 'user@example.com', token: '123456' }, () => undefined);
+
+    await queue.drain();
+
+    const history = (queue as unknown as { history: Array<{ payload?: unknown }> }).history;
+    expect(history).toHaveLength(1);
+    expect(history[0].payload).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1051.

- adds a lightweight in-memory `JobQueue` service with priority ordering, bounded concurrency, retry attempts, and exponential backoff
- moves auth verification and password-reset email provider delivery onto the queue after OTP/token creation succeeds
- keeps existing auth/user-enumeration semantics intact while avoiding slow SMTP/provider calls on the request path
- adds unit coverage for async execution, priority ordering, retry success, and permanent failure accounting

## How did you test this change?

- `npx eslint backend/src/services/job-queue.service.ts backend/src/services/auth/auth.service.ts backend/tests/unit/job-queue.service.test.ts`
- `npm run test --workspace insforge-backend -- tests/unit/job-queue.service.test.ts`
- `npm run typecheck --workspace insforge-backend`
- `npx turbo run build --filter=@insforge/shared-schemas --filter=insforge-backend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues auth emails with an in-memory `JobQueue` to move SMTP off the request path and cut latency. Tokens are created inside the job; undelivered tokens are cleaned up on permanent failure.

- **New Features**
  - Added `JobQueue` with priority ordering, env-configurable concurrency (`JOB_QUEUE_CONCURRENCY`), exponential backoff retries, stats, and drain helpers.
  - Auth emails (verification and reset, code or link) now run as high-priority jobs that create the OTP/token and then send; requests no longer wait on the provider.
  - Unit tests cover async execution, priority ordering, retry/backoff and cleanup, invalid-concurrency fallback, and payload scrubbing; deflaked delayed-timer test.

- **Bug Fixes**
  - On shutdown, stop the HTTP server before draining the queue to prevent new requests during cleanup.
  - If email delivery fails after max retries, delete the undelivered OTP/token via `AuthOTPService.deleteEmailOTP` (uses `expiresAt` when available).

<sup>Written for commit ca86cdbe2cdbaf9e681153a153c532c2a6479f70. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory background job queue with priority ordering, concurrency control, retries/backoff, and job history.

* **Improvements**
  * Email deliveries for verification and password reset are queued and processed asynchronously.
  * Server shutdown now attempts to drain pending jobs so queued email sends can complete.
  * Failed permanent email deliveries trigger cleanup of related email OTPs.

* **Tests**
  * Added unit tests covering queue execution, ordering, retries/backoff, and failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Queue auth email delivery as background jobs with retries and graceful drain on shutdown
> - Introduces a new in-memory `JobQueue` service ([job-queue.service.ts](https://github.com/InsForge/InsForge/pull/1290/files#diff-c5a25db33cf7a7c697f74dd70841477111e35dbabf8f10cbb03cbbc27fb6ac0d)) supporting priority levels, concurrency control, and exponential-backoff retries.
> - Replaces synchronous OTP/token creation and `EmailService` calls in `AuthService` with a private `enqueueEmailTemplateDelivery` helper that runs these steps in a background job. Affects verification-by-code, verification-by-link, reset-password-by-code, and reset-password-by-link flows.
> - On permanent job failure (after 3 retries), the created OTP/token is deleted via `AuthOTPService.deleteEmailOTP` to avoid orphaned records.
> - Extends the server shutdown sequence to close `SocketManager`, stop accepting HTTP connections, drain the `JobQueue` (up to 5s), then close `RealtimeManager`.
> - Behavioral Change: OTP and token records are now created inside the background job rather than synchronously in the request handler, so they do not exist until the job executes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca86cdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->