### PR TITLE
feat(dashboard): drop "Add LLM feature" onboarding step

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/dtest/DashboardPromptStepper.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DashboardPromptStepper.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, CopyButton } from '@insforge/ui';
-import { Database, Sparkles, Rocket } from 'lucide-react';
+import { Database, Rocket } from 'lucide-react';
 import StepUserIcon from '#assets/icons/step_user.svg?react';
 import StepUploadIcon from '#assets/icons/step_upload.svg?react';
 import stepBgDecoration from '#assets/images/step_bg_decoration.svg';
@@ -13,7 +13,7 @@ import { useMcpUsage } from '#features/logs/hooks/useMcpUsage';
 
 // --- Prompt Stepper Data ---
 
-type StepKey = 'database' | 'auth' | 'storage' | 'ai' | 'deployment';
+type StepKey = 'database' | 'auth' | 'storage' | 'deployment';
 
 interface PromptStep {
   id: number;
@@ -57,16 +57,6 @@ const PROMPT_STEPS: PromptStep[] = [
   },
   {
     id: 4,
-    key: 'ai',
-    category: 'Model Gateway',
-    title: 'Add LLM feature',
-    prompt:
-      'Use InsForge Skills to add an AI feature to this app using the InsForge Model Gateway.\nUsers should be able to type natural language and have the AI generate a useful response automatically.',
-    icon: <Sparkles className="size-12 text-[rgb(var(--disabled))]" />,
-    navigateTo: { label: 'Go to Model Gateway', path: '/dashboard/ai/overview' },
-  },
-  {
-    id: 5,
     key: 'deployment',
     category: 'Deployment',
     title: 'Deploy your site',
@@ -316,7 +306,6 @@ export function DashboardPromptStepper() {
       database: databaseStepComplete,
       auth: (totalUsers ?? 0) >= 1,
       storage: storageStepComplete,
-      ai: false,
       deployment: !!currentDeploymentId,
     }),
     [databaseStepComplete, totalUsers, storageStepComplete, currentDeploymentId]


### PR DESCRIPTION
## Summary
- Removes the "Add LLM feature" entry from the dashboard's `DashboardPromptStepper` because its completion predicate has been dead since the cloud-side AI proxy and `/ai/usage*` endpoints were removed in favor of direct OpenRouter key handoff.
- The current predicate is hardcoded `ai: false`, so the step has been permanently unable to tick — just a stale checkbox sitting in the onboarding stepper.
- Drops the `'ai'` entry from the `StepKey` union and `liveCompletedSteps` map, removes the now-unused `Sparkles` icon import. No other consumers reference the `'ai'` key.

## Background
After the move to direct OpenRouter key handoff, `insforge-cloud-backend/src/routes/ai.routes.ts` only exposes `/ai/credentials`, `/ai/models`, and `/ai/limitations`. There is no per-request usage rollup the dashboard can read, and AI completions now happen outside InsForge entirely (the app talks to openrouter.ai directly). The educational nudge isn't worth a permanently-broken checkbox.

If we want the step back later, the right replacement signal is "project has fetched its OpenRouter credentials" (a one-time stamp set in `ai.controller.ts` `getCredentials` after a successful return). That can be reintroduced as a follow-up if product wants the AI nudge to stay in onboarding.

## Test plan
- [x] `npx turbo run typecheck` — 13/13 successful
- [x] `npx turbo run lint` — included in the run above, all green
- [x] `npx turbo run build` — `@insforge/dashboard:build` and `@insforge/ui:build` succeed
- [x] `cd packages/dashboard && npm run build` — clean, ~8s
- [x] `git grep "useAIUsageSummary\|aiUsageSummary\|'ai'.*StepKey\|insforge-ctest-step-ai-done"` returns zero matches across `packages/dashboard/src` and `packages/shared-schemas/src`
- [x] `npx turbo run test` — `insforge-backend#test` has a pre-existing failure in `tests/unit/write-endpoint-limiter.test.ts` (4 tests). Confirmed it also fails on clean `origin/main` with this diff stashed, so it is unrelated to this change.

## Notes
- Stale `insforge-ctest-step-ai-done-<projectId>` localStorage keys in existing browsers are harmless leftovers; the load loop only reads keys for steps still in `PROMPT_STEPS`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Add LLM feature” onboarding step from the dashboard stepper. This step could never complete after usage endpoints were removed, so this cleans up a stale, permanently unchecked item.

- **Refactors**
  - Deleted the step from `PROMPT_STEPS` and removed `'ai'` from `StepKey` and `liveCompletedSteps`.
  - Dropped the unused `Sparkles` icon import.
  - Leftover `insforge-ctest-step-ai-done-*` localStorage keys are ignored and harmless.

<sup>Written for commit 62590275bf34805869ed94d5847fa2f35b37cea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1381?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 'Add LLM feature' step from dashboard onboarding stepper
> Removes the AI/Model Gateway step from `DashboardPromptStepper`, leaving four steps: Database, Authentication, Storage, and Deployment. Deployment is re-sequenced to step 4, and completion tracking no longer includes an `ai` key.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6259027.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the dashboard setup workflow by removing the "Add LLM feature" step. The configuration process now focuses on four key stages: database setup, authentication, storage configuration, and deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->