### PR TITLE
feat: add persistent column re-ordering with localStorage

### DIFF
--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -117,10 +117,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
     [columns.map((c) => c.key).join(',')]
   );
 
-  const { columnKeys, reorderColumns } = useColumnOrder(
-    storageKey ?? '',
-    defaultColumnKeys
-  );
+  const { columnKeys, reorderColumns } = useColumnOrder(storageKey ?? '', defaultColumnKeys);
 
   const orderedColumns = useMemo(() => {
     if (!storageKey) return columns;
@@ -177,7 +174,11 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             onSelectedRowsChange(newSelectedRows);
           };
           if (renderSelectionHeaderCell) {
-            return renderSelectionHeaderCell({ isAllSelected, isPartiallySelected, onToggle: handleSelectionToggle });
+            return renderSelectionHeaderCell({
+              isAllSelected,
+              isPartiallySelected,
+              onToggle: handleSelectionToggle,
+            });
           }
           return (
             <div className="flex h-full w-full items-center gap-2">
@@ -275,7 +276,12 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   }
 
   return (
-    <div className={cn('min-w-0 h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]', className)}>
+    <div
+      className={cn(
+        'min-w-0 h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]',
+        className
+      )}
+    >
       <div className={cn('flex min-h-0 min-w-0 flex-1 overflow-hidden', !noPadding && 'px-3')}>
         <div
           className={cn(
@@ -308,18 +314,27 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             enableVirtualization={true}
             renderers={{
               noRowsFallback: emptyState ? (
-                <div className="absolute inset-x-0 bottom-0 flex items-start justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
+                <div
+                  className="absolute inset-x-0 bottom-0 flex items-start justify-center bg-semantic-1"
+                  style={{ top: headerRowHeight }}
+                >
                   {emptyState}
                 </div>
               ) : (
-                <div className="absolute inset-x-0 bottom-0 flex items-center justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
+                <div
+                  className="absolute inset-x-0 bottom-0 flex items-center justify-center bg-semantic-1"
+                  style={{ top: headerRowHeight }}
+                >
                   <div className="text-sm text-muted-foreground">No data to display</div>
                 </div>
               ),
             }}
           />
           {isRefreshing && (
-            <div className="absolute inset-x-0 bottom-0 z-50 flex items-center justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
+            <div
+              className="absolute inset-x-0 bottom-0 z-50 flex items-center justify-center bg-semantic-1"
+              style={{ top: headerRowHeight }}
+            >
               <div className="flex items-center gap-1">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--alpha-12)] border-t-transparent" />
                 <span className="text-sm text-muted-foreground">Loading</span>

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -111,11 +111,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   const defaultRowKeyGetter = useCallback((row: TRow) => row.id || Math.random().toString(), []);
   const keyGetter = rowKeyGetter || defaultRowKeyGetter;
 
-  const defaultColumnKeys = useMemo(
-    () => columns.map((c) => c.key),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns.map((c) => c.key).join(',')]
-  );
+  const defaultColumnKeys = useMemo(() => columns.map((c) => c.key), [columns]);
 
   const { columnKeys, reorderColumns } = useColumnOrder(storageKey ?? '', defaultColumnKeys);
 
@@ -210,6 +206,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
         minWidth: col.minWidth || 80,
         maxWidth: col.maxWidth,
         resizable: col.resizable !== false,
+        draggable: storageKey ? true : col.draggable,
         sortable: col.sortable !== false,
         sortDescendingFirst: col.sortDescendingFirst ?? true,
         editable: col.editable && !col.isPrimaryKey,

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -120,7 +120,9 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   const { columnKeys, reorderColumns } = useColumnOrder(storageKey ?? '', defaultColumnKeys);
 
   const orderedColumns = useMemo(() => {
-    if (!storageKey) return columns;
+    if (!storageKey) {
+      return columns;
+    }
     return columnKeys
       .map((key) => columns.find((c) => c.key === key))
       .filter(Boolean) as DataGridColumn<TRow>[];

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -14,8 +14,8 @@ import { Checkbox } from '@insforge/ui';
 import { useTheme } from '#lib/contexts/ThemeContext';
 import type { DataGridColumn, DataGridRow, DataGridRowType } from './datagridTypes';
 import SortableHeaderRenderer from './SortableHeader';
+import { useColumnOrder } from './useColumnOrder';
 
-// Custom selection cell renderer props
 export interface SelectionCellProps<TRow extends DataGridRowType = DataGridRow> {
   row: TRow;
   isSelected: boolean;
@@ -23,7 +23,6 @@ export interface SelectionCellProps<TRow extends DataGridRowType = DataGridRow> 
   tabIndex: number;
 }
 
-// Generic DataGrid props
 export interface DataGridProps<TRow extends DataGridRowType = DataGridRow> {
   data: TRow[];
   columns: DataGridColumn<TRow>[];
@@ -65,9 +64,9 @@ export interface DataGridProps<TRow extends DataGridRowType = DataGridRow> {
   rowClass?: (row: TRow) => string | undefined;
   rightPanel?: React.ReactNode;
   onColumnResize?: (columnKey: string, width: number) => void;
+  storageKey?: string;
 }
 
-// Main DataGrid component
 export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   data,
   columns,
@@ -105,16 +104,34 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   rowClass,
   rightPanel,
   onColumnResize,
+  storageKey,
 }: DataGridProps<TRow>) {
   const { resolvedTheme } = useTheme();
 
   const defaultRowKeyGetter = useCallback((row: TRow) => row.id || Math.random().toString(), []);
   const keyGetter = rowKeyGetter || defaultRowKeyGetter;
-  // Convert columns to react-data-grid format
+
+  const defaultColumnKeys = useMemo(
+    () => columns.map((c) => c.key),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columns.map((c) => c.key).join(',')]
+  );
+
+  const { columnKeys, reorderColumns } = useColumnOrder(
+    storageKey ?? '',
+    defaultColumnKeys
+  );
+
+  const orderedColumns = useMemo(() => {
+    if (!storageKey) return columns;
+    return columnKeys
+      .map((key) => columns.find((c) => c.key === key))
+      .filter(Boolean) as DataGridColumn<TRow>[];
+  }, [columnKeys, columns, storageKey]);
+
   const gridColumns = useMemo(() => {
     const cols: Column<TRow>[] = [];
 
-    // Add selection column if enabled and not hidden
     if (showSelection && selectedRows !== undefined && onSelectedRowsChange) {
       const colWidth = selectionColumnWidth ?? 45;
       cols.push({
@@ -136,11 +153,9 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             }
             onSelectedRowsChange(newSelectedRows);
           };
-
           if (renderSelectionCell) {
             return renderSelectionCell({ row, isSelected, onToggle: handleToggle, tabIndex });
           }
-
           return (
             <div className="flex h-full w-full items-center">
               <Checkbox checked={isSelected} onCheckedChange={handleToggle} tabIndex={tabIndex} />
@@ -155,23 +170,15 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
           const handleSelectionToggle = (checked: boolean | 'indeterminate') => {
             const newSelectedRows = new Set(selectedRows);
             if (checked === true || checked === 'indeterminate') {
-              // Select all
               data.forEach((row) => newSelectedRows.add(keyGetter(row)));
             } else {
-              // Unselect all
               data.forEach((row) => newSelectedRows.delete(keyGetter(row)));
             }
             onSelectedRowsChange(newSelectedRows);
           };
-
           if (renderSelectionHeaderCell) {
-            return renderSelectionHeaderCell({
-              isAllSelected,
-              isPartiallySelected,
-              onToggle: handleSelectionToggle,
-            });
+            return renderSelectionHeaderCell({ isAllSelected, isPartiallySelected, onToggle: handleSelectionToggle });
           }
-
           return (
             <div className="flex h-full w-full items-center gap-2">
               <Checkbox
@@ -189,11 +196,9 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
       });
     }
 
-    // Add data columns
-    columns.forEach((col) => {
+    orderedColumns.forEach((col) => {
       const currentSort = sortColumns?.find((sort) => sort.columnKey === col.key);
       const sortDirection = currentSort?.direction;
-
       const gridColumn: Column<TRow> = {
         ...col,
         key: col.key,
@@ -230,13 +235,12 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             />
           )),
       };
-
       cols.push(gridColumn);
     });
 
     return cols;
   }, [
-    columns,
+    orderedColumns,
     selectedRows,
     onSelectedRowsChange,
     data,
@@ -252,26 +256,16 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
 
   const handleColumnResize = useCallback(
     (columnIndex: number, width: number) => {
-      if (!onColumnResize) {
-        return;
-      }
-
+      if (!onColumnResize) return;
       const resizedColumn = gridColumns[columnIndex];
-      if (!resizedColumn) {
-        return;
-      }
-
+      if (!resizedColumn) return;
       const columnKey = String(resizedColumn.key);
-      if (columnKey === SELECT_COLUMN_KEY) {
-        return;
-      }
-
+      if (columnKey === SELECT_COLUMN_KEY) return;
       onColumnResize(columnKey, width);
     },
     [gridColumns, onColumnResize]
   );
 
-  // Loading state - only show full loading screen if not sorting
   if (loading && !isSorting) {
     return (
       <div className="flex h-full items-center justify-center bg-[rgb(var(--semantic-1))]">
@@ -281,12 +275,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   }
 
   return (
-    <div
-      className={cn(
-        'min-w-0 h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]',
-        className
-      )}
-    >
+    <div className={cn('min-w-0 h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]', className)}>
       <div className={cn('flex min-h-0 min-w-0 flex-1 overflow-hidden', !noPadding && 'px-3')}>
         <div
           className={cn(
@@ -308,6 +297,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             onSortColumnsChange={onSortColumnsChange}
             onCellClick={onCellClick}
             onColumnResize={onColumnResize ? handleColumnResize : undefined}
+            onColumnsReorder={storageKey ? reorderColumns : undefined}
             rowClass={rowClass}
             className={cn(
               `h-full fill-grid insforge-rdg ${resolvedTheme === 'dark' ? 'rdg-dark' : 'rdg-light'}`,
@@ -318,29 +308,18 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
             enableVirtualization={true}
             renderers={{
               noRowsFallback: emptyState ? (
-                <div
-                  className="absolute inset-x-0 bottom-0 flex items-start justify-center bg-semantic-1"
-                  style={{ top: headerRowHeight }}
-                >
+                <div className="absolute inset-x-0 bottom-0 flex items-start justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
                   {emptyState}
                 </div>
               ) : (
-                <div
-                  className="absolute inset-x-0 bottom-0 flex items-center justify-center bg-semantic-1"
-                  style={{ top: headerRowHeight }}
-                >
+                <div className="absolute inset-x-0 bottom-0 flex items-center justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
                   <div className="text-sm text-muted-foreground">No data to display</div>
                 </div>
               ),
             }}
           />
-
-          {/* Loading mask overlay */}
           {isRefreshing && (
-            <div
-              className="absolute inset-x-0 bottom-0 z-50 flex items-center justify-center bg-semantic-1"
-              style={{ top: headerRowHeight }}
-            >
+            <div className="absolute inset-x-0 bottom-0 z-50 flex items-center justify-center bg-semantic-1" style={{ top: headerRowHeight }}>
               <div className="flex items-center gap-1">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-[var(--alpha-12)] border-t-transparent" />
                 <span className="text-sm text-muted-foreground">Loading</span>

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -259,11 +259,17 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
 
   const handleColumnResize = useCallback(
     (columnIndex: number, width: number) => {
-      if (!onColumnResize) return;
+      if (!onColumnResize) {
+        return;
+      }
       const resizedColumn = gridColumns[columnIndex];
-      if (!resizedColumn) return;
+      if (!resizedColumn) {
+        return;
+      }
       const columnKey = String(resizedColumn.key);
-      if (columnKey === SELECT_COLUMN_KEY) return;
+      if (columnKey === SELECT_COLUMN_KEY) {
+        return;
+      }
       onColumnResize(columnKey, width);
     },
     [gridColumns, onColumnResize]

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
-  const [columnKeys, setColumnKeys] = useState<string[]>(() => {
+  const buildOrder = useCallback((): string[] => {
     try {
       const saved = localStorage.getItem(storageKey);
       if (saved) {
@@ -11,10 +11,16 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
         return [...valid, ...missing];
       }
     } catch (error) {
-      console.debug('Failed to read column order from storage', error);
+      console.warn('Failed to read column order from storage', error);
     }
     return defaultKeys;
-  });
+  }, [storageKey, defaultKeys]);
+
+  const [columnKeys, setColumnKeys] = useState<string[]>(buildOrder);
+
+  useEffect(() => {
+    setColumnKeys(buildOrder());
+  }, [buildOrder]);
 
   const reorderColumns = useCallback(
     (sourceKey: string, targetKey: string) => {
@@ -31,7 +37,7 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
         try {
           localStorage.setItem(storageKey, JSON.stringify(next));
         } catch (error) {
-          console.debug('Failed to persist column order', error);
+          console.warn('Failed to persist column order', error);
         }
         return next;
       });

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -32,8 +32,7 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
           return prev;
         }
         next.splice(from, 1);
-        const adjustedTo = from < to ? to - 1 : to;
-        next.splice(adjustedTo, 0, sourceKey);
+        next.splice(to, 0, sourceKey);
         try {
           localStorage.setItem(storageKey, JSON.stringify(next));
         } catch (error) {

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -24,7 +24,8 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
         const to = next.indexOf(targetKey);
         if (from === -1 || to === -1) return prev;
         next.splice(from, 1);
-        next.splice(to, 0, sourceKey);
+        const adjustedTo = from < to ? to - 1 : to;
+        next.splice(adjustedTo, 0, sourceKey);
         try {
           localStorage.setItem(storageKey, JSON.stringify(next));
         } catch (_) {}

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -10,8 +10,8 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
         const missing = defaultKeys.filter((k) => !parsed.includes(k));
         return [...valid, ...missing];
       }
-    } catch {
-      // fall through
+    } catch (error) {
+      console.debug('Failed to read column order from storage', error);
     }
     return defaultKeys;
   });
@@ -22,13 +22,17 @@ export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
         const next = [...prev];
         const from = next.indexOf(sourceKey);
         const to = next.indexOf(targetKey);
-        if (from === -1 || to === -1) return prev;
+        if (from === -1 || to === -1) {
+          return prev;
+        }
         next.splice(from, 1);
         const adjustedTo = from < to ? to - 1 : to;
         next.splice(adjustedTo, 0, sourceKey);
         try {
           localStorage.setItem(storageKey, JSON.stringify(next));
-        } catch (_) {}
+        } catch (error) {
+          console.debug('Failed to persist column order', error);
+        }
         return next;
       });
     },

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { useState, useCallback } from 'react';
+
+export function useColumnOrder(storageKey: string, defaultKeys: string[]) {
+  const [columnKeys, setColumnKeys] = useState<string[]>(() => {
+    try {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const parsed = JSON.parse(saved) as string[];
+        const valid = parsed.filter((k) => defaultKeys.includes(k));
+        const missing = defaultKeys.filter((k) => !parsed.includes(k));
+        return [...valid, ...missing];
+      }
+    } catch {
+      // fall through
+    }
+    return defaultKeys;
+  });
+
+  const reorderColumns = useCallback(
+    (sourceKey: string, targetKey: string) => {
+      setColumnKeys((prev: string[]) => {
+        const next = [...prev];
+        const from = next.indexOf(sourceKey);
+        const to = next.indexOf(targetKey);
+        if (from === -1 || to === -1) return prev;
+        next.splice(from, 1);
+        next.splice(to, 0, sourceKey);
+        try {
+          localStorage.setItem(storageKey, JSON.stringify(next));
+        } catch (_) {}
+        return next;
+      });
+    },
+    [storageKey]
+  );
+
+  return { columnKeys, reorderColumns };
+}

--- a/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
+++ b/packages/dashboard/src/components/datagrid/useColumnOrder.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState, useCallback } from 'react';
 
 export function useColumnOrder(storageKey: string, defaultKeys: string[]) {

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -638,6 +638,11 @@ export default function TablesPage() {
                   key={dataGridKey}
                   data={tableData?.records || []}
                   schema={tableData?.schema}
+                  storageKey={
+                    tableData?.schema
+                      ? `db_col_order_${tableData.schema.schemaName}_${tableData.schema.tableName}`
+                      : undefined
+                  }
                   columnWidths={columnWidths}
                   loading={isLoadingTable && !tableData}
                   isSorting={isSorting}


### PR DESCRIPTION
## Summary
Adds persistent column re-ordering to the DataGrid component using localStorage.

## How did you test this change?
- Ran InsForge locally via Docker Compose
- Opened the database table page
- Reordered columns by dragging
- Refreshed the page — column order persisted correctly
- Verified fallback to default order when localStorage is cleared

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent column re-ordering to the `DataGrid` using `localStorage`. Order survives reloads when a per-table `storageKey` is set; new columns append, and invalid saved values fall back safely.

- **New Features**
  - Added `useColumnOrder` to persist/restore column keys and refresh on schema changes.
  - Added optional `storageKey` to `DataGrid`; when set, columns are draggable and moves persist via `onColumnsReorder`. `TablesPage` now sets a per-table key from schema/table names.

- **Bug Fixes**
  - Fixed reorder splice index and improved storage error handling with `console.warn`.
  - Addressed feedback: proper `draggable` and `storageKey` wiring, ESLint cleanups, and clearer early returns in `handleColumnResize`.

<sup>Written for commit 83817be37fb5503133c37bccde0f4d8c4f9289b2. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add persistent column reordering with localStorage to database DataGrid
> - Introduces a `useColumnOrder` hook in [`useColumnOrder.tsx`](https://github.com/InsForge/InsForge/pull/1296/files#diff-b58126a8b5ebc57d504773db0a38e716ea111c0411b7a175a637ab22c41b7fae) that reads, reconciles, and persists column order to localStorage, exposing a `reorderColumns(sourceKey, targetKey)` function.
> - Adds an optional `storageKey` prop to `DataGrid` that, when provided, enables drag-and-drop column reordering and restores column order from localStorage on mount.
> - Passes a per-table `storageKey` (format: `db_col_order_<schema>_<table>`) to the database grid in [`TablesPage.tsx`](https://github.com/InsForge/InsForge/pull/1296/files#diff-103425128d3b3dbb3753e98cf56e8154344e2dfa8a374af1d97af4e65decb4d6).
> - Behavioral Change: when `storageKey` is absent, grid behavior is unchanged; when present, `draggable` defaults to `true` regardless of per-column settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83817be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent column ordering so users’ column arrangements are saved and restored.

* **Improvements**
  * Safer column-resizing behavior with improved handling of edge cases.
  * Selection column preserves default checkbox behavior while allowing custom rendering.
  * Minor cleanup around the grid refresh/overlay for a tidier UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->