### PR TITLE
TEST (do not merge): intentional duplicate migration to prove CI fails

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,25 @@
+name: Check Migrations
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  check-duplicate-numbers:
+    name: Check for duplicate migration numbers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Check for duplicate migration numbers
+        run: node scripts/check-migration-duplicates.js
+        working-directory: backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "migrate:up": "npm run migrate:bootstrap && node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down": "node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:create": "node-pg-migrate create --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
+    "migrate:check-duplicates": "node scripts/check-migration-duplicates.js",
     "migrate:redo": "npm run migrate:bootstrap && node-pg-migrate redo --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:up:local": "dotenv -e ../.env -- npm run migrate:bootstrap && dotenv -e ../.env -- node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down:local": "dotenv -e ../.env -- node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",

--- a/backend/scripts/check-migration-duplicates.js
+++ b/backend/scripts/check-migration-duplicates.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Detects migration files that share the same numeric prefix.
+ *
+ * node-pg-migrate orders migrations by their leading number, so two files with
+ * the same prefix (e.g. `047_a.sql` and `047_b.sql`) have an ambiguous order and
+ * can apply inconsistently across environments. This guard runs in CI (and as a
+ * unit test) to stop new duplicates from landing on main.
+ *
+ * A small set of historical duplicates already exists on main and is grandfathered
+ * in via ALLOWED_DUPLICATES — those are tolerated, anything new is rejected.
+ *
+ * Exports `findDuplicateMigrations()` for the test suite; runs as a CLI (exit 1 on
+ * new duplicates) when executed directly.
+ */
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const MIGRATIONS_DIR = join(__dirname, '..', 'src', 'infra', 'database', 'migrations');
+
+// Pre-existing duplicate prefixes on main. Do not add to this list — fix the
+// duplicate instead. These remain only because the migrations already shipped.
+export const ALLOWED_DUPLICATES = new Set(['033', '047']);
+
+const MIGRATION_FILE = /^(\d+)_.*\.sql$/;
+
+/**
+ * @param {string} [dir] migrations directory to scan
+ * @returns {{ count: number, newDuplicates: Array<{prefix:string, files:string[]}>,
+ *             grandfathered: Array<{prefix:string, files:string[]}>, nextPrefix: string }}
+ */
+export function findDuplicateMigrations(dir = MIGRATIONS_DIR) {
+  const byPrefix = new Map();
+
+  for (const name of readdirSync(dir)) {
+    const match = MIGRATION_FILE.exec(name);
+    if (!match) continue;
+    const prefix = match[1];
+    if (!byPrefix.has(prefix)) byPrefix.set(prefix, []);
+    byPrefix.get(prefix).push(name);
+  }
+
+  const newDuplicates = [];
+  const grandfathered = [];
+
+  for (const [prefix, files] of byPrefix) {
+    if (files.length < 2) continue;
+    files.sort();
+    (ALLOWED_DUPLICATES.has(prefix) ? grandfathered : newDuplicates).push({ prefix, files });
+  }
+
+  const maxPrefix = byPrefix.size
+    ? Math.max(...[...byPrefix.keys()].map((p) => parseInt(p, 10)))
+    : -1;
+
+  return {
+    count: byPrefix.size,
+    newDuplicates,
+    grandfathered,
+    nextPrefix: String(maxPrefix + 1).padStart(3, '0'),
+  };
+}
+
+function main() {
+  const { count, newDuplicates, grandfathered, nextPrefix } = findDuplicateMigrations();
+
+  if (grandfathered.length > 0) {
+    console.log('Known (grandfathered) duplicate migration prefixes:');
+    for (const { prefix, files } of grandfathered) {
+      console.log(`  ${prefix}: ${files.join(', ')}`);
+    }
+  }
+
+  if (newDuplicates.length > 0) {
+    console.error('\nERROR: duplicate migration number(s) detected:');
+    for (const { prefix, files } of newDuplicates) {
+      console.error(`  ${prefix}: ${files.join(', ')}`);
+    }
+    console.error(
+      `\nEach migration needs a unique number. Renumber the new file to the next ` +
+        `available prefix (currently ${nextPrefix}_).`
+    );
+    process.exit(1);
+  }
+
+  console.log(`\nOK: ${count} unique migration number(s), no new duplicates.`);
+}
+
+// Run as a CLI only when executed directly, not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/backend/src/infra/database/migrations/041_dup-proof-DELETEME.sql
+++ b/backend/src/infra/database/migrations/041_dup-proof-DELETEME.sql
@@ -1,0 +1,1 @@
+-- intentional duplicate to prove CI catches it

--- a/backend/tests/unit/migration-duplicate-numbers.test.ts
+++ b/backend/tests/unit/migration-duplicate-numbers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findDuplicateMigrations,
+  ALLOWED_DUPLICATES,
+} from '../../scripts/check-migration-duplicates.js';
+
+describe('migration numbers', () => {
+  it('has no duplicate numbers except the grandfathered 033 and 047', () => {
+    const { newDuplicates } = findDuplicateMigrations();
+
+    // newDuplicates excludes ALLOWED_DUPLICATES (033, 047). Anything here is a
+    // real collision that must be renumbered before merging.
+    expect(
+      newDuplicates,
+      `Duplicate migration number(s): ${newDuplicates
+        .map((d) => `${d.prefix} (${d.files.join(', ')})`)
+        .join('; ')}`
+    ).toEqual([]);
+  });
+
+  it('grandfathers exactly 033 and 047', () => {
+    expect([...ALLOWED_DUPLICATES].sort()).toEqual(['033', '047']);
+  });
+});


### PR DESCRIPTION
Throwaway PR to demonstrate the new Check Migrations CI catches a duplicate migration number (041). Will be closed and branch deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI check to block duplicate migration numbers. Includes a temporary duplicate (041) to prove the check fails.

- New Features
  - Added `backend/scripts/check-migration-duplicates.js` to detect duplicate numeric prefixes, allowlist `033` and `047`, and exit non‑zero on new collisions.
  - Added GitHub Actions workflow to run the check on PRs and pushes to `main`.
  - Added `migrate:check-duplicates` script in `backend/package.json`.
  - Added unit test to assert no new duplicates and validate the allowlist.
  - Added `041_dup-proof-DELETEME.sql` as an intentional duplicate to demonstrate CI failure (temporary, do not merge).

<sup>Written for commit 5aac0239aa038dc46de511ee8224354a62646388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1393?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add duplicate migration number detection via CI workflow and unit tests
> - Adds [`check-migration-duplicates.js`](https://github.com/InsForge/InsForge/pull/1393/files#diff-47c178d0b439bcf8235f3aebbefe14b6d5c91131c98c729e10c8a140981edf06) which scans the migrations directory, groups files by numeric prefix, and exits with code 1 if any non-grandfathered duplicates are found.
> - Adds a GitHub Actions workflow ([`check-migrations.yml`](https://github.com/InsForge/InsForge/pull/1393/files#diff-9c4bfd050ca12885b582fbfd04536460a7a4a0770824ee46694010b1e4e53287)) that runs the checker script on every push to main and on all PRs.
> - Adds a Vitest unit test ([`migration-duplicate-numbers.test.ts`](https://github.com/InsForge/InsForge/pull/1393/files#diff-c7e5914b126435e487e69a0b202d314a626f3e9c24469c1d7601ecc257f9c826)) that asserts no new duplicate prefixes exist and that the `ALLOWED_DUPLICATES` set contains exactly `'033'` and `'047'`.
> - Includes an intentional duplicate migration [`041_dup-proof-DELETEME.sql`](https://github.com/InsForge/InsForge/pull/1393/files#diff-6294edae4c3093062d197cb582fe45f375aa87d2c2ce13fc6e4ab519b7855fd7) to prove CI fails — this file must be removed before merging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5aac023.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation in the CI/CD pipeline to detect and prevent duplicate database migration numbers, ensuring data integrity and preventing potential deployment conflicts.

* **Tests**
  * Added unit tests to verify that all database migrations maintain unique sequential numbering as required by the system's migration framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->