### PR TITLE
feat(database): add schema diagram endpoint and visualizer page

### DIFF
--- a/backend/src/api/routes/database/tables.routes.ts
+++ b/backend/src/api/routes/database/tables.routes.ts
@@ -69,6 +69,18 @@ router.post('/', verifyAdmin, async (req: AuthRequest, res: Response, next: Next
   }
 });
 
+// Schema diagram — returns all tables + columns + FK relationships in one query
+// Must be defined before /:tableName to avoid route collision
+router.get('/diagram', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const schemaName = normalizeDatabaseSchemaName(req.query.schema);
+    const tables = await tableService.getSchemaDiagram(schemaName);
+    successResponse(res, { tables });
+  } catch (error) {
+    next(error);
+  }
+});
+
 // Get table schema
 router.get(
   '/:tableName/schema',

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -782,6 +782,150 @@ export class DatabaseTableService {
     }
   }
 
+  /**
+   * Return all tables in a schema with their columns and FK relationships
+   * in a single query — used by the Schema Visualizer page.
+   */
+  async getSchemaDiagram(schemaName: string): Promise<GetTableSchemaResponse[]> {
+    validateSchemaName(schemaName);
+    const pool = this.getPool();
+
+    // One query: columns + FK constraints + PK/unique flags per table
+    const result = await pool.query(
+      `
+        SELECT
+          t.table_name,
+          c.column_name,
+          c.data_type,
+          c.udt_name,
+          c.is_nullable,
+          c.column_default,
+          c.ordinal_position,
+          EXISTS (
+            SELECT 1
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu2
+              ON kcu2.constraint_name = tc.constraint_name
+              AND kcu2.table_schema   = tc.table_schema
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+              AND tc.table_schema    = t.table_schema
+              AND tc.table_name      = t.table_name
+              AND kcu2.column_name   = c.column_name
+          ) AS is_primary_key,
+          EXISTS (
+            SELECT 1
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu2
+              ON kcu2.constraint_name = tc.constraint_name
+              AND kcu2.table_schema   = tc.table_schema
+            WHERE tc.constraint_type = 'UNIQUE'
+              AND tc.table_schema    = t.table_schema
+              AND tc.table_name      = t.table_name
+              AND kcu2.column_name   = c.column_name
+          ) AS is_unique,
+          fk.fk_table_schema,
+          fk.fk_table,
+          fk.fk_column,
+          fk.on_delete,
+          fk.on_update
+        FROM information_schema.tables t
+        JOIN information_schema.columns c
+          ON  c.table_schema = t.table_schema
+          AND c.table_name   = t.table_name
+        LEFT JOIN (
+          SELECT
+            kcu.table_schema,
+            kcu.table_name,
+            kcu.column_name,
+            ccu.table_schema AS fk_table_schema,
+            ccu.table_name   AS fk_table,
+            ccu.column_name  AS fk_column,
+            rc.delete_rule   AS on_delete,
+            rc.update_rule   AS on_update
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = tc.constraint_name
+            AND kcu.table_schema   = tc.table_schema
+          JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+          JOIN information_schema.referential_constraints rc
+            ON rc.constraint_name  = tc.constraint_name
+            AND rc.constraint_schema = tc.table_schema
+          WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema    = $1
+        ) fk
+          ON  fk.table_schema = c.table_schema
+          AND fk.table_name   = c.table_name
+          AND fk.column_name  = c.column_name
+        WHERE t.table_schema = $1
+          AND t.table_type   = 'BASE TABLE'
+          AND t.table_name NOT LIKE '\\_%' ESCAPE '\\'
+        ORDER BY t.table_name, c.ordinal_position
+      `,
+      [schemaName]
+    );
+
+    // Group rows by table name
+    const tableMap = new Map<
+      string,
+      {
+        columns: ColumnSchema[];
+      }
+    >();
+
+    for (const row of result.rows as Array<{
+      table_name: string;
+      column_name: string;
+      data_type: string;
+      udt_name: string;
+      is_nullable: string;
+      column_default: string | null;
+      is_primary_key: boolean;
+      is_unique: boolean;
+      fk_table_schema: string | null;
+      fk_table: string | null;
+      fk_column: string | null;
+      on_delete: string | null;
+      on_update: string | null;
+    }>) {
+      if (!tableMap.has(row.table_name)) {
+        tableMap.set(row.table_name, { columns: [] });
+      }
+
+      const effectiveType = row.data_type === 'USER-DEFINED' ? row.udt_name : row.data_type;
+
+      const col: ColumnSchema = {
+        columnName: row.column_name,
+        type: convertSqlTypeToColumnType(effectiveType),
+        isNullable: row.is_nullable === 'YES',
+        isPrimaryKey: row.is_primary_key,
+        isUnique: row.is_primary_key || row.is_unique,
+        defaultValue: this.parseDefaultValue(row.column_default),
+      };
+
+      if (row.fk_table) {
+        const referenceTable =
+          row.fk_table_schema && row.fk_table_schema !== 'public'
+            ? `${row.fk_table_schema}.${row.fk_table}`
+            : row.fk_table;
+        col.foreignKey = {
+          referenceTable,
+          referenceColumn: row.fk_column ?? '',
+          onDelete: row.on_delete as OnDeleteActionSchema,
+          onUpdate: row.on_update as OnUpdateActionSchema,
+        };
+      }
+
+      tableMap.get(row.table_name)?.columns.push(col);
+    }
+
+    return Array.from(tableMap.entries()).map(([tableName, { columns }]) => ({
+      schemaName,
+      tableName,
+      columns,
+    }));
+  }
+
   private async getFkeyConstraints(
     schemaName: string,
     table: string

--- a/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
@@ -22,6 +22,12 @@ const DATABASE_STUDIO_SIDEBAR_BASE_ITEMS: Array<{
   sectionEnd?: boolean;
 }> = [
   {
+    id: 'schema',
+    label: 'Schema',
+    href: '/dashboard/database/schema',
+    sectionEnd: true,
+  },
+  {
     id: 'indexes',
     label: 'Indexes',
     href: '/dashboard/database/indexes',

--- a/packages/dashboard/src/features/database/hooks/useTables.ts
+++ b/packages/dashboard/src/features/database/hooks/useTables.ts
@@ -140,3 +140,19 @@ export function useAllTableSchemas(schemaName: string = DEFAULT_DATABASE_SCHEMA,
     isLoading: isLoadingTables || isLoadingSchemas,
   };
 }
+
+export function useSchemaDiagram(schemaName: string, enabled = true) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['database', 'diagram', schemaName],
+    queryFn: () => tableService.getSchemaDiagram(schemaName),
+    staleTime: 2 * 60 * 1000,
+    enabled,
+  });
+
+  return {
+    tables: data?.tables ?? [],
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/packages/dashboard/src/features/database/pages/SchemaPage.tsx
+++ b/packages/dashboard/src/features/database/pages/SchemaPage.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ReactFlow,
+  Node,
+  BuiltInEdge,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  ReactFlowProvider,
+  ConnectionMode,
+  NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { Map, RefreshCw, Search } from 'lucide-react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@insforge/ui';
+import { TableNode } from '#features/visualizer/components/TableNode';
+import { VisualizerSkeleton } from '#features/visualizer/components/VisualizerSkeleton';
+import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
+import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
+import { useDatabaseSchemaSelection } from '#features/database/hooks/useDatabaseSchemaSelection';
+import { useDatabaseSchemas } from '#features/database/hooks/useDatabase';
+import { useSchemaDiagram } from '#features/database/hooks/useTables';
+import { useTheme } from '#lib/contexts/ThemeContext';
+import { getDatabaseSchemaInfo } from '#features/database/helpers';
+import { GetTableSchemaResponse } from '@insforge/shared-schemas';
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+type TableNodeData = {
+  table: GetTableSchemaResponse;
+  referencedColumns: string[];
+  showRecordCount: boolean;
+};
+
+const NODE_WIDTH = 320;
+const NODE_H_GAP = 80;
+const NODE_V_GAP = 60;
+const CANVAS_MARGIN = 40;
+
+function calculateNodeHeight(columnCount: number): number {
+  const headerHeight = 64;
+  const columnHeight = 48;
+  return headerHeight + (columnCount > 0 ? columnCount * columnHeight : 100);
+}
+
+function layoutGrid(tables: GetTableSchemaResponse[]): Node<TableNodeData>[] {
+  const referencedByTable = buildReferencedColumns(tables);
+  const cols = Math.max(1, Math.ceil(Math.sqrt(tables.length)));
+
+  // Group into columns
+  const columnGroups: GetTableSchemaResponse[][] = Array.from({ length: cols }, () => []);
+  tables.forEach((t, i) => columnGroups[i % cols].push(t));
+
+  const nodes: Node<TableNodeData>[] = [];
+
+  columnGroups.forEach((group, colIdx) => {
+    let y = CANVAS_MARGIN;
+    group.forEach((table) => {
+      nodes.push({
+        id: table.tableName,
+        type: 'tableNode',
+        position: { x: CANVAS_MARGIN + colIdx * (NODE_WIDTH + NODE_H_GAP), y },
+        data: {
+          table,
+          referencedColumns: referencedByTable[table.tableName] ?? [],
+          showRecordCount: false,
+        },
+      });
+      y += calculateNodeHeight(table.columns.length) + NODE_V_GAP;
+    });
+  });
+
+  return nodes;
+}
+
+function buildReferencedColumns(tables: GetTableSchemaResponse[]): Record<string, string[]> {
+  const map: Record<string, string[]> = {};
+  tables.forEach((t) => {
+    t.columns.forEach((c) => {
+      if (c.foreignKey) {
+        const target = c.foreignKey.referenceTable;
+        const col = c.foreignKey.referenceColumn;
+        if (!map[target]) {
+          map[target] = [];
+        }
+        if (!map[target].includes(col)) {
+          map[target].push(col);
+        }
+      }
+    });
+  });
+  return map;
+}
+
+function buildEdges(
+  tables: GetTableSchemaResponse[],
+  edgeColor: string,
+  highlightedTable: string | null,
+  connectedTables: Set<string> | null
+): BuiltInEdge[] {
+  const visibleTableNames = new Set(tables.map((t) => t.tableName));
+  const edges: BuiltInEdge[] = [];
+  tables.forEach((t) => {
+    t.columns.forEach((c) => {
+      if (!c.foreignKey) {
+        return;
+      }
+      const target = c.foreignKey.referenceTable;
+      if (!visibleTableNames.has(target)) {
+        return;
+      }
+      const id = `${t.tableName}-${c.columnName}-${target}`;
+      const isConnected =
+        !highlightedTable ||
+        !connectedTables ||
+        (connectedTables.has(t.tableName) && connectedTables.has(target));
+
+      edges.push({
+        id,
+        source: t.tableName,
+        target,
+        sourceHandle: `${c.columnName}-source`,
+        targetHandle: `${c.foreignKey.referenceColumn}-target`,
+        type: 'smoothstep',
+        animated: isConnected,
+        style: {
+          stroke: edgeColor,
+          strokeWidth: isConnected ? 2 : 1,
+          opacity: highlightedTable && !isConnected ? 0.1 : 1,
+          zIndex: 1000,
+        },
+        zIndex: 1000,
+        pathOptions: { offset: 40 },
+      });
+    });
+  });
+  return edges;
+}
+
+// ---------------------------------------------------------------------------
+// Inner canvas component (needs ReactFlowProvider context)
+// ---------------------------------------------------------------------------
+
+const nodeTypes = { tableNode: TableNode };
+
+interface DiagramCanvasProps {
+  tables: GetTableSchemaResponse[];
+  showMinimap: boolean;
+  highlightedTable: string | null;
+  connectedTables: Set<string> | null;
+  onNodeClick: NodeMouseHandler;
+  onPaneClick: () => void;
+}
+
+function DiagramCanvas({
+  tables,
+  showMinimap,
+  highlightedTable,
+  connectedTables,
+  onNodeClick,
+  onPaneClick,
+}: DiagramCanvasProps) {
+  const { resolvedTheme } = useTheme();
+  const edgeColor = resolvedTheme === 'dark' ? 'white' : '#18181b';
+
+  const rawNodes = useMemo(() => layoutGrid(tables), [tables]);
+
+  // Apply highlight opacity to nodes
+  const styledNodes = useMemo(
+    () =>
+      rawNodes.map((node) => ({
+        ...node,
+        style: {
+          ...node.style,
+          opacity: highlightedTable && connectedTables && !connectedTables.has(node.id) ? 0.2 : 1,
+          transition: 'opacity 150ms ease',
+        },
+      })),
+    [rawNodes, highlightedTable, connectedTables]
+  );
+
+  const rawEdges = useMemo(
+    () => buildEdges(tables, edgeColor, highlightedTable, connectedTables),
+    [tables, edgeColor, highlightedTable, connectedTables]
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(styledNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(rawEdges);
+
+  // Sync when data/highlight changes
+  useEffect(() => {
+    setNodes(styledNodes);
+    setEdges(rawEdges);
+  }, [styledNodes, rawEdges, setNodes, setEdges]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onNodeClick={onNodeClick}
+      onPaneClick={onPaneClick}
+      nodeTypes={nodeTypes}
+      connectionMode={ConnectionMode.Loose}
+      fitView
+      fitViewOptions={{ padding: 0.15, maxZoom: 1.5 }}
+      minZoom={0.05}
+      maxZoom={2}
+      proOptions={{ hideAttribution: true }}
+      elevateEdgesOnSelect
+      colorMode={resolvedTheme === 'dark' ? 'dark' : 'light'}
+      className="!bg-transparent"
+    >
+      <Controls
+        showInteractive={false}
+        className="!border !border-border !shadow-md"
+        fitViewOptions={{ padding: 0.15, duration: 300 }}
+      />
+      {showMinimap && (
+        <MiniMap nodeColor={() => '#6ee7b7'} pannable zoomable className="!border !border-border" />
+      )}
+    </ReactFlow>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SchemaPage
+// ---------------------------------------------------------------------------
+
+function SchemaPageInner() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { selectedSchema, setSelectedSchema } = useDatabaseSchemaSelection();
+  const { schemas, isLoading: isLoadingSchemas } = useDatabaseSchemas();
+  const selectedSchemaInfo = getDatabaseSchemaInfo(schemas, selectedSchema);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showMinimap, setShowMinimap] = useState(true);
+  const [highlightedTable, setHighlightedTable] = useState<string | null>(null);
+
+  const { tables, isLoading, error, refetch } = useSchemaDiagram(selectedSchema);
+
+  // Filter tables by search query
+  const visibleTables = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return tables;
+    }
+    const q = searchQuery.toLowerCase();
+    return tables.filter(
+      (t) =>
+        t.tableName.toLowerCase().includes(q) ||
+        t.columns.some((c) => c.columnName.toLowerCase().includes(q))
+    );
+  }, [tables, searchQuery]);
+
+  // Compute connected tables for highlight mode
+  const connectedTables = useMemo<Set<string> | null>(() => {
+    if (!highlightedTable) {
+      return null;
+    }
+    const connected = new Set<string>([highlightedTable]);
+    visibleTables.forEach((t) => {
+      t.columns.forEach((c) => {
+        if (c.foreignKey?.referenceTable === highlightedTable) {
+          connected.add(t.tableName);
+        }
+        if (t.tableName === highlightedTable && c.foreignKey) {
+          connected.add(c.foreignKey.referenceTable);
+        }
+      });
+    });
+    return connected;
+  }, [highlightedTable, visibleTables]);
+
+  const handleNodeClick: NodeMouseHandler = useCallback((_event, node) => {
+    setHighlightedTable((prev) => (prev === node.id ? null : node.id));
+  }, []);
+
+  const handlePaneClick = useCallback(() => {
+    setHighlightedTable(null);
+  }, []);
+
+  // Reset highlight when schema or search changes
+  useEffect(() => {
+    setHighlightedTable(null);
+  }, [selectedSchema, searchQuery]);
+
+  return (
+    <div className="flex h-full min-h-0 overflow-hidden bg-[rgb(var(--semantic-1))]">
+      <DatabaseStudioSidebarPanel
+        onBack={() =>
+          void navigate(
+            { pathname: '/dashboard/database/tables', search: location.search },
+            { state: { slideFromStudio: true } }
+          )
+        }
+      />
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Toolbar */}
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border bg-[rgb(var(--semantic-1))] px-3">
+          {/* Schema selector */}
+          <div className="w-44">
+            <DatabaseSchemaSelect
+              schemas={schemas}
+              value={selectedSchemaInfo.name}
+              onValueChange={(name) => {
+                setSearchQuery('');
+                setSelectedSchema(name, { replace: true });
+              }}
+              disabled={isLoadingSchemas}
+            />
+          </div>
+
+          {/* Search */}
+          <div className="relative w-52">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search tables…"
+              className="h-8 pl-7 text-sm"
+            />
+          </div>
+
+          {/* Table count */}
+          <span className="text-xs text-muted-foreground">
+            {searchQuery && visibleTables.length !== tables.length
+              ? `${visibleTables.length} / ${tables.length} tables`
+              : `${tables.length} table${tables.length !== 1 ? 's' : ''}`}
+          </span>
+
+          <div className="flex-1" />
+
+          <TooltipProvider>
+            {/* Minimap toggle */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={showMinimap ? 'secondary' : 'ghost'}
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setShowMinimap((v) => !v)}
+                >
+                  <Map className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {showMinimap ? 'Hide minimap' : 'Show minimap'}
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Refresh */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  disabled={isLoading}
+                  onClick={() => void refetch()}
+                >
+                  <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Refresh</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        {/* Canvas */}
+        <div className="relative min-h-0 flex-1">
+          {/* Dot grid background */}
+          <div
+            className="pointer-events-none absolute inset-0 opacity-40 dark:opacity-20"
+            style={{
+              backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+              backgroundSize: '20px 20px',
+              color: 'var(--muted-foreground)',
+            }}
+          />
+
+          {isLoading ? (
+            <VisualizerSkeleton />
+          ) : error ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Failed to load schema. Check your connection and try refreshing.
+            </div>
+          ) : visibleTables.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {searchQuery ? 'No tables match your search.' : 'No tables found in this schema.'}
+            </div>
+          ) : (
+            <DiagramCanvas
+              tables={visibleTables}
+              showMinimap={showMinimap}
+              highlightedTable={highlightedTable}
+              connectedTables={connectedTables}
+              onNodeClick={handleNodeClick}
+              onPaneClick={handlePaneClick}
+            />
+          )}
+
+          {/* Highlight hint */}
+          {highlightedTable && (
+            <div className="pointer-events-none absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-muted-foreground shadow-sm backdrop-blur-sm">
+              Showing relations for{' '}
+              <span className="font-medium text-foreground">{highlightedTable}</span> — click table
+              or canvas to clear
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SchemaPage() {
+  return (
+    <ReactFlowProvider>
+      <SchemaPageInner />
+    </ReactFlowProvider>
+  );
+}

--- a/packages/dashboard/src/features/database/services/table.service.ts
+++ b/packages/dashboard/src/features/database/services/table.service.ts
@@ -33,6 +33,14 @@ export class TableService {
     );
   }
 
+  getSchemaDiagram(
+    schemaName: string = DEFAULT_DATABASE_SCHEMA
+  ): Promise<{ tables: GetTableSchemaResponse[] }> {
+    return apiClient.request(`/database/tables/diagram${buildDatabaseSchemaSearch(schemaName)}`, {
+      headers: apiClient.withAccessToken(),
+    });
+  }
+
   createTable(schemaName: string, tableName: string, columns: ColumnSchema[]) {
     const body: CreateTableRequest = { tableName, columns, rlsEnabled: true };
 

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -24,6 +24,7 @@ import PoliciesPage from '#features/database/pages/PoliciesPage';
 import SQLEditorPage from '#features/database/pages/SQLEditorPage';
 import TablesPage from '#features/database/pages/TablesPage';
 import TemplatesPage from '#features/database/pages/TemplatesPage';
+import SchemaPage from '#features/database/pages/SchemaPage';
 import TriggersPage from '#features/database/pages/TriggersPage';
 import DeploymentsLayout from '#features/deployments/components/DeploymentsLayout';
 import DeploymentDomainsPage from '#features/deployments/pages/DeploymentDomainsPage';
@@ -84,6 +85,7 @@ function AuthenticatedRoutes() {
         <Route path="/dashboard/database" element={<DatabaseLayout />}>
           <Route index element={<Navigate to="tables" replace />} />
           <Route path="tables" element={<TablesPage />} />
+          <Route path="schema" element={<SchemaPage />} />
           <Route path="indexes" element={<IndexesPage />} />
           <Route path="functions" element={<DatabaseFunctionsPage />} />
           <Route path="triggers" element={<TriggersPage />} />


### PR DESCRIPTION
- Implemented a new endpoint to retrieve schema diagrams, including tables, columns, and foreign key relationships.
- Added a SchemaPage component for visualizing the database schema.
- Updated the sidebar to include a link to the new Schema page.
- Introduced a custom hook to fetch schema diagram data for use in the visualizer.

## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a schema diagram API and a visual Schema page to explore tables and relationships. Admins can fetch the full schema in one request and visualize it with search, minimap, and relation highlighting.

- **New Features**
  - Backend: GET `/database/tables/diagram` returns tables with columns and FK relations in one query; admin-only; supports `?schema=` selection.
  - Dashboard: new Schema page using `@xyflow/react` to visualize tables and edges; includes search, minimap toggle, fit/zoom, refresh, and click-to-highlight relations.
  - Data fetching: `useSchemaDiagram(schema)` hook with 2-minute cache; uses `@insforge/shared-schemas`; handles error/empty states.
  - Navigation: added sidebar link and route `/dashboard/database/schema`.
  - UI: integrates with `@insforge/ui` components and `ReactFlowProvider` for the canvas.

<sup>Written for commit 9b6c350efeb70a778866aeb9ecc142eab6fc29f2. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add schema diagram endpoint and visualizer page to the database dashboard
> - Adds a `GET /database/tables/diagram` admin endpoint in [tables.routes.ts](https://github.com/InsForge/InsForge/pull/1349/files#diff-e1f4b11bca62f9e15556633977f3e5af2f21ef7f4f513a2502c1dd496040a459) backed by `DatabaseTableService.getSchemaDiagram`, which queries `information_schema` to return all tables, columns, PK/unique flags, and FK relationships in one call.
> - Adds a [SchemaPage.tsx](https://github.com/InsForge/InsForge/pull/1349/files#diff-e033cbeb2907b8e6da2e315d31fd6ce62407a10cadad3432194af6d37d3bfb71) React page with a ReactFlow-powered canvas that renders tables as nodes and FK relationships as edges, with pan/zoom, minimap toggle, table search, and highlight-on-click for connected tables.
> - Registers the page at `/dashboard/database/schema` and adds a 'Schema' entry to the database sidebar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b6c350.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added schema diagram visualization displaying tables, columns, and relationships
* Search and filter functionality for tables and columns
* Minimap navigation support for large schemas
* Schema refresh and table relationship highlighting capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->