### PR TITLE
[codex] Fix AI config soft-delete migration idempotency

### DIFF
--- a/backend/src/infra/database/migrations/023_ai-configs-soft-delete.sql
+++ b/backend/src/infra/database/migrations/023_ai-configs-soft-delete.sql
@@ -8,9 +8,5 @@
 -- - Keep ai.usage.config_id always linked to ai.configs(id)
 -- - Allow disabling/enabling models without hard deletes
 
-BEGIN;
-
 ALTER TABLE ai.configs
-ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE;
-
-COMMIT;
+ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/tests/unit/ai-configs-soft-delete-migration.test.ts
+++ b/backend/tests/unit/ai-configs-soft-delete-migration.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDir,
+  '../../src/infra/database/migrations/023_ai-configs-soft-delete.sql'
+);
+
+describe('023_ai-configs-soft-delete migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('adds is_active idempotently', () => {
+    expect(sql).toMatch(
+      /ALTER TABLE ai\.configs\s+ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;/i
+    );
+  });
+
+  it('does not use a bare ADD COLUMN for is_active', () => {
+    expect(sql).not.toMatch(/ADD COLUMN is_active BOOLEAN/i);
+  });
+
+  it('does not manage its own transaction', () => {
+    expect(sql).not.toMatch(/^\s*BEGIN\s*;/im);
+    expect(sql).not.toMatch(/^\s*COMMIT\s*;/im);
+  });
+});


### PR DESCRIPTION
## Summary
- Make migration `023_ai-configs-soft-delete.sql` idempotent by using `ADD COLUMN IF NOT EXISTS` for `ai.configs.is_active`.
- Remove explicit `BEGIN`/`COMMIT` from the SQL migration so the migration runner manages transaction scope.
- Add a unit test that locks the migration idempotency guard and transaction handling.

## Root Cause
A machine can have `ai.configs.is_active` already present while `system.migrations` does not yet record `023_ai-configs-soft-delete` as applied. The previous bare `ADD COLUMN is_active` then failed with `column "is_active" of relation "configs" already exists`, preventing the migration runner from recording the migration.

## Validation
- `cd backend && npm test -- ai-configs-soft-delete-migration.test.ts`
- `cd backend && npm run migrate:check-duplicates`
- `cd backend && npm test`
- `cd backend && npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `023_ai-configs-soft-delete.sql` migration idempotent and let the migration runner manage transactions. Prevents failures when `ai.configs.is_active` already exists and ensures the migration is recorded reliably.

- **Bug Fixes**
  - Use `ADD COLUMN IF NOT EXISTS` for `ai.configs.is_active` to avoid duplicate-column errors.
  - Remove `BEGIN`/`COMMIT` so the runner controls the transaction.
  - Add a unit test to assert idempotency and no manual transaction statements.

<sup>Written for commit 30c65b2b175e2a9fa698c9846608eaaf9392fcca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix idempotency of AI config soft-delete migration by using `ADD COLUMN IF NOT EXISTS`
> - Updates [023_ai-configs-soft-delete.sql](https://github.com/InsForge/InsForge/pull/1442/files#diff-edccf3df479c7ecb1946faa85489ab98e80fefddb240295881b7cad0a2ba3d15) to use `ADD COLUMN IF NOT EXISTS` so re-running the migration no longer fails if `is_active` already exists.
> - Removes explicit `BEGIN`/`COMMIT` statements so the migration runs within the caller's transaction context.
> - Adds a Vitest unit test in [ai-configs-soft-delete-migration.test.ts](https://github.com/InsForge/InsForge/pull/1442/files#diff-6d6a9717b57385184042ec2b8a4380baf3eb4cab61ecfc3b05ed55e67f325d1b) to assert the correct DDL form and absence of transaction statements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30c65b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled soft-disable functionality for AI configurations, allowing configurations to be disabled while preserving their data.

* **Tests**
  * Added unit test coverage to verify the migration correctly implements idempotent database schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->