### PR TITLE
Skip INSFORGE_INTERNAL_URL cloud seed

### DIFF
--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -15,6 +15,7 @@ import { ERROR_CODES } from '@/types/error-constants.js';
 import { hasPgErrorCode } from '@/utils/errors.js';
 import { DenoSubhostingProvider } from '@/providers/functions/deno-subhosting.provider.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
+import { isCloudEnvironment } from '@/utils/environment.js';
 
 export class FunctionService {
   private static instance: FunctionService;
@@ -794,8 +795,8 @@ export class FunctionService {
 
   /**
    * Get all active secrets for function injection
-   * Note: INSFORGE_INTERNAL_URL is replaced with INSFORGE_BASE_URL value
-   * since internal URLs don't work from Deno Subhosting
+   * In cloud deployments, INSFORGE_INTERNAL_URL is replaced with INSFORGE_BASE_URL
+   * because the internal container URL is not reachable from Deno Subhosting.
    */
   private async getFunctionSecrets(): Promise<Record<string, string>> {
     try {
@@ -816,9 +817,8 @@ export class FunctionService {
         }
       }
 
-      // Replace INSFORGE_INTERNAL_URL with INSFORGE_BASE_URL value
-      // so existing functions using internal URL still work
-      if (baseUrlValue && secretMap['INSFORGE_INTERNAL_URL']) {
+      // Preserve OSS container-to-container routing while keeping cloud compatibility.
+      if (isCloudEnvironment() && baseUrlValue && secretMap['INSFORGE_INTERNAL_URL']) {
         secretMap['INSFORGE_INTERNAL_URL'] = baseUrlValue;
       }
 

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -276,17 +276,19 @@ export async function seedBackend(): Promise<void> {
     }
 
     // Initialize reserved secrets for edge functions
-    // Add INSFORGE_INTERNAL_URL for Deno-to-backend container communication
-    const insforgInternalUrl = 'http://insforge:7130';
-    const existingInternalUrlSecret = await secretService.getSecretByKey('INSFORGE_INTERNAL_URL');
+    if (!isCloudEnvironment()) {
+      // Add INSFORGE_INTERNAL_URL for Deno-to-backend container communication
+      const insforgInternalUrl = 'http://insforge:7130';
+      const existingInternalUrlSecret = await secretService.getSecretByKey('INSFORGE_INTERNAL_URL');
 
-    if (existingInternalUrlSecret === null) {
-      await secretService.createSecret({
-        key: 'INSFORGE_INTERNAL_URL',
-        isReserved: true,
-        value: insforgInternalUrl,
-      });
-      logger.info('✅ INSFORGE_INTERNAL_URL secret initialized');
+      if (existingInternalUrlSecret === null) {
+        await secretService.createSecret({
+          key: 'INSFORGE_INTERNAL_URL',
+          isReserved: true,
+          value: insforgInternalUrl,
+        });
+        logger.info('✅ INSFORGE_INTERNAL_URL secret initialized');
+      }
     }
 
     // Add ANON_KEY for public edge function access

--- a/backend/tests/unit/function-secrets-cloud-behavior.test.ts
+++ b/backend/tests/unit/function-secrets-cloud-behavior.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+describe('FunctionService cloud secret behavior', () => {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+  const functionServicePath = path.resolve(currentDir, '../../src/services/functions/function.service.ts');
+  const functionServiceSource = fs.readFileSync(functionServicePath, 'utf8');
+
+  it('only rewrites INSFORGE_INTERNAL_URL in cloud environments', () => {
+    expect(functionServiceSource).toContain('isCloudEnvironment() && baseUrlValue');
+    expect(functionServiceSource).toContain("secretMap['INSFORGE_INTERNAL_URL'] = baseUrlValue");
+  });
+});

--- a/backend/tests/unit/function-secrets-cloud-behavior.test.ts
+++ b/backend/tests/unit/function-secrets-cloud-behavior.test.ts
@@ -1,15 +1,88 @@
-import { describe, expect, it } from 'vitest';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsCloudEnvironment = vi.fn();
+const mockListSecrets = vi.fn();
+const mockGetSecretByKey = vi.fn();
+
+vi.mock('../../src/utils/environment.js', () => ({
+  isCloudEnvironment: mockIsCloudEnvironment,
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({
+      listSecrets: mockListSecrets,
+      getSecretByKey: mockGetSecretByKey,
+    }),
+  },
+}));
+
+vi.mock('../../src/providers/functions/deno-subhosting.provider.js', () => ({
+  DenoSubhostingProvider: {
+    getInstance: () => ({
+      isConfigured: vi.fn().mockReturnValue(false),
+    }),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe('FunctionService cloud secret behavior', () => {
-  const currentDir = path.dirname(fileURLToPath(import.meta.url));
-  const functionServicePath = path.resolve(currentDir, '../../src/services/functions/function.service.ts');
-  const functionServiceSource = fs.readFileSync(functionServicePath, 'utf8');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSecrets.mockResolvedValue([
+      { key: 'INSFORGE_INTERNAL_URL', isActive: true },
+      { key: 'INSFORGE_BASE_URL', isActive: true },
+    ]);
+    mockGetSecretByKey.mockImplementation(async (key: string) => {
+      if (key === 'INSFORGE_INTERNAL_URL') {
+        return 'http://insforge:7130';
+      }
+      if (key === 'INSFORGE_BASE_URL') {
+        return 'https://api.example.com';
+      }
+      return null;
+    });
+  });
 
-  it('only rewrites INSFORGE_INTERNAL_URL in cloud environments', () => {
-    expect(functionServiceSource).toContain('isCloudEnvironment() && baseUrlValue');
-    expect(functionServiceSource).toContain("secretMap['INSFORGE_INTERNAL_URL'] = baseUrlValue");
+  it('rewrites INSFORGE_INTERNAL_URL to INSFORGE_BASE_URL in cloud', async () => {
+    mockIsCloudEnvironment.mockReturnValue(true);
+
+    const { FunctionService } = await import('../../src/services/functions/function.service.js');
+    const service = FunctionService.getInstance() as unknown as {
+      getFunctionSecrets: () => Promise<Record<string, string>>;
+    };
+
+    const secrets = await service.getFunctionSecrets();
+
+    expect(secrets.INSFORGE_INTERNAL_URL).toBe('https://api.example.com');
+  });
+
+  it('preserves INSFORGE_INTERNAL_URL in OSS', async () => {
+    mockIsCloudEnvironment.mockReturnValue(false);
+
+    const { FunctionService } = await import('../../src/services/functions/function.service.js');
+    const service = FunctionService.getInstance() as unknown as {
+      getFunctionSecrets: () => Promise<Record<string, string>>;
+    };
+
+    const secrets = await service.getFunctionSecrets();
+
+    expect(secrets.INSFORGE_INTERNAL_URL).toBe('http://insforge:7130');
   });
 });

--- a/backend/tests/unit/seed-jwt-secret.test.ts
+++ b/backend/tests/unit/seed-jwt-secret.test.ts
@@ -21,4 +21,10 @@ describe('seedBackend JWT_SECRET initialization', () => {
     expect(seedSource).toContain("getSecretByKey('JWT_SECRET')");
     expect(seedSource).toMatch(/existingJwtSecret\s*===\s*null/);
   });
+
+  it('only seeds INSFORGE_INTERNAL_URL outside cloud environments', () => {
+    expect(seedSource).toMatch(
+      /if\s*\(!isCloudEnvironment\(\)\)\s*\{[\s\S]*getSecretByKey\('INSFORGE_INTERNAL_URL'\)/
+    );
+  });
 });

--- a/backend/tests/unit/seed-jwt-secret.test.ts
+++ b/backend/tests/unit/seed-jwt-secret.test.ts
@@ -1,30 +1,134 @@
-import { describe, it, expect } from 'vitest';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('seedBackend JWT_SECRET initialization', () => {
-  const currentDir = path.dirname(fileURLToPath(import.meta.url));
-  const seedPath = path.resolve(currentDir, '../../src/utils/seed.ts');
-  const seedSource = fs.readFileSync(seedPath, 'utf8');
+const mockGetSecretByKey = vi.fn();
+const mockCreateSecret = vi.fn();
+const mockInitializeApiKey = vi.fn().mockResolvedValue('api-key');
+const mockIsCloudEnvironment = vi.fn();
+const mockGetApiBaseUrl = vi.fn().mockReturnValue('https://api.example.com');
+const mockGenerateAnonToken = vi.fn().mockReturnValue('anon-token');
+const mockClientQuery = vi.fn();
+const mockClientRelease = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue({
+  query: mockClientQuery,
+  release: mockClientRelease,
+});
+const mockGetUserTables = vi.fn().mockResolvedValue([]);
+const mockSeedStripeKeysFromEnv = vi.fn().mockResolvedValue(undefined);
 
-  it('reads JWT_SECRET from process.env', () => {
-    expect(seedSource).toContain('process.env.JWT_SECRET');
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({
+      getSecretByKey: mockGetSecretByKey,
+      createSecret: mockCreateSecret,
+      initializeApiKey: mockInitializeApiKey,
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/environment.js', () => ({
+  isCloudEnvironment: mockIsCloudEnvironment,
+  getApiBaseUrl: mockGetApiBaseUrl,
+}));
+
+vi.mock('../../src/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      generateAnonToken: mockGenerateAnonToken,
+    }),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({
+        connect: mockConnect,
+      }),
+      getUserTables: mockGetUserTables,
+    }),
+  },
+}));
+
+vi.mock('../../src/services/payments/payment.service.js', () => ({
+  PaymentService: {
+    getInstance: () => ({
+      seedStripeKeysFromEnv: mockSeedStripeKeysFromEnv,
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/oauth-config.service.js', () => ({
+  OAuthConfigService: {
+    getInstance: () => ({
+      getAllConfigs: vi.fn().mockResolvedValue([]),
+      createConfig: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getConfig: vi.fn().mockResolvedValue(null),
+      updateConfig: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('seedBackend secret initialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientQuery.mockResolvedValue({ rows: [] });
+    mockGetUserTables.mockResolvedValue([]);
+    process.env.ADMIN_EMAIL = 'admin@example.com';
+    process.env.ADMIN_PASSWORD = 'change-this-password';
+    process.env.JWT_SECRET = 'jwt-secret';
   });
 
-  it('stores JWT_SECRET as a reserved secret', () => {
-    expect(seedSource).toContain("key: 'JWT_SECRET'");
-    expect(seedSource).toContain('isReserved: true');
+  it('seeds INSFORGE_INTERNAL_URL in OSS environments', async () => {
+    mockIsCloudEnvironment.mockReturnValue(false);
+    mockGetSecretByKey.mockResolvedValue(null);
+
+    const { seedBackend } = await import('../../src/utils/seed.js');
+
+    await seedBackend();
+
+    expect(mockCreateSecret).toHaveBeenCalledWith({
+      key: 'INSFORGE_INTERNAL_URL',
+      isReserved: true,
+      value: 'http://insforge:7130',
+    });
   });
 
-  it('only creates JWT_SECRET if it does not already exist', () => {
-    expect(seedSource).toContain("getSecretByKey('JWT_SECRET')");
-    expect(seedSource).toMatch(/existingJwtSecret\s*===\s*null/);
-  });
+  it('skips INSFORGE_INTERNAL_URL in cloud but still seeds JWT_SECRET when missing', async () => {
+    mockIsCloudEnvironment.mockReturnValue(true);
+    mockGetSecretByKey.mockImplementation(async (key: string) => {
+      if (key === 'JWT_SECRET') {
+        return null;
+      }
+      return null;
+    });
 
-  it('only seeds INSFORGE_INTERNAL_URL outside cloud environments', () => {
-    expect(seedSource).toMatch(
-      /if\s*\(!isCloudEnvironment\(\)\)\s*\{[\s\S]*getSecretByKey\('INSFORGE_INTERNAL_URL'\)/
+    const { seedBackend } = await import('../../src/utils/seed.js');
+
+    await seedBackend();
+
+    expect(mockCreateSecret).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'INSFORGE_INTERNAL_URL' })
     );
+    expect(mockCreateSecret).toHaveBeenCalledWith({
+      key: 'JWT_SECRET',
+      isReserved: true,
+      value: 'jwt-secret',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- stop seeding `INSFORGE_INTERNAL_URL` in cloud environments
- keep rewriting `INSFORGE_INTERNAL_URL` to `INSFORGE_BASE_URL` only in cloud so OSS keeps its internal container route
- add focused regression tests covering both source locations

## Why
Cloud deployments never use the hardcoded internal container URL, but the reserved secret still shows up and confuses function authors about whether they should use `INSFORGE_INTERNAL_URL` or `INSFORGE_BASE_URL`.

## Validation
- `cd backend && npm test -- --run tests/unit/seed-jwt-secret.test.ts tests/unit/function-secrets-cloud-behavior.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops seeding `INSFORGE_INTERNAL_URL` in cloud and gates the `INSFORGE_INTERNAL_URL` → `INSFORGE_BASE_URL` rewrite behind a cloud check, reducing confusion while keeping OSS internal routing intact.

- **Bug Fixes**
  - Skip creating the `INSFORGE_INTERNAL_URL` secret during cloud seeding.
  - Rewrite `INSFORGE_INTERNAL_URL` to `INSFORGE_BASE_URL` only when `isCloudEnvironment()` is true; OSS keeps container-to-container routing.
  - Added runtime unit tests for cloud/OSS secret behavior (rewrite and seeding), and ensured `JWT_SECRET` still seeds in cloud.

<sup>Written for commit f6cefa2ce1aac2f341babe6531747f8881668cec. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1298?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip seeding `INSFORGE_INTERNAL_URL` secret in cloud environments
> - `seedBackend` in [seed.ts](https://github.com/InsForge/InsForge/pull/1298/files#diff-63196e4b85e26873baaf8f4688c0de418f99bafec3af5143fdae6a9d44f6e9b7) no longer creates the `INSFORGE_INTERNAL_URL` reserved secret when running in a cloud environment.
> - `FunctionService.getFunctionSecrets` in [function.service.ts](https://github.com/InsForge/InsForge/pull/1298/files#diff-574d7a1f366ea56db7647fc0040c3b519eb81aa6cb3b3f2db71839a46cfaecbc) now only rewrites `INSFORGE_INTERNAL_URL` to `INSFORGE_BASE_URL` in cloud environments, preserving the original value in OSS environments.
> - Unit tests added to verify both behaviors across cloud and OSS environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6cefa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secret handling now differentiates cloud vs non-cloud: internal URL is rewritten in cloud deployments and preserved for on-prem/OSS.
  * Reserved internal URL seeding only runs in non-cloud environments.

* **Tests**
  * Added tests validating cloud vs non-cloud secret behavior.
  * Rewrote seed initialization tests to assert environment-specific seeding outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->