### PR TITLE
feat(database): add 'Add more' option in RecordFormDialog to create m…

### DIFF
--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Switch,
 } from '@insforge/ui';
 import { ScrollArea } from '#components';
 import { useRecords } from '#features/database/hooks/useRecords';
@@ -36,6 +37,7 @@ export function RecordFormDialog({
   onSuccess,
 }: RecordFormDialogProps) {
   const [error, setError] = useState<string | null>(null);
+  const [addMore, setAddMore] = useState(false);
   const { createRecord, isCreating } = useRecords(tableName);
 
   const displayFields = useMemo(() => {
@@ -73,11 +75,13 @@ export function RecordFormDialog({
     async (data) => {
       try {
         await createRecord(data);
-        onOpenChange(false);
         form.reset();
         setError(null);
         if (onSuccess) {
           onSuccess();
+        }
+        if (!addMore) {
+          onOpenChange(false);
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Failed to create record';
@@ -136,6 +140,15 @@ export function RecordFormDialog({
                 <span className="truncate">{error}</span>
               </div>
             )}
+            <label className="mr-auto flex cursor-pointer items-center gap-2 text-sm text-muted-foreground select-none">
+              <Switch
+                size="sm"
+                checked={addMore}
+                onCheckedChange={setAddMore}
+                disabled={isCreating}
+              />
+              Add more
+            </label>
             <Button
               type="button"
               variant="secondary"

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -68,6 +68,7 @@ export function RecordFormDialog({
   useEffect(() => {
     if (!open) {
       setError(null);
+      setAddMore(false);
     }
   }, [open]);
 


### PR DESCRIPTION
…ultiple records

## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Add more” toggle to RecordFormDialog so users can create multiple records without closing the dialog.

- **New Features**
  - Added a `Switch` from `@insforge/ui` labeled “Add more” in the dialog footer (disabled while saving; resets on dialog close).
  - When enabled, the form resets after create and the dialog stays open; when off, it closes as before.

<sup>Written for commit bc682598fa92bb32033f9028fd204999db063c9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Add more' toggle to `RecordFormDialog` to keep dialog open after record creation
> Adds a Switch control in the `RecordFormDialog` footer that, when enabled, keeps the dialog open after a successful record creation so users can create multiple records in sequence. The toggle resets to off whenever the dialog closes. Behavioral Change: `onSuccess` is now called while the dialog may still be open, whereas previously the dialog closed before `onSuccess` was invoked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc68259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add more" toggle in the record form dialog so the dialog stays open for consecutive submissions when enabled.
* **Bug Fixes**
  * Clear errors and reset the "Add more" setting when the dialog closes.
  * Disable the "Add more" toggle while a submission is in progress to prevent duplicate actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->