### PR TITLE
feat: rename public-facing Deployment terminology to Sites (fixes #1414)

### DIFF
--- a/docs/core-concepts/deployments/overview.mdx
+++ b/docs/core-concepts/deployments/overview.mdx
@@ -1,17 +1,17 @@
 ---
-title: "Deployments"
+title: "Sites"
 sidebarTitle: "Overview"
 description: "Deploy frontend apps from your project, powered by Vercel."
 ---
 
-Use InsForge Deployments to ship the browser-facing app that belongs to your project. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production deployment. The dashboard tracks the URL, status, deployment history, environment variables, and domains.
+Use InsForge Sites to ship the browser-facing app that belongs to your project. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production site. The dashboard tracks the URL, status, deployment history, environment variables, and domains.
 
-<Frame caption="Deployments dashboard: status, domains, env vars, and history.">
-  <img src="/images/dashboard-deployments.png" alt="InsForge Deployments dashboard" />
+<Frame caption="Sites dashboard: status, domains, env vars, and history.">
+  <img src="/images/dashboard-deployments.png" alt="InsForge Sites dashboard" />
 </Frame>
 
 <Note>
-  **Need to deploy a container or backend service?** Use [Compute](/core-concepts/compute/overview) for workers, queues, WebSocket servers, and long-running services. Deployments are for frontend websites and framework builds that produce a hosted web app.
+  **Need to deploy a container or backend service?** Use [Compute](/core-concepts/compute/overview) for workers, queues, WebSocket servers, and long-running services. Sites are for frontend websites and framework builds that produce a hosted web app.
 </Note>
 
 ```mermaid
@@ -27,7 +27,7 @@ flowchart TB
 
     Vercel --> App[Frontend app]
     App --> URL[Public URL]
-    App --> Status[Status and deployment history]
+    App --> Status[Status and site history]
 
     style CLI fill:#1e293b,stroke:#475569,color:#e2e8f0
     style Dashboard fill:#1e293b,stroke:#475569,color:#e2e8f0
@@ -64,9 +64,9 @@ npx @insforge/cli deployments env set VITE_INSFORGE_URL https://your-project.reg
 npx @insforge/cli deployments env set VITE_INSFORGE_ANON_KEY ik_xxx
 ```
 
-### Deployment history
+### Site history
 
-Review previous runs, sync Vercel status, inspect metadata, and cancel in-progress deployments from the Deployment Logs page.
+Review previous runs, sync Vercel status, inspect metadata, and cancel in-progress deployments from the Site Logs page.
 
 ```bash
 npx @insforge/cli deployments list

--- a/docs/core-concepts/deployments/overview.mdx
+++ b/docs/core-concepts/deployments/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "Deploy frontend apps from your project, powered by Vercel."
 ---
 
-Use InsForge Sites to ship the browser-facing app that belongs to your project. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production site. The dashboard tracks the URL, status, deployment history, environment variables, and domains.
+Use InsForge Sites to ship the browser-facing app that belongs to your project. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production site. The dashboard tracks the URL, status, site history, environment variables, and domains.
 
 <Frame caption="Sites dashboard: status, domains, env vars, and history.">
   <img src="/images/dashboard-deployments.png" alt="InsForge Sites dashboard" />

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,7 +85,7 @@
                 ]
               },
               {
-                "group": "Deployments",
+                "group": "Sites",
                 "pages": [
                   "core-concepts/deployments/overview"
                 ]

--- a/packages/dashboard/src/features/dashboard/components/dtest/DashboardPromptStepper.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DashboardPromptStepper.tsx
@@ -58,12 +58,12 @@ const PROMPT_STEPS: PromptStep[] = [
   {
     id: 4,
     key: 'deployment',
-    category: 'Deployment',
+    category: 'Sites',
     title: 'Deploy your site',
     prompt:
       'Use InsForge Skills to deploy this app on InsForge, after deploying, share the live URL.',
     icon: <Rocket className="size-12 text-[rgb(var(--disabled))]" />,
-    navigateTo: { label: 'Go to Deployment', path: '/dashboard/deployments' },
+    navigateTo: { label: 'Go to Sites', path: '/dashboard/deployments' },
   },
 ];
 

--- a/packages/dashboard/src/features/deployments/components/DeploymentMetaDataDialog.tsx
+++ b/packages/dashboard/src/features/deployments/components/DeploymentMetaDataDialog.tsx
@@ -39,17 +39,17 @@ export function DeploymentMetaDataDialog({
         <div className="flex flex-col gap-6 p-6 border-b border-neutral-200 dark:border-neutral-700">
           <div className="flex flex-col gap-1">
             <DialogTitle className="text-2xl font-semibold text-zinc-950 dark:text-white tracking-[-0.6px]">
-              Deployment Meta Data
+              Site Meta Data
             </DialogTitle>
             <DialogDescription className="sr-only">
-              View deployment metadata for debugging and auditing
+              View site metadata for debugging and auditing
             </DialogDescription>
             <p className="text-sm text-neutral-500 dark:text-neutral-300">{deployment?.id}</p>
           </div>
 
           <div className="flex flex-col gap-3">
             <p className="text-sm text-neutral-500 dark:text-neutral-400">
-              This metadata captures the context of this deployment and can be used for debugging or
+              This metadata captures the context of this site and can be used for debugging or
               AI-assisted investigation.
             </p>
 
@@ -85,7 +85,7 @@ export function DeploymentMetaDataDialog({
             className="h-8 px-3 bg-zinc-950 text-white hover:bg-zinc-800 dark:bg-emerald-300 dark:text-zinc-950 dark:hover:bg-emerald-400"
           >
             {copied ? <Check className="h-4 w-4 mr-1" /> : <Copy className="h-4 w-4 mr-1" />}
-            {copied ? 'Copied' : 'Copy Meta Data'}
+            {copied ? 'Copied' : 'Copy Site Meta Data'}
           </Button>
         </div>
       </DialogContent>

--- a/packages/dashboard/src/features/deployments/components/DeploymentsEmptyState.tsx
+++ b/packages/dashboard/src/features/deployments/components/DeploymentsEmptyState.tsx
@@ -5,9 +5,9 @@ export default function DeploymentsEmptyState() {
     <div className="flex flex-col items-center justify-center py-8 text-center gap-3 rounded-[8px] bg-neutral-100 dark:bg-[#333333]">
       <Rocket size={40} className="text-neutral-400 dark:text-neutral-600" />
       <div className="flex flex-col items-center justify-center gap-1">
-        <p className="text-sm font-medium text-zinc-950 dark:text-white">No deployments yet</p>
+        <p className="text-sm font-medium text-zinc-950 dark:text-white">No sites yet</p>
         <p className="text-neutral-500 dark:text-neutral-400 text-xs">
-          Deployments will appear here when you deploy your application
+          Sites will appear here when you deploy your application
         </p>
       </div>
     </div>

--- a/packages/dashboard/src/features/deployments/components/DeploymentsSidebar.tsx
+++ b/packages/dashboard/src/features/deployments/components/DeploymentsSidebar.tsx
@@ -8,7 +8,7 @@ const DEPLOYMENTS_SIDEBAR_ITEMS: FeatureSidebarListItem[] = [
   },
   {
     id: 'deployment-logs',
-    label: 'Deployment Logs',
+    label: 'Site Logs',
     href: '/dashboard/deployments/logs',
   },
   {
@@ -24,5 +24,5 @@ const DEPLOYMENTS_SIDEBAR_ITEMS: FeatureSidebarListItem[] = [
 ];
 
 export function DeploymentsSidebar() {
-  return <FeatureSidebar title="Deployments" items={DEPLOYMENTS_SIDEBAR_ITEMS} />;
+  return <FeatureSidebar title="Sites" items={DEPLOYMENTS_SIDEBAR_ITEMS} />;
 }

--- a/packages/dashboard/src/features/deployments/components/EnvVarDialog.tsx
+++ b/packages/dashboard/src/features/deployments/components/EnvVarDialog.tsx
@@ -228,7 +228,7 @@ export function EnvVarDialog({
           </DialogTitle>
         </div>
         <DialogDescription className="sr-only">
-          Configure deployment environment variables
+          Configure site environment variables
         </DialogDescription>
 
         <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto p-6">

--- a/packages/dashboard/src/features/deployments/components/EnvVarsEmptyState.tsx
+++ b/packages/dashboard/src/features/deployments/components/EnvVarsEmptyState.tsx
@@ -10,7 +10,7 @@ export default function EnvVarsEmptyState() {
         No environment variables yet
       </h3>
       <p className="text-sm text-neutral-500 dark:text-neutral-400 max-w-md">
-        Add environment variables to configure your deployment. These will be available to your
+        Add environment variables to configure your site. These will be available to your
         application at runtime.
       </p>
     </div>

--- a/packages/dashboard/src/features/deployments/pages/DeploymentDomainsPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentDomainsPage.tsx
@@ -508,7 +508,7 @@ export default function DeploymentDomainsPage() {
                   </div>
                 ) : (
                   <span className="text-[13px] text-muted-foreground dark:text-neutral-500">
-                    No deployment yet
+                    No site yet
                   </span>
                 )}
               </div>
@@ -681,7 +681,7 @@ export default function DeploymentDomainsPage() {
                 </DialogTitle>
               </div>
               <DialogDescription className="sr-only">
-                Add a custom domain to your deployment
+                Add a custom domain to your site
               </DialogDescription>
 
               <div className="flex flex-col gap-4 p-6">

--- a/packages/dashboard/src/features/deployments/pages/DeploymentLogsPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentLogsPage.tsx
@@ -131,7 +131,7 @@ export default function DeploymentLogsPage() {
       <div className="flex flex-col gap-6 p-4">
         {/* Title */}
         <h1 className="text-xl font-semibold text-zinc-950 dark:text-white tracking-[-0.1px]">
-          Deployment Log
+          Site Log
         </h1>
 
         {/* Filters Row */}
@@ -180,7 +180,7 @@ export default function DeploymentLogsPage() {
 
         {/* Table Header */}
         <div className="grid grid-cols-10 px-3 text-sm text-muted-foreground dark:text-neutral-400">
-          <div className="col-span-3 py-1 px-3">Deployment ID</div>
+          <div className="col-span-3 py-1 px-3">Site ID</div>
           <div className="col-span-3 py-1 px-3">Status</div>
           <div className="col-span-3 py-1 px-3">Created At</div>
           <div className="col-span-1" />
@@ -294,7 +294,7 @@ export default function DeploymentLogsPage() {
             onPageChange={handlePageChange}
             totalRecords={totalDeployments}
             pageSize={pageSize}
-            recordLabel="deployments"
+            recordLabel="sites"
           />
         </div>
       )}

--- a/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
@@ -99,14 +99,12 @@ export default function DeploymentOverviewPage() {
       return (
         <div className="bg-neutral-100 dark:bg-[#333] rounded-lg p-6">
           <div className="flex flex-col gap-6">
-            <h2 className="text-xl font-semibold text-zinc-950 dark:text-white">
-              No Deployments Yet
-            </h2>
+            <h2 className="text-xl font-semibold text-zinc-950 dark:text-white">No Sites Yet</h2>
 
             <div className="flex flex-col gap-3">
               <p className="text-sm text-muted-foreground dark:text-neutral-400">
-                Send the prompt below to your connected AI agent to deploy your project for the
-                first time.
+                Send the prompt below to your connected AI agent to deploy your site for the first
+                time.
               </p>
 
               <div className="bg-neutral-200 dark:bg-[#171717] rounded-lg p-3 flex flex-col gap-2">
@@ -157,7 +155,7 @@ export default function DeploymentOverviewPage() {
                 <iframe
                   key={iframeKey}
                   src={deploymentUrl}
-                  title="Deployment Preview"
+                  title="Site Preview"
                   className="absolute top-0 left-0 w-[1215px] h-[912px] origin-top-left scale-[0.333] border-0 pointer-events-none"
                   sandbox="allow-scripts allow-same-origin"
                   loading="lazy"

--- a/packages/dashboard/src/navigation/menuItems.ts
+++ b/packages/dashboard/src/navigation/menuItems.ts
@@ -132,7 +132,7 @@ export const dashboardSettingsMenuItem: DashboardPrimaryMenuItem = {
 
 export const dashboardDeploymentsMenuItem: DashboardPrimaryMenuItem = {
   id: 'deployments',
-  label: 'Deployments',
+  label: 'Sites',
   href: '/dashboard/deployments',
   icon: Rocket,
 };


### PR DESCRIPTION
### Summary
This PR addresses **Issue #1414** by updating all user-visible references from "Deployment" to "Sites" across the dashboard and OSS product documentation.

As per the issue guidelines, this is strictly a terminology and branding update. All underlying variables, component names, API request/response fields, and database schemas remain unchanged to preserve backward compatibility.

### Scope of Changes
- **Dashboard Navigation:** Updated the primary sidebar item, onboarding stepper prompts, and feature sub-sidebar titles from "Deployments" to "Sites".
- **Dashboard Empty States & Dialogues:** Updated copy across `DeploymentsEmptyState`, `EnvVarsEmptyState`, `EnvVarDialog`, and `DeploymentMetaDataDialog` to use "Sites" and "Site Meta Data" terminology.
- **Dashboard Pages:** 
  - `DeploymentOverviewPage`: Updated text to "No Sites Yet" and "Site Preview".
  - `DeploymentLogsPage`: Updated page titles to "Site Log", "Site ID", and table pagination labels to "sites".
  - `DeploymentDomainsPage`: Updated fallback text to "No site yet" and "Add a custom domain to your site".
- **Mintlify Documentation:** 
  - Updated the `docs.json` navigation group to "Sites".
  - Audited the Deployments `overview.mdx` document to consistently refer to "Sites" and "Site history" (including flowchart diagrams and image `alt` attributes).

### Verification
- [x] Ran `npm run typecheck` to verify no types were broken during the component string updates.
- [x] Ran formatting to ensure no ESLint rules were broken. 
- [x] Verified the `Deployments` to `Sites` changes visually across the dashboard pages.

Fixes #1414

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed all user-visible “Deployments” to “Sites” across the dashboard and docs to match the new branding. Copy-only changes; no API, component, or schema updates. Fixes #1414.

- **Refactors**
  - Dashboard: updated primary nav label, feature sidebar title, onboarding stepper category/CTA, empty states, page titles (Logs → “Site Log”, Overview), table/pagination labels (“sites”), preview title (“Site Preview”), and copy in domains, env var, and metadata dialogs.
  - Docs: changed navigation group to “Sites” and completed wording on the deployments overview page (e.g., “Vercel production site”, “site history”, “Site Logs”, diagram labels, and image alt text).

<sup>Written for commit 8e058409178538fb3847bbdb5687026983b38c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename public-facing 'Deployments' terminology to 'Sites' across dashboard and docs
> Replaces all user-facing instances of 'Deployment'/'Deployments' with 'Site'/'Sites' to align with updated product terminology. Changes affect the primary nav label, sidebar header, logs page, overview page, domain management page, empty states, dialogs, and the docs navigation and content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e05840.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rebranded “Deployments” to “Sites” across docs and navigation; updated overview copy, diagrams, and “Site history” wording.

* **Dashboard**
  * Unified terminology in menus, sidebars, pages, dialogs, empty states, buttons, table headers, pagination labels, env var text, logs, and preview titles to use “Site/Sites” throughout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->