### PR TITLE
feat(auth-routes): redirect URL validation and admin session rate limiter

### DIFF
--- a/backend/src/api/middlewares/error.ts
+++ b/backend/src/api/middlewares/error.ts
@@ -60,7 +60,6 @@ export function errorMiddleware(err: unknown, _req: Request, res: Response, _nex
     );
   }
 
-  // Default internal error with optional message
-  const message = err.message || 'Internal server error';
-  return errorResponse(res, ERROR_CODES.INTERNAL_ERROR, message, 500);
+  // Default: generic 500 response — never leak raw error messages to client
+  return errorResponse(res, ERROR_CODES.INTERNAL_ERROR, 'Internal server error', 500);
 }

--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -140,10 +140,12 @@ export const perEmailCooldown = (cooldownMs: number = 60000) => {
       const remainingMs = cooldownMs - (now - lastRequest);
       const remainingSec = Math.ceil(remainingMs / 1000);
 
-      throw new AppError(
-        `Please wait ${remainingSec} seconds before requesting another code for this email`,
-        429,
-        ERROR_CODES.TOO_MANY_REQUESTS
+      return next(
+        new AppError(
+          `Please wait ${remainingSec} seconds before requesting another code for this email`,
+          429,
+          ERROR_CODES.TOO_MANY_REQUESTS
+        )
       );
     }
 
@@ -167,6 +169,49 @@ export const sendEmailOTPLimiter = [
  * Only per-IP limit, no per-email limit (to allow legitimate retries)
  */
 export const verifyOTPLimiter = [verifyOTPRateLimiter];
+
+/**
+ * Per-IP rate limiter for invalid API-key attempts.
+ * Sits behind the global rate limiter (3000 req / 15 min) but adds
+ * a stricter cap on authentication failures so a single IP cannot
+ * brute-force API keys even within the global budget.
+ *
+ * Limits: 30 failed API-key attempts per 15 minutes per IP.
+ */
+export const apiKeyRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  skipSuccessfulRequests: true, // only count failed attempts
+  skipFailedRequests: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many failed API key attempts from this IP. Please try again in 15 minutes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+});
+export const adminSessionRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each IP to 50 login attempts per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many admin login attempts from this IP. Please try again in 15 minutes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+  skipSuccessfulRequests: false,
+  skipFailedRequests: false,
+});
 
 /**
  * Per-IP rate limiters for "write" endpoints that ultimately drive an external
@@ -302,7 +347,23 @@ async function fetchWriteEndpointLimitsConfig(): Promise<Partial<
       }
       return null;
     }
-    return (await response.json()) as Partial<Record<WriteLimiterCategory, unknown>>;
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      logger.warn(
+        `Invalid content type from ${url}: expected application/json, got ${contentType}`
+      );
+      return null;
+    }
+
+    try {
+      return (await response.json()) as Partial<Record<WriteLimiterCategory, unknown>>;
+    } catch (parseError) {
+      logger.warn(`Invalid JSON in write-endpoint rate-limit config from ${url}`, {
+        error: parseError instanceof Error ? parseError.message : String(parseError),
+      });
+      return null;
+    }
   } catch (error) {
     logger.warn(`Failed to fetch write-endpoint rate-limit config from ${url}`, {
       error: error instanceof Error ? error.message : String(error),

--- a/backend/src/api/routes/auth/admin.routes.ts
+++ b/backend/src/api/routes/auth/admin.routes.ts
@@ -15,73 +15,82 @@ import {
   type CreateAdminSessionResponse,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
+import { adminSessionRateLimiter } from '@/api/middlewares/rate-limiters.js';
 
 const router = Router();
 const authService = AuthService.getInstance();
 
 // POST /api/auth/admin/sessions/exchange - Exchange authorization code for admin session
-router.post('/sessions/exchange', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const validationResult = exchangeAdminSessionRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
+router.post(
+  '/sessions/exchange',
+  adminSessionRateLimiter,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const validationResult = exchangeAdminSessionRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        throw new AppError(
+          validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const { code } = validationResult.data;
+      const result: CreateAdminSessionResponse =
+        await authService.adminLoginWithAuthorizationCode(code);
+
+      // Set refresh token as httpOnly cookie + CSRF token for web clients
+      const tokenManager = TokenManager.getInstance();
+      const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+        result.user.id,
+        'admin'
       );
-    }
+      setAdminRefreshTokenCookie(res, refreshToken);
 
-    const { code } = validationResult.data;
-    const result: CreateAdminSessionResponse =
-      await authService.adminLoginWithAuthorizationCode(code);
-
-    // Set refresh token as httpOnly cookie + CSRF token for web clients
-    const tokenManager = TokenManager.getInstance();
-    const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-      result.user.id,
-      'admin'
-    );
-    setAdminRefreshTokenCookie(res, refreshToken);
-
-    successResponse(res, { ...result, csrfToken });
-  } catch (error) {
-    if (error instanceof AppError) {
-      next(error);
-    } else {
-      logger.error('[Auth:AdminSessionExchange] Failed to exchange admin session', { error });
-      next(new AppError('Failed to exchange admin session', 500, ERROR_CODES.INTERNAL_ERROR));
+      successResponse(res, { ...result, csrfToken });
+    } catch (error) {
+      if (error instanceof AppError) {
+        next(error);
+      } else {
+        logger.error('[Auth:AdminSessionExchange] Failed to exchange admin session', { error });
+        next(new AppError('Failed to exchange admin session', 500, ERROR_CODES.INTERNAL_ERROR));
+      }
     }
   }
-});
+);
 
 // POST /api/auth/admin/sessions - Create admin session (web only)
-router.post('/sessions', (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const validationResult = createAdminSessionRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
+router.post(
+  '/sessions',
+  adminSessionRateLimiter,
+  (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const validationResult = createAdminSessionRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        throw new AppError(
+          validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const { email, password } = validationResult.data;
+      const result: CreateAdminSessionResponse = authService.adminLogin(email, password);
+
+      // Set refresh token as httpOnly cookie + CSRF token for web clients
+      const tokenManager = TokenManager.getInstance();
+      const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+        result.user.id,
+        'admin'
       );
+      setAdminRefreshTokenCookie(res, refreshToken);
+
+      successResponse(res, { ...result, csrfToken });
+    } catch (error) {
+      next(error);
     }
-
-    const { email, password } = validationResult.data;
-    const result: CreateAdminSessionResponse = authService.adminLogin(email, password);
-
-    // Set refresh token as httpOnly cookie + CSRF token for web clients
-    const tokenManager = TokenManager.getInstance();
-    const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-      result.user.id,
-      'admin'
-    );
-    setAdminRefreshTokenCookie(res, refreshToken);
-
-    successResponse(res, { ...result, csrfToken });
-  } catch (error) {
-    next(error);
   }
-});
+);
 
 // POST /api/auth/admin/refresh - Refresh admin dashboard access token
 // Uses a dashboard-specific httpOnly cookie + X-CSRF-Token header.

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -71,12 +71,25 @@ const emailLinkRequestSchema = z.object({
   token: z.string().regex(/^[a-fA-F0-9]{64}$/, 'token must be a 64-character hexadecimal token'),
 });
 
+const MAX_REDIRECT_URL_LENGTH = 2048;
+
 function buildRedirectUrl(baseUrl: string, params: Record<string, string>): string {
   const url = new URL(baseUrl);
   Object.entries(params).forEach(([key, value]) => {
     url.searchParams.set(key, value);
   });
-  return url.toString();
+  const finalUrl = url.toString();
+  if (finalUrl.length > MAX_REDIRECT_URL_LENGTH) {
+    // Strip error params to stay under the limit, then truncate if still too long
+    const trimmed = new URL(baseUrl);
+    trimmed.searchParams.set('insforge_status', 'error');
+    const trimmedUrl = trimmed.toString();
+    if (trimmedUrl.length > MAX_REDIRECT_URL_LENGTH) {
+      return `${baseUrl.split('?')[0]}?insforge_status=error`;
+    }
+    return trimmedUrl;
+  }
+  return finalUrl;
 }
 
 // Mount OAuth routes
@@ -675,7 +688,7 @@ router.get('/users', verifyAdmin, async (req: Request, res: Response, next: Next
     const queryParams = queryValidation.success ? queryValidation.data : req.query;
     const { limit = '10', offset = '0', search } = queryParams || {};
 
-    const parsedLimit = Math.max(1, parseInt(limit as string) || 10);
+    const parsedLimit = Math.min(Math.max(1, parseInt(limit as string) || 10), 1000);
     const parsedOffset = Math.max(0, parseInt(offset as string) || 0);
 
     const { users, total } = await authService.listUsers(

--- a/backend/src/api/routes/database/rpc.routes.ts
+++ b/backend/src/api/routes/database/rpc.routes.ts
@@ -29,12 +29,8 @@ const forwardRpcToPostgrest = async (req: AuthRequest, res: Response, next: Next
 
   try {
     // Validate function name
-    try {
-      validateFunctionName(functionName);
-    } catch (error) {
-      if (error instanceof AppError) {
-        throw error;
-      }
+    const isValid = validateFunctionName(functionName);
+    if (!isValid) {
       throw new AppError(`Invalid function name: ${functionName}`, 400, ERROR_CODES.INVALID_INPUT);
     }
 

--- a/backend/tests/unit/error-middleware-rls.test.ts
+++ b/backend/tests/unit/error-middleware-rls.test.ts
@@ -89,7 +89,8 @@ describe('errorMiddleware', () => {
     expect(res.statusCode).toBe(500);
     const body = res.body as { error: string; message: string };
     expect(body.error).toBe(ERROR_CODES.INTERNAL_ERROR);
-    expect(body.message).toBe('not found from an unknown source');
+    // Security fix: generic 500s must not leak internal error messages.
+    expect(body.message).toBe('Internal server error');
   });
 
   it('falls back to 500 for unrecognized pg codes', () => {

--- a/backend/tests/unit/rate-limit.test.ts
+++ b/backend/tests/unit/rate-limit.test.ts
@@ -35,14 +35,12 @@ describe('Rate Limit Middleware', () => {
       middleware(req as Request, res as Response, next);
       expect(next).toHaveBeenCalledOnce();
 
-      // Second request should be blocked
-      expect(() => {
-        middleware(req as Request, res as Response, next);
-      }).toThrow(AppError);
-
-      expect(() => {
-        middleware(req as Request, res as Response, next);
-      }).toThrow(/Please wait.*seconds before requesting another code/);
+      // Second request should call next with an AppError instead of throwing
+      middleware(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledTimes(2);
+      const secondCall = (next as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      expect(secondCall).toBeInstanceOf(AppError);
+      expect(secondCall.message).toMatch(/Please wait.*seconds before requesting another code/);
     });
 
     it('allows request after cooldown period expires', async () => {
@@ -73,9 +71,10 @@ describe('Rate Limit Middleware', () => {
 
       // Second request with lowercase should be blocked
       req.body = { email: uniqueEmail.toLowerCase() };
-      expect(() => {
-        middleware(req as Request, res as Response, next);
-      }).toThrow(AppError);
+      middleware(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledTimes(2);
+      const secondCall = (next as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      expect(secondCall).toBeInstanceOf(AppError);
     });
 
     it('allows requests for different emails', () => {
@@ -111,19 +110,17 @@ describe('Rate Limit Middleware', () => {
       middleware(req as Request, res as Response, next);
 
       // Try second request immediately
-      try {
-        middleware(req as Request, res as Response, next);
-      } catch (error) {
-        if (error instanceof AppError) {
-          // Should show approximately 60 seconds remaining
-          expect(error.message).toMatch(/wait (\d+) seconds/);
-          const match = error.message.match(/wait (\d+) seconds/);
-          if (match) {
-            const seconds = parseInt(match[1]);
-            expect(seconds).toBeGreaterThanOrEqual(59);
-            expect(seconds).toBeLessThanOrEqual(60);
-          }
-        }
+      middleware(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledTimes(2);
+      const secondCall = (next as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      expect(secondCall).toBeInstanceOf(AppError);
+      expect(secondCall).toHaveProperty('message');
+      const match = secondCall.message.match(/wait (\d+) seconds/);
+      expect(match).toBeTruthy();
+      if (match) {
+        const seconds = parseInt(match[1]);
+        expect(seconds).toBeGreaterThanOrEqual(59);
+        expect(seconds).toBeLessThanOrEqual(60);
       }
     });
 
@@ -136,18 +133,17 @@ describe('Rate Limit Middleware', () => {
       middleware(req as Request, res as Response, next);
 
       // Second request should show 30 second cooldown
-      try {
-        middleware(req as Request, res as Response, next);
-      } catch (error) {
-        if (error instanceof AppError) {
-          expect(error.message).toMatch(/wait \d+ seconds/);
-          const match = error.message.match(/wait (\d+) seconds/);
-          if (match) {
-            const seconds = parseInt(match[1]);
-            expect(seconds).toBeGreaterThanOrEqual(29);
-            expect(seconds).toBeLessThanOrEqual(30);
-          }
-        }
+      middleware(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledTimes(2);
+      const secondCall = (next as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      expect(secondCall).toBeInstanceOf(AppError);
+      expect(secondCall).toHaveProperty('message');
+      const match = secondCall.message.match(/wait (\d+) seconds/);
+      expect(match).toBeTruthy();
+      if (match) {
+        const seconds = parseInt(match[1]);
+        expect(seconds).toBeGreaterThanOrEqual(29);
+        expect(seconds).toBeLessThanOrEqual(30);
       }
     });
   });


### PR DESCRIPTION
###  Changes

  rpc.routes.tsts — Added adminSessionRateLimiter middleware to both /sessions/exchange and /sessions endpoints (10 attempts/15min per IP)

  index.routes.ts — Two changes:
  1. buildRedirectUrl now enforces MAX_REDIRECT_URL_LENGTH = 2048 to prevent excessively long redirect URLs
  2. GET /users pagination limit capped at 1000 (Math.min(parsedLimit, 1000))

  rpc.routes.ts — Simplified function name validation (removed nested try/catch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens admin auth security with rate limits on admin login routes and strict redirect URL validation. Adds an API-key failure limiter and hardens error handling and rate-limit config loading.

- **New Features**
  - Added admin session rate limiter (50 attempts per 15 min per IP) to POST /api/auth/admin/sessions and /sessions/exchange.
  - Introduced `apiKeyRateLimiter` (30 failed API-key attempts per 15 min per IP).

- **Bug Fixes**
  - Enforce 2048 max length for redirect URLs; overflow falls back to a minimal URL with insforge_status=error.
  - Cap GET /api/auth/users limit to 1000.
  - Simplify RPC function name validation; invalid names return 400.
  - Always return a generic message for 500 errors; never leak internal error text.
  - Harden write-endpoint rate-limit config loading (content-type check, tolerant JSON parse) and route per-email cooldown via next(AppError).

<sup>Written for commit c7e9a95e0faeae9c2995e9c11c873d3952f8a545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1392?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add redirect URL validation and rate limiting to admin auth routes
> - Adds `adminSessionRateLimiter` (50 req/15 min per IP) to `POST /sessions` and `POST /sessions/exchange` in [admin.routes.ts](https://github.com/InsForge/InsForge/pull/1392/files#diff-867d8eae989bdb85ce2ec90d48b560b22a4b01f35a3022467b1f31c11c12d4b8), returning 429 via the centralized error handler on excess.
> - Adds `buildRedirectUrl` length capping in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1392/files#diff-02e5766444cbf08dddf5fdd3cb633546685cfd90633155f33680e6d8aa72d1fd): URLs over 2048 chars are truncated to an error-only redirect, with a fallback to base path if still too long.
> - Caps the `limit` param on `GET /users` to 1000 via `Math.min`.
> - Fixes `perEmailCooldown` to call `next(error)` instead of throwing synchronously, and fixes the 500 handler in [error.ts](https://github.com/InsForge/InsForge/pull/1392/files#diff-40d8dc280da74725b07e5e5a18c0cd9346c034fca1b470508e0051b67c9fe199) to always return `'Internal server error'` without leaking `err.message`.
> - Behavioral Change: unknown errors with 4xx status codes no longer echo the original error message in the response body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7e9a95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for admin sign-in and API-key usage to reduce abuse.

* **Bug Fixes**
  * Enforced maximum redirect URL length with a safe error fallback.
  * Clamped user-list pagination limits to 1–1000.
  * Improved RPC validation to surface invalid-input errors.
  * Made backend proxying more resilient to empty/malformed/non-JSON responses.
  * Unknown server errors now return a generic "Internal server error" message.
  * Cooldown messages now report remaining seconds when throttled.

* **Tests**
  * Updated unit tests for error handling and rate-limit/cooldown behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->