### PR TITLE
fix: resolve Windows build failure in @insforge/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "./tailwind-preset": "./tailwind-preset.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && cp src/styles.css dist/styles.css",
+    "build": "tsc -p tsconfig.build.json && node -e \"require('fs').copyFileSync('src/styles.css', 'dist/styles.css')\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run --config vitest.unit.config.ts",


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug that causes the repository's build commands to fail when run on a Windows machine.

## Why is this change needed?
In `packages/ui/package.json`, the `build` script was utilizing the Unix-specific `cp` command (`cp src/styles.css dist/styles.css`). The Windows Command Prompt (`cmd.exe`) does not support the `cp` command natively, which caused `npm run build` and `npm run typecheck` to crash with the error: `'cp' is not recognized as an internal or external command`.

## How was this fixed?
I replaced the Unix `cp` command with a cross-platform inline Node.js script using `fs.copyFileSync`. This ensures the UI package builds successfully across all operating systems without requiring any additional dependencies.

## Verification
- [x] Ran `npm run build` successfully on Windows
- [x] Ran `npm run typecheck` successfully on Windows
- [x] Ran `npm test` successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows build failures in `@insforge/ui` by replacing the Unix `cp` in the build script with a cross‑platform inline Node `fs.copyFileSync`. Builds now succeed on Windows without adding dependencies.

<sup>Written for commit 04063317a4a00412bddd14f999dcc5ca8e818f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows build failure in `@insforge/ui` by replacing `cp` with a Node.js file copy
> The build script in [package.json](https://github.com/InsForge/InsForge/pull/1441/files#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51d) used the Unix `cp` command to copy `src/styles.css` to `dist/styles.css`, which fails on Windows. It now uses an inline Node.js script with `fs.copyFileSync` for cross-platform compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0406331.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script handling for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->