### PR TITLE
fix(auth): Prevent RLS `22P02` UUID crash by removing non-UUID `sub` from admin API-key tokens

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -48,7 +48,7 @@ export function extractApiKey(req: AuthRequest): string | null {
 // Helper function to set user on request
 function setRequestUser(
   req: AuthRequest,
-  payload: { sub: string; email: string; role: RoleSchema }
+  payload: { sub?: string | undefined; email: string; role: RoleSchema }
 ) {
   req.user = {
     id: payload.sub,

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -70,11 +70,17 @@ export class TokenManager {
 
   /**
    * Generate API key token (never expires)
-   * Used for internal API key authenticated requests to PostgREST
+   * Used for internal API key authenticated requests to PostgREST.
+   *
+   * IMPORTANT: `sub` is intentionally omitted (Issue #1436).
+   * A non-UUID `sub` literal causes PostgREST to forward it as
+   * request.jwt.claims.sub, which makes auth.uid() raise SQLSTATE 22P02
+   * (invalid input syntax for type uuid) inside every RLS policy / trigger.
+   * Omitting `sub` makes PostgREST inject NULL, matching the Supabase
+   * service-role contract where auth.uid() returns NULL for system actors.
    */
   generateApiKeyToken(): string {
     const payload = {
-      sub: 'project-admin-with-api-key',
       email: 'project-admin@email.com',
       role: 'project_admin',
     };
@@ -161,12 +167,17 @@ export class TokenManager {
   }
 
   /**
-   * Verify JWT token
+   * Verify JWT token.
+   *
+   * `sub` is optional in the returned payload: system/API-key tokens
+   * carry no subject (Issue #1436) so `sub` will be `undefined` for
+   * those tokens. Callers that need a user ID must guard against this.
    */
   verifyToken(token: string): TokenPayloadSchema {
     try {
       const decoded = jwt.verify(token, JWT_SECRET) as TokenPayloadSchema;
       return {
+        // sub is undefined for system tokens — intentional, see Issue #1436
         sub: decoded.sub,
         email: decoded.email,
         role: decoded.role || 'authenticated',

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -2,7 +2,13 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import { createRemoteJWKSet, JWTPayload, jwtVerify } from 'jose';
 import { AppError } from '@/utils/errors.js';
-import { ERROR_CODES, type TokenPayloadSchema } from '@insforge/shared-schemas';
+import {
+  ERROR_CODES,
+  tokenPayloadSchema,
+  systemTokenPayloadSchema,
+  type TokenPayloadSchema,
+  type SystemTokenPayloadSchema,
+} from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
@@ -169,20 +175,34 @@ export class TokenManager {
   /**
    * Verify JWT token.
    *
-   * `sub` is optional in the returned payload: system/API-key tokens
-   * carry no subject (Issue #1436) so `sub` will be `undefined` for
-   * those tokens. Callers that need a user ID must guard against this.
+   * Two-step validation (fail-closed):
+   *   1. `jwt.verify` checks signature + expiry against JWT_SECRET.
+   *   2. `tokenPayloadSchema.parse` enforces the access-token shape:
+   *      - `email` must be present and valid  (rejects refresh tokens which lack it)
+   *      - `role`  must be a known enum value  (rejects tokens with no role claim)
+   *      - `sub`   must be a UUID if present   (extra guard against non-UUID subjects)
    *
-   * Uses spread so future claims added to TokenPayloadSchema are not
-   * silently dropped (e.g. aud, jti, custom claims).
+   * This prevents refresh tokens — which share JWT_SECRET but carry different
+   * claims — from being accepted as access tokens (coderabbit finding).
+   *
+   * `sub` is optional in the returned payload: system/API-key tokens carry no
+   * subject (Issue #1436), so auth.uid() receives NULL instead of raising 22P02.
    */
-  verifyToken(token: string): TokenPayloadSchema {
+  verifyToken(token: string): TokenPayloadSchema | SystemTokenPayloadSchema {
     try {
-      const decoded = jwt.verify(token, JWT_SECRET) as TokenPayloadSchema;
-      // Spread preserves all claims; role override provides the fallback default.
-      // sub is undefined for system tokens — intentional, see Issue #1436.
-      return { ...decoded, role: decoded.role || 'authenticated' };
-    } catch {
+      const verified = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }) as Record<
+        string,
+        unknown
+      >;
+
+      if (verified.role === 'project_admin') {
+        return systemTokenPayloadSchema.parse(verified);
+      }
+      return tokenPayloadSchema.parse(verified);
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
       throw new AppError('Invalid token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }
   }

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -172,16 +172,16 @@ export class TokenManager {
    * `sub` is optional in the returned payload: system/API-key tokens
    * carry no subject (Issue #1436) so `sub` will be `undefined` for
    * those tokens. Callers that need a user ID must guard against this.
+   *
+   * Uses spread so future claims added to TokenPayloadSchema are not
+   * silently dropped (e.g. aud, jti, custom claims).
    */
   verifyToken(token: string): TokenPayloadSchema {
     try {
       const decoded = jwt.verify(token, JWT_SECRET) as TokenPayloadSchema;
-      return {
-        // sub is undefined for system tokens — intentional, see Issue #1436
-        sub: decoded.sub,
-        email: decoded.email,
-        role: decoded.role || 'authenticated',
-      };
+      // Spread preserves all claims; role override provides the fallback default.
+      // sub is undefined for system tokens — intentional, see Issue #1436.
+      return { ...decoded, role: decoded.role || 'authenticated' };
     } catch {
       throw new AppError('Invalid token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }

--- a/backend/tests/unit/token-manager-api-key.test.ts
+++ b/backend/tests/unit/token-manager-api-key.test.ts
@@ -1,0 +1,72 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+import { TokenManager } from '../../src/infra/security/token.manager';
+
+/**
+ * Tests for the API-key token contract (Issue #1436).
+ *
+ * Admin API-key JWTs must NOT carry a non-UUID `sub` claim.
+ * PostgREST forwards `request.jwt.claims.sub` verbatim into the Postgres
+ * session.  Any non-UUID literal causes auth.uid() to raise 22P02 and
+ * aborts every transaction protected by an RLS policy or trigger that
+ * calls auth.uid() — the exact scenario that broke Supabase-migrated
+ * projects.
+ *
+ * Correct behaviour: omit `sub` entirely so PostgREST injects NULL,
+ * matching the Supabase service-role contract where auth.uid() returns
+ * NULL for system actors.
+ */
+describe('TokenManager – API-key token (Issue #1436)', () => {
+  const tokenManager = TokenManager.getInstance();
+
+  it('generateApiKeyToken() produces a JWT with no sub field', () => {
+    const token = tokenManager.generateApiKeyToken();
+    // Decode without verifying signature so we can inspect the raw payload
+    const decoded = jwt.decode(token) as Record<string, unknown>;
+
+    expect(decoded).not.toBeNull();
+    // sub must be absent — not an empty string, not a non-uuid literal
+    expect(Object.prototype.hasOwnProperty.call(decoded, 'sub')).toBe(false);
+  });
+
+  it('generateApiKeyToken() JWT carries expected role and email claims', () => {
+    const token = tokenManager.generateApiKeyToken();
+    const decoded = jwt.decode(token) as Record<string, unknown>;
+
+    expect(decoded.role).toBe('project_admin');
+    expect(decoded.email).toBe('project-admin@email.com');
+  });
+
+  it('verifyToken() on an API-key token returns sub: undefined', () => {
+    const token = tokenManager.generateApiKeyToken();
+    const payload = tokenManager.verifyToken(token);
+
+    // sub should be undefined — never the non-UUID poison string
+    expect(payload.sub).toBeUndefined();
+    expect(payload.role).toBe('project_admin');
+  });
+
+  it('verifyToken() on an API-key token never returns the old non-UUID literal', () => {
+    const token = tokenManager.generateApiKeyToken();
+    const payload = tokenManager.verifyToken(token);
+
+    expect(payload.sub).not.toBe('project-admin-with-api-key');
+  });
+
+  it('a regular user access token still carries a UUID sub', () => {
+    const userSub = '11111111-2222-3333-4444-555555555555';
+    const userToken = jwt.sign(
+      { sub: userSub, email: 'user@example.com', role: 'authenticated' },
+      process.env.JWT_SECRET ?? '',
+      { algorithm: 'HS256' }
+    );
+    const payload = tokenManager.verifyToken(userToken);
+
+    expect(payload.sub).toBe(userSub);
+  });
+});

--- a/backend/tests/unit/token-manager-api-key.test.ts
+++ b/backend/tests/unit/token-manager-api-key.test.ts
@@ -59,7 +59,7 @@ describe('TokenManager – API-key token (Issue #1436)', () => {
   });
 
   it('a regular user access token still carries a UUID sub', () => {
-    const userSub = '11111111-2222-3333-4444-555555555555';
+    const userSub = '550e8400-e29b-41d4-a716-446655440000';
     // Use the real generator — not a manual jwt.sign — so this test catches
     // any future accidental removal of sub from generateAccessToken().
     const userToken = tokenManager.generateAccessToken({
@@ -70,5 +70,29 @@ describe('TokenManager – API-key token (Issue #1436)', () => {
     const payload = tokenManager.verifyToken(userToken);
 
     expect(payload.sub).toBe(userSub);
+  });
+
+  it('verifyToken() rejects a refresh token even though it shares JWT_SECRET', () => {
+    // Refresh tokens share the same signing secret but carry a different shape:
+    // they have no `email` or `role` claim. verifyToken() must reject them so
+    // a refresh token cannot be presented as an access token (coderabbit finding).
+    const refreshToken = tokenManager.generateRefreshToken(
+      '550e8400-e29b-41d4-a716-446655440000',
+      'user'
+    );
+
+    expect(() => tokenManager.verifyToken(refreshToken)).toThrow();
+  });
+
+  it('verifyToken() rejects a token whose sub is a non-UUID string', () => {
+    // Extra defence: even if someone mints a JWT with JWT_SECRET and sets a
+    // non-UUID sub, tokenPayloadSchema.parse() must reject it.
+    const poisonToken = jwt.sign(
+      { sub: 'project-admin-with-api-key', email: 'x@example.com', role: 'project_admin' },
+      process.env.JWT_SECRET ?? '',
+      { algorithm: 'HS256' }
+    );
+
+    expect(() => tokenManager.verifyToken(poisonToken)).toThrow();
   });
 });

--- a/backend/tests/unit/token-manager-api-key.test.ts
+++ b/backend/tests/unit/token-manager-api-key.test.ts
@@ -60,11 +60,13 @@ describe('TokenManager – API-key token (Issue #1436)', () => {
 
   it('a regular user access token still carries a UUID sub', () => {
     const userSub = '11111111-2222-3333-4444-555555555555';
-    const userToken = jwt.sign(
-      { sub: userSub, email: 'user@example.com', role: 'authenticated' },
-      process.env.JWT_SECRET ?? '',
-      { algorithm: 'HS256' }
-    );
+    // Use the real generator — not a manual jwt.sign — so this test catches
+    // any future accidental removal of sub from generateAccessToken().
+    const userToken = tokenManager.generateAccessToken({
+      sub: userSub,
+      email: 'user@example.com',
+      role: 'authenticated',
+    });
     const payload = tokenManager.verifyToken(userToken);
 
     expect(payload.sub).toBe(userSub);

--- a/packages/shared-schemas/src/auth.schema.ts
+++ b/packages/shared-schemas/src/auth.schema.ts
@@ -162,6 +162,17 @@ export const emailTemplateSchema = z.object({
  * JWT token payload schema
  */
 export const tokenPayloadSchema = z.object({
+  sub: userIdSchema, // Subject (user ID)
+  email: emailSchema,
+  role: roleSchema,
+  iat: z.number().optional(), // Issued at
+  exp: z.number().optional(), // Expiration
+});
+
+/**
+ * System JWT token payload schema (where sub is optional for system/API-key tokens)
+ */
+export const systemTokenPayloadSchema = z.object({
   sub: userIdSchema.optional(), // Subject (user ID) — absent for system/API-key tokens
   email: emailSchema,
   role: roleSchema,
@@ -181,6 +192,7 @@ export type VerificationMethodSchema = z.infer<typeof verificationMethodSchema>;
 export type ProfileSchema = z.infer<typeof profileSchema>;
 export type UserSchema = z.infer<typeof userSchema>;
 export type TokenPayloadSchema = z.infer<typeof tokenPayloadSchema>;
+export type SystemTokenPayloadSchema = z.infer<typeof systemTokenPayloadSchema>;
 export type OAuthConfigSchema = z.infer<typeof oAuthConfigSchema>;
 export type OAuthProvidersSchema = z.infer<typeof oAuthProvidersSchema>;
 export type AuthConfigSchema = z.infer<typeof authConfigSchema>;

--- a/packages/shared-schemas/src/auth.schema.ts
+++ b/packages/shared-schemas/src/auth.schema.ts
@@ -162,7 +162,7 @@ export const emailTemplateSchema = z.object({
  * JWT token payload schema
  */
 export const tokenPayloadSchema = z.object({
-  sub: userIdSchema, // Subject (user ID)
+  sub: userIdSchema.optional(), // Subject (user ID) — absent for system/API-key tokens
   email: emailSchema,
   role: roleSchema,
   iat: z.number().optional(), // Issued at


### PR DESCRIPTION

**Closes #1436**
---
### 🐛 The Bug — Crash on every `auth.uid()` call under admin API key
Any table protected by a Supabase-style RLS policy or trigger that calls `auth.uid()` would throw a hard Postgres error and abort the entire transaction when the request was authenticated with an admin API key (`ik_...`).
**Reproduction**
```sql
-- 1. Create a table with an auth.uid() trigger
CREATE TABLE public.t (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
CREATE OR REPLACE FUNCTION public.touch() RETURNS trigger
LANGUAGE plpgsql AS $$
BEGIN
  PERFORM auth.uid();   -- ← crashes here
  RETURN NEW;
END $$;
CREATE TRIGGER touch_t BEFORE INSERT ON public.t
  FOR EACH ROW EXECUTE FUNCTION public.touch();
```
```bash
# 2. Insert via admin API key
curl -X POST "$INSFORGE_URL/api/database/records/t" \
  -H "Authorization: Bearer ik_..." \
  -H "Content-Type: application/json" \
  -d '[{}]'
```
```json
{
  "code": "22P02",
  "message": "invalid input syntax for type uuid: \"project-admin-with-api-key\""
}
```
---
### 🔍 Root Cause — Poison `sub` in the Admin JWT
**File:** `backend/src/infra/security/token.manager.ts:77`
```typescript
// BEFORE — the poison pill 🧨
generateApiKeyToken(): string {
  const payload = {
    sub: 'project-admin-with-api-key',   // ← non-UUID string
    email: 'project-admin@email.com',
    role: 'project_admin',
  };
  return jwt.sign(payload, JWT_SECRET, { algorithm: 'HS256' });
}
```
**The crash chain:**
```
Admin request (ik_...)
  └─► generateApiKeyToken()     mints JWT with sub = "project-admin-with-api-key"
  └─► PostgREST receives JWT    sets request.jwt.claims.sub = "project-admin-with-api-key"
  └─► auth.uid()                executes: SELECT 'project-admin-with-api-key'::uuid
  └─► PostgreSQL raises          SQLSTATE 22P02 invalid input syntax for type uuid
  └─► Transaction aborted 💥
```
This silently broke **every project migrating from Supabase** that uses audit triggers, row ownership, or any `auth.uid()`-based RLS policy.
---
### ✅ Fix — Option A: Omit `sub` entirely (matching Supabase service-role contract)
When `sub` is absent, PostgREST injects `NULL` into `request.jwt.claims.sub`. `auth.uid()` returns `NULL` — no cast, no crash. This is exactly how Supabase's service-role key behaves: system actors have no user subject.
**3 files changed, 1 new test file:**
---
#### 1. `packages/shared-schemas/src/auth.schema.ts`
```diff
 export const tokenPayloadSchema = z.object({
-  sub: userIdSchema,            // Subject (user ID)
+  sub: userIdSchema.optional(), // Subject (user ID) — absent for system/API-key tokens
   email: emailSchema,
   role: roleSchema,
```
`sub` is now correctly optional at the schema level — both user tokens (with UUID `sub`) and system tokens (no `sub`) satisfy `TokenPayloadSchema`.
---
#### 2. `backend/src/infra/security/token.manager.ts`
```diff
+  * IMPORTANT: `sub` is intentionally omitted (Issue #1436).
+  * A non-UUID `sub` literal causes PostgREST to forward it as
+  * request.jwt.claims.sub, which makes auth.uid() raise SQLSTATE 22P02.
+  * Omitting `sub` makes PostgREST inject NULL, matching the Supabase
+  * service-role contract where auth.uid() returns NULL for system actors.
   generateApiKeyToken(): string {
     const payload = {
-      sub: 'project-admin-with-api-key',
       email: 'project-admin@email.com',
       role: 'project_admin',
     };
```
---
#### 3. `backend/src/api/middlewares/auth.ts`
```diff
 function setRequestUser(
   req: AuthRequest,
-  payload: { sub: string; email: string; role: RoleSchema }
+  payload: { sub?: string | undefined; email: string; role: RoleSchema }
 )
```
`UserContext.id` was already typed `id?: string`, so API-key requests cleanly get `req.user.id = undefined` — the correct "no human actor" semantic.
---
#### 4. `backend/tests/unit/token-manager-api-key.test.ts` *(new — 5 assertions)*
| Test | What it locks |
|---|---|
| `generateApiKeyToken() produces a JWT with no sub field` | Core contract — `sub` must be **absent** from the payload object |
| `generateApiKeyToken() JWT carries expected role and email claims` | Functional claims are still present |
| `verifyToken() on an API-key token returns sub: undefined` | `verifyToken()` propagates absence correctly |
| `verifyToken() never returns the old non-UUID literal` | Explicit regression guard against re-introducing the bug |
| `a regular user access token still carries a UUID sub` | User tokens are unaffected |
---
### 🧪 Test Results
```
 ✓ tests/unit/token-manager-api-key.test.ts  (5 tests)   ← new
 ✓ tests/unit/token-manager-csrf.test.ts     (7 tests)   ← unaffected
 ✓ tests/unit/auth-api-key-middleware.test.ts (2 tests)  ← unaffected
 ✓ tests/unit/records-auth.test.ts           (7 tests)   ← unaffected
 Test Files  4 passed
      Tests  21 passed
```
**Full backend suite: 1223 passed / 4 skipped / 0 new failures**
---
### ⚠️ Pre-existing failures in `main` (not introduced by this PR)
These were failing before this branch was created and are unrelated to auth token logic:
| Failure | Root Cause |
|---|---|
| `@insforge/shared-schemas` lint — `Delete ␍` in untouched files | CRLF line endings across the package (Windows dev environment) |
| `@insforge/ui` build — `'cp' is not recognized` | Unix `cp` shell command in `packages/ui` build script (Windows) |
| `migration-duplicate-numbers.test.ts` — `SyntaxError` | Broken import from commit `acfe33d0` (#1391), zero diff on the file |
---
### 🔗 Related
- Closes #1436
- Referenced: #965 (raw SQL system schema modification — Option B alternative not taken)
- This aligns with the Supabase service-role contract: `auth.uid()` returns `NULL` for system actors, never raises

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents RLS 22P02 UUID crashes by omitting the `sub` claim from admin API-key JWTs so `auth.uid()` returns NULL for system calls, and hardens token verification to block refresh-token bypasses and non-UUID subjects. Closes #1436.

- **Bug Fixes**
  - Removed `sub` from admin API-key tokens; middleware now accepts `sub?: string`, so `req.user.id` is `undefined` for system requests.
  - Added `systemTokenPayloadSchema` in `@insforge/shared-schemas` and updated `verifyToken` to parse `project_admin` tokens with it; other tokens use `tokenPayloadSchema`. Enforces HS256 and schema validation.
  - `verifyToken` rejects refresh tokens, tokens missing `email`/`role`, and any non-UUID `sub` (no role defaulting). Tests cover the API-key token contract and confirm user access tokens (via `generateAccessToken`) still carry a UUID `sub`.

<sup>Written for commit 9115967a417e6ecbc0b590ec08c860ad344b3ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLS `22P02` crash by removing `sub` from admin API-key tokens in `TokenManager`
> - `generateApiKeyToken` no longer includes a `sub` claim in the JWT payload; only `email` and `role: 'project_admin'` are included.
> - `verifyToken` now validates claims against schema: `project_admin` tokens use `systemTokenPayloadSchema` (optional `sub`), all other tokens use `tokenPayloadSchema` (requires UUID `sub`).
> - Tokens with non-UUID `sub` values or missing `role`/`email` are now rejected; the previous fallback defaulting `role` to `'authenticated'` is removed.
> - New unit tests in [token-manager-api-key.test.ts](https://github.com/InsForge/InsForge/pull/1439/files#diff-f287a27c1a6715d4830364a92bff98eb1411abf9d8f638b0de8913db81c5d2ad) assert the full API-key token contract.
> - Behavioral Change: any existing API-key tokens with a non-UUID `sub` will now fail verification; `role` is no longer defaulted for malformed tokens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd732d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication now accepts and correctly validates API-key/system tokens that omit a user ID (subject), avoiding invalid placeholder IDs and improving verification reliability.
  * Token verification now enforces stricter validation for different token types, reducing false positives.

* **New Features**
  * Added a formal payload schema/type for system/API-key tokens to reflect optional subject behavior.

* **Tests**
  * Added unit tests covering API-key token generation/verification and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->