### PR TITLE
fix: clean up orphaned function deployments on function delete

### DIFF
--- a/backend/src/infra/database/migrations/047_create-functions-deployment-cleanup.sql
+++ b/backend/src/infra/database/migrations/047_create-functions-deployment-cleanup.sql
@@ -1,0 +1,90 @@
+-- Migration: 047 - Add orphan cleanup for functions.deployments
+--
+-- functions.deployments has no FK to functions.definitions. When a function
+-- is deleted, its deployment records remain orphaned permanently. This adds
+-- a batched cleanup function and a pg_cron job that runs it daily at 3 AM.
+
+CREATE INDEX IF NOT EXISTS idx_functions_deployments_status_created
+  ON functions.deployments(status, created_at);
+
+CREATE OR REPLACE FUNCTION functions.cleanup_orphan_deployments(
+  p_batch_size INT DEFAULT 1000,
+  p_max_age_days INT DEFAULT NULL
+)
+RETURNS INT AS $$
+DECLARE
+  v_cutoff TIMESTAMPTZ;
+  v_deleted_count INT := 0;
+  v_total_deleted INT := 0;
+BEGIN
+  IF p_batch_size IS NULL OR p_batch_size <= 0 THEN
+    RAISE WARNING 'functions.cleanup_orphan_deployments received invalid batch size: %', p_batch_size;
+    RETURN 0;
+  END IF;
+
+  IF p_max_age_days IS NOT NULL AND p_max_age_days > 0 THEN
+    v_cutoff := NOW() - (p_max_age_days || ' days')::INTERVAL;
+  END IF;
+
+  LOOP
+    WITH candidate_deployments AS (
+      SELECT d.id
+      FROM functions.deployments d
+      WHERE (v_cutoff IS NULL OR d.created_at < v_cutoff)
+        AND jsonb_array_length(d.functions) > 0
+        AND NOT EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements_text(d.functions) AS slug
+          WHERE EXISTS (
+            SELECT 1 FROM functions.definitions fd
+            WHERE fd.slug = slug
+          )
+        )
+      ORDER BY d.created_at ASC
+      LIMIT p_batch_size
+      FOR UPDATE OF d SKIP LOCKED
+    ),
+    deleted AS (
+      DELETE FROM functions.deployments d
+      WHERE d.id IN (SELECT id FROM candidate_deployments)
+      RETURNING d.id
+    )
+    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+
+    v_total_deleted := v_total_deleted + v_deleted_count;
+
+    EXIT WHEN v_deleted_count < p_batch_size;
+  END LOOP;
+
+  RETURN v_total_deleted;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'functions.cleanup_orphan_deployments failed: %', SQLERRM;
+  RETURN v_total_deleted;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+REVOKE ALL ON FUNCTION functions.cleanup_orphan_deployments FROM PUBLIC;
+
+-- Schedule daily at 3 AM (staggered from realtime cleanup at midnight)
+DO $$
+DECLARE
+  v_existing_job_id BIGINT;
+BEGIN
+  FOR v_existing_job_id IN
+    SELECT DISTINCT existing_jobs.jobid
+    FROM (
+      SELECT jobid
+      FROM cron.job
+      WHERE command = 'SELECT functions.cleanup_orphan_deployments()'
+         OR jobname = 'functions-deployment-cleanup'
+    ) AS existing_jobs
+  LOOP
+    PERFORM cron.unschedule(v_existing_job_id);
+  END LOOP;
+
+  PERFORM cron.schedule(
+    'functions-deployment-cleanup',
+    '0 3 * * *',
+    'SELECT functions.cleanup_orphan_deployments()'
+  );
+END $$;

--- a/backend/src/infra/database/migrations/047_create-functions-deployment-cleanup.sql
+++ b/backend/src/infra/database/migrations/047_create-functions-deployment-cleanup.sql
@@ -1,90 +1,35 @@
--- Migration: 047 - Add orphan cleanup for functions.deployments
+-- Migration: 047 - Normalize functions.deployments.functions into a join table
 --
--- functions.deployments has no FK to functions.definitions. When a function
--- is deleted, its deployment records remain orphaned permanently. This adds
--- a batched cleanup function and a pg_cron job that runs it daily at 3 AM.
+-- functions.deployments had no FK to functions.definitions. Function slugs
+-- were stored in a JSONB array (functions column), making orphan cleanup
+-- error-prone and requiring app-level logic or cron jobs.
+--
+-- This migration normalizes the relationship into a join table with a proper
+-- FK constraint so that deleting a function automatically cascades.
 
+-- Add a composite index for common query patterns
 CREATE INDEX IF NOT EXISTS idx_functions_deployments_status_created
   ON functions.deployments(status, created_at);
 
-CREATE OR REPLACE FUNCTION functions.cleanup_orphan_deployments(
-  p_batch_size INT DEFAULT 1000,
-  p_max_age_days INT DEFAULT NULL
-)
-RETURNS INT AS $$
-DECLARE
-  v_cutoff TIMESTAMPTZ;
-  v_deleted_count INT := 0;
-  v_total_deleted INT := 0;
-BEGIN
-  IF p_batch_size IS NULL OR p_batch_size <= 0 THEN
-    RAISE WARNING 'functions.cleanup_orphan_deployments received invalid batch size: %', p_batch_size;
-    RETURN 0;
-  END IF;
+-- Add a GIN index on the functions JSONB column for backward-compatible queries
+CREATE INDEX IF NOT EXISTS idx_functions_deployments_functions_gin
+  ON functions.deployments USING GIN (functions);
 
-  IF p_max_age_days IS NOT NULL AND p_max_age_days > 0 THEN
-    v_cutoff := NOW() - (p_max_age_days || ' days')::INTERVAL;
-  END IF;
+-- Create the join table
+CREATE TABLE IF NOT EXISTS functions.deployment_functions (
+  deployment_id TEXT NOT NULL REFERENCES functions.deployments(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL REFERENCES functions.definitions(slug) ON DELETE CASCADE,
+  PRIMARY KEY (deployment_id, slug)
+);
 
-  LOOP
-    WITH candidate_deployments AS (
-      SELECT d.id
-      FROM functions.deployments d
-      WHERE (v_cutoff IS NULL OR d.created_at < v_cutoff)
-        AND jsonb_array_length(d.functions) > 0
-        AND NOT EXISTS (
-          SELECT 1
-          FROM jsonb_array_elements_text(d.functions) AS slug
-          WHERE EXISTS (
-            SELECT 1 FROM functions.definitions fd
-            WHERE fd.slug = slug
-          )
-        )
-      ORDER BY d.created_at ASC
-      LIMIT p_batch_size
-      FOR UPDATE OF d SKIP LOCKED
-    ),
-    deleted AS (
-      DELETE FROM functions.deployments d
-      WHERE d.id IN (SELECT id FROM candidate_deployments)
-      RETURNING d.id
-    )
-    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+-- Index for looking up deployments by function slug
+CREATE INDEX IF NOT EXISTS idx_deployment_functions_slug
+  ON functions.deployment_functions(slug);
 
-    v_total_deleted := v_total_deleted + v_deleted_count;
-
-    EXIT WHEN v_deleted_count < p_batch_size;
-  END LOOP;
-
-  RETURN v_total_deleted;
-EXCEPTION WHEN OTHERS THEN
-  RAISE WARNING 'functions.cleanup_orphan_deployments failed: %', SQLERRM;
-  RETURN v_total_deleted;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
-REVOKE ALL ON FUNCTION functions.cleanup_orphan_deployments FROM PUBLIC;
-
--- Schedule daily at 3 AM (staggered from realtime cleanup at midnight)
-DO $$
-DECLARE
-  v_existing_job_id BIGINT;
-BEGIN
-  FOR v_existing_job_id IN
-    SELECT DISTINCT existing_jobs.jobid
-    FROM (
-      SELECT jobid
-      FROM cron.job
-      WHERE command = 'SELECT functions.cleanup_orphan_deployments()'
-         OR jobname = 'functions-deployment-cleanup'
-    ) AS existing_jobs
-  LOOP
-    PERFORM cron.unschedule(v_existing_job_id);
-  END LOOP;
-
-  PERFORM cron.schedule(
-    'functions-deployment-cleanup',
-    '0 3 * * *',
-    'SELECT functions.cleanup_orphan_deployments()'
-  );
-END $$;
+-- Backfill existing data from the JSONB array into the join table
+INSERT INTO functions.deployment_functions (deployment_id, slug)
+  SELECT d.id, jsonb_array_elements_text(d.functions) AS slug
+  FROM functions.deployments d
+  WHERE d.functions IS NOT NULL
+    AND jsonb_array_length(d.functions) > 0
+ON CONFLICT DO NOTHING;

--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -9,7 +9,7 @@ import {
   DeploymentResult,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
-import { Pool, PoolClient } from 'pg';
+import { Pool } from 'pg';
 import fetch from 'node-fetch';
 import { AppError, hasPgErrorCode } from '@/utils/errors.js';
 import { DenoSubhostingProvider } from '@/providers/functions/deno-subhosting.provider.js';
@@ -305,56 +305,27 @@ export class FunctionService {
    * Delete a function
    */
   async deleteFunction(slug: string): Promise<boolean> {
-    const client: PoolClient = await this.getPool().connect();
-
     try {
-      await client.query('BEGIN');
-
-      const result = await client.query('DELETE FROM functions.definitions WHERE slug = $1', [
-        slug,
-      ]);
+      const result = await this.getPool().query(
+        'DELETE FROM functions.definitions WHERE slug = $1',
+        [slug]
+      );
 
       if (result.rowCount === 0) {
-        await client.query('ROLLBACK');
         return false;
       }
-
-      // Delete deployments that only referenced this function
-      await client.query(
-        `DELETE FROM functions.deployments
-         WHERE id IN (
-           SELECT id FROM functions.deployments
-           WHERE functions @> to_jsonb(ARRAY[$1]::text[])
-             AND jsonb_array_length(functions - $1) = 0
-         )`,
-        [slug]
-      );
-
-      // Remove the deleted slug from deployments that reference multiple functions
-      await client.query(
-        `UPDATE functions.deployments
-         SET functions = functions - $1
-         WHERE functions @> to_jsonb(ARRAY[$1]::text[])
-           AND jsonb_array_length(functions) > 1`,
-        [slug]
-      );
-
-      await client.query('COMMIT');
 
       // Trigger redeployment without the deleted function
       this.scheduleDeployment();
 
       return true;
     } catch (error) {
-      await client.query('ROLLBACK');
       logger.error('Failed to delete function', {
         error: error instanceof Error ? error.message : String(error),
         operation: 'deleteFunction',
         slug,
       });
       throw error;
-    } finally {
-      client.release();
     }
   }
 
@@ -616,18 +587,44 @@ export class FunctionService {
     functionCount: number;
     functions: string[];
   }): Promise<void> {
-    await this.getPool().query(
-      `INSERT INTO functions.deployments (id, project_id, status, url, function_count, functions)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [
-        deployment.id,
-        deployment.projectId,
-        deployment.status,
-        deployment.url,
-        deployment.functionCount,
-        JSON.stringify(deployment.functions),
-      ]
-    );
+    const client = await this.getPool().connect();
+
+    try {
+      await client.query('BEGIN');
+
+      await client.query(
+        `INSERT INTO functions.deployments (id, project_id, status, url, function_count, functions)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          deployment.id,
+          deployment.projectId,
+          deployment.status,
+          deployment.url,
+          deployment.functionCount,
+          JSON.stringify(deployment.functions),
+        ]
+      );
+
+      for (const slug of deployment.functions) {
+        await client.query(
+          `INSERT INTO functions.deployment_functions (deployment_id, slug)
+           VALUES ($1, $2)
+           ON CONFLICT DO NOTHING`,
+          [deployment.id, slug]
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      logger.error('Failed to save deployment', {
+        error: error instanceof Error ? error.message : String(error),
+        deploymentId: deployment.id,
+      });
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   /**

--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -310,17 +310,16 @@ export class FunctionService {
     try {
       await client.query('BEGIN');
 
-      const result = await client.query(
-        'DELETE FROM functions.definitions WHERE slug = $1',
-        [slug]
-      );
+      const result = await client.query('DELETE FROM functions.definitions WHERE slug = $1', [
+        slug,
+      ]);
 
       if (result.rowCount === 0) {
         await client.query('ROLLBACK');
         return false;
       }
 
-      // Delete deployments that only referenced this function 
+      // Delete deployments that only referenced this function
       await client.query(
         `DELETE FROM functions.deployments
          WHERE id IN (

--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -9,7 +9,7 @@ import {
   DeploymentResult,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
-import { Pool } from 'pg';
+import { Pool, PoolClient } from 'pg';
 import fetch from 'node-fetch';
 import { AppError, hasPgErrorCode } from '@/utils/errors.js';
 import { DenoSubhostingProvider } from '@/providers/functions/deno-subhosting.provider.js';
@@ -305,27 +305,57 @@ export class FunctionService {
    * Delete a function
    */
   async deleteFunction(slug: string): Promise<boolean> {
+    const client: PoolClient = await this.getPool().connect();
+
     try {
-      const result = await this.getPool().query(
+      await client.query('BEGIN');
+
+      const result = await client.query(
         'DELETE FROM functions.definitions WHERE slug = $1',
         [slug]
       );
 
       if (result.rowCount === 0) {
+        await client.query('ROLLBACK');
         return false;
       }
+
+      // Delete deployments that only referenced this function 
+      await client.query(
+        `DELETE FROM functions.deployments
+         WHERE id IN (
+           SELECT id FROM functions.deployments
+           WHERE functions @> to_jsonb(ARRAY[$1]::text[])
+             AND jsonb_array_length(functions - $1) = 0
+         )`,
+        [slug]
+      );
+
+      // Remove the deleted slug from deployments that reference multiple functions
+      await client.query(
+        `UPDATE functions.deployments
+         SET functions = functions - $1
+         WHERE functions @> to_jsonb(ARRAY[$1]::text[])
+           AND jsonb_array_length(functions) > 1`,
+        [slug]
+      );
+
+      await client.query('COMMIT');
 
       // Trigger redeployment without the deleted function
       this.scheduleDeployment();
 
       return true;
     } catch (error) {
+      await client.query('ROLLBACK');
       logger.error('Failed to delete function', {
         error: error instanceof Error ? error.message : String(error),
         operation: 'deleteFunction',
         slug,
       });
       throw error;
+    } finally {
+      client.release();
     }
   }
 

--- a/backend/tests/unit/function-security.test.ts
+++ b/backend/tests/unit/function-security.test.ts
@@ -199,7 +199,7 @@ describe('FunctionService deleteFunction', () => {
   });
 
   it('should return true and call scheduleDeployment on success', async () => {
-    const scheduleSpy = vi.spyOn(service as any, 'scheduleDeployment');
+    const scheduleSpy = vi.spyOn(service as unknown as { scheduleDeployment: () => void }, 'scheduleDeployment');
     mockPool.query.mockResolvedValueOnce({ rowCount: 1 });
 
     const result = await service.deleteFunction('my-func');

--- a/backend/tests/unit/function-security.test.ts
+++ b/backend/tests/unit/function-security.test.ts
@@ -181,3 +181,41 @@ describe('FunctionService Code Validation (Public API)', () => {
     });
   });
 });
+
+describe('FunctionService deleteFunction', () => {
+  let service: FunctionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = FunctionService.getInstance();
+  });
+
+  it('should return false when slug does not exist', async () => {
+    mockPool.query.mockResolvedValueOnce({ rowCount: 0 });
+
+    const result = await service.deleteFunction('non-existent');
+
+    expect(result).toBe(false);
+  });
+
+  it('should return true and call scheduleDeployment on success', async () => {
+    const scheduleSpy = vi.spyOn(service as any, 'scheduleDeployment');
+    mockPool.query.mockResolvedValueOnce({ rowCount: 1 });
+
+    const result = await service.deleteFunction('my-func');
+
+    expect(result).toBe(true);
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'DELETE FROM functions.definitions WHERE slug = $1',
+      ['my-func']
+    );
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should re-throw on DB error', async () => {
+    const dbError = new Error('Connection failure');
+    mockPool.query.mockRejectedValueOnce(dbError);
+
+    await expect(service.deleteFunction('my-func')).rejects.toThrow('Connection failure');
+  });
+});

--- a/backend/tests/unit/functions-deployment-cleanup-migration.test.ts
+++ b/backend/tests/unit/functions-deployment-cleanup-migration.test.ts
@@ -1,0 +1,118 @@
+import { beforeAll, describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationFile = '047_create-functions-deployment-cleanup.sql';
+const migrationPath = path.resolve(
+  currentDir,
+  `../../src/infra/database/migrations/${migrationFile}`
+);
+
+describe('functions deployment cleanup migration', () => {
+  let sql = '';
+
+  beforeAll(() => {
+    sql = fs.readFileSync(migrationPath, 'utf8');
+  });
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  // ── indexes ─────────────────────────────────────────────────
+  it('adds a composite index on status and created_at', () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_functions_deployments_status_created/i);
+    expect(sql).toMatch(/ON functions\.deployments\(status,\s*created_at\)/i);
+  });
+
+  it('adds a GIN index on functions JSONB column', () => {
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_functions_deployments_functions_gin/i
+    );
+    expect(sql).toMatch(/ON functions\.deployments USING GIN\s*\(functions\)/i);
+  });
+
+  // ── join table ──────────────────────────────────────────────
+  it('creates deployment_functions join table', () => {
+    expect(sql).toMatch(
+      /CREATE TABLE IF NOT EXISTS functions\.deployment_functions/i
+    );
+  });
+
+  it('join table has deployment_id FK with CASCADE', () => {
+    expect(sql).toMatch(
+      /deployment_id\s+TEXT\s+NOT\s+NULL\s+REFERENCES\s+functions\.deployments\(id\)\s+ON\s+DELETE\s+CASCADE/i
+    );
+  });
+
+  it('join table has slug FK with CASCADE', () => {
+    expect(sql).toMatch(
+      /slug\s+TEXT\s+NOT\s+NULL\s+REFERENCES\s+functions\.definitions\(slug\)\s+ON\s+DELETE\s+CASCADE/i
+    );
+  });
+
+  it('join table has composite primary key', () => {
+    expect(sql).toMatch(/PRIMARY\s+KEY\s*\(deployment_id,\s*slug\)/i);
+  });
+
+  it('indexes the join table on slug', () => {
+    expect(sql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_deployment_functions_slug/i
+    );
+    expect(sql).toMatch(/ON functions\.deployment_functions\(slug\)/i);
+  });
+
+  // ── backfill ────────────────────────────────────────────────
+  it('backfills existing data from the JSONB array', () => {
+    expect(sql).toMatch(/INSERT INTO functions\.deployment_functions/i);
+    expect(sql).toMatch(/SELECT.*jsonb_array_elements_text\(d\.functions\)/i);
+    expect(sql).toMatch(/FROM functions\.deployments d/i);
+  });
+
+  it('backfill filters out NULL and empty arrays', () => {
+    expect(sql).toMatch(/WHERE d\.functions IS NOT NULL/i);
+    expect(sql).toMatch(/AND jsonb_array_length\(d\.functions\) > 0/i);
+  });
+
+  it('backfill uses ON CONFLICT DO NOTHING', () => {
+    expect(sql).toMatch(/ON CONFLICT DO NOTHING/i);
+  });
+
+  // ── no cron / no trigger ────────────────────────────────────
+  it('does not create a cron cleanup function', () => {
+    expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION.*cleanup/i);
+  });
+
+  it('does not schedule a pg_cron job', () => {
+    expect(sql).not.toMatch(/cron\.schedule/i);
+    expect(sql).not.toMatch(/cron\.job/i);
+    expect(sql).not.toMatch(/cron\.unschedule/i);
+  });
+
+  it('does not create a trigger', () => {
+    expect(sql).not.toMatch(/CREATE TRIGGER/i);
+  });
+
+  it('does not use SECURITY DEFINER', () => {
+    expect(sql).not.toMatch(/SECURITY DEFINER/i);
+  });
+
+  // ── ordering ────────────────────────────────────────────────
+  it('runs after migration 022 (functions.deployments table)', () => {
+    const migrationDir = path.resolve(
+      currentDir,
+      '../../src/infra/database/migrations'
+    );
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+
+    const idx047 = migrations.findIndex((f) => f === migrationFile);
+    const idx022 = migrations.findIndex((f) => f === '022_create-function-deployments.sql');
+    expect(idx022).toBeGreaterThanOrEqual(0);
+    expect(idx047).toBeGreaterThan(idx022);
+  });
+});


### PR DESCRIPTION
Closes #1365

## Summary

Deleting a serverless function (`DELETE /api/functions/:slug`) leaves orphaned deployment records in `functions.deployments` with stale slug references in the `functions` JSONB array. The table has no FK to `functions.definitions`, so no cascade cleanup exists — and no compensating logic was ever added.

**Fix — two layers:**

1. **App-level** (`FunctionService.deleteFunction()`): Runs inside a transaction. After deleting the definition, it deletes deployments that become fully orphaned (only the deleted slug referenced) and removes the slug from deployments that reference multiple functions. Rolls back atomically on failure.

2. **Database-level** (migration `047`): A batched PL/pgSQL function `functions.cleanup_orphan_deployments()` scheduled via pg_cron daily at 3 AM. Catches pre-existing orphans and any missed by non-API paths. Follows the same pattern as `realtime.cleanup_messages()` and `schedules.cleanup_job_logs()`.

**Scope:** Only deployments whose **entire** function set is deleted are removed. Deployments referencing at least one live function are preserved (slug removed from array, record stays).

## How did you test this change?

- `npx tsc --noEmit --project backend/tsconfig.json` — no new type errors (pre-existing errors in stripe/nodemailer/xml2js deps are unrelated)
- Migration `047` reviewed against the existing pattern in migrations `041` and `024`
- Dry-run SQL verified the `NOT EXISTS` subquery logic for orphan detection
- Verified that `PoolClient` type is correctly imported and the transaction path (`BEGIN/COMMIT/ROLLBACK`) is complete in the modified `deleteFunction`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned function deployment records when a function is deleted and adds a nightly database cleanup to remove any existing or missed orphans.

- **Bug Fixes**
  - Wrap function deletion in a transaction; return `false` if the slug is not found.
  - Delete deployments that only referenced the deleted slug.
  - Remove the slug from multi-function deployments and keep the record.
  - Trigger redeployment after commit.

- **Migration**
  - Add `functions.cleanup_orphan_deployments(p_batch_size, p_max_age_days)` to batch-delete fully orphaned deployments.
  - Schedule daily cleanup at 3 AM via `pg_cron`.
  - Create index on `functions.deployments(status, created_at)` to speed up scans.
  - Unschedule any previous job variants before adding the new one.

<sup>Written for commit bc32fd91cafb7b2b3702ceb7dd25c7f27d77cdec. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up orphaned function deployments when a function definition is deleted
> - Adds a `functions.deployment_functions` join table with cascading deletes from both `functions.deployments` and `functions.definitions`, so deleting a function definition automatically removes its associated deployment rows.
> - Migration [047](https://github.com/InsForge/InsForge/pull/1366/files#diff-263a5698d3d45a282f6c49a6cee56a74385e21dc9e39a69a5ab84b9311ca774d) backfills the join table from existing `deployments.functions` JSONB arrays and adds indexes on `(status, created_at)` and the JSONB column.
> - `FunctionService.saveDeployment` is updated to populate `deployment_functions` within a single transaction, rolling back on any failure.
> - Risk: `saveDeployment` now acquires a pooled client and runs an explicit transaction, changing its error and connection-handling behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9611017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Normalized function-to-deployment relationships with a dedicated join table, improved indexes, and automated backfill for more reliable and faster lookups.

* **Bug Fixes**
  * Deployment creation is now fully transactional, ensuring deployments and their function mappings are saved consistently.

* **Tests**
  * Added unit tests validating the migration contents and function-deletion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->