### PR TITLE
feat(ai): add Embeddings quick start mode to AI gateway dashboard

### DIFF
--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -108,4 +108,66 @@ describe('AIModelService', () => {
       },
     ]);
   });
+
+  it('includes embedding-only models with correct pricing', async () => {
+    // Advance time past the 1-hour cache TTL so the stale cache from prior tests is bypassed
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(61 * 60 * 1000);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'openai/text-embedding-3-small',
+              created: 1767225600,
+              architecture: {
+                input_modalities: ['text'],
+                output_modalities: ['embeddings'],
+              },
+              pricing: {
+                prompt: '0.00000002',
+                completion: '0',
+              },
+            },
+            {
+              id: 'google/gemini-embedding-2-preview',
+              created: 1777248000,
+              architecture: {
+                input_modalities: ['text', 'image', 'file', 'audio', 'video'],
+                output_modalities: ['embeddings'],
+              },
+              pricing: {
+                prompt: '0.0000002',
+                completion: '0',
+              },
+            },
+          ],
+        }),
+    });
+
+    const models = await AIModelService.getModels();
+
+    // Both embedding models should be included (not filtered out)
+    expect(models).toHaveLength(2);
+
+    // Embedding-only model: input has text so inputPrice is set, output is embeddings so no outputPrice
+    const smallModel = models.find((m) => m.id === 'openai/text-embedding-3-small');
+    expect(smallModel).toBeDefined();
+    expect(smallModel!.inputModality).toEqual(['text']);
+    expect(smallModel!.outputModality).toEqual(['embeddings']);
+    expect(smallModel!.inputPrice).toBeGreaterThanOrEqual(0);
+    expect(smallModel!.outputPrice).toBeUndefined();
+    expect(smallModel!.outputPriceLabel).toBeUndefined();
+
+    // Multimodal embedding model: input has text (among others) so inputPrice is set
+    const geminiModel = models.find((m) => m.id === 'google/gemini-embedding-2-preview');
+    expect(geminiModel).toBeDefined();
+    expect(geminiModel!.inputModality).toContain('text');
+    expect(geminiModel!.outputModality).toEqual(['embeddings']);
+    expect(geminiModel!.inputPrice).toBeGreaterThanOrEqual(0);
+
+    vi.useRealTimers();
+  });
 });

--- a/packages/dashboard/src/features/ai/__tests__/constants.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/constants.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  QUICK_START_MODES,
+  PROMPT_CARD_COPY,
+  QUICK_START_COPY,
+  getQuickStartScript,
+  getQuickStartPrompt,
+  type QuickStartMode,
+} from '#features/ai/constants';
+
+describe('AI Quick Start constants', () => {
+  it('includes embeddings in QUICK_START_MODES', () => {
+    const modeValues = QUICK_START_MODES.map((m) => m.value);
+    expect(modeValues).toContain('embeddings');
+
+    const embeddingsMode = QUICK_START_MODES.find((m) => m.value === 'embeddings');
+    expect(embeddingsMode?.label).toBe('Embeddings');
+  });
+
+  it('has PROMPT_CARD_COPY for embeddings', () => {
+    expect(PROMPT_CARD_COPY.embeddings).toBeDefined();
+    expect(PROMPT_CARD_COPY.embeddings).toContain('embeddings');
+  });
+
+  it('has QUICK_START_COPY for embeddings with expected fields', () => {
+    const copy = QUICK_START_COPY.embeddings;
+    expect(copy).toBeDefined();
+    expect(copy.projectName).toBe('ai-embeddings-demo');
+    expect(copy.model).toContain('embedding');
+    expect(copy.installCommand).toContain('openai');
+  });
+
+  it('getQuickStartScript generates embeddings.create code for embeddings mode', () => {
+    const script = getQuickStartScript('embeddings', 'openai/text-embedding-3-small');
+    expect(script).toContain('embeddings.create');
+    expect(script).toContain('openai/text-embedding-3-small');
+    expect(script).not.toContain('chat.completions');
+  });
+
+  it('getQuickStartScript generates chat.completions code for text mode', () => {
+    const script = getQuickStartScript('text', 'openai/gpt-5.5');
+    expect(script).toContain('chat.completions.create');
+    expect(script).not.toContain('embeddings.create');
+  });
+
+  it('getQuickStartPrompt includes embeddings API guidance', () => {
+    const prompt = getQuickStartPrompt('embeddings');
+    expect(prompt).toContain('embedding');
+    expect(prompt).toContain('embeddings.create');
+    expect(prompt).toContain('OPENROUTER_API_KEY');
+  });
+
+  it('all modes have consistent QUICK_START_COPY entries', () => {
+    const modes: QuickStartMode[] = ['text', 'image', 'video', 'embeddings'];
+    for (const mode of modes) {
+      const copy = QUICK_START_COPY[mode];
+      expect(copy.projectName).toBeTruthy();
+      expect(copy.description).toBeTruthy();
+      expect(copy.model).toBeTruthy();
+      expect(copy.installCommand).toBeTruthy();
+    }
+  });
+});

--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -3,7 +3,7 @@ import ClaudeIcon from '#assets/logos/claude_code.svg?react';
 import GeminiIcon from '#assets/logos/gemini.svg?react';
 
 export type CodeTab = 'sdk' | 'python' | 'http';
-export type QuickStartMode = 'text' | 'image' | 'video';
+export type QuickStartMode = 'text' | 'image' | 'video' | 'embeddings';
 export type ModelModalityFilter = string;
 
 export function getOverviewCodeSnippets(modelId: string): Record<CodeTab, string> {
@@ -89,12 +89,15 @@ export const QUICK_START_MODES: { value: QuickStartMode; label: string }[] = [
   { value: 'text', label: 'Text Generation' },
   { value: 'image', label: 'Image Generation' },
   { value: 'video', label: 'Video Generation' },
+  { value: 'embeddings', label: 'Embeddings' },
 ];
 
 export const PROMPT_CARD_COPY: Record<QuickStartMode, string> = {
   text: 'Copy this prompt for your agent to generate text through the OpenRouter model gateway.',
   image: 'Copy this prompt for your agent to generate images through the OpenRouter model gateway.',
   video: 'Copy this prompt for your agent to generate videos through the OpenRouter model gateway.',
+  embeddings:
+    'Copy this prompt for your agent to generate text embeddings through the OpenRouter model gateway.',
 };
 
 export const QUICK_START_COPY: Record<
@@ -118,6 +121,12 @@ export const QUICK_START_COPY: Record<
     description: 'Submit an asynchronous video generation job and poll until it completes.',
     model: 'google/veo-3.1',
     installCommand: 'npm install dotenv\nnpm install --save-dev @types/node tsx typescript',
+  },
+  embeddings: {
+    projectName: 'ai-embeddings-demo',
+    description: 'Generate text embeddings through OpenRouter with the OpenAI SDK.',
+    model: 'openai/text-embedding-3-small',
+    installCommand: 'npm install openai dotenv\nnpm install --save-dev @types/node tsx typescript',
   },
 };
 
@@ -175,6 +184,25 @@ while (result.status !== 'completed' && result.status !== 'failed') {
 console.log(result);`;
   }
 
+  if (mode === 'embeddings') {
+    return `import OpenAI from 'openai';
+import 'dotenv/config';
+
+const openai = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const response = await openai.embeddings.create({
+  model: '${model}',
+  input: 'The quick brown fox jumps over the lazy dog.',
+});
+
+console.log('Dimensions:', response.data[0].embedding.length);
+console.log('First 5 values:', response.data[0].embedding.slice(0, 5));
+console.log('Usage:', response.usage);`;
+  }
+
   return `import OpenAI from 'openai';
 import 'dotenv/config';
 
@@ -200,6 +228,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
     image: 'an image generation feature that sends a user prompt and renders the returned image',
     video:
       'a video generation feature that submits a prompt, polls the job status, and renders the completed video',
+    embeddings:
+      'a text embedding feature that converts user input into vector embeddings for semantic search or similarity comparison',
   };
   const apiCopy: Record<QuickStartMode, string> = {
     text: 'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1.',
@@ -207,6 +237,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
       "Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1 and request modalities ['image', 'text'].",
     video:
       'Use fetch with the OpenRouter video endpoint at https://openrouter.ai/api/v1/videos; do not install or use the OpenAI SDK for video.',
+    embeddings:
+      'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1. Call client.embeddings.create() — not chat.completions.create().',
   };
 
   return [


### PR DESCRIPTION
Closes #1147

## Summary
Adds "Embeddings" as a first-class Quick Start mode in the AI Gateway dashboard, making embedding models discoverable to users and agents.

## Problem
The backend already supports embeddings via `POST /api/ai/embeddings`, and 25+ embedding models are returned by the models endpoint. However, the Quick Start page — the primary onboarding flow — only offered Text, Image, and Video modes, leaving embeddings invisible.

## Changes
- **Dashboard constants** — Added `embeddings` to `QuickStartMode` with code snippet (`openai.embeddings.create()`), agent prompt, and project config (`openai/text-embedding-3-small`)
- **Backend test** — Added regression test verifying embedding-only models pass the model filter with correct pricing
- **Dashboard test** — 7 new unit tests covering all embeddings constants

## Testing
- Backend: 1165 tests passed ✅
- Dashboard: 32 tests passed ✅
- Typecheck: Zero new errors ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Embeddings quick start mode to the AI Gateway dashboard so users and agents can discover and use embedding models fast. Addresses Linear #1147 by making embeddings a first-class option with ready-to-use code and prompts.

- **New Features**
  - Added `embeddings` to `QuickStartMode` and `QUICK_START_MODES`, with copy, an agent prompt, and a code snippet using `openai.embeddings.create()`. Default model: `openai/text-embedding-3-small`.
  - Added a backend regression test to include embedding-only and multimodal embedding models in the filter with correct pricing.
  - Added dashboard unit tests for embeddings constants and helpers (`getQuickStartScript`, `getQuickStartPrompt`, `QUICK_START_COPY`, `PROMPT_CARD_COPY`).

<sup>Written for commit bfe0798ba72a6a401b8077c192b0b1221ebd94c2. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1314?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Embeddings quick start mode to AI gateway dashboard
> - Adds `'embeddings'` to the `QuickStartMode` union in [constants.ts](https://github.com/InsForge/InsForge/pull/1314/files#diff-6e0469653322f877c0f2586d4f45b993a0786400fa047f4c64360e5fb7c6a68b), with corresponding entries in `QUICK_START_MODES`, `PROMPT_CARD_COPY`, and `QUICK_START_COPY` (default model: `openai/text-embedding-3-small`).
> - `getQuickStartScript` now generates an OpenAI SDK snippet using `openai.embeddings.create`, logging embedding dimensions, sample values, and usage stats.
> - `getQuickStartPrompt` includes embeddings-specific guidance instructing use of `client.embeddings.create` with the configured `baseURL` and key.
> - Adds unit tests covering embeddings mode presence, copy fields, code generation, and prompt content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfe0798.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embeddings as a new quick-start mode in the dashboard, including example code generation, installation instructions, and API integration guidance for users to get started with embeddings.

* **Tests**
  * Added comprehensive test coverage for embeddings model pricing fields and dashboard quick-start feature validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->