### PR TITLE
dialog descrip added for the s3 access key create dialog

### DIFF
--- a/packages/dashboard/src/features/storage/components/S3AccessKeyCreateDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/S3AccessKeyCreateDialog.tsx
@@ -7,6 +7,7 @@ import {
   Dialog,
   DialogBody,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -78,6 +79,11 @@ export function S3AccessKeyCreateDialog({
       <DialogContent className="max-w-[520px]">
         <DialogHeader>
           <DialogTitle>{showingSecret ? 'S3 Access Key Created' : 'New S3 Access Key'}</DialogTitle>
+          <DialogDescription>
+            {showingSecret
+              ? 'Copy the secret access key now. Acknowledgement is required before closing.'
+              : 'Create a new S3 access key. The secret is shown only once.'}
+          </DialogDescription>
         </DialogHeader>
 
         <DialogBody>


### PR DESCRIPTION
#closes #1462


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a description to the S3 Access Key Create dialog to clarify that the secret is shown only once and must be copied before closing. Aligns with #1462 by guiding users through create vs. post-create states to prevent lost secrets.

<sup>Written for commit c8306368dea0e7d00209864441f501741bb60b51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add contextual description text to the S3 access key create dialog
> Adds a `DialogDescription` element to [S3AccessKeyCreateDialog.tsx](https://github.com/InsForge/InsForge/pull/1467/files#diff-b39bcfe3ee03eb42528ab68551d0fac429d68762048a27edd2bb5699228fbd09) that shows guidance text under the dialog title. Before creation, it reads "Create a new S3 access key. The secret is shown only once."; after creation, it reads "Copy the secret access key now. Acknowledgement is required before closing."
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c830636.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved S3 access key dialog with clearer, context-aware explanatory text. The dialog now requires acknowledgement confirmation before closing in the secret-created state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->