### PR TITLE
fix(analytics): parse YYYY-MM-DD chart dates as local to stop UTC shift

### DIFF
--- a/packages/dashboard/src/features/analytics/components/posthog/KpiSectionWithTrend.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/KpiSectionWithTrend.tsx
@@ -69,7 +69,15 @@ function KpiTab({ metric, item, active, onClick }: KpiTabProps) {
 }
 
 function formatXAxis(date: string, timeframe: string): string {
-  const d = new Date(date);
+  // YYYY-MM-DD strings get parsed as UTC midnight by new Date(), then
+  // toLocaleDateString shifts them back by the local timezone offset — in
+  // UTC-N timezones a 2026-05-22 bucket renders as 5/21. Parse date-only
+  // strings as local components instead. Datetimes (24h timeframe) still
+  // fall through to the standard parser so UTC-to-local conversion stays.
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  const d = dateOnly
+    ? new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+    : new Date(date);
   if (Number.isNaN(d.getTime())) {
     return date;
   }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse `YYYY-MM-DD` chart buckets as local dates to stop UTC-based shifts in analytics KPI trend x-axis labels. This fixes the off-by-one-day display in UTC− time zones while keeping datetime parsing unchanged for 24h views.

<sup>Written for commit acb055b16ab00a7232d375c7fdcd5d4a5f4b18d5. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix UTC day shift in `formatXAxis` by parsing YYYY-MM-DD dates as local time
> In [KpiSectionWithTrend.tsx](https://github.com/InsForge/InsForge/pull/1337/files#diff-cdc9826758498b4369a7ab2c9b244707dd9000ec37ec68897a6148bbdcba94b2), `formatXAxis` now detects date-only strings (`YYYY-MM-DD`) via regex and constructs a `Date` from local year/month/day components instead of passing the string directly to `new Date()`. This prevents the browser's UTC-to-local timezone conversion from shifting the displayed day label by one day. Behavior for datetime strings and all timeframe-based formatting branches is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acb055b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone-related date formatting issues in the analytics dashboard. Date values now display correctly without unexpected bucket shifts, improving the accuracy of date-based analytics visualizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->