### PR TITLE
Fix transfer db objects edge case

### DIFF
--- a/backend/src/infra/database/migrations/046_transfer-public-object-ownership.sql
+++ b/backend/src/infra/database/migrations/046_transfer-public-object-ownership.sql
@@ -27,6 +27,17 @@ BEGIN
       WHERE n.nspname = 'public'
         AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
         AND pg_get_userbyid(c.relowner) <> 'project_admin'
+        -- Table-owned and identity sequences inherit ownership from ALTER TABLE.
+        -- PostgreSQL rejects changing them directly while linked to a table.
+        AND NOT (
+          c.relkind = 'S'
+          AND EXISTS (
+            SELECT 1
+            FROM pg_depend d
+            WHERE d.objid = c.oid
+              AND d.deptype IN ('a', 'i')
+          )
+        )
         AND NOT EXISTS (
           SELECT 1
           FROM pg_depend d
@@ -78,9 +89,13 @@ BEGIN
         t.typname AS object_name
       FROM pg_type t
       JOIN pg_namespace n ON n.oid = t.typnamespace
+      LEFT JOIN pg_class type_class ON type_class.oid = t.typrelid
       WHERE n.nspname = 'public'
         AND t.typtype IN ('c', 'd', 'e', 'm', 'r')
         AND pg_get_userbyid(t.typowner) <> 'project_admin'
+        -- Relation row types inherit ownership from ALTER TABLE/VIEW above.
+        -- User-created composite types are backed by relkind = 'c' and are safe.
+        AND (t.typrelid = 0 OR type_class.relkind = 'c')
         AND NOT EXISTS (
           SELECT 1
           FROM pg_depend d

--- a/backend/tests/unit/transfer-public-object-ownership-migration.test.ts
+++ b/backend/tests/unit/transfer-public-object-ownership-migration.test.ts
@@ -21,23 +21,28 @@ describe('transfer public object ownership migration', () => {
       .filter((file) => file.endsWith('.sql'))
       .sort();
 
-    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(
-      migrations.indexOf('045_project-admin-public-privileges.sql')
-    );
+    const migrationIndex = migrations.indexOf(migrationFile);
+    const predecessorIndex = migrations.indexOf('045_project-admin-public-privileges.sql');
+
+    expect(predecessorIndex).not.toBe(-1);
+    expect(migrationIndex).not.toBe(-1);
+    expect(migrationIndex).toBeGreaterThan(predecessorIndex);
   });
 
   it('does not directly alter table-owned sequences', () => {
     const sql = readMigration();
 
     expect(sql).toMatch(/WHEN 'S' THEN 'SEQUENCE'/i);
-    expect(sql).toMatch(/c\.relkind\s*=\s*'S'/i);
-    expect(sql).toMatch(/d\.deptype\s+IN\s+\('a',\s*'i'\)/i);
+    expect(sql).toMatch(
+      /AND NOT\s*\(\s*c\.relkind\s*=\s*'S'\s+AND EXISTS\s*\(\s*SELECT 1\s+FROM pg_depend d\s+WHERE d\.objid = c\.oid\s+AND d\.deptype IN \('a', 'i'\)\s*\)\s*\)/
+    );
   });
 
   it('does not directly alter table row types', () => {
     const sql = readMigration();
 
     expect(sql).toMatch(/ALTER TYPE %I\.%I OWNER TO project_admin/i);
-    expect(sql).toMatch(/type_class\.relkind\s*=\s*'c'/i);
+    expect(sql).toMatch(/LEFT JOIN pg_class type_class ON type_class\.oid = t\.typrelid/);
+    expect(sql).toMatch(/AND \(t\.typrelid = 0 OR type_class\.relkind = 'c'\)/);
   });
 });

--- a/backend/tests/unit/transfer-public-object-ownership-migration.test.ts
+++ b/backend/tests/unit/transfer-public-object-ownership-migration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '046_transfer-public-object-ownership.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('transfer public object ownership migration', () => {
+  it('migration file exists and runs after project admin public privilege grants', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(
+      migrations.indexOf('045_project-admin-public-privileges.sql')
+    );
+  });
+
+  it('does not directly alter table-owned sequences', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(/WHEN 'S' THEN 'SEQUENCE'/i);
+    expect(sql).toMatch(/c\.relkind\s*=\s*'S'/i);
+    expect(sql).toMatch(/d\.deptype\s+IN\s+\('a',\s*'i'\)/i);
+  });
+
+  it('does not directly alter table row types', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(/ALTER TYPE %I\.%I OWNER TO project_admin/i);
+    expect(sql).toMatch(/type_class\.relkind\s*=\s*'c'/i);
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes migration 046 to safely transfer ownership of public objects to `project_admin`, avoiding errors on table-owned sequences and relation row types. Tightens tests to enforce ordering and verify the SQL guards.

- **Bug Fixes**
  - Skip altering table-owned/identity sequences; detect via `pg_depend.deptype IN ('a','i')`.
  - Avoid altering relation row types; only change user-created composite types (`pg_class` join with `t.typrelid = 0 OR relkind = 'c'`).
  - Tightened unit tests to enforce migration ordering and assert the SQL includes these guards.

<sup>Written for commit e536ae82aa5c1f971d6a747c95c041124bb4837e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1385?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix edge cases in transfer public object ownership migration for sequences and types
> - Updates [046_transfer-public-object-ownership.sql](https://github.com/InsForge/InsForge/pull/1385/files#diff-dff0ea1e23cd3c0b1392fef33901553beab496cf7b6a2dcdb80da13d7c25a7e8) to skip table-owned and identity sequences by filtering on `pg_depend` with `deptype IN ('a','i')`, avoiding invalid direct `ALTER` on such sequences.
> - Fixes type handling to skip relation row types by joining `pg_class` and only altering types where `typrelid = 0` or the underlying class has `relkind = 'c'` (user-created composite types).
> - Adds unit tests in [transfer-public-object-ownership-migration.test.ts](https://github.com/InsForge/InsForge/pull/1385/files#diff-64717ba2957e370c34670058d277ddbd741bb9a054f60b2a872df1ef774358e1) to verify migration ordering and assert the SQL contains the corrected sequence and type filters.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1385 opened
>
> - Refined migration ordering test to explicitly validate both migration indices before comparison [e536ae8]
> - Updated sequence exclusion SQL pattern validation to use composite regex [e536ae8]
> - Refined row type exclusion SQL pattern validation to check for LEFT JOIN and conditional logic [e536ae8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e391c27.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database ownership transfer to more safely handle sequences and composite types, reducing risk of unintended ownership changes.
* **Tests**
  * Added automated checks to validate the migration’s presence, ordering, and key safety behaviors to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->