### PR TITLE
add user_count to usage response

### DIFF
--- a/backend/src/services/usage/usage.service.ts
+++ b/backend/src/services/usage/usage.service.ts
@@ -6,6 +6,7 @@ export interface UsageStats {
   mcp_usage_count: number;
   database_size_bytes: number;
   storage_size_bytes: number;
+  user_count: number;
 }
 
 export interface MCPUsageRecord {
@@ -106,10 +107,19 @@ export class UsageService {
         `SELECT COALESCE(SUM(size), 0) as total_size FROM storage.objects`
       );
 
+      // Get total user count (exclude anonymous and project admin accounts)
+      const userCountResult = await this.getPool().query(
+        `SELECT COUNT(*) as count
+         FROM auth.users
+         WHERE is_anonymous = false
+           AND is_project_admin = false`
+      );
+
       return {
         mcp_usage_count: parseInt(mcpResult.rows[0]?.count || '0'),
         database_size_bytes: parseInt(dbSizeResult.rows[0]?.size || '0'),
         storage_size_bytes: parseInt(storageResult.rows[0]?.total_size || '0'),
+        user_count: parseInt(userCountResult.rows[0]?.count || '0'),
       };
     } catch (error) {
       logger.error('Failed to get usage stats', { error });


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `user_count` to the usage stats response to support reporting and billing. Returns the total number of real users.

- **New Features**
  - Added `user_count` to `UsageStats` and service response.
  - Counts users from `auth.users` where `is_anonymous = false` and `is_project_admin = false`.

<sup>Written for commit 976fd1ac81e241a3561cc89f3524820b4e094c2d. Summary will update on new commits. <a href="https://cubic.dev/pr/InsForge/InsForge/pull/1378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Usage statistics reports now include active user count metrics, providing enhanced visibility into system usage and user engagement data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `user_count` to usage stats response
> Adds a `user_count` field to the `UsageStats` interface and its retrieval method in [usage.service.ts](https://github.com/InsForge/InsForge/pull/1378/files#diff-a64a9243b72afc22055f67d10fc1246d07b148a59bfdc8825373976b0957cef6). The count is computed via a SQL query on `auth.users`, excluding anonymous and project-admin users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 976fd1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->