### PR TITLE
fix(database): strip empty strings for non-text fields

### DIFF
--- a/backend/src/api/routes/database/record-body-filter.ts
+++ b/backend/src/api/routes/database/record-body-filter.ts
@@ -1,5 +1,11 @@
 import { DatabaseRecord } from '@/types/database.js';
 
+const TEXT_LIKE_COLUMN_TYPES = new Set(['text', 'character varying', 'character', 'citext']);
+
+function isTextLikeColumnType(columnType: string | undefined): boolean {
+  return columnType === undefined || TEXT_LIKE_COLUMN_TYPES.has(columnType);
+}
+
 export function filterEmptyStringsForColumnTypes(
   value: unknown,
   columnTypeMap: Record<string, string | undefined>
@@ -14,7 +20,7 @@ export function filterEmptyStringsForColumnTypes(
 
   const filtered: DatabaseRecord = {};
   for (const [key, fieldValue] of Object.entries(value as DatabaseRecord)) {
-    if (columnTypeMap[key] !== 'text' && fieldValue === '') {
+    if (!isTextLikeColumnType(columnTypeMap[key]) && fieldValue === '') {
       continue;
     }
     filtered[key] = fieldValue;

--- a/backend/src/api/routes/database/record-body-filter.ts
+++ b/backend/src/api/routes/database/record-body-filter.ts
@@ -1,0 +1,24 @@
+import { DatabaseRecord } from '@/types/database.js';
+
+export function filterEmptyStringsForColumnTypes(
+  value: unknown,
+  columnTypeMap: Record<string, string | undefined>
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => filterEmptyStringsForColumnTypes(item, columnTypeMap));
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const filtered: DatabaseRecord = {};
+  for (const [key, fieldValue] of Object.entries(value as DatabaseRecord)) {
+    if (columnTypeMap[key] !== 'text' && fieldValue === '') {
+      continue;
+    }
+    filtered[key] = fieldValue;
+  }
+
+  return filtered;
+}

--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -5,12 +5,12 @@ import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES } from '@insforge/shared-schemas';
 import { validateTableName } from '@/utils/validations.js';
-import { DatabaseRecord } from '@/types/database.js';
 import { successResponse } from '@/utils/response.js';
 import { SocketManager } from '@/infra/socket/socket.manager.js';
 import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
 import { DatabaseResourceUpdate } from '@/utils/sql-parser.js';
 import { PostgrestProxyService } from '@/services/database/postgrest-proxy.service.js';
+import { filterEmptyStringsForColumnTypes } from './record-body-filter.js';
 
 const router = Router();
 const proxyService = PostgrestProxyService.getInstance();
@@ -50,27 +50,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
 
     if (['POST', 'PATCH', 'PUT'].includes(method) && body && typeof body === 'object') {
       const columnTypeMap = await DatabaseManager.getColumnTypeMap(tableName);
-      if (Array.isArray(body)) {
-        body = body.map((item) => {
-          if (item && typeof item === 'object') {
-            const filtered: DatabaseRecord = {};
-            for (const key in item) {
-              if (columnTypeMap[key] !== 'text' && item[key] === '') {
-                continue;
-              }
-              filtered[key] = item[key];
-            }
-            return filtered;
-          }
-          return item;
-        });
-      } else {
-        for (const key in body) {
-          if (columnTypeMap[key] === 'uuid' && body[key] === '') {
-            delete body[key];
-          }
-        }
-      }
+      body = filterEmptyStringsForColumnTypes(body, columnTypeMap);
     }
 
     // Forward to PostgREST via service

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -64,12 +64,12 @@ export class DatabaseManager {
     const client = await instance.pool.connect();
     try {
       const result = await client.query(
-        `SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
+        `SELECT column_name, data_type, udt_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`,
         [schemaName, tableName]
       );
       const map: Record<string, string> = {};
       for (const row of result.rows) {
-        map[row.column_name] = row.data_type;
+        map[row.column_name] = row.data_type === 'USER-DEFINED' ? row.udt_name : row.data_type;
       }
 
       DatabaseManager.setColumnTypeCache(cacheKey, map);

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -69,7 +69,8 @@ export class DatabaseManager {
       );
       const map: Record<string, string> = {};
       for (const row of result.rows) {
-        map[row.column_name] = row.data_type === 'USER-DEFINED' ? row.udt_name : row.data_type;
+        map[row.column_name] =
+          row.data_type === 'USER-DEFINED' ? (row.udt_name ?? row.data_type) : row.data_type;
       }
 
       DatabaseManager.setColumnTypeCache(cacheKey, map);

--- a/backend/tests/unit/records-empty-string-filter.test.ts
+++ b/backend/tests/unit/records-empty-string-filter.test.ts
@@ -8,6 +8,9 @@ describe('filterEmptyStringsForColumnTypes', () => {
     count: 'integer',
     enabled: 'boolean',
     publishedAt: 'timestamp with time zone',
+    slug: 'character varying',
+    code: 'character',
+    email: 'citext',
   };
 
   it('strips empty strings from non-text columns for single-record payloads', () => {
@@ -32,6 +35,15 @@ describe('filterEmptyStringsForColumnTypes', () => {
       { title: '', enabled: true },
       { id: 'uuid-1', title: 'ok', count: 0 },
     ]);
+  });
+
+  it('preserves empty strings for all text-like column types and unknown columns', () => {
+    expect(
+      filterEmptyStringsForColumnTypes(
+        { title: '', slug: '', code: '', email: '', unknownCol: '', count: '' },
+        columnTypes
+      )
+    ).toEqual({ title: '', slug: '', code: '', email: '', unknownCol: '' });
   });
 
   it('leaves non-empty falsey values intact', () => {

--- a/backend/tests/unit/records-empty-string-filter.test.ts
+++ b/backend/tests/unit/records-empty-string-filter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { filterEmptyStringsForColumnTypes } from '../../src/api/routes/database/record-body-filter';
+
+describe('filterEmptyStringsForColumnTypes', () => {
+  const columnTypes = {
+    id: 'uuid',
+    title: 'text',
+    count: 'integer',
+    enabled: 'boolean',
+    publishedAt: 'timestamp with time zone',
+  };
+
+  it('strips empty strings from non-text columns for single-record payloads', () => {
+    expect(
+      filterEmptyStringsForColumnTypes(
+        { id: '', title: '', count: '', enabled: '', publishedAt: '', notes: 'keep' },
+        columnTypes
+      )
+    ).toEqual({ title: '', notes: 'keep' });
+  });
+
+  it('uses the same filtering semantics for bulk payloads', () => {
+    expect(
+      filterEmptyStringsForColumnTypes(
+        [
+          { id: '', title: '', count: '', enabled: true },
+          { id: 'uuid-1', title: 'ok', count: 0, publishedAt: '' },
+        ],
+        columnTypes
+      )
+    ).toEqual([
+      { title: '', enabled: true },
+      { id: 'uuid-1', title: 'ok', count: 0 },
+    ]);
+  });
+
+  it('leaves non-empty falsey values intact', () => {
+    expect(
+      filterEmptyStringsForColumnTypes({ count: 0, enabled: false, title: '' }, columnTypes)
+    ).toEqual({ count: 0, enabled: false, title: '' });
+  });
+});


### PR DESCRIPTION
## Summary
- normalizes single-record database writes with the same non-text empty-string filtering already used by bulk writes
- extracts the filtering behavior into a small helper so single and bulk payloads share semantics
- adds unit coverage for single objects, arrays, and falsy non-empty values

Fixes #1332

## Tests
- `cd backend && npm test -- tests/unit/records-empty-string-filter.test.ts`
- `cd backend && npm run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns single-record writes with bulk writes by stripping empty strings from non-text columns, preventing invalid values from reaching PostgREST. Fixes #1332.

- **Bug Fixes**
  - Apply shared `filterEmptyStringsForColumnTypes` to POST/PATCH/PUT bodies (single and bulk).
  - Preserve empty strings for text-like columns (`text`, `character varying`, `character`, `citext`) and unknown columns; resolve Postgres USER-DEFINED types via `udt_name` with fallback to `data_type`; keep 0 and false.
  - Add unit tests for single, bulk, text-like/unknown, and falsy cases.

<sup>Written for commit 11a6018de907ea763226eabb04103f392fb3c91e. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1352?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip empty strings from non-text fields in database record POST/PATCH/PUT payloads
> - Replaces the previous ad-hoc empty-string filtering in [`records.routes.ts`](https://github.com/InsForge/InsForge/pull/1352/files#diff-c01e14d03a824af81835407cd114bbcb735d88c19d79419072c9ab855c80f8ff) with a new `filterEmptyStringsForColumnTypes` utility in [`record-body-filter.ts`](https://github.com/InsForge/InsForge/pull/1352/files#diff-71dddf2afbf75b65b9a7ab4a63009ddf6fe12ce4fc05b262b75ab2f643933fb5) that recursively processes nested objects and arrays.
> - Empty strings are preserved for text-like column types (`text`, `character varying`, `character`, `citext`) and unknown/undefined types; all other column types have empty-string values stripped.
> - `DatabaseManager.getColumnTypeMap` now returns concrete UDT names for user-defined types instead of `'USER-DEFINED'`, so custom types can be classified correctly.
> - Behavioral Change: previously, single-record payloads only stripped empty strings for `uuid` fields; now all non-text-like columns are stripped consistently for both single and bulk payloads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11a6018.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty strings are consistently removed from non-text columns when creating or updating records; single and bulk requests behave uniformly and preserve falsy but meaningful values (e.g., 0, false) and text-like or unknown column types.

* **Tests**
  * Added unit tests covering single and bulk payloads to verify empty-string filtering and preservation of non-empty/falsy values.

* **Chores**
  * Improved column-type detection to better handle user-defined types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->