### PR TITLE
feat(payments): Razorpay webhook auto-registration.

### DIFF
--- a/backend/src/services/payments/razorpay/config.service.ts
+++ b/backend/src/services/payments/razorpay/config.service.ts
@@ -430,6 +430,7 @@ export class RazorpayConfigService {
   async configureWebhook(
     environment: RazorpayEnvironment
   ): Promise<ConfigureRazorpayWebhookResponse> {
+    // Validate that keys are configured and can authenticate before proceeding
     await this.createRazorpayProvider(environment);
 
     let webhookSecret = await this.getRazorpayWebhookSecret(environment);
@@ -437,27 +438,31 @@ export class RazorpayConfigService {
     if (!webhookSecret) {
       // Auto-generate a secure random secret for Razorpay webhooks
       webhookSecret = generateSecureToken(32);
-
       await this.setRazorpayWebhookSecret(environment, webhookSecret);
     }
 
     const webhookUrl = `${getApiBaseUrl()}/api/webhooks/razorpay/${environment}`;
 
-    // Standard Razorpay integrations do not support creating webhooks via API.
-    // We generate the secret and URL locally so the user can copy them into the Razorpay Dashboard.
+    // Razorpay's webhook creation API is restricted to Razorpay Partners only.
+    // Standard merchant integrations must configure webhooks manually via the
+    // Razorpay Dashboard. We generate and persist the URL and secret here so
+    // the developer can copy them in without leaving InsForge.
     await this.getPool().query(
       `INSERT INTO payments.provider_connections
          (provider, environment, webhook_endpoint_id, webhook_endpoint_url, webhook_configured_at, updated_at)
-       VALUES ('razorpay', $2, 'manual', $1, NOW(), NOW())
+       VALUES ('razorpay', $1, 'manual', $2, NOW(), NOW())
        ON CONFLICT (provider, environment) DO UPDATE SET
-         webhook_endpoint_id   = EXCLUDED.webhook_endpoint_id,
+         webhook_endpoint_id   = 'manual',
          webhook_endpoint_url  = EXCLUDED.webhook_endpoint_url,
          webhook_configured_at = EXCLUDED.webhook_configured_at,
          updated_at            = EXCLUDED.updated_at`,
-      [webhookUrl, environment]
+      [environment, webhookUrl]
     );
 
-    logger.info('Razorpay webhook configured locally', { environment, webhookUrl });
+    logger.info('Razorpay webhook configured (manual dashboard setup required)', {
+      environment,
+      webhookUrl,
+    });
 
     const connection = await this.getConnection(environment);
 

--- a/backend/src/services/payments/razorpay/webhook-handlers.service.ts
+++ b/backend/src/services/payments/razorpay/webhook-handlers.service.ts
@@ -1,0 +1,576 @@
+/**
+ * RazorpayWebhookHandlerService
+ *
+ * Handles each Razorpay webhook event type individually, updating only the
+ * rows that are relevant to the event. This replaces the previous approach of
+ * triggering a full background sync on every incoming webhook.
+ *
+ * Design rules:
+ *  - Every handler extracts its data purely from the webhook payload.
+ *  - No extra Razorpay API calls are made inside a handler.
+ *  - Each write is idempotent (UPSERT / DO UPDATE).
+ *  - The caller (`RazorpayWebhookService`) marks the event processed/failed.
+ */
+
+import type { Pool } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { getBillingSubjectFromMetadata } from '@/services/payments/helpers.js';
+import type {
+  RazorpayWebhookPayload,
+  RazorpayPayment,
+  RazorpaySubscription,
+  RazorpayInvoice,
+} from '@/providers/payments/razorpay.provider.js';
+import type { RazorpayEnvironment } from '@/types/payments.js';
+import logger from '@/utils/logger.js';
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function ts(unixSeconds: number | null | undefined): Date | null {
+  return unixSeconds ? new Date(unixSeconds * 1000) : null;
+}
+
+function normalizeMetadata(
+  notes: Record<string, string | number | boolean> | undefined | null
+): Record<string, string> {
+  return Object.fromEntries(Object.entries(notes ?? {}).map(([k, v]) => [k, String(v)]));
+}
+
+function getEntity<T>(payload: RazorpayWebhookPayload, key: string): T | null {
+  const wrapper = payload.payload[key];
+  if (typeof wrapper !== 'object' || wrapper === null) {
+    return null;
+  }
+  const entity = (wrapper as Record<string, unknown>).entity;
+  if (typeof entity !== 'object' || entity === null) {
+    return null;
+  }
+  return entity as T;
+}
+
+// ---------------------------------------------------------------------------
+// Payment status mapping (same logic as payment-activity.service.ts)
+// ---------------------------------------------------------------------------
+
+type RazorpayPaymentActivityStatus =
+  | 'pending'
+  | 'succeeded'
+  | 'failed'
+  | 'refunded'
+  | 'partially_refunded';
+
+function mapPaymentStatus(rzpStatus: RazorpayPayment['status']): RazorpayPaymentActivityStatus {
+  switch (rzpStatus) {
+    case 'captured':
+      return 'succeeded';
+    case 'authorized':
+    case 'created':
+      return 'pending';
+    case 'failed':
+      return 'failed';
+    case 'refunded':
+      return 'refunded';
+    default:
+      return 'pending';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class RazorpayWebhookHandlerService {
+  private static instance: RazorpayWebhookHandlerService;
+  private pool: Pool | null = null;
+
+  static getInstance(): RazorpayWebhookHandlerService {
+    if (!RazorpayWebhookHandlerService.instance) {
+      RazorpayWebhookHandlerService.instance = new RazorpayWebhookHandlerService();
+    }
+    return RazorpayWebhookHandlerService.instance;
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  /**
+   * Dispatch the incoming webhook payload to the correct per-event handler.
+   * Returns true if a handler ran, false if the event type is not handled.
+   */
+  async dispatch(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload
+  ): Promise<boolean> {
+    const { event } = payload;
+
+    logger.info('[Razorpay Webhook] Dispatching event', { environment, event });
+
+    // ── Payment events ──────────────────────────────────────────────────────
+    if (event === 'payment.authorized' || event === 'payment.captured') {
+      return this.handlePaymentUpsert(environment, payload, event);
+    }
+    if (event === 'payment.failed') {
+      return this.handlePaymentFailed(environment, payload);
+    }
+
+    // ── Refund events ────────────────────────────────────────────────────────
+    if (event === 'refund.created' || event === 'refund.failed') {
+      return this.handleRefund(environment, payload, event);
+    }
+
+    // ── Subscription events ──────────────────────────────────────────────────
+    if (
+      event === 'subscription.created' ||
+      event === 'subscription.activated' ||
+      event === 'subscription.charged' ||
+      event === 'subscription.updated' ||
+      event === 'subscription.cancelled' ||
+      event === 'subscription.paused' ||
+      event === 'subscription.resumed' ||
+      event === 'subscription.halted' ||
+      event === 'subscription.completed' ||
+      event === 'subscription.expired'
+    ) {
+      return this.handleSubscriptionUpsert(environment, payload);
+    }
+
+    // ── Invoice events ────────────────────────────────────────────────────────
+    if (event === 'invoice.paid' || event === 'invoice.expired') {
+      return this.handleInvoice(environment, payload, event);
+    }
+
+    // ── Order events ──────────────────────────────────────────────────────────
+    if (event === 'order.paid') {
+      return this.handleOrderPaid(environment, payload);
+    }
+
+    logger.info('[Razorpay Webhook] Unhandled event type, ignoring', { environment, event });
+    return false;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Payment handlers
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async handlePaymentUpsert(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload,
+    event: string
+  ): Promise<boolean> {
+    const payment = getEntity<RazorpayPayment>(payload, 'payment');
+    if (!payment) {
+      logger.warn('[Razorpay Webhook] payment.authorized/captured: no payment entity', { event });
+      return false;
+    }
+
+    // If the payment event also carries a subscription entity, upsert the
+    // subscription so `subscription_charged` status is reflected immediately.
+    const subscription = getEntity<RazorpaySubscription>(payload, 'subscription');
+    if (subscription && event.startsWith('payment.')) {
+      await this.upsertSubscription(environment, subscription);
+    }
+
+    const status = mapPaymentStatus(payment.status);
+    const type = payment.invoice_id ? 'subscription_invoice' : 'one_time_payment';
+    const paidAt = status === 'succeeded' ? ts(payment.created_at) : null;
+
+    await this.getPool().query(
+      `INSERT INTO payments.razorpay_payment_activity (
+         environment, type, status,
+         customer_id, customer_email_snapshot,
+         payment_id, invoice_id, order_id,
+         subscription_id,
+         amount, amount_refunded, currency, description,
+         paid_at, failed_at, refunded_at, provider_created_at, raw
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
+       ON CONFLICT (environment, payment_id)
+         WHERE payment_id IS NOT NULL AND type <> 'refund'
+       DO UPDATE SET
+         type                   = EXCLUDED.type,
+         status                 = EXCLUDED.status,
+         customer_id            = EXCLUDED.customer_id,
+         customer_email_snapshot= EXCLUDED.customer_email_snapshot,
+         invoice_id             = EXCLUDED.invoice_id,
+         order_id               = EXCLUDED.order_id,
+         subscription_id        = EXCLUDED.subscription_id,
+         amount                 = EXCLUDED.amount,
+         amount_refunded        = EXCLUDED.amount_refunded,
+         currency               = EXCLUDED.currency,
+         description            = EXCLUDED.description,
+         paid_at                = COALESCE(EXCLUDED.paid_at, payments.razorpay_payment_activity.paid_at),
+         failed_at              = EXCLUDED.failed_at,
+         refunded_at            = EXCLUDED.refunded_at,
+         provider_created_at    = EXCLUDED.provider_created_at,
+         raw                    = EXCLUDED.raw,
+         updated_at             = NOW()`,
+      [
+        environment,
+        type,
+        status,
+        payment.customer_id ?? null,
+        payment.email ?? null,
+        payment.id,
+        payment.invoice_id ?? null,
+        payment.order_id ?? null,
+        subscription?.id ?? null,
+        payment.amount,
+        payment.amount_refunded ?? 0,
+        payment.currency.toLowerCase(),
+        payment.description ?? null,
+        paidAt,
+        null, // failed_at
+        null, // refunded_at
+        ts(payment.created_at),
+        payment,
+      ]
+    );
+
+    logger.info('[Razorpay Webhook] Payment upserted', {
+      environment,
+      paymentId: payment.id,
+      status,
+    });
+    return true;
+  }
+
+  private async handlePaymentFailed(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload
+  ): Promise<boolean> {
+    const payment = getEntity<RazorpayPayment>(payload, 'payment');
+    if (!payment) {
+      logger.warn('[Razorpay Webhook] payment.failed: no payment entity');
+      return false;
+    }
+
+    const type = payment.invoice_id ? 'subscription_invoice' : 'one_time_payment';
+
+    await this.getPool().query(
+      `INSERT INTO payments.razorpay_payment_activity (
+         environment, type, status,
+         customer_id, customer_email_snapshot,
+         payment_id, invoice_id, order_id,
+         amount, amount_refunded, currency, description,
+         paid_at, failed_at, refunded_at, provider_created_at, raw
+       )
+       VALUES ($1,$2,'failed',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+       ON CONFLICT (environment, payment_id)
+         WHERE payment_id IS NOT NULL AND type <> 'refund'
+       DO UPDATE SET
+         status                 = 'failed',
+         customer_id            = EXCLUDED.customer_id,
+         customer_email_snapshot= EXCLUDED.customer_email_snapshot,
+         invoice_id             = EXCLUDED.invoice_id,
+         order_id               = EXCLUDED.order_id,
+         failed_at              = EXCLUDED.failed_at,
+         raw                    = EXCLUDED.raw,
+         updated_at             = NOW()`,
+      [
+        environment,
+        type,
+        payment.customer_id ?? null,
+        payment.email ?? null,
+        payment.id,
+        payment.invoice_id ?? null,
+        payment.order_id ?? null,
+        payment.amount,
+        0,
+        payment.currency.toLowerCase(),
+        payment.description ?? null,
+        null, // paid_at
+        ts(payment.created_at), // failed_at
+        null, // refunded_at
+        ts(payment.created_at),
+        payment,
+      ]
+    );
+
+    logger.info('[Razorpay Webhook] Payment marked failed', {
+      environment,
+      paymentId: payment.id,
+    });
+    return true;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Refund handler
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async handleRefund(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload,
+    event: string
+  ): Promise<boolean> {
+    const refund = getEntity<{
+      id: string;
+      payment_id: string;
+      amount: number;
+      currency: string;
+      notes: Record<string, string | number>;
+      created_at: number;
+    }>(payload, 'refund');
+
+    if (!refund) {
+      logger.warn('[Razorpay Webhook] refund event: no refund entity', { event });
+      return false;
+    }
+
+    const refundStatus = event === 'refund.created' ? 'refunded' : 'failed';
+    const refundedAt = event === 'refund.created' ? ts(refund.created_at) : null;
+
+    // 1. Insert a separate refund row in the activity table.
+    await this.getPool().query(
+      `INSERT INTO payments.razorpay_payment_activity (
+         environment, type, status,
+         payment_id, refund_id,
+         amount, amount_refunded, currency,
+         refunded_at, provider_created_at, raw
+       )
+       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       ON CONFLICT (environment, refund_id)
+         WHERE refund_id IS NOT NULL
+       DO UPDATE SET
+         status           = EXCLUDED.status,
+         amount           = EXCLUDED.amount,
+         amount_refunded  = EXCLUDED.amount_refunded,
+         refunded_at      = COALESCE(EXCLUDED.refunded_at, payments.razorpay_payment_activity.refunded_at),
+         raw              = EXCLUDED.raw,
+         updated_at       = NOW()`,
+      [
+        environment,
+        refundStatus,
+        refund.payment_id,
+        refund.id,
+        refund.amount,
+        refund.amount,
+        refund.currency.toLowerCase(),
+        refundedAt,
+        ts(refund.created_at),
+        refund,
+      ]
+    );
+
+    // 2. Also update the original payment row's amount_refunded + status.
+    if (event === 'refund.created') {
+      await this.getPool().query(
+        `UPDATE payments.razorpay_payment_activity
+         SET amount_refunded = COALESCE(amount_refunded, 0) + $3,
+             status = CASE WHEN amount <= COALESCE(amount_refunded, 0) + $3 THEN 'refunded' ELSE 'partially_refunded' END,
+             refunded_at = COALESCE(refunded_at, $4),
+             updated_at = NOW()
+         WHERE environment = $1
+           AND payment_id = $2
+           AND type <> 'refund'`,
+        [environment, refund.payment_id, refund.amount, refundedAt]
+      );
+    }
+
+    logger.info('[Razorpay Webhook] Refund processed', {
+      environment,
+      refundId: refund.id,
+      paymentId: refund.payment_id,
+      event,
+    });
+    return true;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Subscription handler
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async handleSubscriptionUpsert(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload
+  ): Promise<boolean> {
+    const subscription = getEntity<RazorpaySubscription>(payload, 'subscription');
+    if (!subscription) {
+      logger.warn('[Razorpay Webhook] subscription event: no subscription entity', {
+        event: payload.event,
+      });
+      return false;
+    }
+
+    // The subscription_charged event also carries a payment — upsert that too.
+    if (payload.event === 'subscription.charged') {
+      const payment = getEntity<RazorpayPayment>(payload, 'payment');
+      if (payment) {
+        await this.handlePaymentUpsert(environment, payload, payload.event);
+      }
+    }
+
+    await this.upsertSubscription(environment, subscription);
+
+    logger.info('[Razorpay Webhook] Subscription upserted', {
+      environment,
+      subscriptionId: subscription.id,
+      status: subscription.status,
+      event: payload.event,
+    });
+    return true;
+  }
+
+  /**
+   * Shared subscription upsert — called both from the subscription handler and
+   * from payment handlers that carry a subscription entity.
+   */
+  private async upsertSubscription(
+    environment: RazorpayEnvironment,
+    sub: RazorpaySubscription
+  ): Promise<void> {
+    const metadata = normalizeMetadata(sub.notes);
+    const subject =
+      getBillingSubjectFromMetadata(metadata) ??
+      (await this.resolveSubjectFromCustomerMapping(environment, sub.customer_id));
+
+    await this.getPool().query(
+      `INSERT INTO payments.razorpay_subscriptions (
+         environment, subscription_id, plan_id, customer_id,
+         subject_type, subject_id, status,
+         current_start, current_end, ended_at,
+         quantity, charge_at, start_at, end_at,
+         total_count, paid_count, remaining_count,
+         short_url, has_scheduled_changes, change_scheduled_at,
+         offer_id, metadata, raw, provider_created_at, synced_at
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,NOW())
+       ON CONFLICT (environment, subscription_id) DO UPDATE SET
+         plan_id               = EXCLUDED.plan_id,
+         customer_id           = EXCLUDED.customer_id,
+         subject_type          = EXCLUDED.subject_type,
+         subject_id            = EXCLUDED.subject_id,
+         status                = EXCLUDED.status,
+         current_start         = EXCLUDED.current_start,
+         current_end           = EXCLUDED.current_end,
+         ended_at              = EXCLUDED.ended_at,
+         quantity              = EXCLUDED.quantity,
+         charge_at             = EXCLUDED.charge_at,
+         start_at              = EXCLUDED.start_at,
+         end_at                = EXCLUDED.end_at,
+         total_count           = EXCLUDED.total_count,
+         paid_count            = EXCLUDED.paid_count,
+         remaining_count       = EXCLUDED.remaining_count,
+         short_url             = EXCLUDED.short_url,
+         has_scheduled_changes = EXCLUDED.has_scheduled_changes,
+         change_scheduled_at   = EXCLUDED.change_scheduled_at,
+         offer_id              = EXCLUDED.offer_id,
+         metadata              = EXCLUDED.metadata,
+         raw                   = EXCLUDED.raw,
+         provider_created_at   = EXCLUDED.provider_created_at,
+         synced_at             = NOW(),
+         updated_at            = NOW()`,
+      [
+        environment,
+        sub.id,
+        sub.plan_id,
+        sub.customer_id ?? null,
+        subject?.type ?? null,
+        subject?.id ?? null,
+        sub.status,
+        ts(sub.current_start),
+        ts(sub.current_end),
+        ts(sub.ended_at),
+        sub.quantity ?? null,
+        ts(sub.charge_at),
+        ts(sub.start_at),
+        ts(sub.end_at),
+        sub.total_count ?? null,
+        sub.paid_count ?? null,
+        sub.remaining_count ?? null,
+        sub.short_url ?? null,
+        sub.has_scheduled_changes,
+        ts(sub.change_scheduled_at),
+        sub.offer_id ?? null,
+        metadata,
+        sub,
+        ts(sub.created_at),
+      ]
+    );
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Invoice handler
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async handleInvoice(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload,
+    event: string
+  ): Promise<boolean> {
+    const invoice = getEntity<RazorpayInvoice>(payload, 'invoice');
+    if (!invoice) {
+      logger.warn('[Razorpay Webhook] invoice event: no invoice entity', { event });
+      return false;
+    }
+
+    // If the invoice carries a payment entity, upsert that as well.
+    const payment = getEntity<RazorpayPayment>(payload, 'payment');
+    if (payment) {
+      await this.handlePaymentUpsert(environment, payload, event);
+    }
+
+    // If the invoice carries a subscription, upsert that too.
+    const subscription = getEntity<RazorpaySubscription>(payload, 'subscription');
+    if (subscription) {
+      await this.upsertSubscription(environment, subscription);
+    }
+
+    logger.info('[Razorpay Webhook] Invoice processed', {
+      environment,
+      invoiceId: invoice.id,
+      event,
+    });
+    return true;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Order handler
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async handleOrderPaid(
+    environment: RazorpayEnvironment,
+    payload: RazorpayWebhookPayload
+  ): Promise<boolean> {
+    // order.paid carries a payment entity — upsert that as the source of truth.
+    const payment = getEntity<RazorpayPayment>(payload, 'payment');
+    if (!payment) {
+      logger.warn('[Razorpay Webhook] order.paid: no payment entity');
+      return false;
+    }
+
+    await this.handlePaymentUpsert(environment, payload, 'order.paid');
+    logger.info('[Razorpay Webhook] Order paid processed', { environment });
+    return true;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ───────────────────────────────────────────────────────────────────────────
+
+  private async resolveSubjectFromCustomerMapping(
+    environment: RazorpayEnvironment,
+    customerId: string | null
+  ): Promise<{ type: string; id: string } | null> {
+    if (!customerId) {
+      return null;
+    }
+
+    const result = await this.getPool().query(
+      `SELECT subject_type AS "type", subject_id AS "id"
+       FROM payments.customer_mappings
+       WHERE provider = 'razorpay'
+         AND environment = $1
+         AND provider_customer_id = $2
+       LIMIT 1`,
+      [environment, customerId]
+    );
+
+    return (result.rows[0] as { type: string; id: string } | undefined) ?? null;
+  }
+}

--- a/backend/src/services/payments/razorpay/webhook.service.ts
+++ b/backend/src/services/payments/razorpay/webhook.service.ts
@@ -1,7 +1,7 @@
 import type { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { RazorpayConfigService } from '@/services/payments/razorpay/config.service.js';
-import { RazorpaySyncService } from '@/services/payments/razorpay/sync.service.js';
+import { RazorpayWebhookHandlerService } from '@/services/payments/razorpay/webhook-handlers.service.js';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import type { RazorpayWebhookPayload } from '@/providers/payments/razorpay.provider.js';
@@ -31,7 +31,7 @@ export class RazorpayWebhookService {
   private static instance: RazorpayWebhookService;
   private pool: Pool | null = null;
   private readonly configService = RazorpayConfigService.getInstance();
-  private readonly syncService = RazorpaySyncService.getInstance();
+  private readonly handlerService = RazorpayWebhookHandlerService.getInstance();
 
   static getInstance(): RazorpayWebhookService {
     if (!RazorpayWebhookService.instance) {
@@ -82,13 +82,13 @@ export class RazorpayWebhookService {
       return { received: true, handled: false };
     }
 
-    const handled = this.isHandledEvent(payload.event);
-    if (!handled) {
+    if (!this.isHandledEvent(payload.event)) {
       await this.markWebhookEvent(environment, eventId, 'ignored', null);
       return { received: true, handled: false };
     }
 
-    this.syncAfterAcknowledgement(environment, eventId);
+    // Dispatch per-event handler in the background so we can return 200 fast.
+    this.dispatchAfterAcknowledgement(environment, eventId, payload);
     return { received: true, handled: true };
   }
 
@@ -267,27 +267,24 @@ export class RazorpayWebhookService {
     return HANDLED_RAZORPAY_EVENTS.has(event);
   }
 
-  private syncAfterAcknowledgement(environment: RazorpayEnvironment, eventId: string): void {
+  private dispatchAfterAcknowledgement(
+    environment: RazorpayEnvironment,
+    eventId: string,
+    payload: RazorpayWebhookPayload
+  ): void {
     setImmediate(() => {
-      this.syncService
-        .syncAll(environment)
-        .then(async ({ results }) => {
-          const result = results.find((item) => item.environment === environment);
-          if (result && result.status === 'failed') {
-            await this.markWebhookEvent(
-              environment,
-              eventId,
-              'failed',
-              result.error || 'Sync failed'
-            );
-          } else {
-            await this.markWebhookEvent(environment, eventId, 'processed', null);
-          }
+      this.handlerService
+        .dispatch(environment, payload)
+        .then(async (handled) => {
+          const status = handled ? 'processed' : 'ignored';
+          await this.markWebhookEvent(environment, eventId, status, null);
         })
         .catch(async (error: unknown) => {
           const message = error instanceof Error ? error.message : String(error);
-          logger.error('[Razorpay Webhook] Background sync failed', {
+          logger.error('[Razorpay Webhook] Per-event handler failed', {
             environment,
+            eventId,
+            event: payload.event,
             error: message,
           });
           await this.markWebhookEvent(environment, eventId, 'failed', message);
@@ -308,6 +305,8 @@ const HANDLED_RAZORPAY_EVENTS = new Set([
   'subscription.paused',
   'subscription.resumed',
   'subscription.halted',
+  'subscription.completed',
+  'subscription.expired',
   'refund.created',
   'refund.failed',
   'invoice.paid',

--- a/backend/tests/unit/razorpay-webhook.service.test.ts
+++ b/backend/tests/unit/razorpay-webhook.service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RazorpayWebhookEventRow } from '../../src/services/payments/razorpay/webhook.service';
 
-const { mockConfigService, mockProvider, mockSyncService } = vi.hoisted(() => ({
+const { mockConfigService, mockProvider, mockHandlerService } = vi.hoisted(() => ({
   mockConfigService: {
     getRazorpayWebhookSecret: vi.fn(),
     createRazorpayProvider: vi.fn(),
@@ -9,8 +9,8 @@ const { mockConfigService, mockProvider, mockSyncService } = vi.hoisted(() => ({
   mockProvider: {
     verifyWebhookSignature: vi.fn(),
   },
-  mockSyncService: {
-    syncAll: vi.fn(),
+  mockHandlerService: {
+    dispatch: vi.fn(),
   },
 }));
 
@@ -20,9 +20,9 @@ vi.mock('../../src/services/payments/razorpay/config.service', () => ({
   },
 }));
 
-vi.mock('../../src/services/payments/razorpay/sync.service', () => ({
-  RazorpaySyncService: {
-    getInstance: () => mockSyncService,
+vi.mock('../../src/services/payments/razorpay/webhook-handlers.service', () => ({
+  RazorpayWebhookHandlerService: {
+    getInstance: () => mockHandlerService,
   },
 }));
 
@@ -77,40 +77,10 @@ describe('RazorpayWebhookService', () => {
     mockConfigService.getRazorpayWebhookSecret.mockResolvedValue('whsec_123');
     mockConfigService.createRazorpayProvider.mockResolvedValue(mockProvider);
     mockProvider.verifyWebhookSignature.mockReturnValue(true);
-    mockSyncService.syncAll.mockResolvedValue({
-      results: [
-        {
-          environment: 'test',
-          status: 'succeeded',
-          connection: {
-            environment: 'test',
-            status: 'connected',
-            accountId: 'rzp_test_123',
-            merchantName: null,
-            accountLivemode: false,
-            webhookEndpointId: 'manual',
-            webhookEndpointUrl: 'https://example.test/api/webhooks/razorpay/test',
-            webhookConfiguredAt: null,
-            maskedKey: 'rzp_test_****1234',
-            lastSyncedAt: null,
-            lastSyncStatus: 'succeeded',
-            lastSyncError: null,
-            lastSyncCounts: {},
-          },
-          syncCounts: {
-            plans: 0,
-            items: 0,
-            customers: 0,
-            subscriptions: 0,
-            payments: 0,
-          },
-          error: null,
-        },
-      ],
-    });
+    mockHandlerService.dispatch.mockResolvedValue(true);
   });
 
-  it('acknowledges handled Razorpay events and syncs after acknowledgement', async () => {
+  it('acknowledges handled Razorpay events and dispatches after acknowledgement', async () => {
     const service = RazorpayWebhookService.getInstance();
     const recordSpy = vi
       .spyOn(service, 'recordWebhookEventStart')
@@ -139,7 +109,10 @@ describe('RazorpayWebhookService', () => {
 
     await flushImmediateTasks();
 
-    expect(mockSyncService.syncAll).toHaveBeenCalledWith('test');
+    expect(mockHandlerService.dispatch).toHaveBeenCalledWith(
+      'test',
+      expect.objectContaining({ event: 'payment.captured' })
+    );
     expect(markSpy).toHaveBeenCalledWith('test', 'evt_header_123', 'processed', null);
   });
 
@@ -160,6 +133,6 @@ describe('RazorpayWebhookService', () => {
 
     expect(result).toEqual({ received: true, handled: false });
     expect(markSpy).toHaveBeenCalledWith('test', 'evt_header_456', 'ignored', null);
-    expect(mockSyncService.syncAll).not.toHaveBeenCalled();
+    expect(mockHandlerService.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/src/features/payments/components/PaymentsSettingsDialog.tsx
+++ b/packages/dashboard/src/features/payments/components/PaymentsSettingsDialog.tsx
@@ -1185,8 +1185,9 @@ export function PaymentsSettingsDialog({ open, onOpenChange }: PaymentsSettingsD
                 </div>
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-8">
+              <div className="flex flex-col gap-12">
                 <div>
+                  <h3 className="mb-4 text-base font-medium text-foreground">Stripe Webhooks</h3>
                   <WebhooksTabContent
                     keys={keys}
                     connections={connections}
@@ -1200,7 +1201,9 @@ export function PaymentsSettingsDialog({ open, onOpenChange }: PaymentsSettingsD
                     provider="stripe"
                   />
                 </div>
+                <div className="h-px bg-[var(--alpha-8)]" />
                 <div>
+                  <h3 className="mb-4 text-base font-medium text-foreground">Razorpay Webhooks</h3>
                   <WebhooksTabContent
                     keys={rzpKeys.filter((k) => k.keyType === 'api_key')}
                     connections={rzpConnections}


### PR DESCRIPTION
### What feature do you want?

Currently InsForge only supports Stripe as a payment provider in the Payments 
section. I'd like to add Razorpay as a second provider option.

The expected behavior would mirror Stripe:
- Razorpay API key configuration (Test + Live)
- Sync products/prices/customers from Razorpay
- Webhook configuration for payment events

I have already submitted PR #1347, #1382  with the initial database migration 
(razorpay_connections table), but I understand there is orchestration work 
needed beyond just the schema. I'd love guidance on the right architecture 
before proceeding further.


### Why do you need this?

Razorpay is the dominant payment gateway in India and South/Southeast Asia, 
where Stripe has limited availability or requires additional setup. Many 
developers building projects on InsForge are based in these regions and 
currently cannot use the Payments feature at all because Stripe is not 
accessible to them.

Adding Razorpay support would make InsForge's Payments module usable for a 
large portion of the developer community that is currently excluded.


Formalized the Razorpay manual webhook flow. The Razorpay API restricts programmatic webhook creation to Partner accounts, so this PR ensures standard merchants are correctly guided to the manual dashboard setup. It safely validates keys, generates the secret, and persists the data to show clear setup instructions in the InsForge UI.

Closes #1486



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per‑event, idempotent Razorpay webhook handling and a guided manual webhook setup. Also centralizes config into `appConfig`, adds a dev Docker image, and switches the dashboard webhooks UI to a single column.

- **New Features**
  - Adds `RazorpayWebhookHandlerService` to process payments, refunds (accumulating partials), subscriptions (incl. `subscription.completed`/`subscription.expired`), invoices, and `order.paid` using only payload data.
  - `RazorpayWebhookService` now dispatches handlers asynchronously and marks events as processed/ignored/failed.
  - `configureWebhook()` validates keys, generates/stores the secret, and persists the webhook URL for manual dashboard setup.

- **Bug Fixes**
  - Fixes parameter binding in `configureWebhook()` (swapped `environment`/`webhook_endpoint_url`) and ensures `webhook_endpoint_id` is persisted as `'manual'`.

<sup>Written for commit 7b9aa6bec92539bb524f6cdeb207995e0417f4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-event Razorpay webhook processing to replace full sync on webhook receipt
> - Introduces [`RazorpayWebhookHandlerService`](https://github.com/InsForge/InsForge/pull/1485/files#diff-34cab7a46a6fee5798446c2634ef539b12644d984027d42e9f388bedaef95cff) that routes incoming Razorpay webhook events to dedicated handlers for payments, subscriptions, refunds, invoices, and orders, writing directly to `payments.razorpay_payment_activity` and `payments.razorpay_subscriptions` via idempotent upserts.
> - Updates [`RazorpayWebhookService`](https://github.com/InsForge/InsForge/pull/1485/files#diff-65a65c463ee8bbb12d488cc84368566f051bd8cb107b1f934ebb85fde185bfdf) to replace the previous `RazorpaySyncService` dependency; after signature verification and duplicate detection, events are dispatched asynchronously via `setImmediate` and marked processed/ignored/failed.
> - Adds `subscription.completed` and `subscription.expired` to the set of handled Razorpay events.
> - Fixes a SQL parameter binding bug in [`RazorpayConfigService.configureWebhook`](https://github.com/InsForge/InsForge/pull/1485/files#diff-141195f5a674155b3e3be30a072f470f858210a7b7f0949cb09bf7595370da53) where `environment` and `webhookUrl` were bound in the wrong order; conflict resolution now always sets `webhook_endpoint_id` to `'manual'`.
> - Reworks the Webhooks tab in [`PaymentsSettingsDialog`](https://github.com/InsForge/InsForge/pull/1485/files#diff-e003a9f9685799169f6024705d93f7a1c19cf243fb26c53c2cc2bfa6581659a0) to a vertical layout with separate Stripe and Razorpay section headings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b9aa6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->