### PR TITLE
fix(backend): use savepoints to gracefully handle table truncate failures in importDatabase (PG 25P02)

### DIFF
--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -760,9 +760,20 @@ export class DatabaseAdvanceService {
 
             for (const row of tablesResult.rows) {
               try {
+                // Use a SAVEPOINT before each TRUNCATE so that a failure only rolls back
+                // this single statement and does NOT abort the entire transaction (PG 25P02).
+                // Without this, a failed TRUNCATE inside a transaction permanently poisons
+                // the transaction and causes every subsequent query to fail with:
+                // "ERROR: current transaction is aborted, commands ignored until end of transaction block"
+                await client.query('SAVEPOINT truncate_attempt');
                 await client.query(pgFormat('TRUNCATE TABLE %I CASCADE', row.tablename));
+                await client.query('RELEASE SAVEPOINT truncate_attempt');
                 logger.info(`Truncated table: ${row.tablename}`);
               } catch (err) {
+                // Roll back to the savepoint to restore the transaction to a healthy state,
+                // then release it to clean up the savepoint and prevent accumulation, then log and continue with the next table.
+                await client.query('ROLLBACK TO SAVEPOINT truncate_attempt');
+                await client.query('RELEASE SAVEPOINT truncate_attempt');
                 logger.warn(`Could not truncate table ${row.tablename}:`, err);
               }
             }

--- a/backend/tests/unit/database-raw-sql-execution.test.ts
+++ b/backend/tests/unit/database-raw-sql-execution.test.ts
@@ -204,6 +204,55 @@ describe('DatabaseAdvanceService - admin SQL execution', () => {
     expect(releaseMock).toHaveBeenCalled();
   });
 
+  it('handles table truncate failures using savepoints in importDatabase', async () => {
+    const releaseMock = vi.fn();
+    const queryMock = vi
+      .fn()
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // SET LOCAL ROLE project_admin
+      .mockResolvedValueOnce({}) // set local request.jwt.claims
+      // For the SELECT tablename query:
+      .mockResolvedValueOnce({
+        rows: [{ tablename: 'table1' }, { tablename: 'table2' }],
+      })
+      // Truncate table1:
+      .mockResolvedValueOnce({}) // SAVEPOINT truncate_attempt
+      .mockRejectedValueOnce(new Error('Truncate table1 failed (mock locked)')) // TRUNCATE TABLE table1 CASCADE (FAILS)
+      .mockResolvedValueOnce({}) // ROLLBACK TO SAVEPOINT truncate_attempt
+      .mockResolvedValueOnce({}) // RELEASE SAVEPOINT truncate_attempt (after rollback)
+      // Truncate table2:
+      .mockResolvedValueOnce({}) // SAVEPOINT truncate_attempt
+      .mockResolvedValueOnce({}) // TRUNCATE TABLE table2 CASCADE (SUCCEEDS)
+      .mockResolvedValueOnce({}) // RELEASE SAVEPOINT truncate_attempt
+      // SQL statements:
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // execute imported SQL
+      // Reset context:
+      .mockResolvedValueOnce({}) // RESET ROLE
+      .mockResolvedValueOnce({}) // reset request.jwt.claims
+      .mockResolvedValueOnce({}) // NOTIFY pgrst
+      .mockResolvedValueOnce({}); // COMMIT
+
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: releaseMock,
+    });
+
+    const service = DatabaseAdvanceService.getInstance();
+    const result = await service.importDatabase(
+      Buffer.from('INSERT INTO products (id) VALUES (1);'),
+      'seed.sql',
+      36,
+      true // truncate = true
+    );
+
+    expect(result.rowsImported).toBe(1);
+    expect(queryMock).toHaveBeenCalledWith('SAVEPOINT truncate_attempt');
+    expect(queryMock).toHaveBeenCalledWith('ROLLBACK TO SAVEPOINT truncate_attempt');
+    expect(queryMock).toHaveBeenCalledWith('RELEASE SAVEPOINT truncate_attempt');
+    expect(queryMock).toHaveBeenLastCalledWith('COMMIT');
+    expect(releaseMock).toHaveBeenCalled();
+  });
+
   it('bulk upserts under project_admin', async () => {
     const releaseMock = vi.fn();
     const queryMock = vi


### PR DESCRIPTION
Fixes #1471

## **Description**
This PR fixes a critical reliability issue where a single table truncation failure during a database import (`truncate = true` flow) would poison the active PostgreSQL transaction block and enter the `25P02` error state. Once aborted, all subsequent queries (such as seed data inserts) would fail with:
`ERROR: current transaction is aborted, commands ignored until end of transaction block`.

### **Root Cause**
Previously, the table truncation logic inside `importDatabase()` ran inside a loop in a single transaction block without isolation. Any query failure (e.g. system tables, schema-locked tables, foreign key constraints) immediately poisoned the transaction block, crashing the entire import process.

---

## **Proposed Changes**
- **Isolate Truncate Operations using Savepoints**: Wrapped each table truncation attempt inside `SAVEPOINT truncate_attempt`, `RELEASE SAVEPOINT`, and `ROLLBACK TO SAVEPOINT` blocks in [database-advance.service.ts](file:///e:/insforge_contribution/backend/src/services/database/database-advance.service.ts).
- **Graceful Error Handling**: If a table fails to truncate, the transaction rolls back specifically to the savepoint—restoring the transaction to a healthy, valid state—logs a warning, and continues with the next table's truncation and subsequent database insertion statements.
- **Unit Test Coverage**: Added a dedicated unit test in [database-raw-sql-execution.test.ts](file:///e:/insforge_contribution/backend/tests/unit/database-raw-sql-execution.test.ts) to verify that single truncation failures do not poison or block the overall database import transaction.

---

## **Verification and Testing Run**

### **Automated Tests**
All backend unit and integration tests were run and passed successfully:
```bash
npm run test:backend
# Result: 103 test files passed, 1245 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for database truncation during imports when truncate mode is enabled. Individual table truncation failures are now logged as warnings and allow the process to continue with remaining tables, preventing complete operation failure.

* **Tests**
  * Added unit test to verify per-table truncation error isolation, savepoint recovery, and successful transaction completion during database import operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use savepoints to handle TRUNCATE failures gracefully in `importDatabase`
> - Wraps each `TRUNCATE TABLE` in `importDatabase` with a `SAVEPOINT` named `truncate_attempt` so a failure rolls back only that statement, not the entire transaction.
> - On truncate failure, the code rolls back to the savepoint, releases it, logs a warning, and continues processing remaining tables.
> - Adds a unit test in [database-raw-sql-execution.test.ts](https://github.com/InsForge/InsForge/pull/1472/files#diff-a664222136d523bb03bdd0b898df5cead27a9a96d66c4f93af5ea4a74674fb93) that simulates a truncate failure and asserts correct savepoint lifecycle and transaction continuation.
> - Behavioral Change: a single table's truncate failure no longer aborts the full import; subsequent SQL statements and the final commit still execute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad419b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->