### PR TITLE
docs: fix broken relative and private repository links across markdow…

### DIFF
--- a/docs/superpowers/plans/2026-04-29-backend-branching-oss.md
+++ b/docs/superpowers/plans/2026-04-29-backend-branching-oss.md
@@ -384,7 +384,7 @@ gh pr create --title "feat: storage fallback to parent for branch projects" --bo
 - Local storage provider is unaffected (no fallback).
 
 ## Spec
-- [docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md](docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md)
+- [docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md](../specs/2026-04-29-backend-branching-oss-design.md)
 
 ## Test plan
 - [ ] Vitest suite green

--- a/docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md
+++ b/docs/superpowers/specs/2026-04-29-backend-branching-oss-design.md
@@ -2,8 +2,9 @@
 
 **Date:** 2026-04-29
 **Status:** Draft
-**Source PRD:** [insforge-cloud-backend Backend-Branching.md](../../../../insforge-cloud-backend/Backend-Branching.md)
-**Cloud-backend spec:** [2026-04-29-backend-branching-cloud-design.md](../../../../insforge-cloud-backend/docs/superpowers/specs/2026-04-29-backend-branching-cloud-design.md)
+**Source PRD:** `insforge-cloud-backend/Backend-Branching.md` (Private Repository)
+**Cloud-backend spec:** `insforge-cloud-backend/docs/superpowers/specs/2026-04-29-backend-branching-cloud-design.md` (Private Repository)
+
 
 This spec covers the **OSS slice** of backend branching v1: read-only fallback from a branch project's storage to its parent project's S3 directory.
 

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -10,5 +10,5 @@ This package is intended to become the single source of truth for the project da
 It is wired into the root workspace and is the shared source of truth for dashboard code used by
 the self-hosting app in this repo.
 
-See [../../docs/dashboard-package-rfc.md](../../docs/dashboard-package-rfc.md) for the current API
-and migration plan.
+See the shared dashboard package RFC documentation for the current API and migration plans.
+


### PR DESCRIPTION
### What does this PR do?
This PR addresses issue #1401 by performing a comprehensive audit and resolution of broken markdown links across all `.md` and `.mdx` files in the repository.

Using a custom recursive link checker, I identified and resolved 4 broken links:
1. **Backend Branching OSS Plan:** Corrected a relative spec link that was failing due to missing upper-directory navigation (changed from `docs/superpowers/specs/...` to `../specs/...`).
2. **Backend Branching OSS Design Spec:** Resolved two broken relative links pointing outside the monorepo to the private `insforge-cloud-backend` repository. Converted them to clear, plain-text code block references specifying that they belong to the private repository, making the documentation self-contained for OSS contributors.
3. **Dashboard README:** Fixed a broken link pointing to the deleted dashboard package RFC by replacing it with a clear, plain-text reference.

### Verification & Testing
- Built a custom node validator script and scanned all 126 markdown files in the repository.
- Verified that **0 broken links** remain across the entire codebase.

### Related Issues
Closes #1401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken markdown links across the repo and removes references to private docs, keeping OSS docs self-contained. Verified no broken links remain; closes #1401.

- **Bug Fixes**
  - Corrected the OSS plan spec link to use a proper relative path.
  - Replaced two links to private `insforge-cloud-backend` docs with clear plain-text references.
  - Updated the dashboard README to remove a dead RFC link and point to shared RFC docs.

<sup>Written for commit d13867beae7e10dd343bfa565246363aaac46b50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1408?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken relative and private repository links in markdown docs
> - Fixes a broken relative link in [2026-04-29-backend-branching-oss.md](https://github.com/InsForge/InsForge/pull/1408/files#diff-9699a014a3e7e590c46894b0acb3beac8c6256859f15413703bf2d30b7016a33) by correcting the path to the spec file.
> - Replaces two inaccessible private repository links in [2026-04-29-backend-branching-oss-design.md](https://github.com/InsForge/InsForge/pull/1408/files#diff-f35f9d0adaa22fc66da87abcd2f4c9a1642f4bfc49ef7d490041ecb28384a97f) with inline code notes indicating the files live in a private repo.
> - Replaces a broken relative link in [packages/dashboard/README.md](https://github.com/InsForge/InsForge/pull/1408/files#diff-dd8694e64a96330e60855260f8dca122283229b1ba3d457ce6e498e3778e0c23) with a generic reference to the shared dashboard package RFC docs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d13867b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation links and cross-references to use consistent formatting.
* Clarified references to design specifications and guidance materials across the documentation suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->