### PR TITLE
test(dashboard): add unit tests for AI helper functions

### DIFF
--- a/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
@@ -21,7 +21,6 @@ import {
 function model(overrides: Partial<AIModelSchema> & { modelId: string }): AIModelSchema {
   return {
     id: overrides.modelId,
-    modelId: overrides.modelId,
     provider: 'openrouter',
     created: 1700000000,
     inputModality: ['text'],

--- a/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+import type { AIModelSchema } from '@insforge/shared-schemas';
+import {
+  getProviderIdFromModelId,
+  getProviderDisplayName,
+  getProviderDisplayOrder,
+  filterModelsByProvider,
+  filterModelsByModalities,
+  generateProviderTabs,
+  formatTokenCount,
+  getFriendlyModelName,
+  toModelOption,
+  formatCredits,
+  formatPrice,
+  formatInputPrice,
+  formatOutputPrice,
+  formatModality,
+  formatReleasedDate,
+} from '#features/ai/helpers';
+
+function model(overrides: Partial<AIModelSchema> & { modelId: string }): AIModelSchema {
+  return {
+    id: overrides.modelId,
+    modelId: overrides.modelId,
+    provider: 'openrouter',
+    created: 1700000000,
+    inputModality: ['text'],
+    outputModality: ['text'],
+    ...overrides,
+  };
+}
+
+describe('getProviderIdFromModelId', () => {
+  it('extracts provider from standard model ID', () => {
+    expect(getProviderIdFromModelId('openai/gpt-5.5')).toBe('openai');
+  });
+
+  it('extracts provider from multi-segment model ID', () => {
+    expect(getProviderIdFromModelId('google/gemini-2.5-pro')).toBe('google');
+  });
+
+  it('returns empty string for model ID without slash', () => {
+    expect(getProviderIdFromModelId('standalone')).toBe('standalone');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(getProviderIdFromModelId('')).toBe('');
+  });
+});
+
+describe('getProviderDisplayName', () => {
+  it('returns display name for known providers', () => {
+    expect(getProviderDisplayName('openai')).toBe('OpenAI');
+    expect(getProviderDisplayName('anthropic')).toBe('Anthropic');
+    expect(getProviderDisplayName('google')).toBe('Google');
+    expect(getProviderDisplayName('x-ai')).toBe('xAI');
+    expect(getProviderDisplayName('deepseek')).toBe('DeepSeek');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getProviderDisplayName('OpenAI')).toBe('OpenAI');
+    expect(getProviderDisplayName('GOOGLE')).toBe('Google');
+  });
+
+  it('capitalizes first letter for unknown providers', () => {
+    expect(getProviderDisplayName('mistral')).toBe('Mistral');
+    expect(getProviderDisplayName('meta')).toBe('Meta');
+  });
+
+  it('handles empty string', () => {
+    expect(getProviderDisplayName('')).toBe('');
+  });
+});
+
+describe('getProviderDisplayOrder', () => {
+  it('returns defined order for known providers', () => {
+    expect(getProviderDisplayOrder('openai')).toBe(1);
+    expect(getProviderDisplayOrder('anthropic')).toBe(2);
+    expect(getProviderDisplayOrder('google')).toBe(3);
+  });
+
+  it('returns fallback 500 for unknown providers', () => {
+    expect(getProviderDisplayOrder('mistral')).toBe(500);
+    expect(getProviderDisplayOrder('meta')).toBe(500);
+  });
+
+  it('is case-insensitive', () => {
+    expect(getProviderDisplayOrder('OpenAI')).toBe(1);
+  });
+});
+
+describe('filterModelsByProvider', () => {
+  const models = [
+    model({ modelId: 'openai/gpt-5.5' }),
+    model({ modelId: 'openai/gpt-4o' }),
+    model({ modelId: 'anthropic/claude-sonnet' }),
+    model({ modelId: 'mistral/large' }),
+  ];
+
+  it('filters models by exact provider ID', () => {
+    const result = filterModelsByProvider(models, 'openai');
+    expect(result).toHaveLength(2);
+    expect(result.every((m) => m.modelId.startsWith('openai/'))).toBe(true);
+  });
+
+  it('returns empty array for nonexistent provider', () => {
+    expect(filterModelsByProvider(models, 'nonexistent')).toHaveLength(0);
+  });
+
+  it('filters "other" tab to models without provider logos', () => {
+    const result = filterModelsByProvider(models, 'other');
+    // mistral has no logo, so it goes to "other"
+    expect(result).toHaveLength(1);
+    expect(result[0].modelId).toBe('mistral/large');
+  });
+});
+
+describe('filterModelsByModalities', () => {
+  const models = [
+    model({ modelId: 'a/text', inputModality: ['text'], outputModality: ['text'] }),
+    model({
+      modelId: 'b/multimodal',
+      inputModality: ['text', 'image'],
+      outputModality: ['text', 'image'],
+    }),
+    model({ modelId: 'c/embed', inputModality: ['text'], outputModality: ['embeddings'] }),
+  ];
+
+  it('returns all models when no modalities are required', () => {
+    expect(filterModelsByModalities(models, [], [])).toHaveLength(3);
+  });
+
+  it('filters by required input modality', () => {
+    const result = filterModelsByModalities(models, ['image'], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].modelId).toBe('b/multimodal');
+  });
+
+  it('filters by required output modality', () => {
+    const result = filterModelsByModalities(models, [], ['embeddings']);
+    expect(result).toHaveLength(1);
+    expect(result[0].modelId).toBe('c/embed');
+  });
+
+  it('applies both input and output filters', () => {
+    const result = filterModelsByModalities(models, ['text'], ['text']);
+    expect(result).toHaveLength(2); // a/text and b/multimodal
+  });
+
+  it('returns empty array for empty model list', () => {
+    expect(filterModelsByModalities([], ['text'], ['text'])).toEqual([]);
+  });
+
+  it('returns empty array for null/undefined model list', () => {
+    expect(filterModelsByModalities(null as any, ['text'], ['text'])).toEqual([]);
+  });
+});
+
+describe('generateProviderTabs', () => {
+  it('generates tabs for providers with logos and adds "Other" for unknown', () => {
+    const models = [
+      model({ modelId: 'openai/gpt-5.5' }),
+      model({ modelId: 'anthropic/claude-sonnet' }),
+      model({ modelId: 'mistral/large' }),
+    ];
+
+    const tabs = generateProviderTabs(models);
+
+    expect(tabs.find((t) => t.id === 'openai')).toBeDefined();
+    expect(tabs.find((t) => t.id === 'anthropic')).toBeDefined();
+    expect(tabs.find((t) => t.id === 'other')).toBeDefined();
+    // mistral should NOT have its own tab
+    expect(tabs.find((t) => t.id === 'mistral')).toBeUndefined();
+  });
+
+  it('sorts tabs by display order', () => {
+    const models = [
+      model({ modelId: 'google/gemini' }),
+      model({ modelId: 'openai/gpt' }),
+      model({ modelId: 'anthropic/claude' }),
+    ];
+
+    const tabs = generateProviderTabs(models);
+    const ids = tabs.map((t) => t.id);
+
+    expect(ids.indexOf('openai')).toBeLessThan(ids.indexOf('anthropic'));
+    expect(ids.indexOf('anthropic')).toBeLessThan(ids.indexOf('google'));
+  });
+
+  it('does not add "Other" tab when all providers have logos', () => {
+    const models = [model({ modelId: 'openai/gpt' }), model({ modelId: 'google/gemini' })];
+
+    const tabs = generateProviderTabs(models);
+
+    expect(tabs.find((t) => t.id === 'other')).toBeUndefined();
+  });
+
+  it('returns empty tabs for empty model list', () => {
+    expect(generateProviderTabs([])).toEqual([]);
+  });
+});
+
+describe('formatTokenCount', () => {
+  it('formats millions', () => {
+    expect(formatTokenCount(1_500_000)).toBe('1.5M');
+    expect(formatTokenCount(1_000_000)).toBe('1.0M');
+  });
+
+  it('formats thousands', () => {
+    expect(formatTokenCount(128_000)).toBe('128.0K');
+    expect(formatTokenCount(1_000)).toBe('1.0K');
+  });
+
+  it('formats small numbers as-is', () => {
+    expect(formatTokenCount(999)).toBe('999');
+    expect(formatTokenCount(0)).toBe('0');
+  });
+});
+
+describe('getFriendlyModelName', () => {
+  it('converts kebab-case to Title Case', () => {
+    expect(getFriendlyModelName('gpt-4o-mini')).toBe('Gpt 4o Mini');
+  });
+
+  it('handles single word', () => {
+    expect(getFriendlyModelName('claude')).toBe('Claude');
+  });
+
+  it('handles empty string', () => {
+    expect(getFriendlyModelName('')).toBe('');
+  });
+});
+
+describe('toModelOption', () => {
+  it('maps AIModelSchema to ModelOption', () => {
+    const result = toModelOption(
+      model({ modelId: 'openai/gpt-5.5', inputPrice: 1, outputPrice: 2 })
+    );
+
+    expect(result.providerName).toBe('OpenAI');
+    expect(result.modelName).toBe('Gpt 5.5');
+    expect(result.inputPrice).toBe(1);
+    expect(result.outputPrice).toBe(2);
+  });
+});
+
+describe('formatCredits', () => {
+  it('formats thousands with K suffix', () => {
+    expect(formatCredits(1500)).toBe('1.5K');
+  });
+
+  it('formats small values with 2 decimal places', () => {
+    expect(formatCredits(42.5)).toBe('42.50');
+  });
+
+  it('formats zero', () => {
+    expect(formatCredits(0)).toBe('0.00');
+  });
+});
+
+describe('formatPrice', () => {
+  it('returns dash for undefined', () => {
+    expect(formatPrice(undefined)).toBe('-');
+  });
+
+  it('returns "Free" for zero', () => {
+    expect(formatPrice(0)).toBe('Free');
+  });
+
+  it('formats very small prices with 4 decimals', () => {
+    expect(formatPrice(0.005)).toBe('$0.0050');
+  });
+
+  it('formats sub-dollar prices with 2 decimals', () => {
+    expect(formatPrice(0.5)).toBe('$0.50');
+  });
+
+  it('formats dollar+ prices with 1 decimal', () => {
+    expect(formatPrice(10)).toBe('$10.0');
+  });
+});
+
+describe('formatInputPrice / formatOutputPrice', () => {
+  it('prefers priceLabel when available', () => {
+    expect(formatInputPrice({ inputPrice: 1, inputPriceLabel: '$1.0 / M tokens' })).toBe(
+      '$1.0 / M tokens'
+    );
+    expect(formatOutputPrice({ outputPrice: 2, outputPriceLabel: 'Free' })).toBe('Free');
+  });
+
+  it('falls back to formatPrice when label is undefined', () => {
+    expect(formatInputPrice({ inputPrice: 1, inputPriceLabel: undefined })).toBe('$1.0');
+    expect(formatOutputPrice({ outputPrice: undefined, outputPriceLabel: undefined })).toBe('-');
+  });
+});
+
+describe('formatModality', () => {
+  it('capitalizes first letter', () => {
+    expect(formatModality('text')).toBe('Text');
+    expect(formatModality('embeddings')).toBe('Embeddings');
+  });
+
+  it('handles empty string', () => {
+    expect(formatModality('')).toBe('');
+  });
+});
+
+describe('formatReleasedDate', () => {
+  it('formats Unix timestamp to MM/DD/YYYY', () => {
+    // 1700000000 = Nov 14, 2023
+    const result = formatReleasedDate(1700000000);
+    expect(result).toMatch(/^\d{2}\/\d{2}\/\d{4}$/);
+  });
+
+  it('returns dash for undefined', () => {
+    expect(formatReleasedDate(undefined)).toBe('-');
+  });
+
+  it('returns dash for null', () => {
+    expect(formatReleasedDate(null as any)).toBe('-');
+  });
+});

--- a/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { AIModelSchema } from '@insforge/shared-schemas';
+import type { AIModelSchema, ModalitySchema } from '@insforge/shared-schemas';
 import {
   getProviderIdFromModelId,
   getProviderDisplayName,
@@ -152,7 +152,13 @@ describe('filterModelsByModalities', () => {
   });
 
   it('returns empty array for null/undefined model list', () => {
-    expect(filterModelsByModalities(null as any, ['text'], ['text'])).toEqual([]);
+    expect(
+      filterModelsByModalities(
+        null as unknown as AIModelSchema[],
+        ['text'] as ModalitySchema[],
+        ['text'] as ModalitySchema[]
+      )
+    ).toEqual([]);
   });
 });
 
@@ -317,6 +323,6 @@ describe('formatReleasedDate', () => {
   });
 
   it('returns dash for null', () => {
-    expect(formatReleasedDate(null as any)).toBe('-');
+    expect(formatReleasedDate(null as unknown as number)).toBe('-');
   });
 });


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for `packages/dashboard/src/features/ai/helpers.ts` — the dashboard module containing all AI model formatting, filtering, and display logic. This file (244 lines, 15+ exported functions) previously had **zero test coverage**.

## Motivation

These helper functions are used across the AI Models page, the model selector, and the overview dashboard to:
- Filter models by provider and modality
- Generate dynamic provider tabs (OpenAI, Anthropic, Google, etc.)
- Format prices, token counts, dates, and modality labels
- Map raw API model schemas to display-ready options

Without tests, any refactor to the filtering or formatting logic risks breaking the entire AI dashboard UI silently.

## What's Tested (46 tests)

### Provider Extraction & Display
- `getProviderIdFromModelId` — extracts provider from `openai/gpt-5.5` format
- `getProviderDisplayName` — maps IDs to display names (openai→OpenAI, x-ai→xAI), case-insensitive, unknown provider capitalization fallback
- `getProviderDisplayOrder` — sort priority for known providers, fallback for unknown

### Model Filtering
- `filterModelsByProvider` — exact provider match, "other" tab aggregation for providers without logos
- `filterModelsByModalities` — input/output modality filtering, handles empty model lists and null safety

### Tab Generation
- `generateProviderTabs` — creates tabs for providers with logos, adds "Other" tab for unknown providers, sorts by display order, handles empty model list

### Formatting
- `formatTokenCount` — M/K/raw thresholds (1.5M, 128.0K, 999)
- `getFriendlyModelName` — kebab-case to Title Case conversion
- `formatCredits` — K suffix for thousands, 2 decimal places for small values
- `formatPrice` — undefined→"-", zero→"Free", small→4 decimals, medium→2 decimals, large→1 decimal
- `formatInputPrice`/`formatOutputPrice` — prefers server-provided label, falls back to formatPrice
- `formatModality` — first-letter capitalization
- `formatReleasedDate` — Unix timestamp to MM/DD/YYYY, null/undefined→"-"

### Schema Mapping
- `toModelOption` — maps AIModelSchema to ModelOption with provider name, friendly model name, and logo

## How I tested this

```bash
npx vitest run --config vitest.unit.config.ts src/features/ai/__tests__/helpers.test.ts  # 46 passed
npx vitest run --config vitest.unit.config.ts                                             # Full dashboard suite passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `packages/dashboard/src/features/ai/helpers.ts`, covering provider parsing, model filtering, tab generation, formatting, and schema mapping. Also replace `as any` with typed casts, remove a duplicate `modelId` in the test factory to fix TS2783, and run Prettier; 46 tests to harden the Models page, model selector, and overview.

<sup>Written for commit 40fe418d30f2295dd30a941e9ad7a2e98e1c6770. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for AI dashboard helper functions
> Adds a new [helpers.test.ts](https://github.com/InsForge/InsForge/pull/1316/files#diff-815f6b3ca424fdeb4e3a4d997f7f2f0d88a4283de85badd758736ae3d0b64fc6) vitest suite covering 14 helper functions including provider lookup, model filtering, tab generation, and price/date formatting. Tests cover edge cases such as case-insensitivity, fallback behavior, 'other' tab logic, and modality filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40fe418.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for AI helper utilities.
  * Covers provider ID extraction and provider display/sort mapping (including case-insensitivity and unknown providers).
  * Verifies model filtering by provider and modality, provider tab generation with “other” grouping, and deterministic ordering.
  * Validates formatting helpers for tokens, friendly model names, credits/prices, modality capitalization, and release date handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->