### PR TITLE
docs: rename Compute to Custom Compute

### DIFF
--- a/docs/core-concepts/compute/overview.mdx
+++ b/docs/core-concepts/compute/overview.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Compute"
+title: "Custom Compute"
 sidebarTitle: "Overview"
 description: "Run long-lived containers next to your InsForge project."
 ---
 
-Use InsForge Compute to run long-lived containers next to your project: queue workers, background processors, AI inference loops, websocket servers, scrapers, anything that needs to stay up. Containers attach to your project's database, storage, and auth with the same credentials a function would use.
+Use InsForge Custom Compute to run long-lived containers next to your project: queue workers, background processors, AI inference loops, websocket servers, scrapers, anything that needs to stay up. Containers attach to your project's database, storage, and auth with the same credentials a function would use.
 
 <Note>
-  **Just need to handle a request?** Use [Edge Functions](/core-concepts/functions/overview) for request/response work and short jobs. Compute is for processes that need to run continuously.
+  **Just need to handle a request?** Use [Edge Functions](/core-concepts/functions/overview) for request/response work and short jobs. Custom Compute is for processes that need to run continuously.
 </Note>
 
 ```mermaid

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,7 +104,7 @@
                 ]
               },
               {
-                "group": "Compute",
+                "group": "Custom Compute",
                 "pages": [
                   "core-concepts/compute/overview"
                 ]


### PR DESCRIPTION
Renames the user-facing feature name from **Compute** to **Custom Compute** in the docs.

## Changes
- `core-concepts/compute/overview.mdx` — frontmatter `title` and the two prose references
- `docs.json` — nav group `"Compute"` → `"Custom Compute"`

Page slug (`core-concepts/compute/overview`) is unchanged, so no redirects needed.

The mermaid diagram node label `Compute Service` is left as-is — it reads as a generic internal component name rather than the product name. Happy to rename it too if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the user-facing feature from Compute to Custom Compute in docs for clarity and consistency.
Updated `core-concepts/compute/overview.mdx` title and prose and the `docs.json` nav group; the page slug stays the same (no redirects), and the mermaid node label remains "Compute Service".

<sup>Written for commit e7790597a05822a2dd1e206ef1d0ba5ee852536b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'Compute' to 'Custom Compute' in docs navigation and overview page
> Updates the group label in [docs.json](https://github.com/InsForge/InsForge/pull/1423/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9) and the page title and body text in [overview.mdx](https://github.com/InsForge/InsForge/pull/1423/files#diff-d971620bac3f949dc71e9920bb975cd174c2226cdb5ee03675e352496123e0e9) to use 'Custom Compute' instead of 'Compute'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e779059.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product naming from "Compute" to "Custom Compute" across documentation pages and navigation menus for consistent terminology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->