### PR TITLE
test(ai): add unit tests for AI helper functions

### DIFF
--- a/backend/tests/unit/ai-helpers.test.ts
+++ b/backend/tests/unit/ai-helpers.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sortModalities,
+  normalizeModalities,
+  calculatePricePerMillion,
+  calculateTokenPrices,
+  getProviderOrder,
+} from '../../src/services/ai/helpers';
+
+describe('sortModalities', () => {
+  it('sorts known modalities by predefined order', () => {
+    expect(sortModalities(['video', 'text', 'image'])).toEqual(['text', 'image', 'video']);
+  });
+
+  it('places unknown modalities after known ones, sorted alphabetically', () => {
+    expect(sortModalities(['transcription', 'text', 'audio'])).toEqual([
+      'text',
+      'audio',
+      'transcription',
+    ]);
+  });
+
+  it('sorts multiple unknown modalities alphabetically among themselves', () => {
+    expect(sortModalities(['zebra', 'alpha', 'text'])).toEqual(['text', 'alpha', 'zebra']);
+  });
+
+  it('deduplicates entries', () => {
+    expect(sortModalities(['text', 'text', 'image', 'image'])).toEqual(['text', 'image']);
+  });
+
+  it('filters out empty and whitespace-only strings', () => {
+    expect(sortModalities(['', 'text', '  ', 'image'])).toEqual(['text', 'image']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(sortModalities([])).toEqual([]);
+  });
+
+  it('handles all known modalities in the correct canonical order', () => {
+    expect(
+      sortModalities(['embeddings', 'file', 'video', 'audio', 'image', 'text'])
+    ).toEqual(['text', 'image', 'audio', 'video', 'file', 'embeddings']);
+  });
+
+  it('handles a single modality', () => {
+    expect(sortModalities(['embeddings'])).toEqual(['embeddings']);
+  });
+});
+
+describe('normalizeModalities', () => {
+  it('delegates to sortModalities (dedup + sort)', () => {
+    expect(normalizeModalities(['image', 'text', 'image'])).toEqual(['text', 'image']);
+  });
+});
+
+describe('calculatePricePerMillion', () => {
+  it('converts per-token pricing to per-million-tokens', () => {
+    const result = calculatePricePerMillion({
+      prompt: '0.000001',
+      completion: '0.000002',
+    });
+    expect(result.inputPrice).toBe(1);
+    expect(result.outputPrice).toBe(2);
+  });
+
+  it('handles zero pricing', () => {
+    const result = calculatePricePerMillion({
+      prompt: '0',
+      completion: '0',
+    });
+    expect(result.inputPrice).toBe(0);
+    expect(result.outputPrice).toBe(0);
+  });
+
+  it('returns empty object when pricing is undefined', () => {
+    const result = calculatePricePerMillion(undefined as any);
+    expect(result).toEqual({});
+  });
+
+  it('treats non-numeric pricing strings as zero', () => {
+    const result = calculatePricePerMillion({
+      prompt: 'abc',
+      completion: '',
+    });
+    expect(result.inputPrice).toBe(0);
+    expect(result.outputPrice).toBe(0);
+  });
+
+  it('handles very small prices (embedding models)', () => {
+    const result = calculatePricePerMillion({
+      prompt: '0.00000002',
+      completion: '0',
+    });
+    expect(result.inputPrice).toBeCloseTo(0.02, 4);
+    expect(result.outputPrice).toBe(0);
+  });
+
+  it('ensures non-negative prices', () => {
+    const result = calculatePricePerMillion({
+      prompt: '0.000001',
+      completion: '0.000001',
+    });
+    expect(result.inputPrice).toBeGreaterThanOrEqual(0);
+    expect(result.outputPrice).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('calculateTokenPrices', () => {
+  const textPricing = {
+    prompt: '0.000001',
+    completion: '0.000002',
+  };
+
+  it('returns token-priced labels for text→text models', () => {
+    const result = calculateTokenPrices(textPricing, ['text'], ['text']);
+    expect(result.inputPrice).toBe(1);
+    expect(result.outputPrice).toBe(2);
+    expect(result.inputPriceLabel).toBe('$1.0 / M tokens');
+    expect(result.outputPriceLabel).toBe('$2.0 / M tokens');
+  });
+
+  it('returns inputPrice but not outputPrice for embedding models', () => {
+    const result = calculateTokenPrices(textPricing, ['text'], ['embeddings']);
+    expect(result.inputPrice).toBe(1);
+    expect(result.outputPrice).toBeUndefined();
+    expect(result.inputPriceLabel).toBe('$1.0 / M tokens');
+    expect(result.outputPriceLabel).toBeUndefined();
+  });
+
+  it('returns undefined prices for image→image models', () => {
+    const result = calculateTokenPrices(textPricing, ['image'], ['image']);
+    expect(result.inputPrice).toBeUndefined();
+    expect(result.outputPrice).toBeUndefined();
+    expect(result.inputPriceLabel).toBeUndefined();
+    expect(result.outputPriceLabel).toBeUndefined();
+  });
+
+  it('returns inputPrice for file input modality', () => {
+    const result = calculateTokenPrices(textPricing, ['file'], ['text']);
+    expect(result.inputPrice).toBe(1);
+    expect(result.inputPriceLabel).toBe('$1.0 / M tokens');
+  });
+
+  it('returns "Free" label when price is zero', () => {
+    const result = calculateTokenPrices(
+      { prompt: '0', completion: '0' },
+      ['text'],
+      ['text']
+    );
+    expect(result.inputPriceLabel).toBe('Free');
+    expect(result.outputPriceLabel).toBe('Free');
+  });
+
+  it('returns empty object when pricing is undefined', () => {
+    const result = calculateTokenPrices(undefined as any, ['text'], ['text']);
+    expect(result).toEqual({});
+  });
+
+  it('formats small prices with 4 decimal places', () => {
+    const result = calculateTokenPrices(
+      { prompt: '0.000000005', completion: '0' },
+      ['text'],
+      ['text']
+    );
+    // 0.000000005 * 1_000_000 = 0.005
+    expect(result.inputPriceLabel).toBe('$0.0050 / M tokens');
+  });
+
+  it('formats medium prices with 2 decimal places', () => {
+    const result = calculateTokenPrices(
+      { prompt: '0.0000005', completion: '0' },
+      ['text'],
+      ['text']
+    );
+    // 0.0000005 * 1_000_000 = 0.5
+    expect(result.inputPriceLabel).toBe('$0.50 / M tokens');
+  });
+
+  it('formats large prices with 1 decimal place', () => {
+    const result = calculateTokenPrices(
+      { prompt: '0.00006', completion: '0' },
+      ['text'],
+      ['text']
+    );
+    // 0.00006 * 1_000_000 = 60
+    expect(result.inputPriceLabel).toBe('$60.0 / M tokens');
+  });
+
+  it('handles multimodal input (text + image) with text output', () => {
+    const result = calculateTokenPrices(textPricing, ['text', 'image'], ['text']);
+    expect(result.inputPrice).toBe(1);
+    expect(result.outputPrice).toBe(2);
+  });
+
+  it('handles audio-only model (no token pricing)', () => {
+    const result = calculateTokenPrices(
+      { prompt: '0.111', completion: '0' },
+      ['audio'],
+      ['transcription']
+    );
+    expect(result.inputPrice).toBeUndefined();
+    expect(result.outputPrice).toBeUndefined();
+  });
+});
+
+describe('getProviderOrder', () => {
+  it('returns correct order for known providers', () => {
+    expect(getProviderOrder('openai/gpt-5.5')).toBe(1);
+    expect(getProviderOrder('anthropic/claude-sonnet-4.6')).toBe(2);
+    expect(getProviderOrder('google/gemini-2.5-pro')).toBe(3);
+    expect(getProviderOrder('amazon/nova-pro-v2')).toBe(4);
+  });
+
+  it('returns 999 for unknown providers', () => {
+    expect(getProviderOrder('mistral/mistral-large')).toBe(999);
+    expect(getProviderOrder('meta/llama-4')).toBe(999);
+  });
+
+  it('handles model IDs without a slash', () => {
+    expect(getProviderOrder('standalone-model')).toBe(999);
+  });
+
+  it('handles empty string', () => {
+    expect(getProviderOrder('')).toBe(999);
+  });
+
+  it('is case-insensitive for provider matching', () => {
+    expect(getProviderOrder('OpenAI/gpt-5.5')).toBe(1);
+    expect(getProviderOrder('GOOGLE/gemini-2.5-pro')).toBe(3);
+  });
+});

--- a/backend/tests/unit/ai-helpers.test.ts
+++ b/backend/tests/unit/ai-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   calculateTokenPrices,
   getProviderOrder,
 } from '../../src/services/ai/helpers';
+import type { RawOpenRouterModel } from '../../src/types/ai';
 
 describe('sortModalities', () => {
   it('sorts known modalities by predefined order', () => {
@@ -73,7 +74,9 @@ describe('calculatePricePerMillion', () => {
   });
 
   it('returns empty object when pricing is undefined', () => {
-    const result = calculatePricePerMillion(undefined as any);
+    const result = calculatePricePerMillion(
+      undefined as unknown as RawOpenRouterModel['pricing']
+    );
     expect(result).toEqual({});
   });
 
@@ -152,7 +155,11 @@ describe('calculateTokenPrices', () => {
   });
 
   it('returns empty object when pricing is undefined', () => {
-    const result = calculateTokenPrices(undefined as any, ['text'], ['text']);
+    const result = calculateTokenPrices(
+      undefined as unknown as RawOpenRouterModel['pricing'],
+      ['text'],
+      ['text']
+    );
     expect(result).toEqual({});
   });
 

--- a/backend/tests/unit/ai-helpers.test.ts
+++ b/backend/tests/unit/ai-helpers.test.ts
@@ -38,9 +38,14 @@ describe('sortModalities', () => {
   });
 
   it('handles all known modalities in the correct canonical order', () => {
-    expect(
-      sortModalities(['embeddings', 'file', 'video', 'audio', 'image', 'text'])
-    ).toEqual(['text', 'image', 'audio', 'video', 'file', 'embeddings']);
+    expect(sortModalities(['embeddings', 'file', 'video', 'audio', 'image', 'text'])).toEqual([
+      'text',
+      'image',
+      'audio',
+      'video',
+      'file',
+      'embeddings',
+    ]);
   });
 
   it('handles a single modality', () => {
@@ -74,9 +79,7 @@ describe('calculatePricePerMillion', () => {
   });
 
   it('returns empty object when pricing is undefined', () => {
-    const result = calculatePricePerMillion(
-      undefined as unknown as RawOpenRouterModel['pricing']
-    );
+    const result = calculatePricePerMillion(undefined as unknown as RawOpenRouterModel['pricing']);
     expect(result).toEqual({});
   });
 
@@ -145,11 +148,7 @@ describe('calculateTokenPrices', () => {
   });
 
   it('returns "Free" label when price is zero', () => {
-    const result = calculateTokenPrices(
-      { prompt: '0', completion: '0' },
-      ['text'],
-      ['text']
-    );
+    const result = calculateTokenPrices({ prompt: '0', completion: '0' }, ['text'], ['text']);
     expect(result.inputPriceLabel).toBe('Free');
     expect(result.outputPriceLabel).toBe('Free');
   });
@@ -184,11 +183,7 @@ describe('calculateTokenPrices', () => {
   });
 
   it('formats large prices with 1 decimal place', () => {
-    const result = calculateTokenPrices(
-      { prompt: '0.00006', completion: '0' },
-      ['text'],
-      ['text']
-    );
+    const result = calculateTokenPrices({ prompt: '0.00006', completion: '0' }, ['text'], ['text']);
     // 0.00006 * 1_000_000 = 60
     expect(result.inputPriceLabel).toBe('$60.0 / M tokens');
   });


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for `backend/src/services/ai/helpers.ts` — the core module responsible for all model pricing calculations and modality display logic across the AI gateway. This file previously had **zero test coverage** despite driving every price label and modality badge users see in the dashboard.

## Motivation

The helper functions in this module handle:
- Converting OpenRouter's per-token pricing into human-readable per-million-token labels
- Sorting and deduplicating model modalities into a canonical display order
- Determining which models get token-based pricing vs. non-token pricing (e.g., image-only models)
- Formatting price labels with appropriate decimal precision ($0.0050 vs $0.50 vs $60.0)

A single rounding bug or incorrect modality filter here silently corrupts pricing across the entire model catalog. These tests ensure correctness and prevent regressions.

## What's Tested (31 tests)

### `sortModalities`
- Sorts known modalities (text, image, audio, video, file, embeddings) by predefined order
- Places unknown modalities after known ones, sorted alphabetically
- Deduplicates entries
- Filters out empty and whitespace-only strings
- Handles empty input

### `normalizeModalities`
- Verifies delegation to sortModalities (dedup + sort)

### `calculatePricePerMillion`
- Converts per-token pricing to per-million-token pricing
- Handles zero pricing, undefined pricing, non-numeric strings
- Handles very small prices (embedding models at $0.00000002/token)
- Ensures non-negative output

### `calculateTokenPrices`
- Returns token-priced labels for text→text models
- Returns inputPrice but not outputPrice for embedding models (completion: '0')
- Returns undefined prices for image→image models (no token pricing)
- Handles file input modality, multimodal input, audio-only models
- Returns "Free" label for zero-cost models
- Verifies formatting thresholds: 4 decimals (<$0.01), 2 decimals (<$1), 1 decimal (≥$1)

### `getProviderOrder`
- Returns correct priority for known providers (openai=1, anthropic=2, google=3, amazon=4)
- Returns 999 for unknown providers
- Handles model IDs without slashes, empty strings
- Verifies case-insensitive matching

## How I tested this
```bash
npx vitest run tests/unit/ai-helpers.test.ts  # 31 tests passed
npx vitest run                                  # Full suite: 1165 tests passed
npx tsc --noEmit                                # Zero type errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `backend/src/services/ai/helpers.ts`, covering modality sorting/dedup, per‑million price conversion, token price labels (including zero and very small values), and provider ordering to prevent pricing and badge regressions. Also replace an `as any` cast with a typed cast and format the test with `prettier`.

<sup>Written for commit ee84e69c832c9902a8fb275b7820fcc1c891fdff. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1315?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for AI helper functions in `services/ai/helpers`
> Adds a [Vitest test file](https://github.com/InsForge/InsForge/pull/1315/files#diff-f2076749ab84ca4df6194967db5c391d0fa633668ead903c01b65952ca5bf2ff) covering `sortModalities`, `normalizeModalities`, `calculatePricePerMillion`, `calculateTokenPrices`, and `getProviderOrder`.
>
> - Modality tests cover sorting order, deduplication, unknown/empty inputs, and canonical ordering
> - Price tests cover zero, undefined, non-numeric, and very small values, plus non-negative checks
> - Token price tests cover text, embeddings, image, file, and audio/transcription modalities with formatting rules for small/medium/large prices and `Free` labels
> - Provider ordering tests cover known/unknown providers, missing segments, empty strings, and case-insensitivity
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee84e69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive unit test suite for AI helper utilities.
  * Verifies modality processing: ordering, deduplication, and empty/whitespace filtering; confirms normalization matches sorted output.
  * Validates pricing conversions and formatting, including handling of undefined/non-numeric inputs, clamping, and “Free” labels.
  * Tests provider ordering and resilient matching for unknown or malformed provider identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->