### PR TITLE
Fix Top Pages long URL overflow with truncation and hover tooltip

### DIFF
--- a/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
+++ b/packages/dashboard/src/features/analytics/components/posthog/BreakdownPanel.tsx
@@ -23,18 +23,26 @@ function renderLabel(breakdown: Breakdown, value: string | null) {
     const flag = flagEmoji(value);
     const name = countryName(value);
     return (
-      <span className="flex items-center gap-2">
+      <span className="flex min-w-0 items-center gap-2" title={name}>
         <span aria-hidden="true">{flag}</span>
-        <span className="truncate">{name}</span>
+        <span className="min-w-0 truncate">{name}</span>
       </span>
     );
   }
   if (breakdown === 'DeviceType') {
     const lower = value.toLowerCase();
     const display = lower.charAt(0).toUpperCase() + lower.slice(1);
-    return <span className="truncate">{display}</span>;
+    return (
+      <span className="block truncate" title={display}>
+        {display}
+      </span>
+    );
   }
-  return <span className="truncate font-mono text-xs">{value}</span>;
+  return (
+    <span className="block truncate font-mono text-xs" title={value}>
+      {value}
+    </span>
+  );
 }
 
 export function BreakdownPanel({ breakdown, enabled }: Props) {


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
oss tag: [v2.2.1-fixoverflow](https://github.com/InsForge/InsForge/tree/refs/tags/v2.2.1-fixoverflow)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long URL overflow in Top Pages by truncating labels and showing the full text on hover in `BreakdownPanel`. Improves readability and prevents layout breakage.

- **Bug Fixes**
  - Added `title` tooltips for country, device type, and generic labels to reveal full values on hover.
  - Ensured truncation works by applying `min-w-0` and `block` classes to label spans in `BreakdownPanel.tsx`.

<sup>Written for commit 68671762671a1fc2faa9fad4933afd5ab4daef70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label display in analytics breakdown panel with better text truncation and hover tooltips for Country, DeviceType, and other metric values.

* **Style**
  * Enhanced visual formatting with improved spacing and text alignment for breakdown panel labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix long URL overflow in Top Pages breakdown labels with truncation and tooltips
> Updates the `renderLabel` helper in [BreakdownPanel.tsx](https://github.com/InsForge/InsForge/pull/1498/files#diff-bcea1524ea1629bc7c6787663a1c18065c8ac034c4fdc0a6e08dc0260fdfb89d) to prevent long URLs and values from overflowing their containers. Adds `title` attributes for native browser tooltips on hover, and applies `min-w-0` and block-level span wrappers to enable CSS truncation across all label variants (Country, DeviceType, and default).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6867176.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->