### PR TITLE
middleware added to handle the non json for function/:slug

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -153,9 +153,9 @@ export async function createApp() {
   });
 
   //default payload size 10 MB and it can be modified, depending upon the usage.
-  const maxFunctionProxyBodyBytes = Number(
-    process.env.FUNCTION_PROXY_MAX_BODY_BYTES || 25 * 1024 * 1024
-  );
+  const _rawLimit = parseInt(process.env.FUNCTION_PROXY_MAX_BODY_BYTES ?? '', 10);
+  const maxFunctionProxyBodyBytes =
+    Number.isFinite(_rawLimit) && _rawLimit > 0 ? _rawLimit : 25 * 1024 * 1024;
 
   // middleware to handle non json body for the function/:slug
   app.use('/functions/:slug', (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -152,6 +152,15 @@ export async function createApp() {
     next();
   });
 
+  app.use('/functions/:slug', (req: Request, res: Response, next: NextFunction) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      req.rawBody = Buffer.concat(chunks);
+      next();
+    });
+  });
+
   // Mount webhooks with raw body parser BEFORE JSON middleware
   // This ensures signature verification uses the original bytes
   app.use('/api/webhooks', express.raw({ type: 'application/json' }), webhooksRouter);
@@ -237,7 +246,7 @@ export async function createApp() {
       const response = await fetch(targetUrl, {
         method: req.method,
         headers,
-        body: ['GET', 'HEAD'].includes(req.method) ? undefined : JSON.stringify(req.body),
+        body: ['GET', 'HEAD'].includes(req.method) ? undefined : req.rawBody,
       });
 
       // Read response as raw bytes to preserve binary data (images, PDFs, etc.)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -197,17 +197,19 @@ export async function createApp() {
       logger.error('Failed to read function proxy request body', { error: error.message });
       next(error);
     };
-    const onAborted = () => {
+    const onClose = () => {
       if (done) {
         return;
       }
-      done = true;
-      next(new Error('Request aborted while reading function proxy body'));
+      if (!req.complete) {
+        done = true;
+        next(new Error('Request aborted while reading function proxy body'));
+      }
     };
     req.on('data', onData);
     req.on('end', onEnd);
     req.on('error', onError);
-    req.on('aborted', onAborted);
+    req.on('close', onClose);
   });
 
   // Mount webhooks with raw body parser BEFORE JSON middleware

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -165,10 +165,16 @@ export async function createApp() {
       return;
     }
     const chunks: Buffer[] = [];
+    let done = false;
     let totalBytes = 0;
+
     const onData = (chunk: Buffer) => {
+      if (done) {
+        return;
+      }
       totalBytes += chunk.length;
       if (totalBytes > maxFunctionProxyBodyBytes) {
+        done = true;
         res.status(413).json({ error: 'Payload too large' });
         req.destroy();
         return;
@@ -176,14 +182,26 @@ export async function createApp() {
       chunks.push(chunk);
     };
     const onEnd = () => {
+      if (done) {
+        return;
+      }
+      done = true;
       req.rawBody = Buffer.concat(chunks);
       next();
     };
     const onError = (error: Error) => {
+      if (done) {
+        return;
+      }
+      done = true;
       logger.error('Failed to read function proxy request body', { error: error.message });
       next(error);
     };
     const onAborted = () => {
+      if (done) {
+        return;
+      }
+      done = true;
       next(new Error('Request aborted while reading function proxy body'));
     };
     req.on('data', onData);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -161,6 +161,7 @@ export async function createApp() {
   app.use('/functions/:slug', (req: Request, res: Response, next: NextFunction) => {
     if (req.method === 'GET' || req.method === 'HEAD') {
       req.rawBody = Buffer.alloc(0);
+      req._body = true;
       next();
       return;
     }
@@ -187,6 +188,7 @@ export async function createApp() {
       }
       done = true;
       req.rawBody = Buffer.concat(chunks);
+      req._body = true;
       next();
     };
     const onError = (error: Error) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -152,13 +152,44 @@ export async function createApp() {
     next();
   });
 
+  //default payload size 10 MB and it can be modified, depending upon the usage.
+  const maxFunctionProxyBodyBytes = Number(
+    process.env.FUNCTION_PROXY_MAX_BODY_BYTES || 25 * 1024 * 1024
+  );
+
+  // middleware to handle non json body for the function/:slug
   app.use('/functions/:slug', (req: Request, res: Response, next: NextFunction) => {
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      req.rawBody = Buffer.alloc(0);
+      next();
+      return;
+    }
     const chunks: Buffer[] = [];
-    req.on('data', (chunk) => chunks.push(chunk));
-    req.on('end', () => {
+    let totalBytes = 0;
+    const onData = (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > maxFunctionProxyBodyBytes) {
+        res.status(413).json({ error: 'Payload too large' });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    };
+    const onEnd = () => {
       req.rawBody = Buffer.concat(chunks);
       next();
-    });
+    };
+    const onError = (error: Error) => {
+      logger.error('Failed to read function proxy request body', { error: error.message });
+      next(error);
+    };
+    const onAborted = () => {
+      next(new Error('Request aborted while reading function proxy body'));
+    };
+    req.on('data', onData);
+    req.on('end', onEnd);
+    req.on('error', onError);
+    req.on('aborted', onAborted);
   });
 
   // Mount webhooks with raw body parser BEFORE JSON middleware

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,9 @@
+import { Request } from 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      rawBody?: Buffer;
+    }
+  }
+}

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import { Request } from 'express';
+export {};
 
 declare global {
   namespace Express {

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -4,6 +4,7 @@ declare global {
   namespace Express {
     interface Request {
       rawBody?: Buffer;
+      _body?: boolean;
     }
   }
 }

--- a/backend/tests/local/test-function-body.sh
+++ b/backend/tests/local/test-function-body.sh
@@ -23,48 +23,47 @@ fi
 print_success "Got admin token"
 echo ""
 
-# Python helper for creating functions (avoids shell escaping hell)
-CREATE_FUNC_PY="/tmp/create_func_$$.py"
-cat > "$CREATE_FUNC_PY" << 'PYEOF'
-import sys, json, urllib.request
+CREATE_FUNC_JS="/tmp/create_func_$$.js"
+cat > "$CREATE_FUNC_JS" << 'JSEOF'
+const slug = process.argv[2];
+const code = process.argv[3];
+const baseUrl = process.argv[4];
+const token = process.argv[5];
 
-slug = sys.argv[1]
-code = sys.argv[2]
-base_url = sys.argv[3]
-token = sys.argv[4]
+const payload = JSON.stringify({
+    name: slug,
+    slug: slug,
+    code: code,
+    status: "active"
+});
 
-payload = json.dumps({
-    "name": slug,
-    "slug": slug,
-    "code": code,
-    "status": "active"
-}).encode()
-
-req = urllib.request.Request(
-    f"{base_url}/functions",
-    data=payload,
-    headers={
-        "Authorization": f"Bearer {token}",
+const url = baseUrl.replace(/\/+$/, '') + '/functions';
+fetch(url, {
+    method: "POST",
+    headers: {
+        "Authorization": `Bearer ${token}`,
         "Content-Type": "application/json"
     },
-    method="POST"
-)
-try:
-    resp = urllib.request.urlopen(req)
-    print(f"Created: {slug} (status={resp.status})", file=sys.stderr)
-except urllib.error.HTTPError as e:
-    body = e.read().decode()
-    if "already exists" in body.lower():
-        print(f"Exists: {slug}", file=sys.stderr)
-    else:
-        print(f"FAILED: {slug} (status={e.code} body={body})", file=sys.stderr)
-        sys.exit(1)
-PYEOF
+    body: payload
+}).then(async resp => {
+    if (resp.ok) {
+        console.error(`Created: ${slug} (status=${resp.status})`);
+    } else {
+        const body = await resp.text();
+        if (body.toLowerCase().includes("already exists")) {
+            console.error(`Exists: ${slug}`);
+        } else {
+            console.error(`FAILED: ${slug} (status=${resp.status} body=${body})`);
+            process.exit(1);
+        }
+    }
+});
+JSEOF
 
 create_function() {
     local slug=$1
     local code=$2
-    python3 "$CREATE_FUNC_PY" "$slug" "$code" "$API_BASE" "$ADMIN_TOKEN" 2>&1
+    node "$CREATE_FUNC_JS" "$slug" "$code" "$API_BASE" "$ADMIN_TOKEN" 2>&1
     return $?
 }
 
@@ -188,7 +187,7 @@ fi
 echo "──────────────────────────────────────────"
 echo "Test 4: Multipart binary file"
 echo "──────────────────────────────────────────"
-python3 -c "open('/tmp/test-body-binary.bin','wb').write(bytes(range(256)))"
+node -e "require('fs').writeFileSync('/tmp/test-body-binary.bin', Buffer.from(Array.from({length:256},(_,i)=>i)))"
 RESP=$(curl -s -w "\n%{http_code}" "$BASE_URL/functions/$MULTI_SLUG" \
     -F "bin=@/tmp/test-body-binary.bin;type=application/octet-stream")
 STATUS=$(echo "$RESP" | tail -n 1)
@@ -240,7 +239,7 @@ echo "Test 7: Binary response"
 echo "──────────────────────────────────────────"
 curl -s -o /tmp/test-binary-response.bin "$BASE_URL/functions/$BIN_SLUG"
 BYTES=$(wc -c < /tmp/test-binary-response.bin)
-EXPECTED=$(python3 -c "print(bytes([0,1,2,3,255,254]) == open('/tmp/test-binary-response.bin','rb').read())")
+EXPECTED=$(node -e "const f=require('fs');const e=Buffer.from([0,1,2,3,255,254]);console.log(f.readFileSync('/tmp/test-binary-response.bin').equals(e)?'True':'False')")
 if [ "$BYTES" = "6" ] && [ "$EXPECTED" = "True" ]; then
     print_success "Binary response (6 bytes, content matches)"
 else
@@ -255,7 +254,7 @@ echo "🧹 Cleaning up..."
 for slug in "${TEST_SLUGS[@]}"; do
     delete_function "$slug"
 done
-rm -f /tmp/test-body-upload.txt /tmp/test-body-binary.bin /tmp/a.txt /tmp/b.txt /tmp/test-binary-response.bin "$CREATE_FUNC_PY"
+rm -f /tmp/test-body-upload.txt /tmp/test-body-binary.bin /tmp/a.txt /tmp/b.txt /tmp/test-binary-response.bin "$CREATE_FUNC_JS"
 print_success "Cleanup done"
 echo ""
 

--- a/backend/tests/local/test-function-body.sh
+++ b/backend/tests/local/test-function-body.sh
@@ -211,8 +211,6 @@ STATUS=$(echo "$RESP" | tail -n 1)
 BODY=$(echo "$RESP" | sed '$d')
 if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"files":\['; then
     print_success "Multipart duplicate keys (array via getAll)"
-elif [ "$STATUS" = "200" ]; then
-    print_success "Multipart duplicate keys (single entry, last wins)"
 else
     print_fail "Multipart duplicate keys (status=$STATUS body=$BODY)"
 fi

--- a/backend/tests/local/test-function-body.sh
+++ b/backend/tests/local/test-function-body.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+
+# Edge Function body handling test script (multipart, JSON, binary)
+# Disable write rate limiting for tests
+export INSFORGE_DISABLE_WRITE_RATE_LIMIT=1
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/../test-config.sh"
+
+echo "🧪 Testing edge function body handling (multipart/JSON/binary)..."
+echo ""
+
+API_BASE="$TEST_API_BASE"
+BASE_URL="${TEST_API_BASE%/api}"
+TS=$(date +%s)
+
+echo "🔑 Getting admin token..."
+ADMIN_TOKEN=$(get_admin_token)
+if [ -z "$ADMIN_TOKEN" ]; then
+    print_fail "Failed to get admin token"
+    exit 1
+fi
+print_success "Got admin token"
+echo ""
+
+# Python helper for creating functions (avoids shell escaping hell)
+CREATE_FUNC_PY="/tmp/create_func_$$.py"
+cat > "$CREATE_FUNC_PY" << 'PYEOF'
+import sys, json, urllib.request
+
+slug = sys.argv[1]
+code = sys.argv[2]
+base_url = sys.argv[3]
+token = sys.argv[4]
+
+payload = json.dumps({
+    "name": slug,
+    "slug": slug,
+    "code": code,
+    "status": "active"
+}).encode()
+
+req = urllib.request.Request(
+    f"{base_url}/functions",
+    data=payload,
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json"
+    },
+    method="POST"
+)
+try:
+    resp = urllib.request.urlopen(req)
+    print(f"Created: {slug} (status={resp.status})", file=sys.stderr)
+except urllib.error.HTTPError as e:
+    body = e.read().decode()
+    if "already exists" in body.lower():
+        print(f"Exists: {slug}", file=sys.stderr)
+    else:
+        print(f"FAILED: {slug} (status={e.code} body={body})", file=sys.stderr)
+        sys.exit(1)
+PYEOF
+
+create_function() {
+    local slug=$1
+    local code=$2
+    python3 "$CREATE_FUNC_PY" "$slug" "$code" "$API_BASE" "$ADMIN_TOKEN" 2>&1
+    return $?
+}
+
+delete_function() {
+    local slug=$1
+    curl -s -X DELETE "$API_BASE/functions/$slug" \
+        -H "Authorization: Bearer $ADMIN_TOKEN" > /dev/null 2>&1
+}
+
+TEST_SLUGS=()
+
+echo "📝 Creating test functions..."
+
+JSON_SLUG="test-json-$TS"
+TEST_SLUGS+=("$JSON_SLUG")
+create_function "$JSON_SLUG" \
+'module.exports = async function(req) {
+  const body = await req.json();
+  body.received = true;
+  return new Response(JSON.stringify(body), {
+    headers: {"Content-Type": "application/json"}
+  });
+};'
+
+MULTI_SLUG="test-multi-$TS"
+TEST_SLUGS+=("$MULTI_SLUG")
+create_function "$MULTI_SLUG" \
+'module.exports = async function(req) {
+  const ct = req.headers.get("content-type") || "";
+  const parts = {};
+  try {
+    const form = await req.formData();
+    for (const [k, v] of form.entries()) {
+      if (v instanceof File) {
+        const all = form.getAll(k);
+        parts[k] = all.length > 1
+          ? all.map(f => ({name: f.name, type: f.type, size: f.size}))
+          : {name: v.name, type: v.type, size: v.size};
+      } else {
+        parts[k] = v;
+      }
+    }
+    return new Response(JSON.stringify({success: true, fields: parts, contentType: ct}), {
+      headers: {"Content-Type": "application/json"}
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({error: e.message, contentType: ct}), {
+      status: 400,
+      headers: {"Content-Type": "application/json"}
+    });
+  }
+};'
+
+BIN_SLUG="test-bin-$TS"
+TEST_SLUGS+=("$BIN_SLUG")
+create_function "$BIN_SLUG" \
+'module.exports = async function(req) {
+  const buf = new Uint8Array([0, 1, 2, 3, 255, 254]);
+  return new Response(buf, {
+    headers: {"Content-Type": "application/octet-stream"}
+  });
+};'
+
+print_success "Test functions created"
+echo ""
+sleep 3
+
+# ──────────────────────────────────────────────
+# Test 1: JSON payload
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 1: JSON payload"
+echo "──────────────────────────────────────────"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/functions/$JSON_SLUG" \
+    -H "Content-Type: application/json" \
+    -d '{"user":"Alice","items":[1,2,3],"nested":{"key":"value"}}')
+STATUS=$(echo "$RESP" | tail -n 1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"received":true'; then
+    print_success "JSON payload"
+else
+    print_fail "JSON payload (status=$STATUS body=$BODY)"
+fi
+
+# ──────────────────────────────────────────────
+# Test 2: Multipart text fields only
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 2: Multipart text fields only"
+echo "──────────────────────────────────────────"
+RESP=$(curl -s -w "\n%{http_code}" "$BASE_URL/functions/$MULTI_SLUG" \
+    -F "name=John" -F "age=30")
+STATUS=$(echo "$RESP" | tail -n 1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"name":"John"'; then
+    print_success "Multipart text fields"
+else
+    print_fail "Multipart text fields (status=$STATUS body=$BODY)"
+fi
+
+# ──────────────────────────────────────────────
+# Test 3: Multipart text + file
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 3: Multipart text + file"
+echo "──────────────────────────────────────────"
+echo "hello world" > /tmp/test-body-upload.txt
+RESP=$(curl -s -w "\n%{http_code}" "$BASE_URL/functions/$MULTI_SLUG" \
+    -F "title=Report" -F "file=@/tmp/test-body-upload.txt;type=text/plain")
+STATUS=$(echo "$RESP" | tail -n 1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"title":"Report"' && echo "$BODY" | grep -q '"size":12'; then
+    print_success "Multipart text + file"
+else
+    print_fail "Multipart text + file (status=$STATUS body=$BODY)"
+fi
+
+# ──────────────────────────────────────────────
+# Test 4: Multipart binary file
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 4: Multipart binary file"
+echo "──────────────────────────────────────────"
+python3 -c "open('/tmp/test-body-binary.bin','wb').write(bytes(range(256)))"
+RESP=$(curl -s -w "\n%{http_code}" "$BASE_URL/functions/$MULTI_SLUG" \
+    -F "bin=@/tmp/test-body-binary.bin;type=application/octet-stream")
+STATUS=$(echo "$RESP" | tail -n 1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"size":256'; then
+    print_success "Multipart binary file (256 bytes)"
+else
+    print_fail "Multipart binary file (status=$STATUS body=$BODY)"
+fi
+
+# ──────────────────────────────────────────────
+# Test 5: Multipart duplicate file keys
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 5: Multipart duplicate file keys"
+echo "──────────────────────────────────────────"
+echo "aaa" > /tmp/a.txt && echo "bbb" > /tmp/b.txt
+RESP=$(curl -s -w "\n%{http_code}" "$BASE_URL/functions/$MULTI_SLUG" \
+    -F "files=@/tmp/a.txt" -F "files=@/tmp/b.txt")
+STATUS=$(echo "$RESP" | tail -n 1)
+BODY=$(echo "$RESP" | sed '$d')
+if [ "$STATUS" = "200" ] && echo "$BODY" | grep -q '"files":\['; then
+    print_success "Multipart duplicate keys (array via getAll)"
+elif [ "$STATUS" = "200" ]; then
+    print_success "Multipart duplicate keys (single entry, last wins)"
+else
+    print_fail "Multipart duplicate keys (status=$STATUS body=$BODY)"
+fi
+
+# ──────────────────────────────────────────────
+# Test 6: Empty POST body
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 6: Empty POST body"
+echo "──────────────────────────────────────────"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/functions/$MULTI_SLUG")
+STATUS=$(echo "$RESP" | tail -n 1)
+if [ "$STATUS" = "200" ] || [ "$STATUS" = "400" ]; then
+    print_success "Empty body handled (status=$STATUS)"
+else
+    print_fail "Empty body (status=$STATUS body=$(echo "$RESP" | sed '$d'))"
+fi
+
+# ──────────────────────────────────────────────
+# Test 7: Binary response
+# ──────────────────────────────────────────────
+echo "──────────────────────────────────────────"
+echo "Test 7: Binary response"
+echo "──────────────────────────────────────────"
+curl -s -o /tmp/test-binary-response.bin "$BASE_URL/functions/$BIN_SLUG"
+BYTES=$(wc -c < /tmp/test-binary-response.bin)
+EXPECTED=$(python3 -c "print(bytes([0,1,2,3,255,254]) == open('/tmp/test-binary-response.bin','rb').read())")
+if [ "$BYTES" = "6" ] && [ "$EXPECTED" = "True" ]; then
+    print_success "Binary response (6 bytes, content matches)"
+else
+    print_fail "Binary response (bytes=$BYTES match=$EXPECTED)"
+fi
+
+# ──────────────────────────────────────────────
+# Cleanup
+# ──────────────────────────────────────────────
+echo ""
+echo "🧹 Cleaning up..."
+for slug in "${TEST_SLUGS[@]}"; do
+    delete_function "$slug"
+done
+rm -f /tmp/test-body-upload.txt /tmp/test-body-binary.bin /tmp/a.txt /tmp/b.txt /tmp/test-binary-response.bin "$CREATE_FUNC_PY"
+print_success "Cleanup done"
+echo ""
+
+print_success "🎉 Function body handling tests completed!"

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -234,16 +234,26 @@ async function executeInWorker(code: string, request: Request): Promise<Response
     };
 
     // Prepare request data
-    const body = request.body ? await request.text() : null;
-    const requestData = {
+    // IMPORTANT: preserve raw request bytes for multipart/binary/text payloads.
+    // Do NOT coerce to text, otherwise multipart boundaries and binary payloads corrupt.
+    const requestData: {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      // ArrayBuffer is cloneable across worker boundaries.
+      body: ArrayBuffer | null;
+    } = {
       url: request.url,
       method: request.method,
       headers: Object.fromEntries(request.headers),
-      body,
+      body: request.body ? await request.arrayBuffer() : null,
     };
 
-    // Send message with code, request data, and secrets
-    worker.postMessage({ code, requestData, secrets });
+    // Send message with code, request data, and secrets.
+    // Transfer the body ArrayBuffer to avoid a memory copy (zero-copy move).
+    // The original ArrayBuffer is neutered after transfer
+    const transferables: Transferable[] = requestData.body ? [requestData.body] : [];
+    worker.postMessage({ code, requestData, secrets }, transferables);
   });
 }
 

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -193,15 +193,36 @@ async function executeInWorker(code: string, request: Request): Promise<Response
       );
     }, WORKER_TIMEOUT_MS);
 
-    // Handle worker response
+    // Prepare request data (raw bytes for multipart/binary support)
+    const requestData: {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body: ArrayBuffer | null;
+    } = {
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers),
+      body: request.body ? await request.arrayBuffer() : null,
+    };
+
+    // Buffer the work payload — send it only after the worker signals ready
+    const transferables: Transferable[] = requestData.body ? [requestData.body] : [];
+    const workPayload = { code, requestData, secrets };
+
+    // Handle worker messages: first ready signal, then function result
     worker.onmessage = (e) => {
+      if (e.data.ready) {
+        worker.postMessage(workPayload, transferables);
+        return;
+      }
+
       clearTimeout(timeout);
       worker.terminate();
       URL.revokeObjectURL(workerUrl);
 
       if (e.data.success) {
         const { response } = e.data;
-        // The worker now properly sends null for bodyless responses
         resolve(
           new Response(response.body, {
             status: response.status,
@@ -232,28 +253,6 @@ async function executeInWorker(code: string, request: Request): Promise<Response
         })
       );
     };
-
-    // Prepare request data
-    // IMPORTANT: preserve raw request bytes for multipart/binary/text payloads.
-    // Do NOT coerce to text, otherwise multipart boundaries and binary payloads corrupt.
-    const requestData: {
-      url: string;
-      method: string;
-      headers: Record<string, string>;
-      // ArrayBuffer is cloneable across worker boundaries.
-      body: ArrayBuffer | null;
-    } = {
-      url: request.url,
-      method: request.method,
-      headers: Object.fromEntries(request.headers),
-      body: request.body ? await request.arrayBuffer() : null,
-    };
-
-    // Send message with code, request data, and secrets.
-    // Transfer the body ArrayBuffer to avoid a memory copy (zero-copy move).
-    // The original ArrayBuffer is neutered after transfer
-    const transferables: Transferable[] = requestData.body ? [requestData.body] : [];
-    worker.postMessage({ code, requestData, secrets }, transferables);
   });
 }
 

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -181,8 +181,11 @@ async function executeInWorker(code: string, request: Request): Promise<Response
       },
     });
 
+    let workerTerminated = false;
+
     // Set timeout for worker execution
     const timeout = setTimeout(() => {
+      workerTerminated = true;
       worker.terminate();
       URL.revokeObjectURL(workerUrl);
       resolve(
@@ -213,6 +216,7 @@ async function executeInWorker(code: string, request: Request): Promise<Response
     // Handle worker messages: first ready signal, then function result
     worker.onmessage = (e) => {
       if (e.data.ready) {
+        if (workerTerminated) return;
         worker.postMessage(workPayload, transferables);
         return;
       }

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -130,7 +130,6 @@ self.onmessage = async (e) => {
       body: requestData.body,
     });
 
-
     // Execute the function
     const response = await functionHandler(request);
 
@@ -152,7 +151,6 @@ self.onmessage = async (e) => {
       } else {
         body = await response.arrayBuffer();
       }
-
     }
 
     const responseData = {
@@ -161,7 +159,6 @@ self.onmessage = async (e) => {
       headers: Object.fromEntries(response.headers),
       body,
     };
-
 
     self.postMessage({ success: true, response: responseData });
   } catch (error) {

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -120,27 +120,45 @@ self.onmessage = async (e) => {
     }
 
     // Create Request object from data
+    // Preserve raw bytes (ArrayBuffer) for multipart/binary payloads.
     const request = new Request(requestData.url, {
       method: requestData.method,
       headers: requestData.headers,
       body: requestData.body,
     });
 
+
     // Execute the function
     const response = await functionHandler(request);
 
     // Serialize and send response
+    // Preserve binary responses by using ArrayBuffer when possible.
+    // We still use text() for JSON/text responses for backward compatibility.
     let body = null;
-    if (![204, 205, 304].includes(response.status)) {
-      body = await response.text();
+    const status = response.status;
+    if (![204, 205, 304].includes(status)) {
+      const contentType = response.headers.get('content-type') ?? '';
+      const isLikelyText =
+        contentType.includes('application/json') ||
+        contentType.startsWith('text/') ||
+        contentType.includes('application/xml') ||
+        contentType.includes('application/x-www-form-urlencoded');
+
+      if (isLikelyText) {
+        body = await response.text();
+      } else {
+        body = await response.arrayBuffer();
+      }
+
     }
 
     const responseData = {
       status: response.status,
       statusText: response.statusText,
       headers: Object.fromEntries(response.headers),
-      body: body,
+      body,
     };
+
 
     self.postMessage({ success: true, response: responseData });
   } catch (error) {

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -60,6 +60,9 @@ const { createClient } = await import('npm:@insforge/sdk');
 const { encodeBase64, decodeBase64 } =
   await import('https://deno.land/std@0.224.0/encoding/base64.ts');
 
+// the host must wait for this before sending the actual work payload.
+self.postMessage({ ready: true });
+
 // Handle the single message with code, request data, and secrets
 self.onmessage = async (e) => {
   const { code, requestData, secrets = {} } = e.data;


### PR DESCRIPTION
closes #1330 

## Summary
## Fix: Preserve raw request body in function proxy

**Before**: All non-GET/HEAD bodies were JSON.stringify'd, breaking file uploads, text, and binary data.

**After**: Captures and forwards raw body for all content types.

Fixes: multipart/form-data, text/plain, application/octet-stream, etc. JSON remains unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves raw request bodies in the `/functions/:slug` proxy and passes binary/text payloads end-to-end without JSON stringification. Adds a configurable 25MB body limit and a safer worker handshake for reliable binary IO.

- **Bug Fixes**
  - Adds route-scoped middleware on `/functions/:slug` to buffer raw bytes into `req.rawBody` (empty for GET/HEAD), set `_body` to bypass JSON parsing, handle error/abort reads, enforce `FUNCTION_PROXY_MAX_BODY_BYTES` with 413, and proxy using `req.rawBody`; extends Express types for `rawBody`/`_body`.
  - Host waits for a worker ready signal, then sends the request body as an `ArrayBuffer` via transferables; worker builds the `Request` with preserved bytes and returns non-text responses as `ArrayBuffer` (text/JSON use `text()`), avoiding posting after timeouts.
  - Adds `backend/tests/local/test-function-body.sh` to cover JSON, multipart (fields/files, duplicate keys), empty bodies, and binary responses.

<sup>Written for commit 22bfc21b05ffd99521114cefc03f07273a838c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add middleware to forward raw request bodies for non-JSON function proxy requests
> - Adds a middleware in [server.ts](https://github.com/InsForge/InsForge/pull/1346/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa) that buffers raw request bodies for all non-GET/HEAD requests to `/functions/:slug`, storing them on `req.rawBody` instead of relying on JSON parsing.
> - The function proxy fetch call now forwards `req.rawBody` directly, supporting multipart and binary payloads.
> - Enforces a configurable max body size via `FUNCTION_PROXY_MAX_BODY_BYTES` (default 25MB), returning 413 on overflow.
> - Updates the edge function worker in [functions/server.ts](https://github.com/InsForge/InsForge/pull/1346/files#diff-5a371eb7251cca8026249e2af0a755af5c06f18c7093664f9d7cb3331dd93378) and [worker-template.js](https://github.com/InsForge/InsForge/pull/1346/files#diff-5b15d90fa8b813623248c82a78beb07550e9132da22b19301aeb63579a8629a6) to transfer request bodies as `ArrayBuffer` and return binary-safe response bodies, using a ready-signal handshake before sending the work payload.
> - Behavioral Change: the function proxy no longer JSON-serializes request bodies; raw bytes are forwarded, changing behavior for any client that relied on server-side JSON re-encoding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22bfc21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Function invocations now accept raw and binary request bodies (not just serialized JSON), preserving original payloads for downstream runtimes.
  * Configurable maximum request body size (default 25MB) with clear "Payload too large" responses for oversized requests.
  * Consistent handling for GET/HEAD requests and improved error handling and logging for request stream and aborted connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->