### PR TITLE
fix(openrouter): retry 429 with Retry-After and exponential backoff

### DIFF
--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -60,6 +60,32 @@ interface ResolvedApiKey {
   source: ApiKeySource;
 }
 
+// Maximum number of retries on a 429 (rate-limited) response from OpenRouter
+// before we give up and surface the error to the caller.
+const OPENROUTER_RATE_LIMIT_MAX_RETRIES = 3;
+
+// Cap on a single 429 retry wait so a misbehaving upstream that returns
+// `Retry-After: 600` cannot park the request for 10 minutes. Mirrors the
+// Deno Subhosting helper's cap.
+const OPENROUTER_RATE_LIMIT_MAX_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Parse the `Retry-After` header for the integer-seconds form per RFC 7231
+ * §7.1.3. Returns the delay in ms, or `NaN` if the header is missing or not
+ * a non-negative integer. We intentionally do NOT parse the HTTP-date form
+ * here; callers fall back to exponential backoff for anything we can't parse.
+ */
+function parseRetryAfterSecondsMs(header: string | null | undefined): number {
+  if (!header) {
+    return NaN;
+  }
+  const trimmed = String(header).trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return NaN;
+  }
+  return parseInt(trimmed, 10) * 1000;
+}
+
 const EMPTY_AI_OVERVIEW: AIOverview = {
   key: {
     limit: null,
@@ -638,6 +664,60 @@ export class OpenRouterProvider {
         }
       }
 
+      // Retry on 429 (rate limited) with exponential backoff, honouring
+      // Retry-After when present. This sits BEFORE the generic APIError
+      // mapping so a transient 429 doesn't get flattened into AppError on
+      // first sight.
+      if (error instanceof OpenAI.APIError && error.status === 429) {
+        const maxRetries = OPENROUTER_RATE_LIMIT_MAX_RETRIES;
+        let lastRateLimitError: OpenAI.APIError = error;
+
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+          // Headers can be a Headers instance or undefined depending on how
+          // the error was produced. Both `.get('retry-after')` and
+          // `.get('Retry-After')` are valid (Headers is case-insensitive),
+          // but we use the lowercase form for consistency.
+          const retryAfterHeader =
+            typeof lastRateLimitError.headers?.get === 'function'
+              ? lastRateLimitError.headers.get('retry-after')
+              : null;
+          const retryAfterMs = parseRetryAfterSecondsMs(retryAfterHeader);
+          const honouredRetryAfter = Number.isFinite(retryAfterMs) && retryAfterMs >= 0;
+          const delayMs = honouredRetryAfter
+            ? Math.min(retryAfterMs, OPENROUTER_RATE_LIMIT_MAX_RETRY_DELAY_MS)
+            : Math.pow(2, attempt - 1) * 1000;
+
+          logger.info(
+            `OpenRouter 429 rate-limited, retrying (attempt ${attempt}/${maxRetries}) after ${delayMs}ms${
+              honouredRetryAfter ? ' (Retry-After honoured)' : ' (exponential backoff)'
+            }`
+          );
+
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+          try {
+            const result = await request(client);
+            logger.info(`OpenRouter request succeeded after ${attempt} retry attempt(s) on 429`);
+            return { result, source };
+          } catch (retryError) {
+            if (retryError instanceof OpenAI.APIError && retryError.status === 429) {
+              lastRateLimitError = retryError;
+              continue;
+            }
+            // A different error surfaced during the retry — fall through to
+            // the standard handling by re-throwing into the outer flow.
+            throw retryError;
+          }
+        }
+
+        throw new AppError(
+          `AI provider rate limit exceeded after ${maxRetries} retries.`,
+          429,
+          ERROR_CODES.RATE_LIMITED,
+          'Wait a moment and retry, or check your API key rate limits.'
+        );
+      }
+
       // Convert upstream API errors to actionable responses
       if (error instanceof OpenAI.APIError) {
         if (error.status === 401 || error.status === 403) {
@@ -648,14 +728,6 @@ export class OpenRouterProvider {
             source === 'cloud'
               ? 'Check the cloud-managed OpenRouter credential.'
               : 'Set a valid OPENROUTER_API_KEY in the backend environment.'
-          );
-        }
-        if (error.status === 429) {
-          throw new AppError(
-            'AI provider rate limit exceeded. Please wait before retrying.',
-            429,
-            ERROR_CODES.RATE_LIMITED,
-            'Wait a moment and retry, or check your API key rate limits.'
           );
         }
       }

--- a/backend/tests/unit/openrouter-auth-errors.test.ts
+++ b/backend/tests/unit/openrouter-auth-errors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import OpenAI from 'openai';
 
 const { mockGetApiKeyWithSource, mockGetClient, mockRenewCloudApiKey } = vi.hoisted(() => ({
@@ -18,12 +18,33 @@ vi.mock('../../src/utils/logger.js', () => ({
 import { OpenRouterProvider } from '../../src/providers/ai/openrouter.provider.js';
 import { ERROR_CODES } from '../../src/types/error-constants.js';
 
-function createAPIError(status: number, message: string): OpenAI.APIError {
-  return new OpenAI.APIError(status, { message }, message, new Headers());
+function createAPIError(
+  status: number,
+  message: string,
+  headers: Headers = new Headers()
+): OpenAI.APIError {
+  return new OpenAI.APIError(status, { message }, message, headers);
 }
 
 describe('OpenRouterProvider authentication error handling', () => {
   let provider: OpenRouterProvider;
+  let setTimeoutSpy: ReturnType<typeof vi.spyOn> | undefined;
+  let recordedDelays: number[] = [];
+
+  // Resolve setTimeout immediately so retry backoff loops complete in real time
+  // during these tests. Match the codebase pattern used by deno-subhosting-429
+  // and vercel-429-helper tests.
+  function installFastSetTimeout(): void {
+    recordedDelays = [];
+    const realSetTimeout = global.setTimeout;
+    setTimeoutSpy = vi.spyOn(global, 'setTimeout').mockImplementation(((
+      cb: (...args: unknown[]) => void,
+      ms?: number
+    ) => {
+      recordedDelays.push(ms ?? 0);
+      return realSetTimeout(cb, 0);
+    }) as unknown as typeof setTimeout);
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -35,6 +56,12 @@ describe('OpenRouterProvider authentication error handling', () => {
     p.getApiKeyWithSource = mockGetApiKeyWithSource;
     p.getClient = mockGetClient.mockResolvedValue(new OpenAI({ apiKey: 'test' }));
     p.renewCloudApiKey = mockRenewCloudApiKey;
+  });
+
+  afterEach(() => {
+    setTimeoutSpy?.mockRestore();
+    setTimeoutSpy = undefined;
+    recordedDelays = [];
   });
 
   it('throws AppError with AI_INVALID_API_KEY for env key 401', async () => {
@@ -65,18 +92,86 @@ describe('OpenRouterProvider authentication error handling', () => {
     });
   });
 
-  it('throws AppError with RATE_LIMITED for 429', async () => {
+  it('throws AppError with RATE_LIMITED for 429 after exhausting retries', async () => {
     mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'env-key', source: 'env' });
+    installFastSetTimeout();
 
-    await expect(
-      provider.sendRequest(() => {
-        throw createAPIError(429, 'Rate limited');
-      })
-    ).rejects.toMatchObject({
+    const request = vi.fn(() => {
+      throw createAPIError(429, 'Rate limited');
+    });
+
+    await expect(provider.sendRequest(request)).rejects.toMatchObject({
       statusCode: 429,
       code: ERROR_CODES.RATE_LIMITED,
-      message: expect.stringContaining('rate limit exceeded'),
+      message: expect.stringContaining('after 3 retries'),
     });
+
+    // initial call + 3 retry attempts = 4 invocations
+    expect(request).toHaveBeenCalledTimes(4);
+    // 3 retry delays should have been scheduled
+    expect(recordedDelays.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('retries 429 and succeeds on second attempt', async () => {
+    mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'env-key', source: 'env' });
+    installFastSetTimeout();
+
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw createAPIError(429, 'Rate limited');
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result, source } = await provider.sendRequest(request);
+
+    expect(result).toEqual({ ok: true });
+    expect(source).toBe('env');
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After header when present', async () => {
+    mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'env-key', source: 'env' });
+    installFastSetTimeout();
+
+    const headers = new Headers({ 'retry-after': '2' });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw createAPIError(429, 'Rate limited', headers);
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result } = await provider.sendRequest(request);
+
+    expect(result).toEqual({ ok: true });
+    expect(request).toHaveBeenCalledTimes(2);
+    // The single retry delay should equal the Retry-After value (2s = 2000ms),
+    // not the exponential-backoff fallback (1000ms on attempt 1).
+    expect(recordedDelays).toContain(2000);
+  });
+
+  it('caps Retry-After at 30s on 429', async () => {
+    mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'env-key', source: 'env' });
+    installFastSetTimeout();
+
+    // Upstream asks us to wait 10 minutes; cap should kick in.
+    const headers = new Headers({ 'retry-after': '600' });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw createAPIError(429, 'Rate limited', headers);
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    await provider.sendRequest(request);
+
+    // No requested delay should exceed the 30s cap.
+    for (const d of recordedDelays) {
+      expect(d).toBeLessThanOrEqual(30_000);
+    }
+    // And the retry actually used the capped value.
+    expect(recordedDelays).toContain(30_000);
   });
 
   it('still throws raw error for non-API errors', async () => {


### PR DESCRIPTION
## Summary
- `OpenRouterProvider.sendRequest` previously threw `RATE_LIMITED` immediately on a 429 from OpenRouter, while the 402/403 (insufficient credits) path already had a 3-attempt retry with exponential backoff. This PR brings 429 handling up to the same standard.
- New behavior: up to 3 retries; honors `Retry-After` (integer seconds per RFC 7231 §7.1.3, capped at 30s); falls back to `2^(attempt-1) * 1000ms` backoff; only throws `AppError(... RATE_LIMITED ...)` after exhaustion, with the attempt count included in the message.
- 402/403 cloud-key-renewal path is untouched.

## Test plan
- [x] `npx vitest run tests/unit/openrouter-auth-errors.test.ts` — 8/8 pass (existing test updated; new tests cover succeed-on-2nd-attempt, Retry-After honored, Retry-After cap at 30s, exhaustion message).
- [x] `npx vitest run tests/unit/openrouter-overview.test.ts tests/unit/ai-model.service.test.ts tests/unit/ai-tool-calling-format.test.ts` — 11/11 pass.
- [x] `npm run lint --workspace=backend` — clean.

Note: the user said "master" — this repo's default is `main`, so the PR targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle OpenRouter 429 rate limits with retries that honor Retry-After and exponential backoff to reduce transient failures. Only throw RATE_LIMITED after retries are exhausted.

- **Bug Fixes**
  - Retry 429 up to 3 times; honor `Retry-After` seconds (cap at 30s).
  - Fallback to exponential backoff `2^(attempt-1) * 1000ms` when header is missing/invalid.
  - Added unit tests for succeed-on-retry, Retry-After handling and cap, and exhaustion.

<sup>Written for commit d93bef20acfc3ec65c0afb9001603b699dd62458. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry OpenRouter 429 responses with `Retry-After` header support and exponential backoff
> - `OpenRouterProvider.sendRequest` now retries up to 3 times on 429 responses before throwing an `AppError`
> - Each retry waits based on the `Retry-After` header (capped at 30s), falling back to exponential backoff (1s, 2s, 4s)
> - A new `parseRetryAfterSecondsMs` helper parses integer-seconds `Retry-After` values; HTTP-date forms are ignored
> - Behavioral Change: 429s no longer fail immediately; the error message on exhausted retries differs from the previous immediate-failure message
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d93bef2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry support for API rate-limit errors with configurable retry limits and exponential backoff.
  * System now respects server rate-limit guidance headers for optimized retry timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->