### PR TITLE
fix(functions): remove orphaned deployment records on function deletion

### DIFF
--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -315,6 +315,11 @@ export class FunctionService {
         return false;
       }
 
+      // Remove deployment records that reference the deleted function
+      await this.getPool().query('DELETE FROM functions.deployments WHERE functions @> $1::jsonb', [
+        JSON.stringify([slug]),
+      ]);
+
       // Trigger redeployment without the deleted function
       this.scheduleDeployment();
 

--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -305,32 +305,42 @@ export class FunctionService {
    * Delete a function
    */
   async deleteFunction(slug: string): Promise<boolean> {
+    const client = await this.getPool().connect();
     try {
-      const result = await this.getPool().query(
-        'DELETE FROM functions.definitions WHERE slug = $1',
-        [slug]
-      );
+      await client.query('BEGIN');
+
+      const result = await client.query('DELETE FROM functions.definitions WHERE slug = $1', [
+        slug,
+      ]);
 
       if (result.rowCount === 0) {
+        await client.query('ROLLBACK');
         return false;
       }
 
-      // Remove deployment records that reference the deleted function
-      await this.getPool().query('DELETE FROM functions.deployments WHERE functions @> $1::jsonb', [
-        JSON.stringify([slug]),
-      ]);
+      // Remove the deleted slug from deployment records' functions array,
+      // preserving shared deployment history for other functions.
+      await client.query(
+        'UPDATE functions.deployments SET functions = functions - $1 WHERE functions @> $2::jsonb',
+        [slug, JSON.stringify([slug])]
+      );
+
+      await client.query('COMMIT');
 
       // Trigger redeployment without the deleted function
       this.scheduleDeployment();
 
       return true;
     } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined);
       logger.error('Failed to delete function', {
         error: error instanceof Error ? error.message : String(error),
         operation: 'deleteFunction',
         slug,
       });
       throw error;
+    } finally {
+      client.release();
     }
   }
 

--- a/backend/tests/unit/function-delete-cleanup.test.ts
+++ b/backend/tests/unit/function-delete-cleanup.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FunctionService } from '../../src/services/functions/function.service.js';
 
+const clientQueryMock = vi.fn();
+const releaseMock = vi.fn();
+
 const mockPool = {
   query: vi.fn(),
-  connect: vi.fn(),
+  connect: vi.fn().mockResolvedValue({
+    query: clientQueryMock,
+    release: releaseMock,
+  }),
 };
 
 vi.mock('../../src/infra/database/database.manager.js', () => ({
@@ -42,38 +48,77 @@ describe('FunctionService.deleteFunction — deployment cleanup', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPool.connect.mockResolvedValue({
+      query: clientQueryMock,
+      release: releaseMock,
+    });
     service = FunctionService.getInstance();
   });
 
-  it('deletes associated deployment records when function is deleted', async () => {
-    mockPool.query
+  it('removes the slug from deployment records inside a transaction', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({}) // BEGIN
       .mockResolvedValueOnce({ rowCount: 1 }) // DELETE FROM functions.definitions
-      .mockResolvedValueOnce({ rowCount: 2 }); // DELETE FROM functions.deployments
+      .mockResolvedValueOnce({ rowCount: 3 }) // UPDATE functions.deployments
+      .mockResolvedValueOnce({}); // COMMIT
 
     const result = await service.deleteFunction('my-func');
 
     expect(result).toBe(true);
-    expect(mockPool.query).toHaveBeenCalledTimes(2);
-    expect(mockPool.query).toHaveBeenNthCalledWith(
-      2,
-      'DELETE FROM functions.deployments WHERE functions @> $1::jsonb',
-      [JSON.stringify(['my-func'])]
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls[0]).toBe('BEGIN');
+    expect(sqlCalls).toContainEqual(expect.stringContaining('DELETE FROM functions.definitions'));
+    expect(sqlCalls).toContainEqual(
+      expect.stringContaining('UPDATE functions.deployments SET functions = functions - $1')
     );
+    expect(sqlCalls[sqlCalls.length - 1]).toBe('COMMIT');
+
+    // Verify the UPDATE uses correct parameters
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE functions.deployments')
+    );
+    expect(updateCall?.[1]).toEqual(['my-func', JSON.stringify(['my-func'])]);
   });
 
-  it('does not clean up deployments if function not found', async () => {
-    mockPool.query.mockResolvedValueOnce({ rowCount: 0 }); // DELETE FROM functions.definitions
+  it('rolls back and returns false when function not found', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // DELETE — no match
+      .mockResolvedValueOnce({}); // ROLLBACK
 
     const result = await service.deleteFunction('nonexistent');
 
     expect(result).toBe(false);
-    expect(mockPool.query).toHaveBeenCalledTimes(1);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls).toContain('ROLLBACK');
+    expect(sqlCalls).not.toContain('COMMIT');
   });
 
-  it('still triggers redeployment after cleanup', async () => {
-    mockPool.query
-      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE FROM functions.definitions
-      .mockResolvedValueOnce({ rowCount: 0 }); // DELETE FROM functions.deployments (none matched)
+  it('rolls back on cleanup failure and releases the client with the error', async () => {
+    const cleanupError = new Error('connection lost');
+
+    clientQueryMock
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE — success
+      .mockRejectedValueOnce(cleanupError) // UPDATE — fails
+      .mockResolvedValueOnce({}); // ROLLBACK
+
+    await expect(service.deleteFunction('my-func')).rejects.toBe(cleanupError);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls).toContain('ROLLBACK');
+    expect(sqlCalls).not.toContain('COMMIT');
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still triggers redeployment after successful cleanup', async () => {
+    clientQueryMock
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE (no deployments matched)
+      .mockResolvedValueOnce({}); // COMMIT
 
     const scheduleSpy = vi.spyOn(service as never, 'scheduleDeployment' as never);
 

--- a/backend/tests/unit/function-delete-cleanup.test.ts
+++ b/backend/tests/unit/function-delete-cleanup.test.ts
@@ -48,10 +48,6 @@ describe('FunctionService.deleteFunction — deployment cleanup', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPool.connect.mockResolvedValue({
-      query: clientQueryMock,
-      release: releaseMock,
-    });
     service = FunctionService.getInstance();
   });
 

--- a/backend/tests/unit/function-delete-cleanup.test.ts
+++ b/backend/tests/unit/function-delete-cleanup.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FunctionService } from '../../src/services/functions/function.service.js';
+
+const mockPool = {
+  query: vi.fn(),
+  connect: vi.fn(),
+};
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+vi.mock('../../src/providers/functions/deno-subhosting.provider.js', () => ({
+  DenoSubhostingProvider: {
+    getInstance: () => ({
+      isConfigured: vi.fn().mockReturnValue(false),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({}),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('FunctionService.deleteFunction — deployment cleanup', () => {
+  let service: FunctionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = FunctionService.getInstance();
+  });
+
+  it('deletes associated deployment records when function is deleted', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE FROM functions.definitions
+      .mockResolvedValueOnce({ rowCount: 2 }); // DELETE FROM functions.deployments
+
+    const result = await service.deleteFunction('my-func');
+
+    expect(result).toBe(true);
+    expect(mockPool.query).toHaveBeenCalledTimes(2);
+    expect(mockPool.query).toHaveBeenNthCalledWith(
+      2,
+      'DELETE FROM functions.deployments WHERE functions @> $1::jsonb',
+      [JSON.stringify(['my-func'])]
+    );
+  });
+
+  it('does not clean up deployments if function not found', async () => {
+    mockPool.query.mockResolvedValueOnce({ rowCount: 0 }); // DELETE FROM functions.definitions
+
+    const result = await service.deleteFunction('nonexistent');
+
+    expect(result).toBe(false);
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('still triggers redeployment after cleanup', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE FROM functions.definitions
+      .mockResolvedValueOnce({ rowCount: 0 }); // DELETE FROM functions.deployments (none matched)
+
+    const scheduleSpy = vi.spyOn(service as never, 'scheduleDeployment' as never);
+
+    await service.deleteFunction('my-func');
+
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

When a function is deleted via `FunctionService.deleteFunction()`, the corresponding records in `functions.deployments` are left behind. Since `functions.deployments.functions` is a JSONB array (no FK constraint), these orphaned rows accumulate indefinitely.

This PR adds a cleanup query that removes all deployment records referencing the deleted function slug immediately after the definition is deleted, before triggering the next deployment cycle.

Closes #1365

## How did you test this change?

- Added 3 unit tests in `backend/tests/unit/function-delete-cleanup.test.ts`:
  - Verifies deployment records are deleted using `@>` JSONB containment when function is found
  - Verifies no cleanup runs when the function doesn't exist (rowCount: 0)
  - Verifies `scheduleDeployment()` is still triggered after cleanup
- Full test suite passing (103 files, 1243 tests)
- `npm run typecheck`, `eslint`, and `prettier` all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up references to deleted functions in `functions.deployments` using a scoped, transactional update to keep deployment data accurate while preserving shared history.

- **Bug Fixes**
  - Wrap definition delete and cleanup in a transaction; rollback if not found or on error.
  - Replace row delete with `UPDATE ... SET functions = functions - $1 WHERE functions @> $2::jsonb` to remove only the deleted slug.
  - Always release the client and still call `scheduleDeployment()` after commit.
  - Tests cover transactional cleanup, not-found no-op, error rollback, and redeploy; simplified redundant mock setup.

<sup>Written for commit ff726b7a69663310b8e68960c33638ec003e6030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove orphaned deployment records atomically on function deletion in `FunctionService`
> - `deleteFunction` now runs inside an explicit DB transaction: it deletes from `functions.definitions` and, if a row was deleted, removes the slug from the `functions` JSONB array in `functions.deployments` using the `-` operator.
> - On a missing slug, the transaction is rolled back and the method returns `false`. On any error during delete or cleanup, the transaction is rolled back and the error is rethrown.
> - `scheduleDeployment` is called only after a successful commit.
> - New unit tests in [`function-delete-cleanup.test.ts`](https://github.com/InsForge/InsForge/pull/1444/files#diff-09e368fbe3863a46826d771dad1bcbf41ec44b5a787256c5482fca178f8e2890) cover the full BEGIN/DELETE/UPDATE/COMMIT flow, rollback paths, and post-commit scheduling.
> - Behavioral Change: cleanup of deployment records is now part of the same transaction as the delete, so a failed cleanup will cause the entire deletion to roll back.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff726b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Function deletion is now atomic: cleanup of deployment records is reliable, with rollback on errors and redeploys triggered as needed.

* **Tests**
  * Added unit tests covering successful deletions, not-found cases, cleanup failures (verifying rollback), and redeploy scheduling and edge behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->