### PR TITLE
Add SQL editor explain tab

### DIFF
--- a/backend/src/api/routes/database/advance.routes.ts
+++ b/backend/src/api/routes/database/advance.routes.ts
@@ -8,6 +8,7 @@ import { ERROR_CODES } from '@/types/error-constants.js';
 import { upload, handleUploadError } from '@/api/middlewares/upload.js';
 import {
   rawSQLRequestSchema,
+  explainSQLRequestSchema,
   exportRequestSchema,
   importRequestSchema,
   bulkUpsertRequestSchema,
@@ -161,6 +162,48 @@ router.post('/rawsql', verifyAdmin, async (req: AuthRequest, res: Response, next
     next(error);
   }
 });
+
+/**
+ * Explain raw SQL query with ANALYZE/BUFFERS enabled.
+ * Runs inside a rollback-only transaction so mutating statements are safe to inspect.
+ * POST /api/database/advance/rawsql/explain
+ */
+router.post(
+  '/rawsql/explain',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const validation = explainSQLRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const { query, params = [] } = validation.data;
+      const sanitizedQuery = dbAdvanceService.sanitizeQuery(query, 'strict');
+      const response = await dbAdvanceService.explainRawSQL(sanitizedQuery, params);
+
+      await auditService.log({
+        actor: req.user?.email || 'api-key',
+        action: 'EXPLAIN_RAW_SQL',
+        module: 'DATABASE',
+        details: {
+          query: query.substring(0, 300),
+          paramCount: params.length,
+        },
+        ip_address: req.ip,
+      });
+
+      successResponse(res, response);
+    } catch (error: unknown) {
+      logger.warn('Raw SQL explain error:', error);
+      next(error);
+    }
+  }
+);
 
 /**
  * Export database data

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -2,6 +2,8 @@ import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/api/middlewares/error.js';
 import {
   type RawSQLResponse,
+  type ExplainSQLResponse,
+  type ExplainPlanNode,
   type ExportDatabaseResponse,
   type ExportDatabaseJsonData,
   type ImportDatabaseResponse,
@@ -21,6 +23,59 @@ import pgFormat from 'pg-format';
 import { parse } from 'csv-parse/sync';
 import { type PoolClient } from 'pg';
 import { assertWritableDatabaseSchema } from './helpers.js';
+import { parseSync } from 'libpg-query';
+
+type ExplainPlanRecord = Record<string, unknown>;
+
+const EXPLAIN_ALLOWED_STATEMENTS = new Set([
+  'SelectStmt',
+  'InsertStmt',
+  'UpdateStmt',
+  'DeleteStmt',
+  'MergeStmt',
+  'ValuesStmt',
+]);
+
+function asNullableNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : undefined;
+}
+
+function normalizeExplainPlan(plan: ExplainPlanRecord): ExplainPlanNode {
+  return {
+    nodeType: String(plan['Node Type'] ?? 'Unknown'),
+    startupCost: asNullableNumber(plan['Startup Cost']),
+    totalCost: asNullableNumber(plan['Total Cost']),
+    planRows: asNullableNumber(plan['Plan Rows']),
+    actualStartupTime: asNullableNumber(plan['Actual Startup Time']),
+    actualTotalTime: asNullableNumber(plan['Actual Total Time']),
+    actualRows: asNullableNumber(plan['Actual Rows']),
+    actualLoops: asNullableNumber(plan['Actual Loops']),
+    relationName: typeof plan['Relation Name'] === 'string' ? plan['Relation Name'] : undefined,
+    alias: typeof plan.Alias === 'string' ? plan.Alias : undefined,
+    joinType: typeof plan['Join Type'] === 'string' ? plan['Join Type'] : undefined,
+    operation: typeof plan.Operation === 'string' ? plan.Operation : undefined,
+    strategy: typeof plan.Strategy === 'string' ? plan.Strategy : undefined,
+    indexName: typeof plan['Index Name'] === 'string' ? plan['Index Name'] : undefined,
+    filter: typeof plan.Filter === 'string' ? plan.Filter : undefined,
+    indexCond: typeof plan['Index Cond'] === 'string' ? plan['Index Cond'] : undefined,
+    hashCond: typeof plan['Hash Cond'] === 'string' ? plan['Hash Cond'] : undefined,
+    mergeCond: typeof plan['Merge Cond'] === 'string' ? plan['Merge Cond'] : undefined,
+    recheckCond: typeof plan['Recheck Cond'] === 'string' ? plan['Recheck Cond'] : undefined,
+    sortKey: asStringArray(plan['Sort Key']),
+    groupKey: asStringArray(plan['Group Key']),
+    plans: Array.isArray(plan.Plans)
+      ? plan.Plans.filter(
+          (child): child is ExplainPlanRecord => typeof child === 'object' && child !== null
+        ).map((child) => normalizeExplainPlan(child))
+      : undefined,
+  };
+}
 
 export class DatabaseAdvanceService {
   private static instance: DatabaseAdvanceService;
@@ -163,6 +218,113 @@ export class DatabaseAdvanceService {
       throw error;
     } finally {
       // Reset timeout to default before releasing client back to pool
+      await client.query('SET statement_timeout = 0');
+      client.release();
+    }
+  }
+
+  private validateExplainableQuery(query: string): void {
+    let statements: string[];
+
+    try {
+      statements = parseSQLStatements(query);
+    } catch (error) {
+      throw new AppError(
+        error instanceof Error ? error.message : 'Invalid SQL format',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    if (statements.length !== 1) {
+      throw new AppError(
+        'Explain supports a single SQL statement at a time',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    try {
+      const parsed = parseSync(statements[0]);
+      const stmt = parsed.stmts[0]?.stmt as Record<string, unknown> | undefined;
+      const stmtType = stmt ? Object.keys(stmt)[0] : null;
+
+      if (!stmtType || !EXPLAIN_ALLOWED_STATEMENTS.has(stmtType)) {
+        throw new AppError(
+          'Explain supports SELECT, INSERT, UPDATE, DELETE, MERGE, and VALUES statements only',
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      throw new AppError(
+        'Explain could not parse this SQL statement',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+  }
+
+  async explainRawSQL(query: string, params: unknown[] = []): Promise<ExplainSQLResponse> {
+    this.validateExplainableQuery(query);
+
+    const pool = this.dbManager.getPool();
+    const client = await pool.connect();
+    let beganTransaction = false;
+
+    try {
+      await client.query('SET statement_timeout = 30000');
+      await client.query('BEGIN');
+      beganTransaction = true;
+
+      const result = await client.query(`EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS) ${query}`, params);
+
+      const explainPayload = result.rows[0]?.['QUERY PLAN'];
+      const explainEntry =
+        Array.isArray(explainPayload) && explainPayload[0] && typeof explainPayload[0] === 'object'
+          ? (explainPayload[0] as ExplainPlanRecord)
+          : null;
+
+      if (!explainEntry || typeof explainEntry.Plan !== 'object' || explainEntry.Plan === null) {
+        throw new Error('Unexpected EXPLAIN response format');
+      }
+
+      await client.query('ROLLBACK');
+      beganTransaction = false;
+
+      const planningTime =
+        typeof explainEntry['Planning Time'] === 'number' ? explainEntry['Planning Time'] : null;
+      const executionTime =
+        typeof explainEntry['Execution Time'] === 'number' ? explainEntry['Execution Time'] : null;
+
+      return {
+        plan: normalizeExplainPlan(explainEntry.Plan as ExplainPlanRecord),
+        planningTime,
+        executionTime,
+        totalTime:
+          planningTime !== null && executionTime !== null ? planningTime + executionTime : null,
+      };
+    } catch (error) {
+      if (hasPgErrorCode(error, '57014')) {
+        throw new Error('Explain timeout: The query took longer than 30 seconds to execute');
+      }
+
+      throw error;
+    } finally {
+      if (beganTransaction) {
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          logger.warn('Failed to roll back EXPLAIN transaction', {
+            error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+          });
+        }
+      }
+
       await client.query('SET statement_timeout = 0');
       client.release();
     }

--- a/backend/tests/unit/database-advance-explain.test.ts
+++ b/backend/tests/unit/database-advance-explain.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/api/middlewares/error';
+
+const { mockClient, mockPool } = vi.hoisted(() => ({
+  mockClient: {
+    query: vi.fn(),
+    release: vi.fn(),
+  },
+  mockPool: {
+    connect: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  __esModule: true,
+  default: mockLogger,
+}));
+
+import { DatabaseAdvanceService } from '../../src/services/database/database-advance.service';
+
+describe('DatabaseAdvanceService - explainRawSQL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.connect.mockResolvedValue(mockClient);
+    mockClient.query.mockReset();
+    mockClient.release.mockReset();
+  });
+
+  it('wraps explain analyze in a rollback transaction and normalizes the plan', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({}) // SET statement_timeout
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            'QUERY PLAN': [
+              {
+                Plan: {
+                  'Node Type': 'Seq Scan',
+                  'Startup Cost': 0,
+                  'Total Cost': 18.1,
+                  'Plan Rows': 4,
+                  'Actual Startup Time': 0.015,
+                  'Actual Total Time': 0.045,
+                  'Actual Rows': 4,
+                  'Actual Loops': 1,
+                  'Relation Name': 'users',
+                  Filter: '(email IS NOT NULL)',
+                  Plans: [
+                    {
+                      'Node Type': 'Index Scan',
+                      'Startup Cost': 0.14,
+                      'Total Cost': 8.4,
+                      'Plan Rows': 1,
+                      'Actual Startup Time': 0.01,
+                      'Actual Total Time': 0.02,
+                      'Actual Rows': 1,
+                      'Actual Loops': 1,
+                      'Index Name': 'users_email_idx',
+                    },
+                  ],
+                },
+                'Planning Time': 0.22,
+                'Execution Time': 0.61,
+              },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({}) // ROLLBACK
+      .mockResolvedValueOnce({}); // reset statement_timeout
+
+    const service = DatabaseAdvanceService.getInstance();
+    const result = await service.explainRawSQL('SELECT * FROM users WHERE email IS NOT NULL');
+
+    expect(mockClient.query).toHaveBeenNthCalledWith(1, 'SET statement_timeout = 30000');
+    expect(mockClient.query).toHaveBeenNthCalledWith(2, 'BEGIN');
+    expect(mockClient.query).toHaveBeenNthCalledWith(
+      3,
+      'EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS) SELECT * FROM users WHERE email IS NOT NULL',
+      []
+    );
+    expect(mockClient.query).toHaveBeenNthCalledWith(4, 'ROLLBACK');
+    expect(mockClient.query).toHaveBeenNthCalledWith(5, 'SET statement_timeout = 0');
+    expect(mockClient.release).toHaveBeenCalled();
+
+    expect(result).toEqual({
+      plan: {
+        nodeType: 'Seq Scan',
+        startupCost: 0,
+        totalCost: 18.1,
+        planRows: 4,
+        actualStartupTime: 0.015,
+        actualTotalTime: 0.045,
+        actualRows: 4,
+        actualLoops: 1,
+        relationName: 'users',
+        filter: '(email IS NOT NULL)',
+        plans: [
+          {
+            nodeType: 'Index Scan',
+            startupCost: 0.14,
+            totalCost: 8.4,
+            planRows: 1,
+            actualStartupTime: 0.01,
+            actualTotalTime: 0.02,
+            actualRows: 1,
+            actualLoops: 1,
+            indexName: 'users_email_idx',
+            plans: undefined,
+          },
+        ],
+      },
+      planningTime: 0.22,
+      executionTime: 0.61,
+      totalTime: 0.83,
+    });
+  });
+
+  it('rejects multiple SQL statements', async () => {
+    const service = DatabaseAdvanceService.getInstance();
+
+    await expect(service.explainRawSQL('SELECT 1; SELECT 2')).rejects.toBeInstanceOf(AppError);
+    await expect(service.explainRawSQL('SELECT 1; SELECT 2')).rejects.toMatchObject({
+      message: 'Explain supports a single SQL statement at a time',
+    });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported explain statements before hitting the database', async () => {
+    const service = DatabaseAdvanceService.getInstance();
+
+    await expect(service.explainRawSQL('CREATE TABLE demo (id int)')).rejects.toMatchObject({
+      message: 'Explain supports SELECT, INSERT, UPDATE, DELETE, MERGE, and VALUES statements only',
+    });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/database/hooks/useExplainSQL.ts
+++ b/packages/dashboard/src/features/database/hooks/useExplainSQL.ts
@@ -1,0 +1,46 @@
+import { useMutation } from '@tanstack/react-query';
+import { advanceService } from '#features/database/services/advance.service';
+import { ExplainSQLResponse } from '@insforge/shared-schemas';
+import { useToast } from '#lib/hooks/useToast';
+
+interface UseExplainSQLOptions {
+  onSuccess?: (data: ExplainSQLResponse) => void;
+  onError?: (error: Error) => void;
+  showErrorToast?: boolean;
+}
+
+interface ExplainSQLParams {
+  query: string;
+  params?: unknown[];
+}
+
+export function useExplainSQL(options?: UseExplainSQLOptions) {
+  const { showToast } = useToast();
+
+  const mutation = useMutation({
+    mutationFn: async ({ query, params = [] }: ExplainSQLParams) => {
+      return advanceService.explainRawSQL(query, params);
+    },
+    onSuccess: (data) => {
+      options?.onSuccess?.(data);
+    },
+    onError: (error: Error) => {
+      if (options?.showErrorToast !== false) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to explain SQL query';
+        showToast(errorMessage, 'error');
+      }
+      options?.onError?.(error);
+    },
+  });
+
+  return {
+    explainSQL: mutation.mutate,
+    explainSQLAsync: mutation.mutateAsync,
+    reset: mutation.reset,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    error: mutation.error,
+    data: mutation.data,
+  };
+}

--- a/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
+++ b/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import { useRawSQL } from '#features/database/hooks/useRawSQL';
+import { useExplainSQL } from '#features/database/hooks/useExplainSQL';
 import { useSQLEditorContext } from '#features/database/contexts/SQLEditorContext';
 import { Button, Tabs, Tab } from '@insforge/ui';
 import { CodeEditor, DataGrid, type DataGridColumn, type DataGridRow } from '#components';
 import { X, Plus } from 'lucide-react';
 import { cn } from '#lib/utils/utils';
+import type { ExplainPlanNode, ExplainSQLResponse } from '@insforge/shared-schemas';
 
 interface ResultsViewerProps {
   data: unknown;
@@ -103,6 +105,103 @@ function ErrorViewer({ error }: ErrorViewerProps) {
   );
 }
 
+interface ExplainPlanViewerProps {
+  explain: ExplainSQLResponse;
+}
+
+function formatMetric(value: number | null | undefined, digits = 2): string {
+  return typeof value === 'number' ? value.toFixed(digits) : 'N/A';
+}
+
+function ExplainPlanCard({ node, depth = 0 }: { node: ExplainPlanNode; depth?: number }) {
+  const detailRows = [
+    node.relationName ? ['Relation', node.relationName] : null,
+    node.indexName ? ['Index', node.indexName] : null,
+    node.joinType ? ['Join Type', node.joinType] : null,
+    node.operation ? ['Operation', node.operation] : null,
+    node.filter ? ['Filter', node.filter] : null,
+    node.indexCond ? ['Index Cond', node.indexCond] : null,
+    node.hashCond ? ['Hash Cond', node.hashCond] : null,
+    node.mergeCond ? ['Merge Cond', node.mergeCond] : null,
+    node.recheckCond ? ['Recheck Cond', node.recheckCond] : null,
+  ].filter((row): row is [string, string] => row !== null);
+
+  return (
+    <div
+      className="rounded-lg border border-[var(--alpha-8)] bg-[var(--alpha-4)] p-3"
+      style={{ marginLeft: depth * 20 }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-foreground">{node.nodeType}</p>
+          <p className="text-xs text-muted-foreground">
+            Cost {formatMetric(node.startupCost)} to {formatMetric(node.totalCost)} • Est. rows{' '}
+            {node.planRows ?? 'N/A'}
+          </p>
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <p>
+            Actual time {formatMetric(node.actualStartupTime)} to{' '}
+            {formatMetric(node.actualTotalTime)} ms
+          </p>
+          <p>
+            Actual rows {node.actualRows ?? 'N/A'}
+            {typeof node.actualLoops === 'number' ? ` • Loops ${node.actualLoops}` : ''}
+          </p>
+        </div>
+      </div>
+
+      {detailRows.length > 0 ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {detailRows.map(([label, value]) => (
+            <div key={`${label}-${value}`} className="rounded bg-[var(--alpha-3)] px-2 py-1.5">
+              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</p>
+              <p className="font-mono text-xs text-foreground break-words">{value}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {node.plans && node.plans.length > 0 ? (
+        <div className="mt-3 space-y-3 border-l border-[var(--alpha-8)] pl-3">
+          {node.plans.map((child, index) => (
+            <ExplainPlanCard key={`${child.nodeType}-${index}`} node={child} depth={depth + 1} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ExplainPlanViewer({ explain }: ExplainPlanViewerProps) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-lg bg-[var(--alpha-4)] p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Planning</p>
+          <p className="mt-1 font-mono text-lg text-foreground">
+            {formatMetric(explain.planningTime)} ms
+          </p>
+        </div>
+        <div className="rounded-lg bg-[var(--alpha-4)] p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Execution</p>
+          <p className="mt-1 font-mono text-lg text-foreground">
+            {formatMetric(explain.executionTime)} ms
+          </p>
+        </div>
+        <div className="rounded-lg bg-[var(--alpha-4)] p-3">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Total Query Time</p>
+          <p className="mt-1 font-mono text-lg text-foreground">
+            {formatMetric(explain.totalTime)} ms
+          </p>
+        </div>
+      </div>
+
+      <ExplainPlanCard node={explain.plan} />
+    </div>
+  );
+}
+
 export default function SQLEditorPage() {
   const {
     tabs,
@@ -117,12 +216,29 @@ export default function SQLEditorPage() {
 
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const [editingTabName, setEditingTabName] = useState('');
-  const [resultView, setResultView] = useState<'result' | 'chart'>('result');
+  const [resultView, setResultView] = useState<'result' | 'chart' | 'explain'>('result');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { executeSQL, isPending, data, isSuccess, error, isError } = useRawSQL({
+  const {
+    executeSQL,
+    isPending: isRunningQuery,
+    data,
+    isSuccess,
+    error,
+    isError,
+  } = useRawSQL({
     showSuccessToast: true,
     showErrorToast: false, // Don't show toast, we'll display in results
+  });
+  const {
+    explainSQL,
+    isPending: isExplainingQuery,
+    data: explainData,
+    isSuccess: isExplainSuccess,
+    error: explainError,
+    isError: isExplainError,
+  } = useExplainSQL({
+    showErrorToast: false,
   });
 
   useEffect(() => {
@@ -132,12 +248,24 @@ export default function SQLEditorPage() {
     }
   }, [editingTabId]);
 
+  const isBusy = isRunningQuery || isExplainingQuery;
+
   const handleExecuteQuery = () => {
-    if (!activeTab?.query.trim() || isPending) {
+    if (!activeTab?.query.trim() || isBusy) {
       return;
     }
 
+    setResultView('result');
     executeSQL({ query: activeTab.query, params: [] });
+  };
+
+  const handleExplainQuery = () => {
+    if (!activeTab?.query.trim() || isBusy) {
+      return;
+    }
+
+    setResultView('explain');
+    explainSQL({ query: activeTab.query, params: [] });
   };
 
   const handleQueryChange = (newQuery: string) => {
@@ -317,21 +445,42 @@ export default function SQLEditorPage() {
                 )}
               </Tab>
               <Tab value="chart">Chart</Tab>
+              <Tab value="explain">Explain</Tab>
             </Tabs>
-            {/* Run Button */}
-            <Button onClick={handleExecuteQuery} disabled={isPending || !activeTab?.query.trim()}>
-              Run
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                onClick={handleExplainQuery}
+                disabled={isBusy || !activeTab?.query.trim()}
+              >
+                {isExplainingQuery ? 'Explaining...' : 'Explain'}
+              </Button>
+              <Button onClick={handleExecuteQuery} disabled={isBusy || !activeTab?.query.trim()}>
+                {isRunningQuery ? 'Running...' : 'Run'}
+              </Button>
+            </div>
           </div>
 
           {/* Results Content */}
           <div
             className={cn(
               'flex-1 min-h-0 w-full overflow-auto bg-[rgb(var(--semantic-0))]',
-              resultView === 'result' && 'px-4 py-3'
+              resultView !== 'chart' && 'px-4 py-3'
             )}
           >
-            {isError && error ? (
+            {resultView === 'explain' ? (
+              isExplainError && explainError ? (
+                <ErrorViewer error={explainError} />
+              ) : isExplainSuccess && explainData ? (
+                <ExplainPlanViewer explain={explainData} />
+              ) : (
+                <p className="font-mono text-sm leading-5 text-foreground">
+                  {isExplainingQuery
+                    ? 'Generating query plan...'
+                    : 'Click Explain to inspect the execution plan'}
+                </p>
+              )
+            ) : isError && error ? (
               <div className={resultView !== 'result' ? 'px-4 py-3' : ''}>
                 <ErrorViewer error={error} />
               </div>
@@ -345,10 +494,10 @@ export default function SQLEditorPage() {
               <p
                 className={cn(
                   'font-mono text-sm leading-5 text-foreground',
-                  resultView !== 'result' && 'px-4 py-3'
+                  resultView !== 'result' && resultView !== 'explain' && 'px-4 py-3'
                 )}
               >
-                {isPending ? 'Executing query...' : 'Click Run to execute your query'}
+                {isRunningQuery ? 'Executing query...' : 'Click Run to execute your query'}
               </p>
             )}
           </div>

--- a/packages/dashboard/src/features/database/services/advance.service.ts
+++ b/packages/dashboard/src/features/database/services/advance.service.ts
@@ -1,5 +1,10 @@
 import { apiClient } from '#lib/api/client';
-import { RawSQLRequest, RawSQLResponse } from '@insforge/shared-schemas';
+import {
+  RawSQLRequest,
+  RawSQLResponse,
+  ExplainSQLRequest,
+  ExplainSQLResponse,
+} from '@insforge/shared-schemas';
 
 export class AdvanceService {
   /**
@@ -14,6 +19,18 @@ export class AdvanceService {
     const body: RawSQLRequest = { query, params };
 
     return apiClient.request('/database/advance/rawsql', {
+      method: 'POST',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(body),
+    });
+  }
+
+  async explainRawSQL(query: string, params: unknown[] = []): Promise<ExplainSQLResponse> {
+    const body: ExplainSQLRequest = { query, params };
+
+    return apiClient.request('/database/advance/rawsql/explain', {
       method: 'POST',
       headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -95,6 +95,56 @@ export const rawSQLRequestSchema = z.object({
   params: z.array(z.unknown()).optional(),
 });
 
+const explainPlanNodeSchema: z.ZodType<{
+  nodeType: string;
+  startupCost?: number;
+  totalCost?: number;
+  planRows?: number;
+  actualStartupTime?: number;
+  actualTotalTime?: number;
+  actualRows?: number;
+  actualLoops?: number;
+  relationName?: string;
+  alias?: string;
+  joinType?: string;
+  operation?: string;
+  strategy?: string;
+  indexName?: string;
+  filter?: string;
+  indexCond?: string;
+  hashCond?: string;
+  mergeCond?: string;
+  recheckCond?: string;
+  sortKey?: string[];
+  groupKey?: string[];
+  plans?: Array<unknown>;
+}> = z.lazy(() =>
+  z.object({
+    nodeType: z.string(),
+    startupCost: z.number().optional(),
+    totalCost: z.number().optional(),
+    planRows: z.number().optional(),
+    actualStartupTime: z.number().optional(),
+    actualTotalTime: z.number().optional(),
+    actualRows: z.number().optional(),
+    actualLoops: z.number().optional(),
+    relationName: z.string().optional(),
+    alias: z.string().optional(),
+    joinType: z.string().optional(),
+    operation: z.string().optional(),
+    strategy: z.string().optional(),
+    indexName: z.string().optional(),
+    filter: z.string().optional(),
+    indexCond: z.string().optional(),
+    hashCond: z.string().optional(),
+    mergeCond: z.string().optional(),
+    recheckCond: z.string().optional(),
+    sortKey: z.array(z.string()).optional(),
+    groupKey: z.array(z.string()).optional(),
+    plans: z.array(explainPlanNodeSchema).optional(),
+  })
+);
+
 export const rawSQLResponseSchema = z.object({
   rows: z.array(z.record(z.string(), z.unknown())),
   rowCount: z.number().nullable(),
@@ -106,6 +156,15 @@ export const rawSQLResponseSchema = z.object({
       })
     )
     .optional(),
+});
+
+export const explainSQLRequestSchema = rawSQLRequestSchema;
+
+export const explainSQLResponseSchema = z.object({
+  plan: explainPlanNodeSchema,
+  planningTime: z.number().nullable(),
+  executionTime: z.number().nullable(),
+  totalTime: z.number().nullable(),
 });
 
 // Export Schemas
@@ -349,6 +408,9 @@ export type DeleteTableResponse = z.infer<typeof deleteTableResponse>;
 // Raw SQL Types
 export type RawSQLRequest = z.infer<typeof rawSQLRequestSchema>;
 export type RawSQLResponse = z.infer<typeof rawSQLResponseSchema>;
+export type ExplainSQLRequest = z.infer<typeof explainSQLRequestSchema>;
+export type ExplainPlanNode = z.infer<typeof explainPlanNodeSchema>;
+export type ExplainSQLResponse = z.infer<typeof explainSQLResponseSchema>;
 
 // Export Types
 export type ExportDatabaseRequest = z.infer<typeof exportRequestSchema>;


### PR DESCRIPTION
## Summary
- add a dedicated SQL explain API that runs EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS) inside a rollback-only transaction
- validate explain requests to a single supported statement and normalize the returned plan tree and timing metadata
- add an Explain tab and action in the SQL Editor that renders node metrics, total query time, and readable explain errors

## Why
The SQL editor could execute queries, but it had no built-in way to inspect execution plans when debugging slow statements. This adds a first-class Explain workflow in the dashboard while keeping mutating ANALYZE runs safe.

## Validation
- `cd backend && npm test -- --run tests/unit/database-advance.test.ts tests/unit/database-advance-explain.test.ts`
- `cd backend && npm run typecheck`
- `cd packages/dashboard && npm run typecheck` *(blocked locally: workspace dependencies are not installed in this checkout)*

Closes #1272


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Explain workflow to the SQL Editor with a backend endpoint that runs EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS) safely in a rollback-only transaction and renders a readable plan with timing in the UI. Helps diagnose slow queries without side effects. Closes #1272.

- New Features
  - Backend: POST `/api/database/advance/rawsql/explain` validates a single statement (SELECT/INSERT/UPDATE/DELETE/MERGE/VALUES), parses via `libpg-query`, runs EXPLAIN in a rollback-only transaction with a 30s timeout, normalizes the plan/timing, and audits requests.
  - Schemas: Added `ExplainSQLRequest`, `ExplainPlanNode`, and `ExplainSQLResponse` to `@insforge/shared-schemas`.
  - Dashboard: Added Explain tab and button to the SQL Editor, `useExplainSQL` hook, and service call; shows node metrics, planning/execution/total time, and readable errors with loading states.
  - Tests: Unit tests cover plan normalization, single-statement validation, and unsupported statement rejection.

<sup>Written for commit 49cb7b7b99d5c8ba228ac3894399d2ea926a88b9. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1309?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL execution plan viewer: Run EXPLAIN queries to inspect query performance details.
  * New "Explain" button and dedicated tab in the SQL editor.
  * Visualizes plan tree structure with operation timings, relations, and index information.

* **Tests**
  * Added unit tests for EXPLAIN functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add EXPLAIN ANALYZE tab to SQL editor
> - Adds a POST `/api/database/advance/rawsql/explain` endpoint that runs `EXPLAIN (FORMAT JSON, ANALYZE, BUFFERS)` inside a rollback-only transaction with a 30s timeout, then returns a normalized plan tree with planning, execution, and total times.
> - Validates that the query is a single DML/SELECT statement using `libpg-query` before any DB interaction; rejects multiple statements and DDL.
> - Adds an `ExplainPlanViewer` component to `SQLEditorPage` with a dedicated Explain tab and mutually exclusive run/explain states so only one operation runs at a time.
> - Defines shared Zod schemas (`explainPlanNodeSchema`, `explainSQLRequestSchema`, `explainSQLResponseSchema`) in `shared-schemas` for request validation and type inference across frontend and backend.
> - Risk: the rollback-only transaction still acquires locks and executes the query, so EXPLAIN on a slow query will block for up to 30s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49cb7b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->