### PR TITLE
ci: guard against duplicate migration numbers

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,25 @@
+name: Check Migrations
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  check-duplicate-numbers:
+    name: Check for duplicate migration numbers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Check for duplicate migration numbers
+        run: node scripts/check-migration-duplicates.js
+        working-directory: backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "migrate:up": "npm run migrate:bootstrap && node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down": "node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:create": "node-pg-migrate create --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
+    "migrate:check-duplicates": "node scripts/check-migration-duplicates.js",
     "migrate:redo": "npm run migrate:bootstrap && node-pg-migrate redo --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:up:local": "dotenv -e ../.env -- npm run migrate:bootstrap && dotenv -e ../.env -- node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down:local": "dotenv -e ../.env -- node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",

--- a/backend/scripts/check-migration-duplicates.js
+++ b/backend/scripts/check-migration-duplicates.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Detects migration files that share the same numeric prefix.
+ *
+ * node-pg-migrate orders migrations by their leading number, so two files with
+ * the same prefix (e.g. `047_a.sql` and `047_b.sql`) have an ambiguous order and
+ * can apply inconsistently across environments. This guard runs in CI (and as a
+ * unit test) to stop new duplicates from landing on main.
+ *
+ * A small set of historical duplicates already exists on main and is grandfathered
+ * in via ALLOWED_DUPLICATES — those are tolerated, anything new is rejected.
+ *
+ * Exports `findDuplicateMigrations()` for the test suite; runs as a CLI (exit 1 on
+ * new duplicates) when executed directly.
+ */
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const MIGRATIONS_DIR = join(__dirname, '..', 'src', 'infra', 'database', 'migrations');
+
+// Pre-existing duplicate prefixes on main. Do not add to this list — fix the
+// duplicate instead. These remain only because the migrations already shipped.
+export const ALLOWED_DUPLICATES = new Set(['033', '047']);
+
+const MIGRATION_FILE = /^(\d+)_.*\.sql$/;
+
+/**
+ * @param {string} [dir] migrations directory to scan
+ * @returns {{ count: number, newDuplicates: Array<{prefix:string, files:string[]}>,
+ *             grandfathered: Array<{prefix:string, files:string[]}>, nextPrefix: string }}
+ */
+export function findDuplicateMigrations(dir = MIGRATIONS_DIR) {
+  const byPrefix = new Map();
+
+  for (const name of readdirSync(dir)) {
+    const match = MIGRATION_FILE.exec(name);
+    if (!match) continue;
+    const prefix = match[1];
+    if (!byPrefix.has(prefix)) byPrefix.set(prefix, []);
+    byPrefix.get(prefix).push(name);
+  }
+
+  const newDuplicates = [];
+  const grandfathered = [];
+
+  for (const [prefix, files] of byPrefix) {
+    if (files.length < 2) continue;
+    files.sort();
+    (ALLOWED_DUPLICATES.has(prefix) ? grandfathered : newDuplicates).push({ prefix, files });
+  }
+
+  const maxPrefix = byPrefix.size
+    ? Math.max(...[...byPrefix.keys()].map((p) => parseInt(p, 10)))
+    : -1;
+
+  return {
+    count: byPrefix.size,
+    newDuplicates,
+    grandfathered,
+    nextPrefix: String(maxPrefix + 1).padStart(3, '0'),
+  };
+}
+
+function main() {
+  const { count, newDuplicates, grandfathered, nextPrefix } = findDuplicateMigrations();
+
+  if (grandfathered.length > 0) {
+    console.log('Known (grandfathered) duplicate migration prefixes:');
+    for (const { prefix, files } of grandfathered) {
+      console.log(`  ${prefix}: ${files.join(', ')}`);
+    }
+  }
+
+  if (newDuplicates.length > 0) {
+    console.error('\nERROR: duplicate migration number(s) detected:');
+    for (const { prefix, files } of newDuplicates) {
+      console.error(`  ${prefix}: ${files.join(', ')}`);
+    }
+    console.error(
+      `\nEach migration needs a unique number. Renumber the new file to the next ` +
+        `available prefix (currently ${nextPrefix}_).`
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nOK: ${count} unique migration number(s), no new duplicates.`);
+}
+
+// Run as a CLI only when executed directly, not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/backend/scripts/check-migration-duplicates.js
+++ b/backend/scripts/check-migration-duplicates.js
@@ -13,6 +13,7 @@
  * Exports `findDuplicateMigrations()` for the test suite; runs as a CLI (exit 1 on
  * new duplicates) when executed directly.
  */
+/* global console, process */
 import { readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';

--- a/backend/tests/unit/migration-duplicate-numbers.test.ts
+++ b/backend/tests/unit/migration-duplicate-numbers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findDuplicateMigrations,
+  ALLOWED_DUPLICATES,
+} from '../../scripts/check-migration-duplicates.js';
+
+describe('migration numbers', () => {
+  it('has no duplicate numbers except the grandfathered 033 and 047', () => {
+    const { newDuplicates } = findDuplicateMigrations();
+
+    // newDuplicates excludes ALLOWED_DUPLICATES (033, 047). Anything here is a
+    // real collision that must be renumbered before merging.
+    expect(
+      newDuplicates,
+      `Duplicate migration number(s): ${newDuplicates
+        .map((d) => `${d.prefix} (${d.files.join(', ')})`)
+        .join('; ')}`
+    ).toEqual([]);
+  });
+
+  it('grandfathers exactly 033 and 047', () => {
+    expect([...ALLOWED_DUPLICATES].sort()).toEqual(['033', '047']);
+  });
+});


### PR DESCRIPTION
## Problem

Two migration files can end up with the same numeric prefix (e.g. `033_*.sql` ×2, `047_*.sql` ×2 already on `main`). node-pg-migrate orders migrations by that leading number, so a collision has an ambiguous apply order and can diverge across environments. Nothing currently stops a new one from landing.

## What this adds

- **`backend/scripts/check-migration-duplicates.js`** — scans `backend/src/infra/database/migrations`, groups files by their `NNN_` prefix, and exits non-zero on any duplicate. Output names the colliding files and suggests the next free number.
- **`.github/workflows/check-migrations.yml`** — runs the checker on every PR and on pushes to `main` (matches existing workflow conventions: `checkout@v6`, `setup-node@v6`, node 20).
- **`backend/tests/unit/migration-duplicate-numbers.test.ts`** — vitest unit test in the existing suite asserting no duplicates beyond the grandfathered set.
- **`migrate:check-duplicates`** npm script for local runs.

The two pre-existing duplicates **033** and **047** are grandfathered via an `ALLOWED_DUPLICATES` allowlist (with a comment to fix rather than extend it). Any *new* collision fails CI.

## Verification

- Clean tree: CLI exits 0, vitest 2/2 pass.
- Injected a real duplicate (`041`): CLI exits 1 and the vitest test fails, naming the colliding files; removing it returns to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI guard to block duplicate migration numbers used by `node-pg-migrate`. This prevents ambiguous apply order and stops new collisions from merging.

- **New Features**
  - Added `backend/scripts/check-migration-duplicates.js` to scan migration files, fail on duplicate numeric prefixes, and suggest the next free number. `033` and `047` are grandfathered only.
  - Added `.github/workflows/check-migrations.yml` to run the checker on PRs and pushes to `main` using Node.js 20 with `actions/checkout@v6` and `actions/setup-node@v6`.
  - Added a `vitest` unit test and an npm script `migrate:check-duplicates` for local runs.

- **Bug Fixes**
  - Declared Node.js globals in the script to satisfy ESLint `no-undef`.

<sup>Written for commit 9060e8e6fa7e759b1b7c67353675328e6c3643d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1391?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard against duplicate migration numbers in CI
> - Adds a [check-migration-duplicates.js](https://github.com/InsForge/InsForge/pull/1391/files#diff-47c178d0b439bcf8235f3aebbefe14b6d5c91131c98c729e10c8a140981edf06) script that scans the migrations directory, groups files by numeric prefix, and exits with code 1 if any new duplicate prefixes are found.
> - Prefixes `033` and `047` are grandfathered via an `ALLOWED_DUPLICATES` set and do not trigger failures.
> - A GitHub Actions workflow ([check-migrations.yml](https://github.com/InsForge/InsForge/pull/1391/files#diff-9c4bfd050ca12885b582fbfd04536460a7a4a0770824ee46694010b1e4e53287)) runs the check on every push to `main` and on all PRs.
> - Unit tests in [migration-duplicate-numbers.test.ts](https://github.com/InsForge/InsForge/pull/1391/files#diff-c7e5914b126435e487e69a0b202d314a626f3e9c24469c1d7601ecc257f9c826) assert no new duplicates exist and that the grandfathered set is exactly `['033', '047']`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1391 opened
>
> - Added global declaration comment for linting in migration duplicate check script [9060e8e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12c7de4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated migration validation that runs in CI for main branch pushes and pull requests.

* **Tests**
  * Added unit tests to detect unexpected duplicate migration numbers, with an allowlist for pre-existing duplicates.

* **Chores**
  * Added a CLI check and an npm script to validate migration numbering as part of the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->