### PR TITLE
[Feature]: Compute container logs — dashboard Logs panel + backend getLogs

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -95,6 +95,33 @@ export const s3AccessKeyManagementRateLimiter = rateLimit({
 });
 
 /**
+ * Per-IP rate limiter for the compute logs endpoint.
+ * Unlike the write limiters, this is a read endpoint the dashboard polls every
+ * ~2s while live-tailing, so the budget is generous — it exists to cap retry
+ * storms / abuse, not to throttle normal tailing (≈30 req/min) across a few
+ * open tabs.
+ *
+ * Limits: 120 requests per minute per IP.
+ */
+export const computeLogsRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many log requests from this IP. Please slow down and try again shortly.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+  skipSuccessfulRequests: false,
+  skipFailedRequests: false,
+});
+
+/**
  * Per-IP rate limiter for email OTP verification attempts
  * Prevents brute-force code guessing
  *

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -1,6 +1,6 @@
 import { Router, Response, NextFunction } from 'express';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
-import { computeWriteLimiter } from '@/api/middlewares/rate-limiters.js';
+import { computeWriteLimiter, computeLogsRateLimiter } from '@/api/middlewares/rate-limiters.js';
 import { ComputeServicesService } from '@/services/compute/services.service.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
@@ -353,10 +353,12 @@ router.get(
 
 // Get container stdout/stderr ("application logs") from Fly's logs API.
 // Backfills from Fly's ~7-day retention; pass `next_token` (returned in the
-// response) to page forward for live tailing.
+// response) to page forward for live tailing. Rate-limited because the
+// dashboard polls this every ~2s while live.
 router.get(
   '/:id/logs',
   verifyAdmin,
+  computeLogsRateLimiter,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const svc = ComputeServicesService.getInstance();

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -351,4 +351,30 @@ router.get(
   }
 );
 
+// Get container stdout/stderr ("application logs") from Fly's logs API.
+// Backfills from Fly's ~7-day retention; pass `next_token` (returned in the
+// response) to page forward for live tailing.
+router.get(
+  '/:id/logs',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const svc = ComputeServicesService.getInstance();
+      const existing = await svc.getService(req.params.id);
+
+      if (existing.projectId !== getProjectId(req)) {
+        throw new AppError('Service not found', 404, ERROR_CODES.COMPUTE_SERVICE_NOT_FOUND);
+      }
+
+      const limit = Math.min(Math.max(Number(req.query.limit) || 100, 1), 1000);
+      const nextToken = typeof req.query.next_token === 'string' ? req.query.next_token : undefined;
+      const logs = await svc.getServiceLogs(req.params.id, { limit, nextToken });
+
+      successResponse(res, logs);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 export { router as servicesRouter };

--- a/backend/src/providers/compute/cloud.provider.ts
+++ b/backend/src/providers/compute/cloud.provider.ts
@@ -8,6 +8,7 @@ import type {
   UpdateMachineParams,
   MachineSummary,
   ComputeEvent,
+  ComputeLogsResult,
 } from './compute.provider.js';
 
 export class CloudComputeProvider implements ComputeProvider {
@@ -187,6 +188,25 @@ export class CloudComputeProvider implements ComputeProvider {
         `/machines/${encodeURIComponent(machineId)}/events${qs}`
       )) ?? []
     );
+  }
+
+  async getLogs(
+    appId: string,
+    machineId: string,
+    options?: { limit?: number; nextToken?: string }
+  ): Promise<ComputeLogsResult> {
+    const params = new URLSearchParams({ appId });
+    if (options?.limit) {
+      params.set('limit', String(options.limit));
+    }
+    if (options?.nextToken) {
+      params.set('next_token', options.nextToken);
+    }
+    const result = await this.call<ComputeLogsResult>(
+      'GET',
+      `/machines/${encodeURIComponent(machineId)}/logs?${params.toString()}`
+    );
+    return result ?? { lines: [], nextToken: null };
   }
 
   async waitForState(

--- a/backend/src/providers/compute/cloud.provider.ts
+++ b/backend/src/providers/compute/cloud.provider.ts
@@ -190,6 +190,11 @@ export class CloudComputeProvider implements ComputeProvider {
     );
   }
 
+  /**
+   * Fetch container logs by delegating to the cloud control plane's
+   * `GET /machines/:id/logs`, which holds the Fly org token and proxies to Fly.
+   * Returns empty results if the control plane responds with no body.
+   */
   async getLogs(
     appId: string,
     machineId: string,

--- a/backend/src/providers/compute/compute.provider.ts
+++ b/backend/src/providers/compute/compute.provider.ts
@@ -49,6 +49,21 @@ export interface ComputeEvent {
   message: string;
 }
 
+// A single container stdout/stderr line. `timestamp` is epoch milliseconds.
+export interface ComputeLogLine {
+  timestamp: number;
+  message: string;
+  instance?: string;
+  region?: string;
+}
+
+// Result of fetching container logs. `nextToken` is an opaque forward cursor
+// (Fly's `next_token`) for live tailing; null when nothing further is available.
+export interface ComputeLogsResult {
+  lines: ComputeLogLine[];
+  nextToken: string | null;
+}
+
 export interface ComputeProvider {
   isConfigured(): boolean;
   createApp(params: { name: string; network: string; org: string }): Promise<{ appId: string }>;
@@ -65,6 +80,11 @@ export interface ComputeProvider {
     machineId: string,
     options?: { limit?: number }
   ): Promise<ComputeEvent[]>;
+  getLogs(
+    appId: string,
+    machineId: string,
+    options?: { limit?: number; nextToken?: string }
+  ): Promise<ComputeLogsResult>;
   waitForState(
     appId: string,
     machineId: string,

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -1,8 +1,16 @@
 import { appConfig } from '@/infra/config/app.config.js';
 import logger from '@/utils/logger.js';
-import type { ComputeProvider } from './compute.provider.js';
+import type { ComputeProvider, ComputeLogsResult } from './compute.provider.js';
 
 const FLY_API_BASE = 'https://api.machines.dev/v1';
+// Container stdout/stderr lives on a different host + auth scheme than the
+// Machines API: api.fly.io with the `FlyV1 <macaroon>` scheme. The Machines
+// host (api.machines.dev) does NOT serve logs, and this endpoint rejects the
+// `Bearer` scheme with 401 — verified against a live Fly app. Same token,
+// different host + prefix. Fly documents this endpoint as stable-but-unofficial
+// (flyctl depends on it); we degrade to a thrown error rather than crash if it
+// ever changes shape.
+const FLY_LOGS_API_BASE = 'https://api.fly.io/api/v1';
 
 // Fly Machines API field names for the autostop/autostart block on a
 // service. Kept narrow on purpose: extend when we expose CLI overrides.
@@ -12,6 +20,20 @@ type ScaleOptions = {
   autostop: 'off' | 'stop' | 'suspend';
   autostart: boolean;
   min_machines_running: number;
+};
+
+// Shape of Fly's logs API response (JSON:API-style). Fields are optional on
+// purpose — we parse defensively since the endpoint is unofficial.
+type FlyLogsResponse = {
+  data?: {
+    attributes?: {
+      timestamp?: string | number;
+      message?: string;
+      instance?: string;
+      region?: string;
+    };
+  }[];
+  meta?: { next_token?: string | number };
 };
 
 export class FlyProvider implements ComputeProvider {
@@ -357,6 +379,71 @@ export class FlyProvider implements ComputeProvider {
 
     const limit = options?.limit ?? 100;
     return mapped.slice(0, limit);
+  }
+
+  /**
+   * Returns container stdout/stderr ("application logs") from Fly's logs API
+   * (api.fly.io/api/v1/apps/:app/logs). Unlike getEvents (machine lifecycle),
+   * these are the lines the running process writes. Supports backfill from
+   * Fly's ~7-day retention window and forward paging via `nextToken` for
+   * live tailing.
+   */
+  async getLogs(
+    appId: string,
+    machineId: string,
+    options?: { limit?: number; nextToken?: string }
+  ): Promise<ComputeLogsResult> {
+    const params = new URLSearchParams();
+    // Scope to this service's single machine — a Fly app may briefly hold more
+    // than one (e.g. mid-redeploy), and we only want this service's lines.
+    if (machineId) {
+      params.set('instance', machineId);
+    }
+    if (options?.nextToken) {
+      params.set('next_token', options.nextToken);
+    }
+    const url = `${FLY_LOGS_API_BASE}/apps/${appId}/logs?${params.toString()}`;
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `FlyV1 ${config.fly.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      logger.error('Fly logs API error', { url, status: response.status, body: text });
+      throw new Error(`Fly logs API error (${response.status}): ${text}`);
+    }
+
+    const raw = await response.text();
+    const body = JSON.parse(raw) as FlyLogsResponse;
+
+    const lines = (body.data ?? []).map((entry) => {
+      const a = entry.attributes ?? {};
+      // Fly returns RFC3339 strings (e.g. "2026-06-04T21:25:05.152Z"); some
+      // shapes carry epoch numbers. Normalize to epoch ms; 0 if unparseable.
+      const parsed = typeof a.timestamp === 'number' ? a.timestamp : Date.parse(a.timestamp ?? '');
+      return {
+        timestamp: Number.isNaN(parsed) ? 0 : parsed,
+        message: a.message ?? '',
+        instance: a.instance,
+        region: a.region,
+      };
+    });
+
+    const limit = options?.limit ?? 100;
+    // Keep the most-recent `limit` lines (Fly returns oldest→newest).
+    const bounded = lines.length > limit ? lines.slice(-limit) : lines;
+
+    // `next_token` is a nanosecond Unix timestamp — it exceeds
+    // Number.MAX_SAFE_INTEGER, so JSON.parse() would silently round it and
+    // corrupt the cursor. Pull the exact digits from the raw text instead.
+    const tokenMatch = raw.match(/"next_token"\s*:\s*"?(\d+)"?/);
+    const nextToken = tokenMatch ? tokenMatch[1] : null;
+
+    return { lines: bounded, nextToken };
   }
 
   // Parse Fly.io's `<kind>-<N>x` format (e.g. shared-2x, performance-8x).

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -416,7 +416,7 @@ export class FlyProvider implements ComputeProvider {
       // Fly request must not pile up and degrade API responsiveness.
       response = await fetch(url, {
         headers: {
-          Authorization: `FlyV1 ${config.fly.apiToken}`,
+          Authorization: `FlyV1 ${appConfig.fly.apiToken}`,
           'Content-Type': 'application/json',
         },
         signal: AbortSignal.timeout(15_000),

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -399,17 +399,32 @@ export class FlyProvider implements ComputeProvider {
     if (machineId) {
       params.set('instance', machineId);
     }
+    if (options?.limit) {
+      // Best-effort: forward the page size so Fly returns enough lines rather
+      // than relying solely on the local slice below (Fly's default is ~100;
+      // unknown params are ignored, so this is safe if unsupported).
+      params.set('limit', String(options.limit));
+    }
     if (options?.nextToken) {
       params.set('next_token', options.nextToken);
     }
     const url = `${FLY_LOGS_API_BASE}/apps/${appId}/logs?${params.toString()}`;
 
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `FlyV1 ${config.fly.apiToken}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    let response: Response;
+    try {
+      // Time-box the upstream call — this endpoint is polled live, so a stalled
+      // Fly request must not pile up and degrade API responsiveness.
+      response = await fetch(url, {
+        headers: {
+          Authorization: `FlyV1 ${config.fly.apiToken}`,
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch (error) {
+      logger.error('Fly logs API request failed', { url, error });
+      throw new Error(`Fly logs API request failed: ${(error as Error).message}`);
+    }
 
     if (!response.ok) {
       const text = await response.text();
@@ -439,9 +454,16 @@ export class FlyProvider implements ComputeProvider {
 
     // `next_token` is a nanosecond Unix timestamp — it exceeds
     // Number.MAX_SAFE_INTEGER, so JSON.parse() would silently round it and
-    // corrupt the cursor. Pull the exact digits from the raw text instead.
+    // corrupt the cursor. Pull the exact digits from the raw text for numeric
+    // tokens. If Fly ever issues a non-numeric (string) cursor, the JSON-parsed
+    // value is already safe, so fall back to it rather than dropping the cursor.
     const tokenMatch = raw.match(/"next_token"\s*:\s*"?(\d+)"?/);
-    const nextToken = tokenMatch ? tokenMatch[1] : null;
+    const parsedToken = body.meta?.next_token;
+    const nextToken = tokenMatch
+      ? tokenMatch[1]
+      : typeof parsedToken === 'string'
+        ? parsedToken
+        : null;
 
     return { lines: bounded, nextToken };
   }

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -4,7 +4,7 @@ import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { EncryptionManager } from '@/infra/security/encryption.manager.js';
 import { FlyProvider } from '@/providers/compute/fly.provider.js';
 import { CloudComputeProvider } from '@/providers/compute/cloud.provider.js';
-import type { ComputeProvider } from '@/providers/compute/compute.provider.js';
+import type { ComputeProvider, ComputeLogsResult } from '@/providers/compute/compute.provider.js';
 import { appConfig } from '@/infra/config/app.config.js';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
@@ -920,6 +920,24 @@ export class ComputeServicesService {
     }
 
     return this.getCompute().getEvents(svc.flyAppId, svc.flyMachineId, options);
+  }
+
+  async getServiceLogs(
+    id: string,
+    options?: { limit?: number; nextToken?: string }
+  ): Promise<ComputeLogsResult> {
+    const svc = await this.getService(id);
+
+    if (!svc.flyAppId || !svc.flyMachineId) {
+      throw new AppError(
+        'Service not found',
+        404,
+        ERROR_CODES.COMPUTE_SERVICE_NOT_FOUND,
+        NEXT_ACTIONS.CHECK_COMPUTE_SERVICE_EXISTS
+      );
+    }
+
+    return this.getCompute().getLogs(svc.flyAppId, svc.flyMachineId, options);
   }
 
   private decryptEnvVars(encrypted: string | null): Record<string, string> {

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -922,6 +922,11 @@ export class ComputeServicesService {
     return this.getCompute().getEvents(svc.flyAppId, svc.flyMachineId, options);
   }
 
+  /**
+   * Fetch container stdout/stderr ("application logs") for a service. Resolves
+   * the service's Fly app + machine, then delegates to the active compute
+   * provider. Throws 404 if the service has not been launched yet.
+   */
   async getServiceLogs(
     id: string,
     options?: { limit?: number; nextToken?: string }

--- a/backend/tests/unit/compute/cloud-provider.test.ts
+++ b/backend/tests/unit/compute/cloud-provider.test.ts
@@ -145,6 +145,34 @@ describe('CloudComputeProvider', () => {
     expect(call[0]).toContain('limit=50');
   });
 
+  it('getLogs GETs /machines/:id/logs forwarding appId, limit, next_token and returns the payload', async () => {
+    const payload = { lines: [{ timestamp: 1, message: 'hi' }], nextToken: '42' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify(payload),
+    } as Response);
+    const provider = CloudComputeProvider.getInstance();
+
+    const result = await provider.getLogs('myapp', 'machine-1', { limit: 200, nextToken: 'cur' });
+
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toContain('/compute/machines/machine-1/logs');
+    expect(call[0]).toContain('appId=myapp');
+    expect(call[0]).toContain('limit=200');
+    expect(call[0]).toContain('next_token=cur');
+    expect((call[1] as RequestInit).method).toBe('GET');
+    expect(result).toEqual(payload);
+  });
+
+  it('getLogs returns empty result when the cloud responds with no body', async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: async () => '' } as Response);
+    const provider = CloudComputeProvider.getInstance();
+
+    const result = await provider.getLogs('myapp', 'machine-1');
+
+    expect(result).toEqual({ lines: [], nextToken: null });
+  });
+
   it('throws COMPUTE_CLOUD_UNAVAILABLE on AbortError (timeout)', async () => {
     const abortError = new DOMException('The operation was aborted', 'AbortError');
     fetchMock.mockRejectedValue(abortError);

--- a/backend/tests/unit/compute/compute-logs-limiter.test.ts
+++ b/backend/tests/unit/compute/compute-logs-limiter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express, { type RequestHandler } from 'express';
+import request from 'supertest';
+import { computeLogsRateLimiter } from '@/api/middlewares/rate-limiters.js';
+
+// express-rate-limit keeps in-memory state per limiter instance; reset the
+// bucket between tests. supertest's default remote address is the key below.
+const DEFAULT_KEY = '::ffff:127.0.0.1';
+const BUDGET = 120; // keep in sync with computeLogsRateLimiter `max`
+
+function resetLimiter(limiter: RequestHandler): void {
+  (limiter as unknown as { resetKey: (k: string) => void }).resetKey(DEFAULT_KEY);
+}
+
+function buildApp() {
+  const app = express();
+  // logs is a GET endpoint — model it as such.
+  app.get('/logs', computeLogsRateLimiter, (_req, res) => {
+    res.json({ ok: true });
+  });
+  return app;
+}
+
+describe('computeLogsRateLimiter', () => {
+  beforeEach(() => {
+    resetLimiter(computeLogsRateLimiter);
+  });
+
+  it(`allows up to ${BUDGET} GETs in the window from a single IP`, async () => {
+    const app = buildApp();
+    for (let i = 0; i < BUDGET; i++) {
+      await request(app).get('/logs').expect(200);
+    }
+  });
+
+  it(`rejects GET #${BUDGET + 1} with 429`, async () => {
+    const app = buildApp();
+    for (let i = 0; i < BUDGET; i++) {
+      await request(app).get('/logs').expect(200);
+    }
+    const r = await request(app).get('/logs');
+    expect(r.status).toBe(429);
+  });
+
+  it('is generous enough for live 2s polling (≈30/min ≪ budget)', () => {
+    // A live tail polls ~30 times/min; the limiter must not throttle that.
+    expect(BUDGET).toBeGreaterThanOrEqual(30 * 2);
+  });
+});

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -323,4 +323,73 @@ describe('FlyProvider', () => {
       );
     });
   });
+
+  describe('getLogs', () => {
+    const okText = (raw: string) => ({ ok: true, text: () => Promise.resolve(raw) });
+
+    it('hits the api.fly.io logs host with the FlyV1 scheme, scoped to the machine', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(okText('{"data":[],"meta":{}}'));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.getLogs('my-app', 'machine-123');
+
+      const [calledUrl, init] = mockFetch.mock.calls[0];
+      expect(calledUrl).toContain('https://api.fly.io/api/v1/apps/my-app/logs');
+      // Scopes to this service's machine via the `instance` query param.
+      expect(calledUrl).toContain('instance=machine-123');
+      // Logs use Fly's macaroon scheme, NOT Bearer (which 401s on this host).
+      expect((init.headers as Record<string, string>).Authorization).toBe('FlyV1 test-token');
+    });
+
+    it('normalizes RFC3339 timestamps to epoch ms', async () => {
+      const raw =
+        '{"data":[{"attributes":{"timestamp":"2026-06-04T21:25:05.000Z",' +
+        '"message":"hello from container","instance":"machine-123","region":"iad"}}],"meta":{}}';
+      const mockFetch = vi.fn().mockResolvedValue(okText(raw));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const result = await provider.getLogs('my-app', 'machine-123');
+
+      expect(result.lines).toEqual([
+        {
+          timestamp: Date.parse('2026-06-04T21:25:05.000Z'),
+          message: 'hello from container',
+          instance: 'machine-123',
+          region: 'iad',
+        },
+      ]);
+    });
+
+    it('returns next_token at full precision (it exceeds Number.MAX_SAFE_INTEGER)', async () => {
+      // A bare JSON number here would round to ...890600 under JSON.parse;
+      // the provider must preserve every digit by reading the raw text.
+      const raw = '{"data":[],"meta":{"next_token":1780608313161890637}}';
+      const mockFetch = vi.fn().mockResolvedValue(okText(raw));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const result = await provider.getLogs('my-app', 'machine-123');
+
+      expect(result.nextToken).toBe('1780608313161890637');
+    });
+
+    it('forwards the nextToken cursor as the Fly next_token query param', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(okText('{"data":[],"meta":{}}'));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.getLogs('my-app', 'machine-123', { nextToken: 'cursor-abc' });
+
+      expect(mockFetch.mock.calls[0][0]).toContain('next_token=cursor-abc');
+    });
+
+    it('throws on a non-2xx logs response', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('Unauthorized'),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await expect(provider.getLogs('my-app', 'machine-123')).rejects.toThrow(/401/);
+    });
+  });
 });

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -372,6 +372,34 @@ describe('FlyProvider', () => {
       expect(result.nextToken).toBe('1780608313161890637');
     });
 
+    it('forwards the requested limit as a Fly query param', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(okText('{"data":[],"meta":{}}'));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.getLogs('my-app', 'machine-123', { limit: 200 });
+
+      expect(mockFetch.mock.calls[0][0]).toContain('limit=200');
+    });
+
+    it('falls back to the parsed string cursor for a non-numeric next_token', async () => {
+      const raw = '{"data":[],"meta":{"next_token":"abc-cursor"}}';
+      const mockFetch = vi.fn().mockResolvedValue(okText(raw));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const result = await provider.getLogs('my-app', 'machine-123');
+
+      expect(result.nextToken).toBe('abc-cursor');
+    });
+
+    it('times out the upstream Fly request (passes an abort signal)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(okText('{"data":[],"meta":{}}'));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.getLogs('my-app', 'machine-123');
+
+      expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    });
+
     it('forwards the nextToken cursor as the Fly next_token query param', async () => {
       const mockFetch = vi.fn().mockResolvedValue(okText('{"data":[],"meta":{}}'));
       vi.stubGlobal('fetch', mockFetch);

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -59,6 +59,7 @@ const mockStopMachine = vi.fn();
 const mockStartMachine = vi.fn();
 const mockDestroyMachine = vi.fn();
 const mockGetEvents = vi.fn();
+const mockGetLogs = vi.fn();
 const mockListMachines = vi.fn();
 const mockIsConfigured = vi.fn(() => true);
 
@@ -71,6 +72,7 @@ const mockFlyInstance = {
   startMachine: mockStartMachine,
   destroyMachine: mockDestroyMachine,
   getEvents: mockGetEvents,
+  getLogs: mockGetLogs,
   listMachines: mockListMachines,
   isConfigured: mockIsConfigured,
 };
@@ -1243,6 +1245,49 @@ describe('ComputeServicesService', () => {
       // No DB write should have happened — the guard rejects before any
       // mutation. Only the initial getService SELECT ran.
       expect(mockUpdateMachine).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getServiceLogs', () => {
+    const serviceRow = {
+      id: 'svc-logs-1',
+      project_id: 'proj-123',
+      name: 'my-api',
+      image_url: 'nginx:latest',
+      port: 8080,
+      cpu: 'shared-1x',
+      memory: 256,
+      region: 'iad',
+      fly_app_id: 'my-api-proj-123',
+      fly_machine_id: 'machine-1',
+      status: 'running',
+      endpoint_url: 'https://my-api-proj-123.fly.dev',
+      env_vars_encrypted: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    };
+
+    it('delegates to provider.getLogs with the app, machine, and options', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow] }); // getService
+      const payload = { lines: [{ timestamp: 1, message: 'hi' }], nextToken: '42' };
+      mockGetLogs.mockResolvedValue(payload);
+
+      const result = await service.getServiceLogs('svc-logs-1', { limit: 200, nextToken: 'cur' });
+
+      expect(mockGetLogs).toHaveBeenCalledWith('my-api-proj-123', 'machine-1', {
+        limit: 200,
+        nextToken: 'cur',
+      });
+      expect(result).toEqual(payload);
+    });
+
+    it('throws COMPUTE_SERVICE_NOT_FOUND when the service has no machine yet', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ...serviceRow, fly_app_id: null, fly_machine_id: null }],
+      });
+
+      await expect(service.getServiceLogs('svc-logs-1')).rejects.toThrow('Service not found');
+      expect(mockGetLogs).not.toHaveBeenCalled();
     });
   });
 });

--- a/docs/styles/config/vocabularies/Mintlify/accept.txt
+++ b/docs/styles/config/vocabularies/Mintlify/accept.txt
@@ -39,6 +39,7 @@ dev
 docker
 dockerfile
 env
+flyctl
 github
 hardcoding
 healthchecks
@@ -59,6 +60,7 @@ linode
 localStorage
 loopback
 mcp
+monorepo
 Multiplatform
 namespace
 nginx

--- a/docs/superpowers/specs/2026-06-04-compute-container-logs-design.md
+++ b/docs/superpowers/specs/2026-06-04-compute-container-logs-design.md
@@ -14,7 +14,7 @@ see container **stdout/stderr** ("application logs") from the dashboard or CLI. 
 Fly exposes an HTTP REST logs endpoint (the same one `flyctl logs` and Fly's dashboard use).
 Tested live against a throwaway Fly container on 2026-06-04:
 
-```
+```text
 GET https://api.fly.io/api/v1/apps/{app}/logs
   Auth:   Authorization: FlyV1 <org-macaroon>        # NOT "Bearer"
   Query:  instance=<machineId>  next_token=<ns-unix-cursor>
@@ -34,7 +34,7 @@ GET https://api.fly.io/api/v1/apps/{app}/logs
 
 ## Auth boundary (org token never leaves the backend)
 
-```
+```text
 CLI       ──Bearer ik_<project key>──┐
 Dashboard ──user access token────────┤──▶ Backend ──FlyV1 <org token>──▶ Fly
 (browser)        (withAccessToken)   ┘     (sole holder of the org token)

--- a/docs/superpowers/specs/2026-06-04-compute-container-logs-design.md
+++ b/docs/superpowers/specs/2026-06-04-compute-container-logs-design.md
@@ -1,0 +1,82 @@
+# Compute Container Logs — Design
+
+**Date:** 2026-06-04
+**Priority:** Dashboard-first — click into a compute service and see its container stdout/stderr.
+
+## Problem
+
+Compute services (containers on Fly.io) expose only **machine lifecycle events**
+(`ServiceEvents` panel / `compute events` — start/stop/exit/restart). There is no way to
+see container **stdout/stderr** ("application logs") from the dashboard or CLI. This adds it.
+
+## Verified foundation
+
+Fly exposes an HTTP REST logs endpoint (the same one `flyctl logs` and Fly's dashboard use).
+Tested live against a throwaway Fly container on 2026-06-04:
+
+```
+GET https://api.fly.io/api/v1/apps/{app}/logs
+  Auth:   Authorization: FlyV1 <org-macaroon>        # NOT "Bearer"
+  Query:  instance=<machineId>  next_token=<ns-unix-cursor>
+  Returns: HTTP 200, data[].attributes { timestamp(RFC3339), message, instance, region }
+           + meta.next_token cursor
+  History: ~7-day retention (populates the view on open); re-poll with next_token to tail
+```
+
+### Gotchas (both load-bearing, both hit during implementation)
+
+1. **Auth scheme.** The existing providers call `api.machines.dev` with `Bearer`. The logs
+   endpoint is on `api.fly.io` and **rejects `Bearer` with 401** — it requires the Fly
+   macaroon scheme `Authorization: FlyV1 <token>`. Same token, different host + prefix.
+2. **`next_token` precision.** It is a nanosecond Unix timestamp that exceeds
+   `Number.MAX_SAFE_INTEGER`. `JSON.parse()` silently rounds it and corrupts the cursor, so
+   the provider extracts it from the raw response text to preserve every digit.
+
+## Auth boundary (org token never leaves the backend)
+
+```
+CLI       ──Bearer ik_<project key>──┐
+Dashboard ──user access token────────┤──▶ Backend ──FlyV1 <org token>──▶ Fly
+(browser)        (withAccessToken)   ┘     (sole holder of the org token)
+```
+
+Neither the CLI nor the dashboard ever holds the Fly org token. The backend authorizes the
+request (project ownership), then calls Fly. Identical boundary to the existing `events` route.
+
+## What shipped in this PR (monorepo: `insforge-current-main`)
+
+Mirrors the `events` feature end to end. New surface is one provider method (`getLogs`) feeding
+a route, a service method, and the dashboard panel.
+
+- `shared-schemas`: `computeLogLineSchema` / `computeLogsResponseSchema` (+ types).
+- `compute.provider.ts`: `ComputeLogLine` / `ComputeLogsResult` + `getLogs()` on the interface.
+- `fly.provider.ts`: `getLogs()` — `api.fly.io` + `FlyV1`, `instance` scoping, RFC3339→epoch-ms
+  normalization, precision-safe `next_token`. (Self-host path; unit-tested.)
+- `cloud.provider.ts`: `getLogs()` — delegates `GET /machines/:id/logs` to the control plane.
+- `services.service.ts`: `getServiceLogs()` (ownership guard, mirrors `getServiceEvents`).
+- `services.routes.ts`: `GET /:id/logs` (`verifyAdmin`, project-ownership, `limit`, `next_token`).
+- Dashboard: `computeServicesApi.logs()`, `useServiceLogs` hook, `ServiceLogs.tsx` (recent on
+  open + **Live** toggle re-polling every 2s), mounted in the service detail view beside Events.
+
+Live tail in v1 = re-fetch the recent window on an interval (stateless; no cursor
+accumulation/dedup to get wrong). SSE is a possible later upgrade.
+
+## Companion PR (separate repo: `insforge-cloud-backend`)
+
+For InsForge Cloud, the dashboard runs through `CloudComputeProvider`, which delegates to the
+cloud control plane. That backend needs the matching `GET …/machines/:id/logs` route (its
+own `fly-client.getLogs` with the same `api.fly.io` + `FlyV1` call). **Self-hosted works
+fully from this PR alone** (FlyProvider path); cloud needs the companion route to light up.
+
+## Non-goals
+
+- No Vector / log-shipper / NATS / WireGuard. The REST endpoint is sufficient.
+- No durable log store / new DB table — relies on Fly's ~7-day retention. A persisted,
+  searchable store is a deferred future phase behind the same surfaces, only if needed.
+- No CLI in this PR — Phase 2 (`compute logs <id> --follow`), reusing the same route.
+
+## Risks
+
+- **Unofficial endpoint.** Fly documents the logs REST endpoint as "stable but not officially
+  supported — flyctl depends on it." Acceptable; the provider degrades to a thrown error (not
+  a crash) on non-200, and the durable-store path is the long-term fallback.

--- a/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
@@ -41,7 +41,7 @@ export function ServiceLogs({ serviceId }: ServiceLogsProps) {
         ) : (
           <pre className="text-xs font-mono text-muted-foreground space-y-0.5">
             {lines.map((entry, i) => (
-              <div key={i}>
+              <div key={`${entry.timestamp}-${i}`}>
                 <span className="text-foreground/60">
                   {(() => {
                     const d = new Date(entry.timestamp);

--- a/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { RefreshCw, Play, Pause } from 'lucide-react';
+import { Button } from '@insforge/ui';
+import { useServiceLogs } from '#features/compute/hooks/useComputeServices';
+
+interface ServiceLogsProps {
+  serviceId: string;
+}
+
+// Container stdout/stderr ("application logs"), distinct from the lifecycle
+// Events panel. Loads the recent window on open; the Live toggle re-polls
+// every 2s. Mirrors ServiceEvents' styling intentionally.
+export function ServiceLogs({ serviceId }: ServiceLogsProps) {
+  const [live, setLive] = useState(false);
+  const { data, isLoading, isError, refetch, isFetching } = useServiceLogs(serviceId, { live });
+
+  const lines = data?.lines ?? [];
+
+  return (
+    <div className="bg-card border border-[var(--alpha-8)] rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--alpha-8)]">
+        <h3 className="text-sm font-medium text-foreground">Logs</h3>
+        <div className="flex items-center gap-1">
+          <Button variant="ghost" size="sm" onClick={() => setLive((v) => !v)}>
+            {live ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+            {live ? 'Pause' : 'Live'}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => void refetch()} disabled={isFetching}>
+            <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-[300px] overflow-y-auto p-4">
+        {isLoading ? (
+          <p className="text-xs text-muted-foreground">Loading logs...</p>
+        ) : isError ? (
+          <p className="text-xs text-destructive">Failed to load logs. Try refreshing.</p>
+        ) : lines.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No logs available.</p>
+        ) : (
+          <pre className="text-xs font-mono text-muted-foreground space-y-0.5">
+            {lines.map((entry, i) => (
+              <div key={i}>
+                <span className="text-foreground/60">
+                  {(() => {
+                    const d = new Date(entry.timestamp);
+                    return isNaN(d.getTime())
+                      ? String(entry.timestamp)
+                      : d.toISOString().replace('T', ' ').slice(0, 19);
+                  })()}
+                </span>
+                {'  '}
+                {entry.message}
+              </div>
+            ))}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/compute/hooks/useComputeServices.ts
+++ b/packages/dashboard/src/features/compute/hooks/useComputeServices.ts
@@ -107,6 +107,21 @@ export function useServiceEvents(serviceId: string | null) {
   });
 }
 
+// Container stdout/stderr for the detail-view Logs panel. When `live` is on we
+// re-pull the recent window every 2s (simple, stateless tail — no cursor
+// accumulation/dedup to get wrong for v1); otherwise it's a one-shot recent
+// fetch the user can refresh manually.
+export function useServiceLogs(serviceId: string | null, opts?: { live?: boolean }) {
+  return useQuery({
+    queryKey: ['compute', 'services', serviceId, 'logs'],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by enabled
+    queryFn: () => computeServicesApi.logs(serviceId!, { limit: 200 }),
+    enabled: !!serviceId,
+    staleTime: 0,
+    refetchInterval: opts?.live ? 2000 : false,
+  });
+}
+
 // Per-service crash-loop indicator for the grid view. Polls the events
 // endpoint at 30s cadence — same data the detail-view ServiceEvents panel uses,
 // so we don't introduce a new backend surface, and React Query dedupes the

--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -13,6 +13,7 @@ import { Button } from '@insforge/ui';
 import { useComputeServices } from '#features/compute/hooks/useComputeServices';
 import { ServiceCard } from '#features/compute/components/ServiceCard';
 import { ServiceEvents } from '#features/compute/components/ServiceEvents';
+import { ServiceLogs } from '#features/compute/components/ServiceLogs';
 import { CreateServiceDialog } from '#features/compute/components/CreateServiceDialog';
 import { DeleteServiceDialog } from '#features/compute/components/DeleteServiceDialog';
 import { statusColors, getReachableUrl } from '#features/compute/constants';
@@ -244,6 +245,7 @@ export default function ComputePage() {
               </dl>
             </div>
 
+            {currentService.flyMachineId && <ServiceLogs serviceId={currentService.id} />}
             {currentService.flyMachineId && <ServiceEvents serviceId={currentService.id} />}
           </div>
         </div>

--- a/packages/dashboard/src/features/compute/services/compute.service.ts
+++ b/packages/dashboard/src/features/compute/services/compute.service.ts
@@ -10,6 +10,8 @@ interface ListServicesResponse {
 }
 
 type EventEntry = { timestamp: number; message: string };
+type LogLine = { timestamp: number; message: string; instance?: string; region?: string };
+type LogsResponse = { lines: LogLine[]; nextToken: string | null };
 
 class ComputeServicesApiService {
   async list(): Promise<ServiceSchema[]> {
@@ -75,6 +77,22 @@ class ComputeServicesApiService {
     return Array.isArray(response)
       ? response
       : ((response as { events: EventEntry[] })?.events ?? []);
+  }
+
+  async logs(id: string, opts?: { limit?: number; nextToken?: string }): Promise<LogsResponse> {
+    const params = new URLSearchParams();
+    if (opts?.limit) {
+      params.set('limit', String(opts.limit));
+    }
+    if (opts?.nextToken) {
+      params.set('next_token', opts.nextToken);
+    }
+    const qs = params.toString() ? `?${params.toString()}` : '';
+    const response = await apiClient.request(`/compute/services/${id}/logs${qs}`, {
+      headers: apiClient.withAccessToken(),
+    });
+    const r = response as Partial<LogsResponse> | null;
+    return { lines: r?.lines ?? [], nextToken: r?.nextToken ?? null };
   }
 }
 

--- a/packages/dashboard/src/features/compute/services/compute.service.ts
+++ b/packages/dashboard/src/features/compute/services/compute.service.ts
@@ -79,6 +79,10 @@ class ComputeServicesApiService {
       : ((response as { events: EventEntry[] })?.events ?? []);
   }
 
+  /**
+   * Fetch container logs for a service. Pass `nextToken` (returned in the
+   * response) to page forward when live-tailing; `limit` caps the window.
+   */
   async logs(id: string, opts?: { limit?: number; nextToken?: string }): Promise<LogsResponse> {
     const params = new URLSearchParams();
     if (opts?.limit) {

--- a/packages/shared-schemas/src/compute-services-api.schema.ts
+++ b/packages/shared-schemas/src/compute-services-api.schema.ts
@@ -120,6 +120,25 @@ export const listServicesResponseSchema = z.object({
   services: z.array(serviceSchema),
 });
 
+// A single container stdout/stderr line, as surfaced from Fly's logs API.
+// `timestamp` is normalized to epoch milliseconds by the backend provider.
+export const computeLogLineSchema = z.object({
+  timestamp: z.number(),
+  message: z.string(),
+  instance: z.string().optional(),
+  region: z.string().optional(),
+});
+
+// Response for GET /compute/services/:id/logs. `nextToken` is an opaque cursor
+// (Fly's nanosecond `next_token`) to poll forward for live tailing; null when
+// there is nothing further to page.
+export const computeLogsResponseSchema = z.object({
+  lines: z.array(computeLogLineSchema),
+  nextToken: z.string().nullable(),
+});
+
 export type CreateServiceRequest = z.infer<typeof createServiceSchema>;
 export type UpdateServiceRequest = z.infer<typeof updateServiceSchema>;
 export type ListServicesResponse = z.infer<typeof listServicesResponseSchema>;
+export type ComputeLogLine = z.infer<typeof computeLogLineSchema>;
+export type ComputeLogsResponse = z.infer<typeof computeLogsResponseSchema>;


### PR DESCRIPTION
## What

Surface **container stdout/stderr** ("application logs") for compute services — distinct from the existing machine-lifecycle **Events** panel. Dashboard-first: click into a compute service → see its logs, with recent history on open and a **Live** tail toggle.

Before: compute only exposed lifecycle events (start/stop/exit/restart). No way to see what the container actually printed.

## How

One new provider method, `getLogs()`, mirroring the existing `getEvents` plumbing end to end:

- **`fly.provider.getLogs`** — `GET https://api.fly.io/api/v1/apps/:app/logs`, scoped to the service's machine via `instance`. Self-hosted path.
- **`cloud.provider.getLogs`** — delegates `GET /machines/:id/logs` to the cloud control plane.
- **`services.service.getServiceLogs`** + **`GET /:id/logs`** route (`verifyAdmin`, project-ownership check, `limit`, `next_token`).
- **shared-schemas** — `computeLogLine` / `computeLogsResponse`.
- **Dashboard** — `computeServicesApi.logs()`, `useServiceLogs` hook, new `ServiceLogs` panel (Live toggle re-polls every 2s), mounted beside Events in the service detail view.

### Two gotchas worth a careful look
1. **Auth scheme.** Unlike the Machines API (`api.machines.dev` + `Bearer`), the logs host `api.fly.io` **rejects `Bearer` with 401** — it needs Fly's macaroon scheme `Authorization: FlyV1 <token>`. Same token, different host + prefix. Verified live against a real Fly container.
2. **`next_token` precision.** Fly's cursor is a nanosecond timestamp that exceeds `Number.MAX_SAFE_INTEGER`; `JSON.parse` silently rounds it and corrupts the cursor. The provider reads it from the raw response text to preserve every digit. (Covered by a unit test.)

## Auth boundary

The Fly org token stays **server-side only**. CLI/dashboard reach logs through the backend (project-key / user-session auth respectively) — identical boundary to the existing `events` route.

## Scope

- ✅ **Self-hosted works from this PR** (FlyProvider path).
- ⏳ **Cloud** needs the companion control-plane route (`GET …/machines/:id/logs`) in `insforge-cloud-backend` — follow-up PR.
- Out of scope (deferred): CLI `compute logs` (Phase 2), durable/searchable log store (relies on Fly's ~7-day retention for now). No Vector/NATS/new infra.

## Testing

- `backend/tests/unit/compute/fly-provider.test.ts` — host/auth scheme, RFC3339→epoch-ms, **next_token full precision**, cursor forwarding, non-2xx error. All 86 compute unit tests pass.
- Typecheck (backend + dashboard) and lint clean.
- The underlying Fly logs endpoint was verified live (deploy throwaway container → fetch logs → cursor-poll new lines → teardown) before implementation.

Design doc: `docs/superpowers/specs/2026-06-04-compute-container-logs-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds container stdout/stderr logs for compute services in the dashboard, with recent history, a Live tail toggle, and a manual Refresh. Introduces a backend `getLogs` API with per‑IP rate limiting and a 15s upstream timeout.

- **New Features**
  - Backend: adds `ComputeProvider.getLogs` and `GET /compute/services/:id/logs` (admin + project check, `limit` 1–1000 default 100, `next_token`, `computeLogsRateLimiter` 120/min/IP).
  - Fly provider: calls `https://api.fly.io/api/v1/apps/:app/logs` with `Authorization: FlyV1 <token>`, scopes via `instance=<machineId>`, forwards `limit`, normalizes timestamps to epoch ms, preserves full‑precision `next_token`, and enforces a 15s timeout.
  - Cloud provider: delegates to `GET /machines/:id/logs`; forwards `appId`, `limit`, `next_token`; returns `{ lines: [], nextToken: null }` on empty bodies.
  - Schemas: adds `computeLogLine` and `computeLogsResponse`.
  - Dashboard: adds `computeServicesApi.logs()`, `useServiceLogs` (2s polling for Live), and a `ServiceLogs` panel with a Refresh button beside Events.
  - Docs: adds a design spec and updates Vale vocabulary to include `flyctl` and `monorepo`.

- **Bug Fixes**
  - Handle string `next_token` cursors as a fallback to the raw numeric path.
  - Prevent DOM reuse during live polling with a composite React key.
  - Tests cover the logs rate limiter, provider/service delegation, limit forwarding, abort timeout, `next_token` precision, and empty‑body handling.

<sup>Written for commit 3cadab60b299f81374ff5c4eebf4a68e2c38c4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add compute container logs endpoint and dashboard Logs panel
> - Adds a `GET /compute/services/:id/logs` backend endpoint guarded by admin auth and a 120 req/min IP rate limiter, with optional `limit` (1–1000, default 100) and `next_token` pagination params.
> - Implements `getLogs` on both `FlyProvider` (fetching from `api.fly.io` with FlyV1 auth, normalized timestamps, precise cursor extraction) and `CloudComputeProvider` (proxying the control plane).
> - Adds a `ServiceLogs` panel to the compute service detail page in the dashboard, with a Live toggle that re-polls every 2s and a manual Refresh button.
> - Shared log schemas (`computeLogLineSchema`, `computeLogsResponseSchema`) are added to `packages/shared-schemas` to ensure a stable response shape across frontend and backend.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cadab6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service logs viewer in the service details panel with play/pause live tailing, refresh, ISO-like timestamp fallback, and cursor-based pagination.
  * Backend endpoint to fetch per-service container logs with pagination support and safe handling of large cursors.
  * Provider support for fetching logs from cloud and Fly backends.

* **Tests**
  * Unit tests covering log retrieval, normalization, pagination, rate-limiting, and error handling.

* **Documentation**
  * Design spec describing compute container logs, auth, and dashboard behavior.

* **Chores**
  * Rate limiter added to the logs endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->