### PR TITLE
platform admin is separated from users

### DIFF
--- a/backend/src/infra/database/migrations/049_system_administrators.sql
+++ b/backend/src/infra/database/migrations/049_system_administrators.sql
@@ -2,6 +2,9 @@
 -- Transitional compatibility (strategy 2): introduce system.administrators and
 -- provide a compatibility view auth.users_compat that mimics legacy flags.
 
+-- Ensure system schema exists (some fresh installs may not have it yet)
+CREATE SCHEMA IF NOT EXISTS system;
+
 -- 1) Create system.administrators table
 CREATE TABLE IF NOT EXISTS system.administrators (
   id UUID PRIMARY KEY,
@@ -14,17 +17,16 @@ CREATE TABLE IF NOT EXISTS system.administrators (
 );
 
 -- 2) Backfill from legacy auth.users rows (admin)
--- Legacy admin row: id = '00000000-0000-0000-0000-000000000001' and is_project_admin=true
+-- We only run the backfill if BOTH legacy columns exist (avoid partial-column runtime errors)
 DO $$
 BEGIN
-  -- If legacy columns exist, copy them.
-  IF EXISTS (
-    SELECT 1
+  IF (
+    SELECT COUNT(*)
     FROM information_schema.columns
     WHERE table_schema = 'auth'
       AND table_name = 'users'
       AND column_name IN ('is_project_admin','is_anonymous')
-  ) THEN
+  ) = 2 THEN
     INSERT INTO system.administrators (id, email, password_hash, profile, email_verified)
     SELECT
       u.id,
@@ -42,18 +44,23 @@ END $$;
 -- do NOT create a system row for anon. Absence of auth is the anon notion.
 
 -- 4) Delete legacy admin/anon rows from auth.users (transitional cleanup)
--- Keep data migrations safe: delete only if legacy flags columns exist.
+-- Only delete if BOTH legacy columns exist to avoid partial-schema runtime errors.
 DO $$
 BEGIN
-  IF EXISTS (
-    SELECT 1
+  IF (
+    SELECT COUNT(*)
     FROM information_schema.columns
     WHERE table_schema = 'auth'
       AND table_name = 'users'
       AND column_name IN ('is_project_admin','is_anonymous')
-  ) THEN
-    -- Delete both admin and anon rows from auth.users
-    DELETE FROM auth.users
+  ) = 2 THEN
+    -- Legacy FK-safe approach:
+    -- Avoid deleting legacy admin/anon UUIDs (they may be referenced by other rows).
+    -- Instead, clear the legacy flags so auth.uid()-based / auth.users-based logic
+    -- cannot treat them as user-like principals anymore.
+    UPDATE auth.users
+    SET is_project_admin = false,
+        is_anonymous = false
     WHERE (is_project_admin = true) OR (is_anonymous = true);
   END IF;
 END $$;
@@ -61,6 +68,33 @@ END $$;
 -- 5) Compatibility view for legacy code/policies.
 -- Exposes a legacy-shaped recordset with is_project_admin/is_anonymous.
 -- WARNING: Deprecated. Remove in next major.
+--
+-- Important: this view must be created even on fresh installs where legacy columns
+-- may not exist. We therefore add missing legacy columns with safe defaults
+-- BEFORE creating the view.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name = 'users'
+      AND column_name = 'is_project_admin'
+  ) THEN
+    ALTER TABLE auth.users ADD COLUMN is_project_admin BOOLEAN NOT NULL DEFAULT false;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name = 'users'
+      AND column_name = 'is_anonymous'
+  ) THEN
+    ALTER TABLE auth.users ADD COLUMN is_anonymous BOOLEAN NOT NULL DEFAULT false;
+  END IF;
+END $$;
+
 CREATE OR REPLACE VIEW auth.users_compat AS
 SELECT
   u.id,
@@ -92,6 +126,5 @@ FROM system.administrators a;
 -- auth.uid() should be NULL for unauthenticated requests, so policies should not rely on anon rows.
 
 -- 6) Preserve RLS/policies behavior during transition:
--- Grant read-only on the compat view to public as needed by existing code.
 GRANT SELECT ON auth.users_compat TO PUBLIC;
 

--- a/backend/src/infra/database/migrations/049_system_administrators.sql
+++ b/backend/src/infra/database/migrations/049_system_administrators.sql
@@ -1,0 +1,97 @@
+-- Migration: 049 - Move platform admin and anon identities out of auth.users
+-- Transitional compatibility (strategy 2): introduce system.administrators and
+-- provide a compatibility view auth.users_compat that mimics legacy flags.
+
+-- 1) Create system.administrators table
+CREATE TABLE IF NOT EXISTS system.administrators (
+  id UUID PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  profile JSONB NOT NULL DEFAULT '{}'::jsonb,
+  email_verified BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 2) Backfill from legacy auth.users rows (admin)
+-- Legacy admin row: id = '00000000-0000-0000-0000-000000000001' and is_project_admin=true
+DO $$
+BEGIN
+  -- If legacy columns exist, copy them.
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name = 'users'
+      AND column_name IN ('is_project_admin','is_anonymous')
+  ) THEN
+    INSERT INTO system.administrators (id, email, password_hash, profile, email_verified)
+    SELECT
+      u.id,
+      u.email,
+      u.password,
+      COALESCE(u.profile, '{}'::jsonb),
+      COALESCE(u.email_verified, TRUE)
+    FROM auth.users u
+    WHERE u.is_project_admin = true
+    ON CONFLICT (id) DO NOTHING;
+  END IF;
+END $$;
+
+-- 3) Backfill system admin email/password not required for anon; we intentionally
+-- do NOT create a system row for anon. Absence of auth is the anon notion.
+
+-- 4) Delete legacy admin/anon rows from auth.users (transitional cleanup)
+-- Keep data migrations safe: delete only if legacy flags columns exist.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name = 'users'
+      AND column_name IN ('is_project_admin','is_anonymous')
+  ) THEN
+    -- Delete both admin and anon rows from auth.users
+    DELETE FROM auth.users
+    WHERE (is_project_admin = true) OR (is_anonymous = true);
+  END IF;
+END $$;
+
+-- 5) Compatibility view for legacy code/policies.
+-- Exposes a legacy-shaped recordset with is_project_admin/is_anonymous.
+-- WARNING: Deprecated. Remove in next major.
+CREATE OR REPLACE VIEW auth.users_compat AS
+SELECT
+  u.id,
+  u.email,
+  u.password,
+  u.profile,
+  u.email_verified,
+  u.is_project_admin,
+  u.is_anonymous,
+  u.created_at,
+  u.updated_at
+FROM auth.users u
+
+UNION ALL
+
+SELECT
+  a.id,
+  a.email,
+  a.password_hash AS password,
+  a.profile,
+  a.email_verified,
+  true  AS is_project_admin,
+  false AS is_anonymous,
+  a.created_at,
+  a.updated_at
+FROM system.administrators a;
+
+-- For anon, legacy behavior expects a special row. We provide an empty set for anon.
+-- auth.uid() should be NULL for unauthenticated requests, so policies should not rely on anon rows.
+
+-- 6) Preserve RLS/policies behavior during transition:
+-- Grant read-only on the compat view to public as needed by existing code.
+GRANT SELECT ON auth.users_compat TO PUBLIC;
+

--- a/backend/src/infra/database/migrations/050_fix_admin_api_key_jwt_sub.sql
+++ b/backend/src/infra/database/migrations/050_fix_admin_api_key_jwt_sub.sql
@@ -1,0 +1,3 @@
+-- Migration: 050 - Fix admin-key JWT contract for auth.uid()
+-- No-op migration placeholder (JWT contract fix is implemented in backend).
+

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -73,8 +73,11 @@ export class TokenManager {
    * Used for internal API key authenticated requests to PostgREST
    */
   generateApiKeyToken(): string {
+    // Admin API key auth is intentionally NOT modeled as a user row.
+    // Keep JWT sub cast-safe for DB helpers (auth.uid()) by using the real
+    // admin UUID.
     const payload = {
-      sub: 'project-admin-with-api-key',
+      sub: '00000000-0000-0000-0000-000000000001',
       email: 'project-admin@email.com',
       role: 'project_admin',
     };

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -8,22 +8,24 @@ import { PaymentService } from '@/services/payments/payment.service.js';
 import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import { OAuthProvidersSchema } from '@insforge/shared-schemas';
 import { AuthConfigService } from '@/services/auth/auth-config.service.js';
-import { ADMIN_ID, ANON_ID } from '@/utils/constants.js';
+import { ADMIN_ID } from '@/utils/constants.js';
 
 /**
- * Seeds system users (admin and anon) if they don't exist in the database
+ * Seeds system administrators (platform admin) if they don't exist in the database
  */
+
 async function seedSystemUsers(adminEmail: string, adminPassword: string): Promise<void> {
   const dbManager = DatabaseManager.getInstance();
   const pool = dbManager.getPool();
   const client = await pool.connect();
 
   try {
-    // Seed admin user
+    // Seed platform admin (dashboard)
     if (adminEmail && adminPassword) {
-      const existingAdmin = await client.query('SELECT id FROM auth.users WHERE id = $1', [
-        ADMIN_ID,
-      ]);
+      const existingAdmin = await client.query(
+        'SELECT id FROM system.administrators WHERE id = $1',
+        [ADMIN_ID]
+      );
 
       if (existingAdmin.rows.length > 0) {
         logger.info(`✅ Admin configured: ${adminEmail}`);
@@ -32,8 +34,8 @@ async function seedSystemUsers(adminEmail: string, adminPassword: string): Promi
         const profile = JSON.stringify({ name: 'Administrator' });
 
         await client.query(
-          `INSERT INTO auth.users (id, email, password, profile, email_verified, is_project_admin, is_anonymous, created_at, updated_at)
-           VALUES ($1, $2, $3, $4::jsonb, true, true, false, NOW(), NOW())
+          `INSERT INTO system.administrators (id, email, password_hash, profile, email_verified, created_at, updated_at)
+           VALUES ($1, $2, $3, $4::jsonb, true, NOW(), NOW())
            ON CONFLICT (id) DO NOTHING`,
           [ADMIN_ID, adminEmail, hashedPassword, profile]
         );
@@ -42,24 +44,6 @@ async function seedSystemUsers(adminEmail: string, adminPassword: string): Promi
       }
     } else {
       logger.warn('⚠️ Admin credentials not configured - check ADMIN_EMAIL and ADMIN_PASSWORD');
-    }
-
-    // Seed anon user
-    const existingAnon = await client.query('SELECT id FROM auth.users WHERE id = $1', [ANON_ID]);
-
-    if (existingAnon.rows.length > 0) {
-      logger.info(`✅ Anon user configured`);
-    } else {
-      const profile = JSON.stringify({ name: 'Anonymous' });
-
-      await client.query(
-        `INSERT INTO auth.users (id, email, password, profile, email_verified, is_project_admin, is_anonymous, created_at, updated_at)
-         VALUES ($1, $2, NULL, $3::jsonb, false, false, true, NOW(), NOW())
-         ON CONFLICT (id) DO NOTHING`,
-        [ANON_ID, 'anon@example.com', profile]
-      );
-
-      logger.info(`✅ Anon user seeded`);
     }
   } catch (error) {
     logger.error('Failed to seed system users', {
@@ -244,7 +228,7 @@ export async function seedBackend(): Promise<void> {
   try {
     logger.info(`\n🚀 Insforge Backend Starting...`);
 
-    // Seed system users (admin and anon) if not exists
+    // Seed system platform administrators (dashboard)
     await seedSystemUsers(adminEmail, adminPassword);
 
     // Initialize API key (from env or generate)


### PR DESCRIPTION
## Summary
Fix: Separate platform admin + anon identities from auth.users (transitional migration)
This PR addresses the identity category error where InsForge stored platform administrators and the system anon principal inside the same auth.users table as real application end-users, distinguished only by is_project_admin / is_anonymous flags.

Key changes
DB migration 049: Introduces system.administrators and migrates legacy admin rows out of auth.users.
Compatibility view: Adds auth.users_compat to preserve legacy expectations during the transition (admin rows projected from system.administrators; anon rows no longer represented as a user row).
Seed update: Stops seeding platform admin/anon into auth.users; seeds the dashboard admin into system.administrators.
#1436 fix (admin API key JWT sub contract): Updates TokenManager.generateApiKeyToken() so the admin-key JWT sub is a real UUID (removes the UUID cast failure caused by the previous hardcoded non-UUID string).
#closes  #1446

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated platform admin and anon identities from `auth.users`, and fixed the admin API key JWT subject to a UUID so `auth.uid()` works correctly. Closes #1446; fixes #1436.

- **Migration**
  - Added `system.administrators` and backfilled admins from `auth.users`; do not create a row for anon.
  - Introduced `auth.users_compat` (unions `auth.users` and `system.administrators`), adds missing legacy columns if absent, and grants SELECT to public.
  - Cleared `is_project_admin`/`is_anonymous` flags on legacy `auth.users` rows instead of deleting to avoid FK issues.
  - Updated seeding to write admins to `system.administrators`; stopped seeding anon.

- **Bug Fixes**
  - `TokenManager.generateApiKeyToken()` now sets `sub` to the admin UUID to avoid UUID cast errors and keep DB helpers working.
  - Added no-op migration noting the JWT contract change.

<sup>Written for commit 0ff936ea5f1d6156e1632da45e8fdc004eb67882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate platform admin identity from auth.users into system.administrators
> - Adds a `system.administrators` table via [migration 049](https://github.com/InsForge/InsForge/pull/1468/files#diff-6cf06313cc0212612ff1bb2ab18644e006582f335cd8a406f0ddc4f51f6b38ed), backfilling existing admins from `auth.users` rows where `is_project_admin=true` and clearing legacy flags.
> - Creates a compatibility view `auth.users_compat` that unions `auth.users` and `system.administrators` into the legacy row shape for backward compatibility.
> - Updates [seed.ts](https://github.com/InsForge/InsForge/pull/1468/files#diff-63196e4b85e26873baaf8f4688c0de418f99bafec3af5143fdae6a9d44f6e9b7) to insert the admin into `system.administrators` instead of `auth.users`, and removes anonymous user seeding entirely.
> - Fixes `TokenManager.generateApiKeyToken` to set `sub` to the UUID `00000000-0000-0000-0000-000000000001` instead of the non-UUID string `'project-admin-with-api-key'`.
> - Behavioral Change: anonymous users are no longer seeded; any code querying `auth.users` directly for the admin will need to use `auth.users_compat` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ff936e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved platform administrator storage out of general user accounts and added a migration to introduce the new admin table while preserving legacy-compatible access.
  * Updated seeding to create platform admin records in the new admin store.
  * Adjusted admin API token generation to use a stable admin subject identifier for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->