### PR TITLE
fix(auth): clear OTP state when deleting users

### DIFF
--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -1407,12 +1407,43 @@ export class AuthService {
     }
 
     const pool = this.getPool();
+    const client = await pool.connect();
     const placeholders = filtered.map((_, i) => `$${i + 1}`).join(',');
-    const result = await pool.query(
-      `DELETE FROM auth.users WHERE id IN (${placeholders})`,
-      filtered
-    );
 
-    return result.rowCount || 0;
+    try {
+      await client.query('BEGIN');
+
+      const emailsResult = await client.query<{ email: string }>(
+        `SELECT email
+         FROM auth.users
+         WHERE id IN (${placeholders})`,
+        filtered
+      );
+
+      const emails = Array.from(
+        new Set(
+          emailsResult.rows
+            .map((row) => row.email)
+            .filter((email): email is string => typeof email === 'string' && email.length > 0)
+        )
+      );
+
+      if (emails.length > 0) {
+        await client.query(`DELETE FROM auth.email_otps WHERE email = ANY($1::text[])`, [emails]);
+      }
+
+      const result = await client.query(
+        `DELETE FROM auth.users WHERE id IN (${placeholders})`,
+        filtered
+      );
+
+      await client.query('COMMIT');
+      return result.rowCount || 0;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 }

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -1440,7 +1440,11 @@ export class AuthService {
       await client.query('COMMIT');
       return result.rowCount || 0;
     } catch (error) {
-      await client.query('ROLLBACK');
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the original error if rollback fails.
+      }
       throw error;
     } finally {
       client.release();

--- a/backend/tests/unit/auth-delete-users.test.ts
+++ b/backend/tests/unit/auth-delete-users.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.ADMIN_EMAIL = 'admin@test.com';
+process.env.ADMIN_PASSWORD = 'admin-password';
+
+const { mockPool, mockClient, mockOAuthProvider } = vi.hoisted(() => ({
+  mockPool: {
+    connect: vi.fn(),
+  },
+  mockClient: {
+    query: vi.fn(),
+    release: vi.fn(),
+  },
+  mockOAuthProvider: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/infra/security/token.manager', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      generateAccessToken: vi.fn().mockReturnValue('test-access-token'),
+      generateRefreshToken: vi.fn().mockReturnValue('test-refresh-token'),
+      generateCsrfToken: vi.fn().mockReturnValue('test-csrf-token'),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-config.service', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getAuthConfig: vi.fn(),
+      getPublicAuthConfig: vi.fn(),
+      validateRedirectUrl: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-otp.service', () => ({
+  AuthOTPService: {
+    getInstance: () => ({
+      createEmailOTP: vi.fn(),
+      verifyEmailOTPWithCode: vi.fn(),
+      verifyEmailOTPWithToken: vi.fn(),
+      getEmailOTPContextByToken: vi.fn(),
+    }),
+  },
+  OTPPurpose: { VERIFY_EMAIL: 'VERIFY_EMAIL', RESET_PASSWORD: 'RESET_PASSWORD' },
+  OTPType: { NUMERIC_CODE: 'NUMERIC_CODE', HASH_TOKEN: 'HASH_TOKEN' },
+}));
+
+vi.mock('../../src/services/auth/oauth-config.service', () => ({
+  OAuthConfigService: {
+    getInstance: () => ({}),
+  },
+}));
+
+vi.mock('../../src/services/auth/custom-oauth-config.service', () => ({
+  CustomOAuthConfigService: {
+    getInstance: () => ({
+      listConfigs: vi.fn().mockResolvedValue([]),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/email/email.service', () => ({
+  EmailService: {
+    getInstance: () => ({
+      sendWithTemplate: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/email/smtp-config.service', () => ({
+  SmtpConfigService: {
+    getInstance: () => ({
+      getConfig: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/providers/oauth/google.provider', () => ({
+  GoogleOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/github.provider', () => ({
+  GitHubOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/discord.provider', () => ({
+  DiscordOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/linkedin.provider', () => ({
+  LinkedInOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/facebook.provider', () => ({
+  FacebookOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/microsoft.provider', () => ({
+  MicrosoftOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/x.provider', () => ({ XOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/apple.provider', () => ({
+  AppleOAuthProvider: mockOAuthProvider,
+}));
+
+vi.mock('../../src/utils/environment', () => ({
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+import { AuthService } from '../../src/services/auth/auth.service';
+import { ADMIN_ID } from '../../src/utils/constants';
+
+describe('AuthService.deleteUsers', () => {
+  let authService: AuthService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.connect.mockResolvedValue(mockClient);
+    mockClient.query.mockReset();
+    mockClient.release.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (AuthService as any).instance = undefined;
+    authService = AuthService.getInstance();
+  });
+
+  it('deletes OTP rows for deleted users before deleting the users', async () => {
+    mockClient.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [{ email: 'alice@example.com' }, { email: 'bob@example.com' }],
+      })
+      .mockResolvedValueOnce({ rowCount: 2 })
+      .mockResolvedValueOnce({ rowCount: 2 })
+      .mockResolvedValueOnce(undefined);
+
+    const deleted = await authService.deleteUsers(['user-1', 'user-2']);
+
+    expect(deleted).toBe(2);
+    expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      2,
+      `SELECT email
+         FROM auth.users
+         WHERE id IN ($1,$2)`,
+      ['user-1', 'user-2']
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      3,
+      'DELETE FROM auth.email_otps WHERE email = ANY($1::text[])',
+      [['alice@example.com', 'bob@example.com']]
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      4,
+      'DELETE FROM auth.users WHERE id IN ($1,$2)',
+      ['user-1', 'user-2']
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(5, 'COMMIT');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips OTP cleanup when no matching users are found', async () => {
+    mockClient.query
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0 })
+      .mockResolvedValueOnce(undefined);
+
+    const deleted = await authService.deleteUsers(['missing-user']);
+
+    expect(deleted).toBe(0);
+    expect(mockClient.query).toHaveBeenNthCalledWith(3, 'DELETE FROM auth.users WHERE id IN ($1)', [
+      'missing-user',
+    ]);
+    expect(mockClient.query).not.toHaveBeenCalledWith(
+      'DELETE FROM auth.email_otps WHERE email = ANY($1::text[])',
+      expect.anything()
+    );
+  });
+
+  it('does nothing when only the admin account is provided', async () => {
+    const deleted = await authService.deleteUsers([ADMIN_ID]);
+
+    expect(deleted).toBe(0);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/auth-delete-users.test.ts
+++ b/backend/tests/unit/auth-delete-users.test.ts
@@ -191,6 +191,29 @@ describe('AuthService.deleteUsers', () => {
     );
   });
 
+  it('rolls back and releases the client when deleting users fails, preserving the original error', async () => {
+    const originalError = new Error('select failed');
+    const rollbackError = new Error('rollback failed');
+
+    mockClient.query
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(originalError)
+      .mockRejectedValueOnce(rollbackError);
+
+    await expect(authService.deleteUsers(['user-1'])).rejects.toBe(originalError);
+
+    expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      2,
+      `SELECT email
+         FROM auth.users
+         WHERE id IN ($1)`,
+      ['user-1']
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(3, 'ROLLBACK');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
   it('does nothing when only the admin account is provided', async () => {
     const deleted = await authService.deleteUsers([ADMIN_ID]);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user deletion to also clear related OTP state so no stale codes remain. Runs the delete flow in a single transaction and preserves the original error if rollback fails.

- **Bug Fixes**
  - Delete related rows in `auth.email_otps` for users’ deduped, non-empty emails before removing users.
  - Wrap cleanup and deletion in one transaction; attempt rollback on error and keep the original error if rollback fails.
  - Skip OTP cleanup when no matching users are found.
  - Keep admin safeguard: ignore the admin account; no DB call if only admin ID is provided.
  - Added unit tests for OTP cleanup, no-users, admin-only, and rollback-error cases.

<sup>Written for commit 80e6d51da6bf4dda579f2caf31ee6c1c1b9e4003. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1293?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AuthService.deleteUsers` to clear OTP state before deleting users
> - Wraps the delete operation in an explicit DB transaction using a dedicated client, ensuring atomicity.
> - Deletes rows from `auth.email_otps` matching the target users' emails before deleting from `auth.users`.
> - Rolls back and propagates the original error if any step fails; always releases the client in a `finally` block.
> - Adds unit tests in [auth-delete-users.test.ts](https://github.com/InsForge/InsForge/pull/1293/files#diff-55e2bfc7a66414d5873d5b7d699c6abae58a7e86050ece10e45f0841259ecd51) covering success, no-op (admin-only), missing users, and rollback scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80e6d51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User deletion now also removes related temporary email OTPs, runs within a proper database transaction for reliable, atomic removals, and ensures the admin account cannot be deleted.

* **Tests**
  * Added unit tests covering deletion scenarios: successful deletions, no-op when no matches, failure/rollback behavior, and protection of the admin account.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->