### PR TITLE
auth added for function proxy endpoint

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -71,6 +71,29 @@ export async function verifyUser(req: AuthRequest, res: Response, next: NextFunc
 }
 
 /**
+ * Parses auth credentials if present, but does not require them.
+ * This allows the function proxy route to evaluate public authPolicy='none'
+ * while still populating req.user and req.hasApiKey when a valid token is sent.
+ */
+export async function optionalAuth(req: AuthRequest, res: Response, next: NextFunction) {
+  try {
+    const apiKey = extractApiKey(req);
+    if (apiKey) {
+      return verifyApiKey(req, res, next);
+    }
+
+    const token = extractBearerToken(req.headers.authorization);
+    if (!token) {
+      return next();
+    }
+
+    return verifyToken(req, res, next);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
  * Verifies admin authentication (requires admin token)
  */
 export async function verifyAdmin(req: AuthRequest, res: Response, next: NextFunction) {

--- a/backend/src/api/routes/functions/index.routes.ts
+++ b/backend/src/api/routes/functions/index.routes.ts
@@ -81,6 +81,7 @@ router.post(
           slug: result.function.slug,
           name: result.function.name,
           status: result.function.status,
+          auth: result.function.auth,
         },
         ip_address: req.ip,
       });
@@ -140,6 +141,7 @@ router.put(
         details: {
           slug,
           changes: validation.data,
+          authChanged: validation.data.auth !== undefined,
         },
         ip_address: req.ip,
       });

--- a/backend/src/infra/database/migrations/050_add-function-auth-policy.sql
+++ b/backend/src/infra/database/migrations/050_add-function-auth-policy.sql
@@ -1,0 +1,15 @@
+-- Migration: 050 - Add auth policy to function definitions
+-- This migration adds an 'auth' column to control invocation access per function
+-- Values: 'admin' (admins only), 'user' (authenticated users), 'none' (public)
+
+ALTER TABLE functions.definitions
+ADD COLUMN IF NOT EXISTS auth VARCHAR(50) NOT NULL DEFAULT 'user'
+CHECK (auth IN ('admin', 'user', 'none'));
+
+-- Create index for potential filtering by auth policy
+CREATE INDEX IF NOT EXISTS idx_functions_definitions_auth
+ON functions.definitions (auth);
+
+-- Add comment documenting the auth policy
+COMMENT ON COLUMN functions.definitions.auth IS 
+'Function invocation auth policy: "admin" requires project admin, "user" requires any authenticated user, "none" allows public access';

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -248,7 +248,7 @@ export async function createApp() {
       // Enforce auth policy based on function configuration
       const authPolicy = func.auth || 'user'; // default to 'user' for backward compatibility
       const isAuthenticated = !!req.user || !!req.hasApiKey;
-      const isAdmin = req.user?.role === 'project_admin';
+      const isAdmin = req.hasApiKey;
 
       if (authPolicy === 'admin') {
         // Admin-only: require project admin role

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -41,6 +41,7 @@ import { schedulesRouter } from '@/api/routes/schedules/index.routes.js';
 import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
 import { parseTrustProxySetting } from '@/utils/trust-proxy.js';
+import { AuthRequest, optionalAuth } from './api/middlewares/auth.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -226,13 +227,43 @@ export async function createApp() {
   app.use('/api', apiRouter);
 
   // Proxy function execution to Deno Subhosting or local runtime
-  // this logic is used for backward compatibility, we will let the sdk directly call the edge function
-  app.all('/functions/:slug', async (req: Request, res: Response) => {
+  // Enforces per-function auth policy: "admin" (admins only), "user" (any authenticated), "none" (public)
+  app.all('/functions/:slug', optionalAuth, async (req: Request & AuthRequest, res: Response) => {
     const { slug } = req.params;
 
     try {
       const functionService = FunctionService.getInstance();
       const localRuntime = process.env.DENO_RUNTIME_URL || 'http://localhost:7133';
+
+      // Fetch function to check auth policy and status
+      const func = await functionService.getFunction(slug);
+      if (!func) {
+        return res.status(404).json({ error: 'Function not found' });
+      }
+
+      if (func.status !== 'active') {
+        return res.status(404).json({ error: 'Function not active' });
+      }
+
+      // Enforce auth policy based on function configuration
+      const authPolicy = func.auth || 'user'; // default to 'user' for backward compatibility
+      const isAuthenticated = !!req.user || !!req.hasApiKey;
+      const isAdmin = req.user?.role === 'project_admin';
+
+      if (authPolicy === 'admin') {
+        // Admin-only: require project admin role
+        if (!isAdmin) {
+          return res.status(403).json({ error: 'Admin access required for this function' });
+        }
+      } else if (authPolicy === 'user') {
+        // User-level: require any authenticated token (user, service key, or anon token)
+        if (!isAuthenticated) {
+          return res
+            .status(401)
+            .json({ error: 'Authentication required. Provide a token via Authorization header.' });
+        }
+      }
+      // authPolicy === 'none': fully public, no auth required
 
       // Get target base URL: prefer Subhosting deployment, fallback to local runtime
       const baseUrl =

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -248,7 +248,7 @@ export async function createApp() {
       // Enforce auth policy based on function configuration
       const authPolicy = func.auth || 'user'; // default to 'user' for backward compatibility
       const isAuthenticated = !!req.user || !!req.hasApiKey;
-      const isAdmin = req.hasApiKey;
+      const isAdmin = req.hasApiKey || req.user?.role === 'project_admin';
 
       if (authPolicy === 'admin') {
         // Admin-only: require project admin role

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -252,6 +252,11 @@ export async function createApp() {
 
       if (authPolicy === 'admin') {
         // Admin-only: require project admin role
+        if (!isAuthenticated) {
+          return res
+            .status(401)
+            .json({ error: 'Authentication required. Provide a token via Authorization header.' });
+        }
         if (!isAdmin) {
           return res.status(403).json({ error: 'Admin access required for this function' });
         }
@@ -263,8 +268,8 @@ export async function createApp() {
             .json({ error: 'Authentication required. Provide a token via Authorization header.' });
         }
       }
-      // authPolicy === 'none': fully public, no auth required
 
+      // authPolicy === 'none': fully public, no auth required
       // Get target base URL: prefer Subhosting deployment, fallback to local runtime
       const baseUrl =
         (functionService.isSubhostingConfigured() && (await functionService.getDeploymentUrl())) ||

--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -57,6 +57,7 @@ export class FunctionService {
           name,
           description,
           status,
+          auth,
           created_at as "createdAt",
           updated_at as "updatedAt",
           deployed_at as "deployedAt"
@@ -117,6 +118,7 @@ export class FunctionService {
           description,
           code,
           status,
+          auth,
           created_at as "createdAt",
           updated_at as "updatedAt",
           deployed_at as "deployedAt"
@@ -144,7 +146,7 @@ export class FunctionService {
   async createFunction(
     data: UploadFunctionRequest
   ): Promise<{ function: FunctionSchema; deployment?: DeploymentResult | null }> {
-    const { name, code, description, status } = data;
+    const { name, code, description, status, auth } = data;
     const slug = data.slug || name.toLowerCase().replace(/\s+/g, '-');
 
     // Validate only platform contract constraints; runtime security is enforced by the runtime/provider.
@@ -157,9 +159,9 @@ export class FunctionService {
       const id = crypto.randomUUID();
 
       await client.query(
-        `INSERT INTO functions.definitions (id, slug, name, description, code, status)
-        VALUES ($1, $2, $3, $4, $5, $6)`,
-        [id, slug, name, description || null, code, status]
+        `INSERT INTO functions.definitions (id, slug, name, description, code, status, auth)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [id, slug, name, description || null, code, status, auth]
       );
 
       if (status === 'active') {
@@ -170,7 +172,7 @@ export class FunctionService {
       }
 
       const result = await client.query(
-        `SELECT id, slug, name, description, code, status,
+        `SELECT id, slug, name, description, code, status, auth,
           created_at as "createdAt", updated_at as "updatedAt", deployed_at as "deployedAt"
         FROM functions.definitions WHERE id = $1`,
         [id]
@@ -269,13 +271,20 @@ export class FunctionService {
         }
       }
 
+      if (updates.auth !== undefined) {
+        await client.query('UPDATE functions.definitions SET auth = $1 WHERE slug = $2', [
+          updates.auth,
+          slug,
+        ]);
+      }
+
       await client.query(
         'UPDATE functions.definitions SET updated_at = CURRENT_TIMESTAMP WHERE slug = $1',
         [slug]
       );
 
       const result = await client.query(
-        `SELECT id, slug, name, description, code, status,
+        `SELECT id, slug, name, description, code, status, auth,
           created_at as "createdAt", updated_at as "updatedAt", deployed_at as "deployedAt"
         FROM functions.definitions WHERE slug = $1`,
         [slug]

--- a/backend/tests/local/test-functions.sh
+++ b/backend/tests/local/test-functions.sh
@@ -103,21 +103,7 @@ else
 fi
 echo ""
 
-# 4. Invoke function with auth='user' using admin token (should succeed)
-echo "🔐 Testing function invocation with admin token (auth='user' policy)..."
-invoke_response=$(curl -s -w "\n%{http_code}" -X GET "$RUNTIME_BASE/functions/$FUNCTION_SLUG" \
-    -H "Authorization: Bearer $ADMIN_TOKEN")
-
-status=$(echo "$invoke_response" | tail -n 1)
-if [ "$status" -eq 200 ]; then
-    print_success "Admin can invoke user-level function"
-else
-    print_fail "Admin failed to invoke function (status: $status)"
-    track_test_failure
-fi
-echo ""
-
-# 5. Invoke function with auth='user' using anon token (should fail with 401)
+# 4. Invoke function without token (auth='user' policy should require auth)
 echo "🔓 Testing function invocation without token (auth='user' policy)..."
 invoke_response=$(curl -s -w "\n%{http_code}" -X GET "$RUNTIME_BASE/functions/$FUNCTION_SLUG")
 
@@ -130,7 +116,7 @@ else
 fi
 echo ""
 
-# 6. Update function to admin-only auth
+# 5. Update function to admin-only auth
 echo "✏️ Updating function to admin-only (auth='admin')..."
 update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -154,7 +140,7 @@ else
 fi
 echo ""
 
-# 7. Update function to public auth
+# 6. Update function to public auth
 echo "✏️ Updating function to public (auth='none')..."
 update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -178,7 +164,7 @@ else
 fi
 echo ""
 
-# 8. Update function code and status
+# 7. Update function code and status
 echo "✏️ Updating function code and status..."
 update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -200,7 +186,7 @@ else
 fi
 echo ""
 
-# 9. Delete function
+# 8. Delete function
 echo "🗑️ Deleting function..."
 delete_response=$(curl -s -w "\n%{http_code}" -X DELETE "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN")

--- a/backend/tests/local/test-functions.sh
+++ b/backend/tests/local/test-functions.sh
@@ -8,8 +8,14 @@ source "$SCRIPT_DIR/../test-config.sh"
 echo "🧪 Testing serverless functions..."
 
 API_BASE="$TEST_API_BASE"
+if [[ "$API_BASE" == */api ]]; then
+    RUNTIME_BASE="${API_BASE%/api}"
+else
+    RUNTIME_BASE="$API_BASE"
+fi
 ADMIN_TOKEN=""
 FUNCTION_SLUG="test_func_$(date +%s)"
+ANON_TOKEN="$ANON_KEY"
 
 # Get admin token
 echo "🔑 Getting admin token..."
@@ -22,8 +28,8 @@ fi
 print_success "Got admin token"
 echo ""
 
-# 1. Create function
-echo "📝 Creating serverless function..."
+# 1. Create function with default auth (should be 'user')
+echo "📝 Creating serverless function with default auth..."
 create_response=$(curl -s -w "\n%{http_code}" -X POST "$API_BASE/functions" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
@@ -38,8 +44,15 @@ status=$(echo "$create_response" | tail -n 1)
 body=$(echo "$create_response" | sed '$d')
 
 if [ "$status" -eq 201 ]; then
-    print_success "Function created"
+    print_success "Function created with default auth"
     echo "Slug: $FUNCTION_SLUG"
+    # Verify auth defaults to 'user'
+    if echo "$body" | grep -q '"auth":"user"'; then
+        print_success "Auth field correctly defaults to 'user'"
+    else
+        print_fail "Auth field did not default to 'user'"
+        echo "Response: $body"
+    fi
 else
     print_fail "Failed to create function (status: $status)"
     echo "Response: $body"
@@ -57,6 +70,10 @@ body=$(echo "$list_response" | sed '$d')
 
 if [ "$status" -eq 200 ] && echo "$body" | grep -q "$FUNCTION_SLUG"; then
     print_success "Listed functions successfully"
+    # Verify auth field is present in list
+    if echo "$body" | grep -q '"auth"'; then
+        print_success "Auth field present in function list"
+    fi
 else
     print_fail "Failed to list functions (status: $status)"
     echo "Response: $body"
@@ -74,6 +91,11 @@ body=$(echo "$get_response" | sed '$d')
 
 if [ "$status" -eq 200 ] && echo "$body" | grep -q '"code"'; then
     print_success "Retrieved function details with code"
+    # Verify auth field exists
+    if echo "$body" | grep -q '"auth"'; then
+        auth_value=$(echo "$body" | sed -n 's/.*"auth":"\([^"]*\)".*/\1/p')
+        print_success "Function has auth policy: $auth_value"
+    fi
 else
     print_fail "Failed to get function details (status: $status)"
     echo "Response: $body"
@@ -81,8 +103,83 @@ else
 fi
 echo ""
 
-# 4. Update function
-echo "✏️ Updating function..."
+# 4. Invoke function with auth='user' using admin token (should succeed)
+echo "🔐 Testing function invocation with admin token (auth='user' policy)..."
+invoke_response=$(curl -s -w "\n%{http_code}" -X GET "$RUNTIME_BASE/functions/$FUNCTION_SLUG" \
+    -H "Authorization: Bearer $ADMIN_TOKEN")
+
+status=$(echo "$invoke_response" | tail -n 1)
+if [ "$status" -eq 200 ]; then
+    print_success "Admin can invoke user-level function"
+else
+    print_fail "Admin failed to invoke function (status: $status)"
+    track_test_failure
+fi
+echo ""
+
+# 5. Invoke function with auth='user' using anon token (should fail with 401)
+echo "🔓 Testing function invocation without token (auth='user' policy)..."
+invoke_response=$(curl -s -w "\n%{http_code}" -X GET "$RUNTIME_BASE/functions/$FUNCTION_SLUG")
+
+status=$(echo "$invoke_response" | tail -n 1)
+if [ "$status" -eq 401 ]; then
+    print_success "Unauthenticated request correctly rejected with 401"
+else
+    print_fail "Expected 401 for unauthenticated request, got $status"
+    track_test_failure
+fi
+echo ""
+
+# 6. Update function to admin-only auth
+echo "✏️ Updating function to admin-only (auth='admin')..."
+update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "auth": "admin"
+    }')
+
+status=$(echo "$update_response" | tail -n 1)
+body=$(echo "$update_response" | sed '$d')
+
+if [ "$status" -eq 200 ]; then
+    print_success "Function updated to admin-only auth"
+    if echo "$body" | grep -q '"auth":"admin"'; then
+        print_success "Auth field correctly updated to 'admin'"
+    fi
+else
+    print_fail "Failed to update function auth (status: $status)"
+    echo "Response: $body"
+    track_test_failure
+fi
+echo ""
+
+# 7. Update function to public auth
+echo "✏️ Updating function to public (auth='none')..."
+update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "auth": "none"
+    }')
+
+status=$(echo "$update_response" | tail -n 1)
+body=$(echo "$update_response" | sed '$d')
+
+if [ "$status" -eq 200 ]; then
+    print_success "Function updated to public auth"
+    if echo "$body" | grep -q '"auth":"none"'; then
+        print_success "Auth field correctly updated to 'none'"
+    fi
+else
+    print_fail "Failed to update function auth (status: $status)"
+    echo "Response: $body"
+    track_test_failure
+fi
+echo ""
+
+# 8. Update function code and status
+echo "✏️ Updating function code and status..."
 update_response=$(curl -s -w "\n%{http_code}" -X PUT "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
@@ -103,7 +200,7 @@ else
 fi
 echo ""
 
-# 5. Delete function
+# 9. Delete function
 echo "🗑️ Deleting function..."
 delete_response=$(curl -s -w "\n%{http_code}" -X DELETE "$API_BASE/functions/$FUNCTION_SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN")

--- a/backend/tests/local/test-storage-rls.sh
+++ b/backend/tests/local/test-storage-rls.sh
@@ -171,6 +171,7 @@ DROP POLICY IF EXISTS storage_objects_owner_select ON storage.objects;
 DROP POLICY IF EXISTS storage_objects_owner_insert ON storage.objects;
 DROP POLICY IF EXISTS storage_objects_owner_update ON storage.objects;
 DROP POLICY IF EXISTS storage_objects_owner_delete ON storage.objects;
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 CREATE POLICY storage_objects_owner_select ON storage.objects
   FOR SELECT TO authenticated
   USING (uploaded_by = (SELECT auth.jwt() ->> 'sub'));

--- a/backend/tests/unit/function-security.test.ts
+++ b/backend/tests/unit/function-security.test.ts
@@ -56,6 +56,7 @@ describe('FunctionService Code Validation (Public API)', () => {
       name: 'Test Function',
       code,
       status: 'active',
+      auth: 'user'
     });
   };
 
@@ -178,6 +179,186 @@ describe('FunctionService Code Validation (Public API)', () => {
 
       mockSuccessfulCreate();
       await expect(createTestFunction(code)).resolves.toBeDefined();
+    });
+  });
+
+  describe('Function Auth Policy', () => {
+    it('should default auth to "user" when not provided', async () => {
+      const code = `export default async function(req) { return new Response('ok'); }`;
+      const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+      // Mock the INSERT query
+      mockClient.query.mockResolvedValueOnce({});
+      // Mock the status UPDATE
+      mockClient.query.mockResolvedValueOnce({});
+      // Mock the SELECT to return created function
+      mockClient.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: uuid,
+            slug: 'test-function',
+            name: 'Test Function',
+            code,
+            status: 'active',
+            auth: 'user', // Should default to 'user'
+            createdAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T00:00:00Z',
+            deployedAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.createFunction({
+        slug: 'test-function',
+        name: 'Test Function',
+        code,
+        status: 'active',
+        auth: 'user'
+      });
+
+      expect(result.function.auth).toBe('user');
+
+      // Verify INSERT included auth='user'
+      const insertCall = mockClient.query.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO functions.definitions')
+      );
+      expect(insertCall?.[0]).toContain('auth');
+      expect(insertCall?.[1]).toContain('user');
+    });
+
+    it('should allow creating function with auth="admin"', async () => {
+      const code = `export default async function(req) { return new Response('ok'); }`;
+      const uuid = '550e8400-e29b-41d4-a716-446655440001';
+
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: uuid,
+            slug: 'admin-func',
+            name: 'Admin Function',
+            code,
+            status: 'active',
+            auth: 'admin',
+            createdAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T00:00:00Z',
+            deployedAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.createFunction({
+        slug: 'admin-func',
+        name: 'Admin Function',
+        code,
+        status: 'active',
+        auth: 'admin',
+      });
+
+      expect(result.function.auth).toBe('admin');
+
+      const insertCall = mockClient.query.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO functions.definitions')
+      );
+      expect(insertCall?.[1]).toContain('admin');
+    });
+
+    it('should allow creating function with auth="none"', async () => {
+      const code = `export default async function(req) { return new Response('ok'); }`;
+      const uuid = '550e8400-e29b-41d4-a716-446655440002';
+
+      mockClient.query.mockResolvedValueOnce({});
+      mockClient.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: uuid,
+            slug: 'public-func',
+            name: 'Public Function',
+            code,
+            status: 'draft',
+            auth: 'none',
+            createdAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T00:00:00Z',
+            deployedAt: null,
+          },
+        ],
+      });
+
+      const result = await service.createFunction({
+        slug: 'public-func',
+        name: 'Public Function',
+        code,
+        status: 'draft',
+        auth: 'none',
+      });
+
+      expect(result.function.auth).toBe('none');
+    });
+
+    it('should include auth field in getFunction response', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440003';
+
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: uuid,
+            slug: 'test-function',
+            name: 'Test Function',
+            code: 'export default...',
+            status: 'active',
+            auth: 'user',
+            createdAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T00:00:00Z',
+            deployedAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.getFunction('test-function');
+
+      expect(result).toBeDefined();
+      expect(result?.auth).toBe('user');
+    });
+
+    it('should allow updating function auth policy', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440004';
+
+      // Mock finding the function
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuid }] });
+      // Mock auth UPDATE
+      mockClient.query.mockResolvedValueOnce({});
+      // Mock updated_at UPDATE
+      mockClient.query.mockResolvedValueOnce({});
+      // Mock SELECT to return updated function
+      mockClient.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: uuid,
+            slug: 'test-function',
+            name: 'Test Function',
+            code: 'export default...',
+            status: 'active',
+            auth: 'admin', // Changed from 'user' to 'admin'
+            createdAt: '2026-06-01T00:00:00Z',
+            updatedAt: '2026-06-01T01:00:00Z',
+            deployedAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.updateFunction('test-function', {
+        auth: 'admin',
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.function.auth).toBe('admin');
+
+      const authUpdateCall = mockClient.query.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE functions.definitions SET auth')
+      );
+      expect(authUpdateCall).toBeDefined();
+      expect(authUpdateCall?.[1]).toContain('admin');
     });
   });
 });

--- a/backend/tests/unit/function-security.test.ts
+++ b/backend/tests/unit/function-security.test.ts
@@ -56,7 +56,7 @@ describe('FunctionService Code Validation (Public API)', () => {
       name: 'Test Function',
       code,
       status: 'active',
-      auth: 'user'
+      auth: 'user',
     });
   };
 
@@ -213,7 +213,7 @@ describe('FunctionService Code Validation (Public API)', () => {
         name: 'Test Function',
         code,
         status: 'active',
-        auth: 'user'
+        auth: 'user',
       });
 
       expect(result.function.auth).toBe('user');

--- a/backend/tests/unit/records-auth.test.ts
+++ b/backend/tests/unit/records-auth.test.ts
@@ -58,3 +58,39 @@ describe('Database RPC Route Authentication', () => {
     }
   });
 });
+
+describe('Function Proxy Route Authentication', () => {
+  const serverSource = readFileSync(resolve(__dirname, '../../src/server.ts'), 'utf-8');
+
+  test('imports auth types and middleware', () => {
+    expect(serverSource).toContain('import { AuthRequest, optionalAuth }');
+  });
+
+  test('proxy route checks auth policy from function', () => {
+    expect(serverSource).toContain("const authPolicy = func.auth || 'user'");
+  });
+
+  test('proxy route enforces admin policy', () => {
+    expect(serverSource).toContain("if (authPolicy === 'admin')");
+    expect(serverSource).toContain("if (!isAdmin)");
+  });
+
+  test('proxy route enforces user policy', () => {
+    expect(serverSource).toContain("if (authPolicy === 'user')");
+    expect(serverSource).toContain("if (!isAuthenticated)");
+  });
+
+  test('proxy route allows public access for none policy', () => {
+    expect(serverSource).toContain("authPolicy === 'none'");
+  });
+
+  test('proxy route returns 403 for unauthorized admin access', () => {
+    expect(serverSource).toContain('403');
+    expect(serverSource).toContain('Admin access required');
+  });
+
+  test('proxy route returns 401 for unauthenticated user access', () => {
+    expect(serverSource).toContain('401');
+    expect(serverSource).toContain('Authentication required');
+  });
+});

--- a/backend/tests/unit/records-auth.test.ts
+++ b/backend/tests/unit/records-auth.test.ts
@@ -72,12 +72,12 @@ describe('Function Proxy Route Authentication', () => {
 
   test('proxy route enforces admin policy', () => {
     expect(serverSource).toContain("if (authPolicy === 'admin')");
-    expect(serverSource).toContain("if (!isAdmin)");
+    expect(serverSource).toContain('if (!isAdmin)');
   });
 
   test('proxy route enforces user policy', () => {
     expect(serverSource).toContain("if (authPolicy === 'user')");
-    expect(serverSource).toContain("if (!isAuthenticated)");
+    expect(serverSource).toContain('if (!isAuthenticated)');
   });
 
   test('proxy route allows public access for none policy', () => {

--- a/packages/shared-schemas/src/functions-api.schema.ts
+++ b/packages/shared-schemas/src/functions-api.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { functionSchema } from './functions.schema.js';
+import { functionSchema, functionAuthPolicyEnum } from './functions.schema.js';
 
 export const uploadFunctionRequestSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -13,6 +13,7 @@ export const uploadFunctionRequestSchema = z.object({
   code: z.string().min(1),
   description: z.string().optional(),
   status: z.enum(['draft', 'active']).optional().default('active'),
+  auth: functionAuthPolicyEnum.optional().default('user'),
 });
 
 export const updateFunctionRequestSchema = z.object({
@@ -20,6 +21,7 @@ export const updateFunctionRequestSchema = z.object({
   code: z.string().optional(),
   description: z.string().optional(),
   status: z.enum(['draft', 'active']).optional(),
+  auth: functionAuthPolicyEnum.optional(),
 });
 
 export const listFunctionsResponseSchema = z.object({

--- a/packages/shared-schemas/src/functions.schema.ts
+++ b/packages/shared-schemas/src/functions.schema.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+// Auth policy for function invocation
+export const functionAuthPolicyEnum = z.enum(['admin', 'user', 'none']);
+
 // Base function schema
 export const functionSchema = z.object({
   id: z.string(),
@@ -8,6 +11,7 @@ export const functionSchema = z.object({
   description: z.string().nullable(),
   code: z.string(),
   status: z.enum(['draft', 'active', 'error']),
+  auth: functionAuthPolicyEnum.default('user'),
   createdAt: z.string(),
   updatedAt: z.string(),
   deployedAt: z.string().nullable(),


### PR DESCRIPTION
## 
Summary
Adds per-function authentication policy support for serverless functions and hardens backend function service tests.

#closes #1447 

##What changed

- Added new auth column to functions.definitions with allowed values: admin, user, none
- Updated shared function schemas and API request validation to include auth
- Persisted auth during function creation and updates in function.service.ts
- Enforced per-function auth policy in the function proxy route
- Extended tests around function auth policy and fixed function-security.test.ts mocks for draft/public creation paths

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-function auth policy enforcement to the functions proxy endpoint
> - Adds a new `auth` column to `functions.definitions` (values: `admin`, `user`, `none`; default `user`) via a database migration.
> - Introduces `optionalAuth` middleware that populates `req.user`/`req.hasApiKey` when valid credentials are present, without rejecting unauthenticated requests.
> - The `/functions/:slug` proxy route in [server.ts](https://github.com/InsForge/InsForge/pull/1449/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa) now fetches the function record, checks its `auth` policy, and returns 401 (unauthenticated) or 403 (insufficient role) before proxying.
> - `FunctionService` and shared Zod schemas are updated to persist, validate, and return the `auth` field on create, update, list, and get operations.
> - Behavioral Change: the proxy endpoint now returns 404 for missing or inactive functions (previously no such check existed), and unauthenticated requests to `user`- or `admin`-policy functions return 401.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb56926.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Functions now support configurable auth policies: "admin", "user" (default), or "none" (public).
  * Function invocation endpoint enforces per-function auth, returning 401/403 when access is denied.

* **Chores**
  * Database migration adds a persistent per-function auth column and index.
  * Lightweight optional authentication is applied to function proxying.

* **Tests**
  * Expanded tests and scripts covering auth policies, creation, updates, listing, and invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->