### PR TITLE
ci: run migration duplicate check on merge_group (prep for merge queue)

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '*' ]
+  # Required by the merge queue: the queue builds a temporary `merge_group` ref
+  # (PR rebased onto the latest main) and waits for this check to report on it.
+  # Without this trigger the check never runs for queued PRs and the queue stalls.
+  merge_group:
 
 jobs:
   check-duplicate-numbers:


### PR DESCRIPTION
## What

Adds a `merge_group:` trigger to the **Check Migrations** workflow.

## Why

We're about to make `Check for duplicate migration numbers` a **required** status check on `main` and enable a **merge queue**. A merge queue tests each PR on a temporary `merge_group` ref (the PR rebased onto the latest `main`). A required check that doesn't trigger on `merge_group` never reports for queued PRs → the queue stalls.

This PR must land **before** the queue is turned on.

## Bonus: this is what actually closes the race

The duplicate-migration guard already scans the *merged* tree (main ∪ PR) thanks to `actions/checkout` using the PR merge commit, so it catches the common case today. What it can't catch is the concurrent-merge race: PR A and PR B both branch from `main` at `047`, both add `048`, both go green, both merge → duplicate `048` on main. The merge queue re-tests each PR on top of the latest `main`, so the second one fails at queue time. This `merge_group` trigger is the piece that lets that happen.

## Follow-up (not in this PR)

After merge: add `Check for duplicate migration numbers` to required status checks on `main` (strict: false) and enable the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the duplicate migration number check on `merge_group` refs created by the merge queue. This ensures the required check reports for queued PRs and prevents concurrent duplicate numbers by retesting each PR on top of the latest `main`.

<sup>Written for commit ed6322a54f8ca72f6907bb60a6c4e5b9844332d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `merge_group` trigger to migration duplicate check workflow
> Updates [check-migrations.yml](.github/workflows/check-migrations.yml) to also run on the `merge_group` event, preparing the workflow for use with GitHub's merge queue feature.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed6322a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->