### PR TITLE
feat(utils): parseClientType and identifier validation

### DIFF
--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
-import { ColumnType, type AuthConfigSchema } from '@insforge/shared-schemas';
+import { ColumnType, type AuthConfigSchema, ERROR_CODES } from '@insforge/shared-schemas';
+import { AppError } from '@/utils/errors.js';
 
 /**
  * Generates a user-friendly error message listing all password requirements
@@ -122,13 +123,22 @@ export function generateSecureToken(bytes: number = 32): string {
  */
 export type ClientType = 'web' | 'mobile' | 'desktop' | 'server';
 
+export const CLIENT_TYPES: readonly ClientType[] = ['web', 'mobile', 'desktop', 'server'] as const;
+
 /**
- * Parse and validate client_type query parameter
- * Returns 'web' as default if not provided or invalid
+ * Parse and validate client_type query parameter.
+ * Defaults to 'web' when not provided; throws for unknown values.
  */
 export function parseClientType(value: unknown): ClientType {
+  if (!value) {
+    return 'web';
+  }
   if (value === 'mobile' || value === 'desktop' || value === 'server') {
     return value;
   }
-  return 'web';
+  throw new AppError(
+    `Invalid client_type: "${value}". Must be one of: ${CLIENT_TYPES.join(', ')}`,
+    400,
+    ERROR_CODES.INVALID_INPUT
+  );
 }

--- a/backend/src/utils/validations.ts
+++ b/backend/src/utils/validations.ts
@@ -48,9 +48,10 @@ export function validatePassword(password: string, config: AuthConfigSchema): bo
  * - " (double quotes) - could break SQL queries
  * - \x00-\x1F (ASCII 0-31) - control characters like null, tab, newline
  * - \x7F (ASCII 127) - DEL character
+ * - \ (backslash) - could be used in escape sequences
  */
 // eslint-disable-next-line no-control-regex
-const IDENTIFIER_REGEX = /^[^"\x00-\x1F\x7F]+$/;
+const IDENTIFIER_REGEX = /^[^"\x00-\x1F\x7F\\]+$/;
 
 /**
  * Validates a PostgreSQL identifier (table name, column name, etc.)


### PR DESCRIPTION
###  Changes

  utils.ts — parseClientType now throws AppError for invalid values instead of silently defaulting to 'web':
   export function parseClientType(value: unknown): ClientType {
  +  if (!value) {
  +    return 'web';
  +  }
     if (value === 'mobile' || value === 'desktop' || value === 'server') {
       return value;
     }
  -  return 'web';
  +  throw new AppError(
  +    `Invalid client_type: "${value}". Must be one of: ${CLIENT_TYPES.join(', ')}`,
  +    400,
  +    ERROR_CODES.INVALID_INPUT
  +  );
   }

  validations.ts — Added backslash (\) to the identifier validation regex to prevent escape sequence attacks:
  -const IDENTIFIER_REGEX = /^[^"\x00-\x1F\x7F]+$/;
  +const IDENTIFIER_REGEX = /^[^"\x00-\x1F\x7F\\]+$/;


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten client_type parsing and identifier validation to prevent unsafe defaults and escape sequence issues. Invalid client_type now returns a 400 AppError; identifiers now reject backslashes.

- **Bug Fixes**
  - parseClientType: default to 'web' only when missing; throw AppError (400, ERROR_CODES.INVALID_INPUT) for unknown values; add CLIENT_TYPES.
  - validations: exclude backslash in IDENTIFIER_REGEX to block escape sequences.

- **Migration**
  - Handle AppError where parseClientType is used, or validate input before calling.
  - If clients relied on fallback to 'web' for invalid values, send a valid client_type or omit the param.

<sup>Written for commit 06575cfca9e307781ccabca148242021ac9149cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1387?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseClientType` to reject invalid non-empty values and harden identifier validation
> - `parseClientType` in [`utils.ts`](https://github.com/InsForge/InsForge/pull/1387/files#diff-c5b576a597a1297a9da313313c48636e12029be9cb78607b394b05fe42af601e) now throws an `AppError(400, INVALID_INPUT)` for non-empty values that are not one of the allowed client types (`web`, `mobile`, `desktop`, `server`); absent or falsy values still default to `'web'`.
> - A new exported `CLIENT_TYPES` constant provides the canonical list of allowed values.
> - `IDENTIFIER_REGEX` in [`validations.ts`](https://github.com/InsForge/InsForge/pull/1387/files#diff-86dbbbd12fdc504410b040b0736a5023de4acf2b68749e32e262ae410b8a850a) is updated to reject backslash characters in PostgreSQL identifiers.
> - Risk: callers that previously passed unrecognized non-empty `client_type` values (and silently received `'web'`) will now get a 400 error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06575cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client type validation to reject invalid values with descriptive error messages instead of silently defaulting to a fallback option.
  * Strengthened PostgreSQL identifier validation to reject identifiers containing backslashes in addition to other restricted characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->