### PR TITLE
bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.1.10",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.1.10",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.1.10",
+  "version": "2.2.0",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump the root package version from 2.1.10 to 2.2.0.
- Refresh the root package lockfile version entries via npm install.

## Validation
- npm run format:check
- npx turbo run typecheck
- npx turbo run lint
- npx turbo run test
- npx turbo run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump root `insforge` package version from 2.1.10 to 2.2.0. Update `package-lock.json` to align with the new version.

<sup>Written for commit e3b97021be8631018ca7786e7d95cf43e67077d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to 2.2.0
> Updates the version field in [package.json](https://github.com/InsForge/InsForge/pull/1479/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `2.1.10` to `2.2.0`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3b9702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->