### PR TITLE
Add storage file rename support

### DIFF
--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -16,6 +16,7 @@ import {
   updateBucketRequestSchema,
   updateStorageConfigRequestSchema,
   createS3AccessKeyRequestSchema,
+  renameObjectRequestSchema,
 } from '@insforge/shared-schemas';
 import { SocketManager } from '@/infra/socket/socket.manager.js';
 import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
@@ -450,6 +451,74 @@ router.get(
       res.send(file);
     } catch (error) {
       if (error instanceof Error && error.message.includes('Invalid')) {
+        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
+      } else {
+        next(error);
+      }
+    }
+  }
+);
+
+// PATCH /api/storage/buckets/:bucketName/objects/:objectKey - Rename object in bucket (requires auth)
+router.patch(
+  '/buckets/:bucketName/objects/*',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { bucketName } = req.params;
+      const objectKey = req.params[0];
+
+      if (!objectKey) {
+        throw new AppError('Object key is required', 400, ERROR_CODES.STORAGE_INVALID_PARAMETER);
+      }
+
+      const validation = renameObjectRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.STORAGE_INVALID_PARAMETER
+        );
+      }
+
+      const renamedFile = await StorageService.getInstance().renameObject(
+        getUserContextFromReq(req),
+        bucketName,
+        objectKey,
+        validation.data.newKey
+      );
+
+      if (!renamedFile) {
+        throw new AppError('Object not found', 404, ERROR_CODES.NOT_FOUND);
+      }
+
+      try {
+        const socket = SocketManager.getInstance();
+        socket.broadcastToRoom(
+          'role:project_admin',
+          ServerEvents.DATA_UPDATE,
+          { resource: DataUpdateResourceType.BUCKETS, data: { bucketName } },
+          'system'
+        );
+      } catch {
+        // Best-effort notification; do not fail completed storage mutation
+      }
+
+      successResponse(res, renamedFile);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        ((error as { code?: string }).code === '23505' ||
+          error.message.toLowerCase().includes('duplicate'))
+      ) {
+        next(
+          new AppError(
+            'A file with that name already exists in this bucket',
+            409,
+            ERROR_CODES.ALREADY_EXISTS
+          )
+        );
+      } else if (error instanceof Error && error.message.includes('Invalid')) {
         next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
       } else {
         next(error);

--- a/backend/src/providers/storage/base.provider.ts
+++ b/backend/src/providers/storage/base.provider.ts
@@ -27,6 +27,12 @@ export interface StorageProvider {
   putObject(bucket: string, key: string, file: Express.Multer.File): Promise<{ etag: string }>;
   getObject(bucket: string, key: string): Promise<Buffer | null>;
   deleteObject(bucket: string, key: string): Promise<void>;
+  renameObject(
+    srcBucket: string,
+    srcKey: string,
+    dstBucket: string,
+    dstKey: string
+  ): Promise<{ etag: string; lastModified: Date }>;
   createBucket(bucket: string): Promise<void>;
   deleteBucket(bucket: string): Promise<void>;
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -78,6 +78,27 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
+  async renameObject(
+    srcBucket: string,
+    srcKey: string,
+    dstBucket: string,
+    dstKey: string
+  ): Promise<{ etag: string; lastModified: Date }> {
+    const sourcePath = this.getFilePath(srcBucket, srcKey);
+    const destinationPath = this.getFilePath(dstBucket, dstKey);
+
+    await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+    await fs.rename(sourcePath, destinationPath);
+
+    const stats = await fs.stat(destinationPath);
+    const buffer = await fs.readFile(destinationPath);
+
+    return {
+      etag: crypto.createHash('md5').update(buffer).digest('hex'),
+      lastModified: stats.mtime,
+    };
+  }
+
   async createBucket(bucket: string): Promise<void> {
     const bucketPath = this.getValidatedPath(bucket);
     await fs.mkdir(bucketPath, { recursive: true });

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -217,6 +217,34 @@ export class S3StorageProvider implements StorageProvider {
     await this.s3Client.send(command);
   }
 
+  async renameObject(
+    srcBucket: string,
+    srcKey: string,
+    dstBucket: string,
+    dstKey: string
+  ): Promise<{ etag: string; lastModified: Date }> {
+    const copied = await this.copyObject(srcBucket, srcKey, dstBucket, dstKey);
+
+    try {
+      await this.deleteObject(srcBucket, srcKey);
+      return copied;
+    } catch (error) {
+      try {
+        await this.deleteObject(dstBucket, dstKey);
+      } catch (cleanupError) {
+        logger.warn('Failed to roll back copied S3 object after rename delete failure', {
+          srcBucket,
+          srcKey,
+          dstBucket,
+          dstKey,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        });
+      }
+
+      throw error;
+    }
+  }
+
   async createBucket(_bucket: string): Promise<void> {
     // In S3 with multi-tenant, we don't create actual buckets
     // We just use folders under the app key

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -323,6 +323,85 @@ export class StorageService {
     return true;
   }
 
+  async renameObject(
+    ctx: UserContext,
+    bucket: string,
+    key: string,
+    newKey: string
+  ): Promise<StorageFileSchema | null> {
+    this.validateBucketName(bucket);
+    this.validateKey(key);
+    this.validateKey(newKey);
+
+    if (key === newKey) {
+      const existing = await this.getObject(ctx, bucket, key);
+      return existing?.metadata ?? null;
+    }
+
+    let providerRenamed = false;
+
+    return withUserContext(this.getPool(), ctx, async (db) => {
+      const existingResult = await db.query(
+        `
+          SELECT key, bucket, size, mime_type, uploaded_at, etag
+          FROM storage.objects
+          WHERE bucket = $1 AND key = $2
+          FOR UPDATE
+        `,
+        [bucket, key]
+      );
+
+      const existing = existingResult.rows[0] as StorageRecord | undefined;
+      if (!existing) {
+        return null;
+      }
+
+      const renamedObject = await this.provider.renameObject(bucket, key, bucket, newKey);
+      providerRenamed = true;
+
+      try {
+        const updateResult = await db.query(
+          `
+            UPDATE storage.objects
+            SET key = $3, etag = $4
+            WHERE bucket = $1 AND key = $2
+            RETURNING key, bucket, size, mime_type, uploaded_at, etag
+          `,
+          [bucket, key, newKey, renamedObject.etag]
+        );
+
+        const updated = updateResult.rows[0] as StorageRecord | undefined;
+        if (!updated) {
+          throw new Error('Failed to update storage metadata after renaming object');
+        }
+
+        return {
+          key: updated.key,
+          bucket: updated.bucket,
+          size: updated.size,
+          mimeType: updated.mime_type,
+          uploadedAt: updated.uploaded_at,
+          url: this.buildObjectUrl(bucket, updated.key, updated.etag || updated.uploaded_at),
+        };
+      } catch (error) {
+        if (providerRenamed) {
+          try {
+            await this.provider.renameObject(bucket, newKey, bucket, key);
+          } catch (rollbackError) {
+            logger.warn('Failed to roll back storage rename after metadata update error', {
+              bucket,
+              key,
+              newKey,
+              error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+            });
+          }
+        }
+
+        throw error;
+      }
+    });
+  }
+
   async listObjects(
     ctx: UserContext,
     bucket: string,

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -156,3 +156,51 @@ describe('LocalStorageProvider - getDownloadStrategy versioning', () => {
     expect(s.url).toBe('https://app.test/api/storage/buckets/b/objects/k.png?v=a%20b%26c');
   });
 });
+
+describe('LocalStorageProvider - renameObject', () => {
+  const baseDir = path.join(__dirname, 'test-storage-rename');
+  let provider: LocalStorageProvider;
+
+  beforeEach(async () => {
+    provider = new LocalStorageProvider(baseDir);
+    await provider.initialize();
+    await provider.createBucket('renameBucket');
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function makeFile(buffer: Buffer): Express.Multer.File {
+    return {
+      buffer,
+      mimetype: 'text/plain',
+      originalname: 'notes.txt',
+      size: buffer.length,
+      fieldname: 'file',
+      encoding: '7bit',
+      stream: undefined as never,
+      destination: '',
+      filename: '',
+      path: '',
+    } as Express.Multer.File;
+  }
+
+  it('renames an object and preserves its contents', async () => {
+    await provider.putObject('renameBucket', 'folder/old.txt', makeFile(Buffer.from('hello')));
+
+    const renamed = await provider.renameObject(
+      'renameBucket',
+      'folder/old.txt',
+      'renameBucket',
+      'folder/new.txt'
+    );
+
+    await expect(provider.getObject('renameBucket', 'folder/old.txt')).resolves.toBeNull();
+    await expect(provider.getObject('renameBucket', 'folder/new.txt')).resolves.toEqual(
+      Buffer.from('hello')
+    );
+    expect(renamed.etag).toBe('5d41402abc4b2a76b9719d911017c592');
+  });
+});

--- a/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/RenameFileDialog.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useId, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogCloseButton,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from '@insforge/ui';
+
+interface RenameFileDialogProps {
+  open: boolean;
+  initialName: string;
+  onOpenChange: (open: boolean) => void;
+  onSave: (fileName: string) => Promise<void>;
+}
+
+export function RenameFileDialog({
+  open,
+  initialName,
+  onOpenChange,
+  onSave,
+}: RenameFileDialogProps) {
+  const fileNameId = useId();
+  const [fileName, setFileName] = useState(initialName);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setFileName(initialName);
+      setIsSaving(false);
+    }
+  }, [initialName, open]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+
+    try {
+      await onSave(fileName.trim());
+      onOpenChange(false);
+    } catch {
+      // Keep the dialog open when saving fails; the caller handles the error state.
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="max-w-[480px] p-0">
+        <div className="flex flex-col">
+          <DialogHeader className="gap-0">
+            <div className="flex w-full items-center gap-3">
+              <div className="min-w-0 flex-1">
+                <DialogTitle>Rename File</DialogTitle>
+                <DialogDescription className="sr-only">Rename a storage file.</DialogDescription>
+              </div>
+              <DialogCloseButton className="relative right-auto top-auto h-7 w-7 rounded p-1" />
+            </div>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-6 p-4">
+            <div className="flex flex-col gap-1.5">
+              <label htmlFor={fileNameId} className="text-sm font-normal leading-5 text-foreground">
+                File Name
+              </label>
+              <Input
+                id={fileNameId}
+                value={fileName}
+                onChange={(event) => setFileName(event.target.value)}
+                autoFocus
+                className="h-8 px-1.5 py-1.5 text-sm leading-5"
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 p-4">
+            <Button
+              type="button"
+              variant="secondary"
+              className="h-8 rounded px-2"
+              disabled={isSaving}
+              onClick={() => onOpenChange(false)}
+            >
+              Close
+            </Button>
+            <Button
+              type="button"
+              className="h-8 rounded px-2"
+              disabled={!fileName.trim() || isSaving}
+              onClick={() => {
+                void handleSave();
+              }}
+            >
+              {isSaving ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Download,
   Eye,
+  Pencil,
   Trash2,
   Image,
   FileText,
@@ -31,6 +32,7 @@ import { useConfirm } from '#lib/hooks/useConfirm';
 import { useToast } from '#lib/hooks/useToast';
 import { SortColumn } from 'react-data-grid';
 import { usePageSize } from '#lib/hooks/usePageSize';
+import { RenameFileDialog } from './RenameFileDialog';
 
 // Create a type that makes StorageFileSchema compatible with DataGridRowType
 // This allows StorageFileSchema to be used with the generic DataGrid while maintaining type safety
@@ -128,6 +130,7 @@ const UploadedAtRenderer = ({ row, column }: RenderCellProps<StorageDataGridRow>
 export function createStorageColumns(
   onPreview?: (file: StorageFileSchema) => void,
   onDownload?: (file: StorageFileSchema) => void,
+  onRename?: (file: StorageFileSchema) => void,
   onDelete?: (file: StorageFileSchema) => void,
   isDownloading?: (key: string) => boolean
 ): DataGridColumn<StorageDataGridRow>[] {
@@ -171,12 +174,12 @@ export function createStorageColumns(
   ];
 
   // Add actions column if any handlers are provided
-  if (onPreview || onDownload || onDelete) {
+  if (onPreview || onDownload || onRename || onDelete) {
     columns.push({
       key: 'actions',
       name: '',
-      minWidth: 108,
-      maxWidth: 108,
+      minWidth: 140,
+      maxWidth: 140,
       resizable: false,
       sortable: false,
       renderCell: ({ row }: RenderCellProps<StorageDataGridRow>) => {
@@ -215,6 +218,20 @@ export function createStorageColumns(
                 <Download className="h-5 w-5 stroke-[1.5]" />
               </Button>
             )}
+            {onRename && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 rounded p-0 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRename(row as StorageFileSchema);
+                }}
+                title="Rename file"
+              >
+                <Pencil className="h-4 w-4 stroke-[1.5]" />
+              </Button>
+            )}
             {onDelete && (
               <Button
                 variant="ghost"
@@ -241,6 +258,7 @@ export function createStorageColumns(
 interface StorageFilesGridProps extends Omit<DataGridProps<StorageDataGridRow>, 'columns'> {
   onPreview?: (file: StorageFileSchema) => void;
   onDownload?: (file: StorageFileSchema) => void;
+  onRename?: (file: StorageFileSchema) => void;
   onDelete?: (file: StorageFileSchema) => void;
   isDownloading?: (key: string) => boolean;
 }
@@ -248,13 +266,14 @@ interface StorageFilesGridProps extends Omit<DataGridProps<StorageDataGridRow>, 
 function StorageFilesGrid({
   onPreview,
   onDownload,
+  onRename,
   onDelete,
   isDownloading,
   ...props
 }: StorageFilesGridProps) {
   const columns = useMemo(
-    () => createStorageColumns(onPreview, onDownload, onDelete, isDownloading),
-    [onPreview, onDownload, onDelete, isDownloading]
+    () => createStorageColumns(onPreview, onDownload, onRename, onDelete, isDownloading),
+    [onPreview, onDownload, onRename, onDelete, isDownloading]
   );
 
   // Ensure each row has an id for selection
@@ -298,6 +317,7 @@ export function StorageDataGrid({
 }: StorageDataGridProps) {
   const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set());
   const [previewFile, setPreviewFile] = useState<StorageFileSchema | null>(null);
+  const [renameFile, setRenameFile] = useState<StorageFileSchema | null>(null);
   const [showPreviewDialog, setShowPreviewDialog] = useState(false);
   const [sortColumns, setSortColumns] = useState<SortColumn[]>([]);
   const { showToast } = useToast();
@@ -313,7 +333,7 @@ export function StorageDataGrid({
     setCurrentPage(1);
   }, [searchQuery, bucketName]);
 
-  const { useListObjects, deleteObjects, downloadObject } = useStorageObjects();
+  const { useListObjects, deleteObjects, downloadObject, renameObject } = useStorageObjects();
   const {
     data: objectsData,
     isLoading: objectsLoading,
@@ -391,6 +411,44 @@ export function StorageDataGrid({
     setShowPreviewDialog(true);
   }, []);
 
+  const handleRename = useCallback((file: StorageFileSchema) => {
+    setRenameFile(file);
+  }, []);
+
+  const handleRenameSave = useCallback(
+    async (nextFileName: string) => {
+      if (!renameFile) {
+        return;
+      }
+
+      if (nextFileName.includes('/')) {
+        showToast('File name cannot include "/"', 'error');
+        throw new Error('File name cannot include "/"');
+      }
+
+      const segments = renameFile.key.split('/');
+      segments[segments.length - 1] = nextFileName;
+      const newKey = segments.join('/');
+      const previousKey = renameFile.key;
+
+      const renamed = await renameObject({
+        bucket: bucketName,
+        key: previousKey,
+        newKey,
+      });
+
+      setRenameFile(renamed);
+
+      if (selectedFiles.has(previousKey)) {
+        const nextSelectedFiles = new Set(selectedFiles);
+        nextSelectedFiles.delete(previousKey);
+        nextSelectedFiles.add(renamed.key);
+        onSelectedFilesChange(nextSelectedFiles);
+      }
+    },
+    [bucketName, onSelectedFilesChange, renameFile, renameObject, selectedFiles, showToast]
+  );
+
   const handleDelete = useCallback(
     async (file: StorageFileSchema) => {
       const confirmOptions = {
@@ -467,6 +525,7 @@ export function StorageDataGrid({
           onSortColumnsChange={setSortColumns}
           onPreview={handlePreview}
           onDownload={(file) => void handleDownload(file)}
+          onRename={handleRename}
           onDelete={(file) => void handleDelete(file)}
           isDownloading={isDownloading}
           emptyState={
@@ -484,6 +543,17 @@ export function StorageDataGrid({
         onOpenChange={setShowPreviewDialog}
         file={previewFile}
         bucket={bucketName}
+      />
+
+      <RenameFileDialog
+        open={renameFile !== null}
+        initialName={renameFile?.key.split('/').pop() ?? ''}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameFile(null);
+          }
+        }}
+        onSave={handleRenameSave}
       />
     </div>
   );

--- a/packages/dashboard/src/features/storage/components/__tests__/RenameFileDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/RenameFileDialog.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { RenameFileDialog } from '#features/storage/components/RenameFileDialog';
+
+describe('RenameFileDialog', () => {
+  it('saves a trimmed file name and closes on success', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    render(
+      <RenameFileDialog open initialName="old.png" onOpenChange={onOpenChange} onSave={onSave} />
+    );
+
+    const input = screen.getByLabelText('File Name');
+    await user.clear(input);
+    await user.type(input, ' new.png ');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('new.png');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/packages/dashboard/src/features/storage/hooks/useStorageObjects.ts
+++ b/packages/dashboard/src/features/storage/hooks/useStorageObjects.ts
@@ -70,14 +70,29 @@ export function useStorageObjects() {
     },
   });
 
+  const renameObjectMutation = useMutation({
+    mutationFn: ({ bucket, key, newKey }: { bucket: string; key: string; newKey: string }) =>
+      storageService.renameObject(bucket, key, newKey),
+    onSuccess: () => {
+      showToast('File renamed successfully.', 'success');
+      void queryClient.invalidateQueries({ queryKey: ['storage'] });
+    },
+    onError: (error: Error) => {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to rename file';
+      showToast(errorMessage, 'error');
+    },
+  });
+
   return {
     // Loading states
     isUploadingObject: uploadObjectMutation.isPending,
     isDeletingObject: deleteObjectsMutation.isPending,
+    isRenamingObject: renameObjectMutation.isPending,
 
     // Actions
     uploadObject: uploadObjectMutation.mutateAsync,
     deleteObjects: deleteObjectsMutation.mutate,
+    renameObject: renameObjectMutation.mutateAsync,
 
     // Helpers
     useListObjects,

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -137,6 +137,21 @@ export const storageService = {
     return { success, failures };
   },
 
+  async renameObject(
+    bucketName: string,
+    objectKey: string,
+    newKey: string
+  ): Promise<StorageFileSchema> {
+    return apiClient.request(
+      `/storage/buckets/${encodeURIComponent(bucketName)}/objects/${encodeURIComponent(objectKey)}`,
+      {
+        method: 'PATCH',
+        headers: apiClient.withAccessToken(),
+        body: JSON.stringify({ newKey }),
+      }
+    );
+  },
+
   // Create a new bucket
   async createBucket(bucketName: string, isPublic: boolean = true): Promise<void> {
     await apiClient.request('/storage/buckets', {

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -10,6 +10,10 @@ export const updateBucketRequestSchema = z.object({
   isPublic: z.boolean(),
 });
 
+export const renameObjectRequestSchema = z.object({
+  newKey: z.string().min(1, 'New object key cannot be empty'),
+});
+
 export const listObjectsResponseSchema = z.object({
   objects: z.array(storageFileSchema),
   pagination: z.object({
@@ -67,6 +71,7 @@ export const getStorageConfigResponseSchema = storageConfigSchema;
 
 export type CreateBucketRequest = z.infer<typeof createBucketRequestSchema>;
 export type UpdateBucketRequest = z.infer<typeof updateBucketRequestSchema>;
+export type RenameObjectRequest = z.infer<typeof renameObjectRequestSchema>;
 export type ListObjectsResponseSchema = z.infer<typeof listObjectsResponseSchema>;
 export type UploadStrategyRequest = z.infer<typeof uploadStrategyRequestSchema>;
 export type UploadStrategyResponse = z.infer<typeof uploadStrategyResponseSchema>;


### PR DESCRIPTION
## Summary

- add a storage object rename API and provider support for local and S3 backends
- add a rename action and dialog to the storage dashboard while preserving folder paths
- add focused rename coverage for the local storage provider and dialog flow

## Why

The storage dashboard currently lets users preview, download, and delete files, but not rename them. This change adds first-class rename support so users can correct file names without re-uploading.

## Validation

- `cd backend && npm test -- --run tests/unit/localstorageprovider.test.ts`
- `cd backend && npm run typecheck`
- `cd packages/dashboard && npm run test:component -- RenameFileDialog.test.tsx BucketFormDialog.test.tsx` *(blocked locally: missing `@testing-library/jest-dom/vitest` in this checkout)*
- `cd packages/dashboard && npm run typecheck` *(blocked locally: workspace dependencies are not installed in this checkout)*

Closes #1036


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add file rename support to storage across API and dashboard so users can rename files without re-uploading. Works with local and S3 providers and keeps the file in the same folder path.

- **New Features**
  - API: PATCH `/api/storage/buckets/:bucketName/objects/:objectKey` with `{ newKey }` using `renameObjectRequestSchema` from `@insforge/shared-schemas`; returns updated file, broadcasts bucket update, 400 on invalid, 409 on duplicate.
  - Providers: Local uses filesystem rename and MD5 `etag`; S3 uses copy-then-delete with rollback on failure.
  - Service: Renames object and updates `storage.objects` `key` and `etag`; rolls back provider rename if DB update fails.
  - Dashboard: Added Rename action (pencil) and `RenameFileDialog` using `@insforge/ui`; trims input, disallows “/”, preserves folder path, updates selection, shows success/error toasts.
  - Tests: Added focused tests for local provider rename and the dialog flow.

<sup>Written for commit 5f4be715abde23d4ccceffaaf55bb39730112bba. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1304?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file rename support to storage across backend and dashboard
> - Adds a `PATCH /api/storage/buckets/:bucketName/objects/*` endpoint that renames a storage object, returning updated metadata; responds 404 if missing and 409 on key conflict.
> - Implements `renameObject` in both `LocalStorageProvider` (atomic fs rename) and `S3StorageProvider` (copy-then-delete with rollback on delete failure).
> - `StorageService.renameObject` keeps DB and provider in sync, attempting a provider rollback if the DB update fails after the file has already been moved.
> - Adds a `RenameFileDialog` component and a Pencil action button in `StorageDataGrid`, wired through `useStorageObjects.renameObject` with toast feedback and cache invalidation on success.
> - Risk: S3 rename is not atomic — a failure between copy and delete can leave both keys present; rollback is best-effort and may also fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f4be71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File rename functionality is now available in the storage dashboard. Users can rename stored objects with input validation. The system automatically updates file metadata and references with atomic operations and built-in error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->