### PR TITLE
prevent silent data loss in bulkInsert when optional fields appear in later records

### DIFF
--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -914,87 +914,122 @@ export class DatabaseAdvanceService {
     const pool = this.dbManager.getPool();
 
     try {
-      // Build the column list from the union of keys across ALL records.
-      // Previously only records[0] was inspected, which silently discarded
-      // optional fields that appeared only in later records (issue #8).
-      const columns = Array.from(new Set(records.flatMap((rec) => Object.keys(rec))));
+      // Group records by their key shape (sorted keys signature) to prevent data loss
+      // and avoid overwriting existing non-null columns with NULL during upserts.
+      const groupsMap = new Map<
+        string,
+        { columns: string[]; records: Record<string, unknown>[] }
+      >();
 
-      // Convert records to array format for pg-format.
-      // Fields absent from a given record are mapped to null so that every
-      // row in the INSERT has the same number of values as the column list.
-      const values = records.map((record) =>
-        columns.map((col) => {
-          const value = record[col];
-          // pg-format handles NULL, dates, JSON automatically.
-          // Convert empty strings and undefined to NULL for consistency.
-          return value === '' || value === undefined ? null : value;
-        })
-      );
-
-      let query: string;
-
-      if (upsertKey) {
-        // Validate upsert key exists in columns
-        if (!columns.includes(upsertKey)) {
-          throw new AppError(
-            `Upsert key '${upsertKey}' not found in record columns`,
-            400,
-            ERROR_CODES.INVALID_INPUT
-          );
+      for (const record of records) {
+        const keys: string[] = [];
+        for (const key of Object.keys(record)) {
+          keys.push(key);
         }
+        keys.sort();
+        const signature = keys.join(',');
 
-        // Build upsert query with pg-format
-        const updateColumns = columns.filter((c) => c !== upsertKey);
-
-        if (updateColumns.length) {
-          // Build UPDATE SET clause
-          const updateClause = updateColumns
-            .map((col) => pgFormat('%I = EXCLUDED.%I', col, col))
-            .join(', ');
-
-          query = pgFormat(
-            'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO UPDATE SET %s',
-            schemaName,
-            table,
-            columns,
-            values,
-            upsertKey,
-            updateClause
-          );
-        } else {
-          // No columns to update, just do nothing on conflict
-          query = pgFormat(
-            'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO NOTHING',
-            schemaName,
-            table,
-            columns,
-            values,
-            upsertKey
-          );
+        let group = groupsMap.get(signature);
+        if (!group) {
+          group = {
+            columns: keys,
+            records: [],
+          };
+          groupsMap.set(signature, group);
         }
-      } else {
-        // Simple insert
-        query = pgFormat('INSERT INTO %I.%I (%I) VALUES %L', schemaName, table, columns, values);
+        group.records.push(record);
       }
 
       const client = await pool.connect();
       let releaseError: Error | undefined;
+      let totalRowCount = 0;
+      const allRows: unknown[] = [];
+
       try {
-        const result = await withAdminContext(
-          client,
-          () => client.query(query),
-          false,
-          (error) => {
-            releaseError = error;
+        for (const { columns, records: groupRecords } of groupsMap.values()) {
+          // Convert records to array format for pg-format.
+          const values = groupRecords.map((record) =>
+            columns.map((col) => {
+              const value = record[col];
+              // pg-format handles NULL, dates, JSON automatically.
+              // Convert empty strings and undefined to NULL for consistency (preserving original behaviour).
+              return value === '' || value === undefined ? null : value;
+            })
+          );
+
+          let query: string;
+
+          if (upsertKey) {
+            // Validate upsert key exists in columns
+            if (!columns.includes(upsertKey)) {
+              throw new AppError(
+                `Upsert key '${upsertKey}' not found in record columns`,
+                400,
+                ERROR_CODES.INVALID_INPUT
+              );
+            }
+
+            // Build upsert query with pg-format
+            const updateColumns = columns.filter((c) => c !== upsertKey);
+
+            if (updateColumns.length) {
+              // Build UPDATE SET clause
+              const updateClause = updateColumns
+                .map((col) => pgFormat('%I = EXCLUDED.%I', col, col))
+                .join(', ');
+
+              query = pgFormat(
+                'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO UPDATE SET %s',
+                schemaName,
+                table,
+                columns,
+                values,
+                upsertKey,
+                updateClause
+              );
+            } else {
+              // No columns to update, just do nothing on conflict
+              query = pgFormat(
+                'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO NOTHING',
+                schemaName,
+                table,
+                columns,
+                values,
+                upsertKey
+              );
+            }
+          } else {
+            // Simple insert
+            query = pgFormat(
+              'INSERT INTO %I.%I (%I) VALUES %L',
+              schemaName,
+              table,
+              columns,
+              values
+            );
           }
-        );
+
+          const result = await withAdminContext(
+            client,
+            () => client.query(query),
+            false,
+            (error) => {
+              releaseError = error;
+            }
+          );
+
+          totalRowCount += result.rowCount || 0;
+          if (result.rows) {
+            allRows.push(...result.rows);
+          }
+        }
 
         // Refresh schema cache if needed
         await client.query(`NOTIFY pgrst, 'reload schema';`);
 
         return {
-          rowCount: result.rowCount || 0,
-          rows: result.rows,
+          rowCount: totalRowCount,
+          rows: allRows,
         };
       } finally {
         client.release(releaseError);

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -914,16 +914,20 @@ export class DatabaseAdvanceService {
     const pool = this.dbManager.getPool();
 
     try {
-      // Get column names from first record
-      const columns = Object.keys(records[0]);
+      // Build the column list from the union of keys across ALL records.
+      // Previously only records[0] was inspected, which silently discarded
+      // optional fields that appeared only in later records (issue #8).
+      const columns = Array.from(new Set(records.flatMap((rec) => Object.keys(rec))));
 
-      // Convert records to array format for pg-format
+      // Convert records to array format for pg-format.
+      // Fields absent from a given record are mapped to null so that every
+      // row in the INSERT has the same number of values as the column list.
       const values = records.map((record) =>
         columns.map((col) => {
           const value = record[col];
-          // pg-format handles NULL, dates, JSON automatically
-          // Convert empty strings to NULL for consistency
-          return value === '' ? null : value;
+          // pg-format handles NULL, dates, JSON automatically.
+          // Convert empty strings and undefined to NULL for consistency.
+          return value === '' || value === undefined ? null : value;
         })
       );
 

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -946,86 +946,95 @@ export class DatabaseAdvanceService {
       const allRows: unknown[] = [];
 
       try {
-        for (const { columns, records: groupRecords } of groupsMap.values()) {
-          // Convert records to array format for pg-format.
-          const values = groupRecords.map((record) =>
-            columns.map((col) => {
-              const value = record[col];
-              // pg-format handles NULL, dates, JSON automatically.
-              // Convert empty strings and undefined to NULL for consistency (preserving original behaviour).
-              return value === '' || value === undefined ? null : value;
-            })
-          );
+        await withAdminContext(
+          client,
+          async () => {
+            await client.query('BEGIN');
+            try {
+              for (const { columns, records: groupRecords } of groupsMap.values()) {
+                // Convert records to array format for pg-format.
+                const values = groupRecords.map((record) =>
+                  columns.map((col) => {
+                    const value = record[col];
+                    // pg-format handles NULL, dates, JSON automatically.
+                    // Convert empty strings and undefined to NULL for consistency (preserving original behaviour).
+                    return value === '' || value === undefined ? null : value;
+                  })
+                );
 
-          let query: string;
+                let query: string;
 
-          if (upsertKey) {
-            // Validate upsert key exists in columns
-            if (!columns.includes(upsertKey)) {
-              throw new AppError(
-                `Upsert key '${upsertKey}' not found in record columns`,
-                400,
-                ERROR_CODES.INVALID_INPUT
-              );
+                if (upsertKey) {
+                  // Validate upsert key exists in columns
+                  if (!columns.includes(upsertKey)) {
+                    throw new AppError(
+                      `Upsert key '${upsertKey}' not found in record columns`,
+                      400,
+                      ERROR_CODES.INVALID_INPUT
+                    );
+                  }
+
+                  // Build upsert query with pg-format
+                  const updateColumns = columns.filter((c) => c !== upsertKey);
+
+                  if (updateColumns.length) {
+                    // Build UPDATE SET clause
+                    const updateClause = updateColumns
+                      .map((col) => pgFormat('%I = EXCLUDED.%I', col, col))
+                      .join(', ');
+
+                    query = pgFormat(
+                      'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO UPDATE SET %s',
+                      schemaName,
+                      table,
+                      columns,
+                      values,
+                      upsertKey,
+                      updateClause
+                    );
+                  } else {
+                    // No columns to update, just do nothing on conflict
+                    query = pgFormat(
+                      'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO NOTHING',
+                      schemaName,
+                      table,
+                      columns,
+                      values,
+                      upsertKey
+                    );
+                  }
+                } else {
+                  // Simple insert
+                  query = pgFormat(
+                    'INSERT INTO %I.%I (%I) VALUES %L',
+                    schemaName,
+                    table,
+                    columns,
+                    values
+                  );
+                }
+
+                const result = await client.query(query);
+
+                totalRowCount += result.rowCount || 0;
+                if (result.rows) {
+                  allRows.push(...result.rows);
+                }
+              }
+
+              // Refresh schema cache if needed
+              await client.query(`NOTIFY pgrst, 'reload schema';`);
+              await client.query('COMMIT');
+            } catch (err) {
+              await client.query('ROLLBACK').catch(() => {});
+              throw err;
             }
-
-            // Build upsert query with pg-format
-            const updateColumns = columns.filter((c) => c !== upsertKey);
-
-            if (updateColumns.length) {
-              // Build UPDATE SET clause
-              const updateClause = updateColumns
-                .map((col) => pgFormat('%I = EXCLUDED.%I', col, col))
-                .join(', ');
-
-              query = pgFormat(
-                'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO UPDATE SET %s',
-                schemaName,
-                table,
-                columns,
-                values,
-                upsertKey,
-                updateClause
-              );
-            } else {
-              // No columns to update, just do nothing on conflict
-              query = pgFormat(
-                'INSERT INTO %I.%I (%I) VALUES %L ON CONFLICT (%I) DO NOTHING',
-                schemaName,
-                table,
-                columns,
-                values,
-                upsertKey
-              );
-            }
-          } else {
-            // Simple insert
-            query = pgFormat(
-              'INSERT INTO %I.%I (%I) VALUES %L',
-              schemaName,
-              table,
-              columns,
-              values
-            );
+          },
+          false,
+          (error) => {
+            releaseError = error;
           }
-
-          const result = await withAdminContext(
-            client,
-            () => client.query(query),
-            false,
-            (error) => {
-              releaseError = error;
-            }
-          );
-
-          totalRowCount += result.rowCount || 0;
-          if (result.rows) {
-            allRows.push(...result.rows);
-          }
-        }
-
-        // Refresh schema cache if needed
-        await client.query(`NOTIFY pgrst, 'reload schema';`);
+        );
 
         return {
           rowCount: totalRowCount,

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -240,4 +240,33 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
     expect(sqlQueries[0]).toContain('phone');
     expect(sqlQueries[0]).toContain('NULL');
   });
+
+  test('rolls back entire transaction if one shape group insert fails', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+
+    mockClientQuery.mockReset();
+    mockClientQuery
+      .mockResolvedValueOnce({}) // SET ROLE project_admin
+      .mockResolvedValueOnce({}) // set_config claims
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // First INSERT (Alice)
+      .mockRejectedValueOnce(new Error('Constraint violation on second group')) // Second INSERT (Bob)
+      .mockResolvedValueOnce({}) // ROLLBACK
+      .mockResolvedValueOnce({}) // RESET ROLE
+      .mockResolvedValueOnce({}); // set_config empty claims
+
+    const records = [
+      { id: '1', name: 'Alice' },
+      { id: '2', name: 'Bob', phone: '555-0001' },
+    ];
+
+    await expect(svc.bulkInsert('public', 'contacts', records)).rejects.toThrow(
+      'Constraint violation on second group'
+    );
+
+    const calls = mockClientQuery.mock.calls.map(([sql]) => sql);
+    expect(calls).toContain('BEGIN');
+    expect(calls).toContain('ROLLBACK');
+    expect(calls).not.toContain('COMMIT');
+  });
 });

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -98,12 +98,19 @@ describe('DatabaseAdvanceService - sanitizeQuery', () => {
 // bulkInsert — optional-column data-loss fix (issue #8)
 // ─────────────────────────────────────────────────────────────────────────────
 
-const { mockPoolQuery } = vi.hoisted(() => ({ mockPoolQuery: vi.fn() }));
+const { mockClientQuery, mockRelease, mockConnect } = vi.hoisted(() => ({
+  mockClientQuery: vi.fn(),
+  mockRelease: vi.fn(),
+  mockConnect: vi.fn(),
+}));
 
 vi.mock('../../src/infra/database/database.manager', () => ({
   DatabaseManager: {
     getInstance: vi.fn(() => ({
-      getPool: vi.fn(() => ({ query: mockPoolQuery })),
+      getPool: vi.fn(() => ({
+        query: vi.fn(),
+        connect: mockConnect,
+      })),
     })),
   },
 }));
@@ -111,8 +118,23 @@ vi.mock('../../src/infra/database/database.manager', () => ({
 describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 2 });
+    // pool.connect() returns a pg client with query + release
+    mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockRelease,
+    });
+    // Default: all queries succeed
+    mockClientQuery.mockResolvedValue({ rows: [], rowCount: 2 });
   });
+
+  /** Helper: find the INSERT SQL among all client.query calls */
+  function captureInsertSql(): string {
+    const call = mockClientQuery.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && (sql as string).startsWith('INSERT INTO')
+    );
+    if (!call) throw new Error('No INSERT query was executed');
+    return call[0] as string;
+  }
 
   test('includes columns from ALL records, not only the first', async () => {
     // records[0] has no `phone`; records[1] and records[2] do.
@@ -125,10 +147,10 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       { id: '3', name: 'Carol', phone: '555-0002' },
     ]);
 
-    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+    const sql = captureInsertSql();
 
     // phone must appear in the INSERT column list
-    expect(sql).toContain('"phone"');
+    expect(sql).toContain('phone');
     // Bob and Carol phone values must be present in the values literal
     expect(sql).toContain('555-0001');
     expect(sql).toContain('555-0002');
@@ -142,7 +164,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       { id: '2', name: 'Bob', phone: '555-0001' },
     ]);
 
-    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+    const sql = captureInsertSql();
 
     // Alice's row must not embed a raw JS `undefined` string
     expect(sql).not.toContain('undefined');
@@ -158,10 +180,10 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       { id: '2', name: 'Bob', phone: '555-0002' },
     ]);
 
-    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
-    expect(sql).toContain('"id"');
-    expect(sql).toContain('"name"');
-    expect(sql).toContain('"phone"');
+    const sql = captureInsertSql();
+    expect(sql).toContain('id');
+    expect(sql).toContain('name');
+    expect(sql).toContain('phone');
     expect(sql).toContain('555-0001');
     expect(sql).toContain('555-0002');
   });
@@ -184,8 +206,8 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       'id'
     );
 
-    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
-    expect(sql).toContain('"phone"');
+    const sql = captureInsertSql();
+    expect(sql).toContain('phone');
     expect(sql).toContain('ON CONFLICT');
     expect(sql).toContain('DO UPDATE SET');
   });

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -127,18 +127,14 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
     mockClientQuery.mockResolvedValue({ rows: [], rowCount: 2 });
   });
 
-  /** Helper: find the INSERT SQL among all client.query calls */
-  function captureInsertSql(): string {
-    const call = mockClientQuery.mock.calls.find(
-      ([sql]) => typeof sql === 'string' && (sql as string).startsWith('INSERT INTO')
-    );
-    if (!call) throw new Error('No INSERT query was executed');
-    return call[0] as string;
+  /** Helper: find all INSERT SQL queries executed */
+  function captureAllInsertSql(): string[] {
+    return mockClientQuery.mock.calls
+      .map(([sql]) => sql as string)
+      .filter((sql) => typeof sql === 'string' && sql.startsWith('INSERT INTO'));
   }
 
-  test('includes columns from ALL records, not only the first', async () => {
-    // records[0] has no `phone`; records[1] and records[2] do.
-    // Before the fix, `phone` was silently omitted from the INSERT entirely.
+  test('groups records by shape and executes shape-coherent batch queries', async () => {
     const svc = DatabaseAdvanceService.getInstance();
 
     await svc.bulkInsert('public', 'contacts', [
@@ -147,29 +143,37 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       { id: '3', name: 'Carol', phone: '555-0002' },
     ]);
 
-    const sql = captureInsertSql();
+    const sqlQueries = captureAllInsertSql();
+    expect(sqlQueries).toHaveLength(2);
 
-    // phone must appear in the INSERT column list
-    expect(sql).toContain('phone');
-    // Bob and Carol phone values must be present in the values literal
-    expect(sql).toContain('555-0001');
-    expect(sql).toContain('555-0002');
+    // First query (Alice) has no phone
+    const query1 = sqlQueries[0];
+    expect(query1).toContain('id');
+    expect(query1).toContain('name');
+    expect(query1).not.toContain('phone');
+    expect(query1).toContain('Alice');
+
+    // Second query (Bob and Carol) has phone
+    const query2 = sqlQueries[1];
+    expect(query2).toContain('id');
+    expect(query2).toContain('name');
+    expect(query2).toContain('phone');
+    expect(query2).toContain('555-0001');
+    expect(query2).toContain('555-0002');
   });
 
-  test('records missing an optional field get NULL, not undefined', async () => {
+  test('explicit undefined values are converted to NULL', async () => {
     const svc = DatabaseAdvanceService.getInstance();
 
     await svc.bulkInsert('public', 'contacts', [
-      { id: '1', name: 'Alice' },
-      { id: '2', name: 'Bob', phone: '555-0001' },
+      { id: '1', name: 'Alice', phone: undefined },
     ]);
 
-    const sql = captureInsertSql();
-
-    // Alice's row must not embed a raw JS `undefined` string
-    expect(sql).not.toContain('undefined');
-    // Her phone slot must be NULL
-    expect(sql).toContain('NULL');
+    const sqlQueries = captureAllInsertSql();
+    expect(sqlQueries).toHaveLength(1);
+    expect(sqlQueries[0]).toContain('phone');
+    expect(sqlQueries[0]).not.toContain('undefined');
+    expect(sqlQueries[0]).toContain('NULL');
   });
 
   test('uniform records (all same columns) still work correctly', async () => {
@@ -180,7 +184,9 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       { id: '2', name: 'Bob', phone: '555-0002' },
     ]);
 
-    const sql = captureInsertSql();
+    const sqlQueries = captureAllInsertSql();
+    expect(sqlQueries).toHaveLength(1);
+    const sql = sqlQueries[0];
     expect(sql).toContain('id');
     expect(sql).toContain('name');
     expect(sql).toContain('phone');
@@ -193,7 +199,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
     await expect(svc.bulkInsert('public', 'contacts', [])).rejects.toBeInstanceOf(AppError);
   });
 
-  test('upsert: optional column from later records is included in ON CONFLICT SET', async () => {
+  test('upsert: optional column from later records is included in ON CONFLICT SET for its group', async () => {
     const svc = DatabaseAdvanceService.getInstance();
 
     await svc.bulkInsert(
@@ -206,9 +212,32 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
       'id'
     );
 
-    const sql = captureInsertSql();
-    expect(sql).toContain('phone');
-    expect(sql).toContain('ON CONFLICT');
-    expect(sql).toContain('DO UPDATE SET');
+    const sqlQueries = captureAllInsertSql();
+    expect(sqlQueries).toHaveLength(2);
+
+    const query1 = sqlQueries[0]; // Alice: keys ['id', 'name']
+    expect(query1).toContain('ON CONFLICT');
+    expect(query1).toContain('DO UPDATE SET');
+    expect(query1).toContain('name = EXCLUDED.name');
+    expect(query1).not.toContain('phone');
+
+    const query2 = sqlQueries[1]; // Bob: keys ['id', 'name', 'phone']
+    expect(query2).toContain('ON CONFLICT');
+    expect(query2).toContain('DO UPDATE SET');
+    expect(query2).toContain('name = EXCLUDED.name');
+    expect(query2).toContain('phone = EXCLUDED.phone');
+  });
+
+  test('explicit null values are preserved in the SQL', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+
+    await svc.bulkInsert('public', 'contacts', [
+      { id: '1', name: 'Alice', phone: null },
+    ]);
+
+    const sqlQueries = captureAllInsertSql();
+    expect(sqlQueries).toHaveLength(1);
+    expect(sqlQueries[0]).toContain('phone');
+    expect(sqlQueries[0]).toContain('NULL');
   });
 });

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -165,9 +165,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
   test('explicit undefined values are converted to NULL', async () => {
     const svc = DatabaseAdvanceService.getInstance();
 
-    await svc.bulkInsert('public', 'contacts', [
-      { id: '1', name: 'Alice', phone: undefined },
-    ]);
+    await svc.bulkInsert('public', 'contacts', [{ id: '1', name: 'Alice', phone: undefined }]);
 
     const sqlQueries = captureAllInsertSql();
     expect(sqlQueries).toHaveLength(1);
@@ -231,9 +229,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
   test('explicit null values are preserved in the SQL', async () => {
     const svc = DatabaseAdvanceService.getInstance();
 
-    await svc.bulkInsert('public', 'contacts', [
-      { id: '1', name: 'Alice', phone: null },
-    ]);
+    await svc.bulkInsert('public', 'contacts', [{ id: '1', name: 'Alice', phone: null }]);
 
     const sqlQueries = captureAllInsertSql();
     expect(sqlQueries).toHaveLength(1);

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -121,7 +121,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
 
     await svc.bulkInsert('public', 'contacts', [
       { id: '1', name: 'Alice' },
-      { id: '2', name: 'Bob',   phone: '555-0001' },
+      { id: '2', name: 'Bob', phone: '555-0001' },
       { id: '3', name: 'Carol', phone: '555-0002' },
     ]);
 
@@ -155,7 +155,7 @@ describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
 
     await svc.bulkInsert('public', 'contacts', [
       { id: '1', name: 'Alice', phone: '555-0001' },
-      { id: '2', name: 'Bob',   phone: '555-0002' },
+      { id: '2', name: 'Bob', phone: '555-0002' },
     ]);
 
     const sql: string = mockPoolQuery.mock.calls[0][0] as string;

--- a/backend/tests/unit/database-advance.test.ts
+++ b/backend/tests/unit/database-advance.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { DatabaseAdvanceService } from '../../src/services/database/database-advance.service';
 import { AppError } from '../../src/utils/errors';
 import { ERROR_CODES } from '@insforge/shared-schemas';
@@ -91,5 +91,102 @@ describe('DatabaseAdvanceService - sanitizeQuery', () => {
     for (const query of queries) {
       expect(() => service.sanitizeQuery(query)).not.toThrow();
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bulkInsert — optional-column data-loss fix (issue #8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { mockPoolQuery } = vi.hoisted(() => ({ mockPoolQuery: vi.fn() }));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({ query: mockPoolQuery })),
+    })),
+  },
+}));
+
+describe('DatabaseAdvanceService - bulkInsert optional-column fix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 2 });
+  });
+
+  test('includes columns from ALL records, not only the first', async () => {
+    // records[0] has no `phone`; records[1] and records[2] do.
+    // Before the fix, `phone` was silently omitted from the INSERT entirely.
+    const svc = DatabaseAdvanceService.getInstance();
+
+    await svc.bulkInsert('public', 'contacts', [
+      { id: '1', name: 'Alice' },
+      { id: '2', name: 'Bob',   phone: '555-0001' },
+      { id: '3', name: 'Carol', phone: '555-0002' },
+    ]);
+
+    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+
+    // phone must appear in the INSERT column list
+    expect(sql).toContain('"phone"');
+    // Bob and Carol phone values must be present in the values literal
+    expect(sql).toContain('555-0001');
+    expect(sql).toContain('555-0002');
+  });
+
+  test('records missing an optional field get NULL, not undefined', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+
+    await svc.bulkInsert('public', 'contacts', [
+      { id: '1', name: 'Alice' },
+      { id: '2', name: 'Bob', phone: '555-0001' },
+    ]);
+
+    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+
+    // Alice's row must not embed a raw JS `undefined` string
+    expect(sql).not.toContain('undefined');
+    // Her phone slot must be NULL
+    expect(sql).toContain('NULL');
+  });
+
+  test('uniform records (all same columns) still work correctly', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+
+    await svc.bulkInsert('public', 'contacts', [
+      { id: '1', name: 'Alice', phone: '555-0001' },
+      { id: '2', name: 'Bob',   phone: '555-0002' },
+    ]);
+
+    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('"id"');
+    expect(sql).toContain('"name"');
+    expect(sql).toContain('"phone"');
+    expect(sql).toContain('555-0001');
+    expect(sql).toContain('555-0002');
+  });
+
+  test('throws AppError when records array is empty', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+    await expect(svc.bulkInsert('public', 'contacts', [])).rejects.toBeInstanceOf(AppError);
+  });
+
+  test('upsert: optional column from later records is included in ON CONFLICT SET', async () => {
+    const svc = DatabaseAdvanceService.getInstance();
+
+    await svc.bulkInsert(
+      'public',
+      'contacts',
+      [
+        { id: '1', name: 'Alice' },
+        { id: '2', name: 'Bob', phone: '555-0001' },
+      ],
+      'id'
+    );
+
+    const sql: string = mockPoolQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('"phone"');
+    expect(sql).toContain('ON CONFLICT');
+    expect(sql).toContain('DO UPDATE SET');
   });
 });

--- a/backend/tests/unit/database-raw-sql-execution.test.ts
+++ b/backend/tests/unit/database-raw-sql-execution.test.ts
@@ -208,12 +208,14 @@ describe('DatabaseAdvanceService - admin SQL execution', () => {
     const releaseMock = vi.fn();
     const queryMock = vi
       .fn()
-      .mockResolvedValueOnce({}) // SET ROLE project_admin
-      .mockResolvedValueOnce({}) // set request.jwt.claims
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // execute bulk upsert
-      .mockResolvedValueOnce({}) // RESET ROLE
-      .mockResolvedValueOnce({}) // reset request.jwt.claims
-      .mockResolvedValueOnce({}); // NOTIFY pgrst
+      .mockResolvedValueOnce({}) // 1. SET ROLE project_admin
+      .mockResolvedValueOnce({}) // 2. set request.jwt.claims
+      .mockResolvedValueOnce({}) // 3. BEGIN
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 4. execute bulk upsert
+      .mockResolvedValueOnce({}) // 5. NOTIFY pgrst
+      .mockResolvedValueOnce({}) // 6. COMMIT
+      .mockResolvedValueOnce({}) // 7. RESET ROLE
+      .mockResolvedValueOnce({}); // 8. reset request.jwt.claims
 
     connectMock.mockResolvedValue({
       query: queryMock,
@@ -236,15 +238,17 @@ describe('DatabaseAdvanceService - admin SQL execution', () => {
       JSON.stringify({ role: 'project_admin' }),
       false,
     ]);
-    expect(String(queryMock.mock.calls[2][0])).toContain('INSERT INTO public.profiles');
-    expect(String(queryMock.mock.calls[2][0])).toContain('ON CONFLICT (id) DO UPDATE');
-    expect(queryMock).toHaveBeenNthCalledWith(4, 'RESET ROLE');
-    expect(queryMock).toHaveBeenNthCalledWith(5, 'SELECT set_config($1, $2, $3)', [
+    expect(queryMock).toHaveBeenNthCalledWith(3, 'BEGIN');
+    expect(String(queryMock.mock.calls[3][0])).toContain('INSERT INTO public.profiles');
+    expect(String(queryMock.mock.calls[3][0])).toContain('ON CONFLICT (id) DO UPDATE');
+    expect(queryMock).toHaveBeenNthCalledWith(5, `NOTIFY pgrst, 'reload schema';`);
+    expect(queryMock).toHaveBeenNthCalledWith(6, 'COMMIT');
+    expect(queryMock).toHaveBeenNthCalledWith(7, 'RESET ROLE');
+    expect(queryMock).toHaveBeenNthCalledWith(8, 'SELECT set_config($1, $2, $3)', [
       'request.jwt.claims',
       '{}',
       false,
     ]);
-    expect(queryMock).toHaveBeenNthCalledWith(6, `NOTIFY pgrst, 'reload schema';`);
     expect(releaseMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a data integrity bug in `DatabaseAdvanceService.bulkInsert()` where 
optional fields present only in records after the first were silently dropped 
from bulk INSERT operations.

## Root Cause

The column list was built from `Object.keys(records[0])` only. Any field 
appearing in records[1..n] but not in records[0] was never included in the 
INSERT column list and its value was permanently lost with no warning.

## Fix

Replace the first-record lookup with a Set-based key union across all records:

```ts
const columns = Array.from(new Set(records.flatMap((rec) => Object.keys(rec))));

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent data loss and NULL overwrites in `DatabaseAdvanceService.bulkInsert()` by grouping records by column shape and executing per‑group INSERT/UPSERTs inside a single transaction. Preserves optional fields, returns accurate totals, and aligns tests with transactional behavior.

- **Bug Fixes**
  - Group records by sorted key signature and run per‑group INSERT/UPSERTs with matching columns to avoid dropping optional fields.
  - Convert empty strings and undefined to NULL; preserve explicit nulls.
  - Validate `upsertKey` per group and limit UPSERT updates to the group’s columns to prevent NULL overwrites.
  - Wrap the grouped loop in one transaction; rollback on failure; aggregate `rowCount`/`rows`; emit one schema reload `NOTIFY`. Tests cover shape grouping, undefined→NULL, uniform records, empty input, per‑group ON CONFLICT SET, transaction rollback, and admin SQL path BEGIN/COMMIT + `NOTIFY` sequencing.

<sup>Written for commit 1447d587823547d3bc0502756375ef14ffafe0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silent data loss in `DatabaseAdvanceService.bulkInsert` when optional fields appear in later records
> - Groups input records by their sorted key signature (column shape) and executes one `INSERT` per group, so columns absent from some records are never written as NULL for unrelated rows
> - Converts `undefined` and empty strings to NULL while preserving explicit `null` values; validates `upsertKey` existence per group before building `ON CONFLICT DO UPDATE` clauses
> - Aggregates `rowCount` and returned rows across all group inserts, then issues a single `NOTIFY` to reload the schema
> - Adds unit tests in [database-advance.test.ts](https://github.com/InsForge/InsForge/pull/1459/files#diff-1d9b6000ff8adc358091294ea0261cc24de6ba237145c8a92ffd1385e9751d7c) covering shape grouping, `undefined`-to-NULL conversion, upsert SET inclusion, and explicit NULL preservation
> - Behavioral Change: `bulkInsert` now issues multiple `INSERT` statements per call when records have differing column shapes, rather than a single statement
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2e1fca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk insert now preserves optional fields from any record to prevent data loss.
  * Empty strings and undefined values are consistently treated as NULL.
  * Bulk insert rejects empty input arrays with a clear error.
  * Upserts now include later-introduced fields for conflict updates and return accurate affected-row totals.

* **Tests**
  * Added tests covering column-union behavior, NULL handling, empty-input rejection, and upsert handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->