### PR TITLE
docs(skills): fold humanizer rules into doc-author + insforge-dev docs

### DIFF
--- a/.agents/skills/insforge-dev/docs/SKILL.md
+++ b/.agents/skills/insforge-dev/docs/SKILL.md
@@ -27,6 +27,7 @@ The documentation in this repo is primarily product documentation for InsForge u
 
 2. Match the writing style to the audience.
    - Public docs should be human-friendly and explain the implementation clearly.
+   - Keep public docs human-sounding: avoid AI-writing tells such as em dashes, rule-of-three lists, "not just X but Y" parallelism, inflated significance, vague attribution, and AI vocabulary (delve, leverage, underscore, seamless, robust). See the `doc-author` skill's `INSFORGE.md` overlay, "Sound human, not AI-generated".
    - `architecture.md` pages in `docs/core-concepts/` should explain how the feature works in detail.
    - Agent docs in `docs/agent-docs/` should be instruction-first and execution-oriented.
    - Agent docs should avoid explanatory filler and focus on the exact steps an agent should follow to complete the work.

--- a/.claude/skills/doc-author/INSFORGE.md
+++ b/.claude/skills/doc-author/INSFORGE.md
@@ -39,3 +39,18 @@ import Installation from '/snippets/sdk-installation.mdx';
 
 Address the reader as "you"; use imperative verbs. See `docs/quickstart.mdx`
 for the canonical voice.
+
+## Sound human, not AI-generated
+
+InsForge docs are public-facing; they should not read as machine-written. Strip
+the common AI tells (from the humanizer skill, based on Wikipedia's "Signs of AI
+writing"):
+
+- **Em dashes** for asides or emphasis. Use a comma, period, colon, or parentheses instead.
+- **Rule of three.** Don't auto-triple ("fast, reliable, and scalable"); name the one that matters.
+- **Negative parallelism** ("It's not just X, it's Y"). State the positive claim directly.
+- **Inflated significance** ("plays a vital role", "underscores the importance of").
+- **Vague attribution** ("studies show", "widely regarded"). Name the source or drop the claim.
+- **AI vocabulary**: delve, leverage, utilize, underscore, foster, realm, landscape, tapestry, seamless, robust, pivotal. Use the plain word.
+
+Read it back. If it sounds like a press release or a term paper, flatten it.

--- a/.claude/skills/insforge-dev/docs/SKILL.md
+++ b/.claude/skills/insforge-dev/docs/SKILL.md
@@ -27,6 +27,7 @@ The documentation in this repo is primarily product documentation for InsForge u
 
 2. Match the writing style to the audience.
    - Public docs should be human-friendly and explain the implementation clearly.
+   - Keep public docs human-sounding: avoid AI-writing tells such as em dashes, rule-of-three lists, "not just X but Y" parallelism, inflated significance, vague attribution, and AI vocabulary (delve, leverage, underscore, seamless, robust). See the `doc-author` skill's `INSFORGE.md` overlay, "Sound human, not AI-generated".
    - `architecture.md` pages in `docs/core-concepts/` should explain how the feature works in detail.
    - Agent docs in `docs/agent-docs/` should be instruction-first and execution-oriented.
    - Agent docs should avoid explanatory filler and focus on the exact steps an agent should follow to complete the work.

--- a/.codex/skills/insforge-dev/docs/SKILL.md
+++ b/.codex/skills/insforge-dev/docs/SKILL.md
@@ -27,6 +27,7 @@ The documentation in this repo is primarily product documentation for InsForge u
 
 2. Match the writing style to the audience.
    - Public docs should be human-friendly and explain the implementation clearly.
+   - Keep public docs human-sounding: avoid AI-writing tells such as em dashes, rule-of-three lists, "not just X but Y" parallelism, inflated significance, vague attribution, and AI vocabulary (delve, leverage, underscore, seamless, robust). See the `doc-author` skill's `INSFORGE.md` overlay, "Sound human, not AI-generated".
    - `architecture.md` pages in `docs/core-concepts/` should explain how the feature works in detail.
    - Agent docs in `docs/agent-docs/` should be instruction-first and execution-oriented.
    - Agent docs should avoid explanatory filler and focus on the exact steps an agent should follow to complete the work.


### PR DESCRIPTION
## What

Integrates the **humanizer** anti-AI-writing rules into the monorepo's doc-writing skills, so public-facing docs don't read as machine-generated. No new skill; folded into existing skill files.

**`.claude/skills/doc-author/INSFORGE.md`** (the editable InsForge overlay)
- New **"Sound human, not AI-generated"** section: em dashes, rule of three, negative parallelism, inflated significance, vague attribution, AI vocabulary (delve/leverage/underscore/seamless/robust/...).

**`insforge-dev/docs/SKILL.md`** (mirrored across `.claude/`, `.agents/`, `.codex/`)
- One new rule under "Match the writing style to the audience" pointing at the overlay above.

The vendored Mintlify `doc-author/SKILL.md` is **left untouched** (it's refreshed by `scripts/update-mintlify-skill.sh`), per the repo's contract that InsForge-specific guidance lives in `INSFORGE.md`.

Source: the [humanizer skill](https://github.com/blader/humanizer) / Wikipedia's "Signs of AI writing." Companion to the CMS blog change (insforge-content-management-system#162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folded the humanizer rules into the InsForge doc-author overlay and added a small pointer in insforge-dev docs skills, so public docs read naturally and avoid machine-like patterns.

- **New Features**
  - Added “Sound human, not AI-generated” to `.claude/skills/doc-author/INSFORGE.md` with rules to avoid em dashes, rule-of-three lists, “not just X but Y”, inflated significance, vague attribution, and loaded vocabulary (delve, leverage, underscore, seamless, robust).
  - Added a one-line reminder in `insforge-dev/docs/SKILL.md` mirrored under `.claude`, `.agents`, and `.codex`, pointing to the overlay; vendored Mintlify `doc-author/SKILL.md` stays unchanged.

<sup>Written for commit 3c268bcd79bb4c0b6a8a472149feb77194d648c0. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation writing guidelines with new style rules to ensure public documentation maintains a natural human voice.
  * Added specific guidance on avoiding common AI-generated phrasing patterns, vocabulary, and formatting conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Sound human, not AI-generated' guidance to doc-author and insforge-dev skills
> Folds humanizer rules into the doc-author and insforge-dev skill docs so AI-writing tells are avoided in public-facing documentation.
>
> - Adds a new section 'Sound human, not AI-generated' to [INSFORGE.md](.claude/skills/doc-author/INSFORGE.md) listing concrete patterns to avoid: em dashes, rule-of-three lists, negative parallelism, inflated significance, vague attribution, and AI-tinged vocabulary.
> - Updates the `insforge-dev` `SKILL.md` in `.agents`, `.claude`, and `.codex` skill directories to reference this new section under the 'Match the writing style to the audience' guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c268bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->