### PR TITLE
[codex] Bump release version and Postgres image

### DIFF
--- a/backend/src/infra/database/migrations/048_project-admin-database-create-privilege.sql
+++ b/backend/src/infra/database/migrations/048_project-admin-database-create-privilege.sql
@@ -1,0 +1,12 @@
+-- Migration: 048 - Allow project_admin to create database-scoped developer objects
+--
+-- PostgreSQL uses the database-level CREATE privilege for creating schemas and
+-- publications. Grant it to project_admin so dashboard/custom migration DDL can
+-- rely on the role's native permissions instead of root-owned backdoors.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
+    EXECUTE format('GRANT CREATE ON DATABASE %I TO project_admin', current_database());
+  END IF;
+END $$;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -1,9 +1,11 @@
 import { AppError } from '@/utils/errors.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { ERROR_CODES } from '@insforge/shared-schemas';
+import type { PoolClient } from 'pg';
 import type { DatabaseRecord } from '@/types/database.js';
 import { escapeSqlLikePattern, validateTableName } from '@/utils/validations.js';
-import { assertWritableDatabaseSchema, quoteIdentifier, quoteQualifiedName } from './helpers.js';
+import { quoteIdentifier, quoteQualifiedName } from './helpers.js';
+import { withAdminContext } from './user-context.service.js';
 
 interface SortClause {
   columnName: string;
@@ -46,29 +48,35 @@ export class AdminRecordService {
     options: ListTableRecordsOptions
   ): Promise<{ records: DatabaseRecord[]; total: number }> {
     validateTableName(tableName);
-    const metadata = await this.getTableColumnMetadata(schemaName, tableName);
-    const { whereSql, params } = this.buildWhereClause(metadata, options);
-    const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-    const orderBySql = this.buildOrderByClause(metadata, options.sort);
+    const client = await this.dbManager.getPool().connect();
 
-    const countResult = await this.dbManager.getPool().query<{
-      total: string;
-    }>(`SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}${whereSql}`, params);
+    try {
+      return await withAdminContext(client, async () => {
+        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+        const { whereSql, params } = this.buildWhereClause(metadata, options);
+        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+        const orderBySql = this.buildOrderByClause(metadata, options.sort);
 
-    const dataParams = [...params, options.limit, options.offset];
-    const limitPlaceholder = `$${params.length + 1}`;
-    const offsetPlaceholder = `$${params.length + 2}`;
-    const recordsResult = await this.dbManager
-      .getPool()
-      .query<DatabaseRecord>(
-        `SELECT * FROM ${qualifiedTableName}${whereSql}${orderBySql} LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
-        dataParams
-      );
+        const countResult = await client.query<{
+          total: string;
+        }>(`SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}${whereSql}`, params);
 
-    return {
-      records: recordsResult.rows,
-      total: Number(countResult.rows[0]?.total ?? 0),
-    };
+        const dataParams = [...params, options.limit, options.offset];
+        const limitPlaceholder = `$${params.length + 1}`;
+        const offsetPlaceholder = `$${params.length + 2}`;
+        const recordsResult = await client.query<DatabaseRecord>(
+          `SELECT * FROM ${qualifiedTableName}${whereSql}${orderBySql} LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
+          dataParams
+        );
+
+        return {
+          records: recordsResult.rows,
+          total: Number(countResult.rows[0]?.total ?? 0),
+        };
+      });
+    } finally {
+      client.release();
+    }
   }
 
   async lookupRecord(
@@ -78,18 +86,24 @@ export class AdminRecordService {
     value: string
   ): Promise<DatabaseRecord | null> {
     validateTableName(tableName);
-    const metadata = await this.getTableColumnMetadata(schemaName, tableName);
-    this.assertColumnExists(metadata, columnName);
+    const client = await this.dbManager.getPool().connect();
 
-    const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-    const result = await this.dbManager
-      .getPool()
-      .query<DatabaseRecord>(
-        `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
-        [value]
-      );
+    try {
+      return await withAdminContext(client, async () => {
+        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+        this.assertColumnExists(metadata, columnName);
 
-    return result.rows[0] ?? null;
+        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+        const result = await client.query<DatabaseRecord>(
+          `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
+          [value]
+        );
+
+        return result.rows[0] ?? null;
+      });
+    } finally {
+      client.release();
+    }
   }
 
   async createRecords(
@@ -98,10 +112,7 @@ export class AdminRecordService {
     records: DatabaseRecord[]
   ): Promise<DatabaseRecord[]> {
     validateTableName(tableName);
-    assertWritableDatabaseSchema(schemaName);
 
-    const metadata = await this.getTableColumnMetadata(schemaName, tableName);
-    const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
     const client = await this.dbManager.getPool().connect();
     const createdRecords: DatabaseRecord[] = [];
     let transactionStarted = false;
@@ -110,28 +121,37 @@ export class AdminRecordService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      for (const record of records) {
-        const sanitizedRecord = this.sanitizeInsertRecord(record, metadata);
-        const entries = Object.entries(sanitizedRecord);
+      await withAdminContext(
+        client,
+        async () => {
+          const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+          const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
 
-        if (entries.length === 0) {
-          const result = await client.query<DatabaseRecord>(
-            `INSERT INTO ${qualifiedTableName} DEFAULT VALUES RETURNING *`
-          );
-          createdRecords.push(...result.rows);
-          continue;
-        }
+          for (const record of records) {
+            const sanitizedRecord = this.sanitizeInsertRecord(record, metadata);
+            const entries = Object.entries(sanitizedRecord);
 
-        const columns = entries.map(([columnName]) => quoteIdentifier(columnName));
-        const placeholders = entries.map((_, index) => `$${index + 1}`);
-        const values = entries.map(([, value]) => value);
+            if (entries.length === 0) {
+              const result = await client.query<DatabaseRecord>(
+                `INSERT INTO ${qualifiedTableName} DEFAULT VALUES RETURNING *`
+              );
+              createdRecords.push(...result.rows);
+              continue;
+            }
 
-        const result = await client.query<DatabaseRecord>(
-          `INSERT INTO ${qualifiedTableName} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`,
-          values
-        );
-        createdRecords.push(...result.rows);
-      }
+            const columns = entries.map(([columnName]) => quoteIdentifier(columnName));
+            const placeholders = entries.map((_, index) => `$${index + 1}`);
+            const values = entries.map(([, value]) => value);
+
+            const result = await client.query<DatabaseRecord>(
+              `INSERT INTO ${qualifiedTableName} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`,
+              values
+            );
+            createdRecords.push(...result.rows);
+          }
+        },
+        true
+      );
 
       await client.query('COMMIT');
       transactionStarted = false;
@@ -155,48 +175,53 @@ export class AdminRecordService {
     data: DatabaseRecord
   ): Promise<DatabaseRecord> {
     validateTableName(tableName);
-    assertWritableDatabaseSchema(schemaName);
 
-    const metadata = await this.getTableColumnMetadata(schemaName, tableName);
-    this.assertColumnExists(metadata, pkColumn);
+    const client = await this.dbManager.getPool().connect();
 
-    const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
-    const entries = Object.entries(sanitizedRecord);
+    try {
+      return await withAdminContext(client, async () => {
+        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+        this.assertColumnExists(metadata, pkColumn);
 
-    if (entries.length === 0) {
-      throw new AppError(
-        'No valid fields to update.',
-        400,
-        ERROR_CODES.INVALID_INPUT,
-        'Provide at least one editable field with a non-empty value.'
-      );
+        const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
+        const entries = Object.entries(sanitizedRecord);
+
+        if (entries.length === 0) {
+          throw new AppError(
+            'No valid fields to update.',
+            400,
+            ERROR_CODES.INVALID_INPUT,
+            'Provide at least one editable field with a non-empty value.'
+          );
+        }
+
+        const assignments = entries.map(
+          ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
+        );
+        const values = entries.map(([, value]) => value);
+        values.push(pkValue);
+
+        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+        const result = await client.query<DatabaseRecord>(
+          `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
+          values
+        );
+
+        const updatedRecord = result.rows[0];
+        if (!updatedRecord) {
+          throw new AppError(
+            'Record not found.',
+            404,
+            ERROR_CODES.DATABASE_NOT_FOUND,
+            'Check the record identifier and try again.'
+          );
+        }
+
+        return updatedRecord;
+      });
+    } finally {
+      client.release();
     }
-
-    const assignments = entries.map(
-      ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
-    );
-    const values = entries.map(([, value]) => value);
-    values.push(pkValue);
-
-    const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-    const result = await this.dbManager
-      .getPool()
-      .query<DatabaseRecord>(
-        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
-        values
-      );
-
-    const updatedRecord = result.rows[0];
-    if (!updatedRecord) {
-      throw new AppError(
-        'Record not found.',
-        404,
-        ERROR_CODES.DATABASE_NOT_FOUND,
-        'Check the record identifier and try again.'
-      );
-    }
-
-    return updatedRecord;
   }
 
   async deleteRecords(
@@ -206,32 +231,39 @@ export class AdminRecordService {
     pkValues: string[]
   ): Promise<number> {
     validateTableName(tableName);
-    assertWritableDatabaseSchema(schemaName);
 
-    const metadata = await this.getTableColumnMetadata(schemaName, tableName);
-    this.assertColumnExists(metadata, pkColumn);
+    const client = await this.dbManager.getPool().connect();
 
-    if (pkValues.length === 0) {
-      return 0;
+    try {
+      return await withAdminContext(client, async () => {
+        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+        this.assertColumnExists(metadata, pkColumn);
+
+        if (pkValues.length === 0) {
+          return 0;
+        }
+
+        const placeholders = pkValues.map((_, index) => `$${index + 1}`);
+        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+        const result = await client.query(
+          `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
+          pkValues
+        );
+
+        return result.rowCount ?? 0;
+      });
+    } finally {
+      client.release();
     }
-
-    const placeholders = pkValues.map((_, index) => `$${index + 1}`);
-    const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-    const result = await this.dbManager
-      .getPool()
-      .query(
-        `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
-        pkValues
-      );
-
-    return result.rowCount ?? 0;
   }
 
   private async getTableColumnMetadata(
     schemaName: string,
-    tableName: string
+    tableName: string,
+    client?: PoolClient
   ): Promise<TableColumnMetadata> {
-    const result = await this.dbManager.getPool().query<{
+    const queryable = client ?? this.dbManager.getPool();
+    const result = await queryable.query<{
       column_name: string;
       data_type: string;
       is_nullable: string;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -48,35 +48,30 @@ export class AdminRecordService {
     options: ListTableRecordsOptions
   ): Promise<{ records: DatabaseRecord[]; total: number }> {
     validateTableName(tableName);
-    const client = await this.dbManager.getPool().connect();
 
-    try {
-      return await withAdminContext(client, async () => {
-        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-        const { whereSql, params } = this.buildWhereClause(metadata, options);
-        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-        const orderBySql = this.buildOrderByClause(metadata, options.sort);
+    return this.withAdminTransaction(async (client) => {
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const { whereSql, params } = this.buildWhereClause(metadata, options);
+      const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const orderBySql = this.buildOrderByClause(metadata, options.sort);
 
-        const countResult = await client.query<{
-          total: string;
-        }>(`SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}${whereSql}`, params);
+      const countResult = await client.query<{
+        total: string;
+      }>(`SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}${whereSql}`, params);
 
-        const dataParams = [...params, options.limit, options.offset];
-        const limitPlaceholder = `$${params.length + 1}`;
-        const offsetPlaceholder = `$${params.length + 2}`;
-        const recordsResult = await client.query<DatabaseRecord>(
-          `SELECT * FROM ${qualifiedTableName}${whereSql}${orderBySql} LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
-          dataParams
-        );
+      const dataParams = [...params, options.limit, options.offset];
+      const limitPlaceholder = `$${params.length + 1}`;
+      const offsetPlaceholder = `$${params.length + 2}`;
+      const recordsResult = await client.query<DatabaseRecord>(
+        `SELECT * FROM ${qualifiedTableName}${whereSql}${orderBySql} LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
+        dataParams
+      );
 
-        return {
-          records: recordsResult.rows,
-          total: Number(countResult.rows[0]?.total ?? 0),
-        };
-      });
-    } finally {
-      client.release();
-    }
+      return {
+        records: recordsResult.rows,
+        total: Number(countResult.rows[0]?.total ?? 0),
+      };
+    });
   }
 
   async lookupRecord(
@@ -86,24 +81,19 @@ export class AdminRecordService {
     value: string
   ): Promise<DatabaseRecord | null> {
     validateTableName(tableName);
-    const client = await this.dbManager.getPool().connect();
 
-    try {
-      return await withAdminContext(client, async () => {
-        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-        this.assertColumnExists(metadata, columnName);
+    return this.withAdminTransaction(async (client) => {
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      this.assertColumnExists(metadata, columnName);
 
-        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-        const result = await client.query<DatabaseRecord>(
-          `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
-          [value]
-        );
+      const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const result = await client.query<DatabaseRecord>(
+        `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
+        [value]
+      );
 
-        return result.rows[0] ?? null;
-      });
-    } finally {
-      client.release();
-    }
+      return result.rows[0] ?? null;
+    });
   }
 
   async createRecords(
@@ -113,58 +103,36 @@ export class AdminRecordService {
   ): Promise<DatabaseRecord[]> {
     validateTableName(tableName);
 
-    const client = await this.dbManager.getPool().connect();
-    const createdRecords: DatabaseRecord[] = [];
-    let transactionStarted = false;
+    return this.withAdminTransaction(async (client) => {
+      const createdRecords: DatabaseRecord[] = [];
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
 
-    try {
-      await client.query('BEGIN');
-      transactionStarted = true;
+      for (const record of records) {
+        const sanitizedRecord = this.sanitizeInsertRecord(record, metadata);
+        const entries = Object.entries(sanitizedRecord);
 
-      await withAdminContext(
-        client,
-        async () => {
-          const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-          const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+        if (entries.length === 0) {
+          const result = await client.query<DatabaseRecord>(
+            `INSERT INTO ${qualifiedTableName} DEFAULT VALUES RETURNING *`
+          );
+          createdRecords.push(...result.rows);
+          continue;
+        }
 
-          for (const record of records) {
-            const sanitizedRecord = this.sanitizeInsertRecord(record, metadata);
-            const entries = Object.entries(sanitizedRecord);
+        const columns = entries.map(([columnName]) => quoteIdentifier(columnName));
+        const placeholders = entries.map((_, index) => `$${index + 1}`);
+        const values = entries.map(([, value]) => value);
 
-            if (entries.length === 0) {
-              const result = await client.query<DatabaseRecord>(
-                `INSERT INTO ${qualifiedTableName} DEFAULT VALUES RETURNING *`
-              );
-              createdRecords.push(...result.rows);
-              continue;
-            }
-
-            const columns = entries.map(([columnName]) => quoteIdentifier(columnName));
-            const placeholders = entries.map((_, index) => `$${index + 1}`);
-            const values = entries.map(([, value]) => value);
-
-            const result = await client.query<DatabaseRecord>(
-              `INSERT INTO ${qualifiedTableName} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`,
-              values
-            );
-            createdRecords.push(...result.rows);
-          }
-        },
-        true
-      );
-
-      await client.query('COMMIT');
-      transactionStarted = false;
+        const result = await client.query<DatabaseRecord>(
+          `INSERT INTO ${qualifiedTableName} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) RETURNING *`,
+          values
+        );
+        createdRecords.push(...result.rows);
+      }
 
       return createdRecords;
-    } catch (error) {
-      if (transactionStarted) {
-        await client.query('ROLLBACK');
-      }
-      throw error;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async updateRecord(
@@ -176,52 +144,46 @@ export class AdminRecordService {
   ): Promise<DatabaseRecord> {
     validateTableName(tableName);
 
-    const client = await this.dbManager.getPool().connect();
+    return this.withAdminTransaction(async (client) => {
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      this.assertColumnExists(metadata, pkColumn);
 
-    try {
-      return await withAdminContext(client, async () => {
-        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-        this.assertColumnExists(metadata, pkColumn);
+      const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
+      const entries = Object.entries(sanitizedRecord);
 
-        const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
-        const entries = Object.entries(sanitizedRecord);
-
-        if (entries.length === 0) {
-          throw new AppError(
-            'No valid fields to update.',
-            400,
-            ERROR_CODES.INVALID_INPUT,
-            'Provide at least one editable field with a non-empty value.'
-          );
-        }
-
-        const assignments = entries.map(
-          ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
+      if (entries.length === 0) {
+        throw new AppError(
+          'No valid fields to update.',
+          400,
+          ERROR_CODES.INVALID_INPUT,
+          'Provide at least one editable field with a non-empty value.'
         );
-        const values = entries.map(([, value]) => value);
-        values.push(pkValue);
+      }
 
-        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-        const result = await client.query<DatabaseRecord>(
-          `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
-          values
+      const assignments = entries.map(
+        ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
+      );
+      const values = entries.map(([, value]) => value);
+      values.push(pkValue);
+
+      const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const result = await client.query<DatabaseRecord>(
+        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
+        values
+      );
+
+      const updatedRecord = result.rows[0];
+      if (!updatedRecord) {
+        throw new AppError(
+          'Record not found.',
+          404,
+          ERROR_CODES.DATABASE_NOT_FOUND,
+          'Check the record identifier and try again.'
         );
+      }
 
-        const updatedRecord = result.rows[0];
-        if (!updatedRecord) {
-          throw new AppError(
-            'Record not found.',
-            404,
-            ERROR_CODES.DATABASE_NOT_FOUND,
-            'Check the record identifier and try again.'
-          );
-        }
-
-        return updatedRecord;
-      });
-    } finally {
-      client.release();
-    }
+      return updatedRecord;
+    });
   }
 
   async deleteRecords(
@@ -232,28 +194,58 @@ export class AdminRecordService {
   ): Promise<number> {
     validateTableName(tableName);
 
+    return this.withAdminTransaction(async (client) => {
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      this.assertColumnExists(metadata, pkColumn);
+
+      if (pkValues.length === 0) {
+        return 0;
+      }
+
+      const placeholders = pkValues.map((_, index) => `$${index + 1}`);
+      const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const result = await client.query(
+        `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
+        pkValues
+      );
+
+      return result.rowCount ?? 0;
+    });
+  }
+
+  private async withAdminTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
     const client = await this.dbManager.getPool().connect();
+    let transactionStarted = false;
+    let releaseError: Error | undefined;
 
     try {
-      return await withAdminContext(client, async () => {
-        const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-        this.assertColumnExists(metadata, pkColumn);
+      await client.query('BEGIN');
+      transactionStarted = true;
 
-        if (pkValues.length === 0) {
-          return 0;
+      const result = await withAdminContext(
+        client,
+        () => fn(client),
+        true,
+        (error) => {
+          releaseError = error;
         }
+      );
 
-        const placeholders = pkValues.map((_, index) => `$${index + 1}`);
-        const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-        const result = await client.query(
-          `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
-          pkValues
-        );
-
-        return result.rowCount ?? 0;
-      });
+      await client.query('COMMIT');
+      transactionStarted = false;
+      return result;
+    } catch (error) {
+      if (transactionStarted) {
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          releaseError =
+            rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError));
+        }
+      }
+      throw error;
     } finally {
-      client.release();
+      client.release(releaseError);
     }
   }
 

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -14,7 +14,6 @@ import { validateSchemaName, validateTableName } from '@/utils/validations.js';
 import pgFormat from 'pg-format';
 import { parse } from 'csv-parse/sync';
 import { type PoolClient } from 'pg';
-import { assertWritableDatabaseSchema } from './helpers.js';
 import { withAdminContext } from './user-context.service.js';
 
 export class DatabaseAdvanceService {
@@ -851,7 +850,6 @@ export class DatabaseAdvanceService {
   ): Promise<BulkUpsertResponse> {
     validateSchemaName(schemaName);
     validateTableName(table);
-    assertWritableDatabaseSchema(schemaName);
 
     const fileExtension = filename.toLowerCase().substring(filename.lastIndexOf('.'));
     let records: Record<string, unknown>[] = [];

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -24,11 +24,11 @@ import {
 import { validateIdentifier, validateSchemaName } from '@/utils/validations.js';
 import { convertSqlTypeToColumnType } from '@/utils/utils.js';
 import {
-  assertWritableDatabaseSchema,
   DEFAULT_DATABASE_SCHEMA,
   quoteQualifiedName,
   splitQualifiedTableReference,
 } from './helpers.js';
+import { withAdminContext } from './user-context.service.js';
 
 const reservedColumns = {
   id: ColumnType.UUID,
@@ -149,7 +149,6 @@ export class DatabaseTableService {
     use_RLS = true
   ): Promise<CreateTableResponse> {
     validateSchemaName(schemaName);
-    assertWritableDatabaseSchema(schemaName);
     // Validate table name
     validateIdentifier(table_name, 'table');
 
@@ -189,108 +188,110 @@ export class DatabaseTableService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      const safeQualifiedTableName = quoteQualifiedName(schemaName, table_name);
+      const response = await withAdminContext(client, async () => {
+        const safeQualifiedTableName = quoteQualifiedName(schemaName, table_name);
 
-      // Check if table exists
-      const tableExistsResult = await client.query(
-        `
-          SELECT EXISTS (
-            SELECT FROM information_schema.tables
-            WHERE table_schema = $1
-            AND table_name = $2
-          ) as exists
-        `,
-        [schemaName, table_name]
-      );
-
-      if (tableExistsResult.rows[0]?.exists) {
-        throw new AppError(
-          `table ${table_name} already exists`,
-          400,
-          ERROR_CODES.DATABASE_DUPLICATE,
-          `table ${table_name} already exists. Please check the table name, it must be a unique table name.`
+        // Check if table exists
+        const tableExistsResult = await client.query(
+          `
+            SELECT EXISTS (
+              SELECT FROM information_schema.tables
+              WHERE table_schema = $1
+              AND table_name = $2
+            ) as exists
+          `,
+          [schemaName, table_name]
         );
-      }
 
-      // Map columns to SQL with proper type conversion
-      const columnDefs = validatedColumns
-        .map((col: ColumnSchema) => {
-          const fieldType = COLUMN_TYPES[col.type as ColumnType];
-          const sqlType = fieldType.sqlType;
-
-          // Handle default values
-          const defaultClause = formatDefaultValue(
-            col.defaultValue,
-            col.type as ColumnType,
-            col.isNullable
+        if (tableExistsResult.rows[0]?.exists) {
+          throw new AppError(
+            `table ${table_name} already exists`,
+            400,
+            ERROR_CODES.DATABASE_DUPLICATE,
+            `table ${table_name} already exists. Please check the table name, it must be a unique table name.`
           );
+        }
 
-          const nullable = col.isNullable ? '' : 'NOT NULL';
-          const unique = col.isUnique ? 'UNIQUE' : '';
+        // Map columns to SQL with proper type conversion
+        const columnDefs = validatedColumns
+          .map((col: ColumnSchema) => {
+            const fieldType = COLUMN_TYPES[col.type as ColumnType];
+            const sqlType = fieldType.sqlType;
 
-          return `${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}`.trim();
-        })
-        .join(', ');
+            // Handle default values
+            const defaultClause = formatDefaultValue(
+              col.defaultValue,
+              col.type as ColumnType,
+              col.isNullable
+            );
 
-      // Prepare foreign key constraints
-      const foreignKeyConstraints = validatedColumns
-        .filter((col) => col.foreignKey)
-        .map((col) => this.generateFkeyConstraintStatement(col, schemaName, true))
-        .join(', ');
+            const nullable = col.isNullable ? '' : 'NOT NULL';
+            const unique = col.isUnique ? 'UNIQUE' : '';
 
-      // Create table with auto fields and foreign keys
-      const tableDefinition = [
-        'id UUID PRIMARY KEY DEFAULT gen_random_uuid()',
-        columnDefs,
-        'created_at TIMESTAMPTZ DEFAULT now()',
-        'updated_at TIMESTAMPTZ DEFAULT now()',
-        foreignKeyConstraints,
-      ]
-        .filter(Boolean)
-        .join(', ');
+            return `${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}`.trim();
+          })
+          .join(', ');
 
-      await client.query(
-        `
-          CREATE TABLE ${safeQualifiedTableName} (
-            ${tableDefinition}
-          );
-          NOTIFY pgrst, 'reload schema';
-        `
-      );
+        // Prepare foreign key constraints
+        const foreignKeyConstraints = validatedColumns
+          .filter((col) => col.foreignKey)
+          .map((col) => this.generateFkeyConstraintStatement(col, schemaName, true))
+          .join(', ');
 
-      if (use_RLS) {
-        // Enable RLS policies
+        // Create table with auto fields and foreign keys
+        const tableDefinition = [
+          'id UUID PRIMARY KEY DEFAULT gen_random_uuid()',
+          columnDefs,
+          'created_at TIMESTAMPTZ DEFAULT now()',
+          'updated_at TIMESTAMPTZ DEFAULT now()',
+          foreignKeyConstraints,
+        ]
+          .filter(Boolean)
+          .join(', ');
+
         await client.query(
           `
-            ALTER TABLE ${safeQualifiedTableName} ENABLE ROW LEVEL SECURITY;
+            CREATE TABLE ${safeQualifiedTableName} (
+              ${tableDefinition}
+            );
+            NOTIFY pgrst, 'reload schema';
           `
         );
-      }
 
-      // Create trigger for updated_at
-      await client.query(
-        `
-          CREATE TRIGGER ${this.quoteIdentifier(table_name + '_update_timestamp')}
-          BEFORE UPDATE ON ${safeQualifiedTableName}
-          FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
-        `
-      );
+        if (use_RLS) {
+          // Enable RLS policies
+          await client.query(
+            `
+              ALTER TABLE ${safeQualifiedTableName} ENABLE ROW LEVEL SECURITY;
+            `
+          );
+        }
 
-      // Update metadata
-      // Metadata is now updated on-demand
+        // Create trigger for updated_at
+        await client.query(
+          `
+            CREATE TRIGGER ${this.quoteIdentifier(table_name + '_update_timestamp')}
+            BEFORE UPDATE ON ${safeQualifiedTableName}
+            FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
+          `
+        );
 
-      const response = {
-        schemaName,
-        message: 'table created successfully',
-        tableName: table_name,
-        columns: validatedColumns.map((col) => ({
-          ...col,
-          sqlType: COLUMN_TYPES[col.type as ColumnType].sqlType,
-        })),
-        autoFields: ['id', 'created_at', 'updated_at'],
-        nextActions:
-          'you can now use the table with the POST /api/database/tables/{table} endpoint',
-      };
+        // Update metadata
+        // Metadata is now updated on-demand
+
+        return {
+          schemaName,
+          message: 'table created successfully',
+          tableName: table_name,
+          columns: validatedColumns.map((col) => ({
+            ...col,
+            sqlType: COLUMN_TYPES[col.type as ColumnType].sqlType,
+          })),
+          autoFields: ['id', 'created_at', 'updated_at'],
+          nextActions:
+            'you can now use the table with the POST /api/database/tables/{table} endpoint',
+        };
+      }, true);
 
       await client.query('COMMIT');
       transactionStarted = false;
@@ -450,7 +451,6 @@ export class DatabaseTableService {
     operations: UpdateTableSchemaRequest
   ): Promise<UpdateTableSchemaResponse> {
     validateSchemaName(schemaName);
-    assertWritableDatabaseSchema(schemaName);
     const { addColumns, dropColumns, updateColumns, addForeignKeys, dropForeignKeys, renameTable } =
       operations;
 
@@ -460,226 +460,228 @@ export class DatabaseTableService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      const safeQualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const response = await withAdminContext(client, async () => {
+        const safeQualifiedTableName = quoteQualifiedName(schemaName, tableName);
 
-      // Check if table exists
-      const tableExistsResult = await client.query(
-        `
-          SELECT EXISTS (
-            SELECT FROM information_schema.tables
-            WHERE table_schema = $1
-            AND table_name = $2
-          ) as exists
-        `,
-        [schemaName, tableName]
-      );
-
-      if (!tableExistsResult.rows[0]?.exists) {
-        throw new AppError(
-          'table not found',
-          404,
-          ERROR_CODES.DATABASE_NOT_FOUND,
-          'Please check the table name, it must be a valid table name, or you can create a new table with the POST /api/database/tables endpoint'
+        // Check if table exists
+        const tableExistsResult = await client.query(
+          `
+            SELECT EXISTS (
+              SELECT FROM information_schema.tables
+              WHERE table_schema = $1
+              AND table_name = $2
+            ) as exists
+          `,
+          [schemaName, tableName]
         );
-      }
-      const currentSchema = await this.getTableSchema(schemaName, tableName);
-      const currentUserColumns = currentSchema.columns.filter(
-        (col) => !Object.keys(reservedColumns).includes(col.columnName)
-      );
 
-      // Filter dropped and added user columns
-      const droppedUserColumns = dropColumns
-        ? dropColumns.filter((col) => !Object.keys(reservedColumns).includes(col))
-        : [];
-      const addedUserColumns = addColumns ? this.validateReservedFields(addColumns) : [];
-
-      // Calculate final user column count
-      const finalUserColumnsCount =
-        currentUserColumns.length - droppedUserColumns.length + addedUserColumns.length;
-
-      if (finalUserColumnsCount <= 0) {
-        throw new AppError(
-          'Table must have at least one user-defined column after update',
-          400,
-          ERROR_CODES.DATABASE_VALIDATION_ERROR,
-          'The update would leave the table with no custom columns. Please add columns or avoid dropping all user-defined columns.'
+        if (!tableExistsResult.rows[0]?.exists) {
+          throw new AppError(
+            'table not found',
+            404,
+            ERROR_CODES.DATABASE_NOT_FOUND,
+            'Please check the table name, it must be a valid table name, or you can create a new table with the POST /api/database/tables endpoint'
+          );
+        }
+        const currentSchema = await this.getTableSchema(schemaName, tableName);
+        const currentUserColumns = currentSchema.columns.filter(
+          (col) => !Object.keys(reservedColumns).includes(col.columnName)
         );
-      }
 
-      const foreignKeyMap = await this.getFkeyConstraints(schemaName, tableName);
-      const completedOperations: string[] = [];
+        // Filter dropped and added user columns
+        const droppedUserColumns = dropColumns
+          ? dropColumns.filter((col) => !Object.keys(reservedColumns).includes(col))
+          : [];
+        const addedUserColumns = addColumns ? this.validateReservedFields(addColumns) : [];
 
-      // Execute operations
+        // Calculate final user column count
+        const finalUserColumnsCount =
+          currentUserColumns.length - droppedUserColumns.length + addedUserColumns.length;
 
-      // Drop foreign key constraints
-      if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
-        for (const col of dropForeignKeys) {
-          const constraintName = foreignKeyMap.get(col)?.constraint_name;
-          if (constraintName) {
+        if (finalUserColumnsCount <= 0) {
+          throw new AppError(
+            'Table must have at least one user-defined column after update',
+            400,
+            ERROR_CODES.DATABASE_VALIDATION_ERROR,
+            'The update would leave the table with no custom columns. Please add columns or avoid dropping all user-defined columns.'
+          );
+        }
+
+        const foreignKeyMap = await this.getFkeyConstraints(schemaName, tableName);
+        const completedOperations: string[] = [];
+
+        // Execute operations
+
+        // Drop foreign key constraints
+        if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
+          for (const col of dropForeignKeys) {
+            const constraintName = foreignKeyMap.get(col)?.constraint_name;
+            if (constraintName) {
+              await client.query(
+                `
+                  ALTER TABLE ${safeQualifiedTableName}
+                  DROP CONSTRAINT ${this.quoteIdentifier(constraintName)}
+                `
+              );
+
+              completedOperations.push(`Dropped foreign key constraint on column: ${col}`);
+            }
+          }
+        }
+
+        // Drop columns first (to avoid conflicts with renames)
+        if (dropColumns && Array.isArray(dropColumns)) {
+          for (const col of dropColumns) {
+            if (Object.keys(reservedColumns).includes(col)) {
+              throw new AppError(
+                'cannot drop system columns',
+                404,
+                ERROR_CODES.DATABASE_FORBIDDEN,
+                `You cannot drop the system column '${col}'`
+              );
+            }
             await client.query(
               `
                 ALTER TABLE ${safeQualifiedTableName}
-                DROP CONSTRAINT ${this.quoteIdentifier(constraintName)}
+                DROP COLUMN ${this.quoteIdentifier(col)}
               `
             );
 
-            completedOperations.push(`Dropped foreign key constraint on column: ${col}`);
+            completedOperations.push(`Dropped column: ${col}`);
           }
         }
-      }
 
-      // Drop columns first (to avoid conflicts with renames)
-      if (dropColumns && Array.isArray(dropColumns)) {
-        for (const col of dropColumns) {
-          if (Object.keys(reservedColumns).includes(col)) {
-            throw new AppError(
-              'cannot drop system columns',
-              404,
-              ERROR_CODES.DATABASE_FORBIDDEN,
-              `You cannot drop the system column '${col}'`
-            );
-          }
-          await client.query(
-            `
-              ALTER TABLE ${safeQualifiedTableName}
-              DROP COLUMN ${this.quoteIdentifier(col)}
-            `
-          );
-
-          completedOperations.push(`Dropped column: ${col}`);
-        }
-      }
-
-      // Update columns
-      if (updateColumns && Array.isArray(updateColumns)) {
-        for (const column of updateColumns) {
-          if (Object.keys(reservedColumns).includes(column.columnName)) {
-            throw new AppError(
-              'cannot update system columns',
-              404,
-              ERROR_CODES.DATABASE_FORBIDDEN,
-              `You cannot update the system column '${column.columnName}'`
-            );
-          }
-
-          // Handle default value changes
-          if (column.defaultValue !== undefined) {
-            if (column.defaultValue === '') {
-              // Drop default
-              await client.query(
-                `
-                ALTER TABLE ${safeQualifiedTableName}
-                ALTER COLUMN ${this.quoteIdentifier(column.columnName)} DROP DEFAULT
-              `
+        // Update columns
+        if (updateColumns && Array.isArray(updateColumns)) {
+          for (const column of updateColumns) {
+            if (Object.keys(reservedColumns).includes(column.columnName)) {
+              throw new AppError(
+                'cannot update system columns',
+                404,
+                ERROR_CODES.DATABASE_FORBIDDEN,
+                `You cannot update the system column '${column.columnName}'`
               );
-            } else {
-              // Set default
+            }
+
+            // Handle default value changes
+            if (column.defaultValue !== undefined) {
+              if (column.defaultValue === '') {
+                // Drop default
+                await client.query(
+                  `
+                  ALTER TABLE ${safeQualifiedTableName}
+                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} DROP DEFAULT
+                `
+                );
+              } else {
+                // Set default
+                await client.query(
+                  `
+                  ALTER TABLE ${safeQualifiedTableName}
+                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} SET ${formatDefaultValue(column.defaultValue)}
+                `
+                );
+              }
+            }
+
+            // Handle column rename - do this last to avoid issues with other operations
+            if (column.newColumnName) {
               await client.query(
                 `
                 ALTER TABLE ${safeQualifiedTableName}
-                ALTER COLUMN ${this.quoteIdentifier(column.columnName)} SET ${formatDefaultValue(column.defaultValue)}
+                RENAME COLUMN ${this.quoteIdentifier(column.columnName)} TO ${this.quoteIdentifier(column.newColumnName as string)}
               `
               );
             }
+            completedOperations.push(`Updated column: ${column.columnName}`);
           }
+        }
 
-          // Handle column rename - do this last to avoid issues with other operations
-          if (column.newColumnName) {
+        // Add new columns
+        if (addColumns && Array.isArray(addColumns)) {
+          // Validate and filter reserved fields
+          const columnsToAdd = this.validateReservedFields(addColumns);
+
+          for (const col of columnsToAdd) {
+            const fieldType = COLUMN_TYPES[col.type as ColumnType];
+            let sqlType = fieldType.sqlType;
+            if (col.type === ColumnType.UUID) {
+              sqlType = 'UUID';
+            }
+
+            const nullable = col.isNullable !== false ? '' : 'NOT NULL';
+            const unique = col.isUnique ? 'UNIQUE' : '';
+            const defaultClause = formatDefaultValue(
+              col.defaultValue,
+              col.type as ColumnType,
+              col.isNullable
+            );
+
             await client.query(
               `
-              ALTER TABLE ${safeQualifiedTableName}
-              RENAME COLUMN ${this.quoteIdentifier(column.columnName)} TO ${this.quoteIdentifier(column.newColumnName as string)}
-            `
+                ALTER TABLE ${safeQualifiedTableName}
+                ADD COLUMN ${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}
+              `
             );
+
+            completedOperations.push(`Added column: ${col.columnName}`);
           }
-          completedOperations.push(`Updated column: ${column.columnName}`);
         }
-      }
 
-      // Add new columns
-      if (addColumns && Array.isArray(addColumns)) {
-        // Validate and filter reserved fields
-        const columnsToAdd = this.validateReservedFields(addColumns);
+        // Add foreign key constraints
+        if (addForeignKeys && Array.isArray(addForeignKeys)) {
+          for (const col of addForeignKeys) {
+            if (Object.keys(reservedColumns).includes(col.columnName)) {
+              throw new AppError(
+                'cannot add foreign key on system columns',
+                404,
+                ERROR_CODES.DATABASE_FORBIDDEN,
+                `You cannot add foreign key on the system column '${col.columnName}'`
+              );
+            }
+            const fkeyConstraint = this.generateFkeyConstraintStatement(col, schemaName, true);
+            await client.query(
+              `
+                ALTER TABLE ${safeQualifiedTableName}
+                ADD ${fkeyConstraint}
+              `
+            );
 
-        for (const col of columnsToAdd) {
-          const fieldType = COLUMN_TYPES[col.type as ColumnType];
-          let sqlType = fieldType.sqlType;
-          if (col.type === ColumnType.UUID) {
-            sqlType = 'UUID';
+            completedOperations.push(`Added foreign key constraint on column: ${col.columnName}`);
           }
+        }
 
-          const nullable = col.isNullable !== false ? '' : 'NOT NULL';
-          const unique = col.isUnique ? 'UNIQUE' : '';
-          const defaultClause = formatDefaultValue(
-            col.defaultValue,
-            col.type as ColumnType,
-            col.isNullable
-          );
-
+        if (renameTable && renameTable.newTableName) {
+          validateIdentifier(renameTable.newTableName, 'table');
+          const safeNewTableName = this.quoteIdentifier(renameTable.newTableName);
+          // Rename the table
           await client.query(
             `
               ALTER TABLE ${safeQualifiedTableName}
-              ADD COLUMN ${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}
+              RENAME TO ${safeNewTableName}
             `
           );
 
-          completedOperations.push(`Added column: ${col.columnName}`);
+          completedOperations.push(`Renamed table from ${tableName} to ${renameTable.newTableName}`);
         }
-      }
 
-      // Add foreign key constraints
-      if (addForeignKeys && Array.isArray(addForeignKeys)) {
-        for (const col of addForeignKeys) {
-          if (Object.keys(reservedColumns).includes(col.columnName)) {
-            throw new AppError(
-              'cannot add foreign key on system columns',
-              404,
-              ERROR_CODES.DATABASE_FORBIDDEN,
-              `You cannot add foreign key on the system column '${col.columnName}'`
-            );
-          }
-          const fkeyConstraint = this.generateFkeyConstraintStatement(col, schemaName, true);
-          await client.query(
-            `
-              ALTER TABLE ${safeQualifiedTableName}
-              ADD ${fkeyConstraint}
-            `
-          );
+        // Update metadata after schema changes
+        // Metadata is now updated on-demand
 
-          completedOperations.push(`Added foreign key constraint on column: ${col.columnName}`);
-        }
-      }
-
-      if (renameTable && renameTable.newTableName) {
-        validateIdentifier(renameTable.newTableName, 'table');
-        const safeNewTableName = this.quoteIdentifier(renameTable.newTableName);
-        // Rename the table
+        // enable postgrest to query this table
         await client.query(
           `
-            ALTER TABLE ${safeQualifiedTableName}
-            RENAME TO ${safeNewTableName}
+            NOTIFY pgrst, 'reload schema';
           `
         );
 
-        completedOperations.push(`Renamed table from ${tableName} to ${renameTable.newTableName}`);
-      }
-
-      // Update metadata after schema changes
-      // Metadata is now updated on-demand
-
-      // enable postgrest to query this table
-      await client.query(
-        `
-          NOTIFY pgrst, 'reload schema';
-        `
-      );
-
-      const response = {
-        schemaName,
-        message: 'table schema updated successfully',
-        tableName,
-        operations: completedOperations,
-      };
+        return {
+          schemaName,
+          message: 'table schema updated successfully',
+          tableName,
+          operations: completedOperations,
+        };
+      }, true);
 
       await client.query('COMMIT');
       transactionStarted = false;
@@ -700,28 +702,43 @@ export class DatabaseTableService {
    */
   async deleteTable(schemaName: string, table: string): Promise<DeleteTableResponse> {
     validateSchemaName(schemaName);
-    assertWritableDatabaseSchema(schemaName);
     const client = await this.getPool().connect();
+    let transactionStarted = false;
     try {
-      await client.query(`DROP TABLE IF EXISTS ${quoteQualifiedName(schemaName, table)} CASCADE`);
+      await client.query('BEGIN');
+      transactionStarted = true;
 
-      // Update metadata
-      // Metadata is now updated on-demand
+      const response = await withAdminContext(client, async () => {
+        await client.query(`DROP TABLE IF EXISTS ${quoteQualifiedName(schemaName, table)} CASCADE`);
 
-      // enable postgrest to query this table
-      await client.query(
+        // Update metadata
+        // Metadata is now updated on-demand
+
+        // enable postgrest to query this table
+        await client.query(
+          `
+          NOTIFY pgrst, 'reload schema';
         `
-        NOTIFY pgrst, 'reload schema';
-      `
-      );
+        );
 
-      return {
-        schemaName,
-        message: 'table deleted successfully',
-        tableName: table,
-        nextActions:
-          'table deleted successfully, you can create a new table with the POST /api/database/tables endpoint',
-      };
+        return {
+          schemaName,
+          message: 'table deleted successfully',
+          tableName: table,
+          nextActions:
+            'table deleted successfully, you can create a new table with the POST /api/database/tables endpoint',
+        };
+      }, true);
+
+      await client.query('COMMIT');
+      transactionStarted = false;
+      return response;
+    } catch (error) {
+      if (transactionStarted) {
+        await client.query('ROLLBACK');
+        transactionStarted = false;
+      }
+      throw error;
     } finally {
       client.release();
     }

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -188,110 +188,114 @@ export class DatabaseTableService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      const response = await withAdminContext(client, async () => {
-        const safeQualifiedTableName = quoteQualifiedName(schemaName, table_name);
+      const response = await withAdminContext(
+        client,
+        async () => {
+          const safeQualifiedTableName = quoteQualifiedName(schemaName, table_name);
 
-        // Check if table exists
-        const tableExistsResult = await client.query(
-          `
+          // Check if table exists
+          const tableExistsResult = await client.query(
+            `
             SELECT EXISTS (
               SELECT FROM information_schema.tables
               WHERE table_schema = $1
               AND table_name = $2
             ) as exists
           `,
-          [schemaName, table_name]
-        );
-
-        if (tableExistsResult.rows[0]?.exists) {
-          throw new AppError(
-            `table ${table_name} already exists`,
-            400,
-            ERROR_CODES.DATABASE_DUPLICATE,
-            `table ${table_name} already exists. Please check the table name, it must be a unique table name.`
+            [schemaName, table_name]
           );
-        }
 
-        // Map columns to SQL with proper type conversion
-        const columnDefs = validatedColumns
-          .map((col: ColumnSchema) => {
-            const fieldType = COLUMN_TYPES[col.type as ColumnType];
-            const sqlType = fieldType.sqlType;
-
-            // Handle default values
-            const defaultClause = formatDefaultValue(
-              col.defaultValue,
-              col.type as ColumnType,
-              col.isNullable
+          if (tableExistsResult.rows[0]?.exists) {
+            throw new AppError(
+              `table ${table_name} already exists`,
+              400,
+              ERROR_CODES.DATABASE_DUPLICATE,
+              `table ${table_name} already exists. Please check the table name, it must be a unique table name.`
             );
+          }
 
-            const nullable = col.isNullable ? '' : 'NOT NULL';
-            const unique = col.isUnique ? 'UNIQUE' : '';
+          // Map columns to SQL with proper type conversion
+          const columnDefs = validatedColumns
+            .map((col: ColumnSchema) => {
+              const fieldType = COLUMN_TYPES[col.type as ColumnType];
+              const sqlType = fieldType.sqlType;
 
-            return `${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}`.trim();
-          })
-          .join(', ');
+              // Handle default values
+              const defaultClause = formatDefaultValue(
+                col.defaultValue,
+                col.type as ColumnType,
+                col.isNullable
+              );
 
-        // Prepare foreign key constraints
-        const foreignKeyConstraints = validatedColumns
-          .filter((col) => col.foreignKey)
-          .map((col) => this.generateFkeyConstraintStatement(col, schemaName, true))
-          .join(', ');
+              const nullable = col.isNullable ? '' : 'NOT NULL';
+              const unique = col.isUnique ? 'UNIQUE' : '';
 
-        // Create table with auto fields and foreign keys
-        const tableDefinition = [
-          'id UUID PRIMARY KEY DEFAULT gen_random_uuid()',
-          columnDefs,
-          'created_at TIMESTAMPTZ DEFAULT now()',
-          'updated_at TIMESTAMPTZ DEFAULT now()',
-          foreignKeyConstraints,
-        ]
-          .filter(Boolean)
-          .join(', ');
+              return `${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}`.trim();
+            })
+            .join(', ');
 
-        await client.query(
-          `
+          // Prepare foreign key constraints
+          const foreignKeyConstraints = validatedColumns
+            .filter((col) => col.foreignKey)
+            .map((col) => this.generateFkeyConstraintStatement(col, schemaName, true))
+            .join(', ');
+
+          // Create table with auto fields and foreign keys
+          const tableDefinition = [
+            'id UUID PRIMARY KEY DEFAULT gen_random_uuid()',
+            columnDefs,
+            'created_at TIMESTAMPTZ DEFAULT now()',
+            'updated_at TIMESTAMPTZ DEFAULT now()',
+            foreignKeyConstraints,
+          ]
+            .filter(Boolean)
+            .join(', ');
+
+          await client.query(
+            `
             CREATE TABLE ${safeQualifiedTableName} (
               ${tableDefinition}
             );
             NOTIFY pgrst, 'reload schema';
           `
-        );
+          );
 
-        if (use_RLS) {
-          // Enable RLS policies
-          await client.query(
-            `
+          if (use_RLS) {
+            // Enable RLS policies
+            await client.query(
+              `
               ALTER TABLE ${safeQualifiedTableName} ENABLE ROW LEVEL SECURITY;
             `
-          );
-        }
+            );
+          }
 
-        // Create trigger for updated_at
-        await client.query(
-          `
+          // Create trigger for updated_at
+          await client.query(
+            `
             CREATE TRIGGER ${this.quoteIdentifier(table_name + '_update_timestamp')}
             BEFORE UPDATE ON ${safeQualifiedTableName}
             FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
           `
-        );
+          );
 
-        // Update metadata
-        // Metadata is now updated on-demand
+          // Update metadata
+          // Metadata is now updated on-demand
 
-        return {
-          schemaName,
-          message: 'table created successfully',
-          tableName: table_name,
-          columns: validatedColumns.map((col) => ({
-            ...col,
-            sqlType: COLUMN_TYPES[col.type as ColumnType].sqlType,
-          })),
-          autoFields: ['id', 'created_at', 'updated_at'],
-          nextActions:
-            'you can now use the table with the POST /api/database/tables/{table} endpoint',
-        };
-      }, true);
+          return {
+            schemaName,
+            message: 'table created successfully',
+            tableName: table_name,
+            columns: validatedColumns.map((col) => ({
+              ...col,
+              sqlType: COLUMN_TYPES[col.type as ColumnType].sqlType,
+            })),
+            autoFields: ['id', 'created_at', 'updated_at'],
+            nextActions:
+              'you can now use the table with the POST /api/database/tables/{table} endpoint',
+          };
+        },
+        true
+      );
 
       await client.query('COMMIT');
       transactionStarted = false;
@@ -460,228 +464,234 @@ export class DatabaseTableService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      const response = await withAdminContext(client, async () => {
-        const safeQualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const response = await withAdminContext(
+        client,
+        async () => {
+          const safeQualifiedTableName = quoteQualifiedName(schemaName, tableName);
 
-        // Check if table exists
-        const tableExistsResult = await client.query(
-          `
+          // Check if table exists
+          const tableExistsResult = await client.query(
+            `
             SELECT EXISTS (
               SELECT FROM information_schema.tables
               WHERE table_schema = $1
               AND table_name = $2
             ) as exists
           `,
-          [schemaName, tableName]
-        );
-
-        if (!tableExistsResult.rows[0]?.exists) {
-          throw new AppError(
-            'table not found',
-            404,
-            ERROR_CODES.DATABASE_NOT_FOUND,
-            'Please check the table name, it must be a valid table name, or you can create a new table with the POST /api/database/tables endpoint'
+            [schemaName, tableName]
           );
-        }
-        const currentSchema = await this.getTableSchema(schemaName, tableName);
-        const currentUserColumns = currentSchema.columns.filter(
-          (col) => !Object.keys(reservedColumns).includes(col.columnName)
-        );
 
-        // Filter dropped and added user columns
-        const droppedUserColumns = dropColumns
-          ? dropColumns.filter((col) => !Object.keys(reservedColumns).includes(col))
-          : [];
-        const addedUserColumns = addColumns ? this.validateReservedFields(addColumns) : [];
-
-        // Calculate final user column count
-        const finalUserColumnsCount =
-          currentUserColumns.length - droppedUserColumns.length + addedUserColumns.length;
-
-        if (finalUserColumnsCount <= 0) {
-          throw new AppError(
-            'Table must have at least one user-defined column after update',
-            400,
-            ERROR_CODES.DATABASE_VALIDATION_ERROR,
-            'The update would leave the table with no custom columns. Please add columns or avoid dropping all user-defined columns.'
+          if (!tableExistsResult.rows[0]?.exists) {
+            throw new AppError(
+              'table not found',
+              404,
+              ERROR_CODES.DATABASE_NOT_FOUND,
+              'Please check the table name, it must be a valid table name, or you can create a new table with the POST /api/database/tables endpoint'
+            );
+          }
+          const currentSchema = await this.getTableSchema(schemaName, tableName);
+          const currentUserColumns = currentSchema.columns.filter(
+            (col) => !Object.keys(reservedColumns).includes(col.columnName)
           );
-        }
 
-        const foreignKeyMap = await this.getFkeyConstraints(schemaName, tableName);
-        const completedOperations: string[] = [];
+          // Filter dropped and added user columns
+          const droppedUserColumns = dropColumns
+            ? dropColumns.filter((col) => !Object.keys(reservedColumns).includes(col))
+            : [];
+          const addedUserColumns = addColumns ? this.validateReservedFields(addColumns) : [];
 
-        // Execute operations
+          // Calculate final user column count
+          const finalUserColumnsCount =
+            currentUserColumns.length - droppedUserColumns.length + addedUserColumns.length;
 
-        // Drop foreign key constraints
-        if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
-          for (const col of dropForeignKeys) {
-            const constraintName = foreignKeyMap.get(col)?.constraint_name;
-            if (constraintName) {
-              await client.query(
-                `
+          if (finalUserColumnsCount <= 0) {
+            throw new AppError(
+              'Table must have at least one user-defined column after update',
+              400,
+              ERROR_CODES.DATABASE_VALIDATION_ERROR,
+              'The update would leave the table with no custom columns. Please add columns or avoid dropping all user-defined columns.'
+            );
+          }
+
+          const foreignKeyMap = await this.getFkeyConstraints(schemaName, tableName);
+          const completedOperations: string[] = [];
+
+          // Execute operations
+
+          // Drop foreign key constraints
+          if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
+            for (const col of dropForeignKeys) {
+              const constraintName = foreignKeyMap.get(col)?.constraint_name;
+              if (constraintName) {
+                await client.query(
+                  `
                   ALTER TABLE ${safeQualifiedTableName}
                   DROP CONSTRAINT ${this.quoteIdentifier(constraintName)}
                 `
-              );
-
-              completedOperations.push(`Dropped foreign key constraint on column: ${col}`);
-            }
-          }
-        }
-
-        // Drop columns first (to avoid conflicts with renames)
-        if (dropColumns && Array.isArray(dropColumns)) {
-          for (const col of dropColumns) {
-            if (Object.keys(reservedColumns).includes(col)) {
-              throw new AppError(
-                'cannot drop system columns',
-                404,
-                ERROR_CODES.DATABASE_FORBIDDEN,
-                `You cannot drop the system column '${col}'`
-              );
-            }
-            await client.query(
-              `
-                ALTER TABLE ${safeQualifiedTableName}
-                DROP COLUMN ${this.quoteIdentifier(col)}
-              `
-            );
-
-            completedOperations.push(`Dropped column: ${col}`);
-          }
-        }
-
-        // Update columns
-        if (updateColumns && Array.isArray(updateColumns)) {
-          for (const column of updateColumns) {
-            if (Object.keys(reservedColumns).includes(column.columnName)) {
-              throw new AppError(
-                'cannot update system columns',
-                404,
-                ERROR_CODES.DATABASE_FORBIDDEN,
-                `You cannot update the system column '${column.columnName}'`
-              );
-            }
-
-            // Handle default value changes
-            if (column.defaultValue !== undefined) {
-              if (column.defaultValue === '') {
-                // Drop default
-                await client.query(
-                  `
-                  ALTER TABLE ${safeQualifiedTableName}
-                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} DROP DEFAULT
-                `
                 );
-              } else {
-                // Set default
-                await client.query(
-                  `
-                  ALTER TABLE ${safeQualifiedTableName}
-                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} SET ${formatDefaultValue(column.defaultValue)}
-                `
-                );
+
+                completedOperations.push(`Dropped foreign key constraint on column: ${col}`);
               }
             }
+          }
 
-            // Handle column rename - do this last to avoid issues with other operations
-            if (column.newColumnName) {
+          // Drop columns first (to avoid conflicts with renames)
+          if (dropColumns && Array.isArray(dropColumns)) {
+            for (const col of dropColumns) {
+              if (Object.keys(reservedColumns).includes(col)) {
+                throw new AppError(
+                  'cannot drop system columns',
+                  404,
+                  ERROR_CODES.DATABASE_FORBIDDEN,
+                  `You cannot drop the system column '${col}'`
+                );
+              }
               await client.query(
                 `
                 ALTER TABLE ${safeQualifiedTableName}
-                RENAME COLUMN ${this.quoteIdentifier(column.columnName)} TO ${this.quoteIdentifier(column.newColumnName as string)}
+                DROP COLUMN ${this.quoteIdentifier(col)}
               `
               );
+
+              completedOperations.push(`Dropped column: ${col}`);
             }
-            completedOperations.push(`Updated column: ${column.columnName}`);
           }
-        }
 
-        // Add new columns
-        if (addColumns && Array.isArray(addColumns)) {
-          // Validate and filter reserved fields
-          const columnsToAdd = this.validateReservedFields(addColumns);
+          // Update columns
+          if (updateColumns && Array.isArray(updateColumns)) {
+            for (const column of updateColumns) {
+              if (Object.keys(reservedColumns).includes(column.columnName)) {
+                throw new AppError(
+                  'cannot update system columns',
+                  404,
+                  ERROR_CODES.DATABASE_FORBIDDEN,
+                  `You cannot update the system column '${column.columnName}'`
+                );
+              }
 
-          for (const col of columnsToAdd) {
-            const fieldType = COLUMN_TYPES[col.type as ColumnType];
-            let sqlType = fieldType.sqlType;
-            if (col.type === ColumnType.UUID) {
-              sqlType = 'UUID';
-            }
+              // Handle default value changes
+              if (column.defaultValue !== undefined) {
+                if (column.defaultValue === '') {
+                  // Drop default
+                  await client.query(
+                    `
+                  ALTER TABLE ${safeQualifiedTableName}
+                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} DROP DEFAULT
+                `
+                  );
+                } else {
+                  // Set default
+                  await client.query(
+                    `
+                  ALTER TABLE ${safeQualifiedTableName}
+                  ALTER COLUMN ${this.quoteIdentifier(column.columnName)} SET ${formatDefaultValue(column.defaultValue)}
+                `
+                  );
+                }
+              }
 
-            const nullable = col.isNullable !== false ? '' : 'NOT NULL';
-            const unique = col.isUnique ? 'UNIQUE' : '';
-            const defaultClause = formatDefaultValue(
-              col.defaultValue,
-              col.type as ColumnType,
-              col.isNullable
-            );
-
-            await client.query(
+              // Handle column rename - do this last to avoid issues with other operations
+              if (column.newColumnName) {
+                await client.query(
+                  `
+                ALTER TABLE ${safeQualifiedTableName}
+                RENAME COLUMN ${this.quoteIdentifier(column.columnName)} TO ${this.quoteIdentifier(column.newColumnName as string)}
               `
+                );
+              }
+              completedOperations.push(`Updated column: ${column.columnName}`);
+            }
+          }
+
+          // Add new columns
+          if (addColumns && Array.isArray(addColumns)) {
+            // Validate and filter reserved fields
+            const columnsToAdd = this.validateReservedFields(addColumns);
+
+            for (const col of columnsToAdd) {
+              const fieldType = COLUMN_TYPES[col.type as ColumnType];
+              let sqlType = fieldType.sqlType;
+              if (col.type === ColumnType.UUID) {
+                sqlType = 'UUID';
+              }
+
+              const nullable = col.isNullable !== false ? '' : 'NOT NULL';
+              const unique = col.isUnique ? 'UNIQUE' : '';
+              const defaultClause = formatDefaultValue(
+                col.defaultValue,
+                col.type as ColumnType,
+                col.isNullable
+              );
+
+              await client.query(
+                `
                 ALTER TABLE ${safeQualifiedTableName}
                 ADD COLUMN ${this.quoteIdentifier(col.columnName)} ${sqlType} ${nullable} ${unique} ${defaultClause}
               `
-            );
-
-            completedOperations.push(`Added column: ${col.columnName}`);
-          }
-        }
-
-        // Add foreign key constraints
-        if (addForeignKeys && Array.isArray(addForeignKeys)) {
-          for (const col of addForeignKeys) {
-            if (Object.keys(reservedColumns).includes(col.columnName)) {
-              throw new AppError(
-                'cannot add foreign key on system columns',
-                404,
-                ERROR_CODES.DATABASE_FORBIDDEN,
-                `You cannot add foreign key on the system column '${col.columnName}'`
               );
+
+              completedOperations.push(`Added column: ${col.columnName}`);
             }
-            const fkeyConstraint = this.generateFkeyConstraintStatement(col, schemaName, true);
-            await client.query(
-              `
+          }
+
+          // Add foreign key constraints
+          if (addForeignKeys && Array.isArray(addForeignKeys)) {
+            for (const col of addForeignKeys) {
+              if (Object.keys(reservedColumns).includes(col.columnName)) {
+                throw new AppError(
+                  'cannot add foreign key on system columns',
+                  404,
+                  ERROR_CODES.DATABASE_FORBIDDEN,
+                  `You cannot add foreign key on the system column '${col.columnName}'`
+                );
+              }
+              const fkeyConstraint = this.generateFkeyConstraintStatement(col, schemaName, true);
+              await client.query(
+                `
                 ALTER TABLE ${safeQualifiedTableName}
                 ADD ${fkeyConstraint}
               `
-            );
+              );
 
-            completedOperations.push(`Added foreign key constraint on column: ${col.columnName}`);
+              completedOperations.push(`Added foreign key constraint on column: ${col.columnName}`);
+            }
           }
-        }
 
-        if (renameTable && renameTable.newTableName) {
-          validateIdentifier(renameTable.newTableName, 'table');
-          const safeNewTableName = this.quoteIdentifier(renameTable.newTableName);
-          // Rename the table
-          await client.query(
-            `
+          if (renameTable && renameTable.newTableName) {
+            validateIdentifier(renameTable.newTableName, 'table');
+            const safeNewTableName = this.quoteIdentifier(renameTable.newTableName);
+            // Rename the table
+            await client.query(
+              `
               ALTER TABLE ${safeQualifiedTableName}
               RENAME TO ${safeNewTableName}
             `
-          );
+            );
 
-          completedOperations.push(`Renamed table from ${tableName} to ${renameTable.newTableName}`);
-        }
+            completedOperations.push(
+              `Renamed table from ${tableName} to ${renameTable.newTableName}`
+            );
+          }
 
-        // Update metadata after schema changes
-        // Metadata is now updated on-demand
+          // Update metadata after schema changes
+          // Metadata is now updated on-demand
 
-        // enable postgrest to query this table
-        await client.query(
-          `
+          // enable postgrest to query this table
+          await client.query(
+            `
             NOTIFY pgrst, 'reload schema';
           `
-        );
+          );
 
-        return {
-          schemaName,
-          message: 'table schema updated successfully',
-          tableName,
-          operations: completedOperations,
-        };
-      }, true);
+          return {
+            schemaName,
+            message: 'table schema updated successfully',
+            tableName,
+            operations: completedOperations,
+          };
+        },
+        true
+      );
 
       await client.query('COMMIT');
       transactionStarted = false;
@@ -708,27 +718,33 @@ export class DatabaseTableService {
       await client.query('BEGIN');
       transactionStarted = true;
 
-      const response = await withAdminContext(client, async () => {
-        await client.query(`DROP TABLE IF EXISTS ${quoteQualifiedName(schemaName, table)} CASCADE`);
+      const response = await withAdminContext(
+        client,
+        async () => {
+          await client.query(
+            `DROP TABLE IF EXISTS ${quoteQualifiedName(schemaName, table)} CASCADE`
+          );
 
-        // Update metadata
-        // Metadata is now updated on-demand
+          // Update metadata
+          // Metadata is now updated on-demand
 
-        // enable postgrest to query this table
-        await client.query(
-          `
+          // enable postgrest to query this table
+          await client.query(
+            `
           NOTIFY pgrst, 'reload schema';
         `
-        );
+          );
 
-        return {
-          schemaName,
-          message: 'table deleted successfully',
-          tableName: table,
-          nextActions:
-            'table deleted successfully, you can create a new table with the POST /api/database/tables endpoint',
-        };
-      }, true);
+          return {
+            schemaName,
+            message: 'table deleted successfully',
+            tableName: table,
+            nextActions:
+              'table deleted successfully, you can create a new table with the POST /api/database/tables endpoint',
+          };
+        },
+        true
+      );
 
       await client.query('COMMIT');
       transactionStarted = false;

--- a/backend/src/services/database/database.service.ts
+++ b/backend/src/services/database/database.service.ts
@@ -6,7 +6,7 @@ import type {
   DatabasePoliciesResponse,
   DatabaseTriggersResponse,
 } from '@insforge/shared-schemas';
-import { DEFAULT_DATABASE_SCHEMA, INSFORGE_MANAGED_DATABASE_SCHEMAS } from './helpers.js';
+import { DEFAULT_DATABASE_SCHEMA } from './helpers.js';
 
 export class DatabaseService {
   private static instance: DatabaseService;
@@ -22,36 +22,44 @@ export class DatabaseService {
   }
 
   /**
-   * List all non-internal schemas visible to the dashboard and flag the
-   * InsForge-managed ones as protected/read-only.
+   * List all non-internal schemas visible to the dashboard and flag schemas
+   * where project_admin cannot create objects as protected/read-only.
    */
   async getSchemas(): Promise<DatabaseSchemasResponse> {
     const pool = this.dbManager.getPool();
 
     const result = await pool.query(
       `
+        WITH visible_schemas AS (
+          SELECT
+            n.nspname AS name,
+            COALESCE(
+              has_schema_privilege(to_regrole('project_admin'), n.oid, 'CREATE'),
+              false
+            ) AS can_create
+          FROM pg_namespace n
+          WHERE n.nspname <> 'information_schema'
+            AND n.nspname NOT LIKE 'pg_%'
+        )
         SELECT
-          n.nspname AS name,
-          (n.nspname = ANY($1::text[])) AS "isProtected"
-        FROM pg_namespace n
-        WHERE n.nspname <> 'information_schema'
-          AND n.nspname NOT LIKE 'pg_%'
+          name,
+          NOT can_create AS "isProtected"
+        FROM visible_schemas
         ORDER BY
           CASE
-            WHEN n.nspname = $2 THEN 0
-            WHEN n.nspname = ANY($1::text[]) THEN 1
+            WHEN name = $1 THEN 0
+            WHEN can_create THEN 1
             ELSE 2
           END,
-          array_position($1::text[], n.nspname),
-          n.nspname
+          name
       `,
-      [INSFORGE_MANAGED_DATABASE_SCHEMAS, DEFAULT_DATABASE_SCHEMA]
+      [DEFAULT_DATABASE_SCHEMA]
     );
 
     return {
       schemas: result.rows.map((row: { name: string; isProtected: boolean }) => ({
         name: row.name,
-        isProtected: row.name !== DEFAULT_DATABASE_SCHEMA && row.isProtected,
+        isProtected: row.isProtected,
       })),
     };
   }

--- a/backend/src/services/database/helpers.ts
+++ b/backend/src/services/database/helpers.ts
@@ -4,29 +4,8 @@ import { validateIdentifier, validateSchemaName, validateTableName } from '@/uti
 
 export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
 
-export const INSFORGE_MANAGED_DATABASE_SCHEMAS = [
-  'ai',
-  'auth',
-  'compute',
-  'cron',
-  'deployments',
-  'email',
-  'functions',
-  'payments',
-  'realtime',
-  'schedules',
-  'storage',
-  'system',
-] as const;
-
-const insforgeManagedDatabaseSchemaSet = new Set<string>(INSFORGE_MANAGED_DATABASE_SCHEMAS);
-
 export function isInternalDashboardSchema(schemaName: string): boolean {
   return schemaName === 'information_schema' || schemaName.startsWith('pg_');
-}
-
-export function isInsForgeManagedDatabaseSchema(schemaName: string): boolean {
-  return insforgeManagedDatabaseSchemaSet.has(schemaName);
 }
 
 export function normalizeDatabaseSchemaName(schemaName: unknown): string {
@@ -47,17 +26,6 @@ export function normalizeDatabaseSchemaName(schemaName: unknown): string {
   }
 
   return normalizedSchemaName;
-}
-
-export function assertWritableDatabaseSchema(schemaName: string): void {
-  if (isInsForgeManagedDatabaseSchema(schemaName)) {
-    throw new AppError(
-      `Schema "${schemaName}" is protected in the dashboard`,
-      403,
-      ERROR_CODES.DATABASE_FORBIDDEN,
-      'Switch to public to create or modify tables and records.'
-    );
-  }
 }
 
 export function buildQualifiedTableKey(tableName: string, schemaName: string): string {

--- a/backend/src/services/database/user-context.service.ts
+++ b/backend/src/services/database/user-context.service.ts
@@ -76,6 +76,14 @@ export async function withUserContext<T>(
   }
 }
 
+/**
+ * Run `fn` as project_admin on an existing client.
+ *
+ * By default, role and request claims are session-scoped and must be cleaned
+ * before returning the client to the pool. Pass `transactionLocal: true` only
+ * when the caller has already opened an explicit transaction; rollback can then
+ * clear local role/config state if fn or cleanup fails.
+ */
 export async function withAdminContext<T>(
   client: PoolClient,
   fn: () => Promise<T>,

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppError } from '../../src/utils/errors';
 
-const { poolQueryMock, connectMock } = vi.hoisted(() => ({
+const { poolQueryMock, connectMock, clientQueryMock, releaseMock } = vi.hoisted(() => ({
   poolQueryMock: vi.fn(),
   connectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  releaseMock: vi.fn(),
 }));
 
 vi.mock('../../src/infra/database/database.manager', () => ({
@@ -22,23 +24,35 @@ import { AdminRecordService } from '../../src/services/database/admin-record.ser
 describe('AdminRecordService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    connectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: releaseMock,
+    });
   });
 
   it('reads protected-schema records through direct SQL with search and sorting', async () => {
-    poolQueryMock
-      .mockResolvedValueOnce({
-        rows: [
-          { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
-          { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
-        ],
-      })
-      .mockResolvedValueOnce({ rows: [{ total: '2' }] })
-      .mockResolvedValueOnce({
-        rows: [
-          { id: '1', email: 'demo-1@example.com' },
-          { id: '2', email: 'demo-2@example.com' },
-        ],
-      });
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('COUNT(*)::text AS total')) {
+        return { rows: [{ total: '2' }] };
+      }
+      if (sql.includes('SELECT * FROM "auth"."users"')) {
+        return {
+          rows: [
+            { id: '1', email: 'demo-1@example.com' },
+            { id: '2', email: 'demo-2@example.com' },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
 
     const service = AdminRecordService.getInstance();
     const result = await service.listRecords('auth', 'users', {
@@ -51,34 +65,68 @@ describe('AdminRecordService', () => {
     expect(result.total).toBe(2);
     expect(result.records).toHaveLength(2);
 
-    expect(poolQueryMock.mock.calls[1]?.[0]).toContain('FROM "auth"."users"');
-    expect(poolQueryMock.mock.calls[1]?.[1]).toEqual(['%demo%']);
-    expect(poolQueryMock.mock.calls[2]?.[0]).toContain('ORDER BY "email" ASC LIMIT $2 OFFSET $3');
-    expect(poolQueryMock.mock.calls[2]?.[1]).toEqual(['%demo%', 10, 0]);
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET ROLE project_admin');
+    const dataQueryIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('ORDER BY "email" ASC LIMIT $2 OFFSET $3')
+    );
+    const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(dataQueryIndex).toBeGreaterThan(setRoleIndex);
+    expect(resetRoleIndex).toBeGreaterThan(dataQueryIndex);
+    expect(clientQueryMock.mock.calls[dataQueryIndex]?.[1]).toEqual(['%demo%', 10, 0]);
   });
 
-  it('blocks writes on protected schemas before opening a transaction', async () => {
-    const service = AdminRecordService.getInstance();
-
-    await expect(
-      service.createRecords('auth', 'users', [{ email: 'demo@example.com' }])
-    ).rejects.toBeInstanceOf(AppError);
-
-    expect(connectMock).not.toHaveBeenCalled();
-  });
-
-  it('updates public records and converts blank nullable uuid values to null', async () => {
-    poolQueryMock
+  it('delegates protected-schema writes to project_admin privileges', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SET LOCAL ROLE
+      .mockResolvedValueOnce({}) // set request.jwt.claims
       .mockResolvedValueOnce({
         rows: [
           { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
-          { column_name: 'owner_id', data_type: 'uuid', is_nullable: 'YES', udt_name: 'uuid' },
-          { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
         ],
-      })
+      }) // metadata
       .mockResolvedValueOnce({
-        rows: [{ id: 'p1', owner_id: null, name: 'Renamed project' }],
-      });
+        rows: [{ id: 'u1', email: 'demo@example.com' }],
+      }) // INSERT
+      .mockResolvedValueOnce({}) // RESET ROLE
+      .mockResolvedValueOnce({}) // reset config
+      .mockResolvedValueOnce({}); // COMMIT
+
+    const service = AdminRecordService.getInstance();
+    const result = await service.createRecords('auth', 'users', [{ email: 'demo@example.com' }]);
+
+    expect(result).toEqual([{ id: 'u1', email: 'demo@example.com' }]);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const insertIndex = sqlCalls.findIndex((sql) => sql.includes('INSERT INTO "auth"."users"'));
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(insertIndex).toBeGreaterThan(setRoleIndex);
+  });
+
+  it('updates public records and converts blank nullable uuid values to null', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'owner_id', data_type: 'uuid', is_nullable: 'YES', udt_name: 'uuid' },
+            { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE "public"."projects"')) {
+        return {
+          rows: [{ id: 'p1', owner_id: null, name: 'Renamed project' }],
+        };
+      }
+      return { rows: [] };
+    });
 
     const service = AdminRecordService.getInstance();
     const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
@@ -87,61 +135,70 @@ describe('AdminRecordService', () => {
     });
 
     expect(record).toEqual({ id: 'p1', owner_id: null, name: 'Renamed project' });
-    expect(poolQueryMock.mock.calls[1]?.[0]).toContain(
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."projects"')
+    );
+    expect(updateCall?.[0]).toContain(
       'SET "owner_id" = $1, "name" = $2 WHERE "id" = $3 RETURNING *'
     );
-    expect(poolQueryMock.mock.calls[1]?.[1]).toEqual([null, 'Renamed project', 'p1']);
+    expect(updateCall?.[1]).toEqual([null, 'Renamed project', 'p1']);
   });
 
   it('preserves empty strings for character varying inserts', async () => {
-    const clientQueryMock = vi
-      .fn()
+    clientQueryMock
       .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SET LOCAL ROLE
+      .mockResolvedValueOnce({}) // set_config
+      .mockResolvedValueOnce({
+        rows: [
+          { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+          {
+            column_name: 'name',
+            data_type: 'character varying',
+            is_nullable: 'YES',
+            udt_name: 'varchar',
+          },
+        ],
+      }) // metadata
       .mockResolvedValueOnce({
         rows: [{ id: 'r1', name: '' }],
       }) // INSERT
+      .mockResolvedValueOnce({}) // RESET ROLE
+      .mockResolvedValueOnce({}) // reset config
       .mockResolvedValueOnce({}); // COMMIT
-
-    connectMock.mockResolvedValue({
-      query: clientQueryMock,
-      release: vi.fn(),
-    });
-
-    poolQueryMock.mockResolvedValueOnce({
-      rows: [
-        { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
-        {
-          column_name: 'name',
-          data_type: 'character varying',
-          is_nullable: 'YES',
-          udt_name: 'varchar',
-        },
-      ],
-    });
 
     const service = AdminRecordService.getInstance();
     const result = await service.createRecords('public', 'projects', [{ name: '' }]);
 
     expect(result).toEqual([{ id: 'r1', name: '' }]);
-    expect(clientQueryMock.mock.calls[1]?.[1]).toEqual(['']);
+    const insertCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO "public"."projects"')
+    );
+    expect(insertCall?.[1]).toEqual(['']);
   });
 
   it('converts blank updates on nullable non-text columns to null', async () => {
-    poolQueryMock
-      .mockResolvedValueOnce({
-        rows: [
-          { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
-          {
-            column_name: 'priority',
-            data_type: 'integer',
-            is_nullable: 'YES',
-            udt_name: 'int4',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [{ id: 'p1', priority: null }],
-      });
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            {
+              column_name: 'priority',
+              data_type: 'integer',
+              is_nullable: 'YES',
+              udt_name: 'int4',
+            },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE "public"."projects"')) {
+        return {
+          rows: [{ id: 'p1', priority: null }],
+        };
+      }
+      return { rows: [] };
+    });
 
     const service = AdminRecordService.getInstance();
     const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
@@ -149,20 +206,28 @@ describe('AdminRecordService', () => {
     });
 
     expect(record).toEqual({ id: 'p1', priority: null });
-    expect(poolQueryMock.mock.calls[1]?.[1]).toEqual([null, 'p1']);
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."projects"')
+    );
+    expect(updateCall?.[1]).toEqual([null, 'p1']);
   });
 
   it('rejects blank updates on required non-text columns with a 400', async () => {
-    poolQueryMock.mockResolvedValueOnce({
-      rows: [
-        { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
-        {
-          column_name: 'priority',
-          data_type: 'integer',
-          is_nullable: 'NO',
-          udt_name: 'int4',
-        },
-      ],
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            {
+              column_name: 'priority',
+              data_type: 'integer',
+              is_nullable: 'NO',
+              udt_name: 'int4',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
     });
 
     const service = AdminRecordService.getInstance();

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -66,15 +66,19 @@ describe('AdminRecordService', () => {
     expect(result.records).toHaveLength(2);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
-    const setRoleIndex = sqlCalls.indexOf('SET ROLE project_admin');
+    const beginIndex = sqlCalls.indexOf('BEGIN');
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
     const dataQueryIndex = sqlCalls.findIndex((sql) =>
       sql.includes('ORDER BY "email" ASC LIMIT $2 OFFSET $3')
     );
     const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
+    const commitIndex = sqlCalls.indexOf('COMMIT');
 
+    expect(beginIndex).toBe(0);
     expect(setRoleIndex).toBeGreaterThan(-1);
     expect(dataQueryIndex).toBeGreaterThan(setRoleIndex);
     expect(resetRoleIndex).toBeGreaterThan(dataQueryIndex);
+    expect(commitIndex).toBeGreaterThan(resetRoleIndex);
     expect(clientQueryMock.mock.calls[dataQueryIndex]?.[1]).toEqual(['%demo%', 10, 0]);
   });
 
@@ -104,9 +108,12 @@ describe('AdminRecordService', () => {
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
     const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
     const insertIndex = sqlCalls.findIndex((sql) => sql.includes('INSERT INTO "auth"."users"'));
+    const commitIndex = sqlCalls.indexOf('COMMIT');
 
+    expect(sqlCalls[0]).toBe('BEGIN');
     expect(setRoleIndex).toBeGreaterThan(-1);
     expect(insertIndex).toBeGreaterThan(setRoleIndex);
+    expect(commitIndex).toBeGreaterThan(insertIndex);
   });
 
   it('updates public records and converts blank nullable uuid values to null', async () => {
@@ -142,6 +149,16 @@ describe('AdminRecordService', () => {
       'SET "owner_id" = $1, "name" = $2 WHERE "id" = $3 RETURNING *'
     );
     expect(updateCall?.[1]).toEqual([null, 'Renamed project', 'p1']);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const updateIndex = sqlCalls.findIndex((sql) => sql.includes('UPDATE "public"."projects"'));
+    const commitIndex = sqlCalls.indexOf('COMMIT');
+
+    expect(sqlCalls[0]).toBe('BEGIN');
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(updateIndex).toBeGreaterThan(setRoleIndex);
+    expect(commitIndex).toBeGreaterThan(updateIndex);
   });
 
   it('preserves empty strings for character varying inserts', async () => {
@@ -237,5 +254,74 @@ describe('AdminRecordService', () => {
         priority: '',
       })
     ).rejects.toBeInstanceOf(AppError);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls).toContain('ROLLBACK');
+  });
+
+  it('deletes records inside a project_admin transaction', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('DELETE FROM "public"."projects"')) {
+        return { rowCount: 2, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+    const deletedCount = await service.deleteRecords('public', 'projects', 'id', ['p1', 'p2']);
+
+    expect(deletedCount).toBe(2);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const deleteIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('DELETE FROM "public"."projects"')
+    );
+    const commitIndex = sqlCalls.indexOf('COMMIT');
+
+    expect(sqlCalls[0]).toBe('BEGIN');
+    expect(deleteIndex).toBeGreaterThan(setRoleIndex);
+    expect(commitIndex).toBeGreaterThan(deleteIndex);
+  });
+
+  it('discards the pooled client when admin transaction cleanup fails', async () => {
+    const resetError = new Error('reset failed');
+
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE "public"."projects"')) {
+        return { rows: [{ id: 'p1', name: 'Renamed project' }] };
+      }
+      if (sql === 'RESET ROLE') {
+        throw resetError;
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    await expect(
+      service.updateRecord('public', 'projects', 'id', 'p1', {
+        name: 'Renamed project',
+      })
+    ).rejects.toBe(resetError);
+
+    expect(clientQueryMock.mock.calls.map(([sql]) => sql as string)).toContain('ROLLBACK');
+    expect(releaseMock).toHaveBeenCalledWith(resetError);
   });
 });

--- a/backend/tests/unit/database-helpers.test.ts
+++ b/backend/tests/unit/database-helpers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AppError } from '../../src/utils/errors';
 import {
-  assertWritableDatabaseSchema,
   buildQualifiedTableKey,
   isInternalDashboardSchema,
   normalizeDatabaseSchemaName,
@@ -39,13 +38,6 @@ describe('database helpers', () => {
 
   it('rejects malformed qualified table references', () => {
     expect(() => splitQualifiedTableReference('too.many.parts')).toThrow(AppError);
-  });
-
-  it('marks insforge managed schemas as read only', () => {
-    expect(() => assertWritableDatabaseSchema('auth')).toThrow(AppError);
-    expect(() => assertWritableDatabaseSchema('cron')).toThrow(AppError);
-    expect(() => assertWritableDatabaseSchema('payments')).toThrow(AppError);
-    expect(() => assertWritableDatabaseSchema('public')).not.toThrow();
   });
 
   it('formats qualified names and cache keys consistently', () => {

--- a/backend/tests/unit/database-table-project-admin.test.ts
+++ b/backend/tests/unit/database-table-project-admin.test.ts
@@ -90,7 +90,9 @@ describe('DatabaseTableService project_admin DDL context', () => {
 
     const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
     const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
-    const createTableIndex = sqlCalls.findIndex((sql) => sql.includes('CREATE TABLE "public"."posts"'));
+    const createTableIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('CREATE TABLE "public"."posts"')
+    );
     const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
     const commitIndex = sqlCalls.indexOf('COMMIT');
 
@@ -109,8 +111,8 @@ describe('DatabaseTableService project_admin DDL context', () => {
 
     const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
     const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
-    const alterTableIndex = sqlCalls.findIndex((sql) =>
-      sql.includes('ALTER TABLE "public"."posts"') && sql.includes('ADD COLUMN "summary"')
+    const alterTableIndex = sqlCalls.findIndex(
+      (sql) => sql.includes('ALTER TABLE "public"."posts"') && sql.includes('ADD COLUMN "summary"')
     );
     const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
     const commitIndex = sqlCalls.indexOf('COMMIT');

--- a/backend/tests/unit/database-table-project-admin.test.ts
+++ b/backend/tests/unit/database-table-project-admin.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ColumnType } from '@insforge/shared-schemas';
+import { DatabaseTableService } from '../../src/services/database/database-table.service';
+
+const queryMock = vi.fn();
+const releaseMock = vi.fn();
+const connectMock = vi.fn();
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        connect: connectMock,
+        query: queryMock,
+      })),
+    })),
+  },
+}));
+
+describe('DatabaseTableService project_admin DDL context', () => {
+  let service: DatabaseTableService;
+  let tableExists = false;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tableExists = false;
+    service = DatabaseTableService.getInstance();
+
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: releaseMock,
+    });
+
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT EXISTS')) {
+        return { rows: [{ exists: tableExists }], rowCount: 1 };
+      }
+
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            {
+              column_name: 'id',
+              data_type: 'uuid',
+              udt_name: 'uuid',
+              is_nullable: 'NO',
+              column_default: 'gen_random_uuid()',
+              character_maximum_length: null,
+            },
+            {
+              column_name: 'title',
+              data_type: 'text',
+              udt_name: 'text',
+              is_nullable: 'YES',
+              column_default: null,
+              character_maximum_length: null,
+            },
+          ],
+          rowCount: 2,
+        };
+      }
+
+      if (sql.includes("tc.constraint_type = 'FOREIGN KEY'")) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (sql.includes("AND constraint_type = 'PRIMARY KEY'")) {
+        return { rows: [{ column_name: 'id' }], rowCount: 1 };
+      }
+
+      if (sql.includes("AND tc.constraint_type = 'UNIQUE'")) {
+        return { rows: [], rowCount: 0 };
+      }
+
+      if (sql.includes('COUNT(*) as row_count')) {
+        return { rows: [{ row_count: '0' }], rowCount: 1 };
+      }
+
+      return { rows: [], rowCount: 0 };
+    });
+  });
+
+  it('creates dashboard tables as project_admin', async () => {
+    await service.createTable(
+      'public',
+      'posts',
+      [{ columnName: 'title', type: ColumnType.STRING, isNullable: false }],
+      true
+    );
+
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const createTableIndex = sqlCalls.findIndex((sql) => sql.includes('CREATE TABLE "public"."posts"'));
+    const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
+    const commitIndex = sqlCalls.indexOf('COMMIT');
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(createTableIndex).toBeGreaterThan(setRoleIndex);
+    expect(resetRoleIndex).toBeGreaterThan(createTableIndex);
+    expect(commitIndex).toBeGreaterThan(resetRoleIndex);
+  });
+
+  it('updates dashboard table schema as project_admin', async () => {
+    tableExists = true;
+
+    await service.updateTableSchema('public', 'posts', {
+      addColumns: [{ columnName: 'summary', type: ColumnType.STRING, isNullable: true }],
+    });
+
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const alterTableIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('ALTER TABLE "public"."posts"') && sql.includes('ADD COLUMN "summary"')
+    );
+    const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
+    const commitIndex = sqlCalls.indexOf('COMMIT');
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(alterTableIndex).toBeGreaterThan(setRoleIndex);
+    expect(resetRoleIndex).toBeGreaterThan(alterTableIndex);
+    expect(commitIndex).toBeGreaterThan(resetRoleIndex);
+  });
+
+  it('deletes dashboard tables as project_admin', async () => {
+    await service.deleteTable('public', 'posts');
+
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const dropTableIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('DROP TABLE IF EXISTS "public"."posts" CASCADE')
+    );
+    const resetRoleIndex = sqlCalls.indexOf('RESET ROLE');
+    const commitIndex = sqlCalls.indexOf('COMMIT');
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(dropTableIndex).toBeGreaterThan(setRoleIndex);
+    expect(resetRoleIndex).toBeGreaterThan(dropTableIndex);
+    expect(commitIndex).toBeGreaterThan(resetRoleIndex);
+  });
+
+  it('delegates protected-schema create attempts to project_admin privileges', async () => {
+    await service.createTable(
+      'auth',
+      'users_copy',
+      [{ columnName: 'email', type: ColumnType.STRING, isNullable: false }],
+      true
+    );
+
+    const sqlCalls = queryMock.mock.calls.map(([sql]) => sql as string);
+    const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
+    const createTableIndex = sqlCalls.findIndex((sql) =>
+      sql.includes('CREATE TABLE "auth"."users_copy"')
+    );
+
+    expect(setRoleIndex).toBeGreaterThan(-1);
+    expect(createTableIndex).toBeGreaterThan(setRoleIndex);
+  });
+});

--- a/backend/tests/unit/database.service.test.ts
+++ b/backend/tests/unit/database.service.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { poolQueryMock } = vi.hoisted(() => ({
+  poolQueryMock: vi.fn(),
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        query: poolQueryMock,
+      })),
+    })),
+  },
+}));
+
+import { DatabaseService } from '../../src/services/database/database.service';
+
+describe('DatabaseService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('derives dashboard schema protection from project_admin CREATE privilege', async () => {
+    poolQueryMock.mockResolvedValue({
+      rows: [
+        { name: 'public', isProtected: false },
+        { name: 'analytics', isProtected: false },
+        { name: 'auth', isProtected: true },
+      ],
+    });
+
+    const service = DatabaseService.getInstance();
+    const result = await service.getSchemas();
+
+    expect(result).toEqual({
+      schemas: [
+        { name: 'public', isProtected: false },
+        { name: 'analytics', isProtected: false },
+        { name: 'auth', isProtected: true },
+      ],
+    });
+
+    expect(poolQueryMock).toHaveBeenCalledWith(expect.any(String), ['public']);
+
+    const sql = poolQueryMock.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("has_schema_privilege(to_regrole('project_admin'), n.oid, 'CREATE')");
+    expect(sql).not.toContain('ANY($1::text[])');
+  });
+});

--- a/backend/tests/unit/project-admin-database-create-privilege-migration.test.ts
+++ b/backend/tests/unit/project-admin-database-create-privilege-migration.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '048_project-admin-database-create-privilege.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('project admin database create privilege migration', () => {
+  it('migration file exists and runs after internal runtime defaults hardening', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const migrationIndex = migrations.indexOf(migrationFile);
+    const predecessorIndex = migrations.indexOf('047_harden-internal-runtime-defaults.sql');
+
+    expect(predecessorIndex).not.toBe(-1);
+    expect(migrationIndex).not.toBe(-1);
+    expect(migrationIndex).toBeGreaterThan(predecessorIndex);
+  });
+
+  it('grants database CREATE to project_admin without assuming the role or database name', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(/IF EXISTS \(SELECT 1 FROM pg_roles WHERE rolname = 'project_admin'\)/i);
+    expect(sql).toMatch(
+      /EXECUTE format\('GRANT CREATE ON DATABASE %I TO project_admin', current_database\(\)\)/i
+    );
+    expect(sql).not.toMatch(/GRANT CREATE ON DATABASE\s+(?!%I)/i);
+  });
+});

--- a/deploy/Dockerfile.postgres
+++ b/deploy/Dockerfile.postgres
@@ -1,4 +1,4 @@
-FROM ghcr.io/insforge/postgres:v15.13.3
+FROM ghcr.io/insforge/postgres:v15.13.4
 COPY deploy/docker-init/db/postgresql.conf /etc/postgresql/postgresql.conf
 COPY deploy/docker-init/db/db-init.sql /docker-entrypoint-initdb.d/01-init.sql
 COPY deploy/docker-init/db/jwt.sql /docker-entrypoint-initdb.d/02-jwt.sql

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -81,7 +81,7 @@ spec:
           template: PREBUILT_V2
           spec:
             source:
-                image: ghcr.io/insforge/postgres:v15.13.3
+                image: ghcr.io/insforge/postgres:v15.13.4
                 command:
                     - docker-entrypoint.sh
                     - postgres

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/insforge/postgres:v15.13.3
+    image: ghcr.io/insforge/postgres:v15.13.4
 
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: ghcr.io/insforge/postgres:v15.13.3
+    image: ghcr.io/insforge/postgres:v15.13.4
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12120,6 +12120,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12141,6 +12142,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12162,6 +12164,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12183,6 +12186,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12204,6 +12208,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12225,6 +12230,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12246,6 +12252,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12267,6 +12274,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12288,6 +12296,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12309,6 +12318,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12330,6 +12340,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -6,7 +6,6 @@ import {
   buildDynamicSchema,
   getDatabaseSchemaInfo,
   getInitialValues,
-  isInsForgeManagedDatabaseSchema,
   parseDatabaseTableReference,
 } from '#features/database/helpers';
 
@@ -22,11 +21,6 @@ function column(overrides: Partial<ColumnSchema>): ColumnSchema {
 }
 
 describe('database helpers', () => {
-  it('detects InsForge-managed schemas', () => {
-    expect(isInsForgeManagedDatabaseSchema('auth')).toBe(true);
-    expect(isInsForgeManagedDatabaseSchema('public')).toBe(false);
-  });
-
   it('builds schema query strings only for non-default schemas', () => {
     expect(buildDatabaseSchemaSearch(DEFAULT_DATABASE_SCHEMA)).toBe('');
     expect(buildDatabaseSchemaSearch('auth')).toBe('?schema=auth');
@@ -71,8 +65,12 @@ describe('database helpers', () => {
     expect(schema.safeParse({ id: 'ignored', name: 'Ada', age: 1 }).success).toBe(true);
   });
 
-  it('falls back schema info for unknown schemas', () => {
+  it('uses backend schema metadata for protection state and keeps unknown schemas writable by default', () => {
     expect(getDatabaseSchemaInfo(undefined, 'auth')).toEqual({
+      name: 'auth',
+      isProtected: false,
+    });
+    expect(getDatabaseSchemaInfo([{ name: 'auth', isProtected: true }], 'auth')).toEqual({
       name: 'auth',
       isProtected: true,
     });

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -4,27 +4,6 @@ import { z } from 'zod';
 
 export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
 
-export const INSFORGE_MANAGED_DATABASE_SCHEMAS = [
-  'ai',
-  'auth',
-  'compute',
-  'cron',
-  'deployments',
-  'email',
-  'functions',
-  'payments',
-  'realtime',
-  'schedules',
-  'storage',
-  'system',
-] as const;
-
-const insforgeManagedDatabaseSchemaSet = new Set<string>(INSFORGE_MANAGED_DATABASE_SCHEMAS);
-
-export function isInsForgeManagedDatabaseSchema(schemaName: string): boolean {
-  return insforgeManagedDatabaseSchemaSet.has(schemaName);
-}
-
 export const SYSTEM_FIELDS = ['id', 'created_at', 'updated_at'];
 
 // Helper function to build dynamic Zod schema based on column definitions
@@ -196,7 +175,7 @@ export function getDatabaseSchemaInfo(
   return (
     schemas?.find((schema) => schema.name === schemaName) ?? {
       name: schemaName,
-      isProtected: isInsForgeManagedDatabaseSchema(schemaName),
+      isProtected: false,
     }
   );
 }

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -654,7 +654,7 @@ export default function TablesPage() {
                     title={`No tables in ${selectedSchema}`}
                     description={
                       selectedSchemaInfo.isProtected
-                        ? 'InsForge-managed schemas are protected in the dashboard.'
+                        ? 'This schema is protected in the dashboard.'
                         : 'Create a table from the sidebar to get started.'
                     }
                   />


### PR DESCRIPTION
## Summary

- Bump the root package version from `2.1.9` to `2.1.10` and keep `package-lock.json` in sync.
- Update all `ghcr.io/insforge/postgres:v15.13.3` image references to `v15.13.4` across Docker Compose, Dockerfile, and deployment template files.

## Validation

- `rg -n "ghcr\\.io/insforge/postgres:v15\\.13\\.3|postgres:v15\\.13\\.3|15\\.13\\.3"` returned no matches.
- `npx turbo run typecheck`
- `npx turbo run lint`
- `npx turbo run test` (run outside sandbox because local port binding is blocked in sandbox)
- `npx turbo run build`

Note: `npx turbo run build` emitted the existing Vite outDir/chunk-size warnings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant `project_admin` database-level CREATE privilege and run all DDL under admin context
> - Adds a migration ([048_project-admin-database-create-privilege.sql](https://github.com/InsForge/InsForge/pull/1390/files#diff-ea49cee8e09ae282f70a82dc5ae0ba1f813ecb81ff82c04b53dd9abb4576b3d3)) that grants CREATE on the current database to the `project_admin` role, guarded by a role-existence check.
> - Removes `assertWritableDatabaseSchema` prechecks from `AdminRecordService`, `DatabaseTableService`, and `DatabaseAdvanceService`; all CRUD and DDL operations now run inside `withAdminContext` on a single `PoolClient`.
> - Schema protection in `DatabaseService.getSchemas` is now computed dynamically via `has_schema_privilege(to_regrole('project_admin'), n.oid, 'CREATE')` instead of a static list; `INSFORGE_MANAGED_DATABASE_SCHEMAS` and related helpers are removed.
> - Dashboard `getDatabaseSchemaInfo` defaults `isProtected` to `false` when schema metadata is absent from the backend.
> - Bumps the Postgres image from `v15.13.3` to `v15.13.4` and the package version to `2.1.10`.
> - Behavioral Change: writes to previously protected schemas (e.g. internal schemas not in the static list) are now permitted wherever `project_admin` holds CREATE privilege, rather than being blocked at the application layer.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1390 opened
>
> - Introduced `AdminRecordService.withAdminTransaction` helper method and refactored `AdminRecordService.listRecords`, `AdminRecordService.lookupRecord`, `AdminRecordService.createRecords`, `AdminRecordService.updateRecord`, and `AdminRecordService.deleteRecords` methods to execute within this wrapper [f0627f3]
> - Added documentation comment to `user-context.service.ts` describing `withAdminContext` behavior [f0627f3]
> - Updated unit tests in `admin-record.service.test.ts` to verify transactional execution patterns and client discard behavior [f0627f3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d774d7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL image to v15.13.4
  * Bumped application version to 2.1.10

* **Improvements**
  * Schema protection is now determined dynamically from database role privileges
  * Dashboard empty-state message for protected schemas clarified ("This schema is protected in the dashboard.")

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->