### PR TITLE
INS-328 fix(logs): return all severities for function.logs

### DIFF
--- a/backend/src/services/logs/log.service.ts
+++ b/backend/src/services/logs/log.service.ts
@@ -128,7 +128,9 @@ export class LogService {
         limit,
         until: beforeTimestamp,
         order: 'desc',
-        level: 'debug',
+        // Deno's `level` param is an exact-match filter (comma-separated), not a
+        // minimum-severity threshold. Omitting it returns all levels (error, warning,
+        // info, debug); passing `debug` would return ONLY debug-level entries.
       });
 
       const logs: LogSchema[] = result.logs.map((entry, index) => ({

--- a/backend/tests/unit/deno-app-logs.test.ts
+++ b/backend/tests/unit/deno-app-logs.test.ts
@@ -332,6 +332,39 @@ describe('LogService.getLogsBySource with Deno Subhosting', () => {
     expect(calledUrl).toContain('order=desc');
   });
 
+  it('does not send a level filter so all severities are returned', async () => {
+    // Deno's `level` param is an exact-match filter, not a min-severity threshold.
+    // Hardcoding level=debug previously dropped all info/warning/error logs, so we
+    // must omit it entirely to surface the full runtime log stream.
+    mockPool.query.mockResolvedValue({
+      rows: [{ id: 'deploy-latest' }],
+    });
+
+    const mockLogs = [
+      {
+        time: '2025-01-15T10:00:00Z',
+        level: 'debug',
+        message: 'isolate start time',
+        region: 'us-east1',
+      },
+      {
+        time: '2025-01-15T10:00:01Z',
+        level: 'info',
+        message: 'request handled',
+        region: 'us-east1',
+      },
+      { time: '2025-01-15T10:00:02Z', level: 'error', message: 'boom', region: 'us-east1' },
+    ];
+    mockFetch.mockResolvedValue(createMockResponse(mockLogs));
+
+    const result = await logService.getLogsBySource('function.logs', 100);
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain('level=');
+    // All severities flow through, not just debug
+    expect(result.logs.map((l) => l.body.level)).toEqual(['debug', 'info', 'error']);
+  });
+
   it('generates unique log IDs from deployment ID and timestamp', async () => {
     mockPool.query.mockResolvedValue({
       rows: [{ id: 'deploy-abc' }],


### PR DESCRIPTION
## Problem

`GET /api/logs/function.logs` only ever returned a handful of `debug`-level **"isolate start time"** entries (122 total spanning a full day), while the Deno dashboard for the same deployment showed the full runtime stream — the `info`-level request logs (`fetch-minute-bars`, `fetch-chains`, …), `error` logs, and `debug` logs all together.

## Root cause

In `log.service.ts` we hardcoded `level: 'debug'` when calling Deno's `app_logs` API:

```ts
const result = await denoProvider.getDeploymentAppLogs(deploymentId, {
  limit, until: beforeTimestamp, order: 'desc',
  level: 'debug', // ← problem
});
```

Per Deno's OpenAPI spec, the `level` query param is an **exact-match filter** (comma-separated levels), **not** a minimum-severity threshold. So `level=debug` returned *only* debug-level entries — which happen to be exactly the "isolate start time" logs — and silently dropped every `info` / `warning` / `error` log.

## Fix

Omit the `level` parameter entirely so Deno returns all severities (the same full stream visible in the dashboard).

## Tests

- Added a regression test asserting the request URL contains no `level=` filter and that `debug`/`info`/`error` entries all flow through.
- Full `deno-app-logs.test.ts` suite passes (18/18).

## Validation

- `npx tsc --noEmit` ✅
- `npx eslint` on changed files ✅
- `npx vitest run tests/unit/deno-app-logs.test.ts` ✅ 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
INS-328: Return the full runtime log stream in `GET /api/logs/function.logs` by omitting the exact-match `level` filter when calling Deno `app_logs`. Now `debug`, `info`, `warning`, and `error` logs are returned to match the Deno dashboard.

- **Bug Fixes**
  - Remove `level` from Deno `app_logs` call; exact-match filter was dropping non-`debug` logs.
  - Add regression test asserting no `level` query and that multiple severities are returned.

<sup>Written for commit 89517b05814e285c93cd657f48d3c6129c2437de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LogService.getLogsBySource` to return all severities for Deno Subhosting logs
> Removes the `level: 'debug'` argument from the `denoProvider.getDeploymentAppLogs` call in [log.service.ts](https://github.com/InsForge/InsForge/pull/1477/files#diff-d6b5e93133e9e25cfb17629f57dc1a20a49593dc0fd57c22de28c1a1abde0f2c). Deno's `level` parameter is an exact-match filter, so passing `'debug'` was excluding error, warning, and info entries. Omitting the parameter returns all severities as intended.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89517b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log retrieval from Deno Subhosting no longer filters by debug level; it now returns all severities (debug, info, error).

* **Tests**
  * Added unit test verifying the external request omits any level filter and that returned logs include the full severity sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->