### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,87 @@
+Contact: https://github.com/InsForge/InsForge/security/advisories/new
+Contact: mailto:security@insforge.dev
+
+
+At InsForge, we consider the security of our systems a top priority. But no matter how much effort we put into system security, there can still be vulnerabilities present.
+
+If you discover a vulnerability, we would like to know about it so we can take steps to address it as quickly as possible. We ask you to help us better protect our users and our systems.
+
+## Supported Versions
+
+We provide security fixes for the latest minor release of the current major version.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+If you are running an older release, please upgrade before reporting, or include the exact version and commit so we can determine whether the issue still affects `main`.
+
+## Out of scope
+
+Here is a brief list of some common out-of-scope vulnerabilities:
+
+- Clickjacking on pages with no sensitive actions.
+- Unauthenticated, logout, or login CSRF.
+- Attacks requiring MITM or physical access to a user's device.
+- Attacks requiring social engineering.
+- Any activity that could lead to the disruption of our service (DoS).
+- Content spoofing and text injection issues without a clear attack vector or the ability to modify HTML/CSS.
+- Email spoofing.
+- Missing DNSSEC, CAA, or CSP headers.
+- Lack of Secure or HttpOnly flags on non-sensitive cookies.
+- Dead links.
+- User enumeration on public registration endpoints.
+
+## Testing guidelines
+
+- Do not run automated scanners against other customers' projects. Running automated scanners can run up costs for our users, may disrupt services, and our own security tooling cannot distinguish hostile reconnaissance from whitehat research. If you wish to run an automated scanner, notify us first at `security@insforge.dev` and only run it against your own InsForge project. Do NOT attack projects belonging to other customers.
+- Do not take advantage of the vulnerability you discover, for example by downloading more data than necessary to demonstrate the issue, or by deleting or modifying other people's data.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+- File a private report through GitHub Security Advisories:
+  https://github.com/InsForge/InsForge/security/advisories/new
+- Or email `security@insforge.dev`. If you do not receive a reply within 3 business days, please follow up via GitHub Security Advisories so the report does not get lost.
+
+Provide enough information to reproduce the problem so we can resolve it quickly. Helpful details include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a minimal proof-of-concept.
+- The affected version, commit, or deployment (self-hosted vs. `insforge.dev`).
+- Any logs, screenshots, or scripts that help us reproduce the issue.
+- Your contact information so we can follow up.
+
+## Disclosure guidelines
+
+- In order to protect our users, please do not reveal the problem to others until we have researched, addressed, and informed any affected customers.
+- If you want to publicly share your research about InsForge (at a conference, in a blog post, or any other public forum), please share a draft with us for review at least 30 days before publication. The following should not be included:
+  - Data regarding any InsForge customer projects.
+  - InsForge customers' data.
+  - Information about InsForge employees, contractors, or partners.
+
+## What we promise
+
+- We will respond to your report within 5 business days with our evaluation of the report and an expected resolution date.
+- If you have followed the instructions above, we will not take any legal action against you in regard to the report.
+- We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission.
+- We will keep you informed of the progress towards resolving the problem.
+- In the public information concerning the problem reported, we will give your name as the discoverer of the problem (unless you ask us not to).
+
+We strive to resolve all reports as quickly as possible, and we want to play an active role in the ultimate publication of the issue once it is resolved.
+
+## Safe harbor
+
+We support good-faith security research. If you make a good-faith effort to comply with this policy during your research, we will:
+
+- Consider your research authorized under this policy.
+- Not pursue or support legal action against you for the research.
+- Work with you to understand and resolve the issue quickly.
+
+If at any point you are unsure whether a particular action is allowed, please ask us first via the reporting channels above.
+
+---
+
+*This policy is adapted from [Supabase's security policy](https://github.com/supabase/supabase/blob/master/SECURITY.md), with reporting channels and scope updated for InsForge.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+# Security Policy
+
 Contact: https://github.com/InsForge/InsForge/security/advisories/new
 Contact: mailto:security@insforge.dev
 
@@ -44,7 +46,7 @@ Here is a brief list of some common out-of-scope vulnerabilities:
 
 - File a private report through GitHub Security Advisories:
   https://github.com/InsForge/InsForge/security/advisories/new
-- Or email `security@insforge.dev`. If you do not receive a reply within 3 business days, please follow up via GitHub Security Advisories so the report does not get lost.
+- Or email `security@insforge.dev`. If you do not receive a reply within 5 business days, please follow up via GitHub Security Advisories so the report does not get lost.
 
 Provide enough information to reproduce the problem so we can resolve it quickly. Helpful details include:
 


### PR DESCRIPTION
## Summary

Adds a top-level `SECURITY.md` so contributors and security researchers have a clear, private path to report vulnerabilities (and so GitHub surfaces the policy under the repo's Security tab).

The content is adapted from [Supabase's security policy](https://github.com/supabase/supabase/blob/master/SECURITY.md), with reporting channels and scope updated for InsForge. Sections included:

- **security.txt-style `Contact:` header** pointing to GitHub Security Advisories and `security@insforge.dev`.
- **Supported versions** table (2.x supported, <2.0 not).
- **Out of scope** list (clickjacking on non-sensitive pages, unauth/login/logout CSRF, MITM/physical, social engineering, DoS, content spoofing, email spoofing, missing DNSSEC/CAA/CSP, Secure/HttpOnly on non-sensitive cookies, deadlinks, user enumeration on public signup).
- **Testing guidelines** (no automated scanners against other customers' projects, do not exploit beyond minimum needed).
- **Reporting**: GitHub Security Advisories as primary channel, `security@insforge.dev` as fallback.
- **Disclosure guidelines** (30-day pre-publication review for conference/blog content; no customer data or staff info).
- **What we promise** (5 business day response, confidentiality, progress updates, credit, safe harbor).
- **Attribution** linking back to Supabase's policy.

## Before merging

- [ ] Confirm `security@insforge.dev` is set up and monitored (or drop that paragraph and rely on GitHub PVR only).
- [ ] Enable **Private vulnerability reporting** under Settings → Code security and analysis so the GHSA link in the policy works for external researchers.
- [ ] Adjust the supported-versions table if you back-port to a 1.x line.

## Test plan

- [ ] After merge, verify `SECURITY.md` appears under the repo's Security tab.
- [ ] Click the `Contact:` GHSA URL and confirm a private advisory form opens.
- [ ] Send a test email to `security@insforge.dev` and confirm receipt by a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top-level SECURITY.md with a clear, private vulnerability reporting process and scope. Also adds an H1 title for the Security tab and aligns the email follow-up window to 5 business days to match the response SLA.

- **New Features**
  - SECURITY.md with security.txt-style Contacts (GitHub Security Advisories and `security@insforge.dev`).
  - Supported versions: 2.x supported; <2.0 not.
  - Out-of-scope list and testing guidelines to reduce noise.
  - Reporting and disclosure rules, response commitments, and safe harbor.

- **Migration**
  - Enable Private vulnerability reporting in GitHub settings.
  - Confirm `security@insforge.dev` is set up and monitored.
  - Update the supported-versions table if maintaining a 1.x line.

<sup>Written for commit 0ca90b2e76e0defc55a6052700ba602a9dcc339e. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1308?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy document outlining vulnerability reporting channels and required triage information, supported product versions for security fixes, responsible disclosure guidelines and timeline commitments, testing guidelines to avoid scanning others’ projects, safe-harbor assurances for good-faith researchers, and confidentiality/no-legal-action commitments when guidelines are followed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SECURITY.md security policy document
> Adds a [SECURITY.md](https://github.com/InsForge/InsForge/pull/1308/files#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7) outlining how to report vulnerabilities, supported versions (2.x only), out-of-scope items, testing guidelines, disclosure expectations, and safe harbor terms. Adapted from Supabase's security policy. Reporting is handled via GitHub Security Advisories or email.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b59e82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->