### PR TITLE
fix(server): make trust proxy configurable

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -40,6 +40,7 @@ import packageJson from '../../package.json';
 import { schedulesRouter } from '@/api/routes/schedules/index.routes.js';
 import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
+import { parseTrustProxySetting } from '@/utils/trust-proxy.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -80,8 +81,9 @@ export async function createApp() {
 
   const app = express();
 
-  // Enable trust proxy setting for rate limiting behind proxies/load balancers
-  app.set('trust proxy', 2);
+  // Enable trust proxy setting for rate limiting behind proxies/load balancers.
+  // TRUST_PROXY can be a boolean, hop count, or Express trust proxy string.
+  app.set('trust proxy', parseTrustProxySetting());
 
   const limiter = rateLimit({
     windowMs: 15 * 60 * 1000,

--- a/backend/src/utils/trust-proxy.ts
+++ b/backend/src/utils/trust-proxy.ts
@@ -21,7 +21,9 @@ export function parseTrustProxySetting(value = process.env.TRUST_PROXY): TrustPr
       return hopCount;
     }
 
-    throw new Error('TRUST_PROXY must be a non-negative integer, boolean, or Express trust proxy string');
+    throw new Error(
+      'TRUST_PROXY must be a non-negative integer, boolean, or Express trust proxy string'
+    );
   }
 
   // Express also accepts named/address trust proxy values such as

--- a/backend/src/utils/trust-proxy.ts
+++ b/backend/src/utils/trust-proxy.ts
@@ -16,8 +16,12 @@ export function parseTrustProxySetting(value = process.env.TRUST_PROXY): TrustPr
   }
 
   const hopCount = Number(normalized);
-  if (Number.isInteger(hopCount) && hopCount >= 0) {
-    return hopCount;
+  if (Number.isFinite(hopCount)) {
+    if (Number.isInteger(hopCount) && hopCount >= 0) {
+      return hopCount;
+    }
+
+    throw new Error('TRUST_PROXY must be a non-negative integer, boolean, or Express trust proxy string');
   }
 
   // Express also accepts named/address trust proxy values such as

--- a/backend/src/utils/trust-proxy.ts
+++ b/backend/src/utils/trust-proxy.ts
@@ -1,0 +1,26 @@
+const DEFAULT_TRUST_PROXY_HOPS = 2;
+
+export type TrustProxySetting = boolean | number | string;
+
+export function parseTrustProxySetting(value = process.env.TRUST_PROXY): TrustProxySetting {
+  if (value === undefined || value.trim() === '') {
+    return DEFAULT_TRUST_PROXY_HOPS;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true') {
+    return true;
+  }
+  if (normalized === 'false') {
+    return false;
+  }
+
+  const hopCount = Number(normalized);
+  if (Number.isInteger(hopCount) && hopCount >= 0) {
+    return hopCount;
+  }
+
+  // Express also accepts named/address trust proxy values such as
+  // "loopback", "linklocal", "uniquelocal", or comma-separated subnets.
+  return value.trim();
+}

--- a/backend/tests/unit/trust-proxy.test.ts
+++ b/backend/tests/unit/trust-proxy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { parseTrustProxySetting } from '../../src/utils/trust-proxy';
+
+describe('parseTrustProxySetting', () => {
+  it('keeps the existing two-hop default for backwards compatibility', () => {
+    expect(parseTrustProxySetting(undefined)).toBe(2);
+    expect(parseTrustProxySetting('')).toBe(2);
+  });
+
+  it('parses explicit boolean values', () => {
+    expect(parseTrustProxySetting('true')).toBe(true);
+    expect(parseTrustProxySetting('FALSE')).toBe(false);
+  });
+
+  it('parses explicit proxy hop counts', () => {
+    expect(parseTrustProxySetting('0')).toBe(0);
+    expect(parseTrustProxySetting('1')).toBe(1);
+    expect(parseTrustProxySetting('3')).toBe(3);
+  });
+
+  it('passes through Express named or subnet trust proxy values', () => {
+    expect(parseTrustProxySetting('loopback')).toBe('loopback');
+    expect(parseTrustProxySetting('loopback, 10.0.0.0/8')).toBe('loopback, 10.0.0.0/8');
+  });
+});

--- a/backend/tests/unit/trust-proxy.test.ts
+++ b/backend/tests/unit/trust-proxy.test.ts
@@ -22,4 +22,14 @@ describe('parseTrustProxySetting', () => {
     expect(parseTrustProxySetting('loopback')).toBe('loopback');
     expect(parseTrustProxySetting('loopback, 10.0.0.0/8')).toBe('loopback, 10.0.0.0/8');
   });
+
+  it('trims whitespace before parsing scalar values', () => {
+    expect(parseTrustProxySetting(' 2 ')).toBe(2);
+    expect(parseTrustProxySetting(' true ')).toBe(true);
+  });
+
+  it('rejects finite non-integer numeric values instead of passing them to Express', () => {
+    expect(() => parseTrustProxySetting('1.5')).toThrow(/non-negative integer/);
+    expect(() => parseTrustProxySetting('-1')).toThrow(/non-negative integer/);
+  });
 });


### PR DESCRIPTION
## Summary
- adds a `TRUST_PROXY` configuration parser for Express' trust proxy setting
- keeps the existing default of 2 hops for compatibility
- supports boolean, numeric hop-count, and Express string values for self-hosted proxy topologies

Fixes #1331

## Tests
- `cd backend && npm test -- tests/unit/trust-proxy.test.ts`
- `cd backend && npm run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `express` trust proxy configurable via `TRUST_PROXY` to support different proxy setups. Defaults to 2 hops when unset.

- **New Features**
  - Added `parseTrustProxySetting` that accepts booleans, non‑negative integers, or Express trust-proxy strings; trims whitespace; case-insensitive; rejects negative or non-integer numbers.
  - Used in `server.ts` to set `app.set('trust proxy', ...)`; added unit tests for parsing, defaults, and error cases. Fixes #1331

<sup>Written for commit 8f84cd1d35ee6b455625c148639283c4eee5369d. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Express trust proxy configurable via `TRUST_PROXY` environment variable
> - Replaces the hardcoded trust proxy value of `2` in `createApp` with a call to the new [`parseTrustProxySetting`](https://github.com/InsForge/InsForge/pull/1353/files#diff-5a68c970bfc5723ed0b4d32a5407c095c737f0b653e1c850ad467257d24d1dd3) utility.
> - The parser accepts booleans (`true`/`false`), non-negative integers, or named/subnet strings valid for Express; defaults to `2` when unset or empty.
> - Throws on invalid numeric inputs (non-integer or negative values).
> - Unit tests in [`trust-proxy.test.ts`](https://github.com/InsForge/InsForge/pull/1353/files#diff-9327b513b3e01b0d93293f0e0521c951725e20d3fb51167729f2ffad5c7c6208) cover all parsing branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f84cd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More flexible proxy/trust-proxy configuration with smarter parsing and safer defaults to better support load balancers and reverse proxies
* **Bug Fixes**
  * Improved accuracy of client IP interpretation, enhancing rate limiting and other security-sensitive behavior
* **Tests**
  * Added unit tests covering parsing, validation, trimming, passthrough cases, and rejection of invalid proxy settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->