### PR TITLE
INS-294: Align Analytics page UI states with other pages

### DIFF
--- a/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
@@ -30,7 +30,7 @@ type Section = 'general' | 'setup-prompt';
 interface AnalyticsConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  connection: PosthogConnection;
+  connection: PosthogConnection | null;
   projectId: string;
 }
 
@@ -44,7 +44,7 @@ export function AnalyticsConfigDialog({
   const [revealed, setRevealed] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
 
-  const { onOpenPosthog } = useDashboardHost();
+  const { onOpenPosthog, onConnectPosthog } = useDashboardHost();
   const { showToast } = useToast();
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -55,16 +55,20 @@ export function AnalyticsConfigDialog({
     onOpenChange(nextOpen);
   };
 
-  const maskedKey =
-    connection.apiKey.length > 8
+  const maskedKey = connection
+    ? connection.apiKey.length > 8
       ? `${connection.apiKey.slice(0, 4)}${'•'.repeat(connection.apiKey.length - 8)}${connection.apiKey.slice(-4)}`
-      : '•'.repeat(connection.apiKey.length);
+      : '•'.repeat(connection.apiKey.length)
+    : '';
 
   const title = section === 'general' ? 'General' : 'Setup Prompt';
 
-  const directUrl = `${connection.host}/project/${connection.posthogProjectId}`;
+  const directUrl = connection ? `${connection.host}/project/${connection.posthogProjectId}` : '';
 
   const handleOpenPosthog = () => {
+    if (!connection) {
+      return;
+    }
     if (!onOpenPosthog) {
       window.open(directUrl, '_blank', 'noopener,noreferrer');
       return;
@@ -132,80 +136,98 @@ export function AnalyticsConfigDialog({
 
             <MenuDialogBody>
               {section === 'general' ? (
-                <div className="flex flex-col gap-2">
-                  {/* Project info row + actions */}
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex min-w-0 flex-col">
-                      <p className="truncate text-base font-normal leading-7 text-foreground">
-                        {connection.projectName}
-                      </p>
-                      <div className="flex items-center gap-2 text-sm leading-5 text-muted-foreground">
-                        <span>{connection.region}</span>
-                        {connection.organizationName && (
-                          <>
-                            <span aria-hidden className="size-1 rounded-full bg-muted-foreground" />
-                            <span className="truncate">{connection.organizationName}</span>
-                          </>
-                        )}
+                connection ? (
+                  <div className="flex flex-col gap-2">
+                    {/* Project info row + actions */}
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex min-w-0 flex-col">
+                        <p className="truncate text-base font-normal leading-7 text-foreground">
+                          {connection.projectName}
+                        </p>
+                        <div className="flex items-center gap-2 text-sm leading-5 text-muted-foreground">
+                          <span>{connection.region}</span>
+                          {connection.organizationName && (
+                            <>
+                              <span
+                                aria-hidden
+                                className="size-1 rounded-full bg-muted-foreground"
+                              />
+                              <span className="truncate">{connection.organizationName}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Button variant="secondary" onClick={handleOpenPosthog}>
+                          Open in PostHog
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          className="border-warning bg-warning/10 text-warning hover:bg-warning/20"
+                          onClick={() => setDisconnecting(true)}
+                        >
+                          Disconnect
+                        </Button>
                       </div>
                     </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <Button variant="secondary" onClick={handleOpenPosthog}>
-                        Open in PostHog
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        className="border-warning bg-warning/10 text-warning hover:bg-warning/20"
-                        onClick={() => setDisconnecting(true)}
-                      >
-                        Disconnect
-                      </Button>
-                    </div>
-                  </div>
 
-                  <div className="h-px w-full bg-[var(--alpha-8)]" />
+                    <div className="h-px w-full bg-[var(--alpha-8)]" />
 
-                  <FieldRow label="Project API Key">
-                    <div className="relative flex-1">
-                      <Input
-                        readOnly
-                        value={revealed ? connection.apiKey : maskedKey}
-                        className="pr-9 font-mono"
+                    <FieldRow label="Project API Key">
+                      <div className="relative flex-1">
+                        <Input
+                          readOnly
+                          value={revealed ? connection.apiKey : maskedKey}
+                          className="pr-9 font-mono"
+                        />
+                        <button
+                          type="button"
+                          aria-label={revealed ? 'Hide API key' : 'Reveal API key'}
+                          onClick={() => setRevealed((v) => !v)}
+                          className="absolute right-1.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-[var(--alpha-8)] hover:text-foreground"
+                        >
+                          {revealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        </button>
+                      </div>
+                      <CopyButton
+                        text={connection.apiKey}
+                        showText={false}
+                        aria-label="Copy API key"
                       />
-                      <button
-                        type="button"
-                        aria-label={revealed ? 'Hide API key' : 'Reveal API key'}
-                        onClick={() => setRevealed((v) => !v)}
-                        className="absolute right-1.5 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-[var(--alpha-8)] hover:text-foreground"
-                      >
-                        {revealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                      </button>
-                    </div>
-                    <CopyButton
-                      text={connection.apiKey}
-                      showText={false}
-                      aria-label="Copy API key"
-                    />
-                  </FieldRow>
+                    </FieldRow>
 
-                  <div className="h-px w-full bg-[var(--alpha-8)]" />
+                    <div className="h-px w-full bg-[var(--alpha-8)]" />
 
-                  <FieldRow label="Host">
-                    <Input readOnly value={connection.host} className="font-mono" />
-                    <CopyButton text={connection.host} showText={false} aria-label="Copy host" />
-                  </FieldRow>
+                    <FieldRow label="Host">
+                      <Input readOnly value={connection.host} className="font-mono" />
+                      <CopyButton text={connection.host} showText={false} aria-label="Copy host" />
+                    </FieldRow>
 
-                  <div className="h-px w-full bg-[var(--alpha-8)]" />
+                    <div className="h-px w-full bg-[var(--alpha-8)]" />
 
-                  <FieldRow label="Project ID">
-                    <Input readOnly value={connection.posthogProjectId} className="font-mono" />
-                    <CopyButton
-                      text={connection.posthogProjectId}
-                      showText={false}
-                      aria-label="Copy Project ID"
-                    />
-                  </FieldRow>
-                </div>
+                    <FieldRow label="Project ID">
+                      <Input readOnly value={connection.posthogProjectId} className="font-mono" />
+                      <CopyButton
+                        text={connection.posthogProjectId}
+                        showText={false}
+                        aria-label="Copy Project ID"
+                      />
+                    </FieldRow>
+                  </div>
+                ) : (
+                  <div className="flex min-h-[240px] flex-col items-center justify-center gap-3 text-center">
+                    <p className="text-sm leading-6 text-foreground">
+                      You haven&apos;t connected PostHog yet.
+                    </p>
+                    <Button
+                      variant="primary"
+                      disabled={!onConnectPosthog}
+                      onClick={() => onConnectPosthog?.(projectId)}
+                    >
+                      Connect PostHog
+                    </Button>
+                  </div>
+                )
               ) : (
                 <div className="flex flex-col gap-3">
                   <p className="text-sm leading-6 text-muted-foreground">
@@ -235,13 +257,15 @@ export function AnalyticsConfigDialog({
         </MenuDialogContent>
       </MenuDialog>
 
-      <DisconnectDialog
-        open={disconnecting}
-        onClose={() => {
-          setDisconnecting(false);
-          onOpenChange(false);
-        }}
-      />
+      {connection && (
+        <DisconnectDialog
+          open={disconnecting}
+          onClose={() => {
+            setDisconnecting(false);
+            onOpenChange(false);
+          }}
+        />
+      )}
     </>
   );
 }

--- a/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
@@ -221,7 +221,7 @@ export function AnalyticsConfigDialog({
                     </p>
                     <Button
                       variant="primary"
-                      disabled={!onConnectPosthog}
+                      disabled={!onConnectPosthog || !projectId}
                       onClick={() => onConnectPosthog?.(projectId)}
                     >
                       Connect PostHog

--- a/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsConfigDialog.tsx
@@ -221,7 +221,7 @@ export function AnalyticsConfigDialog({
                     </p>
                     <Button
                       variant="primary"
-                      disabled={!onConnectPosthog || !projectId}
+                      disabled={!onConnectPosthog}
                       onClick={() => onConnectPosthog?.(projectId)}
                     >
                       Connect PostHog

--- a/packages/dashboard/src/features/analytics/components/AnalyticsLayout.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { ErrorState, LoadingState } from '#components';
@@ -8,7 +8,6 @@ import { useToast } from '#lib/hooks/useToast';
 import { TimeRangeProvider } from '#features/analytics/context/TimeRangeContext';
 import { usePosthogConnection } from '#features/analytics/hooks/usePosthogConnection';
 import { AnalyticsSidebar } from './AnalyticsSidebar';
-import { EmptyConnectPanel } from './posthog/EmptyConnectPanel';
 
 export default function AnalyticsLayout() {
   const conn = usePosthogConnection();
@@ -43,67 +42,45 @@ export default function AnalyticsLayout() {
     });
   }, [qc, navigate, showToast, subscribePosthogConnectionStatus]);
 
+  const connection = conn.data ?? null;
+
+  let topLevelStatus: ReactNode | null = null;
+  if (conn.isLoading || projectIdLoading) {
+    topLevelStatus = (
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <LoadingState className="py-0" message="Loading Analytics…" />
+      </div>
+    );
+  } else if (conn.isError) {
+    topLevelStatus = (
+      <div className="flex h-full min-h-0 items-center justify-center px-6">
+        <div className="w-full max-w-[420px]">
+          <ErrorState
+            title="Failed to load PostHog connection"
+            error="Please refresh, or contact support if the problem persists."
+          />
+        </div>
+      </div>
+    );
+  } else if (projectIdError || !projectId) {
+    topLevelStatus = (
+      <div className="flex h-full min-h-0 items-center justify-center px-6">
+        <div className="w-full max-w-[420px]">
+          <ErrorState
+            title="Failed to load project ID"
+            error="Please refresh, or contact support if the problem persists."
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <TimeRangeProvider>
       <div className="flex h-full min-h-0 overflow-hidden bg-[rgb(var(--semantic-1))]">
-        {renderLayout({
-          conn,
-          projectId,
-          projectIdLoading,
-          projectIdError,
-        })}
+        <AnalyticsSidebar connection={connection} projectId={projectId ?? ''} />
+        <div className="min-w-0 flex-1 overflow-hidden">{topLevelStatus ?? <Outlet />}</div>
       </div>
     </TimeRangeProvider>
-  );
-}
-
-function renderLayout({
-  conn,
-  projectId,
-  projectIdLoading,
-  projectIdError,
-}: {
-  conn: ReturnType<typeof usePosthogConnection>;
-  projectId: string | null | undefined;
-  projectIdLoading: boolean;
-  projectIdError: Error | null;
-}) {
-  if (conn.isLoading || projectIdLoading) {
-    return <LoadingState />;
-  }
-  if (conn.isError) {
-    return (
-      <ErrorState
-        title="Failed to load PostHog connection"
-        error="Please refresh, or contact support if the problem persists."
-      />
-    );
-  }
-  if (projectIdError || !projectId) {
-    return (
-      <ErrorState
-        title="Failed to load project ID"
-        error="Please refresh, or contact support if the problem persists."
-      />
-    );
-  }
-
-  const connection = conn.data ?? null;
-  return (
-    <>
-      <AnalyticsSidebar connection={connection} projectId={projectId} />
-      <div className="min-w-0 flex-1 overflow-auto">
-        {connection ? (
-          <Outlet />
-        ) : (
-          <div className="h-full overflow-y-auto">
-            <div className="mx-auto flex w-4/5 max-w-[1024px] flex-col gap-6 pb-10 pt-10">
-              <h1 className="text-2xl font-medium leading-8 text-foreground">Setup Analytics</h1>
-              <EmptyConnectPanel projectId={projectId} />
-            </div>
-          </div>
-        )}
-      </div>
-    </>
   );
 }

--- a/packages/dashboard/src/features/analytics/components/AnalyticsSidebar.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsSidebar.tsx
@@ -40,6 +40,7 @@ export function AnalyticsSidebar({ connection, projectId }: AnalyticsSidebarProp
       label: 'Analytics Config',
       icon: Settings,
       onClick: () => setSettingsOpen(true),
+      disabled: !projectId,
     },
   ];
 

--- a/packages/dashboard/src/features/analytics/components/AnalyticsSidebar.tsx
+++ b/packages/dashboard/src/features/analytics/components/AnalyticsSidebar.tsx
@@ -15,26 +15,22 @@ interface AnalyticsSidebarProps {
 
 export function AnalyticsSidebar({ connection, projectId }: AnalyticsSidebarProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const connected = connection !== null;
 
   const items: FeatureSidebarListItem[] = [
     {
       id: 'traffic',
       label: 'Traffic',
       href: '/dashboard/analytics/traffic',
-      disabled: !connected,
     },
     {
       id: 'retention',
       label: 'User Retention',
       href: '/dashboard/analytics/retention',
-      disabled: !connected,
     },
     {
       id: 'session-replay',
       label: 'Session Replay',
       href: '/dashboard/analytics/session-replay',
-      disabled: !connected,
     },
   ];
 
@@ -44,21 +40,18 @@ export function AnalyticsSidebar({ connection, projectId }: AnalyticsSidebarProp
       label: 'Analytics Config',
       icon: Settings,
       onClick: () => setSettingsOpen(true),
-      disabled: !connected,
     },
   ];
 
   return (
     <>
       <FeatureSidebar title="Analytics" items={items} headerButtons={headerButtons} />
-      {connection && (
-        <AnalyticsConfigDialog
-          open={settingsOpen}
-          onOpenChange={setSettingsOpen}
-          connection={connection}
-          projectId={projectId}
-        />
-      )}
+      <AnalyticsConfigDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        connection={connection}
+        projectId={projectId}
+      />
     </>
   );
 }

--- a/packages/dashboard/src/features/analytics/components/RequirePosthogConnection.tsx
+++ b/packages/dashboard/src/features/analytics/components/RequirePosthogConnection.tsx
@@ -1,0 +1,44 @@
+import { type ReactNode } from 'react';
+import { ErrorState, LoadingState } from '#components';
+import { useProjectId } from '#lib/hooks/useMetadata';
+import { usePosthogConnection } from '#features/analytics/hooks/usePosthogConnection';
+import { EmptyConnectPanel } from './posthog/EmptyConnectPanel';
+
+interface Props {
+  children: ReactNode;
+}
+
+export function RequirePosthogConnection({ children }: Props) {
+  const conn = usePosthogConnection();
+  const { projectId, isLoading: projectIdLoading, error: projectIdError } = useProjectId();
+
+  if (conn.isLoading || projectIdLoading) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <LoadingState className="py-0" />
+      </div>
+    );
+  }
+  if (conn.isError || projectIdError || !projectId) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center px-6">
+        <div className="w-full max-w-[420px]">
+          <ErrorState
+            title="Failed to load analytics"
+            error="Please refresh, or contact support if the problem persists."
+          />
+        </div>
+      </div>
+    );
+  }
+  if (!conn.data) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center px-6 py-10">
+        <div className="w-full max-w-[640px]">
+          <EmptyConnectPanel projectId={projectId} />
+        </div>
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/packages/dashboard/src/features/analytics/components/RequirePosthogConnection.tsx
+++ b/packages/dashboard/src/features/analytics/components/RequirePosthogConnection.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode } from 'react';
-import { ErrorState, LoadingState } from '#components';
 import { useProjectId } from '#lib/hooks/useMetadata';
 import { usePosthogConnection } from '#features/analytics/hooks/usePosthogConnection';
 import { EmptyConnectPanel } from './posthog/EmptyConnectPanel';
@@ -8,34 +7,19 @@ interface Props {
   children: ReactNode;
 }
 
+// AnalyticsLayout short-circuits loading / error / missing-projectId at the layout level
+// before this wrapper renders, so the only state we need to handle here is "metadata ready,
+// connection query resolved" — either render the EmptyConnectPanel (not connected) or
+// pass through to the sub-page.
 export function RequirePosthogConnection({ children }: Props) {
   const conn = usePosthogConnection();
-  const { projectId, isLoading: projectIdLoading, error: projectIdError } = useProjectId();
+  const { projectId } = useProjectId();
 
-  if (conn.isLoading || projectIdLoading) {
-    return (
-      <div className="flex h-full min-h-0 items-center justify-center">
-        <LoadingState className="py-0" />
-      </div>
-    );
-  }
-  if (conn.isError || projectIdError || !projectId) {
-    return (
-      <div className="flex h-full min-h-0 items-center justify-center px-6">
-        <div className="w-full max-w-[420px]">
-          <ErrorState
-            title="Failed to load analytics"
-            error="Please refresh, or contact support if the problem persists."
-          />
-        </div>
-      </div>
-    );
-  }
   if (!conn.data) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center px-6 py-10">
         <div className="w-full max-w-[640px]">
-          <EmptyConnectPanel projectId={projectId} />
+          <EmptyConnectPanel projectId={projectId ?? ''} />
         </div>
       </div>
     );

--- a/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
@@ -1,3 +1,4 @@
+import { EmptyState, ErrorState, LoadingState } from '#components';
 import { useTimeframe } from '#features/analytics/context/TimeRangeContext';
 import { useWebStats } from '#features/analytics/hooks/useWebStats';
 import { type Breakdown } from '#features/analytics/services/analytics.service';
@@ -50,11 +51,11 @@ export function BreakdownPanel({ breakdown, enabled }: Props) {
       <p className="text-sm text-muted-foreground">{title}</p>
 
       {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <LoadingState className="py-4" />
       ) : error ? (
-        <p className="text-sm text-destructive">Failed to load.</p>
+        <ErrorState title="Failed to load" error="Please try again." />
       ) : top.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No data</p>
+        <EmptyState title="No data" />
       ) : (
         <ul className="flex w-full flex-col">
           {top.map((row, i) => (

--- a/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
@@ -51,11 +51,11 @@ export function BreakdownPanel({ breakdown, enabled }: Props) {
       <p className="text-sm text-muted-foreground">{title}</p>
 
       {isLoading ? (
-        <LoadingState className="py-4" />
+        <LoadingState className="py-4 self-center" />
       ) : error ? (
-        <ErrorState title="Failed to load" error="Please try again." />
+        <ErrorState title="Failed to load" error="Please try again." className="self-center" />
       ) : top.length === 0 ? (
-        <EmptyState title="No data available" />
+        <EmptyState title="No data available" className="self-center" />
       ) : (
         <ul className="flex w-full flex-col">
           {top.map((row, i) => (

--- a/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
@@ -55,7 +55,7 @@ export function BreakdownPanel({ breakdown, enabled }: Props) {
       ) : error ? (
         <ErrorState title="Failed to load" error="Please try again." />
       ) : top.length === 0 ? (
-        <EmptyState title="No data" />
+        <EmptyState title="No data available" />
       ) : (
         <ul className="flex w-full flex-col">
           {top.map((row, i) => (

--- a/packages/dashboard/src/features/analytics/components/posthog/KpiSectionWithTrend.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/KpiSectionWithTrend.tsx
@@ -8,6 +8,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { EmptyState, ErrorState, LoadingState } from '#components';
 import type { PosthogWebOverviewItem } from '@insforge/shared-schemas';
 import { useTimeframe } from '#features/analytics/context/TimeRangeContext';
 import { useWebOverview } from '#features/analytics/hooks/useWebOverview';
@@ -150,16 +151,18 @@ export function KpiSectionWithTrend({ enabled }: { enabled: boolean }) {
       </div>
       <div className="h-[260px] p-4">
         {trend.isLoading ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Loading…
+          <div className="flex h-full items-center justify-center">
+            <LoadingState className="py-0" />
           </div>
         ) : trend.error ? (
-          <div className="flex h-full items-center justify-center text-sm text-destructive">
-            Failed to load trend.
+          <div className="flex h-full items-center justify-center px-6">
+            <div className="w-full max-w-[420px]">
+              <ErrorState title="Failed to load trend" error="Please try again." />
+            </div>
           </div>
         ) : chartData.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            No data available
+          <div className="flex h-full items-center justify-center">
+            <EmptyState title="No data available" />
           </div>
         ) : (
           <ResponsiveContainer width="100%" height="100%">

--- a/packages/dashboard/src/features/analytics/components/posthog/RecentReplaysCard.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/RecentReplaysCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { PosthogRecordingItem } from '@insforge/shared-schemas';
-import { EmptyState } from '#components';
+import { EmptyState, ErrorState, LoadingState } from '#components';
 import { formatDuration, formatRelativeTime, truncateId } from '#features/analytics/lib/format';
 import { ReplayModal } from './ReplayModal';
 
@@ -16,11 +16,11 @@ export function RecentReplaysCard({
   const [openId, setOpenId] = useState<string | null>(null);
 
   if (isLoading) {
-    return <div className="px-4 py-6 text-sm text-muted-foreground">Loading…</div>;
+    return <LoadingState className="py-6" message="Loading replays…" />;
   }
 
   if (error) {
-    return <div className="px-4 py-6 text-sm text-destructive">Failed to load replays.</div>;
+    return <ErrorState title="Failed to load replays" error="Please try again." />;
   }
 
   if (items.length === 0) {

--- a/packages/dashboard/src/features/analytics/components/posthog/RetentionCard.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/RetentionCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { EmptyState, ErrorState, LoadingState } from '#components';
 import { useRetention } from '#features/analytics/hooks/useRetention';
 import { formatNumber } from '#features/analytics/lib/format';
 
@@ -33,15 +34,29 @@ export function RetentionCard({ enabled }: { enabled: boolean }) {
   }, [data]);
 
   if (isLoading) {
-    return <div className="px-4 py-6 text-sm text-muted-foreground">Loading…</div>;
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <LoadingState className="py-0" />
+      </div>
+    );
   }
 
   if (error) {
-    return <div className="px-4 py-6 text-sm text-destructive">Failed to load retention.</div>;
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center px-6">
+        <div className="w-full max-w-[420px]">
+          <ErrorState title="Failed to load retention" error="Please try again." />
+        </div>
+      </div>
+    );
   }
 
   if (!grid || grid.length === 0) {
-    return <div className="px-4 py-6 text-sm text-muted-foreground">No data</div>;
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center">
+        <EmptyState title="No data" />
+      </div>
+    );
   }
 
   const intervals = grid[0].cells.length;

--- a/packages/dashboard/src/features/analytics/components/posthog/RetentionCard.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/RetentionCard.tsx
@@ -54,7 +54,7 @@ export function RetentionCard({ enabled }: { enabled: boolean }) {
   if (!grid || grid.length === 0) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center">
-        <EmptyState title="No data" />
+        <EmptyState title="No data available" />
       </div>
     );
   }

--- a/packages/dashboard/src/features/analytics/pages/RetentionPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/RetentionPage.tsx
@@ -1,19 +1,22 @@
+import { TableHeader } from '#components';
 import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { RetentionCard } from '#features/analytics/components/posthog/RetentionCard';
 
 export function RetentionPage() {
   return (
-    <RequirePosthogConnection>
-      <div className="flex h-full min-h-0 flex-col">
-        <div className="flex items-center justify-between border-b border-[var(--alpha-8)] bg-semantic-0 py-3 pl-4 pr-3">
-          <h1 className="text-base font-medium text-foreground">User Retention</h1>
+    <div className="flex h-full min-h-0 flex-col">
+      <TableHeader
+        title="User Retention"
+        showSearch={false}
+        rightActions={
           <span className="text-sm text-muted-foreground">Weekly cohort - 8 weeks</span>
-        </div>
-
-        <div className="flex-1 overflow-auto">
+        }
+      />
+      <div className="min-h-0 flex-1 overflow-auto">
+        <RequirePosthogConnection>
           <RetentionCard enabled />
-        </div>
+        </RequirePosthogConnection>
       </div>
-    </RequirePosthogConnection>
+    </div>
   );
 }

--- a/packages/dashboard/src/features/analytics/pages/RetentionPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/RetentionPage.tsx
@@ -1,16 +1,19 @@
+import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { RetentionCard } from '#features/analytics/components/posthog/RetentionCard';
 
 export function RetentionPage() {
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-b border-[var(--alpha-8)] bg-semantic-0 py-3 pl-4 pr-3">
-        <h1 className="text-base font-medium text-foreground">User Retention</h1>
-        <span className="text-sm text-muted-foreground">Weekly cohort - 8 weeks</span>
-      </div>
+    <RequirePosthogConnection>
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex items-center justify-between border-b border-[var(--alpha-8)] bg-semantic-0 py-3 pl-4 pr-3">
+          <h1 className="text-base font-medium text-foreground">User Retention</h1>
+          <span className="text-sm text-muted-foreground">Weekly cohort - 8 weeks</span>
+        </div>
 
-      <div className="flex-1 overflow-auto">
-        <RetentionCard enabled />
+        <div className="flex-1 overflow-auto">
+          <RetentionCard enabled />
+        </div>
       </div>
-    </div>
+    </RequirePosthogConnection>
   );
 }

--- a/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
@@ -1,5 +1,11 @@
 import { useMemo, useState } from 'react';
-import { EmptyState, ErrorState, LoadingState, PaginationControls, TableHeader } from '#components';
+import {
+  EmptyStateIllustration,
+  ErrorState,
+  LoadingState,
+  PaginationControls,
+  TableHeader,
+} from '#components';
 import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { useRecordings } from '#features/analytics/hooks/useRecordings';
 import { SessionRow } from '#features/analytics/components/posthog/SessionRow';
@@ -61,10 +67,15 @@ function SessionReplayPageBody() {
             ) : error ? (
               <ErrorState title="Failed to load replays" error="Please try again." />
             ) : pageItems.length === 0 ? (
-              <EmptyState
-                title="No replays yet"
-                description="Make sure session_recording is enabled in your PostHog project."
-              />
+              <div className="flex flex-col items-center gap-2 pb-12 pt-6 text-center">
+                <EmptyStateIllustration />
+                <p className="text-sm font-medium leading-6 text-muted-foreground">
+                  No replays yet
+                </p>
+                <p className="text-xs leading-4 text-muted-foreground">
+                  Make sure session_recording is enabled in your PostHog project.
+                </p>
+              </div>
             ) : (
               pageItems.map((rec) => <SessionRow key={rec.id} recording={rec} onOpen={setOpenId} />)
             )}

--- a/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
@@ -10,9 +10,14 @@ const PAGE_SIZE = 10;
 
 export function SessionReplayPage() {
   return (
-    <RequirePosthogConnection>
-      <SessionReplayPageBody />
-    </RequirePosthogConnection>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-semantic-1">
+      <TableHeader title="Session Replay" showSearch={false} />
+      <div className="min-h-0 flex-1">
+        <RequirePosthogConnection>
+          <SessionReplayPageBody />
+        </RequirePosthogConnection>
+      </div>
+    </div>
   );
 }
 
@@ -30,9 +35,7 @@ function SessionReplayPageBody() {
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-semantic-1">
-      <TableHeader title="Session Replay" showSearch={false} />
-
+    <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-4/5 max-w-[1024px] pb-10 pt-10">
           {/* Table header */}

--- a/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/SessionReplayPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { PaginationControls, TableHeader } from '#components';
+import { EmptyState, ErrorState, LoadingState, PaginationControls, TableHeader } from '#components';
+import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { useRecordings } from '#features/analytics/hooks/useRecordings';
 import { SessionRow } from '#features/analytics/components/posthog/SessionRow';
 import { ReplayModal } from '#features/analytics/components/posthog/ReplayModal';
@@ -8,6 +9,14 @@ const WINDOW_SIZE = 50;
 const PAGE_SIZE = 10;
 
 export function SessionReplayPage() {
+  return (
+    <RequirePosthogConnection>
+      <SessionReplayPageBody />
+    </RequirePosthogConnection>
+  );
+}
+
+function SessionReplayPageBody() {
   const { data, isLoading, error } = useRecordings(WINDOW_SIZE, true);
   const [page, setPage] = useState(1);
   const [openId, setOpenId] = useState<string | null>(null);
@@ -45,13 +54,14 @@ export function SessionReplayPage() {
           {/* Table body */}
           <div className="mt-1 flex flex-col gap-1">
             {isLoading ? (
-              <div className="px-2.5 py-4 text-sm text-muted-foreground">Loading…</div>
+              <LoadingState message="Loading replays…" />
             ) : error ? (
-              <div className="px-2.5 py-4 text-sm text-destructive">Failed to load replays.</div>
+              <ErrorState title="Failed to load replays" error="Please try again." />
             ) : pageItems.length === 0 ? (
-              <div className="px-2.5 py-4 text-sm text-muted-foreground">
-                No replays yet. Make sure session_recording is enabled in your PostHog project.
-              </div>
+              <EmptyState
+                title="No replays yet"
+                description="Make sure session_recording is enabled in your PostHog project."
+              />
             ) : (
               pageItems.map((rec) => <SessionRow key={rec.id} recording={rec} onOpen={setOpenId} />)
             )}

--- a/packages/dashboard/src/features/analytics/pages/TrafficPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/TrafficPage.tsx
@@ -1,3 +1,4 @@
+import { TableHeader } from '#components';
 import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { TimeRangeSelector } from '#features/analytics/components/posthog/TimeRangeSelector';
 import { KpiSectionWithTrend } from '#features/analytics/components/posthog/KpiSectionWithTrend';
@@ -5,23 +6,23 @@ import { BreakdownPanel } from '#features/analytics/components/posthog/Breakdown
 
 export function TrafficPage() {
   return (
-    <RequirePosthogConnection>
-      <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
-        <div className="mx-auto flex w-4/5 max-w-[1024px] flex-col gap-6 pb-10 pt-10">
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-medium leading-8 text-foreground">Traffic</h1>
-            <TimeRangeSelector />
-          </div>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
+      <TableHeader title="Traffic" showSearch={false} rightActions={<TimeRangeSelector />} />
+      <div className="min-h-0 flex-1">
+        <RequirePosthogConnection>
+          <div className="h-full overflow-y-auto">
+            <div className="mx-auto flex w-4/5 max-w-[1024px] flex-col gap-6 pb-10 pt-10">
+              <KpiSectionWithTrend enabled />
 
-          <KpiSectionWithTrend enabled />
-
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-            <BreakdownPanel breakdown="Page" enabled />
-            <BreakdownPanel breakdown="Country" enabled />
-            <BreakdownPanel breakdown="DeviceType" enabled />
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <BreakdownPanel breakdown="Page" enabled />
+                <BreakdownPanel breakdown="Country" enabled />
+                <BreakdownPanel breakdown="DeviceType" enabled />
+              </div>
+            </div>
           </div>
-        </div>
+        </RequirePosthogConnection>
       </div>
-    </RequirePosthogConnection>
+    </div>
   );
 }

--- a/packages/dashboard/src/features/analytics/pages/TrafficPage.tsx
+++ b/packages/dashboard/src/features/analytics/pages/TrafficPage.tsx
@@ -1,24 +1,27 @@
+import { RequirePosthogConnection } from '#features/analytics/components/RequirePosthogConnection';
 import { TimeRangeSelector } from '#features/analytics/components/posthog/TimeRangeSelector';
 import { KpiSectionWithTrend } from '#features/analytics/components/posthog/KpiSectionWithTrend';
 import { BreakdownPanel } from '#features/analytics/components/posthog/BreakdownPanel';
 
 export function TrafficPage() {
   return (
-    <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
-      <div className="mx-auto flex w-4/5 max-w-[1024px] flex-col gap-6 pb-10 pt-10">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-medium leading-8 text-foreground">Traffic</h1>
-          <TimeRangeSelector />
-        </div>
+    <RequirePosthogConnection>
+      <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
+        <div className="mx-auto flex w-4/5 max-w-[1024px] flex-col gap-6 pb-10 pt-10">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-medium leading-8 text-foreground">Traffic</h1>
+            <TimeRangeSelector />
+          </div>
 
-        <KpiSectionWithTrend enabled />
+          <KpiSectionWithTrend enabled />
 
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-          <BreakdownPanel breakdown="Page" enabled />
-          <BreakdownPanel breakdown="Country" enabled />
-          <BreakdownPanel breakdown="DeviceType" enabled />
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <BreakdownPanel breakdown="Page" enabled />
+            <BreakdownPanel breakdown="Country" enabled />
+            <BreakdownPanel breakdown="DeviceType" enabled />
+          </div>
         </div>
       </div>
-    </div>
+    </RequirePosthogConnection>
   );
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
oss tag: [v2.1.11-updateui3](https://github.com/InsForge/InsForge/tree/refs/tags/v2.1.11-updateui3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings dialog adapts to connected vs disconnected states, shows project details, read-only API/host/project fields with reveal/copy, and presents connect/disconnect actions; connect button enabled only when available.
  * Sidebar always exposes analytics items and keeps settings accessible; settings button enabled/disabled by project presence.
  * New connection guard wraps pages to show a connect prompt when no connection exists.

* **Refactor**
  * Unified loading/error/empty UI across analytics cards, charts and pages and simplified layout with a persistent sidebar and top-level status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->