### PR TITLE
Improve storage cache invalidation and dashboard docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,44 +1,34 @@
-# Mintlify Starter Kit
+# InsForge Documentation
 
-Use the starter kit to get your docs deployed and ready to customize.
+This directory contains the public documentation source for InsForge.
 
-Click the green **Use this template** button at the top of this repo to copy the Mintlify starter kit. The starter kit contains examples with
+## Main areas
 
-- Guide pages
-- Navigation
-- Customizations
-- API reference pages
-- Use of popular components
+- `core-concepts/`: product architecture and feature behavior
+- `sdks/`: SDK usage guides by language
+- `agent-docs/`: agent-oriented execution docs
+- `examples/`: framework and integration examples
+- `docs.json`: Mintlify site configuration and navigation
+- `../openapi/*.yaml`: API reference specs used by docs navigation
 
-**[Follow the full quickstart guide](https://starter.mintlify.com/quickstart)**
+## Local preview
 
-## Development
+Install the [Mintlify CLI](https://www.npmjs.com/package/mint):
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview your documentation changes locally. To install, use the following command:
-
-```
+```bash
 npm i -g mint
 ```
 
-Run the following command at the root of your documentation, where your `docs.json` is located:
+Run from `docs/`:
 
-```
+```bash
 mint dev
 ```
 
 View your local preview at `http://localhost:3000`.
 
-## Publishing changes
+## Contributor notes
 
-Install our GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
-
-## Need help?
-
-### Troubleshooting
-
-- If your dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
-- If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
-
-### Resources
-- [Mintlify documentation](https://mintlify.com/docs)
-- [Mintlify community](https://mintlify.com/community)
+- Keep `docs.json` navigation and file paths in sync.
+- If API request or response shapes change, update the matching OpenAPI spec under `openapi/`.
+- If backend docs endpoints change, update `backend/src/api/routes/docs/index.routes.ts` mappings.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,5 +30,5 @@ View your local preview at `http://localhost:3000`.
 ## Contributor notes
 
 - Keep `docs.json` navigation and file paths in sync.
-- If API request or response shapes change, update the matching OpenAPI spec under `openapi/`.
-- If backend docs endpoints change, update `backend/src/api/routes/docs/index.routes.ts` mappings.
+- If API request or response shapes change, update the matching OpenAPI spec under `../openapi/`.
+- If backend docs endpoints change, update `../backend/src/api/routes/docs/index.routes.ts` mappings.

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,14 +1,29 @@
 # @insforge/dashboard
 
-Scaffold for the shared InsForge dashboard package.
+Shared InsForge dashboard package.
 
-This package is intended to become the single source of truth for the project dashboard used by:
+This package is the source of truth for dashboard UI and feature behavior used by:
 
 - the self-hosting dashboard app inside `frontend/` in this repo
 - the `insforge-cloud` repo
 
-It is wired into the root workspace and is the shared source of truth for dashboard code used by
-the self-hosting app in this repo.
+## Package role
 
-See [../../docs/dashboard-package-rfc.md](../../docs/dashboard-package-rfc.md) for the current API
-and migration plan.
+- `packages/dashboard/`: shared dashboard routes, features, host contract types, and styling
+- `frontend/`: local host shell that mounts this package in self-hosting mode
+
+## Entry points
+
+- Package exports: `src/index.ts`
+- Dashboard app root: `src/app/InsforgeDashboard.tsx`
+- Main route tree: `src/router/AppRoutes.tsx`
+
+## Validation
+
+Run package-level checks when editing this package:
+
+```bash
+npm --workspace @insforge/dashboard run typecheck
+npm --workspace @insforge/dashboard run test:unit
+npm --workspace @insforge/dashboard run test:component
+```

--- a/packages/dashboard/src/features/storage/hooks/__tests__/useStorageObjects.test.tsx
+++ b/packages/dashboard/src/features/storage/hooks/__tests__/useStorageObjects.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useStorageObjects } from '#features/storage/hooks/useStorageObjects';
 import { storageService } from '#features/storage/services/storage.service';
@@ -25,7 +26,7 @@ vi.mock('#features/storage/services/storage.service', () => ({
 }));
 
 function createWrapper(queryClient: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) => (
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 }
@@ -88,9 +89,8 @@ describe('useStorageObjects', () => {
 
     await waitFor(() => {
       expect(storageService.deleteObjects).toHaveBeenCalledWith('logs', ['events.txt']);
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'objects', 'logs'] });
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'bucket-stats'] });
     });
-
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'objects', 'logs'] });
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'bucket-stats'] });
   });
 });

--- a/packages/dashboard/src/features/storage/hooks/__tests__/useStorageObjects.test.tsx
+++ b/packages/dashboard/src/features/storage/hooks/__tests__/useStorageObjects.test.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useStorageObjects } from '#features/storage/hooks/useStorageObjects';
+import { storageService } from '#features/storage/services/storage.service';
+
+const toastMocks = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('#lib/hooks/useToast', () => ({
+  useToast: () => ({
+    showToast: toastMocks.showToast,
+  }),
+}));
+
+vi.mock('#features/storage/services/storage.service', () => ({
+  storageService: {
+    listObjects: vi.fn(),
+    uploadObject: vi.fn(),
+    deleteObjects: vi.fn(),
+    getDownloadUrl: vi.fn(),
+    downloadObject: vi.fn(),
+  },
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useStorageObjects', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invalidates bucket object and bucket stats queries after upload success', async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(storageService.uploadObject).mockResolvedValue({
+      bucket: 'logs',
+      key: 'events.txt',
+      size: 4,
+      mimeType: 'text/plain',
+      uploadedAt: new Date().toISOString(),
+      url: '/api/storage/buckets/logs/objects/events.txt',
+    });
+
+    const { result } = renderHook(() => useStorageObjects(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.uploadObject({
+        bucket: 'logs',
+        objectKey: 'events.txt',
+        file: new File(['test'], 'events.txt', { type: 'text/plain' }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(storageService.uploadObject).toHaveBeenCalled();
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'objects', 'logs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'bucket-stats'] });
+  });
+
+  it('invalidates bucket object and bucket stats queries after delete success', async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+    vi.mocked(storageService.deleteObjects).mockResolvedValue({
+      success: ['events.txt'],
+      failures: [],
+    });
+
+    const { result } = renderHook(() => useStorageObjects(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.deleteObjects({
+        bucket: 'logs',
+        keys: ['events.txt'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(storageService.deleteObjects).toHaveBeenCalledWith('logs', ['events.txt']);
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'objects', 'logs'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['storage', 'bucket-stats'] });
+  });
+});

--- a/packages/dashboard/src/features/storage/hooks/useBuckets.ts
+++ b/packages/dashboard/src/features/storage/hooks/useBuckets.ts
@@ -17,10 +17,14 @@ export function useBuckets() {
     queryFn: () => storageService.listBuckets(),
   });
 
+  const bucketStatsKey = (buckets || []).map(
+    (bucket) => `${bucket.name}:${bucket.public ? 'public' : 'private'}:${bucket.createdAt ?? ''}`
+  );
+
   // Query to fetch bucket statistics
   const useBucketStats = (enabled = true) => {
     return useQuery({
-      queryKey: ['storage', 'bucket-stats', buckets],
+      queryKey: ['storage', 'bucket-stats', bucketStatsKey],
       queryFn: async () => {
         const stats: Record<string, { fileCount: number; public: boolean; createdAt?: string }> =
           {};

--- a/packages/dashboard/src/features/storage/hooks/useStorageObjects.ts
+++ b/packages/dashboard/src/features/storage/hooks/useStorageObjects.ts
@@ -6,6 +6,11 @@ export function useStorageObjects() {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
 
+  const invalidateBucketStorageQueries = (bucketName: string) => {
+    void queryClient.invalidateQueries({ queryKey: ['storage', 'objects', bucketName] });
+    void queryClient.invalidateQueries({ queryKey: ['storage', 'bucket-stats'] });
+  };
+
   // Hook to fetch objects in a bucket
   const useListObjects = (
     bucketName: string,
@@ -32,8 +37,8 @@ export function useStorageObjects() {
       objectKey: string;
       file: File;
     }) => storageService.uploadObject(bucket, objectKey, file),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['storage'] });
+    onSuccess: (_, variables) => {
+      invalidateBucketStorageQueries(variables.bucket);
     },
   });
 
@@ -41,7 +46,7 @@ export function useStorageObjects() {
   const deleteObjectsMutation = useMutation({
     mutationFn: ({ bucket, keys }: { bucket: string; keys: string[] }) =>
       storageService.deleteObjects(bucket, keys),
-    onSuccess: (result) => {
+    onSuccess: (result, variables) => {
       const { success, failures } = result;
       const successCount = success.length;
       const failureCount = failures.length;
@@ -62,7 +67,7 @@ export function useStorageObjects() {
         );
       }
 
-      void queryClient.invalidateQueries({ queryKey: ['storage'] });
+      invalidateBucketStorageQueries(variables.bucket);
     },
     onError: (error: Error) => {
       const errorMessage = error instanceof Error ? error.message : 'Failed to delete file';

--- a/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
+++ b/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
@@ -128,7 +128,9 @@ export default function BucketsPage() {
       setSearchValue('');
       const invalidateStorageQueries = [
         queryClient.invalidateQueries({
-          queryKey: selectedBucket ? ['storage', 'objects', selectedBucket] : ['storage', 'objects'],
+          queryKey: selectedBucket
+            ? ['storage', 'objects', selectedBucket]
+            : ['storage', 'objects'],
         }),
         queryClient.invalidateQueries({ queryKey: ['storage', 'bucket-stats'] }),
       ];

--- a/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
+++ b/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
@@ -126,10 +126,13 @@ export default function BucketsPage() {
     try {
       setSelectedFiles(new Set());
       setSearchValue('');
-      await Promise.all([
-        refetchBuckets(),
-        queryClient.invalidateQueries({ queryKey: ['storage'] }),
-      ]);
+      const invalidateStorageQueries = [
+        queryClient.invalidateQueries({
+          queryKey: selectedBucket ? ['storage', 'objects', selectedBucket] : ['storage', 'objects'],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['storage', 'bucket-stats'] }),
+      ];
+      await Promise.all([refetchBuckets(), ...invalidateStorageQueries]);
     } finally {
       setIsRefreshing(false);
     }

--- a/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
+++ b/packages/dashboard/src/features/storage/pages/BucketsPage.tsx
@@ -135,6 +135,10 @@ export default function BucketsPage() {
         queryClient.invalidateQueries({ queryKey: ['storage', 'bucket-stats'] }),
       ];
       await Promise.all([refetchBuckets(), ...invalidateStorageQueries]);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to refresh storage data';
+      showToast(errorMessage, 'error');
     } finally {
       setIsRefreshing(false);
     }


### PR DESCRIPTION
## Summary
- stabilize storage bucket-stats query key generation in useBuckets
- narrow storage invalidations in useStorageObjects and BucketsPage to object/bucket-stats scopes
- add component tests for upload/delete invalidation behavior in useStorageObjects
- refresh stale dashboard/docs READMEs with current package and docs guidance

## Validation
- npm --workspace @insforge/dashboard run build
- npm --workspace @insforge/dashboard run test
- npm --workspace @insforge/dashboard run typecheck
- npm --workspace @insforge/dashboard run test:component
- npm --workspace @insforge/dashboard run test:unit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves storage cache invalidation in `@insforge/dashboard` by targeting bucket-scoped queries and stabilizing bucket-stats keys. Adds tests, refresh error handling with toasts, and updated dashboard/docs READMEs with clearer entry points and local preview.

- **Bug Fixes**
  - Narrowed invalidations to `['storage','objects',<bucket>]` (or `['storage','objects']` when none) and `['storage','bucket-stats']` in `useStorageObjects` and `BucketsPage`; shows a toast on refresh errors.
  - Stabilized `useBuckets` bucket-stats query key using name/public/createdAt.

<sup>Written for commit 5466a9baf28f91d4f50e547910ad8edb53217715. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1303?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow storage cache invalidation to affected bucket queries after upload and delete
> - Replaces broad `['storage']` cache invalidations in [`useStorageObjects`](https://github.com/InsForge/InsForge/pull/1303/files#diff-0c62862f0fd0db491de70a6b02901fda2489b6ec6d12f5c1e9c070d62f68cd52) and [`BucketsPage`](https://github.com/InsForge/InsForge/pull/1303/files#diff-580491c3ef577f813406f3e9aed00d7898e54c24ef51d0075ee51f66d1b3f233) with targeted invalidations of `['storage','objects',bucket]` and `['storage','bucket-stats']`.
> - Introduces a `invalidateBucketStorageQueries` helper in `useStorageObjects` used by both `uploadObject` and `deleteObjects` on success.
> - Updates the `useBucketStats` query key in [`useBuckets`](https://github.com/InsForge/InsForge/pull/1303/files#diff-a46ef5c931efbeccbc0637498fe3a147c57a234a4196abcaae0e78a38d072fb8) to use a derived array of strings instead of the raw buckets object.
> - Adds a test suite in [`useStorageObjects.test.tsx`](https://github.com/InsForge/InsForge/pull/1303/files#diff-4ed4dd7262044903d8b6f6d3d657a8f1120f14cba19230f91434b99ee9fbeb38) verifying correct query invalidation after uploads and deletions.
> - Also updates `docs/README.md` and `packages/dashboard/README.md` with contributor notes and package role documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b7ca23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote project docs landing and dashboard package README with clearer structure, package role, entry points, local preview instructions, and contributor guidance.

* **Improvements**
  * Storage upload/delete flows and manual refresh now use targeted cache invalidation for more responsive dashboard updates and fewer unnecessary refreshes.

* **Tests**
  * Added tests for storage behavior confirming cache invalidation after uploads and deletes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->