### PR TITLE
INS-140: Investigate stale page state after being idle

### DIFF
--- a/packages/dashboard/src/features/auth/hooks/useUsers.ts
+++ b/packages/dashboard/src/features/auth/hooks/useUsers.ts
@@ -22,13 +22,13 @@ export function useUsers(options: UseUsersOptions = {}) {
     refetch,
   } = useQuery({
     queryKey: ['users', currentPage, searchQuery, pageSize],
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       const params = new URLSearchParams({
         limit: pageSize.toString(),
         offset: ((currentPage - 1) * pageSize).toString(),
       });
       // Use the user service to get users with search, backend handles filtering
-      return userService.getUsers(params.toString(), searchQuery);
+      return userService.getUsers(params.toString(), searchQuery, signal);
     },
     enabled: enabled,
     placeholderData: (previousData) => previousData, // Keep previous data while loading

--- a/packages/dashboard/src/features/auth/services/user.service.ts
+++ b/packages/dashboard/src/features/auth/services/user.service.ts
@@ -10,7 +10,8 @@ export class UserService {
    */
   async getUsers(
     queryParams: string = '',
-    searchQuery?: string
+    searchQuery?: string,
+    signal?: AbortSignal
   ): Promise<{
     users: UserSchema[];
     pagination: { offset: number; limit: number; total: number };
@@ -26,7 +27,7 @@ export class UserService {
       url += `?${params.toString()}`;
     }
 
-    const response = await apiClient.request(url);
+    const response = await apiClient.request(url, { signal });
 
     return {
       users: response.data,

--- a/packages/dashboard/src/features/database/hooks/useTables.ts
+++ b/packages/dashboard/src/features/database/hooks/useTables.ts
@@ -21,7 +21,7 @@ export function useTables(schemaName: string = DEFAULT_DATABASE_SCHEMA) {
     refetch: refetchTables,
   } = useQuery({
     queryKey: databaseTableQueryKeys.tables(schemaName),
-    queryFn: () => tableService.listTables(schemaName),
+    queryFn: ({ signal }) => tableService.listTables(schemaName, signal),
     staleTime: 2 * 60 * 1000,
   });
 
@@ -33,7 +33,7 @@ export function useTables(schemaName: string = DEFAULT_DATABASE_SCHEMA) {
   ) => {
     return useQuery({
       queryKey: databaseTableQueryKeys.tableSchema(tableSchemaName, tableName),
-      queryFn: () => tableService.getTableSchema(tableName, tableSchemaName),
+      queryFn: ({ signal }) => tableService.getTableSchema(tableName, tableSchemaName, signal),
       enabled: enabled && !!tableName,
       staleTime: 2 * 60 * 1000,
     });
@@ -124,7 +124,8 @@ export function useAllTableSchemas(schemaName: string = DEFAULT_DATABASE_SCHEMA,
     queries: enabled
       ? tables.map((tableName) => ({
           queryKey: databaseTableQueryKeys.tableSchema(schemaName, tableName),
-          queryFn: () => tableService.getTableSchema(tableName, schemaName),
+          queryFn: ({ signal }: { signal: AbortSignal }) =>
+            tableService.getTableSchema(tableName, schemaName, signal),
           staleTime: 2 * 60 * 1000,
         }))
       : [],

--- a/packages/dashboard/src/features/database/services/table.service.ts
+++ b/packages/dashboard/src/features/database/services/table.service.ts
@@ -9,20 +9,26 @@ import {
 } from '@insforge/shared-schemas';
 
 export class TableService {
-  async listTables(schemaName: string = DEFAULT_DATABASE_SCHEMA): Promise<string[]> {
+  async listTables(
+    schemaName: string = DEFAULT_DATABASE_SCHEMA,
+    signal?: AbortSignal
+  ): Promise<string[]> {
     return await apiClient.request(`/database/tables${buildDatabaseSchemaSearch(schemaName)}`, {
       headers: apiClient.withAccessToken(),
+      signal,
     });
   }
 
   getTableSchema(
     tableName: string,
-    schemaName: string = DEFAULT_DATABASE_SCHEMA
+    schemaName: string = DEFAULT_DATABASE_SCHEMA,
+    signal?: AbortSignal
   ): Promise<GetTableSchemaResponse> {
     return apiClient.request(
       `/database/tables/${tableName}/schema${buildDatabaseSchemaSearch(schemaName)}`,
       {
         headers: apiClient.withAccessToken(),
+        signal,
       }
     );
   }

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -85,12 +85,6 @@ export class LoginService {
       return false;
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(
-      () => controller.abort(new DOMException('Refresh timed out', 'TimeoutError')),
-      30_000
-    );
-
     try {
       const response = await fetch('/api/auth/refresh', {
         method: 'POST',
@@ -99,7 +93,7 @@ export class LoginService {
           'X-CSRF-Token': csrfToken,
         },
         credentials: 'include',
-        signal: controller.signal,
+        signal: AbortSignal.timeout(30_000),
       });
 
       if (!response.ok) {
@@ -119,8 +113,6 @@ export class LoginService {
       return false;
     } catch {
       return false;
-    } finally {
-      clearTimeout(timeoutId);
     }
   }
 

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '#lib/api/client';
+import { apiClient, REQUEST_TIMEOUT_MS } from '#lib/api/client';
 import type { UserSchema } from '@insforge/shared-schemas';
 
 interface LoginResult {
@@ -93,7 +93,7 @@ export class LoginService {
           'X-CSRF-Token': csrfToken,
         },
         credentials: 'include',
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
 
       if (!response.ok) {

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -85,6 +85,12 @@ export class LoginService {
       return false;
     }
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(new DOMException('Refresh timed out', 'TimeoutError')),
+      30_000
+    );
+
     try {
       const response = await fetch('/api/auth/refresh', {
         method: 'POST',
@@ -93,6 +99,7 @@ export class LoginService {
           'X-CSRF-Token': csrfToken,
         },
         credentials: 'include',
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -112,6 +119,8 @@ export class LoginService {
       return false;
     } catch {
       return false;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/packages/dashboard/src/features/logs/hooks/useMcpUsage.ts
+++ b/packages/dashboard/src/features/logs/hooks/useMcpUsage.ts
@@ -41,7 +41,7 @@ export function useMcpUsage(options: UseMcpUsageOptions = {}) {
     refetch,
   } = useQuery<McpUsageRecord[]>({
     queryKey: ['mcp-usage', successFilter, limit],
-    queryFn: () => usageService.getMcpUsage(successFilter, limit),
+    queryFn: ({ signal }) => usageService.getMcpUsage(successFilter, limit, signal),
     enabled: isAuthenticated,
     staleTime: 30 * 1000, // Cache for 30 seconds
     refetchInterval: false,

--- a/packages/dashboard/src/features/logs/services/usage.service.ts
+++ b/packages/dashboard/src/features/logs/services/usage.service.ts
@@ -17,7 +17,8 @@ export class UsageService {
    */
   async getMcpUsage(
     success: boolean | null = true,
-    limit: number = 200
+    limit: number = 200,
+    signal?: AbortSignal
   ): Promise<McpUsageRecord[]> {
     const params = new URLSearchParams({
       limit: limit.toString(),
@@ -28,6 +29,7 @@ export class UsageService {
 
     const data = (await apiClient.request(`/usage/mcp?${params.toString()}`, {
       headers: apiClient.withAccessToken(),
+      signal,
     })) as McpUsageResponse;
 
     return data.records || [];

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -74,25 +74,19 @@ export class ApiClient {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
       }
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
-        REQUEST_TIMEOUT_MS
-      );
+      const timeoutSignal = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+      const signal = fetchOptions.signal
+        ? AbortSignal.any([fetchOptions.signal, timeoutSignal])
+        : timeoutSignal;
 
       const config: RequestInit = {
         ...fetchOptions,
         headers,
         credentials: 'include',
-        signal: controller.signal,
+        signal,
       };
 
-      let response: Response;
-      try {
-        response = await fetch(url, config);
-      } finally {
-        clearTimeout(timeoutId);
-      }
+      const response = await fetch(url, config);
 
       if (!response.ok) {
         let errorData;

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -1,7 +1,7 @@
 import { getDashboardApiBaseUrl } from '#lib/config/runtime';
 
 const CSRF_COOKIE_NAME = 'insforge_csrf';
-const REQUEST_TIMEOUT_MS = 30_000;
+export const REQUEST_TIMEOUT_MS = 30_000;
 
 interface ApiError extends Error {
   response?: {

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -1,6 +1,7 @@
 import { getDashboardApiBaseUrl } from '#lib/config/runtime';
 
 const CSRF_COOKIE_NAME = 'insforge_csrf';
+const REQUEST_TIMEOUT_MS = 30_000;
 
 interface ApiError extends Error {
   response?: {
@@ -73,13 +74,25 @@ export class ApiClient {
         headers['Content-Type'] = headers['Content-Type'] || 'application/json';
       }
 
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(new DOMException('Request timed out', 'TimeoutError')),
+        REQUEST_TIMEOUT_MS
+      );
+
       const config: RequestInit = {
         ...fetchOptions,
         headers,
         credentials: 'include',
+        signal: controller.signal,
       };
 
-      const response = await fetch(url, config);
+      let response: Response;
+      try {
+        response = await fetch(url, config);
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       if (!response.ok) {
         let errorData;

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -48,10 +48,25 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const shouldUseAuthorizationCodeRefresh =
     isCloudHosting && host.useAuthorizationCodeRefresh === true;
 
+  // Drop all user-scoped query data. Called whenever the authenticated user
+  // changes (login / logout / auth error) so the next user never sees the
+  // previous user's cached tables, api keys, users, or mcp-usage records.
+  // Critical now that `useMetadata` uses `gcTime: Infinity` — without explicit
+  // removal, stale tenant-scoped data could persist across sessions in the
+  // same browser tab.
+  const removeAuthScopedQueries = useCallback(() => {
+    queryClient.removeQueries({ queryKey: ['apiKey'] });
+    queryClient.removeQueries({ queryKey: ['metadata'] });
+    queryClient.removeQueries({ queryKey: ['users'] });
+    queryClient.removeQueries({ queryKey: ['database', 'tables'] });
+    queryClient.removeQueries({ queryKey: ['mcp-usage'] });
+  }, [queryClient]);
+
   const handleAuthError = useCallback(() => {
     setUser(null);
     setIsAuthenticated(false);
-  }, []);
+    removeAuthScopedQueries();
+  }, [removeAuthScopedQueries]);
 
   useEffect(() => {
     loginService.setAuthErrorHandler(handleAuthError);
@@ -59,16 +74,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       loginService.setAuthErrorHandler(undefined);
     };
   }, [handleAuthError]);
-
-  const invalidateAuthQueries = useCallback(async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ['apiKey'] }),
-      queryClient.invalidateQueries({ queryKey: ['metadata'] }),
-      queryClient.invalidateQueries({ queryKey: ['users'] }),
-      queryClient.invalidateQueries({ queryKey: ['database', 'tables'] }),
-      queryClient.invalidateQueries({ queryKey: ['mcp-usage'] }),
-    ]);
-  }, [queryClient]);
 
   const performPostHogIdentify = useCallback(async (): Promise<void> => {
     if (!onRequestUserInfo) {
@@ -95,11 +100,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const applyAuthenticatedUser = useCallback(
     async (nextUser: UserSchema): Promise<void> => {
       await performPostHogIdentify();
+      // Drop the previous user's cached data BEFORE switching identity so
+      // components mount against an empty cache and fetch fresh for nextUser.
+      removeAuthScopedQueries();
       setUser(nextUser);
       setIsAuthenticated(true);
-      await invalidateAuthQueries();
     },
-    [invalidateAuthQueries, performPostHogIdentify]
+    [performPostHogIdentify, removeAuthScopedQueries]
   );
 
   const exchangeAuthorizationCode = useCallback(
@@ -217,7 +224,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
     setIsAuthenticated(false);
     setError(null);
-  }, []);
+    removeAuthScopedQueries();
+  }, [removeAuthScopedQueries]);
 
   const refreshAuth = useCallback(async () => {
     await checkAuthStatus();

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -124,8 +124,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       // ONLY when identity actually changes. Same-user token refresh (cloud
       // authorization-code re-exchange after a 401) must NOT wipe the cache,
       // otherwise the dashboard flashes empty/skeleton state on every refresh.
-      const previousUserId = previousUserIdRef.current;
-      if (previousUserId !== null && previousUserId !== nextUser.id) {
+      // First login from a fresh session has previousUserIdRef.current === null,
+      // so `null !== nextUser.id` and the wipe runs — but the cache is already
+      // empty, so it's a harmless no-op.
+      if (previousUserIdRef.current !== nextUser.id) {
         removeAuthScopedQueries();
       }
       previousUserIdRef.current = nextUser.id;
@@ -219,9 +221,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       const currentUser = await loginService.getCurrentUser();
       if (currentUser) {
-        await performPostHogIdentify();
-        setUser(currentUser);
-        setIsAuthenticated(true);
+        // Route through applyAuthenticatedUser so previousUserIdRef stays in
+        // sync. Otherwise a session hydrated here as user A, followed later
+        // by an auth-code re-exchange that switches to user B, would skip the
+        // cache wipe (ref still null) and leak A's tenant-scoped queries to B.
+        await applyAuthenticatedUser(currentUser);
         return currentUser;
       }
 
@@ -243,7 +247,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } finally {
       setIsLoading(false);
     }
-  }, [authenticateCloudSession, performPostHogIdentify, shouldAttemptCloudAuthentication]);
+  }, [applyAuthenticatedUser, authenticateCloudSession, shouldAttemptCloudAuthentication]);
 
   const logout = useCallback(async () => {
     await loginService.logout();

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -223,7 +223,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     await checkAuthStatus();
   }, [checkAuthStatus]);
 
+  // Run the initial auth check exactly once on mount. We intentionally do NOT
+  // re-run when `checkAuthStatus` changes identity: host callback refs from
+  // cloud-hosting parents flip on every parent render, which would otherwise
+  // re-fire this effect, flipping `isLoading` true and unmounting the entire
+  // authenticated subtree (and along with it the React Query observers that
+  // keep dashboard caches alive).
+  const initialCheckRanRef = useRef(false);
   useEffect(() => {
+    if (initialCheckRanRef.current) {
+      return;
+    }
+    initialCheckRanRef.current = true;
     void checkAuthStatus();
   }, [checkAuthStatus]);
 

--- a/packages/dashboard/src/lib/contexts/AuthContext.tsx
+++ b/packages/dashboard/src/lib/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import { loginService } from '#features/login/services/login.service';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
@@ -49,22 +49,42 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isCloudHosting && host.useAuthorizationCodeRefresh === true;
 
   // Drop all user-scoped query data. Called whenever the authenticated user
-  // changes (login / logout / auth error) so the next user never sees the
-  // previous user's cached tables, api keys, users, or mcp-usage records.
-  // Critical now that `useMetadata` uses `gcTime: Infinity` — without explicit
-  // removal, stale tenant-scoped data could persist across sessions in the
-  // same browser tab.
+  // identity actually changes (login / logout / auth error) so the next user
+  // never sees the previous user's cached tables, api keys, users, or
+  // mcp-usage records. Critical now that `useMetadata` uses `gcTime: Infinity`
+  // — without explicit removal, stale tenant-scoped data could persist across
+  // sessions in the same browser tab.
+  //
+  // `cancelQueries` is called before `removeQueries` so any in-flight requests
+  // (issued under the previous identity's auth token) are aborted via the
+  // AbortSignal each queryFn forwards. Without the cancel, an in-flight fetch
+  // could resolve after removal and have its response race against the new
+  // user's freshly-mounted query.
   const removeAuthScopedQueries = useCallback(() => {
-    queryClient.removeQueries({ queryKey: ['apiKey'] });
-    queryClient.removeQueries({ queryKey: ['metadata'] });
-    queryClient.removeQueries({ queryKey: ['users'] });
-    queryClient.removeQueries({ queryKey: ['database', 'tables'] });
-    queryClient.removeQueries({ queryKey: ['mcp-usage'] });
+    const keys: QueryKey[] = [
+      ['apiKey'],
+      ['metadata'],
+      ['users'],
+      ['database', 'tables'],
+      ['mcp-usage'],
+    ];
+    for (const queryKey of keys) {
+      void queryClient.cancelQueries({ queryKey });
+      queryClient.removeQueries({ queryKey });
+    }
   }, [queryClient]);
+
+  // Tracks the currently authenticated user id so `applyAuthenticatedUser`
+  // can tell a same-user token refresh apart from a real identity switch and
+  // only drop cached data in the latter case. Initial value `null` means
+  // "no prior session"; first login transitions null → userId without
+  // wiping (the cache is already empty).
+  const previousUserIdRef = useRef<string | null>(null);
 
   const handleAuthError = useCallback(() => {
     setUser(null);
     setIsAuthenticated(false);
+    previousUserIdRef.current = null;
     removeAuthScopedQueries();
   }, [removeAuthScopedQueries]);
 
@@ -100,9 +120,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const applyAuthenticatedUser = useCallback(
     async (nextUser: UserSchema): Promise<void> => {
       await performPostHogIdentify();
-      // Drop the previous user's cached data BEFORE switching identity so
-      // components mount against an empty cache and fetch fresh for nextUser.
-      removeAuthScopedQueries();
+      // Drop the previous user's cached data BEFORE switching identity, but
+      // ONLY when identity actually changes. Same-user token refresh (cloud
+      // authorization-code re-exchange after a 401) must NOT wipe the cache,
+      // otherwise the dashboard flashes empty/skeleton state on every refresh.
+      const previousUserId = previousUserIdRef.current;
+      if (previousUserId !== null && previousUserId !== nextUser.id) {
+        removeAuthScopedQueries();
+      }
+      previousUserIdRef.current = nextUser.id;
       setUser(nextUser);
       setIsAuthenticated(true);
     },
@@ -224,6 +250,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUser(null);
     setIsAuthenticated(false);
     setError(null);
+    previousUserIdRef.current = null;
     removeAuthScopedQueries();
   }, [removeAuthScopedQueries]);
 

--- a/packages/dashboard/src/lib/hooks/useMetadata.ts
+++ b/packages/dashboard/src/lib/hooks/useMetadata.ts
@@ -14,7 +14,7 @@ export function useMetadata(options?: UseMetadataOptions) {
     refetch,
   } = useQuery({
     queryKey: ['metadata', 'full'],
-    queryFn: () => metadataService.getFullMetadata(),
+    queryFn: ({ signal }) => metadataService.getFullMetadata(signal),
     staleTime: options?.staleTime ?? 5 * 60 * 1000, // Cache for 5 minutes by default
     gcTime: Infinity, // Never garbage-collect: cached metadata survives navigation
     // away from /dashboard so returning to it doesn't trigger a cold skeleton/
@@ -42,7 +42,7 @@ export function useApiKey(options?: UseMetadataOptions) {
     refetch,
   } = useQuery({
     queryKey: ['metadata', 'apiKey'],
-    queryFn: () => metadataService.fetchApiKey(),
+    queryFn: ({ signal }) => metadataService.fetchApiKey(signal),
     staleTime: options?.staleTime ?? 10 * 60 * 1000, // Cache for 10 minutes by default
     enabled: options?.enabled ?? true,
   });
@@ -63,7 +63,7 @@ export function useProjectId(options?: UseMetadataOptions) {
     refetch,
   } = useQuery({
     queryKey: ['metadata', 'projectId'],
-    queryFn: () => metadataService.fetchProjectId(),
+    queryFn: ({ signal }) => metadataService.fetchProjectId(signal),
     staleTime: options?.staleTime ?? 10 * 60 * 1000,
     enabled: options?.enabled ?? true,
   });
@@ -84,7 +84,7 @@ export function useDatabaseConnectionString(options?: UseMetadataOptions) {
     refetch,
   } = useQuery({
     queryKey: ['metadata', 'databaseConnectionString'],
-    queryFn: () => metadataService.getDatabaseConnectionString(),
+    queryFn: ({ signal }) => metadataService.getDatabaseConnectionString(signal),
     staleTime: 0,
     gcTime: 0,
     enabled: options?.enabled ?? true,
@@ -106,7 +106,7 @@ export function useDatabasePassword(options?: UseMetadataOptions) {
     refetch,
   } = useQuery({
     queryKey: ['metadata', 'databasePassword'],
-    queryFn: () => metadataService.getDatabasePassword(),
+    queryFn: ({ signal }) => metadataService.getDatabasePassword(signal),
     staleTime: 0,
     gcTime: 0,
     enabled: options?.enabled ?? true,

--- a/packages/dashboard/src/lib/hooks/useMetadata.ts
+++ b/packages/dashboard/src/lib/hooks/useMetadata.ts
@@ -16,6 +16,9 @@ export function useMetadata(options?: UseMetadataOptions) {
     queryKey: ['metadata', 'full'],
     queryFn: () => metadataService.getFullMetadata(),
     staleTime: options?.staleTime ?? 5 * 60 * 1000, // Cache for 5 minutes by default
+    gcTime: Infinity, // Never garbage-collect: cached metadata survives navigation
+    // away from /dashboard so returning to it doesn't trigger a cold skeleton/
+    // empty-metric-card render while the fetch is in flight.
     enabled: options?.enabled ?? true,
   });
 

--- a/packages/dashboard/src/lib/services/metadata.service.ts
+++ b/packages/dashboard/src/lib/services/metadata.service.ts
@@ -15,33 +15,37 @@ export interface RotateApiKeyResponse {
 }
 
 export class MetadataService {
-  async fetchApiKey(): Promise<string> {
-    const data: ApiKeyResponse = await apiClient.request('/metadata/api-key');
+  async fetchApiKey(signal?: AbortSignal): Promise<string> {
+    const data: ApiKeyResponse = await apiClient.request('/metadata/api-key', { signal });
     return data.apiKey;
   }
 
-  async fetchProjectId(): Promise<string | null> {
+  async fetchProjectId(signal?: AbortSignal): Promise<string | null> {
     const data: ProjectIdResponse = await apiClient.request('/metadata/project-id', {
       headers: apiClient.withAccessToken(),
+      signal,
     });
     return data.projectId;
   }
 
-  async getFullMetadata(): Promise<AppMetadataSchema> {
+  async getFullMetadata(signal?: AbortSignal): Promise<AppMetadataSchema> {
     return apiClient.request('/metadata', {
       headers: apiClient.withAccessToken(),
+      signal,
     });
   }
 
-  async getDatabaseConnectionString(): Promise<DatabaseConnectionInfo> {
+  async getDatabaseConnectionString(signal?: AbortSignal): Promise<DatabaseConnectionInfo> {
     return apiClient.request('/metadata/database-connection-string', {
       headers: apiClient.withAccessToken(),
+      signal,
     });
   }
 
-  async getDatabasePassword(): Promise<DatabasePasswordInfo> {
+  async getDatabasePassword(signal?: AbortSignal): Promise<DatabasePasswordInfo> {
     return apiClient.request('/metadata/database-password', {
       headers: apiClient.withAccessToken(),
+      signal,
     });
   }
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
oss tag: [v2.1.7-idle](https://github.com/InsForge/InsForge/tree/refs/tags/v2.1.7-idle)
reproduce it: If you're in control flag, staying on another tab (e.g., Authentication) for more than 10 minutes, then clicking back to the Database tab. For the d_test, it will keep showing loading instead of the real status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the blank dashboard after idle and prevents cross-user state leaks. Adds 30s timeouts, forwards abort signals, keeps metadata cached, and clears user-scoped caches on any user-id change. Addresses Linear INS-140.

- **Bug Fixes**
  - Add 30s timeouts to all API requests and token refresh; combine with caller `AbortSignal` via `AbortSignal.any`, and thread through all query fns/services.
  - Run the initial auth check exactly once to prevent loading flicker and cache unmounts.
  - Set metadata query `gcTime: Infinity` so returning to /dashboard doesn’t show empty states.
  - Cancel in-flight auth-scoped queries and remove their caches on login, logout, auth errors, and whenever the authenticated user id changes (including post-bootstrap re-auth) to avoid stale or cross-user data.

<sup>Written for commit 7d13bda3054699cfd0e7ff959271570feacfa09e. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale page state after idle by clearing auth-scoped query caches and adding request timeouts
> - [`AuthContext`](https://github.com/InsForge/InsForge/pull/1294/files#diff-1c35d45b3559c95ecd6ba3afe0d777479cc3aef06742b56259352656793ecd4f) now removes cached queries for `apiKey`, `metadata`, `users`, `database/tables`, and `mcp-usage` on login, logout, or auth error, preventing previous-user data from persisting across sessions
> - Adds a 30-second timeout to all [`ApiClient.request`](https://github.com/InsForge/InsForge/pull/1294/files#diff-e2f5226cf922a7bed6ffbb75bb103944e727dcfcefc1aa8e2f33de221249cf6a) calls and to [`LoginService.refreshAccessToken`](https://github.com/InsForge/InsForge/pull/1294/files#diff-1c35d45b3559c95ecd6ba3afe0d777479cc3aef06742b56259352656793ecd4f); caller-provided signals are combined with the timeout via `AbortSignal.any`
> - An `initialCheckRanRef` guard in `AuthProvider` ensures the initial auth check runs exactly once on mount, preventing repeated `isLoading` toggles when callback identities change
> - Sets `gcTime: Infinity` in [`useMetadata`](https://github.com/InsForge/InsForge/pull/1294/files#diff-1c36f4f3a229fed8ba89dbbe16fd7e7140967decdcc7fd56e8fabda4e8195a4a) so metadata cache persists for the app lifetime unless explicitly removed
> - Behavioral Change: query caches are now removed (not invalidated) on auth transitions, so components will show loading states rather than stale data on re-login
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1294 opened
>
> - Modified the `AuthProvider` in `lib.contexts` to track user identity across authentication state transitions, only clearing query cache when the authenticated user id actually changes rather than on every token refresh, and to cancel in-flight auth-scoped queries (apiKey, metadata, users, database tables, mcp-usage) before removal [9ffcce2]
> - Added `AbortSignal` parameter support throughout all React Query hooks and their corresponding service methods in `auth`, `database`, `logs`, and `lib` modules to enable request cancellation [9ffcce2]
> - Refactored the `LoginService.refresh` method in `login` module to use the exported `REQUEST_TIMEOUT_MS` constant from the api client module instead of a hardcoded timeout value, and exported `REQUEST_TIMEOUT_MS` from `lib.api.client` [9ffcce2]
> - Modified authentication flow in `AuthProvider` to ensure cache invalidation through `removeAuthScopedQueries` during all authentication state changes [7d13bda]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bef94b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added a 30s timeout for API requests and token refreshes to avoid hanging requests.
  * Persisted full metadata cache across navigation to prevent cold “skeleton” renders.
  * Network requests (tables, users, usage, metadata) now support cancellation to reduce wasted work during navigation.

* **Bug Fixes**
  * Auth now clears auth-scoped cached data on login/logout/auth-failure to avoid stale or unauthorized data.
  * Initial authentication check runs once at startup to reduce unnecessary loading and cache churn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->