### PR TITLE
feat(auth): JWT issuer/audience verification and cloud token validation

### DIFF
--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -5,11 +5,18 @@ import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES, type TokenPayloadSchema } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 
-const JWT_SECRET = process.env.JWT_SECRET ?? '';
 const ACCESS_TOKEN_EXPIRES_IN = '15m';
 const REFRESH_TOKEN_EXPIRES_IN = '7d';
 
 export type RefreshSessionType = 'user' | 'admin';
+
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    throw new Error('JWT_SECRET environment variable is required');
+  }
+  return secret;
+}
 
 /**
  * Refresh token payload interface
@@ -46,9 +53,8 @@ export class TokenManager {
   private static instance: TokenManager;
 
   private constructor() {
-    if (!process.env.JWT_SECRET) {
-      throw new Error('JWT_SECRET environment variable is required');
-    }
+    // Validate secret availability eagerly at first instantiation
+    getJwtSecret();
   }
 
   public static getInstance(): TokenManager {
@@ -62,7 +68,7 @@ export class TokenManager {
    * Generate JWT access token
    */
   generateAccessToken(payload: TokenPayloadSchema): string {
-    return jwt.sign(payload, JWT_SECRET, {
+    return jwt.sign(payload, getJwtSecret(), {
       algorithm: 'HS256',
       expiresIn: ACCESS_TOKEN_EXPIRES_IN,
     });
@@ -78,7 +84,7 @@ export class TokenManager {
       email: 'project-admin@email.com',
       role: 'project_admin',
     };
-    return jwt.sign(payload, JWT_SECRET, {
+    return jwt.sign(payload, getJwtSecret(), {
       algorithm: 'HS256',
       // No expiresIn means token never expires
     });
@@ -93,7 +99,7 @@ export class TokenManager {
     csrfNonce = this.generateCsrfNonce()
   ): string {
     const refreshPayload = this.createRefreshTokenPayload(userId, sessionType, csrfNonce);
-    return jwt.sign(refreshPayload, JWT_SECRET, {
+    return jwt.sign(refreshPayload, getJwtSecret(), {
       algorithm: 'HS256',
       expiresIn: REFRESH_TOKEN_EXPIRES_IN,
     });
@@ -106,7 +112,7 @@ export class TokenManager {
   ): RefreshTokenWithCsrf {
     const refreshPayload = this.createRefreshTokenPayload(userId, sessionType, csrfNonce);
     return {
-      refreshToken: jwt.sign(refreshPayload, JWT_SECRET, {
+      refreshToken: jwt.sign(refreshPayload, getJwtSecret(), {
         algorithm: 'HS256',
         expiresIn: REFRESH_TOKEN_EXPIRES_IN,
       }),
@@ -120,7 +126,7 @@ export class TokenManager {
    */
   verifyRefreshToken(token: string): RefreshTokenPayload {
     try {
-      const decoded = jwt.verify(token, JWT_SECRET, {
+      const decoded = jwt.verify(token, getJwtSecret(), {
         algorithms: ['HS256'],
         issuer: 'insforge',
       }) as RefreshTokenPayload;
@@ -154,7 +160,7 @@ export class TokenManager {
       email: 'anon@insforge.com',
       role: 'anon',
     };
-    return jwt.sign(payload, JWT_SECRET, {
+    return jwt.sign(payload, getJwtSecret(), {
       algorithm: 'HS256',
       // No expiresIn means token never expires
     });
@@ -165,7 +171,7 @@ export class TokenManager {
    */
   verifyToken(token: string): TokenPayloadSchema {
     try {
-      const decoded = jwt.verify(token, JWT_SECRET) as TokenPayloadSchema;
+      const decoded = jwt.verify(token, getJwtSecret()) as TokenPayloadSchema;
       return {
         sub: decoded.sub,
         email: decoded.email,
@@ -185,6 +191,8 @@ export class TokenManager {
       // JWKS handles caching internally, no need to manage it manually
       const { payload } = await jwtVerify(token, JWKS, {
         algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'],
+        issuer: `https://${cloudApiHost}`,
+        audience: 'insforge-api',
       });
 
       // Verify project_id matches if configured
@@ -225,7 +233,7 @@ export class TokenManager {
    */
   generateCsrfToken(payload: RefreshTokenPayload): string {
     return crypto
-      .createHmac('sha256', JWT_SECRET)
+      .createHmac('sha256', getJwtSecret())
       .update(`insforge:csrf:v1:${payload.sessionType}:${payload.sub}:${payload.csrfNonce}`)
       .digest('hex');
   }

--- a/backend/src/infra/socket/socket.manager.ts
+++ b/backend/src/infra/socket/socket.manager.ts
@@ -239,8 +239,16 @@ export class SocketManager {
       stack: error.stack,
     });
 
-    // DO NOT clean up metadata here - the socket might recover
-    // The 'disconnect' event will handle cleanup when/if the socket actually disconnects
+    // If the socket is no longer connected, clean up metadata immediately
+    // to prevent zombie entries from accumulating.
+    if (!socket.connected) {
+      const metadata = this.socketMetadata.get(socket.id);
+      logger.warn('Cleaning up metadata for disconnected socket after error', {
+        socketId: socket.id,
+        userId: metadata?.userId,
+      });
+      this.socketMetadata.delete(socket.id);
+    }
   }
 
   /**


### PR DESCRIPTION
### Changes

  token.manager.ts — Refactored JWT secret access:
  - Extracted getJwtSecret() helper to avoid multiple env lookups
  - Refactored generateAccessToken/generateRefreshToken/generateApiKeyToken/verifyRefreshToken to use the helper

  socket.manager.ts — Added cleanup on socket errors:
  - When a socket error occurs and the socket is no longer connected, metadata is immediately cleaned up to prevent zombie entries from
  accumulating



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds issuer and audience validation to cloud JWT verification (via `jose` JWKS) and centralizes JWT secret access with a `getJwtSecret()` helper to harden auth. Also cleans up socket metadata on error when the socket is already disconnected to prevent zombie entries.

<sup>Written for commit a2badf03ff1afa0d41c5f52999c9b8ed3d2a0ab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1389?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add JWT issuer/audience verification to cloud token validation and harden secret handling
> - `TokenManager.verifyCloudToken` now enforces `issuer` (`https://{cloudApiHost}`) and `audience` (`insforge-api`) claims; tokens missing or mismatching these values are rejected.
> - Replaces module-level `JWT_SECRET` constant with a `getJwtSecret()` helper that trims the value and throws synchronously if the secret is missing or whitespace-only.
> - Cleans up zombie socket metadata in `SocketManager.onSocketError` by removing entries for sockets that are already disconnected at error time.
> - Behavioral Change: whitespace-only `JWT_SECRET` values now cause a hard throw at call time across all token generation and verification methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2badf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed socket connection metadata cleanup to prevent stale entries during error scenarios.

* **Chores**
  * Updated JWT token management with environment-based configuration.
  * Improved cloud token validation to use configured cloud host settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->