### PR TITLE
feature-export table as a csv file

### DIFF
--- a/packages/dashboard/src/features/database/hooks/useCSVExport.ts
+++ b/packages/dashboard/src/features/database/hooks/useCSVExport.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { recordService } from '#features/database/services/record.service.js';
+import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
+
+interface UseCSVExportOptions {
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function useCSVExport(
+  tableName: string,
+  schemaName: string = DEFAULT_DATABASE_SCHEMA,
+  options?: UseCSVExportOptions
+) {
+  const mutation = useMutation({
+    mutationFn: () => recordService.exportTableAsCSV(tableName, schemaName),
+    onSuccess: () => {
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      options?.onError?.(error);
+    },
+  });
+
+  return {
+    mutate: mutation.mutate,
+    reset: mutation.reset,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/dashboard/src/features/database/hooks/useCSVExport.ts
+++ b/packages/dashboard/src/features/database/hooks/useCSVExport.ts
@@ -2,11 +2,30 @@ import { useMutation } from '@tanstack/react-query';
 import { recordService } from '#features/database/services/record.service.js';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 
+/**
+ * Options for configuring CSV export behavior and callbacks
+ * @property {() => void} [onSuccess] - Callback invoked after successful export
+ * @property {(error: Error) => void} [onError] - Callback invoked if export fails
+ * @property {(message: string) => void} [onWarning] - Callback invoked if export is limited to 10k rows
+ */
 interface UseCSVExportOptions {
   onSuccess?: () => void;
   onError?: (error: Error) => void;
+  onWarning?: (message: string) => void;
 }
 
+/**
+ * React hook for exporting table records as CSV
+ * Exports up to 10,000 rows to prevent browser memory issues
+ * @param {string} tableName - Name of the table to export
+ * @param {string} [schemaName=DEFAULT_DATABASE_SCHEMA] - Database schema name
+ * @param {UseCSVExportOptions} [options] - Configuration options and callbacks
+ * @returns {Object} Mutation control object
+ * @returns {Function} returns.mutate - Triggers the export operation
+ * @returns {Function} returns.reset - Resets mutation state
+ * @returns {boolean} returns.isPending - Loading state during export
+ * @returns {Error | null} returns.error - Export error if any
+ */
 export function useCSVExport(
   tableName: string,
   schemaName: string = DEFAULT_DATABASE_SCHEMA,
@@ -14,7 +33,10 @@ export function useCSVExport(
 ) {
   const mutation = useMutation({
     mutationFn: () => recordService.exportTableAsCSV(tableName, schemaName),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      if (data.limited) {
+        options?.onWarning?.('Export limited to 10,000 rows. Your table contains more data.');
+      }
       options?.onSuccess?.();
     },
     onError: (error) => {

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -250,6 +250,9 @@ export default function TablesPage() {
       showToast('Export successful!', 'success');
       resetExport();
     },
+    onWarning: (message: string) => {
+      showToast(message, 'warn');
+    },
     onError: (error: Error) => {
       const message =
         error?.message || 'An unexpected error occurred during export. Please try again.';
@@ -607,20 +610,20 @@ export default function TablesPage() {
                               {isImporting ? 'Importing...' : 'Import CSV'}
                             </span>
                           </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 rounded px-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
-                            onClick={() => exportCSV()}
-                            disabled={isExporting}
-                          >
-                            <FolderOutput className="h-6 w-6 stroke-[1.5]" />
-                            <span className="px-1 text-sm font-medium leading-5">
-                              {isExporting ? 'Exporting...' : 'Export CSV'}
-                            </span>
-                          </Button>
                         </>
                       )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 rounded px-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
+                        onClick={() => exportCSV()}
+                        disabled={isExporting}
+                      >
+                        <FolderOutput className="h-6 w-6 stroke-[1.5]" />
+                        <span className="px-1 text-sm font-medium leading-5">
+                          {isExporting ? 'Exporting...' : 'Export CSV'}
+                        </span>
+                      </Button>
                     </div>
                   )
                 }

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { CirclePlus, LogIn } from 'lucide-react';
+import { CirclePlus, FolderInput, FolderOutput } from 'lucide-react';
 import PencilIcon from '#assets/icons/pencil.svg?react';
 import RefreshIcon from '#assets/icons/refresh.svg?react';
 import { useDatabaseSchemas } from '#features/database/hooks/useDatabase';
@@ -35,6 +35,7 @@ import { DatabaseDataGrid } from '#features/database/components/DatabaseDataGrid
 import { SortColumn } from 'react-data-grid';
 import { convertValueForColumn } from '#lib/utils/utils';
 import { useCSVImport } from '#features/database/hooks/useCSVImport';
+import { useCSVExport } from '#features/database/hooks/useCSVExport';
 import { useTablePreferences } from '#features/database/hooks/useTablePreferences';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { usePageSize } from '#lib/hooks/usePageSize';
@@ -237,6 +238,23 @@ export default function TablesPage() {
         error?.message || 'An unexpected error occurred during import. Please try again.';
       showToast(message, 'error');
       resetImport();
+    },
+  });
+
+  const {
+    mutate: exportCSV,
+    isPending: isExporting,
+    reset: resetExport,
+  } = useCSVExport(selectedTable || '', selectedSchema, {
+    onSuccess: () => {
+      showToast('Export successful!', 'success');
+      resetExport();
+    },
+    onError: (error: Error) => {
+      const message =
+        error?.message || 'An unexpected error occurred during export. Please try again.';
+      showToast(message, 'error');
+      resetExport();
     },
   });
 
@@ -584,9 +602,21 @@ export default function TablesPage() {
                             onClick={() => fileInputRef.current?.click()}
                             disabled={isImporting}
                           >
-                            <LogIn className="h-6 w-6 stroke-[1.5]" />
+                            <FolderInput className="h-6 w-6 stroke-[1.5]" />
                             <span className="px-1 text-sm font-medium leading-5">
                               {isImporting ? 'Importing...' : 'Import CSV'}
+                            </span>
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 rounded px-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] hover:text-foreground active:bg-[var(--alpha-8)]"
+                            onClick={() => exportCSV()}
+                            disabled={isExporting}
+                          >
+                            <FolderOutput className="h-6 w-6 stroke-[1.5]" />
+                            <span className="px-1 text-sm font-medium leading-5">
+                              {isExporting ? 'Exporting...' : 'Export CSV'}
                             </span>
                           </Button>
                         </>

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -2,6 +2,7 @@ import { ConvertedValue } from '#components/datagrid/datagridTypes';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 import { apiClient } from '#lib/api/client';
 import { BulkUpsertResponse } from '@insforge/shared-schemas';
+import { convertToCSV } from '#lib/utils/csv';
 
 interface AdminRecordListResponse {
   data: { [key: string]: ConvertedValue }[];
@@ -274,6 +275,37 @@ export class RecordService {
       body: formData,
     });
     return response;
+  }
+
+  async exportTableAsCSV(
+    tableName: string,
+    schemaName: string = DEFAULT_DATABASE_SCHEMA
+  ): Promise<void> {
+    // Fetch all records from the table (with pagination to ensure we get all data)
+    // Backend API max limit is 500 records per request
+    const limit = 500;
+    const allRecords: { [key: string]: ConvertedValue }[] = [];
+    let offset = 0;
+    let hasMore = true;
+
+    while (hasMore) {
+      const { records } = await this.getTableRecords(tableName, schemaName, limit, offset);
+
+      allRecords.push(...records);
+
+      if (records.length < limit) {
+        hasMore = false;
+      } else {
+        offset += limit;
+      }
+    }
+
+    // Generate filename with timestamp
+    const timestamp = new Date().toISOString().split('T')[0];
+    const filename = `${tableName}-${timestamp}.csv`;
+
+    // Convert and download
+    convertToCSV(allRecords, filename);
   }
 }
 

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -280,24 +280,41 @@ export class RecordService {
   async exportTableAsCSV(
     tableName: string,
     schemaName: string = DEFAULT_DATABASE_SCHEMA
-  ): Promise<void> {
-    // Fetch all records from the table (with pagination to ensure we get all data)
+  ): Promise<{ limited: boolean }> {
+    // Export limit to prevent browser crashes on large tables
+    const MAX_EXPORT_ROWS = 10_000;
     // Backend API max limit is 500 records per request
     const limit = 500;
     const allRecords: { [key: string]: ConvertedValue }[] = [];
     let offset = 0;
-    let hasMore = true;
+    let isLimited = false;
 
-    while (hasMore) {
+    while (allRecords.length < MAX_EXPORT_ROWS) {
       const { records } = await this.getTableRecords(tableName, schemaName, limit, offset);
 
-      allRecords.push(...records);
+      if (records.length === 0) {
+        break;
+      }
+
+      // Only take what we need up to the limit
+      const remaining = MAX_EXPORT_ROWS - allRecords.length;
+      allRecords.push(...records.slice(0, remaining));
+
+      // Check if we've hit the limit or exhausted records
+      if (allRecords.length >= MAX_EXPORT_ROWS) {
+        isLimited = true;
+        break;
+      }
 
       if (records.length < limit) {
-        hasMore = false;
-      } else {
-        offset += limit;
+        break;
       }
+
+      offset += limit;
+    }
+
+    if (allRecords.length === 0) {
+      throw new Error('No records found in this table. Cannot export an empty table.');
     }
 
     // Generate filename with timestamp
@@ -306,6 +323,8 @@ export class RecordService {
 
     // Convert and download
     convertToCSV(allRecords, filename);
+
+    return { limited: isLimited };
   }
 }
 

--- a/packages/dashboard/src/lib/utils/csv.ts
+++ b/packages/dashboard/src/lib/utils/csv.ts
@@ -1,0 +1,58 @@
+/**
+ * Converts records to CSV format with proper escaping
+ */
+export function convertToCSV(records: Record<string, unknown>[], filename: string): void {
+  if (records.length === 0) {
+    return;
+  }
+
+  // Get headers from first record
+  const headers = Object.keys(records[0]);
+
+  // Create CSV header row
+  const csvHeader = headers.map(escapeCSVField).join(',');
+
+  // Create CSV data rows
+  const csvRows = records.map((record) =>
+    headers.map((header) => escapeCSVField(record[header])).join(',')
+  );
+
+  // Combine header and rows
+  const csv = [csvHeader, ...csvRows].join('\n');
+
+  // Create blob and download
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  downloadFile(blob, filename);
+}
+
+/**
+ * Escapes CSV field values to handle commas, quotes, and newlines
+ */
+function escapeCSVField(field: unknown): string {
+  if (field === null || field === undefined) {
+    return '';
+  }
+
+  let value = String(field);
+
+  // If field contains comma, newline, or double quote, wrap in quotes and escape inner quotes
+  if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+    value = `"${value.replace(/"/g, '""')}"`;
+  }
+
+  return value;
+}
+
+/**
+ * Triggers file download in the browser
+ */
+function downloadFile(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename || 'download.csv';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/packages/dashboard/src/lib/utils/csv.ts
+++ b/packages/dashboard/src/lib/utils/csv.ts
@@ -2,10 +2,6 @@
  * Converts records to CSV format with proper escaping
  */
 export function convertToCSV(records: Record<string, unknown>[], filename: string): void {
-  if (records.length === 0) {
-    return;
-  }
-
   // Get headers from first record
   const headers = Object.keys(records[0]);
 
@@ -21,12 +17,12 @@ export function convertToCSV(records: Record<string, unknown>[], filename: strin
   const csv = [csvHeader, ...csvRows].join('\n');
 
   // Create blob and download
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const blob = new Blob(['\uFEFF', csv], { type: 'text/csv;charset=utf-8;' });
   downloadFile(blob, filename);
 }
 
 /**
- * Escapes CSV field values to handle commas, quotes, and newlines
+ * Escapes CSV field values to handle commas, quotes, newlines, and formula injection
  */
 function escapeCSVField(field: unknown): string {
   if (field === null || field === undefined) {
@@ -35,8 +31,14 @@ function escapeCSVField(field: unknown): string {
 
   let value = String(field);
 
+  // Sanitize formula injection: prefix dangerous characters with single quote
+  // Values starting with =, +, -, or @ can execute formulas in spreadsheet tools
+  if (value.match(/^[=+\-@]/)) {
+    value = `'${value}`;
+  }
+
   // If field contains comma, newline, or double quote, wrap in quotes and escape inner quotes
-  if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+  if (value.includes(',') || value.includes('\n') || value.includes('"') || value.includes('\r')) {
     value = `"${value.replace(/"/g, '""')}"`;
   }
 

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -203,7 +203,7 @@ export const exportJsonDataSchema = z.object({
 });
 
 export const exportResponseSchema = z.object({
-  format: z.enum(['sql', 'json']),
+  format: z.enum(['sql', 'json', 'csv']),
   data: z.union([z.string(), exportJsonDataSchema]),
   timestamp: z.string(),
 });

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -203,7 +203,7 @@ export const exportJsonDataSchema = z.object({
 });
 
 export const exportResponseSchema = z.object({
-  format: z.enum(['sql', 'json', 'csv']),
+  format: z.enum(['sql', 'json']),
   data: z.union([z.string(), exportJsonDataSchema]),
   timestamp: z.string(),
 });


### PR DESCRIPTION
#Closes #1361 
Add a one-click “Download CSV” export feature to the Database table panel so users can easily export the current table data as a CSV file with column headers included. This would improve usability by removing the need for manual copy-paste or external conversion tools when handling table data. I came across issue #1357 today, and I felt this feature would complement it well by making data management and sharing more convenient. The feature could be implemented as a simple download icon or an Export CSV option within the table toolbar/menu for quick access.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-click “Export CSV” to the Database table toolbar to download the current table with headers. Exports up to 10,000 rows, warns when limited, and safely escapes fields.

- **New Features**
  - Tables page: “Export CSV” button with loading state and success/error/warning toasts. Import icon switched to FolderInput; export uses FolderOutput.
  - Hook `useCSVExport` uses `@tanstack/react-query` to run exports and surface pending/reset and callbacks.
  - Service `recordService.exportTableAsCSV` paginates (500/req), caps at 10k rows with warning, throws on empty tables, and downloads `${tableName}-YYYY-MM-DD.csv`.
  - Utility `convertToCSV` adds UTF-8 BOM, escapes quotes/commas/newlines, prevents formula injection, and triggers browser download.

<sup>Written for commit 343a33de8d81a9df19931876baad35c1ac1bb4d0. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1362?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CSV export for database tables with client-side pagination
> - Adds an Export CSV button to [`TablesPage`](https://github.com/InsForge/InsForge/pull/1362/files#diff-103425128d3b3dbb3753e98cf56e8154344e2dfa8a374af1d97af4e65decb4d6) that downloads all records for the selected table and schema.
> - [`RecordService.exportTableAsCSV`](https://github.com/InsForge/InsForge/pull/1362/files#diff-ed867f0c32c546814b9759be6f5e149687f92d6431806c8997328827cc6b12df) paginates through records in 500-row batches up to a 10,000-row cap, then triggers a browser download; throws if the table is empty.
> - CSV conversion and download logic lives in [`lib/utils/csv.ts`](https://github.com/InsForge/InsForge/pull/1362/files#diff-771ab3ab2f93b3b63005c3fef13a0eb9a2190ed3f1556e715cf95d62156e9b2c), which includes formula injection mitigation by prefixing dangerous field values with a single quote.
> - Success, warning (export was capped at 10k rows), and error states are surfaced via toasts using the [`useCSVExport`](https://github.com/InsForge/InsForge/pull/1362/files#diff-6027170263f887ec49a2dbcae356af0f80be3f9d989ae6386098a52bbcf9069b) hook.
> - Risk: export is fully client-side, so large tables approaching the 10,000-row cap may cause noticeable memory and performance impact in the browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 343a33d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV export functionality for database tables with automatic date-stamped filenames.
  * Export feature limited to 10,000 rows; users receive a warning notification when this limit is reached.
  * New "Export CSV" button added to table header with updated folder-based icons for import and export actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->