### PR TITLE
feat(api): advertise rate-limit headers on global limiter (INS-306)

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -92,8 +92,9 @@ export async function createApp() {
     skip: shouldSkipGlobalRateLimit,
     // Advertise rate-limit headers so API/agent clients (and readiness scanners)
     // can discover the limits. Enforcement is unchanged; this only emits headers.
+    // Only standard RateLimit-* headers are emitted so per-route limiters (which
+    // also use standardHeaders) overwrite them with their stricter values.
     standardHeaders: true, // emit RateLimit-* (IETF draft) headers
-    legacyHeaders: true, // also emit X-RateLimit-* for broad client/scanner compat
   });
 
   // Basic middleware

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -90,6 +90,10 @@ export async function createApp() {
     max: 3000,
     message: 'Too many requests from this IP',
     skip: shouldSkipGlobalRateLimit,
+    // Advertise rate-limit headers so API/agent clients (and readiness scanners)
+    // can discover the limits. Enforcement is unchanged; this only emits headers.
+    standardHeaders: true, // emit RateLimit-* (IETF draft) headers
+    legacyHeaders: true, // also emit X-RateLimit-* for broad client/scanner compat
   });
 
   // Basic middleware


### PR DESCRIPTION
## What

Enables `standardHeaders` and `legacyHeaders` on the **existing** global rate limiter in `backend/src/server.ts` so that rate-limit response headers are advertised to API and agent clients.

```ts
const limiter = rateLimit({
  windowMs: 15 * 60 * 1000,
  max: 3000,
  message: 'Too many requests from this IP',
  skip: shouldSkipGlobalRateLimit,
  standardHeaders: true, // emit RateLimit-* (IETF draft) headers
  legacyHeaders: true,   // also emit X-RateLimit-* for broad client/scanner compat
});
```

## Why

For INS-306 (ora Agent Readiness Score), ora reports "No rate-limit headers found on API endpoints." The backend already enforces a global rate limit (3000 requests / 15 min per IP); it just wasn't emitting the headers that announce it. This change makes the limit discoverable via standard `RateLimit-*` (IETF draft) and legacy `X-RateLimit-*` headers.

## Behavior-preserving

- `max` (3000), `windowMs` (15 min), `message`, and `skip` are **unchanged**.
- No change to which routes are limited or to enforcement.
- This **only** turns on header emission. `express-rate-limit` is v7 (`^7.1.5`, v7.5.1 installed), which supports both options.
- Per-route limiters in `backend/src/api/middlewares/rate-limiters.ts` already set `standardHeaders: true` and are intentionally left untouched to keep this PR minimal.

## Verification

- `npm run build` (tsup) — succeeds; confirmed `legacyHeaders: true` and `standardHeaders: true` present in the emitted bundle.
- `npm run typecheck` (tsc --noEmit) — no new errors introduced by this change (pre-existing errors in this checkout are from dependencies not installed in the verification environment: `stripe`, `xml2js`, `picomatch`; error count is identical with and without this change, and none are in `server.ts`).
- `npx eslint src/server.ts` — clean.
- `npx vitest run tests/unit/rate-limit.test.ts` — 8/8 pass.
- Header emission verified directly: ran a minimal express app with the exact limiter config against `express-rate-limit@7.5.1` and confirmed the response carries both `RateLimit-limit/-remaining/-reset/-policy` and `X-RateLimit-limit/-remaining/-reset`.
- Full server boot + curl was not performed (requires Postgres/env not available in this environment). Note: `/api/health` is skipped by the limiter, so any header check must target a non-health endpoint.

## Caveat

Whether ora detects these depends on the edge/CDN in front of `api.insforge.dev` not stripping them. If ora still reports no headers after deploy, the next step is to check the proxy/CDN header pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable standard `RateLimit-*` response headers on the global API limiter so clients and scanners can discover limits. Addresses INS-306; emits only standard headers (no `X-RateLimit-*`) to avoid masking stricter per-route limits, with enforcement, limits, and skip rules unchanged.

<sup>Written for commit c307a5d391b725c59abd4b8d27c6dac8b0b1e977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise standard `RateLimit-*` headers on global rate limiter responses
> Sets `standardHeaders: true` in the global rate limiter middleware in [server.ts](https://github.com/InsForge/InsForge/pull/1452/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa), causing responses to include `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers. Rate limiting enforcement behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c307a5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API responses with standardized IETF `RateLimit-*` headers and legacy `X-RateLimit-*` headers for improved rate-limit visibility and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->