### PR TITLE
INS-305 Update config as code docs

### DIFF
--- a/docs/agent-native/cli-harness.mdx
+++ b/docs/agent-native/cli-harness.mdx
@@ -58,5 +58,5 @@ This pairs the raw signals (advisor findings, DB health, error logs) with a plai
 
 ## Next steps
 
-- Put auth and SMTP in version control with [config as code](/agent-native/config-as-code).
+- Put auth, SMTP, storage, retention, and deployment settings in version control with [config as code](/agent-native/config-as-code).
 - Test risky changes on a [backend branch](/agent-native/branching) before touching production.

--- a/docs/agent-native/config-as-code.mdx
+++ b/docs/agent-native/config-as-code.mdx
@@ -90,9 +90,9 @@ The file mirrors a curated subset of project config, the parts that are useful t
 | `[schedules]` | `retention_days` |
 | `[deployments]` | `subdomain` |
 
-`retention_days = 0` disables retention cleanup for realtime messages or schedule execution logs. Email templates, OAuth provider app credentials, buckets, realtime channels, functions, deployment environment variables, and secrets are not managed through this file.
+Because TOML has no `null` literal, use `retention_days = 0` to disable retention cleanup for realtime messages or schedule execution logs; `config apply` sends `null` to the backend for that value. Email templates, OAuth provider app credentials, buckets, realtime channels, functions, deployment environment variables, and secrets are not managed through this file.
 
-A minimal example:
+A complete example:
 
 ```toml
 [auth]

--- a/docs/agent-native/config-as-code.mdx
+++ b/docs/agent-native/config-as-code.mdx
@@ -1,11 +1,11 @@
 ---
 title: Config as code
-description: Manage InsForge auth, SMTP, and deployment settings declaratively from a single insforge.toml using the CLI's plan, apply, and export workflow.
+description: Manage InsForge auth, SMTP, storage, retention, and deployment settings declaratively from a single insforge.toml using the CLI's plan, apply, and export workflow.
 ---
 
 ## Overview
 
-`insforge.toml` is a declarative, version-controlled snapshot of a subset of your project's config: auth policy, allowed redirect URLs, password rules, SMTP, and the deployment subdomain. The CLI provides three commands that work against this file:
+`insforge.toml` is a declarative, version-controlled snapshot of a subset of your project's config: auth policy, allowed redirect URLs, password rules, SMTP, storage upload size, realtime and schedule retention, and the deployment subdomain. The CLI provides three commands that work against this file:
 
 - **`config plan`**: diff `insforge.toml` against the linked project. Shows what would change.
 - **`config apply`**: push the diff to the live project. Per-change capability gating, env-resolved secrets, dry-run mode.
@@ -82,10 +82,15 @@ The file mirrors a curated subset of project config, the parts that are useful t
 
 | Section | Keys |
 |---------|------|
-| `[auth]` | `allowed_redirect_urls`, `require_email_verification`, `verify_email_method`, `reset_password_method` |
-| `[auth.password]` | `min_length`, `max_length`, `require_uppercase`, `require_lowercase`, `require_number`, `require_special` |
+| `[auth]` | `allowed_redirect_urls`, `require_email_verification`, `verify_email_method`, `reset_password_method`, `disable_signup` |
+| `[auth.password]` | `min_length`, `require_number`, `require_lowercase`, `require_uppercase`, `require_special_char` |
 | `[auth.smtp]` | `enabled`, `host`, `port`, `username`, `password`, `sender_email`, `sender_name`, `min_interval_seconds` |
+| `[storage]` | `max_file_size_mb` |
+| `[realtime]` | `retention_days` |
+| `[schedules]` | `retention_days` |
 | `[deployments]` | `subdomain` |
+
+`retention_days = 0` disables retention cleanup for realtime messages or schedule execution logs. Email templates, OAuth provider app credentials, buckets, realtime channels, functions, deployment environment variables, and secrets are not managed through this file.
 
 A minimal example:
 
@@ -94,6 +99,7 @@ A minimal example:
 require_email_verification = true
 verify_email_method = "code"
 reset_password_method = "code"
+disable_signup = false
 allowed_redirect_urls = [
   "https://app.example.com/auth/callback",
   "http://localhost:3000/auth/callback",
@@ -101,8 +107,10 @@ allowed_redirect_urls = [
 
 [auth.password]
 min_length = 12
-require_uppercase = true
 require_number = true
+require_lowercase = true
+require_uppercase = true
+require_special_char = false
 
 [auth.smtp]
 enabled = true
@@ -112,6 +120,15 @@ username = "apikey"
 password = "env(SENDGRID_API_KEY)"
 sender_email = "noreply@example.com"
 sender_name = "Acme"
+
+[storage]
+max_file_size_mb = 100
+
+[realtime]
+retention_days = 7
+
+[schedules]
+retention_days = 0
 
 [deployments]
 subdomain = "acme-prod"
@@ -125,7 +142,7 @@ npx @insforge/cli config plan --file ./config/insforge.toml
 npx @insforge/cli --json config plan
 ```
 
-`plan` reads `insforge.toml`, fetches live state via `/api/metadata`, and prints a rendered diff. It also tags any section the live backend doesn't expose yet (older self-hosted versions, etc.). Apply will skip those instead of failing the whole run.
+`plan` reads `insforge.toml`, fetches live state via `/api/metadata` and the optional config endpoints for storage, realtime, and schedules, then prints a rendered diff. It also tags any section the live backend doesn't expose yet (older self-hosted versions, etc.). Apply will skip those instead of failing the whole run.
 
 Use `plan` before every `apply` in interactive sessions, and as a CI gate to catch unintended drift.
 
@@ -140,9 +157,9 @@ npx @insforge/cli --json config apply --auto-approve
 
 `apply` runs the same diff as `plan`, then walks the change set:
 
-1. **Per-change capability gate.** Each change is checked against the backend's metadata. If the backend doesn't support a section (e.g. an older self-hosted instance without SMTP exposed), that section is skipped with a named warning, and the rest of the changes still apply.
+1. **Per-change capability gate.** Each change is checked against the backend's metadata or the section's config endpoint. If the backend doesn't support a section (e.g. an older self-hosted instance without SMTP exposed), that section is skipped with a named warning, and the rest of the changes still apply.
 2. **Secret resolution.** `env(...)` references in the TOML are resolved at apply time from the local environment. If a referenced variable is missing, the command aborts before sending any update, so the backend isn't left half-configured.
-3. **Per-section dispatch.** Each change is sent to the appropriate backend endpoint (`/api/auth/config`, `/api/auth/smtp-config`, `/api/deployments/slug`, etc.). Changes are independent, so a failure on one section won't roll back earlier successful sections.
+3. **Per-section dispatch.** Each change is sent to the appropriate backend endpoint (`/api/auth/config`, `/api/auth/smtp-config`, `/api/storage/config`, `/api/realtime/config`, `/api/schedules/config`, `/api/deployments/slug`, etc.). Changes are independent, so a failure on one section won't roll back earlier successful sections.
 
 Flags:
 
@@ -185,10 +202,10 @@ This is what lets one `insforge.toml` apply cleanly to multiple environments: th
 
 ## When to use this
 
-- **Version control for auth.** Redirect URLs, password policy, and email verification mode (all the things you'd otherwise change through the dashboard or curl) live in a file your team reviews via PR.
-- **Multi-environment parity.** One TOML, applied to dev, staging, and prod, guarantees the same auth shape everywhere. Environment-specific values (subdomain, SMTP credentials) flow through `--project-id` overrides and `env(...)` refs.
+- **Version control for project config.** Redirect URLs, signup policy, password policy, email verification mode, SMTP, storage upload size, and retention windows live in a file your team reviews via PR.
+- **Multi-environment parity.** One TOML, applied to dev, staging, and prod, keeps the supported project settings aligned everywhere. Environment-specific values (subdomain, SMTP credentials) flow through `--project-id` overrides and `env(...)` refs.
 - **CI-driven config changes.** Run `config apply --auto-approve --json` from your deploy pipeline. Combine with `config plan` as a PR check so reviewers see what the merge will change in prod.
-- **Disaster recovery.** A committed `insforge.toml` is a known-good config snapshot. Re-apply it after restoring a project to bring auth/SMTP back to the expected shape in seconds.
+- **Disaster recovery.** A committed `insforge.toml` is a known-good config snapshot. Re-apply it after restoring a project to bring auth, SMTP, storage, retention, and deployment settings back to the expected shape in seconds.
 - **Self-hosted and local OSS development.** Run `npx @insforge/cli link --api-base-url http://localhost:7130 --api-key <local-key>` against a docker-compose stack, then point the CLI's config commands at your local OSS instance the same way you'd point at cloud.
 
 ## Troubleshooting

--- a/docs/agent-native/config-as-code.mdx
+++ b/docs/agent-native/config-as-code.mdx
@@ -202,7 +202,7 @@ This is what lets one `insforge.toml` apply cleanly to multiple environments: th
 
 ## When to use this
 
-- **Version control for project config.** Redirect URLs, signup policy, password policy, email verification mode, SMTP, storage upload size, and retention windows live in a file your team reviews via PR.
+- **Version control for project config.** Redirect URLs, sign-up policy, password policy, email verification mode, SMTP, storage upload size, and retention windows live in a file your team reviews via PR.
 - **Multi-environment parity.** One TOML, applied to dev, staging, and prod, keeps the supported project settings aligned everywhere. Environment-specific values (subdomain, SMTP credentials) flow through `--project-id` overrides and `env(...)` refs.
 - **CI-driven config changes.** Run `config apply --auto-approve --json` from your deploy pipeline. Combine with `config plan` as a PR check so reviewers see what the merge will change in prod.
 - **Disaster recovery.** A committed `insforge.toml` is a known-good config snapshot. Re-apply it after restoring a project to bring auth, SMTP, storage, retention, and deployment settings back to the expected shape in seconds.

--- a/docs/agent-native/overview.mdx
+++ b/docs/agent-native/overview.mdx
@@ -20,7 +20,7 @@ Most backends assume a human in a dashboard. InsForge assumes a coding agent at 
     Pull advisor findings, DB health, metrics, and error logs the agent can read and fix.
   </Card>
   <Card title="Config as code" icon="file-code" href="/agent-native/config-as-code">
-    Auth, SMTP, and deployment settings live in `insforge.toml`. Plan and apply like infrastructure.
+    Auth, SMTP, storage, retention, and deployment settings live in `insforge.toml`. Plan and apply like infrastructure.
   </Card>
   <Card title="Branching" icon="code-branch" href="/agent-native/branching">
     Clone the whole backend into an isolated branch to test risky changes, then merge or reset.
@@ -46,5 +46,5 @@ These chain together. A session usually goes:
 ## Next steps
 
 - Read the [CLI harness](/agent-native/cli-harness) to see the full command surface an agent drives.
-- Set up [config as code](/agent-native/config-as-code) so auth and SMTP live in version control.
+- Set up [config as code](/agent-native/config-as-code) so project settings live in version control.
 - Use [diagnostics](/agent-native/diagnostics) to let the agent find and fix backend issues.


### PR DESCRIPTION
## Summary
- document the expanded insforge.toml surface: auth.disable_signup, storage, realtime, and schedules
- clarify retention_days = 0 and that email templates/external resources are not managed through config as code
- update agent-native overview/CLI harness references

## Validation
- git diff --check
- backend route/schema contract inspected locally; no backend code changes needed because the config endpoints already exist

Related CLI PR: https://github.com/InsForge/CLI/pull/156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Config as Code docs to cover storage upload limits, realtime/schedules retention, and `auth.disable_signup` (INS-305). Clarifies that `retention_days = 0` disables cleanup and is sent as `null` by `@insforge/cli`, renames `[auth.password]` keys (`require_special_char`; adds `require_lowercase`/`require_uppercase`), updates `config plan`/`apply` to use optional per‑section endpoints, refreshes overview/CLI to note that auth, SMTP, storage, retention, and deployment settings are versioned, and clarifies what’s out of scope.

<sup>Written for commit 8036a704c3b3ed1769b629161d3f89068a5b8b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand config as code docs to include storage and retention settings
> Updates [config-as-code.mdx](https://github.com/InsForge/InsForge/pull/1450/files#diff-b5ffc7cb68ee72e76b8e061cc537c384dceced8873a0daabf2c1ee6704c77a95), [cli-harness.mdx](https://github.com/InsForge/InsForge/pull/1450/files#diff-def154254f5b80fae9d0ec3cff04a3a5d917ccae4b311c0dd2ff5a3d79dd8c85), and [overview.mdx](https://github.com/InsForge/InsForge/pull/1450/files#diff-dca480a5ab9d8d57afd4b0440c144bef9ed2b709e4c962f690edc470399e4497) to reflect that declarative config now covers storage, realtime retention, and schedule retention in addition to auth, SMTP, and deployments.
>
> - Adds `[storage]`, `[realtime]`, and `[schedules]` sections to the configuration table and example TOML, including `max_file_size_mb` and `retention_days` fields.
> - Documents that `retention_days = 0` disables cleanup and clarifies what the config file does not manage.
> - Updates `plan` and `apply` step descriptions to include the `/api/storage/config`, `/api/realtime/config`, and `/api/schedules/config` endpoints.
> - Adds `disable_signup` to `[auth]` and renames `require_special` to `require_special_char`, adding explicit `require_lowercase` and `require_uppercase` keys in `[auth.password]`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1450 opened
>
> - Changed 'signup policy' to 'sign-up policy' in a bullet point within the `config-as-code.mdx` documentation [f505918]
> - Updated config-as-code documentation to clarify TOML null handling and correct example labeling [8036a70]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9efefa.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded "config as code" docs to include storage, retention, realtime/schedules, and deployment in addition to auth and SMTP.
  * Updated config plan/apply guidance to document live-state fetching, per-section capability gating, env-based secret resolution, and per-section dispatch semantics.
  * Revised overview and "Next steps" to reflect the broader config scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->