### PR TITLE
Add PgBouncer connection pooling support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,16 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=insforge
 
 # -----------------------------------------------------------------------------
+# PgBouncer Connection Pooler
+# -----------------------------------------------------------------------------
+# PgBouncer sits between the app and Postgres, reducing connection overhead.
+# These defaults work well for most workloads.
+PGBOUNCER_DEFAULT_POOL_SIZE=20
+PGBOUNCER_MAX_CLIENT_CONN=100
+PGBOUNCER_MAX_DB_CONNECTIONS=0
+PGBOUNCER_QUERY_WAIT_TIMEOUT=120
+
+# -----------------------------------------------------------------------------
 # Ports (Configurable)
 # -----------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ USER node
 EXPOSE 7130 7131
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["sh", "-c", "cd backend && npm run migrate:up && cd .. && exec npm start"]
+CMD ["sh", "-c", "cd backend && DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_DIRECT_HOST:-${POSTGRES_HOST:-localhost}}:${POSTGRES_DIRECT_PORT:-${POSTGRES_PORT:-5432}}/${POSTGRES_DB:-insforge} npm run migrate:up && cd .. && exec npm start"]
 
 
 # ============================================================

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -199,12 +199,14 @@ export class DatabaseManager {
   }
 
   /**
-   * Create a dedicated client for operations that can't use pooled connections (e.g., LISTEN/NOTIFY)
+   * Create a dedicated client for operations that can't use pooled connections (e.g., LISTEN/NOTIFY).
+   * Always connects directly to Postgres, bypassing PgBouncer (transaction pooling
+   * does not support LISTEN/NOTIFY or prepared statements).
    */
   createClient(): Client {
     return new Client({
-      host: process.env.POSTGRES_HOST || 'localhost',
-      port: parseInt(process.env.POSTGRES_PORT || '5432'),
+      host: process.env.POSTGRES_DIRECT_HOST || process.env.POSTGRES_HOST || 'localhost',
+      port: parseInt(process.env.POSTGRES_DIRECT_PORT || process.env.POSTGRES_PORT || '5432'),
       database: process.env.POSTGRES_DB || 'insforge',
       user: process.env.POSTGRES_USER || 'postgres',
       password: process.env.POSTGRES_PASSWORD || 'postgres',

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -19,11 +19,36 @@ services:
       timeout: 5s
       retries: 5
 
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
+      - DEFAULT_POOL_SIZE=${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      - MAX_CLIENT_CONN=${PGBOUNCER_MAX_CLIENT_CONN:-100}
+      - MAX_DB_CONNECTIONS=${PGBOUNCER_MAX_DB_CONNECTIONS:-0}
+      - QUERY_WAIT_TIMEOUT=${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - insforge-network
+
   postgrest:
     image: postgrest/postgrest:v12.2.12
 
     restart: unless-stopped
     environment:
+      # PostgREST connects directly to Postgres (needs LISTEN/NOTIFY for schema reload)
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
@@ -53,6 +78,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
       postgrest:
         condition: service_healthy
     ports:
@@ -67,13 +94,16 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@pgbouncer:5432/${POSTGRES_DB:-insforge}
+      # Direct Postgres connection (for LISTEN/NOTIFY, migrations)
+      - POSTGRES_DIRECT_HOST=postgres
+      - POSTGRES_DIRECT_PORT=5432
       - POSTGREST_BASE_URL=http://postgrest:3000
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
@@ -116,7 +146,7 @@ services:
 
     working_dir: /app
     depends_on:
-      - postgres
+      - pgbouncer
       - postgrest
     ports:
       - "${DENO_PORT:-7133}:7133"
@@ -124,8 +154,8 @@ services:
       - PORT=7133
       - DENO_ENV=development
       - DENO_DIR=/deno-dir
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -17,10 +17,33 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      AUTH_TYPE: scram-sha-256
+      POOL_MODE: transaction
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-100}
+      MAX_DB_CONNECTIONS: ${PGBOUNCER_MAX_DB_CONNECTIONS:-0}
+      QUERY_WAIT_TIMEOUT: ${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    security_opt:
+      - no-new-privileges:true
+
   postgrest:
     image: postgrest/postgrest:v12.2.12
     restart: unless-stopped
     environment:
+      # PostgREST connects directly to Postgres (needs LISTEN/NOTIFY for schema reload)
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: ${POSTGREST_OPENAPI_SERVER_PROXY_URI:-http://localhost:3000}
       PGRST_DB_SCHEMA: public
@@ -47,6 +70,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
       postgrest:
         condition: service_started
     environment:
@@ -58,12 +83,14 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-changeme123}
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: pgbouncer
       POSTGRES_PORT: "5432"
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@pgbouncer:5432/${POSTGRES_DB:-insforge}
+      POSTGRES_DIRECT_HOST: postgres
+      POSTGRES_DIRECT_PORT: "5432"
       POSTGREST_BASE_URL: http://postgrest:3000
       DENO_RUNTIME_URL: http://deno:7133
       LOGS_DIR: /insforge-logs
@@ -96,13 +123,13 @@ services:
     working_dir: /app
     restart: unless-stopped
     depends_on:
-      - postgres
+      - pgbouncer
       - postgrest
     environment:
       PORT: "7133"
       DENO_ENV: production
       DENO_DIR: /deno-dir
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: pgbouncer
       POSTGRES_PORT: "5432"
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,30 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
+      - DEFAULT_POOL_SIZE=${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      - MAX_CLIENT_CONN=${PGBOUNCER_MAX_CLIENT_CONN:-100}
+      - MAX_DB_CONNECTIONS=${PGBOUNCER_MAX_DB_CONNECTIONS:-0}
+      - QUERY_WAIT_TIMEOUT=${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - insforge-network
+
   postgrest:
     image: postgrest/postgrest:v12.2.12
 
@@ -31,9 +55,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      #POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      #POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      #POSTGRES_DB: ${POSTGRES_DB:-insforge}
+      # PostgREST connects directly to Postgres (needs LISTEN/NOTIFY for schema reload)
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
@@ -59,6 +81,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
     ports:
       - "${APP_PORT:-7130}:7130"
       - "${AUTH_PORT:-7131}:7131"
@@ -72,13 +96,16 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@pgbouncer:5432/${POSTGRES_DB:-insforge}
+      # Direct Postgres connection (for LISTEN/NOTIFY, migrations)
+      - POSTGRES_DIRECT_HOST=postgres
+      - POSTGRES_DIRECT_PORT=5432
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Deno Runtime URL for serverless functions
       - DENO_RUNTIME_URL=http://deno:7133
@@ -143,7 +170,7 @@ services:
     security_opt:
       - no-new-privileges:true
     depends_on:
-      - postgres
+      - pgbouncer
       - postgrest
     ports:
       - "${DENO_PORT:-7133}:7133"
@@ -151,8 +178,8 @@ services:
       - PORT=7133
       - DENO_ENV=${DENO_ENV:-production}
       - DENO_DIR=/deno-dir
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,13 +25,35 @@ services:
       timeout: 5s
       retries: 5
 
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
+      - DEFAULT_POOL_SIZE=${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      - MAX_CLIENT_CONN=${PGBOUNCER_MAX_CLIENT_CONN:-100}
+      - MAX_DB_CONNECTIONS=${PGBOUNCER_MAX_DB_CONNECTIONS:-0}
+      - QUERY_WAIT_TIMEOUT=${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - insforge-network
+
   postgrest:
     image: postgrest/postgrest:v12.2.12
     restart: unless-stopped
     environment:
-      # POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      # POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      # POSTGRES_DB: ${POSTGRES_DB:-insforge}
+      # PostgREST connects directly to Postgres (needs LISTEN/NOTIFY for schema reload)
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
@@ -60,6 +82,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_healthy
     ports:
       - "${APP_PORT:-7130}:7130"
       - "${AUTH_PORT:-7131}:7131"
@@ -82,13 +106,16 @@ services:
       - MAX_FILE_SIZE=${MAX_FILE_SIZE:-}
       - MAX_JSON_BODY_SIZE=${MAX_JSON_BODY_SIZE:-}
       - MAX_URLENCODED_BODY_SIZE=${MAX_URLENCODED_BODY_SIZE:-}
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@pgbouncer:5432/${POSTGRES_DB:-insforge}
+      # Direct Postgres connection (for LISTEN/NOTIFY, migrations)
+      - POSTGRES_DIRECT_HOST=postgres
+      - POSTGRES_DIRECT_PORT=5432
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Deno Runtime URL for serverless functions
       - DENO_RUNTIME_URL=http://deno:7133
@@ -161,7 +188,7 @@ services:
       - ui_node_modules:/app/packages/ui/node_modules
       - shared-logs:/insforge-logs
       - storage-data:/insforge-storage
-    command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'
+    command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_DIRECT_HOST:-postgres}:${POSTGRES_DIRECT_PORT:-5432}/${POSTGRES_DB:-insforge} npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -173,7 +200,7 @@ services:
     image: denoland/deno:alpine-2.0.6
     working_dir: /app
     depends_on:
-      - postgres
+      - pgbouncer
       - postgrest
     ports:
       - "${DENO_PORT:-7133}:7133"
@@ -181,8 +208,8 @@ services:
       - PORT=7133
       - DENO_ENV=${DENO_ENV:-development}
       - DENO_DIR=/deno-dir
-      # PostgreSQL connection
-      - POSTGRES_HOST=postgres
+      # PostgreSQL connection (via PgBouncer)
+      - POSTGRES_HOST=pgbouncer
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/docs/pgbouncer-connection-pooler.md
+++ b/docs/pgbouncer-connection-pooler.md
@@ -1,0 +1,230 @@
+# PgBouncer Connection Pooler
+
+## Overview
+
+InsForge uses [PgBouncer](https://www.pgbouncer.org/) as a lightweight connection pooler between the application layer and PostgreSQL. Instead of every request opening a new Postgres connection (expensive: TCP handshake, auth, memory allocation), PgBouncer maintains a pool of reusable connections that are shared across all incoming requests.
+
+## Why Connection Pooling Matters
+
+**Without PgBouncer:**
+```
+Request 1 --> Open connection --> Postgres (holds ~5-10MB RAM)
+Request 2 --> Open connection --> Postgres (holds ~5-10MB RAM)
+...
+Request 500 --> Open connection --> Postgres CRASHES (out of memory/connections)
+```
+
+**With PgBouncer:**
+```
+Request 1 --|
+Request 2 --|
+...         |--> PgBouncer (20 pooled connections) --> Postgres (stable, low memory)
+Request 500 |
+```
+
+Each Postgres connection costs ~5-10MB of RAM. Postgres performance degrades significantly beyond ~100 concurrent connections and can crash at ~500. PgBouncer solves this by multiplexing thousands of client connections over a small, fixed pool of real Postgres connections.
+
+## Architecture
+
+```
+                                    +------------------+
+                                    |                  |
+                              +---->|    PostgreSQL     |<----+
+                              |     |   (port 5432)    |     |
+                              |     +------------------+     |
+                              |              ^               |
+                              |              |               |
+                     +--------+-------+      |        +------+------+
+                     |                |      |        |             |
+                     |   PgBouncer    |      |        |  PostgREST  |
+                     |  (port 5432)   |      |        |  (direct)   |
+                     +--------+-------+      |        +------+------+
+                              ^              |
+                              |              |
+              +---------------+-------+      |
+              |               |       |      |
+        +-----+----+  +------+--+  +-+------+---+
+        |          |  |         |  |             |
+        | Backend  |  |  Deno   |  |  Realtime   |
+        | (pooled) |  | (pooled)|  | (direct)    |
+        +----------+  +---------+  +-------------+
+```
+
+### Connection Routing
+
+| Service | Connects To | Why |
+|---------|------------|-----|
+| **Backend (insforge)** | PgBouncer | All API queries use pooled connections for efficiency |
+| **Deno (edge functions)** | PgBouncer | Short-lived function queries benefit from pooling |
+| **PostgREST** | Postgres (direct) | Requires LISTEN/NOTIFY for automatic schema reload |
+| **Realtime (WebSocket)** | Postgres (direct) | Uses LISTEN for real-time event streaming |
+| **Migrations (node-pg-migrate)** | Postgres (direct) | Advisory locks are session-level, incompatible with transaction pooling |
+
+## How Transaction Pooling Works
+
+PgBouncer runs in **transaction pooling mode**. Here's what that means:
+
+1. PgBouncer maintains a pool of 20 open connections to Postgres (configurable).
+2. When the backend needs to run a query, it asks PgBouncer for a connection.
+3. PgBouncer assigns an idle connection from the pool.
+4. The backend runs its query/transaction.
+5. When the transaction completes, PgBouncer returns the connection to the pool.
+6. The next request reuses that same connection.
+
+A single pooled connection can serve hundreds of sequential requests per second because each request only holds it for a few milliseconds.
+
+### What Works Through PgBouncer (Transaction Mode)
+
+- Regular queries (SELECT, INSERT, UPDATE, DELETE)
+- Transactions (BEGIN ... COMMIT)
+- NOTIFY (sending notifications)
+- Temporary tables (within a single transaction)
+
+### What Does NOT Work Through PgBouncer (Transaction Mode)
+
+- **LISTEN** -- requires a persistent, session-level connection
+- **Advisory locks** -- session-level locks are released when PgBouncer reassigns the connection
+- **Prepared statements** -- bound to a session, lost on reassignment
+- **SET** commands -- session-level settings don't persist across transactions
+
+This is why the Realtime service and migrations use direct Postgres connections.
+
+## Configuration
+
+### Environment Variables
+
+Set these in your `.env` file to tune PgBouncer:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PGBOUNCER_DEFAULT_POOL_SIZE` | `20` | Number of server connections per database. This is how many concurrent Postgres connections PgBouncer maintains. |
+| `PGBOUNCER_MAX_CLIENT_CONN` | `100` | Maximum number of client connections PgBouncer will accept. Requests beyond this limit are rejected. |
+| `PGBOUNCER_MAX_DB_CONNECTIONS` | `0` | Hard cap on connections to Postgres. `0` = unlimited (bounded by pool size). |
+| `PGBOUNCER_QUERY_WAIT_TIMEOUT` | `120` | Seconds a query waits for a free connection before returning an error. |
+
+### Direct Connection Variables
+
+These are used internally by services that bypass PgBouncer:
+
+| Variable | Default | Used By |
+|----------|---------|---------|
+| `POSTGRES_DIRECT_HOST` | `postgres` | Realtime LISTEN, migrations |
+| `POSTGRES_DIRECT_PORT` | `5432` | Realtime LISTEN, migrations |
+
+### Tuning Guidelines
+
+**Small deployments (< 50 concurrent users):**
+```
+PGBOUNCER_DEFAULT_POOL_SIZE=10
+PGBOUNCER_MAX_CLIENT_CONN=50
+```
+
+**Medium deployments (50-500 concurrent users):**
+```
+PGBOUNCER_DEFAULT_POOL_SIZE=20
+PGBOUNCER_MAX_CLIENT_CONN=200
+```
+
+**Large deployments (500+ concurrent users):**
+```
+PGBOUNCER_DEFAULT_POOL_SIZE=50
+PGBOUNCER_MAX_CLIENT_CONN=500
+```
+
+Rule of thumb: `DEFAULT_POOL_SIZE` should stay under your Postgres `max_connections` (default: 100) minus connections used by PostgREST and direct clients (~10). So keep it at 50 or below for default Postgres settings.
+
+## Files Changed
+
+### Docker Compose (all 4 files)
+
+- `docker-compose.yml` (dev)
+- `docker-compose.prod.yml` (production)
+- `docker-compose.dokploy.yml` (Dokploy deployment)
+- `deploy/docker-compose/docker-compose.yml` (standalone deploy)
+
+Changes in each:
+
+1. **Added `pgbouncer` service** -- `edoburu/pgbouncer:latest`, depends on `postgres` being healthy, with its own healthcheck.
+2. **Routed `insforge` service through PgBouncer** -- `POSTGRES_HOST=pgbouncer`, `DATABASE_URL` points to `pgbouncer:5432`. Added `POSTGRES_DIRECT_HOST` and `POSTGRES_DIRECT_PORT` for direct access.
+3. **Routed `deno` service through PgBouncer** -- `POSTGRES_HOST=pgbouncer`, depends on `pgbouncer` instead of `postgres`.
+4. **PostgREST stays direct** -- still connects to `postgres:5432` for LISTEN/NOTIFY schema reload.
+
+### Backend Code
+
+**`backend/src/infra/database/database.manager.ts`**
+
+- `getPool()` -- connects via `POSTGRES_HOST` (PgBouncer) for all regular queries.
+- `createClient()` -- connects via `POSTGRES_DIRECT_HOST` (Postgres) for LISTEN/NOTIFY operations. Falls back to `POSTGRES_HOST` if direct vars are not set.
+
+### Dockerfile
+
+- Migration step in `CMD` overrides `DATABASE_URL` to use `POSTGRES_DIRECT_HOST` so that `node-pg-migrate` advisory locks work correctly against Postgres directly.
+
+### .env.example
+
+- Added `PGBOUNCER_DEFAULT_POOL_SIZE`, `PGBOUNCER_MAX_CLIENT_CONN`, `PGBOUNCER_MAX_DB_CONNECTIONS`, and `PGBOUNCER_QUERY_WAIT_TIMEOUT` with documentation.
+
+## End-to-End Request Flow
+
+Here's what happens when an API request hits InsForge:
+
+```
+1. HTTP request arrives at the backend (port 7130)
+
+2. Backend handler calls DatabaseManager.getPool().connect()
+   --> This asks the Node.js `pg` Pool for a connection
+   --> The Pool connects to pgbouncer:5432 (not Postgres directly)
+
+3. PgBouncer receives the connection request
+   --> Authenticates using scram-sha-256
+   --> Assigns an idle Postgres connection from its pool
+   --> If none are idle, the request waits (up to query_wait_timeout)
+
+4. Query executes on the real Postgres connection
+
+5. Response returns through PgBouncer to the backend
+
+6. Backend calls client.release()
+   --> Node.js Pool returns the client to its local pool
+   --> PgBouncer marks the Postgres connection as idle and available
+   --> The same Postgres connection is now ready for the next request
+
+7. HTTP response sent to the client
+```
+
+For Realtime (WebSocket) events:
+
+```
+1. RealtimeManager calls DatabaseManager.createClient()
+   --> Creates a direct connection to postgres:5432 (bypasses PgBouncer)
+
+2. Client sends LISTEN realtime_message
+   --> This is a persistent, session-level operation
+   --> The connection stays open for the lifetime of the server
+
+3. When a database trigger fires NOTIFY realtime_message
+   --> Postgres delivers the notification to the listening client
+   --> RealtimeManager broadcasts it to connected WebSocket clients
+```
+
+## Troubleshooting
+
+**"connection refused" from PgBouncer:**
+- Check that Postgres is healthy: `docker compose ps postgres`
+- Check PgBouncer logs: `docker compose logs pgbouncer`
+
+**"too many clients" error:**
+- Increase `PGBOUNCER_MAX_CLIENT_CONN` in your `.env`
+- Check for connection leaks (unreleased pool clients in backend code)
+
+**Slow queries / timeouts:**
+- Increase `PGBOUNCER_DEFAULT_POOL_SIZE` if queries are waiting for connections
+- Check `PGBOUNCER_QUERY_WAIT_TIMEOUT` -- default 120s should be sufficient
+
+**Migrations fail with lock errors:**
+- Verify `POSTGRES_DIRECT_HOST` and `POSTGRES_DIRECT_PORT` are set in your compose file
+- Migrations must bypass PgBouncer (advisory locks are session-level)
+
+**LISTEN/NOTIFY not working (Realtime broken):**
+- Verify `POSTGRES_DIRECT_HOST` is set -- Realtime's `createClient()` uses it
+- LISTEN does not work through PgBouncer in transaction mode


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pgbouncer` transaction pooling to reduce Postgres connection overhead and improve stability. Backend and Deno now use pooled connections by default; migrations and LISTEN/NOTIFY connect directly to Postgres for correctness.

- **New Features**
  - Added `pgbouncer` service with health checks across all compose variants; routed `insforge` and Deno to `pgbouncer:5432`, kept PostgREST direct.
  - Introduced `PGBOUNCER_*` envs (`PGBOUNCER_DEFAULT_POOL_SIZE`, `PGBOUNCER_MAX_CLIENT_CONN`, `PGBOUNCER_MAX_DB_CONNECTIONS`, `PGBOUNCER_QUERY_WAIT_TIMEOUT`).
  - Added `POSTGRES_DIRECT_HOST`/`POSTGRES_DIRECT_PORT`; backend `createClient()` uses them for LISTEN/NOTIFY and other session-level ops.
  - Ensured migrations run directly against Postgres by overriding `DATABASE_URL` in the `Dockerfile` and dev compose command.
  - Added docs at `docs/pgbouncer-connection-pooler.md`.

- **Migration**
  - Update and `docker compose up -d` to bring up the new `pgbouncer` service.
  - If using non-default Postgres hosts/ports, set `POSTGRES_DIRECT_HOST`/`POSTGRES_DIRECT_PORT`; otherwise defaults work.
  - Optionally tune pooling with `PGBOUNCER_*` in `.env`; defaults are safe for most setups.
  - Verify realtime and migrations; they must connect directly to Postgres (check logs if issues).

<sup>Written for commit 895fa744e974dddc582ac14d6d1c6e59bf7d3553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PgBouncer connection pooling between application services and Postgres
> - Introduces a `pgbouncer` service in all Docker Compose variants ([docker-compose.yml](https://github.com/InsForge/InsForge/pull/1434/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3), [docker-compose.prod.yml](https://github.com/InsForge/InsForge/pull/1434/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3), [docker-compose.dokploy.yml](https://github.com/InsForge/InsForge/pull/1434/files#diff-2905563f607f9c4fb6d4a86cf4a09f08f2b6d9b4774ecb0cd6192a97c9dd922f), [deploy/docker-compose/docker-compose.yml](https://github.com/InsForge/InsForge/pull/1434/files#diff-03bf84599af57a5fcf0f9d11adf30d9cf3ee8a54d5f0cf0f22125c414d7efc69)) configured for transaction pooling with health checks.
> - Routes `insforge`, `deno`, and app services through PgBouncer by setting `POSTGRES_HOST=pgbouncer` and updating `DATABASE_URL` accordingly.
> - Adds `POSTGRES_DIRECT_HOST` and `POSTGRES_DIRECT_PORT` env vars for operations that require a direct Postgres connection (LISTEN/NOTIFY, prepared statements); `DatabaseManager.createClient` in [database.manager.ts](https://github.com/InsForge/InsForge/pull/1434/files#diff-87be7972af532e332149b821a1998be60387341564cef1030f7f2f3ff8337dc9) uses these when set.
> - Migrations are run against Postgres directly using the direct connection vars before the app starts.
> - Risk: transaction pooling mode is incompatible with session-level features (advisory locks, `SET` commands); any code relying on session state must use direct connections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 895fa74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database connection pooling is now available for managing concurrent connections more efficiently.
  * Added direct database connection mode for operations requiring non-pooled access.

* **Documentation**
  * New guide explaining connection pooling setup, supported operations, configuration options, and troubleshooting steps.

* **Configuration**
  * Environment and deployment configuration files updated to support the connection pooling system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InsForge/InsForge/pull/1434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->