### PR TITLE
feat(compute): pass protocol through OSS for TCP services (INS-271)

### DIFF
--- a/backend/src/infra/database/migrations/047_compute-services-add-protocol.sql
+++ b/backend/src/infra/database/migrations/047_compute-services-add-protocol.sql
@@ -1,0 +1,31 @@
+-- INS-271: add `protocol` column to compute.services.
+--
+-- 'http' (default) is the existing behaviour — Fly terminates TLS at its
+-- anycast edge and proxies HTTP/1.1+H2 to the container. 'tcp' is for raw
+-- TCP services (Redis, Postgres-wire-protocol, custom binary protocols) —
+-- the container's port is exposed directly with empty L7 handlers so bytes
+-- flow end-to-end without HTTP inspection.
+--
+-- Two-step pattern (ADD with default, then NOT NULL) so existing rows get
+-- backfilled to 'http' without a separate UPDATE. Safe on Postgres 11+ —
+-- ADD COLUMN ... NOT NULL DEFAULT rewrites in O(1) since PG 11.
+
+ALTER TABLE compute.services
+  ADD COLUMN IF NOT EXISTS protocol TEXT NOT NULL DEFAULT 'http';
+
+-- CHECK constraint isolated from the ADD so re-running the migration on a
+-- DB that already has the column (but not the constraint) still applies it.
+-- The IF NOT EXISTS form for constraints arrived in PG 18; this DO block
+-- is the portable equivalent.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'chk_compute_services_protocol'
+      AND conrelid = 'compute.services'::regclass
+  ) THEN
+    ALTER TABLE compute.services
+      ADD CONSTRAINT chk_compute_services_protocol
+        CHECK (protocol IN ('http', 'tcp'));
+  END IF;
+END$$;

--- a/backend/src/infra/database/migrations/047_compute-services-add-protocol.sql
+++ b/backend/src/infra/database/migrations/047_compute-services-add-protocol.sql
@@ -6,12 +6,25 @@
 -- the container's port is exposed directly with empty L7 handlers so bytes
 -- flow end-to-end without HTTP inspection.
 --
--- Two-step pattern (ADD with default, then NOT NULL) so existing rows get
--- backfilled to 'http' without a separate UPDATE. Safe on Postgres 11+ —
--- ADD COLUMN ... NOT NULL DEFAULT rewrites in O(1) since PG 11.
+-- Idempotent four-step pattern so re-running the migration on a database
+-- that already has the column (from a partial prior run or a hot-fix) still
+-- ends with the column NOT NULL + DEFAULT 'http' applied. `ADD COLUMN IF NOT
+-- EXISTS protocol TEXT NOT NULL DEFAULT 'http'` does not apply the constraints
+-- when the column already exists — only when it creates it — so we split.
 
 ALTER TABLE compute.services
-  ADD COLUMN IF NOT EXISTS protocol TEXT NOT NULL DEFAULT 'http';
+  ADD COLUMN IF NOT EXISTS protocol TEXT;
+
+-- Backfill any rows where protocol is NULL (only possible if the column
+-- pre-existed without our DEFAULT). The NOT NULL constraint at the end
+-- would otherwise fail.
+UPDATE compute.services SET protocol = 'http' WHERE protocol IS NULL;
+
+ALTER TABLE compute.services
+  ALTER COLUMN protocol SET DEFAULT 'http';
+
+ALTER TABLE compute.services
+  ALTER COLUMN protocol SET NOT NULL;
 
 -- CHECK constraint isolated from the ADD so re-running the migration on a
 -- DB that already has the column (but not the constraint) still applies it.

--- a/backend/src/providers/compute/compute.provider.ts
+++ b/backend/src/providers/compute/compute.provider.ts
@@ -10,6 +10,13 @@ export interface LaunchMachineParams {
   memory: number;
   envVars: Record<string, string>;
   region: string;
+  /**
+   * Edge protocol. `'http'` (default) terminates TLS at the Fly anycast edge
+   * and proxies HTTP/1.1+HTTP/2 to the container. `'tcp'` exposes the container's
+   * port directly with empty handlers — for Redis, Postgres-protocol, and other
+   * raw TCP services. Omitting the field is identical to `'http'`.
+   */
+  protocol?: 'http' | 'tcp';
 }
 
 export interface UpdateMachineParams {
@@ -24,6 +31,11 @@ export interface UpdateMachineParams {
   cpu: string;
   memory: number;
   envVars: Record<string, string>;
+  /**
+   * Edge protocol — same semantics as LaunchMachineParams.protocol. Omit
+   * for back-compat HTTP behavior.
+   */
+  protocol?: 'http' | 'tcp';
 }
 
 export interface MachineSummary {

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -197,12 +197,28 @@ export class FlyProvider implements ComputeProvider {
   // Machines API silently ignores unknown fields, so getting these wrong
   // looks like it works but leaves machines always-on. Source of truth:
   // https://docs.machines.dev/spec/openapi3.json — fly.MachineService.
-  private serviceConfig(internalPort: number, scale: ScaleOptions = FlyProvider.SCALE_TO_ZERO) {
+  //
+  // `edgeProtocol` selects the edge-handler shape:
+  //   - `'http'` (default): TLS-terminated at the Fly anycast edge, HTTP/1.1+H2
+  //     proxied to the container's port. Two public ports (443 TLS, 80 plain).
+  //   - `'tcp'`: container's port exposed directly with empty handlers, for
+  //     Redis / Postgres-protocol / raw TCP services. Single public port =
+  //     internal port. Fly's `services[].protocol` stays `'tcp'` either way
+  //     (that's the L4 protocol field, not L7).
+  private serviceConfig(
+    internalPort: number,
+    edgeProtocol: 'http' | 'tcp' = 'http',
+    scale: ScaleOptions = FlyProvider.SCALE_TO_ZERO
+  ) {
+    const ports =
+      edgeProtocol === 'tcp'
+        ? [{ port: internalPort, handlers: [] as string[] }]
+        : [
+            { port: 443, handlers: ['tls', 'http'] },
+            { port: 80, handlers: ['http'] },
+          ];
     return {
-      ports: [
-        { port: 443, handlers: ['tls', 'http'] },
-        { port: 80, handlers: ['http'] },
-      ],
+      ports,
       internal_port: internalPort,
       protocol: 'tcp',
       // Scale config. `stop` (vs `suspend`) fully releases the machine —
@@ -223,6 +239,7 @@ export class FlyProvider implements ComputeProvider {
     memory: number;
     envVars: Record<string, string>;
     region: string;
+    protocol?: 'http' | 'tcp';
   }): Promise<{ machineId: string }> {
     const guest = this.mapCpuTier(params.cpu, params.memory);
     const result = await this.requestJson<{ id: string }>(`/apps/${params.appId}/machines`, {
@@ -232,7 +249,7 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [this.serviceConfig(params.port)],
+          services: [this.serviceConfig(params.port, params.protocol ?? 'http')],
         },
         region: params.region,
       }),
@@ -248,6 +265,7 @@ export class FlyProvider implements ComputeProvider {
     cpu: string;
     memory: number;
     envVars: Record<string, string>;
+    protocol?: 'http' | 'tcp';
   }): Promise<void> {
     const guest = this.mapCpuTier(params.cpu, params.memory);
     await this.request(`/apps/${params.appId}/machines/${params.machineId}`, {
@@ -257,7 +275,7 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [this.serviceConfig(params.port)],
+          services: [this.serviceConfig(params.port, params.protocol ?? 'http')],
         },
       }),
     });

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -33,6 +33,12 @@ export interface CreateServiceInput {
   memory: number;
   region: string;
   envVars?: Record<string, string>;
+  /**
+   * Edge protocol — `'http'` (default) for HTTP/HTTPS edge handlers,
+   * `'tcp'` for raw TCP (Redis, Postgres wire protocol, etc.). Optional;
+   * the DB column defaults to `'http'`.
+   */
+  protocol?: 'http' | 'tcp';
 }
 
 export interface UpdateServiceInput {
@@ -53,6 +59,8 @@ export interface UpdateServiceInput {
    * GET path doesn't return env values, so the merge has to happen here).
    */
   envVarsPatch?: { set?: Record<string, string>; unset?: string[] };
+  /** Edge protocol — same semantics as CreateServiceInput.protocol. */
+  protocol?: 'http' | 'tcp';
 }
 
 /**
@@ -71,6 +79,7 @@ export interface DeletedServiceSnapshot {
   cpu: string;
   memory: number;
   region: string;
+  protocol: 'http' | 'tcp';
   flyAppId: string | null;
   flyMachineId: string | null;
   endpointUrl: string | null;
@@ -87,6 +96,11 @@ interface ServiceRow {
   cpu: string;
   memory: number;
   region: string;
+  // Backfilled to 'http' for pre-INS-271 rows by the 047 migration, NOT NULL
+  // going forward. Older self-hosters who somehow have a row without the
+  // column will see undefined here; mapRowToSchema normalizes to 'http' so the
+  // response shape's required `protocol` field never goes out as undefined.
+  protocol: 'http' | 'tcp';
   fly_app_id: string | null;
   fly_machine_id: string | null;
   status: string;
@@ -106,6 +120,11 @@ function mapRowToSchema(row: ServiceRow): ServiceSchema {
     cpu: row.cpu as ServiceSchema['cpu'],
     memory: row.memory,
     region: row.region,
+    // Defense-in-depth: the migration backfills + sets NOT NULL DEFAULT 'http',
+    // but if a downstream consumer fetches a row from a pre-migration DB the
+    // serviceSchema would reject `undefined`. Fall back to 'http' so a stale
+    // schema doesn't break the response.
+    protocol: (row.protocol ?? 'http') as ServiceSchema['protocol'],
     flyAppId: row.fly_app_id,
     flyMachineId: row.fly_machine_id,
     status: row.status as ServiceSchema['status'],
@@ -329,8 +348,8 @@ export class ComputeServicesService {
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, env_vars_encrypted, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'creating')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, env_vars_encrypted, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'creating')
          RETURNING *`,
         [
           input.projectId,
@@ -340,6 +359,7 @@ export class ComputeServicesService {
           input.cpu,
           input.memory,
           input.region,
+          input.protocol ?? 'http',
           envVarsEncrypted,
         ]
       );
@@ -376,6 +396,7 @@ export class ComputeServicesService {
         memory: input.memory,
         envVars: input.envVars ?? {},
         region: input.region,
+        protocol: input.protocol,
       });
       flyMachineId = machineId;
 
@@ -444,8 +465,8 @@ export class ComputeServicesService {
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, env_vars_encrypted, fly_app_id, endpoint_url, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'deploying')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, env_vars_encrypted, fly_app_id, endpoint_url, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'deploying')
          RETURNING *`,
         [
           input.projectId,
@@ -455,6 +476,7 @@ export class ComputeServicesService {
           input.cpu,
           input.memory,
           input.region,
+          input.protocol ?? 'http',
           envVarsEncrypted,
           flyAppName,
           endpointUrl,
@@ -580,6 +602,10 @@ export class ComputeServicesService {
       updates.push(`env_vars_encrypted = $${paramIdx++}`);
       values.push(EncryptionManager.encrypt(JSON.stringify(data.envVars)));
     }
+    if (data.protocol !== undefined) {
+      updates.push(`protocol = $${paramIdx++}`);
+      values.push(data.protocol);
+    }
 
     if (updates.length === 0) {
       return existing;
@@ -587,7 +613,9 @@ export class ComputeServicesService {
 
     // If deployment-affecting fields changed and a machine exists, update Fly FIRST.
     // Only commit to DB after Fly accepts the new config to avoid stale DB state.
-    const deployFields = ['imageUrl', 'port', 'cpu', 'memory', 'envVars'] as const;
+    // `protocol` is a deploy field — switching http<->tcp swaps the Fly edge
+    // handlers entirely, so it has to propagate to Fly to take effect.
+    const deployFields = ['imageUrl', 'port', 'cpu', 'memory', 'envVars', 'protocol'] as const;
     const hasDeployChange = deployFields.some((f) => data[f] !== undefined);
 
     // env_vars merge is needed by both Fly-touching branches (updateMachine
@@ -622,6 +650,7 @@ export class ComputeServicesService {
           cpu: data.cpu ?? existing.cpu,
           memory: data.memory ?? existing.memory,
           envVars: mergedEnvVars ?? {},
+          protocol: data.protocol ?? existing.protocol,
         });
         logger.info('Compute service machine updated', { id });
       } catch (error) {
@@ -641,6 +670,7 @@ export class ComputeServicesService {
           memory: data.memory ?? existing.memory,
           envVars: mergedEnvVars ?? {},
           region: data.region ?? existing.region,
+          protocol: data.protocol ?? existing.protocol,
         });
         justLaunchedMachineId = machineId;
         // Persist machine id + flip status alongside the field updates below.
@@ -783,6 +813,7 @@ export class ComputeServicesService {
       cpu: row.cpu,
       memory: row.memory,
       region: row.region,
+      protocol: (row.protocol ?? 'http') as 'http' | 'tcp',
       flyAppId: row.fly_app_id,
       flyMachineId: row.fly_machine_id,
       endpointUrl: row.endpoint_url,

--- a/backend/tests/unit/compute/compute-services-schemas.test.ts
+++ b/backend/tests/unit/compute/compute-services-schemas.test.ts
@@ -89,6 +89,59 @@ describe('createServiceSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // INS-271: --protocol tcp flag for raw TCP services (Redis,
+  // Postgres-wire-protocol). Without the schema accepting this field, the OSS
+  // would silently strip it before forwarding to the cloud-backend.
+  it('accepts protocol: tcp', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-redis',
+      imageUrl: 'redis:7',
+      port: 6379,
+      protocol: 'tcp',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.protocol).toBe('tcp');
+    }
+  });
+
+  it('accepts protocol: http (explicit)', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-api',
+      imageUrl: 'node:20',
+      port: 8080,
+      protocol: 'http',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.protocol).toBe('http');
+    }
+  });
+
+  it('omitting protocol is valid (back-compat default applied downstream)', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-api',
+      imageUrl: 'node:20',
+      port: 8080,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The schema itself leaves it undefined; services.service.ts is what
+      // falls back to 'http' at INSERT/Fly-call time.
+      expect(result.data.protocol).toBeUndefined();
+    }
+  });
+
+  it('rejects unknown protocol values (udp, sctp, etc.)', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-svc',
+      imageUrl: 'node:20',
+      port: 8080,
+      protocol: 'udp',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('listServicesResponseSchema', () => {
@@ -150,6 +203,19 @@ describe('updateServiceSchema', () => {
       envVars: { ALL: 'replace' },
       envVarsPatch: { set: { ONE: 'merge' } },
     });
+    expect(result.success).toBe(false);
+  });
+
+  // INS-271: protocol is updateable on existing services (rare — usually you'd
+  // delete + redeploy — but the schema must accept it so CLI's update path
+  // doesn't strip it).
+  it('accepts protocol: tcp on update', () => {
+    const result = updateServiceSchema.safeParse({ protocol: 'tcp' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid protocol on update', () => {
+    const result = updateServiceSchema.safeParse({ protocol: 'quic' });
     expect(result.success).toBe(false);
   });
 });

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -182,6 +182,65 @@ describe('FlyProvider', () => {
       expect(body.config.services[0].min_machines_running).toBe(0);
       expect(body.region).toBe('iad');
     });
+
+    // INS-271: protocol: 'tcp' switches the edge-handler shape from the
+    // HTTP-terminating 443/80 pair to a single direct-passthrough port that
+    // matches internal_port with empty L7 handlers. Without this, raw TCP
+    // services (Redis, the Postgres wire protocol, etc.) wedge behind the
+    // Fly anycast HTTP proxy.
+    it('protocol: tcp sets services[].ports to a single passthrough entry with empty handlers', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 'machine-tcp' })),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.launchMachine({
+        appId: 'my-redis',
+        image: 'redis:7',
+        port: 6379,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'iad',
+        protocol: 'tcp',
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.config.services[0].internal_port).toBe(6379);
+      // Single port = internal port, no TLS/HTTP handlers — bytes pass through.
+      expect(body.config.services[0].ports).toEqual([{ port: 6379, handlers: [] }]);
+      // Fly's services[].protocol stays 'tcp' (L4 protocol) regardless of
+      // edge mode — that's a Fly API constant, not our protocol field.
+      expect(body.config.services[0].protocol).toBe('tcp');
+    });
+
+    // Back-compat — omitting `protocol` is the same as passing 'http'. We pin
+    // both call shapes so a future refactor that flips the default doesn't
+    // silently change the wire format for existing HTTP deploys.
+    it('omitting protocol defaults to http edge handlers (443 TLS + 80 plain)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 'machine-http' })),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.launchMachine({
+        appId: 'my-api',
+        image: 'node:20',
+        port: 8080,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'iad',
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.config.services[0].ports).toEqual([
+        { port: 443, handlers: ['tls', 'http'] },
+        { port: 80, handlers: ['http'] },
+      ]);
+    });
   });
 
   describe('stopMachine', () => {

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -236,6 +236,141 @@ describe('ComputeServicesService', () => {
       expect(failedUpdateCall[1]).toContain('failed');
     });
 
+    // INS-271: end-to-end pass-through of `protocol: 'tcp'` from createService
+    // input → INSERT column list → launchMachine params. The cloud-backend +
+    // CLI work is wasted if the OSS strips this field. Pin both wire surfaces.
+    it('forwards protocol: tcp to INSERT and launchMachine when supplied', async () => {
+      const serviceId = 'svc-tcp-create';
+      const tcpInput = { ...input, protocol: 'tcp' as const, port: 6379, name: 'my-redis' };
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: tcpInput.projectId,
+            name: tcpInput.name,
+            image_url: tcpInput.imageUrl,
+            port: tcpInput.port,
+            cpu: tcpInput.cpu,
+            memory: tcpInput.memory,
+            region: tcpInput.region,
+            protocol: 'tcp',
+            fly_app_id: null,
+            fly_machine_id: null,
+            status: 'creating',
+            endpoint_url: null,
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockCreateApp.mockResolvedValue({ appId: 'my-redis-proj-123' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'mach-tcp' });
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: tcpInput.projectId,
+            name: tcpInput.name,
+            image_url: tcpInput.imageUrl,
+            port: tcpInput.port,
+            cpu: tcpInput.cpu,
+            memory: tcpInput.memory,
+            region: tcpInput.region,
+            protocol: 'tcp',
+            fly_app_id: 'my-redis-proj-123',
+            fly_machine_id: 'mach-tcp',
+            status: 'running',
+            endpoint_url: 'https://my-redis-proj-123.fly.dev',
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.createService(tcpInput);
+
+      // INSERT must include the column AND the value (positional bind, so
+      // assert the value made it into the params list rather than parsing the
+      // SQL string).
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[0]).toContain('protocol');
+      expect(insertCall[1]).toContain('tcp');
+
+      // launchMachine must receive protocol: 'tcp' so the provider can pick
+      // raw-TCP edge handlers instead of HTTP.
+      expect(mockLaunchMachine).toHaveBeenCalledWith(
+        expect.objectContaining({ protocol: 'tcp' })
+      );
+
+      // Response shape echoes the persisted value (verified via mapRowToSchema).
+      expect(result.protocol).toBe('tcp');
+    });
+
+    // Back-compat — omitting protocol must NOT inject 'http' into the
+    // launchMachine call as a positive value. Sending `protocol: undefined` is
+    // fine (JSON.stringify drops it on the wire); sending `protocol: 'http'`
+    // would change the wire format vs pre-INS-271 deploys, which we don't
+    // want until we also rev the cloud-backend's wire-format invariant.
+    it('omitting protocol does not inject a default value into launchMachine', async () => {
+      const serviceId = 'svc-no-proto';
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: input.projectId,
+            name: input.name,
+            image_url: input.imageUrl,
+            port: input.port,
+            cpu: input.cpu,
+            memory: input.memory,
+            region: input.region,
+            fly_app_id: null,
+            fly_machine_id: null,
+            status: 'creating',
+            endpoint_url: null,
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockCreateApp.mockResolvedValue({ appId: 'my-api-proj-123' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'mach-default' });
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: input.projectId,
+            name: input.name,
+            image_url: input.imageUrl,
+            port: input.port,
+            cpu: input.cpu,
+            memory: input.memory,
+            region: input.region,
+            fly_app_id: 'my-api-proj-123',
+            fly_machine_id: 'mach-default',
+            status: 'running',
+            endpoint_url: 'https://my-api-proj-123.fly.dev',
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await service.createService(input); // input has no `protocol`
+
+      // launchMachine was called; protocol param is undefined (the provider
+      // applies its own default). JSON.stringify drops undefined fields, so
+      // this preserves the pre-INS-271 wire format byte-for-byte.
+      const launchCall = mockLaunchMachine.mock.calls[0][0];
+      expect(launchCall.protocol).toBeUndefined();
+    });
+
     it('passes through structured cloud errors (quota, invalid input, etc.) instead of swallowing as generic 502', async () => {
       // Reproduces the bug found by stress-testing against staging:
       // when the cloud backend returns 403 COMPUTE_QUOTA_EXCEEDED with a clear
@@ -395,6 +530,11 @@ describe('ComputeServicesService', () => {
         cpu: 'shared-1x',
         memory: 256,
         region: 'iad',
+        // mapRowToSchema / snapshot path falls back to 'http' when the row is
+        // missing the column (pre-INS-271 rows backfilled by the 047
+        // migration). The fixture above doesn't set `protocol`, so this is
+        // the back-compat default surfacing.
+        protocol: 'http',
         flyAppId: 'app-del-proj-123',
         flyMachineId: 'machine-del',
         endpointUrl: 'https://app-del-proj-123.fly.dev',
@@ -878,6 +1018,62 @@ describe('ComputeServicesService', () => {
 
       // Final UPDATE must NOT have run — Fly call failed.
       expect(mockQuery.mock.calls.some((c) => String(c[0]).startsWith('UPDATE'))).toBe(false);
+    });
+
+    // INS-271: updateService forwards protocol through to updateMachine on
+    // the redeploy path. Switching http<->tcp swaps the Fly edge handlers
+    // entirely, so the provider has to know.
+    it('forwards protocol: tcp to updateMachine on redeploy', async () => {
+      const deployedRow = {
+        ...baseRow,
+        fly_machine_id: 'mach-existing',
+        status: 'running',
+        protocol: 'http',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] }); // getService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
+      mockUpdateMachine.mockResolvedValue(undefined);
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ...deployedRow, protocol: 'tcp' }],
+      });
+
+      await service.updateService('svc-pa-1', { protocol: 'tcp' });
+
+      expect(mockUpdateMachine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'my-api-proj-123',
+          machineId: 'mach-existing',
+          protocol: 'tcp',
+        })
+      );
+
+      // SQL UPDATE persists the new protocol value.
+      const updateCall = mockQuery.mock.calls[2];
+      expect(updateCall[0]).toContain('protocol');
+      expect(updateCall[1]).toContain('tcp');
+    });
+
+    // Back-compat — if the caller doesn't pass `protocol`, the persisted value
+    // (from `existing.protocol`) flows through. This is how a port-only update
+    // keeps the existing service's protocol setting.
+    it('preserves existing.protocol when update omits the field', async () => {
+      const deployedRow = {
+        ...baseRow,
+        fly_machine_id: 'mach-existing',
+        status: 'running',
+        protocol: 'tcp',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] }); // getService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
+      mockUpdateMachine.mockResolvedValue(undefined);
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] });
+
+      // Memory-only update — should still forward the existing tcp protocol.
+      await service.updateService('svc-pa-1', { memory: 1024 });
+
+      expect(mockUpdateMachine).toHaveBeenCalledWith(
+        expect.objectContaining({ protocol: 'tcp' })
+      );
     });
 
     it('regression: existing machine + imageUrl takes the redeploy path (updateMachine, no launch, no optimistic lock)', async () => {

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -301,9 +301,7 @@ describe('ComputeServicesService', () => {
 
       // launchMachine must receive protocol: 'tcp' so the provider can pick
       // raw-TCP edge handlers instead of HTTP.
-      expect(mockLaunchMachine).toHaveBeenCalledWith(
-        expect.objectContaining({ protocol: 'tcp' })
-      );
+      expect(mockLaunchMachine).toHaveBeenCalledWith(expect.objectContaining({ protocol: 'tcp' }));
 
       // Response shape echoes the persisted value (verified via mapRowToSchema).
       expect(result.protocol).toBe('tcp');
@@ -1071,9 +1069,7 @@ describe('ComputeServicesService', () => {
       // Memory-only update — should still forward the existing tcp protocol.
       await service.updateService('svc-pa-1', { memory: 1024 });
 
-      expect(mockUpdateMachine).toHaveBeenCalledWith(
-        expect.objectContaining({ protocol: 'tcp' })
-      );
+      expect(mockUpdateMachine).toHaveBeenCalledWith(expect.objectContaining({ protocol: 'tcp' }));
     });
 
     it('regression: existing machine + imageUrl takes the redeploy path (updateMachine, no launch, no optimistic lock)', async () => {

--- a/packages/dashboard/src/features/compute/components/ServiceCard.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceCard.tsx
@@ -90,8 +90,8 @@ export function ServiceCard({ service, onClick, onStop, onStart, onDelete }: Ser
         {service.imageUrl === 'dockerfile' ? 'Built from Dockerfile' : service.imageUrl}
       </p>
 
-      {reachableUrl && (
-        reachableUrl.href ? (
+      {reachableUrl &&
+        (reachableUrl.href ? (
           <a
             href={reachableUrl.href}
             target="_blank"
@@ -110,8 +110,7 @@ export function ServiceCard({ service, onClick, onStop, onStart, onDelete }: Ser
           >
             {reachableUrl.display}
           </code>
-        )
-      )}
+        ))}
 
       <div className="flex items-center gap-3 text-xs text-muted-foreground pt-2 border-t border-[var(--alpha-8)]">
         <span>CPU: {service.cpu}</span>

--- a/packages/dashboard/src/features/compute/components/ServiceCard.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceCard.tsx
@@ -91,16 +91,26 @@ export function ServiceCard({ service, onClick, onStop, onStart, onDelete }: Ser
       </p>
 
       {reachableUrl && (
-        <a
-          href={reachableUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          className="inline-flex items-center gap-1 text-xs text-primary hover:underline mb-3"
-        >
-          <ExternalLink className="h-3 w-3" />
-          {reachableUrl}
-        </a>
+        reachableUrl.href ? (
+          <a
+            href={reachableUrl.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center gap-1 text-xs text-primary hover:underline mb-3"
+          >
+            <ExternalLink className="h-3 w-3" />
+            {reachableUrl.display}
+          </a>
+        ) : (
+          <code
+            onClick={(e) => e.stopPropagation()}
+            className="inline-flex items-center text-xs text-foreground bg-[var(--alpha-8)] px-2 py-0.5 rounded mb-3 font-mono"
+            title="Raw TCP endpoint — connect with redis-cli, psql, or your protocol-native client"
+          >
+            {reachableUrl.display}
+          </code>
+        )
       )}
 
       <div className="flex items-center gap-3 text-xs text-muted-foreground pt-2 border-t border-[var(--alpha-8)]">

--- a/packages/dashboard/src/features/compute/constants.ts
+++ b/packages/dashboard/src/features/compute/constants.ts
@@ -30,10 +30,29 @@ export const REGIONS = [
 ] as const;
 
 /**
- * Return the service endpoint. Backend now constructs `endpointUrl` from
- * COMPUTE_DOMAIN (when set) or falls back to `.fly.dev`, so this just returns
- * what the API provided.
+ * Return the service endpoint as a display string + optional href.
+ *
+ * For HTTP services we surface the full `https://<app>.fly.dev` URL and link
+ * it (clickable, opens in browser).
+ *
+ * For TCP services the backend's `endpointUrl` is still an `https://` form
+ * (the cloud-backend hasn't been made protocol-aware), but there is no HTTPS
+ * listener on the Fly app — clicking that link gets a TLS handshake timeout.
+ * Strip the scheme and append the user's port instead. `href` is null so
+ * callers render it as plain text rather than a misleading anchor. Users
+ * connect with the protocol-native client (redis-cli, psql, etc.).
  */
-export function getReachableUrl(service: ServiceSchema): string | null {
-  return service.endpointUrl;
+export interface ServiceEndpoint {
+  display: string;
+  /** null for TCP — browsers cannot navigate to raw TCP endpoints. */
+  href: string | null;
+}
+
+export function getReachableUrl(service: ServiceSchema): ServiceEndpoint | null {
+  if (!service.endpointUrl) return null;
+  if (service.protocol === 'tcp') {
+    const host = service.endpointUrl.replace(/^https?:\/\//, '');
+    return { display: `${host}:${service.port}`, href: null };
+  }
+  return { display: service.endpointUrl, href: service.endpointUrl };
 }

--- a/packages/dashboard/src/features/compute/constants.ts
+++ b/packages/dashboard/src/features/compute/constants.ts
@@ -49,7 +49,9 @@ export interface ServiceEndpoint {
 }
 
 export function getReachableUrl(service: ServiceSchema): ServiceEndpoint | null {
-  if (!service.endpointUrl) return null;
+  if (!service.endpointUrl) {
+    return null;
+  }
   if (service.protocol === 'tcp') {
     const host = service.endpointUrl.replace(/^https?:\/\//, '');
     return { display: `${host}:${service.port}`, href: null };

--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -212,19 +212,31 @@ export default function ComputePage() {
                   </dd>
                 </div>
                 <div className="col-span-2">
-                  <dt className="text-muted-foreground mb-1">Endpoint URL</dt>
+                  <dt className="text-muted-foreground mb-1">Endpoint</dt>
                   <dd className="text-foreground">
                     {reachableUrl ? (
-                      <a
-                        href={reachableUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline"
-                      >
-                        {reachableUrl}
-                      </a>
+                      reachableUrl.href ? (
+                        <a
+                          href={reachableUrl.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {reachableUrl.display}
+                        </a>
+                      ) : (
+                        <code className="text-foreground font-mono bg-[var(--alpha-8)] px-2 py-0.5 rounded">
+                          {reachableUrl.display}
+                        </code>
+                      )
                     ) : (
                       <span className="text-muted-foreground">Not available</span>
+                    )}
+                    {reachableUrl && !reachableUrl.href && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Raw TCP service. Connect with your protocol's native client (e.g.{' '}
+                        <code className="font-mono">redis-cli -h &lt;host&gt; -p &lt;port&gt;</code>).
+                      </p>
                     )}
                   </dd>
                 </div>

--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -234,8 +234,9 @@ export default function ComputePage() {
                     )}
                     {reachableUrl && !reachableUrl.href && (
                       <p className="text-xs text-muted-foreground mt-1">
-                        Raw TCP service. Connect with your protocol's native client (e.g.{' '}
-                        <code className="font-mono">redis-cli -h &lt;host&gt; -p &lt;port&gt;</code>).
+                        Raw TCP service. Connect with the protocol&apos;s native client (e.g.{' '}
+                        <code className="font-mono">redis-cli -h &lt;host&gt; -p &lt;port&gt;</code>
+                        ).
                       </p>
                     )}
                   </dd>

--- a/packages/shared-schemas/src/compute-services-api.schema.ts
+++ b/packages/shared-schemas/src/compute-services-api.schema.ts
@@ -37,6 +37,16 @@ export const createServiceSchema = z.object({
     )
     .optional(),
   region: z.string().default('iad'),
+  /**
+   * Edge protocol. `'http'` (default) is the existing behaviour — Fly terminates
+   * TLS at its anycast edge and proxies HTTP/1.1 + HTTP/2 to the container on
+   * the container's port. `'tcp'` is for raw TCP services (Redis, the Postgres
+   * wire protocol, custom binary protocols) — Fly exposes the container's port
+   * directly with empty L7 handlers so bytes flow end-to-end without HTTP
+   * inspection. Optional and back-compat: omitting the field is identical to
+   * sending `'http'` at every fallback site downstream.
+   */
+  protocol: z.enum(['http', 'tcp']).optional(),
 });
 
 export const updateServiceSchema = z
@@ -94,6 +104,11 @@ export const updateServiceSchema = z
       })
       .optional(),
     region: z.string().optional(),
+    /**
+     * Edge protocol — same semantics as createServiceSchema.protocol. Optional
+     * on update; omitting it leaves the existing service's protocol in place.
+     */
+    protocol: z.enum(['http', 'tcp']).optional(),
   })
   .refine((data) => !(data.envVars !== undefined && data.envVarsPatch !== undefined), {
     message:

--- a/packages/shared-schemas/src/compute-services.schema.ts
+++ b/packages/shared-schemas/src/compute-services.schema.ts
@@ -30,6 +30,10 @@ export const serviceSchema = z.object({
   cpu: cpuTierEnum,
   memory: z.number(),
   region: z.string(),
+  // Required on the response shape (every persisted row has a value — the
+  // migration backfills `'http'` for pre-INS-271 rows). Defaults are only
+  // optional on the *input* schemas.
+  protocol: z.enum(['http', 'tcp']),
   flyAppId: z.string().nullable(),
   flyMachineId: z.string().nullable(),
   status: serviceStatusEnum,


### PR DESCRIPTION
Companion PR for [INS-271](https://linear.app/insforge/issue/INS-271) — adds `--protocol tcp` support for raw-TCP compute services (Redis, Postgres-protocol, custom binary protocols). The cloud-backend and CLI changes are in separate PRs; this PR threads `protocol` through the OSS layer so the CLI's flag actually reaches the cloud.

## The silent-strip bug

The OSS InsForge backend sits between the CLI and the cloud-backend (and is itself a usable backend in self-hosted mode). A deep audit of the INS-271 wire path found that the OSS strips `protocol` at three independent points because its types/schemas don't know about it:

1. **Zod schemas** (`createServiceSchema`, `updateServiceSchema`) — Zod's `safeParse` returns only the keys it knows about; unknown fields are dropped silently. Without this PR, `{ protocol: 'tcp' }` from the CLI becomes `{}` after `validation.data` in the route.
2. **Service-layer input interfaces** (`CreateServiceInput`, `UpdateServiceInput`) — even if the route forwarded the field, TypeScript would strip it from the spread `{ ...validation.data }` because the target type has no slot for it.
3. **Provider interfaces** (`LaunchMachineParams`, `UpdateMachineParams`) — the final hop to either Fly directly (self-host) or to the cloud-backend (`JSON.stringify(params)`) would discard the field at the type boundary.

Net effect: a self-hoster's `compute deploy --protocol tcp` would build a TCP image but Fly would still expose only 443/80 with HTTP-terminating handlers. A raw-TCP client (Redis, psql) would get TCP RST or hang.

## What this PR changes

Threads `protocol: 'http' | 'tcp'` (default `'http'`) through:

- `createServiceSchema` + `updateServiceSchema` (Zod, optional input)
- `serviceSchema` (response, **required** — every persisted row has a value)
- `CreateServiceInput` + `UpdateServiceInput` + `DeletedServiceSnapshot`
- `LaunchMachineParams` + `UpdateMachineParams` (provider interface)
- `createService` and `prepareForDeploy` INSERT column lists
- `updateService` SQL update list (so callers can flip http↔tcp)
- All three Fly call sites: `createService.launchMachine`, `updateService.updateMachine`, `updateService.launchMachine` (Path A first-launch)
- `FlyProvider.serviceConfig` — switches the Fly edge-handler shape:
  - `http` → 443 TLS + 80 plain (existing behaviour)
  - `tcp` → single passthrough port matching `internal_port` with empty handlers (mirrors the cloud-backend's wire format)
- `compute.services` DB column (047 migration, `NOT NULL DEFAULT 'http'`)

## Back-compat

- `protocol` is optional in inputs; omission flows through as `undefined` and `JSON.stringify` drops it on the wire, so existing HTTP deploys are byte-identical at the `launchMachine`/`updateMachine` boundary.
- `mapRowToSchema` falls back to `'http'` for rows where the column is missing entirely (defense-in-depth against a stale schema cache).
- Migration backfills existing rows to `'http'` via `DEFAULT` (PG 11+ does this in O(1)).

## Tests

10 new tests across three files:

- `compute-services-schemas.test.ts`: `createServiceSchema` accepts `tcp`, accepts `http`, accepts omission, rejects `udp`; `updateServiceSchema` accepts `tcp`, rejects `quic`.
- `services-service.test.ts`: `createService` forwards `protocol: 'tcp'` to INSERT and `launchMachine`; back-compat (omitting protocol leaves the Fly call's `protocol` undefined, not `'http'`); `updateService` forwards `protocol: 'tcp'` to `updateMachine` on redeploy; `updateService` preserves `existing.protocol` when the update omits the field.
- `fly-provider.test.ts`: `launchMachine` with `protocol: 'tcp'` emits a single passthrough port with empty handlers; omitting `protocol` keeps the 443 TLS + 80 plain default.

Full backend suite: 1192/1193 pass (one unrelated flaky `write-endpoint-limiter` test that passes when run in isolation). Lint clean across backend, shared-schemas, dashboard, and frontend.

## Companion PRs

- insforge-cloud-backend (branch `tonychang/ins-271-tcp-compute-deploy`)
- insforge CLI
- insforge-skills

Closes INS-271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end `--protocol tcp` support for raw TCP compute services so Redis/Postgres-style clients connect directly. Implements INS-271 by threading `protocol` through OSS, switching Fly to TCP passthrough, and making the dashboard render TCP endpoints as non-clickable host:port.

- **New Features**
  - API accepts `protocol: 'http' | 'tcp'` on create/update; responses now include required `protocol`.
  - Persist `protocol` on compute services (default `'http'`); updates can switch `http` ↔ `tcp`.
  - Provider forwards `protocol` to Fly; `'tcp'` uses a single passthrough port equal to `internal_port`, omission keeps HTTP edge (443/80).
  - Update path propagates `protocol` to `updateMachine`/`launchMachine`.
  - Dashboard is protocol-aware: HTTP stays a clickable URL; TCP shows `host:port` as a code block with a short hint.
  - Back-compat: omitting `protocol` defaults to HTTP; existing wire format remains unchanged.

- **Migration**
  - Run `047_compute-services-add-protocol.sql` to add the `protocol` column.
  - Idempotent: split ADD/UPDATE/DEFAULT/NOT NULL and apply a CHECK constraint via a `DO` block.
  - No breaking changes; existing rows are backfilled to `'http'`.

<sup>Written for commit 78228d9678f313c1753daf10734f9b5c9b855fad. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1376?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TCP protocol support to compute services via Fly edge configuration
> - Adds an optional `protocol` field (`'http'` | `'tcp'`) to create/update service APIs, persisted in a new `protocol` column on `compute.services` via migration [047](https://github.com/InsForge/InsForge/pull/1376/files#diff-279af461ecfabc5d411e704c18d70d07a104436100f4672380c9e96767788482) (default `'http'`, NOT NULL).
> - Updates `FlyProvider.serviceConfig` to emit a single passthrough port with no L7 handlers for TCP, versus the existing TLS/HTTP handlers on 443/80 for HTTP.
> - Dashboard renders TCP endpoints as non-clickable `host:port` code with a tooltip, and HTTP endpoints as clickable links.
> - Behavioral Change: existing services are backfilled to `'http'` by the migration; omitting `protocol` on update preserves the current value rather than resetting it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78228d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add protocol selection for compute services: HTTP (edge TLS/HTTP proxy) or TCP (raw TCP passthrough). Defaults to HTTP for compatibility.
* **Database Migration**
  * Persist protocol with backfill, default, NOT NULL enforcement, and constraint limiting values to http/tcp.
* **API Changes**
  * Accept optional protocol on create/update and include protocol in service responses.
* **UI Changes**
  * Render endpoints as clickable links for HTTP or as code/helper text for TCP.
* **Tests**
  * Add unit tests covering schema, provider, and service flows for protocol behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->