### PR TITLE
fix(migrations): guard against destructive replay on an empty migration ledger

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "test:ui": "vitest --ui",
     "test:e2e": "./tests/run-all-tests.sh",
     "migrate:bootstrap": "tsx src/infra/database/migrations/bootstrap/bootstrap-migrations.js",
+    "migrate:baseline": "tsx src/infra/database/migrations/bootstrap/baseline-migrations.js",
     "migrate:up": "npm run migrate:bootstrap && node-pg-migrate up --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:down": "node-pg-migrate down --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",
     "migrate:create": "node-pg-migrate create --migrations-dir src/infra/database/migrations --migrations-schema system --migrations-table migrations",

--- a/backend/src/infra/database/migrations/bootstrap/baseline-migrations.js
+++ b/backend/src/infra/database/migrations/bootstrap/baseline-migrations.js
@@ -1,0 +1,127 @@
+/**
+ * Baseline script for the node-pg-migrate ledger.
+ *
+ * Recovery tool for the case the bootstrap guard refuses: the database schema is
+ * already provisioned (restored from a backup / branched) but `system.migrations`
+ * is empty. This stamps the ledger with every migration currently on disk, so
+ * node-pg-migrate treats them as applied and only runs genuinely-new migrations
+ * on the next `migrate:up`.
+ *
+ * SAFETY:
+ * - Only runs when the ledger is EMPTY. If it already has rows it refuses, so it
+ *   can never clobber real migration history.
+ * - Use ONLY when the restored schema is at the SAME migration version as this
+ *   build (the normal same-version restore / branch / DR case). If the schema is
+ *   from an OLDER version, stamping every on-disk migration would skip the newer
+ *   ones — in that case restore from a backup that includes system.migrations
+ *   instead.
+ *
+ * The cloud-backend restore path should invoke this after a same-version restore,
+ * or an operator can run `npm run migrate:baseline` manually.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import pg from 'pg';
+import logger from '@/utils/logger.js';
+
+const { Pool } = pg;
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+// bootstrap -> migrations
+const MIGRATIONS_DIR = path.resolve(currentDir, '..');
+
+/**
+ * The migration "name" node-pg-migrate stores is the filename without the `.sql`
+ * extension, ordered lexicographically (matching node-pg-migrate's own ordering).
+ * Exported for unit testing.
+ */
+export function readMigrationNames(dir = MIGRATIONS_DIR) {
+  return fs
+    .readdirSync(dir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort()
+    .map((file) => file.replace(/\.sql$/, ''));
+}
+
+export async function baselineMigrations() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    logger.error('DATABASE_URL environment variable is not set');
+    process.exit(1);
+  }
+
+  const names = readMigrationNames();
+  if (names.length === 0) {
+    logger.error('Baseline: no migration files found, aborting');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString });
+
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query('CREATE SCHEMA IF NOT EXISTS system');
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS system.migrations (
+          id SERIAL PRIMARY KEY,
+          name varchar(255) NOT NULL,
+          run_on timestamp NOT NULL
+        )
+      `);
+
+      await client.query('BEGIN');
+      try {
+        // Lock the table so a concurrent boot can't race us, then re-check empty.
+        await client.query('LOCK TABLE system.migrations IN EXCLUSIVE MODE');
+        const { rows } = await client.query('SELECT count(*)::int AS n FROM system.migrations');
+        if ((rows[0]?.n ?? 0) > 0) {
+          await client.query('ROLLBACK');
+          logger.error(
+            'Baseline: system.migrations is not empty — refusing to clobber existing ' +
+              'migration history. No changes made.'
+          );
+          process.exit(1);
+        }
+
+        await client.query(
+          `INSERT INTO system.migrations (name, run_on)
+           SELECT name, now() FROM unnest($1::text[]) AS name`,
+          [names]
+        );
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      }
+
+      logger.info(
+        `Baseline: stamped ${names.length} migrations as applied ` +
+          `(${names[0]} … ${names[names.length - 1]}). node-pg-migrate will now only run new migrations.`
+      );
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    logger.error('Baseline failed', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}
+
+if (!process.env.VITEST) {
+  baselineMigrations().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Baseline failed', {
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/infra/database/migrations/bootstrap/bootstrap-migrations.js
+++ b/backend/src/infra/database/migrations/bootstrap/bootstrap-migrations.js
@@ -11,6 +11,14 @@
  * - This would cause all migrations to appear as "pending" and fail
  *
  * This script runs BEFORE node-pg-migrate and handles the table move gracefully.
+ *
+ * It also acts as a SAFETY GUARD against a corrupted migration ledger: if the
+ * database schema is already provisioned (e.g. it was restored from a backup)
+ * but `system.migrations` is empty, node-pg-migrate would otherwise replay every
+ * migration from scratch. Those migrations are NOT idempotent (018 moves/renames
+ * tables, others DROP or mutate data), so replaying them against an already-built
+ * database crashes or corrupts it. We detect that state and refuse to continue,
+ * with actionable remediation, instead of letting the replay run.
  */
 
 import pg from 'pg';
@@ -21,7 +29,67 @@ import logger from '@/utils/logger.js';
 
 const { Pool } = pg;
 
-async function bootstrapMigrations() {
+/**
+ * Tables that only exist once migrations have run (created/renamed by 018+).
+ * If any of these exist, the database has been migrated before — so an empty
+ * ledger means the ledger was lost, not that this is a fresh install.
+ */
+const PROVISIONED_SCHEMA_MARKERS = ['auth.users', 'system.secrets', 'storage.objects'];
+
+/**
+ * Pure decision helper (exported for unit testing).
+ *
+ * Returns true when node-pg-migrate must NOT be allowed to run, because doing so
+ * would replay already-applied, non-idempotent migrations against a populated
+ * database. That happens precisely when the ledger table exists but is empty
+ * while the schema is already provisioned.
+ *
+ * A genuine fresh install also has an empty ledger, but its schema is NOT
+ * provisioned, so this returns false and node-pg-migrate runs normally.
+ */
+export function shouldRefuseReplay({ ledgerTableExists, ledgerRowCount, schemaProvisioned }) {
+  return Boolean(ledgerTableExists) && ledgerRowCount === 0 && Boolean(schemaProvisioned);
+}
+
+async function isSchemaProvisioned(client) {
+  const { rows } = await client.query(
+    `SELECT bool_or(to_regclass($1) IS NOT NULL
+                 OR to_regclass($2) IS NOT NULL
+                 OR to_regclass($3) IS NOT NULL) AS provisioned`,
+    PROVISIONED_SCHEMA_MARKERS
+  );
+  return Boolean(rows[0]?.provisioned);
+}
+
+async function countLedgerRows(client) {
+  const { rows } = await client.query('SELECT count(*)::int AS n FROM system.migrations');
+  return rows[0]?.n ?? 0;
+}
+
+function logInconsistentLedgerError() {
+  logger.error(
+    [
+      'Bootstrap: REFUSING TO RUN MIGRATIONS — inconsistent migration state detected.',
+      '',
+      'The database schema is already provisioned (auth/system/storage tables exist),',
+      'but the system.migrations ledger is EMPTY. This almost always means the database',
+      'was restored from a backup (or branched) WITHOUT its system.migrations rows.',
+      '',
+      'Running node-pg-migrate now would replay every migration from 000 against an',
+      'already-migrated database. Those migrations are not idempotent (e.g. 018 moves',
+      'and renames tables, others DROP/mutate data), so the replay would crash or corrupt',
+      'the database. Refusing instead.',
+      '',
+      'To recover:',
+      '  - Same-version restore/branch: run `npm run migrate:baseline` to stamp the ledger',
+      '    to match the migrations already present, then restart.',
+      '  - Otherwise: restore from a FULL pg_dump that includes the `system` schema',
+      '    (so system.migrations is repopulated). Backups must not exclude it.',
+    ].join('\n')
+  );
+}
+
+export async function bootstrapMigrations() {
   // Use DATABASE_URL from environment (set by dotenv-cli in npm scripts)
   const connectionString = process.env.DATABASE_URL;
 
@@ -71,6 +139,24 @@ async function bootstrapMigrations() {
 
         logger.info('Bootstrap: Successfully moved _migrations to system.migrations');
       } else if (newTableExists.rows[0].exists) {
+        // The ledger table already exists. Before letting node-pg-migrate proceed,
+        // guard against a lost ledger on an already-provisioned database.
+        const [ledgerRowCount, schemaProvisioned] = await Promise.all([
+          countLedgerRows(client),
+          isSchemaProvisioned(client),
+        ]);
+
+        if (
+          shouldRefuseReplay({
+            ledgerTableExists: true,
+            ledgerRowCount,
+            schemaProvisioned,
+          })
+        ) {
+          logInconsistentLedgerError();
+          process.exit(1);
+        }
+
         // Already migrated, nothing to do
         logger.info('Bootstrap: system.migrations already exists, skipping');
       } else if (!oldTableExists.rows[0].exists && !newTableExists.rows[0].exists) {
@@ -93,11 +179,14 @@ async function bootstrapMigrations() {
   }
 }
 
-bootstrapMigrations().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  logger.error('Bootstrap migration failed', {
-    error: message,
-    stack: error instanceof Error ? error.stack : undefined,
+// Auto-run when executed as a script, but not when imported by unit tests.
+if (!process.env.VITEST) {
+  bootstrapMigrations().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('Bootstrap migration failed', {
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    process.exitCode = 1;
   });
-  process.exitCode = 1;
-});
+}

--- a/backend/tests/unit/bootstrap-migrations-guard.test.ts
+++ b/backend/tests/unit/bootstrap-migrations-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRefuseReplay } from '@/infra/database/migrations/bootstrap/bootstrap-migrations.js';
+import { readMigrationNames } from '@/infra/database/migrations/bootstrap/baseline-migrations.js';
+
+// Guards the regression where a database restored without its system.migrations
+// ledger (empty ledger, fully-provisioned schema) caused node-pg-migrate to
+// replay every migration from 000 and crash on the non-idempotent 018.
+describe('bootstrap migration ledger guard', () => {
+  describe('shouldRefuseReplay', () => {
+    it('refuses replay when the ledger is empty but the schema is already provisioned', () => {
+      expect(
+        shouldRefuseReplay({ ledgerTableExists: true, ledgerRowCount: 0, schemaProvisioned: true })
+      ).toBe(true);
+    });
+
+    it('allows a genuine fresh install (empty ledger, unprovisioned schema)', () => {
+      expect(
+        shouldRefuseReplay({ ledgerTableExists: true, ledgerRowCount: 0, schemaProvisioned: false })
+      ).toBe(false);
+    });
+
+    it('allows a normal boot when the ledger already has rows', () => {
+      expect(
+        shouldRefuseReplay({ ledgerTableExists: true, ledgerRowCount: 48, schemaProvisioned: true })
+      ).toBe(false);
+    });
+
+    it('does not fire before the ledger table exists', () => {
+      expect(
+        shouldRefuseReplay({ ledgerTableExists: false, ledgerRowCount: 0, schemaProvisioned: true })
+      ).toBe(false);
+    });
+  });
+
+  describe('readMigrationNames (baseline)', () => {
+    const names = readMigrationNames();
+
+    it('returns migration names without the .sql extension or any path', () => {
+      expect(names.length).toBeGreaterThan(0);
+      expect(names.every((n) => !n.endsWith('.sql') && !n.includes('/'))).toBe(true);
+    });
+
+    it('is lexicographically sorted (matching node-pg-migrate ordering)', () => {
+      expect(names).toEqual([...names].sort());
+    });
+
+    it('includes known migrations in the ledger name format', () => {
+      expect(names).toContain('000_create-base-tables');
+      expect(names).toContain('018_schema-rework');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a project is upgraded (the instance is rebuilt and its Postgres is **restored from an S3 backup**), the database can come back with a **fully-provisioned schema but an empty `system.migrations` ledger**. node-pg-migrate keys entirely off that ledger, so it concludes *nothing* has been applied and replays every migration from `000`. It then crashes on the **non-idempotent** `018_schema-rework` (`ALTER TABLE public._secrets SET SCHEMA system` → `type "_secrets" already exists in schema "system"`), and because `migrate:up` runs in the container entrypoint (`Dockerfile`), the container enters an **infinite restart loop** with a cryptic error.

This took down a production instance for hours. The trigger is "Upgrade Project"; the root mechanism is a restore that doesn't preserve the migration ledger, and a bootstrap that doesn't notice.

## Why this slips through today

`bootstrap-migrations.js` only handles the legacy `public._migrations → system.migrations` *move*. Its "already migrated" branch checks that the table **exists** — never that it is **consistent with the schema**. So "table present, 0 rows, schema fully built" sails straight through into a destructive replay.

## Fix (this PR — OSS side)

1. **Bootstrap guard** (`bootstrap-migrations.js`): when `system.migrations` exists but is **empty** while the schema is already provisioned (`auth.users` / `system.secrets` / `storage.objects` exist), **refuse to run** with an actionable error instead of letting node-pg-migrate replay. Turns a multi-hour silent outage into an instant, self-explaining failure. A genuine fresh install (empty ledger, unprovisioned schema) is unaffected.
2. **`migrate:baseline`** recovery command (`baseline-migrations.js` + npm script): stamps the ledger to match the on-disk migrations, **only when the ledger is empty** (locks + re-checks, refuses to clobber real history). The documented recovery path for a same-version restore/branch, and what the cloud-backend restore path should call.
3. **Unit tests** for the guard decision and the baseline name derivation (static + pure-logic, no DB — matches the existing migration-test style).

## Required companion change (cloud-backend — NOT in this repo)

The true root cause is that the **backup/restore path drops `system.migrations`**. Backups must be a **full `pg_dump` that includes the `system` schema** (no `--schema-only` / `--exclude-schema=system`), and restore should use `ON_ERROR_STOP=1` so a failed ledger load is loud, not silently swallowed. With that, the ledger round-trips and no replay is ever attempted. This PR is the defense-in-depth backstop for when that fails.

## Test plan

- `npm run test` (backend) — new `bootstrap-migrations-guard.test.ts` passes.
- Manual: on a DB with a populated schema and `TRUNCATE system.migrations`, `npm run migrate:up` now exits with the guard error (was: crash loop on 018). `npm run migrate:baseline` then stamps the ledger and `migrate:up` proceeds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents destructive migration replay when a restored DB has a fully built schema but an empty `system.migrations` ledger, and adds a safe `migrate:baseline` command for recovery. This stops crash loops and provides a clear, fast path to fix.

- **Bug Fixes**
  - Bootstrap guard: if `system.migrations` exists but is empty while the schema is provisioned (`auth.users`, `system.secrets`, `storage.objects`), exit with an actionable error instead of letting `node-pg-migrate` replay; fresh installs are unaffected.
  - Avoids the replay crash on non-idempotent `018_schema-rework`; includes unit tests for the guard decision and baseline name derivation.

- **Migration**
  - Recovery: run `npm run migrate:baseline` only when the ledger is empty after a same-version restore/branch. It stamps the ledger with on-disk migrations under lock and refuses if any rows exist.
  - Backups/restores should include the `system` schema and use `ON_ERROR_STOP=1` so `system.migrations` is preserved and consistent.

<sup>Written for commit 088008ed36f3602b5cc435b561d3daeb12ac010d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard against destructive migration replay on an empty migration ledger
> - Adds a guard in [`bootstrap-migrations.js`](https://github.com/InsForge/InsForge/pull/1419/files#diff-7746b3b0ee5829501ca9332bc9574ca15fb2902f47230f18a0d74de83c2de569) that detects when `system.migrations` exists but is empty while the schema is already provisioned, then exits with an error instead of letting `node-pg-migrate` replay all migrations.
> - Adds a new [`baseline-migrations.js`](https://github.com/InsForge/InsForge/pull/1419/files#diff-932a726c1c36436dbdb1bcfc87eef864c765d1eda11c4fe4593de28fe6c3e3b9) script (exposed as `migrate:baseline`) that stamps `system.migrations` with all on-disk migration names when the ledger is empty, providing the remediation path for the inconsistent state.
> - Adds unit tests covering the `shouldRefuseReplay` guard logic and `readMigrationNames` ordering behavior.
> - Behavioral Change: on startup, an empty ledger with a provisioned schema now causes a hard exit(1) instead of proceeding with migrations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 088008e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline migration functionality to initialize the migration ledger when database schema already exists but migration history is missing.

* **Bug Fixes**
  * Implemented safety guard to prevent replaying non-idempotent migrations during inconsistent ledger states.

* **Tests**
  * Added test suite for migration ledger guard and baseline migration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->