### PR TITLE
feat(storage): honor caller-supplied expiresIn on download-strategy

### DIFF
--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -432,7 +432,18 @@ const downloadStrategyHandler = async (
       throw new AppError('Object not found', 404, ERROR_CODES.STORAGE_NOT_FOUND);
     }
 
-    const strategy = await storageService.getDownloadStrategy(bucketName, objectKey);
+    // Optional caller-supplied TTL (seconds) for the signed URL. Accepted from
+    // the query string (canonical GET) or body (deprecated POST alias). The
+    // service clamps it to a safe range and applies it to private buckets only.
+    const rawExpiresIn = req.query.expiresIn ?? authReq.body?.expiresIn;
+    const requestedExpiresIn =
+      rawExpiresIn !== undefined && rawExpiresIn !== '' ? Number(rawExpiresIn) : undefined;
+
+    const strategy = await storageService.getDownloadStrategy(
+      bucketName,
+      objectKey,
+      requestedExpiresIn
+    );
 
     // Strategy responses embed presigned URLs with short, server-decided
     // expiries. Prevent intermediaries (proxies, CDNs) from caching this

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -435,9 +435,22 @@ const downloadStrategyHandler = async (
     // Optional caller-supplied TTL (seconds) for the signed URL. Accepted from
     // the query string (canonical GET) or body (deprecated POST alias). The
     // service clamps it to a safe range and applies it to private buckets only.
+    // Reject malformed input (e.g. `?expiresIn=abc`) rather than silently
+    // coercing it: `Number('abc')` is NaN and `Number(null)` is 0, either of
+    // which would otherwise hand back a URL with a TTL the caller never asked for.
     const rawExpiresIn = req.query.expiresIn ?? authReq.body?.expiresIn;
-    const requestedExpiresIn =
-      rawExpiresIn !== undefined && rawExpiresIn !== '' ? Number(rawExpiresIn) : undefined;
+    let requestedExpiresIn: number | undefined;
+    if (rawExpiresIn !== undefined && rawExpiresIn !== null && rawExpiresIn !== '') {
+      const parsed = Number(rawExpiresIn);
+      if (!Number.isFinite(parsed)) {
+        throw new AppError(
+          'expiresIn must be a finite number of seconds',
+          400,
+          ERROR_CODES.STORAGE_INVALID_PARAMETER
+        );
+      }
+      requestedExpiresIn = parsed;
+    }
 
     const strategy = await storageService.getDownloadStrategy(
       bucketName,

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -24,6 +24,8 @@ const DEFAULT_LIST_LIMIT = 100;
 const GIGABYTE_IN_BYTES = 1024 * 1024 * 1024;
 const PUBLIC_BUCKET_EXPIRY = 0; // Public buckets don't expire
 const PRIVATE_BUCKET_EXPIRY = 3600; // Private buckets expire in 1 hour
+const MIN_SIGNED_URL_EXPIRY = 1; // 1 second
+const MAX_SIGNED_URL_EXPIRY = 604800; // 7 days — S3 SigV4 presign ceiling
 
 type StorageObjectResult = {
   file: Buffer;
@@ -561,15 +563,25 @@ export class StorageService {
     return this.provider.getUploadStrategy(bucket, key, metadata, maxFileSizeBytes);
   }
 
-  async getDownloadStrategy(bucket: string, key: string) {
+  async getDownloadStrategy(bucket: string, key: string, requestedExpiresIn?: number) {
     this.validateBucketName(bucket);
     this.validateKey(key);
 
     // Check if bucket is public
     const isPublic = await this.isBucketPublic(bucket);
 
-    // Auto-calculate expiry based on bucket visibility if not provided
-    const expiresIn = isPublic ? PUBLIC_BUCKET_EXPIRY : PRIVATE_BUCKET_EXPIRY;
+    // Auto-calculate expiry based on bucket visibility if not provided.
+    // Private buckets honor a caller-supplied TTL (clamped to a safe range) so
+    // `createSignedUrl(key, expiresIn)` can mint short-lived links; public
+    // buckets keep their long, server-decided expiry regardless (the provider
+    // also forces 7 days for public objects).
+    let expiresIn = isPublic ? PUBLIC_BUCKET_EXPIRY : PRIVATE_BUCKET_EXPIRY;
+    if (!isPublic && requestedExpiresIn !== undefined && Number.isFinite(requestedExpiresIn)) {
+      expiresIn = Math.min(
+        Math.max(Math.floor(requestedExpiresIn), MIN_SIGNED_URL_EXPIRY),
+        MAX_SIGNED_URL_EXPIRY
+      );
+    }
 
     // Fetch the version stamp (etag preferred, uploaded_at fallback) and pass
     // it to the provider, which knows whether its URL flavor tolerates an

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -122,7 +122,8 @@ describe('Storage routes', () => {
     expect(response.statusCode, response.body).toBe(200);
     expect(storageMocks.getDownloadStrategy).toHaveBeenCalledWith(
       'product-images',
-      'products/prod_123/main.jpg'
+      'products/prod_123/main.jpg',
+      undefined
     );
     expect(authMocks.verifyUser).not.toHaveBeenCalled();
   });
@@ -188,7 +189,46 @@ describe('Storage routes', () => {
     expect(authMocks.verifyUser).toHaveBeenCalledOnce();
     expect(storageMocks.getDownloadStrategy).toHaveBeenCalledWith(
       'product-images',
-      'products/prod_123/main.jpg'
+      'products/prod_123/main.jpg',
+      undefined
+    );
+  });
+
+  test('download strategy route forwards a caller-supplied expiresIn', async () => {
+    vi.resetModules();
+    storageMocks.isBucketPublic.mockResolvedValue(false);
+    storageMocks.objectIsVisible.mockResolvedValue(true);
+    storageMocks.getDownloadStrategy.mockResolvedValue({
+      method: 'presigned',
+      url: 'https://cdn.example.com/product-images/products%2Fprod_123%2Fmain.jpg?Signature=abc',
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await post(
+      address.port,
+      '/api/storage/buckets/product-images/objects/products/prod_123/main.jpg/download-strategy?expiresIn=120'
+    );
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(storageMocks.getDownloadStrategy).toHaveBeenCalledWith(
+      'product-images',
+      'products/prod_123/main.jpg',
+      120
     );
   });
 });

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -13,28 +13,27 @@ const authMocks = vi.hoisted(() => ({
   verifyUser: vi.fn((_req, _res, next) => next()),
 }));
 
-const post = (port: number, path: string): Promise<{ statusCode: number; body: string }> =>
+const requestMethod = (
+  method: 'GET' | 'POST',
+  port: number,
+  path: string
+): Promise<{ statusCode: number; body: string }> =>
   new Promise((resolve, reject) => {
-    const request = http.request(
-      {
-        hostname: '127.0.0.1',
-        port,
-        path,
-        method: 'POST',
-      },
-      (response) => {
-        let body = '';
-        response.setEncoding('utf8');
-        response.on('data', (chunk) => {
-          body += chunk;
-        });
-        response.on('end', () => resolve({ statusCode: response.statusCode ?? 0, body }));
-      }
-    );
+    const request = http.request({ hostname: '127.0.0.1', port, path, method }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => resolve({ statusCode: response.statusCode ?? 0, body }));
+    });
 
     request.on('error', reject);
     request.end();
   });
+
+const post = (port: number, path: string) => requestMethod('POST', port, path);
+const get = (port: number, path: string) => requestMethod('GET', port, path);
 
 const routeErrorHandler: ErrorRequestHandler = (error, _req, res, next) => {
   void next;
@@ -230,5 +229,72 @@ describe('Storage routes', () => {
       'products/prod_123/main.jpg',
       120
     );
+  });
+
+  test('canonical GET download-strategy route forwards expiresIn', async () => {
+    vi.resetModules();
+    storageMocks.isBucketPublic.mockResolvedValue(false);
+    storageMocks.objectIsVisible.mockResolvedValue(true);
+    storageMocks.getDownloadStrategy.mockResolvedValue({
+      method: 'presigned',
+      url: 'https://cdn.example.com/product-images/products%2Fprod_123%2Fmain.jpg?Signature=abc',
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await get(
+      address.port,
+      '/api/storage/buckets/product-images/download-strategy/objects/products/prod_123/main.jpg?expiresIn=120'
+    );
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(storageMocks.getDownloadStrategy).toHaveBeenCalledWith(
+      'product-images',
+      'products/prod_123/main.jpg',
+      120
+    );
+  });
+
+  test('download strategy route rejects a non-numeric expiresIn with 400', async () => {
+    vi.resetModules();
+    storageMocks.isBucketPublic.mockResolvedValue(false);
+    storageMocks.objectIsVisible.mockResolvedValue(true);
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await get(
+      address.port,
+      '/api/storage/buckets/product-images/download-strategy/objects/products/prod_123/main.jpg?expiresIn=abc'
+    );
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(storageMocks.getDownloadStrategy).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -336,4 +336,23 @@ describe('S3StorageProvider — branch fallback', () => {
       expect(sendMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('getDownloadStrategy expiry', () => {
+    // Uses the real presigner (signs locally with the dummy creds), so the
+    // returned URL actually carries `X-Amz-Expires` — proving the caller's
+    // expiresIn reaches the signature, not just the function arguments.
+    it('private bucket: caller expiresIn flows into the S3 presigned signature', async () => {
+      const p = makeProvider(); // no parent -> no HEAD round-trip, pure S3 presign
+      const strat = await p.getDownloadStrategy('photos', 'a.txt', 120, false);
+      expect(strat.method).toBe('presigned');
+      expect(new URL(strat.url).searchParams.get('X-Amz-Expires')).toBe('120');
+    });
+
+    it('public bucket: expiry is overridden to 7 days regardless of caller value', async () => {
+      const p = makeProvider();
+      const strat = await p.getDownloadStrategy('photos', 'a.txt', 120, true);
+      expect(strat.method).toBe('presigned');
+      expect(new URL(strat.url).searchParams.get('X-Amz-Expires')).toBe('604800');
+    });
+  });
 });


### PR DESCRIPTION
## What

Threads an optional `expiresIn` (seconds) from the `download-strategy` route through `StorageService.getDownloadStrategy`, so the SDK's `createSignedUrl(key, expiresIn)` can mint short-lived signed URLs.

- Accepted from the query string (canonical GET) or body (deprecated POST alias).
- Clamped to `[1s, 7d]` (7d = S3 SigV4 presign ceiling) and applied to **private buckets only**; public buckets keep their long, server-decided expiry.
- RLS is still enforced at mint (`objectIsVisible`) before any URL is issued — a presigned URL bypasses RLS at redeem, so ownership must be checked first. Unchanged.

Cloud-only by nature: the S3/CloudFront provider signs real presigned URLs; local-disk self-host still returns `method: 'direct'` (auth-required). Tokenized-JWT parity for local disk is a separate follow-up.

Pairs with InsForge/InsForge-sdk-js#91 (SDK: `createSignedUrl`/`createSignedUrls`).

## Tests
- `storage-routes.test.ts`: new test asserting a caller-supplied `expiresIn` is forwarded to `getDownloadStrategy`; updated existing assertions for the new 3rd arg. 4/4 pass (+ provider 12/12).
- `tsc` 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for caller-supplied `expiresIn` on the download-strategy endpoint so the SDK can mint short‑lived signed URLs for private buckets, and rejects malformed values with 400. Public buckets ignore caller TTL and are forced to 7d by the provider.

- **New Features**
  - Accept `expiresIn` (seconds) from query or body and pass it to `StorageService.getDownloadStrategy`.
  - Clamp to 1s–7d and apply only to private buckets; public buckets ignore caller TTL and are forced to 7d by the provider.
  - Keep RLS checks at mint via `objectIsVisible` before returning any URL.

<sup>Written for commit f514f910a0da33e7be5154fcece160f42d5e3a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor caller-supplied `expiresIn` on download-strategy route for private bucket signed URLs
> - The `GET`/`POST` download-strategy endpoints now accept an optional `expiresIn` query/body parameter (seconds) and forward it to `StorageService.getDownloadStrategy`.
> - `StorageService.getDownloadStrategy` clamps the value to `[1, 604800]` seconds for private buckets; public buckets continue to use the server-defined expiry.
> - Invalid (non-numeric) `expiresIn` values are rejected with a `400` error before reaching the service layer.
> - Behavioral Change: callers that previously relied on the server default TTL for private bucket signed URLs will now get a different TTL if they pass `expiresIn`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f514f91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download URLs accept an optional custom expiration time; private content expirations are clamped to safe min/max limits.

* **Bug Fixes**
  * Non-numeric or invalid expiration values are rejected with a 400 response.

* **Tests**
  * Added coverage for expiration handling: valid forwarding, clamping for private/public buckets, and invalid-value rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->