### PR TITLE
fix(auth): require CSRF token for web logout

### DIFF
--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -58,6 +58,7 @@ import { EMAIL_TEMPLATE_TYPES, type EmailTemplate } from '@/types/email.js';
 import { SocketManager } from '@/infra/socket/socket.manager.js';
 import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
 import logger from '@/utils/logger.js';
+import { assertValidWebLogoutCsrf } from './logout-csrf.js';
 
 const router = Router();
 const authService = AuthService.getInstance();
@@ -628,6 +629,10 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
     const clientType = parseClientType(req.query.client_type);
 
     if (clientType === 'web') {
+      assertValidWebLogoutCsrf({
+        refreshToken: req.cookies?.[REFRESH_TOKEN_COOKIE_NAME],
+        csrfToken: req.headers['x-csrf-token'] as string | undefined,
+      });
       clearRefreshTokenCookie(res);
     }
     // For non-web clients: no server-side cleanup needed.

--- a/backend/src/api/routes/auth/logout-csrf.ts
+++ b/backend/src/api/routes/auth/logout-csrf.ts
@@ -1,0 +1,31 @@
+import { TokenManager, type RefreshTokenPayload } from '@/infra/security/token.manager.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+export interface WebLogoutCsrfInput {
+  refreshToken?: string;
+  csrfToken?: string;
+}
+
+export interface CsrfTokenVerifier {
+  verifyRefreshToken(refreshToken: string): RefreshTokenPayload;
+  verifyCsrfToken(csrfHeader: string | undefined, payload: RefreshTokenPayload): boolean;
+}
+
+export function assertValidWebLogoutCsrf(
+  input: WebLogoutCsrfInput,
+  tokenManager: CsrfTokenVerifier = TokenManager.getInstance()
+): void {
+  if (!input.refreshToken) {
+    return;
+  }
+
+  const payload = tokenManager.verifyRefreshToken(input.refreshToken);
+  if (payload.sessionType !== 'user') {
+    throw new AppError('Invalid refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+  }
+
+  if (!tokenManager.verifyCsrfToken(input.csrfToken, payload)) {
+    throw new AppError('Invalid CSRF token', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+  }
+}

--- a/backend/src/api/routes/auth/logout-csrf.ts
+++ b/backend/src/api/routes/auth/logout-csrf.ts
@@ -20,7 +20,16 @@ export function assertValidWebLogoutCsrf(
     return;
   }
 
-  const payload = tokenManager.verifyRefreshToken(input.refreshToken);
+  let payload: RefreshTokenPayload;
+  try {
+    payload = tokenManager.verifyRefreshToken(input.refreshToken);
+  } catch (error) {
+    if (error instanceof AppError && error.statusCode === 401) {
+      return;
+    }
+    throw error;
+  }
+
   if (payload.sessionType !== 'user') {
     throw new AppError('Invalid refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
   }

--- a/backend/tests/unit/logout-csrf.test.ts
+++ b/backend/tests/unit/logout-csrf.test.ts
@@ -37,11 +37,9 @@ describe('assertValidWebLogoutCsrf', () => {
 
   it('allows logout cleanup when the refresh token is expired or invalid', () => {
     const tokenVerifier: CsrfTokenVerifier = {
-      verifyRefreshToken: vi
-        .fn()
-        .mockImplementation(() => {
-          throw new AppError('Invalid refresh token', 401, 'AUTH_UNAUTHORIZED');
-        }),
+      verifyRefreshToken: vi.fn().mockImplementation(() => {
+        throw new AppError('Invalid refresh token', 401, 'AUTH_UNAUTHORIZED');
+      }),
       verifyCsrfToken: vi.fn(),
     };
 

--- a/backend/tests/unit/logout-csrf.test.ts
+++ b/backend/tests/unit/logout-csrf.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/utils/errors';
+import {
+  assertValidWebLogoutCsrf,
+  type CsrfTokenVerifier,
+} from '../../src/api/routes/auth/logout-csrf';
+
+const payload = {
+  sub: 'user-1',
+  type: 'refresh' as const,
+  iss: 'insforge',
+  csrfNonce: 'nonce',
+  sessionType: 'user' as const,
+};
+
+function verifier(csrfValid: boolean): CsrfTokenVerifier {
+  return {
+    verifyRefreshToken: vi.fn().mockReturnValue(payload),
+    verifyCsrfToken: vi.fn().mockReturnValue(csrfValid),
+  };
+}
+
+describe('assertValidWebLogoutCsrf', () => {
+  it('allows idempotent web logout when no refresh cookie is present', () => {
+    const tokenVerifier = verifier(false);
+
+    expect(() => assertValidWebLogoutCsrf({}, tokenVerifier)).not.toThrow();
+    expect(tokenVerifier.verifyRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('requires a valid csrf token before clearing a web refresh cookie', () => {
+    expect(() =>
+      assertValidWebLogoutCsrf({ refreshToken: 'refresh-token' }, verifier(false))
+    ).toThrow(AppError);
+  });
+
+  it('accepts a matching csrf token for a user refresh session', () => {
+    const tokenVerifier = verifier(true);
+
+    expect(() =>
+      assertValidWebLogoutCsrf(
+        { refreshToken: 'refresh-token', csrfToken: 'csrf-token' },
+        tokenVerifier
+      )
+    ).not.toThrow();
+    expect(tokenVerifier.verifyCsrfToken).toHaveBeenCalledWith('csrf-token', payload);
+  });
+
+  it('rejects refresh tokens from other session types', () => {
+    const tokenVerifier: CsrfTokenVerifier = {
+      verifyRefreshToken: vi.fn().mockReturnValue({ ...payload, sessionType: 'admin' }),
+      verifyCsrfToken: vi.fn(),
+    };
+
+    expect(() =>
+      assertValidWebLogoutCsrf(
+        { refreshToken: 'refresh-token', csrfToken: 'csrf-token' },
+        tokenVerifier
+      )
+    ).toThrow(AppError);
+    expect(tokenVerifier.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/logout-csrf.test.ts
+++ b/backend/tests/unit/logout-csrf.test.ts
@@ -29,9 +29,26 @@ describe('assertValidWebLogoutCsrf', () => {
   });
 
   it('requires a valid csrf token before clearing a web refresh cookie', () => {
+    const call = () => assertValidWebLogoutCsrf({ refreshToken: 'refresh-token' }, verifier(false));
+
+    expect(call).toThrow(AppError);
+    expect(call).toThrow(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it('allows logout cleanup when the refresh token is expired or invalid', () => {
+    const tokenVerifier: CsrfTokenVerifier = {
+      verifyRefreshToken: vi
+        .fn()
+        .mockImplementation(() => {
+          throw new AppError('Invalid refresh token', 401, 'AUTH_UNAUTHORIZED');
+        }),
+      verifyCsrfToken: vi.fn(),
+    };
+
     expect(() =>
-      assertValidWebLogoutCsrf({ refreshToken: 'refresh-token' }, verifier(false))
-    ).toThrow(AppError);
+      assertValidWebLogoutCsrf({ refreshToken: 'stale-refresh-token' }, tokenVerifier)
+    ).not.toThrow();
+    expect(tokenVerifier.verifyCsrfToken).not.toHaveBeenCalled();
   });
 
   it('accepts a matching csrf token for a user refresh session', () => {
@@ -52,12 +69,15 @@ describe('assertValidWebLogoutCsrf', () => {
       verifyCsrfToken: vi.fn(),
     };
 
-    expect(() =>
+    const call = () => {
       assertValidWebLogoutCsrf(
         { refreshToken: 'refresh-token', csrfToken: 'csrf-token' },
         tokenVerifier
-      )
-    ).toThrow(AppError);
+      );
+    };
+
+    expect(call).toThrow(AppError);
+    expect(call).toThrow(expect.objectContaining({ statusCode: 401 }));
     expect(tokenVerifier.verifyCsrfToken).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- validates the CSRF token before clearing a browser refresh-token cookie on `/api/auth/logout`
- preserves idempotent logout behavior when no web refresh cookie is present
- rejects non-user refresh sessions and missing/invalid CSRF headers for cookie-backed logout requests

Fixes #1329

## Tests
- `cd backend && npm test -- tests/unit/logout-csrf.test.ts`
- `cd backend && npm run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a valid CSRF token to clear the web refresh cookie on POST /api/auth/logout. Blocks CSRF logout for web clients while keeping logout idempotent and allowing cookie cleanup even if the refresh token is missing, expired, or invalid.

- **Bug Fixes**
  - Validate `x-csrf-token` before clearing the web refresh cookie.
  - Reject non-user refresh sessions with 401.
  - Allow cookie cleanup when the refresh token is expired/invalid (skip CSRF check).
  - Keep no-op behavior when the refresh cookie is absent.

<sup>Written for commit 9e4a2a14f94c5ca9fb32c3bbbb91de365d1c065c. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require CSRF token validation on web `POST /api/auth/logout`
> - Adds `assertValidWebLogoutCsrf` in [`logout-csrf.ts`](https://github.com/InsForge/InsForge/pull/1354/files#diff-2d4a6e024112c675b7329764a389bf9d478f632e7d97949f65b1b6c2efb7ac76), which validates the CSRF token (from `x-csrf-token` header) against the refresh token payload before clearing the session cookie.
> - The validator is a no-op when no refresh token cookie is present, and tolerates expired/invalid refresh tokens (swallows 401) to allow idempotent logout.
> - Returns 401 if the refresh token belongs to a non-user session type, and 403 if the CSRF token does not match.
> - Behavioral Change: Web clients with a valid refresh token cookie must now supply a matching CSRF token or the logout request is rejected with 403.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e4a2a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web logout now validates CSRF tokens alongside refresh tokens before clearing session cookies; non-web logout behavior is unchanged.

* **Tests**
  * Added unit tests covering missing refresh token, expired/invalid refresh tokens, missing/invalid CSRF, session-type mismatches, and successful CSRF validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->