### PR TITLE
added feature as per #1478 closes #1478

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -11,6 +11,7 @@ export interface AuthRequest extends Request {
     id: string;
     email: string;
     role: RoleSchema;
+    isRoot: boolean;
   };
   authenticated?: boolean;
   apiKey?: string;
@@ -60,12 +61,13 @@ export function getUserContextFromReq(req: AuthRequest): UserContext {
 // Helper function to set user on request
 function setRequestUser(
   req: AuthRequest,
-  payload: { sub: string; email: string; role: RoleSchema }
+  payload: { sub: string; email: string; role: RoleSchema; isRoot: boolean }
 ) {
   req.user = {
     id: payload.sub,
     email: payload.email,
     role: payload.role,
+    isRoot: payload.isRoot,
   };
 }
 

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -754,13 +754,7 @@ router.post('/admin/addAdmin', verifyAdmin, async (req: AuthRequest, res: Respon
 
     const result: CreateAdminSessionResponse = await authService.addAdmin(name, password, req.user.id);
 
-    // Set refresh token as httpOnly cookie + CSRF token for web clients
-    const tokenManager = TokenManager.getInstance();
-    const refreshToken = tokenManager.generateRefreshToken(result.user.id);
-    setRefreshTokenCookie(res, refreshToken);
-    const csrfToken = tokenManager.generateCsrfToken(refreshToken);
-
-    successResponse(res, { ...result, csrfToken });
+    successResponse(res, result);
 
   } catch (error) {
     next(error);

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -28,6 +28,7 @@ import {
   createUserRequestSchema,
   createSessionRequestSchema,
   createAdminSessionRequestSchema,
+  changePasswordUsingOldPasswordRequestSchema,
   refreshSessionRequestSchema,
   deleteUsersRequestSchema,
   listUsersRequestSchema,
@@ -669,7 +670,7 @@ router.post('/admin/sessions/exchange', async (req: Request, res: Response, next
 });
 
 // POST /api/auth/admin/sessions - Create admin session (web only)
-router.post('/admin/sessions', (req: Request, res: Response, next: NextFunction) => {
+router.post('/admin/sessions', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const validationResult = createAdminSessionRequestSchema.safeParse(req.body);
     if (!validationResult.success) {
@@ -680,8 +681,8 @@ router.post('/admin/sessions', (req: Request, res: Response, next: NextFunction)
       );
     }
 
-    const { email, password } = validationResult.data;
-    const result: CreateAdminSessionResponse = authService.adminLogin(email, password);
+    const { name, password } = validationResult.data;
+    const result: CreateAdminSessionResponse = await authService.adminLogin(name, password);
 
     // Set refresh token as httpOnly cookie + CSRF token for web clients
     const tokenManager = TokenManager.getInstance();
@@ -694,6 +695,19 @@ router.post('/admin/sessions', (req: Request, res: Response, next: NextFunction)
     next(error);
   }
 });
+
+//GET admin Session
+router.get('/admin/sessions/current', verifyToken, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user) {
+      throw new AppError('User not authenticated', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS);
+    }
+    const result: boolean = req.user.isRoot
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
+  }
+})
 
 // GET /api/auth/sessions/current - Get current session user
 router.get(
@@ -720,6 +734,96 @@ router.get(
     }
   }
 );
+
+//POST /admin/addAdmin
+router.post('/admin/addAdmin', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user?.isRoot) {
+      throw new AppError('Forbidden: Only root admin can add other admins', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+    const validationResult = createAdminSessionRequestSchema.safeParse(req.body);
+    if (!validationResult.success) {
+      throw new AppError(
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    const { name, password } = validationResult.data;
+
+    const result: CreateAdminSessionResponse = await authService.addAdmin(name, password, req.user.id);
+
+    // Set refresh token as httpOnly cookie + CSRF token for web clients
+    const tokenManager = TokenManager.getInstance();
+    const refreshToken = tokenManager.generateRefreshToken(result.user.id);
+    setRefreshTokenCookie(res, refreshToken);
+    const csrfToken = tokenManager.generateCsrfToken(refreshToken);
+
+    successResponse(res, { ...result, csrfToken });
+
+  } catch (error) {
+    next(error);
+  }
+});
+
+//change Password using old password
+router.put("/admin/resetPassword", verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const valiDateSchema = changePasswordUsingOldPasswordRequestSchema.safeParse(req.body);
+    if (!valiDateSchema.success) {
+      throw new AppError(
+        valiDateSchema.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+    const { oldPassword, newPassword } = req.body;
+
+    if (!req.user) {
+      throw new AppError('User not authenticated', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS);
+    }
+    const result: ResetPasswordResponse = await authService.resetPasswordUsingOldPassword(
+      newPassword,
+      oldPassword,
+      req.user.id
+    );
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
+  }
+})
+
+//GET all admins to show
+router.get("/admin/allAdmins", verifyAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result: ListUsersResponse = await authService.getAllAdmins();
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
+  }
+})
+
+router.delete("/admin/deleteAdmin", verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    if (!req.user?.isRoot) {
+      throw new AppError('Forbidden: Only root admin can delete other admins', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+    const validationResult = userIdSchema.safeParse(req.body.id);
+    if (!validationResult.success) {
+      throw new AppError(
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+    const adminId = validationResult.data;
+    await authService.deleteSubAdmin(adminId);
+    successResponse(res, {});
+  } catch (error) {
+    next(error);
+  }
+})
 
 // GET /api/auth/users - List all users (admin only)
 router.get('/users', verifyAdmin, async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -643,7 +643,7 @@ router.post('/admin/sessions/exchange', async (req: Request, res: Response, next
     }
 
     const { code } = validationResult.data;
-    const result: CreateAdminSessionResponse =
+    const result: CreateSessionResponse =
       await authService.adminLoginWithAuthorizationCode(code);
 
     // Set refresh token as httpOnly cookie + CSRF token for web clients
@@ -681,8 +681,8 @@ router.post('/admin/sessions', async (req: Request, res: Response, next: NextFun
       );
     }
 
-    const { name, password } = validationResult.data;
-    const result: CreateAdminSessionResponse = await authService.adminLogin(name, password);
+    const { username, password } = validationResult.data;
+    const result: CreateAdminSessionResponse = await authService.adminLogin(username, password);
 
     // Set refresh token as httpOnly cookie + CSRF token for web clients
     const tokenManager = TokenManager.getInstance();
@@ -750,9 +750,9 @@ router.post('/admin/addAdmin', verifyAdmin, async (req: AuthRequest, res: Respon
       );
     }
 
-    const { name, password } = validationResult.data;
+    const { username, password } = validationResult.data;
 
-    const result: CreateAdminSessionResponse = await authService.addAdmin(name, password, req.user.id);
+    const result: CreateAdminSessionResponse = await authService.addAdmin(username, password, req.user.id);
 
     successResponse(res, result);
 

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -702,7 +702,7 @@ router.get('/admin/sessions/current', verifyToken, async (req: AuthRequest, res:
     if (!req.user) {
       throw new AppError('User not authenticated', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS);
     }
-    const result: boolean = req.user.isRoot
+    const result: boolean = req.user.isRoot;
     successResponse(res, result);
   } catch (error) {
     next(error);
@@ -772,7 +772,7 @@ router.put("/admin/resetPassword", verifyAdmin, async (req: AuthRequest, res: Re
         ERROR_CODES.INVALID_INPUT
       );
     }
-    const { oldPassword, newPassword } = req.body;
+    const { oldPassword, newPassword } = valiDateSchema.data;
 
     if (!req.user) {
       throw new AppError('User not authenticated', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS);
@@ -791,7 +791,7 @@ router.put("/admin/resetPassword", verifyAdmin, async (req: AuthRequest, res: Re
 //GET all admins to show
 router.get("/admin/allAdmins", verifyAdmin, async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const result: ListUsersResponse = await authService.getAllAdmins();
+    const result = await authService.getAllAdmins();
     successResponse(res, result);
   } catch (error) {
     next(error);

--- a/backend/src/infra/database/migrations/044_create-project-admins.sql
+++ b/backend/src/infra/database/migrations/044_create-project-admins.sql
@@ -1,0 +1,25 @@
+-- Migration: 044 - Create project admins table
+--
+-- Replaces the single env-backed admin credential (ADMIN_EMAIL / ADMIN_PASSWORD)
+-- with a database-backed auth.project_admins table. The root admin is identified
+-- by username matching the ROOT_ADMIN_USERNAME env var at runtime - no explicit
+-- column needed. Non-root admins can change their own password only root can
+-- create or delete other admins.
+
+CREATE TABLE IF NOT EXISTS auth.project_admins (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  username       TEXT        NOT NULL UNIQUE,
+  password_hash  TEXT        NOT NULL,
+  created_by     UUID        REFERENCES auth.project_admins(id) ON DELETE SET NULL,
+  last_login_at  TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_admins_username
+  ON auth.project_admins (username);
+
+DROP TRIGGER IF EXISTS update_project_admins_updated_at ON auth.project_admins;
+CREATE TRIGGER update_project_admins_updated_at
+  BEFORE UPDATE ON auth.project_admins
+  FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -139,6 +139,7 @@ export class TokenManager {
       return {
         sub: decoded.sub,
         email: decoded.email,
+        username: decoded.username,
         role: decoded.role || 'authenticated',
         isRoot: decoded.isRoot || false
       };

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -140,6 +140,7 @@ export class TokenManager {
         sub: decoded.sub,
         email: decoded.email,
         role: decoded.role || 'authenticated',
+        isRoot: decoded.isRoot || false
       };
     } catch {
       throw new AppError('Invalid token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -672,7 +672,7 @@ export class AuthService {
       }
 
       const hashedPassword = result.rows[0].password_hash;
-      if (!bcrypt.compareSync(oldPassword, hashedPassword)) {
+      if (!await bcrypt.compare(oldPassword, hashedPassword)) {
         throw new AppError('Invalid old password', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
       }
 
@@ -778,7 +778,7 @@ export class AuthService {
       }
       const admin = result.rows[0];
       logger.info('Admin found', { adminId: admin.id, username: admin.username });
-      if (!bcrypt.compareSync(password, admin.password_hash)) {
+      if (!await bcrypt.compare(password, admin.password_hash)) {
         throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
       }
       const isRoot = admin.username === process.env.ROOT_ADMIN_USERNAME;

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -14,6 +14,7 @@ import type {
   AuthMetadataSchema,
   OAuthProvidersSchema,
   GetPublicAuthConfigResponse,
+  ListUsersResponse,
 } from '@insforge/shared-schemas';
 import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import { CustomOAuthConfigService } from '@/services/auth/custom-oauth-config.service.js';
@@ -54,7 +55,7 @@ import { getApiBaseUrl } from '@/utils/environment.js';
  */
 export class AuthService {
   private static instance: AuthService;
-  private adminEmail: string;
+  private adminName: string;
   private adminPassword: string;
   private pool: Pool | null = null;
   private tokenManager: TokenManager;
@@ -70,11 +71,11 @@ export class AuthService {
   private appleOAuthProvider: AppleOAuthProvider;
 
   private constructor() {
-    this.adminEmail = process.env.ADMIN_EMAIL ?? '';
-    this.adminPassword = process.env.ADMIN_PASSWORD ?? '';
+    this.adminName = process.env.ROOT_ADMIN_USERNAME || process.env.ADMIN_EMAIL?.split('@')[0] || '';
+    this.adminPassword = process.env.ROOT_ADMIN_PASSWORD || process.env.ADMIN_PASSWORD || '';
 
-    if (!this.adminEmail || !this.adminPassword) {
-      throw new Error('ADMIN_EMAIL and ADMIN_PASSWORD environment variables are required');
+    if (!this.adminName || !this.adminPassword) {
+      throw new Error('ROOT_ADMIN_USERNAME or ROOT_ADMIN_PASSWORD environment variables are required');
     }
 
     // Initialize token manager
@@ -651,36 +652,158 @@ export class AuthService {
     }
   }
 
+  //reset password using old password (only available for project admin)
+  async resetPasswordUsingOldPassword(newPassword: string, oldPassword: string, userId: string): Promise<ResetPasswordResponse> {
+    const dbManager = DatabaseManager.getInstance();
+    const pool = dbManager.getPool();
+    const client = await pool.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      // Verify old password
+      const result = await client.query(
+        `SELECT password_hash FROM auth.project_admins WHERE id = $1`,
+        [userId]
+      );
+
+      if (result.rows.length === 0) {
+        throw new Error('User not found');
+      }
+
+      const hashedPassword = result.rows[0].password_hash;
+      if (!bcrypt.compareSync(oldPassword, hashedPassword)) {
+        throw new AppError('Invalid old password', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+      }
+
+      // Hash the new password
+      const newHashedPassword = await bcrypt.hash(newPassword, 10);
+
+      // Update password in the database
+      await client.query(
+        `UPDATE auth.project_admins
+         SET password_hash = $1, updated_at = NOW()
+         WHERE id = $2`,
+        [newHashedPassword, userId]
+      );
+
+      await client.query('COMMIT');
+
+      logger.info('Password reset successfully with old password', { userId });
+
+      return {
+        message: 'Password reset successfully. Please login with your new password.',
+      };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  //get all admins
+  async getAllAdmins(): Promise<ListUsersResponse> {
+    const dbManager = DatabaseManager.getInstance();
+    const pool = dbManager.getPool();
+    const result = await pool.query(`SELECT id, username, created_at, updated_at FROM auth.project_admins WHERE created_by IS NOT NULL`);
+    if (result.rows.length === 0) {
+      return [];
+    }
+    return result.rows;
+  }
+
+  //adding admin function
+  async addAdmin(name: string, password: string, createdBy: string): Promise<CreateAdminSessionResponse> {
+    const dbManager = DatabaseManager.getInstance();
+    const pool = dbManager.getPool();
+    const client = await pool.connect();
+
+    try {
+      const existted = await client.query(`select * from auth.project_admins where username=$1`, [name])
+      if (existted.rows.length > 0) {
+        throw new AppError('Admin already exists', 400, ERROR_CODES.INVALID_INPUT);
+      }
+      const hashedPassword = await bcrypt.hash(password, 10);
+      const result = await client.query(`insert into auth.project_admins (username, password_hash, created_by) values ($1, $2, $3) RETURNING *`, [name, hashedPassword, createdBy])
+      const admin = result.rows[0];
+      logger.info('Admin added', { admin });
+      return {
+        user: {
+          id: admin.id,
+          name,
+          createdAt: admin.created_at,
+          updatedAt: admin.updated_at,
+        }
+      };
+    } catch (error) {
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  //admin deleting sub admin
+  async deleteSubAdmin(adminId: string): Promise<void> {
+    const dbManager = DatabaseManager.getInstance();
+    const pool = dbManager.getPool();
+    const client = await pool.connect();
+
+    try {
+      const result = await client.query(`delete from auth.project_admins where id=$1 AND created_by is not null`, [adminId])
+      if (result.rows.length === 0) {
+        throw new Error('Admin not found');
+      }
+      logger.info('Admin deleted', { adminId });
+    } catch (error) {
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
   /**
    * Admin login (validates against env variables only)
    */
-  adminLogin(email: string, password: string): CreateAdminSessionResponse {
+  async adminLogin(name: string, password: string): Promise<CreateAdminSessionResponse> {
     // Simply validate against environment variables
-    if (email !== this.adminEmail || password !== this.adminPassword) {
-      throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+    const dbManager = DatabaseManager.getInstance();
+    const pool = dbManager.getPool();
+    const client = await pool.connect();
+
+    try {
+      const result = await client.query(`select * from auth.project_admins where username=$1`, [name])
+      if (result.rows.length === 0) {
+        throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+      }
+      const admin = result.rows[0];
+      logger.info('Admin found', { admin });
+      if (!bcrypt.compareSync(password, admin.password_hash)) {
+        throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+      }
+      const isRoot = admin.username === process.env.ROOT_ADMIN_USERNAME;
+      const accessToken = this.tokenManager.generateAccessToken({
+        sub: admin.id,
+        name,
+        role: 'project_admin',
+        isRoot
+      });
+      await client.query('update auth.project_admins set last_login_at=$1 where id=$2', [new Date(), admin.id])
+      return {
+        user: {
+          id: admin.id,
+          name,
+          createdAt: admin.created_at,
+          updatedAt: admin.updated_at,
+        },
+        accessToken,
+      };
+    } catch (error) {
+      throw error;
+    } finally {
+      client.release();
     }
 
-    // Use a fixed admin ID for the system administrator
-
-    // Return admin user with JWT token (24h expiration) - no database interaction
-    const accessToken = this.tokenManager.generateAccessToken({
-      sub: ADMIN_ID,
-      email,
-      role: 'project_admin',
-    });
-
-    return {
-      user: {
-        id: ADMIN_ID,
-        email: email,
-        emailVerified: true,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        profile: { name: 'Administrator' },
-        metadata: null,
-      },
-      accessToken,
-    };
   }
 
   /**

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -703,7 +703,7 @@ export class AuthService {
   }
 
   //get all admins
-  async getAllAdmins(): Promise<ListUsersResponse> {
+  async getAllAdmins(): Promise<any> {
     const dbManager = DatabaseManager.getInstance();
     const pool = dbManager.getPool();
     const result = await pool.query(`SELECT id, username, created_at, updated_at FROM auth.project_admins WHERE created_by IS NOT NULL`);
@@ -731,10 +731,11 @@ export class AuthService {
       return {
         user: {
           id: admin.id,
-          name,
+          username: admin.username,
           createdAt: admin.created_at,
           updatedAt: admin.updated_at,
-        }
+        },
+        accessToken: '',
       };
     } catch (error) {
       throw error;
@@ -786,7 +787,8 @@ export class AuthService {
         sub: admin.id,
         username: admin.username,
         role: 'project_admin',
-        isRoot
+        isRoot,
+        email: ''
       });
       await client.query('update auth.project_admins set last_login_at=$1 where id=$2', [new Date(), admin.id])
       return {
@@ -809,7 +811,7 @@ export class AuthService {
   /**
    * Admin login with authorization token (validates JWT from external issuer)
    */
-  async adminLoginWithAuthorizationCode(code: string): Promise<CreateAdminSessionResponse> {
+  async adminLoginWithAuthorizationCode(code: string): Promise<CreateSessionResponse> {
     try {
       // Use TokenManager to verify cloud token
       const { payload } = await this.tokenManager.verifyCloudToken(code);
@@ -1361,7 +1363,7 @@ export class AuthService {
       const now = new Date().toISOString();
       return {
         id: ADMIN_ID,
-        email: this.adminEmail,
+        email: this.adminName,
         profile: { name: 'Administrator' },
         metadata: {},
         email_verified: true,

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -751,7 +751,7 @@ export class AuthService {
 
     try {
       const result = await client.query(`delete from auth.project_admins where id=$1 AND created_by is not null`, [adminId])
-      if (result.rows.length === 0) {
+      if (result.rowCount === 0) {
         throw new Error('Admin not found');
       }
       logger.info('Admin deleted', { adminId });
@@ -784,7 +784,7 @@ export class AuthService {
       const isRoot = admin.username === process.env.ROOT_ADMIN_USERNAME;
       const accessToken = this.tokenManager.generateAccessToken({
         sub: admin.id,
-        name,
+        username: admin.username,
         role: 'project_admin',
         isRoot
       });
@@ -792,7 +792,7 @@ export class AuthService {
       return {
         user: {
           id: admin.id,
-          name,
+          username: admin.username,
           createdAt: admin.created_at,
           updatedAt: admin.updated_at,
         },

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -777,7 +777,7 @@ export class AuthService {
         throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
       }
       const admin = result.rows[0];
-      logger.info('Admin found', { admin });
+      logger.info('Admin found', { adminId: admin.id, username: admin.username });
       if (!bcrypt.compareSync(password, admin.password_hash)) {
         throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
       }

--- a/backend/src/types/error-constants.ts
+++ b/backend/src/types/error-constants.ts
@@ -81,6 +81,7 @@ export enum ERROR_CODES {
   TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
   FORBIDDEN = 'FORBIDDEN',
   RATE_LIMITED = 'RATE_LIMITED',
+  AUTH_USER_NOT_FOUND = "AUTH_USER_NOT_FOUND",
 }
 
 // Next actions - what the user should do

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -13,35 +13,34 @@ import { ADMIN_ID, ANON_ID } from '@/utils/constants.js';
 /**
  * Seeds system users (admin and anon) if they don't exist in the database
  */
-async function seedSystemUsers(adminEmail: string, adminPassword: string): Promise<void> {
+async function seedSystemUsers(adminName: string, adminPassword: string): Promise<void> {
   const dbManager = DatabaseManager.getInstance();
   const pool = dbManager.getPool();
   const client = await pool.connect();
 
   try {
     // Seed admin user
-    if (adminEmail && adminPassword) {
-      const existingAdmin = await client.query('SELECT id FROM auth.users WHERE id = $1', [
-        ADMIN_ID,
+    if (adminName && adminPassword) {
+      const existingAdmin = await client.query('SELECT id FROM auth.project_admins WHERE username = $1', [
+        adminName,
       ]);
 
       if (existingAdmin.rows.length > 0) {
-        logger.info(`✅ Admin configured: ${adminEmail}`);
+        logger.info(`✅ Admin configured: ${adminName}`);
       } else {
         const hashedPassword = await bcrypt.hash(adminPassword, 10);
-        const profile = JSON.stringify({ name: 'Administrator' });
 
         await client.query(
-          `INSERT INTO auth.users (id, email, password, profile, email_verified, is_project_admin, is_anonymous, created_at, updated_at)
-           VALUES ($1, $2, $3, $4::jsonb, true, true, false, NOW(), NOW())
+          `INSERT INTO auth.project_admins (username, password_hash, created_by, created_at, updated_at)
+           VALUES ($1, $2, NULL, NOW(), NOW())
            ON CONFLICT (id) DO NOTHING`,
-          [ADMIN_ID, adminEmail, hashedPassword, profile]
+          [adminName, hashedPassword]
         );
 
-        logger.info(`✅ Admin user seeded: ${adminEmail}`);
+        logger.info(`✅ Admin user seeded: ${adminName}`);
       }
     } else {
-      logger.warn('⚠️ Admin credentials not configured - check ADMIN_EMAIL and ADMIN_PASSWORD');
+      logger.warn('⚠️ Admin credentials not configured - check ADMIN_NAME and ADMIN_PASSWORD');
     }
 
     // Seed anon user
@@ -174,42 +173,42 @@ async function seedLocalOAuthConfigs(): Promise<void> {
       clientIdEnv: string;
       clientSecretEnv: string;
     }> = [
-      {
-        provider: 'google',
-        clientIdEnv: 'GOOGLE_CLIENT_ID',
-        clientSecretEnv: 'GOOGLE_CLIENT_SECRET',
-      },
-      {
-        provider: 'github',
-        clientIdEnv: 'GITHUB_CLIENT_ID',
-        clientSecretEnv: 'GITHUB_CLIENT_SECRET',
-      },
-      {
-        provider: 'discord',
-        clientIdEnv: 'DISCORD_CLIENT_ID',
-        clientSecretEnv: 'DISCORD_CLIENT_SECRET',
-      },
-      {
-        provider: 'linkedin',
-        clientIdEnv: 'LINKEDIN_CLIENT_ID',
-        clientSecretEnv: 'LINKEDIN_CLIENT_SECRET',
-      },
-      {
-        provider: 'microsoft',
-        clientIdEnv: 'MICROSOFT_CLIENT_ID',
-        clientSecretEnv: 'MICROSOFT_CLIENT_SECRET',
-      },
-      {
-        provider: 'x',
-        clientIdEnv: 'X_CLIENT_ID',
-        clientSecretEnv: 'X_CLIENT_SECRET',
-      },
-      {
-        provider: 'apple',
-        clientIdEnv: 'APPLE_CLIENT_ID',
-        clientSecretEnv: 'APPLE_CLIENT_SECRET',
-      },
-    ];
+        {
+          provider: 'google',
+          clientIdEnv: 'GOOGLE_CLIENT_ID',
+          clientSecretEnv: 'GOOGLE_CLIENT_SECRET',
+        },
+        {
+          provider: 'github',
+          clientIdEnv: 'GITHUB_CLIENT_ID',
+          clientSecretEnv: 'GITHUB_CLIENT_SECRET',
+        },
+        {
+          provider: 'discord',
+          clientIdEnv: 'DISCORD_CLIENT_ID',
+          clientSecretEnv: 'DISCORD_CLIENT_SECRET',
+        },
+        {
+          provider: 'linkedin',
+          clientIdEnv: 'LINKEDIN_CLIENT_ID',
+          clientSecretEnv: 'LINKEDIN_CLIENT_SECRET',
+        },
+        {
+          provider: 'microsoft',
+          clientIdEnv: 'MICROSOFT_CLIENT_ID',
+          clientSecretEnv: 'MICROSOFT_CLIENT_SECRET',
+        },
+        {
+          provider: 'x',
+          clientIdEnv: 'X_CLIENT_ID',
+          clientSecretEnv: 'X_CLIENT_SECRET',
+        },
+        {
+          provider: 'apple',
+          clientIdEnv: 'APPLE_CLIENT_ID',
+          clientSecretEnv: 'APPLE_CLIENT_SECRET',
+        },
+      ];
 
     for (const { provider, clientIdEnv, clientSecretEnv } of envMappings) {
       const clientId = process.env[clientIdEnv];
@@ -237,15 +236,14 @@ export async function seedBackend(): Promise<void> {
   const secretService = SecretService.getInstance();
 
   const dbManager = DatabaseManager.getInstance();
-
-  const adminEmail = process.env.ADMIN_EMAIL || 'admin@example.com';
-  const adminPassword = process.env.ADMIN_PASSWORD || 'change-this-password';
+  const adminName = process.env.ROOT_ADMIN_USERNAME ?? process.env.ADMIN_EMAIL?.split('@')[0] ?? 'admin@example.com';
+  const adminPassword = process.env.ROOT_ADMIN_PASSWORD ?? process.env.ADMIN_PASSWORD ?? 'change-this-password';
 
   try {
     logger.info(`\n🚀 Insforge Backend Starting...`);
 
     // Seed system users (admin and anon) if not exists
-    await seedSystemUsers(adminEmail, adminPassword);
+    await seedSystemUsers(adminName, adminPassword);
 
     // Initialize API key (from env or generate)
     const apiKey = await secretService.initializeApiKey();

--- a/backend/tests/local/test-e2e.sh
+++ b/backend/tests/local/test-e2e.sh
@@ -230,6 +230,70 @@ response=$(curl -s -w "\n%{http_code}" -X DELETE "$TEST_API_BASE/storage/buckets
   -H "Authorization: Bearer $API_KEY")
 test_endpoint "Delete file" "$response" "200"
 
+
+TEST_SUB_ADMIN_USERNAME="test_subadmin_$(date +%s)"
+TEST_SUB_ADMIN_PASSWORD="SubAdmin123!"
+SUB_ADMIN_ID=""
+
+# 15. Test Admin Login with username
+print_info "15. Testing Admin Login with username"
+response=$(curl -s -w "\n%{http_code}" -X POST "$TEST_API_BASE/auth/admin/sessions" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$TEST_ADMIN_USERNAME\",\"password\":\"$TEST_ADMIN_PASSWORD\"}")
+test_endpoint "Admin login with username" "$response" "200"
+
+# 16. Test Add Sub-Admin (root only)
+print_info "16. Testing Add Sub-Admin"
+response=$(curl -s -w "\n%{http_code}" -X POST "$TEST_API_BASE/auth/admin/addAdmin" \
+  -H "Authorization: Bearer $admin_token" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"$TEST_SUB_ADMIN_USERNAME\",\"password\":\"$TEST_SUB_ADMIN_PASSWORD\"}")
+test_endpoint "Add sub-admin" "$response" "200"
+
+# Extract sub-admin ID
+SUB_ADMIN_ID=$(echo "$response" | sed '$d' | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+echo "Sub-admin ID: $SUB_ADMIN_ID"
+
+# 17. Test Sub-Admin Login
+print_info "17. Testing Sub-Admin Login"
+response=$(curl -s -w "\n%{http_code}" -X POST "$TEST_API_BASE/auth/admin/sessions" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$TEST_SUB_ADMIN_USERNAME\",\"password\":\"$TEST_SUB_ADMIN_PASSWORD\"}")
+test_endpoint "Sub-admin login" "$response" "200"
+
+# 18. Test Sub-Admin cannot add admin (non-root)
+print_info "18. Testing Sub-Admin cannot add another admin"
+sub_admin_token=$(echo "$response" | sed '$d' | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4)
+response=$(curl -s -w "\n%{http_code}" -X POST "$TEST_API_BASE/auth/admin/addAdmin" \
+  -H "Authorization: Bearer $sub_admin_token" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"should_fail\",\"password\":\"ShouldFail123!\"}")
+test_endpoint "Non-root cannot add admin" "$response" "403"
+
+# 19. Test Change Password
+print_info "19. Testing Change Password"
+response=$(curl -s -w "\n%{http_code}" -X PUT "$TEST_API_BASE/auth/admin/resetPassword" \
+  -H "Authorization: Bearer $admin_token" \
+  -H "Content-Type: application/json" \
+  -d "{\"oldPassword\":\"$TEST_ADMIN_PASSWORD\",\"newPassword\":\"NewPassword123!\"}")
+test_endpoint "Change password" "$response" "200"
+
+# Reset password back so other tests don't break
+curl -s -X PUT "$TEST_API_BASE/auth/admin/resetPassword" \
+  -H "Authorization: Bearer $admin_token" \
+  -H "Content-Type: application/json" \
+  -d "{\"oldPassword\":\"NewPassword123!\",\"newPassword\":\"$TEST_ADMIN_PASSWORD\"}" > /dev/null
+
+# 20. Test Delete Sub-Admin (root only)
+if [ -n "$SUB_ADMIN_ID" ]; then
+    print_info "20. Testing Delete Sub-Admin"
+    response=$(curl -s -w "\n%{http_code}" -X DELETE "$TEST_API_BASE/auth/admin/deleteAdmin/$SUB_ADMIN_ID" \
+      -H "Authorization: Bearer $admin_token")
+    test_endpoint "Delete sub-admin" "$response" "200"
+else
+    print_info "20. Skipping Delete Sub-Admin - no sub-admin ID"
+fi
+
 # Clean up temp files
 rm -f /tmp/test-upload.txt
 

--- a/backend/tests/test-config.sh
+++ b/backend/tests/test-config.sh
@@ -7,8 +7,10 @@
 export TEST_API_BASE="${TEST_API_BASE:-http://localhost:7130/api}"
 
 # Admin credentials - can be overridden by environment variables
-export TEST_ADMIN_EMAIL="${TEST_ADMIN_EMAIL:-${ADMIN_EMAIL:-admin@example.com}}"
-export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}"
+
+export TEST_ADMIN_USERNAME="${TEST_ADMIN_USERNAME:-${ROOT_ADMIN_USERNAME:-admin}}"
+export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-${ROOT_ADMIN_PASSWORD:-password}}"
+export TEST_ADMIN_EMAIL="${TEST_ADMIN_EMAIL:-${TEST_ADMIN_USERNAME:-admin}}
 
 # User test credentials
 export TEST_USER_EMAIL_PREFIX="${TEST_USER_EMAIL_PREFIX:-testuser_}"
@@ -43,7 +45,7 @@ get_admin_token() {
     # Use JWT admin endpoint
     local response=$(curl -s -X POST "$TEST_API_BASE/auth/admin/sessions" \
         -H "Content-Type: application/json" \
-        -d "{\"email\":\"$TEST_ADMIN_EMAIL\",\"password\":\"$TEST_ADMIN_PASSWORD\"}")
+        -d "{\"username\":\"$TEST_ADMIN_USERNAME\",\"password\":\"$TEST_ADMIN_PASSWORD\"}")
     
     if echo "$response" | grep -q '"accessToken"'; then
             echo "$response" | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4
@@ -206,7 +208,7 @@ cleanup_test_data() {
                 local user_id=$(echo "$users_json" | grep -B2 -A2 "\"email\":\"$test_email\"" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
                 if [ -n "$user_id" ]; then
                     user_ids+=("$user_id")
-                    print_info "  - Found test user: $test_email (ID: $user_id)"
+                    echo "  - Found test user: $test_email (ID: $user_id)"
                 fi
             done
             

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - insforge-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -73,6 +73,8 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.com}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-change-this-password}
+      - ROOT_ADMIN_USERNAME=${ROOT_ADMIN_USERNAME:-admin}
+      - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-password}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # S3-specific credentials (for Wasabi, MinIO, etc. — falls back to AWS_* if not set)

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
       "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1236,6 +1237,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1644,6 +1646,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
       "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1684,7 +1687,8 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -2527,6 +2531,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5952,6 +5957,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6575,6 +6581,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -6670,6 +6677,7 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6835,6 +6843,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -7353,6 +7362,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7807,6 +7817,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8524,6 +8535,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9217,6 +9229,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9286,6 +9299,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9346,6 +9360,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11014,6 +11029,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12372,6 +12388,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -12524,6 +12541,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12668,6 +12686,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12816,6 +12835,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12838,6 +12858,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12850,6 +12871,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14205,7 +14227,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -14505,6 +14528,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14666,6 +14690,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14876,6 +14901,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15471,6 +15497,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
       "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1237,7 +1236,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1646,7 +1644,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
       "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1687,8 +1684,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -2531,7 +2527,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5957,7 +5952,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6581,7 +6575,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -6677,7 +6670,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6843,7 +6835,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -7362,7 +7353,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7817,7 +7807,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8535,7 +8524,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9229,7 +9217,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9299,7 +9286,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9360,7 +9346,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11029,7 +11014,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12388,7 +12372,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -12541,7 +12524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12686,7 +12668,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12835,7 +12816,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12858,7 +12838,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12871,7 +12850,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14227,8 +14205,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -14528,7 +14505,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -14690,7 +14666,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14901,7 +14876,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15497,7 +15471,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/dashboard/src/features/login/pages/LoginPage.tsx
+++ b/packages/dashboard/src/features/login/pages/LoginPage.tsx
@@ -32,8 +32,8 @@ export default function LoginPage() {
   const form = useForm<LoginForm>({
     resolver: zodResolver(loginFormSchema),
     defaultValues: {
-      email: 'admin@example.com',
-      password: 'change-this-password',
+      email: 'admin',
+      password: 'password',
     },
   });
 
@@ -45,7 +45,7 @@ export default function LoginPage() {
       const success = await loginWithPassword(data.email, data.password);
 
       if (!success) {
-        throw new Error('Invalid email or password');
+        throw new Error('Invalid username or password');
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'An error occurred';
@@ -87,16 +87,16 @@ export default function LoginPage() {
                   name="email"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Email</FormLabel>
+                      <FormLabel>Username</FormLabel>
                       <FormControl>
                         <div className="relative">
                           <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                           <Input
                             {...field}
-                            type="email"
-                            placeholder="admin@example.com"
+                            type="text"
+                            placeholder="admin"
                             className="pl-10"
-                            autoComplete="email"
+                            autoComplete="username"
                           />
                         </div>
                       </FormControl>

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -8,10 +8,10 @@ interface LoginResult {
 }
 
 export class LoginService {
-  async loginWithPassword(name: string, password: string): Promise<LoginResult> {
+  async loginWithPassword(username: string, password: string): Promise<LoginResult> {
     const response = await apiClient.request('/auth/admin/sessions', {
       method: 'POST',
-      body: JSON.stringify({ name, password }),
+      body: JSON.stringify({ username, password }),
       skipRefresh: true,
     });
 
@@ -33,10 +33,10 @@ export class LoginService {
     };
   }
 
-  async addAdmin(name: string, password: string): Promise<LoginResult> {
+  async addAdmin(username: string, password: string): Promise<LoginResult> {
     const response = await apiClient.request('/auth/admin/addAdmin', {
       method: 'POST',
-      body: JSON.stringify({ name, password }),
+      body: JSON.stringify({ username, password }),
       skipRefresh: true,
     });
 

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -8,10 +8,35 @@ interface LoginResult {
 }
 
 export class LoginService {
-  async loginWithPassword(email: string, password: string): Promise<LoginResult> {
+  async loginWithPassword(name: string, password: string): Promise<LoginResult> {
     const response = await apiClient.request('/auth/admin/sessions', {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ name, password }),
+      skipRefresh: true,
+    });
+
+    if (!response.user || !response.accessToken) {
+      throw new Error('Invalid login response');
+    }
+
+    apiClient.setAccessToken(response.accessToken);
+    if (response.csrfToken) {
+      apiClient.setCsrfToken(response.csrfToken);
+    } else {
+      apiClient.clearCsrfToken();
+    }
+
+    return {
+      user: response.user,
+      accessToken: response.accessToken,
+      csrfToken: response.csrfToken ?? undefined,
+    };
+  }
+
+  async addAdmin(name: string, password: string): Promise<LoginResult> {
+    const response = await apiClient.request('/auth/admin/addAdmin', {
+      method: 'POST',
+      body: JSON.stringify({ name, password }),
       skipRefresh: true,
     });
 

--- a/packages/dashboard/src/layout/AppHeader.tsx
+++ b/packages/dashboard/src/layout/AppHeader.tsx
@@ -1,13 +1,18 @@
 import { useState, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { LogOut, ChevronDown, Plug } from 'lucide-react';
+import { LogOut, ChevronDown, Plug, Plus, User, Trash } from 'lucide-react';
 import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
 } from '@insforge/ui';
+import { apiClient } from '#lib/api/client';
 import { Avatar, AvatarFallback, Separator, ThemeSelect } from '#components';
 import { cn } from '#lib/utils/utils';
 import { useTheme } from '#lib/contexts/ThemeContext';
@@ -28,8 +33,72 @@ export default function AppHeader() {
   const dashboardVariant = getFeatureFlag('dashboard-v4-experiment');
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const [isAddAdminOpen, setIsAddAdminOpen] = useState(false);
+  const [newUsername, setNewUsername] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRootAdmin, setIsRootAdmin] = useState(false);
+  const [getAllAdmins, setAllAdmins] = useState<any[]>([]);
   const isDTest = dashboardVariant === 'd_test';
+  const [setPasswordOpen, setIsSetPasswordOpen] = useState(false);
+  const [oldPassword, setOldPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const isConnectDisabled = isDTest && pathname === '/dashboard/install';
+
+  const handleAddAdmin = async () => {
+    setIsSubmitting(true);
+    try {
+      await apiClient.request('/auth/admin/addAdmin', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: newUsername,
+          password: newPassword,
+        })
+      })
+      setIsAddAdminOpen(false);
+    } catch (error) {
+      console.error('Failed to add admin', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      setIsSubmitting(true);
+      await apiClient.request(`/auth/admin/deleteAdmin`, {
+        method: 'DELETE',
+        body: JSON.stringify({
+          id,
+        })
+      })
+    } catch (error) {
+      console.error('Failed to delete admin', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const changePassword = async () => {
+    setIsSubmitting(true);
+    try {
+      if (confirmPassword !== newPassword) {
+        throw new Error('Passwords do not match');
+      }
+      await apiClient.request('/auth/admin/resetPassword', {
+        method: 'PUT',
+        body: JSON.stringify({
+          oldPassword,
+          newPassword,
+        })
+      })
+      setIsSetPasswordOpen(false);
+    } catch (error) {
+      console.error('Failed to change password', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const handleConnectClick = () => {
     if (isDTest) {
@@ -54,6 +123,19 @@ export default function AppHeader() {
         console.error('Failed to fetch GitHub stars:', err);
       });
   }, []);
+  useEffect(() => {
+    apiClient.request('/auth/admin/allAdmins', {
+      method: "GET",
+    }).then((result) => {
+      setAllAdmins(result);
+    })
+
+  }, [isSubmitting])
+  useEffect(() => {
+    apiClient.request('/auth/admin/sessions/current').then((response) => {
+      setIsRootAdmin(response);
+    })
+  }, [])
 
   const formatStars = (count: number): string => {
     if (count >= 1000) {
@@ -169,6 +251,26 @@ export default function AppHeader() {
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48" sideOffset={8} collisionPadding={16}>
+              {isRootAdmin &&
+                (<DropdownMenuItem
+                  onClick={() => { setIsAddAdminOpen(true) }}
+                  className="cursor-pointer dark:text-zinc-400"
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  <span>Add Admin</span>
+                </DropdownMenuItem>)}
+              {(getAllAdmins ?? []).map((admin: any, idx: any) => (
+                <DropdownMenuItem
+                  key={idx}
+                  className="cursor-pointer flex justify-normal dark:text-zinc-400"
+                >
+                  <User className="mr-2 h-4 w-4" />
+                  <span>{admin.username}</span>
+                  {isRootAdmin && (<div className="bg-red-400 p-1 rounded-md" onClick={() => void handleDelete(admin.id)}>
+                    <Trash className="h-4 w-4" />
+                  </div>)}
+                </DropdownMenuItem>
+              ))}
               <DropdownMenuItem
                 onClick={() => void logout()}
                 className="cursor-pointer text-red-600 dark:text-red-400"
@@ -176,8 +278,69 @@ export default function AppHeader() {
                 <LogOut className="mr-2 h-4 w-4" />
                 <span>Sign Out</span>
               </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => { setIsSetPasswordOpen(true); }}
+                className="cursor-pointer dark:text-blue-400"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                <span>change password</span>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          <Dialog open={isAddAdminOpen} onOpenChange={setIsAddAdminOpen}>
+            <DialogContent className='w-80'>
+              <DialogHeader>
+                <DialogTitle>Add Admin</DialogTitle>
+              </DialogHeader>
+              <div className="flex flex-col p-10 gap-4 text-white">
+                <input
+                  placeholder="Username"
+                  className="border-[var(--alpha-8)] border"
+                  value={newUsername}
+                  onChange={(e) => setNewUsername(e.target.value)}
+                />
+                <input
+                  type="password"
+                  className="border-[var(--alpha-8)] border"
+                  placeholder="Password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+                <Button onClick={() => void handleAddAdmin()}>Add</Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+          <Dialog open={setPasswordOpen} onOpenChange={setIsSetPasswordOpen}>
+            <DialogContent className='w-80'>
+              <DialogHeader>
+                <DialogTitle>change password</DialogTitle>
+              </DialogHeader>
+              <div className="flex flex-col p-10 gap-4 text-white">
+                <input
+                  placeholder="old password"
+                  type="password"
+                  className="border-[var(--alpha-8)] border"
+                  value={oldPassword}
+                  onChange={(e) => setOldPassword(e.target.value)}
+                />
+                <input
+                  type="password"
+                  className="border-[var(--alpha-8)] border"
+                  placeholder="new password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                />
+                <input
+                  type="password"
+                  className="border-[var(--alpha-8)] border"
+                  placeholder="confirm password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                />
+                <Button onClick={() => void changePassword()}>change password</Button>
+              </div>
+            </DialogContent>
+          </Dialog>
         </div>
       </div>
     </>

--- a/packages/dashboard/src/lib/utils/schemaValidations.ts
+++ b/packages/dashboard/src/lib/utils/schemaValidations.ts
@@ -119,7 +119,6 @@ export const stringSchema = z.union([z.string(), z.null()]);
 export const emailSchema = z
   .string()
   .min(1, 'Email is required')
-  .email('Please enter a valid email address')
   .toLowerCase()
   .trim();
 

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -13,6 +13,7 @@ import {
   customOAuthKeySchema,
   smtpConfigSchema,
   emailTemplateSchema,
+  adminSchema,
 } from './auth.schema.js';
 
 // ============================================================================
@@ -43,14 +44,18 @@ export const createUserRequestSchema = z.object({
  * POST /api/auth/sessions - Create session
  */
 export const createSessionRequestSchema = z.object({
-  name: nameSchema,
+  email: emailSchema,
   password: passwordSchema,
 });
+
 
 /**
  * POST /api/auth/admin/sessions - Create admin session
  */
-export const createAdminSessionRequestSchema = createSessionRequestSchema;
+export const createAdminSessionRequestSchema = z.object({
+  username: nameSchema,
+  password: passwordSchema,
+});
 
 /**
  * POST /api/auth/refresh - Refresh session
@@ -213,7 +218,10 @@ export const resetPasswordResponseSchema = z.object({
 /**
  * Response for POST /api/auth/admin/sessions
  */
-export const createAdminSessionResponseSchema = createSessionResponseSchema;
+export const createAdminSessionResponseSchema = z.object({
+  user: adminSchema,
+  accessToken: z.string()
+});
 
 /**
  * Response for GET /api/auth/sessions/current

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -43,7 +43,7 @@ export const createUserRequestSchema = z.object({
  * POST /api/auth/sessions - Create session
  */
 export const createSessionRequestSchema = z.object({
-  email: emailSchema,
+  name: nameSchema,
   password: passwordSchema,
 });
 
@@ -123,6 +123,11 @@ export const exchangeResetPasswordTokenRequestSchema = z.object({
   email: emailSchema,
   code: z.string().regex(/^\d{6}$/, 'Reset password code must be a 6-digit numeric code'),
 });
+
+export const changePasswordUsingOldPasswordRequestSchema = z.object({
+  oldPassword: passwordSchema,
+  newPassword: passwordSchema,
+})
 
 /**
  * POST /api/auth/email/reset-password - Reset password with token

--- a/packages/shared-schemas/src/auth.schema.ts
+++ b/packages/shared-schemas/src/auth.schema.ts
@@ -164,6 +164,7 @@ export const emailTemplateSchema = z.object({
 export const tokenPayloadSchema = z.object({
   sub: userIdSchema, // Subject (user ID)
   email: emailSchema,
+  username: nameSchema,
   role: roleSchema,
   iat: z.number().optional(), // Issued at
   exp: z.number().optional(), // Expiration

--- a/packages/shared-schemas/src/auth.schema.ts
+++ b/packages/shared-schemas/src/auth.schema.ts
@@ -55,6 +55,14 @@ export const userSchema = z.object({
   metadata: z.record(z.unknown()).nullable(), // System metadata (device ID, login IP, etc.)
 });
 
+// admin schema
+export const adminSchema = z.object({
+  id: userIdSchema,
+  username: nameSchema,
+  createdAt: z.string(), // PostgreSQL timestamp
+  updatedAt: z.string(), // PostgreSQL timestamp
+});
+
 /**
  * OAuth state for redirect handling
  */
@@ -164,8 +172,9 @@ export const emailTemplateSchema = z.object({
 export const tokenPayloadSchema = z.object({
   sub: userIdSchema, // Subject (user ID)
   email: emailSchema,
-  username: nameSchema,
+  username: nameSchema.optional(),
   role: roleSchema,
+  isRoot: z.boolean().optional(),
   iat: z.number().optional(), // Issued at
   exp: z.number().optional(), // Expiration
 });


### PR DESCRIPTION
Now admin can add/delete sub-admins
<img width="1432" height="691" alt="Screenshot 2026-06-08 at 4 11 33 PM" src="https://github.com/user-attachments/assets/26ab90a3-7fe7-4bc2-bca2-e0e421dc038d" />
<img width="1076" height="696" alt="Screenshot 2026-06-08 at 4 11 44 PM" src="https://github.com/user-attachments/assets/fcaa6232-7171-4ca1-8461-4734f7648b80" />
<img width="1103" height="648" alt="Screenshot 2026-06-08 at 4 12 00 PM" src="https://github.com/user-attachments/assets/85b39636-3550-44fc-877d-5178e4b61e01" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database-backed admin management with a root admin who can add/delete sub-admins, and switches admin login to username-based auth using `auth.project_admins`. JWTs now include `isRoot`, and the dashboard adds admin listing, root-only actions, and self password changes.

- **New Features**
  - Added `auth.project_admins` (hashed passwords, `created_by`, `last_login_at`); root is `ROOT_ADMIN_USERNAME`.
  - Admin login by username verified against DB; updates `last_login_at`; tokens include `isRoot`.
  - Endpoints: POST `/auth/admin/sessions` (username+password), GET `/auth/admin/sessions/current` (boolean), POST `/auth/admin/addAdmin` (root only), DELETE `/auth/admin/deleteAdmin` (root only), GET `/auth/admin/allAdmins`, PUT `/auth/admin/resetPassword` (self, old→new).
  - Dashboard: login field is “Username”; header lists admins; root can add/delete; any admin can change their password.

- **Migration**
  - Run migration 044 to create `auth.project_admins`.
  - Set `ROOT_ADMIN_USERNAME` and `ROOT_ADMIN_PASSWORD` (added in `docker-compose.yml`); seeding now writes to `auth.project_admins`. `ADMIN_EMAIL`/`ADMIN_PASSWORD` remain fallbacks.
  - Update callers to send `{ username, password }` to `/auth/admin/sessions` (breaking change).

<sup>Written for commit 9431e5e5c48aea18f23e57c723471e43e5e9ebc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add username-based admin authentication and sub-admin management
> - Replaces email-based admin login with username-based login against a new `auth.project_admins` database table, using bcrypt password verification and JWTs carrying `username` and `isRoot`.
> - Adds root-admin-only endpoints to create, list, and delete sub-admins (`POST /auth/admin/addAdmin`, `GET /auth/admin/allAdmins`, `DELETE /auth/admin/deleteAdmin`).
> - Adds a password-change endpoint (`PUT /auth/admin/resetPassword`) available to all admins using their current password.
> - Updates the dashboard login page and `AppHeader` to use username instead of email, and adds admin management UI (add/delete/list admins, change password) visible to root admins.
> - Risk: existing admin credentials stored in `auth.users` are no longer used; admin seeding and login now require `ROOT_ADMIN_USERNAME`/`ROOT_ADMIN_PASSWORD` env vars.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9431e5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin management UI in header: add/delete sub-admins, view admin list, and change admin passwords.
  * Database-backed project-admins and seeding (replaces env-only admin).

* **Updates**
  * Sessions expose root-status for conditional UI/actions.
  * Admin login and API use username instead of email; login form relabeled "Username" with updated demo credentials.
  * Admin password-reset flow using old password added.

* **Tests**
  * E2E tests extended to cover admin/sub-admin flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->