### PR TITLE
feat(storage): O(1) cached aggregates with safe cross-bucket triggers (#1435)

### DIFF
--- a/backend/src/infra/database/migrations/049_cached-storage-aggregates.sql
+++ b/backend/src/infra/database/migrations/049_cached-storage-aggregates.sql
@@ -1,0 +1,70 @@
+-- Migration: 049 - Cached Storage Aggregates
+--
+-- Optimize O(N) storage queries by tracking object counts and total sizes 
+-- incrementally via AFTER INSERT/UPDATE/DELETE triggers on storage.objects.
+
+-- 1. Add cached aggregate columns to storage.buckets
+ALTER TABLE storage.buckets 
+ADD COLUMN object_count BIGINT DEFAULT 0 NOT NULL,
+ADD COLUMN total_size_bytes BIGINT DEFAULT 0 NOT NULL;
+
+-- 2. Define trigger function to sync aggregates
+CREATE OR REPLACE FUNCTION storage.update_bucket_aggregates()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        UPDATE storage.buckets
+        SET 
+            object_count = object_count + 1,
+            total_size_bytes = total_size_bytes + COALESCE(NEW.size, 0),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE name = NEW.bucket;
+        
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE storage.buckets
+        SET 
+            object_count = GREATEST(0, object_count - 1),
+            total_size_bytes = GREATEST(0, total_size_bytes - COALESCE(OLD.size, 0)),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE name = OLD.bucket;
+        
+    ELSIF (TG_OP = 'UPDATE') THEN
+        IF (OLD.bucket <> NEW.bucket) THEN
+            -- Deduct from old bucket
+            UPDATE storage.buckets
+            SET 
+                object_count = GREATEST(0, object_count - 1),
+                total_size_bytes = GREATEST(0, total_size_bytes - COALESCE(OLD.size, 0)),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE name = OLD.bucket;
+            
+            -- Add to new bucket
+            UPDATE storage.buckets
+            SET 
+                object_count = object_count + 1,
+                total_size_bytes = total_size_bytes + COALESCE(NEW.size, 0),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE name = NEW.bucket;
+        ELSIF (COALESCE(OLD.size, 0) <> COALESCE(NEW.size, 0)) THEN
+            UPDATE storage.buckets
+            SET 
+                total_size_bytes = GREATEST(0, total_size_bytes + (COALESCE(NEW.size, 0) - COALESCE(OLD.size, 0))),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE name = NEW.bucket;
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Bind the trigger to storage.objects
+CREATE TRIGGER trg_storage_objects_aggregate_sync
+AFTER INSERT OR UPDATE OR DELETE ON storage.objects
+FOR EACH ROW
+EXECUTE FUNCTION storage.update_bucket_aggregates();
+
+-- 4. Transactionally backfill existing bucket counts and sizes
+UPDATE storage.buckets b
+SET 
+  object_count = COALESCE((SELECT COUNT(*) FROM storage.objects o WHERE o.bucket = b.name), 0),
+  total_size_bytes = COALESCE((SELECT SUM(size) FROM storage.objects o WHERE o.bucket = b.name), 0);

--- a/backend/src/infra/database/migrations/049_cached-storage-aggregates.sql
+++ b/backend/src/infra/database/migrations/049_cached-storage-aggregates.sql
@@ -5,13 +5,21 @@
 
 -- 1. Add cached aggregate columns to storage.buckets
 ALTER TABLE storage.buckets 
-ADD COLUMN object_count BIGINT DEFAULT 0 NOT NULL,
-ADD COLUMN total_size_bytes BIGINT DEFAULT 0 NOT NULL;
+ADD COLUMN IF NOT EXISTS object_count BIGINT DEFAULT 0 NOT NULL,
+ADD COLUMN IF NOT EXISTS total_size_bytes BIGINT DEFAULT 0 NOT NULL;
 
 -- 2. Define trigger function to sync aggregates
 CREATE OR REPLACE FUNCTION storage.update_bucket_aggregates()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = storage
+AS $$
 BEGIN
+    -- Guard against NULL bucket values to prevent aggregate drift
+    IF (TG_OP = 'INSERT' AND NEW.bucket IS NULL) THEN RETURN NEW; END IF;
+    IF (TG_OP = 'DELETE' AND OLD.bucket IS NULL) THEN RETURN OLD; END IF;
+    IF (TG_OP = 'UPDATE' AND NEW.bucket IS NULL AND OLD.bucket IS NULL) THEN RETURN NEW; END IF;
+
     IF (TG_OP = 'INSERT') THEN
         UPDATE storage.buckets
         SET 
@@ -29,7 +37,14 @@ BEGIN
         WHERE name = OLD.bucket;
         
     ELSIF (TG_OP = 'UPDATE') THEN
-        IF (OLD.bucket <> NEW.bucket) THEN
+        IF (OLD.bucket IS DISTINCT FROM NEW.bucket) THEN
+            -- Lock buckets in alphabetical order to prevent deadlocks
+            PERFORM 1 
+            FROM storage.buckets 
+            WHERE name IN (OLD.bucket, NEW.bucket) 
+            ORDER BY name 
+            FOR UPDATE;
+
             -- Deduct from old bucket
             UPDATE storage.buckets
             SET 
@@ -58,13 +73,15 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- 3. Bind the trigger to storage.objects
+DROP TRIGGER IF EXISTS trg_storage_objects_aggregate_sync ON storage.objects;
 CREATE TRIGGER trg_storage_objects_aggregate_sync
-AFTER INSERT OR UPDATE OR DELETE ON storage.objects
+AFTER INSERT OR UPDATE OF bucket, size OR DELETE ON storage.objects
 FOR EACH ROW
 EXECUTE FUNCTION storage.update_bucket_aggregates();
 
 -- 4. Transactionally backfill existing bucket counts and sizes
 UPDATE storage.buckets b
 SET 
-  object_count = COALESCE((SELECT COUNT(*) FROM storage.objects o WHERE o.bucket = b.name), 0),
-  total_size_bytes = COALESCE((SELECT SUM(size) FROM storage.objects o WHERE o.bucket = b.name), 0);
+  object_count = (SELECT COUNT(*) FROM storage.objects o WHERE o.bucket = b.name),
+  total_size_bytes = COALESCE((SELECT SUM(size) FROM storage.objects o WHERE o.bucket = b.name), 0),
+  updated_at = CURRENT_TIMESTAMP;

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -716,31 +716,34 @@ export class StorageService {
    * Get storage metadata
    */
   async getMetadata(): Promise<StorageMetadataSchema> {
-    // Get storage buckets from storage.buckets table
+    // Get storage buckets from storage.buckets table with cached aggregates
     const result = await this.getPool().query(
-      'SELECT name, public, created_at as "createdAt" FROM storage.buckets ORDER BY name'
+      `SELECT name, public, created_at as "createdAt", 
+              object_count as "objectCount", 
+              total_size_bytes as "totalSize" 
+       FROM storage.buckets 
+       ORDER BY name`
     );
 
-    const storageBuckets = result.rows as StorageBucketSchema[];
-
-    // Get object counts for each bucket
-    const bucketsObjectCountMap = await this.getBucketsObjectCount();
-    const storageSize = await this.getStorageSizeInGB();
+    const buckets = result.rows;
+    const totalSizeBytes = buckets.reduce((sum, b) => sum + Number(b.totalSize), 0);
 
     return {
-      buckets: storageBuckets.map((bucket) => ({
-        ...bucket,
-        objectCount: bucketsObjectCountMap.get(bucket.name) ?? 0,
+      buckets: buckets.map((bucket) => ({
+        name: bucket.name,
+        public: bucket.public,
+        createdAt: bucket.createdAt,
+        objectCount: Number(bucket.objectCount),
       })),
-      totalSizeInGB: storageSize,
+      totalSizeInGB: totalSizeBytes / GIGABYTE_IN_BYTES,
     };
   }
 
   private async getBucketsObjectCount(): Promise<Map<string, number>> {
     try {
-      // Query to get object count for each bucket
+      // Query to get object count for each bucket from cached columns
       const result = await this.getPool().query(
-        'SELECT bucket, COUNT(*) as count FROM storage.objects GROUP BY bucket'
+        'SELECT name as bucket, object_count as count FROM storage.buckets'
       );
 
       const bucketCounts = result.rows as { bucket: string; count: string }[];
@@ -763,12 +766,9 @@ export class StorageService {
 
   private async getStorageSizeInGB(): Promise<number> {
     try {
-      // Query the storage.objects table to sum all file sizes
+      // Sum the total cached size of all buckets
       const result = await this.getPool().query(
-        `
-        SELECT COALESCE(SUM(size), 0) as total_size
-        FROM storage.objects
-      `
+        'SELECT COALESCE(SUM(total_size_bytes), 0) as total_size FROM storage.buckets'
       );
 
       const totalSize = result.rows[0]?.total_size || 0;

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -29,6 +29,14 @@ type StorageObjectResult = {
   metadata: StorageFileSchema;
 };
 
+interface BucketRow {
+  name: string;
+  public: boolean;
+  createdAt: Date | string;
+  objectCount: string;
+  totalSize: string;
+}
+
 export class StorageService {
   private static instance: StorageService;
   private provider: StorageProvider;
@@ -725,62 +733,19 @@ export class StorageService {
        ORDER BY name`
     );
 
-    const buckets = result.rows;
-    const totalSizeBytes = buckets.reduce((sum, b) => sum + Number(b.totalSize), 0);
+    const buckets = result.rows as BucketRow[];
+    const totalSizeBytes = buckets.reduce((sum, b) => sum + (Number(b.totalSize) || 0), 0);
 
     return {
       buckets: buckets.map((bucket) => ({
         name: bucket.name,
         public: bucket.public,
-        createdAt: bucket.createdAt,
-        objectCount: Number(bucket.objectCount),
+        createdAt:
+          bucket.createdAt instanceof Date ? bucket.createdAt.toISOString() : bucket.createdAt,
+        objectCount: Number(bucket.objectCount) || 0,
       })),
       totalSizeInGB: totalSizeBytes / GIGABYTE_IN_BYTES,
     };
-  }
-
-  private async getBucketsObjectCount(): Promise<Map<string, number>> {
-    try {
-      // Query to get object count for each bucket from cached columns
-      const result = await this.getPool().query(
-        'SELECT name as bucket, object_count as count FROM storage.buckets'
-      );
-
-      const bucketCounts = result.rows as { bucket: string; count: string }[];
-
-      // Convert to Map for easy lookup
-      const countMap = new Map<string, number>();
-      bucketCounts.forEach((row) => {
-        countMap.set(row.bucket, parseInt(row.count, 10));
-      });
-
-      return countMap;
-    } catch (error) {
-      logger.error('Error getting bucket object counts', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      // Return empty map on error
-      return new Map<string, number>();
-    }
-  }
-
-  private async getStorageSizeInGB(): Promise<number> {
-    try {
-      // Sum the total cached size of all buckets
-      const result = await this.getPool().query(
-        'SELECT COALESCE(SUM(total_size_bytes), 0) as total_size FROM storage.buckets'
-      );
-
-      const totalSize = result.rows[0]?.total_size || 0;
-
-      // Convert bytes to GB
-      return Number(totalSize) / GIGABYTE_IN_BYTES;
-    } catch (error) {
-      logger.error('Error getting storage size', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return 0;
-    }
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary
This PR implements the $O(1)$ cached aggregate architecture for storage metadata to resolve the unbounded $O(N)$ table scan bottleneck identified in #1435. 

I am opening this PR to help unblock the pipeline, as it contains the fully tested PL/pgSQL logic and type-safety guards necessary to prevent the data corruption risks currently blocking PR #1437.

Closes #1435 

## Why this implementation is safe (Addressing known edge cases):
1. **Cross-Bucket Moves Handled:** The `UPDATE` trigger explicitly branches for `IF (OLD.bucket <> NEW.bucket)`. This prevents permanent cache corruption by properly decrementing the old bucket and incrementing the new bucket when an object is reassigned.
2. **`BIGINT` String Coercion Fixed:** `node-postgres` returns `BIGINT` (like `total_size_bytes`) as JavaScript strings at runtime. This PR explicitly casts these using `Number()` during summation to prevent massive string concatenation bugs (`"100" + "200" = "100200"`).
3. **`NULL` Size Contamination Prevented:** All trigger arithmetic wraps object sizes in `COALESCE(size, 0)` to ensure a `NULL` file size doesn't wipe out the entire bucket's aggregate total.
4. **Race-Condition Free Migration:** The backfill runs safely at the end of the migration transaction.

## Testing
- [x] Tested cross-bucket file moves (counts and sizes update correctly)
- [x] Tested string-coercion guards for BIGINT
- [x] All backend unit tests passing
- [x] `eslint` and `prettier` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds O(1) cached storage aggregates with safe triggers to replace O(N) scans. Improves metadata performance and correctness for cross-bucket moves, size deltas, and BIGINT reads. Closes #1435.

- **New Features**
  - Add `object_count` and `total_size_bytes` to `storage.buckets`, with transactional backfill.
  - Add `storage.update_bucket_aggregates()` and an AFTER `INSERT`/`UPDATE OF bucket, size`/`DELETE` trigger on `storage.objects`; lock buckets in alphabetical order on cross-bucket moves; handle size-only deltas.
  - Update `StorageService.getMetadata()` to read cached columns and compute `totalSizeInGB` from bucket totals; remove legacy O(N) helpers.

- **Bug Fixes**
  - Cast `BIGINT` fields to numbers in `getMetadata`; use `COALESCE(...)` and `GREATEST(0, ...)` to guard NULLs and negatives.
  - Skip rows with `NULL` buckets in triggers to prevent drift.
  - Update `updated_at` on aggregate changes to prevent stale metadata.

<sup>Written for commit d60f9e5633c18bf538b4d1ffd9ec8c150a3f6135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache object count and total size on `storage.buckets` with O(1) aggregate reads
> - Adds `object_count` and `total_size_bytes` columns to `storage.buckets` via [migration 049](https://github.com/InsForge/InsForge/pull/1445/files#diff-be8e8ac086b7e0e933d1b7dc9947ce1d2c737ccc7387d4222f5307b891f0c301), backfilling existing rows on deploy.
> - Introduces the `storage.update_bucket_aggregates` trigger function, fired after INSERT, UPDATE, or DELETE on `storage.objects`, to keep per-bucket aggregates up to date incrementally.
> - Updates `StorageService.getMetadata` in [storage.service.ts](https://github.com/InsForge/InsForge/pull/1445/files#diff-a3d23aa25b7dc8c15c3e5c694ed2e19a62e6cb123b48a805a1d07e6944fda625) to read aggregates directly from `storage.buckets`, removing separate queries over `storage.objects`.
> - Behavioral Change: `getMetadata` no longer scans `storage.objects` for totals; accuracy now depends on trigger correctness. Any objects inserted outside the trigger path will not be reflected until the next migration backfill.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d60f9e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buckets now store cached object counts and total sizes for immediate visibility and are kept up-to-date as objects change.

* **Refactor**
  * Storage metadata endpoint now returns these precomputed per-bucket aggregates, improving response speed and consistency.

* **Chores**
  * All existing buckets were backfilled with current aggregate values to ensure accurate initial counts and sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->