### PR TITLE
INS-325 add OpenRouter key rotation

### DIFF
--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -79,6 +79,25 @@ router.get(
   }
 );
 
+/**
+ * POST /api/ai/:provider/api-key/rotate
+ * Rotate the active provider API key for cloud-managed Model Gateway credentials.
+ */
+router.post(
+  '/:provider/api-key/rotate',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const provider = parseAIProvider(req.params.provider);
+      const openRouterProvider = OpenRouterProvider.getInstance();
+      const key = await rotateProviderApiKey(provider, openRouterProvider);
+      successResponse(res, key);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 function parseAIProvider(value: string | undefined): AIProvider {
   if (value === 'openrouter') {
     return value;
@@ -95,6 +114,21 @@ function getProviderApiKey(provider: AIProvider, openRouterProvider: OpenRouterP
   switch (provider) {
     case 'openrouter':
       return openRouterProvider.getMaskedApiKey();
+    default: {
+      const exhaustiveProvider: never = provider;
+      throw new AppError(
+        `Unsupported AI provider: ${exhaustiveProvider}`,
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+  }
+}
+
+function rotateProviderApiKey(provider: AIProvider, openRouterProvider: OpenRouterProvider) {
+  switch (provider) {
+    case 'openrouter':
+      return openRouterProvider.rotateManagedApiKey();
     default: {
       const exhaustiveProvider: never = provider;
       throw new AppError(

--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -88,6 +88,7 @@ export class OpenRouterProvider {
   private currentApiKey: string | undefined;
   private renewalPromise: Promise<string> | null = null;
   private fetchPromise: Promise<string> | null = null;
+  private rotationPromise: Promise<string> | null = null;
 
   private constructor() {}
 
@@ -183,6 +184,23 @@ export class OpenRouterProvider {
       return true;
     }
     return !!process.env.OPENROUTER_API_KEY;
+  }
+
+  async rotateManagedApiKey(): Promise<{ apiKey: string; maskedKey: string }> {
+    if (!isCloudEnvironment()) {
+      throw new AppError(
+        'OpenRouter API key rotation is only available for InsForge Cloud-managed keys.',
+        400,
+        ERROR_CODES.INVALID_INPUT,
+        'For self-hosted projects, update OPENROUTER_API_KEY in the backend environment.'
+      );
+    }
+
+    const apiKey = await this.rotateCloudApiKey();
+    return {
+      apiKey,
+      maskedKey: this.maskApiKey(apiKey),
+    };
   }
 
   /**
@@ -467,6 +485,19 @@ export class OpenRouterProvider {
     return jwt.sign({ projectId }, jwtSecret, { expiresIn: '1h' });
   }
 
+  private applyCloudCredentials(data: CloudCredentialsResponse): string {
+    if (!data.openrouter?.api_key) {
+      throw new Error('Invalid response: missing openrouter API Key');
+    }
+
+    this.cloudCredentials = {
+      apiKey: data.openrouter.api_key,
+      limitRemaining: data.openrouter.limit_remaining,
+    };
+
+    return data.openrouter.api_key;
+  }
+
   /**
    * Fetch API key from cloud service
    * Uses promise memoization to prevent duplicate fetch requests
@@ -498,20 +529,11 @@ export class OpenRouterProvider {
 
         const data = (await response.json()) as CloudCredentialsResponse;
 
-        // Extract API key from the openrouter object in response
-        if (!data.openrouter?.api_key) {
-          throw new Error('Invalid response: missing openrouter API Key');
-        }
-
-        // Store credentials with metadata
-        this.cloudCredentials = {
-          apiKey: data.openrouter.api_key,
-          limitRemaining: data.openrouter.limit_remaining,
-        };
+        const apiKey = this.applyCloudCredentials(data);
 
         logger.info('Successfully fetched cloud API key');
 
-        return data.openrouter.api_key;
+        return apiKey;
       } catch (error) {
         logger.error('Failed to fetch cloud API key', {
           error: error instanceof Error ? error.message : String(error),
@@ -565,23 +587,14 @@ export class OpenRouterProvider {
 
         const data = (await response.json()) as CloudCredentialsResponse;
 
-        // Extract API key from the openrouter object in response
-        if (!data.openrouter?.api_key) {
-          throw new Error('Invalid response: missing openrouter API Key');
-        }
-
-        // Store credentials with metadata
-        this.cloudCredentials = {
-          apiKey: data.openrouter.api_key,
-          limitRemaining: data.openrouter.limit_remaining,
-        };
+        const apiKey = this.applyCloudCredentials(data);
 
         logger.info('Successfully renewed cloud API key');
 
         // Wait for OpenRouter to propagate the updated credits
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
-        return data.openrouter.api_key;
+        return apiKey;
       } catch (error) {
         logger.error('Failed to renew cloud API key', {
           error: error instanceof Error ? error.message : String(error),
@@ -595,6 +608,59 @@ export class OpenRouterProvider {
     })();
 
     return this.renewalPromise;
+  }
+
+  private async rotateCloudApiKey(): Promise<string> {
+    if (this.rotationPromise) {
+      logger.info('Rotation already in progress, waiting for completion...');
+      return this.rotationPromise;
+    }
+
+    this.rotationPromise = (async () => {
+      try {
+        const projectId = process.env.PROJECT_ID;
+        if (!projectId) {
+          throw new Error('PROJECT_ID not found in environment variables');
+        }
+        const token = this.createCloudProjectToken(projectId);
+
+        const response = await fetch(
+          `${process.env.CLOUD_API_HOST || 'https://api.insforge.dev'}/ai/v1/credentials/${projectId}/rotate`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ sign: token }),
+          }
+        );
+
+        if (!response.ok) {
+          const message =
+            (await response.text()) ||
+            response.statusText ||
+            'Cloud OpenRouter key rotation failed';
+          throw new AppError(message, response.status, ERROR_CODES.AI_UPSTREAM_UNAVAILABLE);
+        }
+
+        const data = (await response.json()) as CloudCredentialsResponse;
+        const apiKey = this.applyCloudCredentials(data);
+
+        logger.info('Successfully rotated cloud OpenRouter API key');
+
+        return apiKey;
+      } catch (error) {
+        logger.error('Failed to rotate cloud OpenRouter API key', {
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        });
+        throw error;
+      } finally {
+        this.rotationPromise = null;
+      }
+    })();
+
+    return this.rotationPromise;
   }
 
   /**

--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -506,6 +506,44 @@ export class OpenRouterProvider {
   }
 
   /**
+   * Map a non-ok cloud credentials response to a client-safe AppError.
+   * Only statuses whose semantics are meaningful to the caller pass through
+   * (trial denial, rotation conflict, rate limit); everything else — notably
+   * the cloud's 401 for an invalid project token — becomes a 502 so the
+   * dashboard cannot mistake it for the admin's own session expiring (its
+   * apiClient retries and logs out on 401). The raw body is logged here and
+   * never surfaced to the client; only the cloud's structured JSON `message`
+   * field is, length-capped.
+   */
+  private async cloudCredentialsError(response: Response, action: string): Promise<AppError> {
+    const rawBody = await response.text().catch(() => '');
+    logger.error(`Failed to ${action} cloud OpenRouter credentials`, {
+      status: response.status,
+      body: rawBody.slice(0, 2000),
+    });
+
+    let upstreamMessage: string | undefined;
+    try {
+      const parsed = JSON.parse(rawBody) as { message?: unknown };
+      if (typeof parsed.message === 'string') {
+        upstreamMessage = parsed.message;
+      }
+    } catch {
+      // Non-JSON body — keep it out of the client-facing message.
+    }
+
+    const message =
+      upstreamMessage?.slice(0, 300) ||
+      `Failed to ${action} cloud OpenRouter credentials (upstream status ${response.status})`;
+
+    if (response.status === 429) {
+      return new AppError(message, 429, ERROR_CODES.RATE_LIMITED);
+    }
+    const status = response.status === 403 || response.status === 409 ? response.status : 502;
+    return new AppError(message, status, ERROR_CODES.AI_UPSTREAM_UNAVAILABLE);
+  }
+
+  /**
    * Fetch API key from cloud service
    * Uses promise memoization to prevent duplicate fetch requests
    */
@@ -542,11 +580,7 @@ export class OpenRouterProvider {
         );
 
         if (!response.ok) {
-          throw new AppError(
-            `Failed to fetch cloud API key: ${response.statusText}`,
-            response.status,
-            ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
-          );
+          throw await this.cloudCredentialsError(response, 'fetch');
         }
 
         const data = (await response.json()) as CloudCredentialsResponse;
@@ -609,11 +643,7 @@ export class OpenRouterProvider {
         );
 
         if (!response.ok) {
-          const message =
-            (await response.text()) ||
-            response.statusText ||
-            'Cloud OpenRouter key rotation failed';
-          throw new AppError(message, response.status, ERROR_CODES.AI_UPSTREAM_UNAVAILABLE);
+          throw await this.cloudCredentialsError(response, 'rotate');
         }
 
         const data = (await response.json()) as CloudCredentialsResponse;

--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -86,7 +86,6 @@ export class OpenRouterProvider {
   private cloudCredentials: CloudCredentials | undefined;
   private openRouterClient: OpenAI | null = null;
   private currentApiKey: string | undefined;
-  private renewalPromise: Promise<string> | null = null;
   private fetchPromise: Promise<string> | null = null;
   private rotationPromise: Promise<string> | null = null;
 
@@ -572,83 +571,6 @@ export class OpenRouterProvider {
     return this.fetchPromise;
   }
 
-  /**
-   * Renew API key from cloud service when credits are exhausted
-   * Uses promise memoization to prevent duplicate renewal requests
-   */
-  async renewCloudApiKey(): Promise<string> {
-    // A rotation in flight just minted a fresh key — return it instead of
-    // racing a renew response that reflects the pre-rotation credential. If
-    // the rotated key is still out of credits, the next 402/403 renews it.
-    if (this.rotationPromise) {
-      logger.info('Rotation in progress, waiting for the rotated key...');
-      return this.rotationPromise;
-    }
-
-    // If renewal is already in progress, wait for it
-    if (this.renewalPromise) {
-      logger.info('Renewal already in progress, waiting for completion...');
-      return this.renewalPromise;
-    }
-
-    // Start new renewal and store the promise
-    this.renewalPromise = (async () => {
-      try {
-        const projectId = process.env.PROJECT_ID;
-        if (!projectId) {
-          throw new AppError(
-            'PROJECT_ID not found in environment variables',
-            500,
-            ERROR_CODES.INTERNAL_ERROR
-          );
-        }
-        const token = this.createCloudProjectToken(projectId);
-
-        // Renew API key from cloud service with sign token in request body
-        const response = await fetch(
-          `${process.env.CLOUD_API_HOST || 'https://api.insforge.dev'}/ai/v1/credentials/${projectId}/renew`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ sign: token }),
-          }
-        );
-
-        if (!response.ok) {
-          throw new AppError(
-            `Failed to renew cloud API key: ${response.statusText}`,
-            response.status,
-            ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
-          );
-        }
-
-        const data = (await response.json()) as CloudCredentialsResponse;
-
-        const apiKey = this.applyCloudCredentials(data);
-
-        logger.info('Successfully renewed cloud API key');
-
-        // Wait for OpenRouter to propagate the updated credits
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
-        return apiKey;
-      } catch (error) {
-        logger.error('Failed to renew cloud API key', {
-          error: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-        });
-        throw error;
-      } finally {
-        // Clear the promise after completion (success or failure)
-        this.renewalPromise = null;
-      }
-    })();
-
-    return this.renewalPromise;
-  }
-
   private async rotateCloudApiKey(): Promise<string> {
     if (this.rotationPromise) {
       logger.info('Rotation already in progress, waiting for completion...');
@@ -657,13 +579,13 @@ export class OpenRouterProvider {
 
     this.rotationPromise = (async () => {
       try {
-        // Let any in-flight fetch/renewal settle before rotating: their response
-        // carries the pre-rotation key, and if it landed after the rotated key it
-        // would clobber cloudCredentials with a just-revoked key — which then
-        // 401s, and 401 never triggers a renewal.
-        await Promise.allSettled(
-          [this.fetchPromise, this.renewalPromise].filter((promise) => promise !== null)
-        );
+        // Let an in-flight fetch settle before rotating: its response carries
+        // the pre-rotation key, and if it landed after the rotated key it would
+        // clobber cloudCredentials with a just-revoked key — which then 401s
+        // on every request until a restart.
+        if (this.fetchPromise) {
+          await this.fetchPromise.catch(() => undefined);
+        }
 
         const projectId = process.env.PROJECT_ID;
         if (!projectId) {
@@ -715,8 +637,10 @@ export class OpenRouterProvider {
   }
 
   /**
-   * Send a request to OpenRouter with automatic renewal and retry logic
-   * Handles 403 insufficient credits errors by renewing the API key and retrying
+   * Send a request to OpenRouter and convert upstream errors to actionable responses.
+   * Cloud-managed keys are minted unlimited for paid orgs and hard-capped for free
+   * orgs, so a 402 means the plan's AI credit is exhausted — there is no renewal
+   * to attempt (the legacy /renew top-up flow only serves old project images).
    * @param request - Function that takes an OpenAI client and returns a Promise
    * @returns The result of the request
    */
@@ -730,43 +654,18 @@ export class OpenRouterProvider {
     try {
       return { result: await request(client), source };
     } catch (error) {
-      // Only renew cloud-managed keys on 402/403; self-hosted env keys are never renewed.
-      if (
-        source === 'cloud' &&
-        error instanceof OpenAI.APIError &&
-        (error.status === 402 || error.status === 403)
-      ) {
-        logger.info(`Received ${error.status} insufficient credits, renewing API key...`);
-        const renewedApiKey = await this.renewCloudApiKey();
-
-        // Get fresh client with the renewed key — pass it directly to avoid re-resolution
-        const renewedClient = await this.getClient(renewedApiKey);
-
-        // Retry with exponential backoff (3 attempts)
-        const maxRetries = 3;
-
-        for (let attempt = 1; attempt <= maxRetries; attempt++) {
-          try {
-            const backoffMs = Math.pow(2, attempt - 1) * 1000; // 1s, 2s, 4s
-            logger.info(
-              `Retrying request after renewal (attempt ${attempt}/${maxRetries}), waiting ${backoffMs}ms...`
-            );
-            await new Promise((resolve) => setTimeout(resolve, backoffMs));
-
-            const result = await request(renewedClient);
-            logger.info('Request succeeded after API key renewal');
-            return { result, source };
-          } catch (retryError) {
-            if (attempt === maxRetries) {
-              logger.error(`All ${maxRetries} retry attempts failed after API key renewal`);
-              throw retryError;
-            }
-          }
-        }
-      }
-
       // Convert upstream API errors to actionable responses
       if (error instanceof OpenAI.APIError) {
+        if (error.status === 402) {
+          throw new AppError(
+            'AI credit limit reached.',
+            402,
+            ERROR_CODES.BILLING_INSUFFICIENT_BALANCE,
+            source === 'cloud'
+              ? 'This project has used all of its AI credits. Upgrade your plan to continue using AI.'
+              : 'Add credits to your OpenRouter account.'
+          );
+        }
         if (error.status === 401 || error.status === 403) {
           throw new AppError(
             'AI provider authentication failed. Check your API key configuration.',

--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -480,14 +480,22 @@ export class OpenRouterProvider {
   private createCloudProjectToken(projectId: string): string {
     const jwtSecret = process.env.JWT_SECRET;
     if (!jwtSecret) {
-      throw new Error('JWT_SECRET not found in environment variables');
+      throw new AppError(
+        'JWT_SECRET not found in environment variables',
+        500,
+        ERROR_CODES.INTERNAL_ERROR
+      );
     }
     return jwt.sign({ projectId }, jwtSecret, { expiresIn: '1h' });
   }
 
   private applyCloudCredentials(data: CloudCredentialsResponse): string {
     if (!data.openrouter?.api_key) {
-      throw new Error('Invalid response: missing openrouter API Key');
+      throw new AppError(
+        'Invalid cloud credentials response: missing openrouter API key',
+        502,
+        ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+      );
     }
 
     this.cloudCredentials = {
@@ -503,6 +511,13 @@ export class OpenRouterProvider {
    * Uses promise memoization to prevent duplicate fetch requests
    */
   private async fetchCloudApiKey(): Promise<string> {
+    // A rotation in flight will refresh cloudCredentials with the newest key;
+    // fetching concurrently could land a stale pre-rotation key after it.
+    if (this.rotationPromise) {
+      logger.info('Rotation in progress, waiting for the rotated key...');
+      return this.rotationPromise;
+    }
+
     // If fetch is already in progress, wait for it
     if (this.fetchPromise) {
       logger.info('Fetch already in progress, waiting for completion...');
@@ -514,7 +529,11 @@ export class OpenRouterProvider {
       try {
         const projectId = process.env.PROJECT_ID;
         if (!projectId) {
-          throw new Error('PROJECT_ID not found in environment variables');
+          throw new AppError(
+            'PROJECT_ID not found in environment variables',
+            500,
+            ERROR_CODES.INTERNAL_ERROR
+          );
         }
         const token = this.createCloudProjectToken(projectId);
 
@@ -524,7 +543,11 @@ export class OpenRouterProvider {
         );
 
         if (!response.ok) {
-          throw new Error(`Failed to fetch cloud API key: ${response.statusText}`);
+          throw new AppError(
+            `Failed to fetch cloud API key: ${response.statusText}`,
+            response.status,
+            ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+          );
         }
 
         const data = (await response.json()) as CloudCredentialsResponse;
@@ -554,6 +577,14 @@ export class OpenRouterProvider {
    * Uses promise memoization to prevent duplicate renewal requests
    */
   async renewCloudApiKey(): Promise<string> {
+    // A rotation in flight just minted a fresh key — return it instead of
+    // racing a renew response that reflects the pre-rotation credential. If
+    // the rotated key is still out of credits, the next 402/403 renews it.
+    if (this.rotationPromise) {
+      logger.info('Rotation in progress, waiting for the rotated key...');
+      return this.rotationPromise;
+    }
+
     // If renewal is already in progress, wait for it
     if (this.renewalPromise) {
       logger.info('Renewal already in progress, waiting for completion...');
@@ -565,7 +596,11 @@ export class OpenRouterProvider {
       try {
         const projectId = process.env.PROJECT_ID;
         if (!projectId) {
-          throw new Error('PROJECT_ID not found in environment variables');
+          throw new AppError(
+            'PROJECT_ID not found in environment variables',
+            500,
+            ERROR_CODES.INTERNAL_ERROR
+          );
         }
         const token = this.createCloudProjectToken(projectId);
 
@@ -582,7 +617,11 @@ export class OpenRouterProvider {
         );
 
         if (!response.ok) {
-          throw new Error(`Failed to renew cloud API key: ${response.statusText}`);
+          throw new AppError(
+            `Failed to renew cloud API key: ${response.statusText}`,
+            response.status,
+            ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+          );
         }
 
         const data = (await response.json()) as CloudCredentialsResponse;
@@ -618,9 +657,21 @@ export class OpenRouterProvider {
 
     this.rotationPromise = (async () => {
       try {
+        // Let any in-flight fetch/renewal settle before rotating: their response
+        // carries the pre-rotation key, and if it landed after the rotated key it
+        // would clobber cloudCredentials with a just-revoked key — which then
+        // 401s, and 401 never triggers a renewal.
+        await Promise.allSettled(
+          [this.fetchPromise, this.renewalPromise].filter((promise) => promise !== null)
+        );
+
         const projectId = process.env.PROJECT_ID;
         if (!projectId) {
-          throw new Error('PROJECT_ID not found in environment variables');
+          throw new AppError(
+            'PROJECT_ID not found in environment variables',
+            500,
+            ERROR_CODES.INTERNAL_ERROR
+          );
         }
         const token = this.createCloudProjectToken(projectId);
 

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -274,7 +274,7 @@ export class ChatCompletionService {
         parallel_tool_calls: options.parallelToolCalls,
       };
 
-      // Send request with automatic renewal and retry logic
+      // Send request with upstream error mapping
       const { result: response } = await this.openRouterProvider.sendRequest((client) =>
         client.chat.completions.create(
           request as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming
@@ -370,7 +370,7 @@ export class ChatCompletionService {
         parallel_tool_calls: options.parallelToolCalls,
       };
 
-      // Send request with automatic renewal and retry logic
+      // Send request with upstream error mapping
       const { result: stream } = await this.openRouterProvider.sendRequest((client) =>
         client.chat.completions.create(request as OpenAI.Chat.ChatCompletionCreateParamsStreaming)
       );

--- a/backend/src/services/ai/embedding.service.ts
+++ b/backend/src/services/ai/embedding.service.ts
@@ -22,13 +22,13 @@ export class EmbeddingService {
 
   /**
    * Generate embeddings for the given input using OpenRouter API
-   * Uses sendRequest for automatic renewal and retry logic
+   * Uses sendRequest for upstream error mapping
    * @param options - Embeddings request options including model, input, and encoding_format
    * @returns Embeddings response with vector data and metadata
    */
   async createEmbeddings(options: EmbeddingsRequest): Promise<EmbeddingsResponse> {
     try {
-      // Send request with automatic renewal and retry logic (same pattern as chat-completion)
+      // Send request with upstream error mapping (same pattern as chat-completion)
       const { result: response } = await this.openRouterProvider.sendRequest((client) =>
         client.embeddings.create({
           model: options.model,

--- a/backend/src/services/ai/image-generation.service.ts
+++ b/backend/src/services/ai/image-generation.service.ts
@@ -46,7 +46,7 @@ export class ImageGenerationService {
         modalities: ['text', 'image'],
       };
 
-      // Send request with automatic renewal and retry logic
+      // Send request with upstream error mapping
       const { result: response } = await this.openRouterProvider.sendRequest((client) =>
         client.chat.completions.create(
           request as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming

--- a/backend/tests/unit/ai-routes.test.ts
+++ b/backend/tests/unit/ai-routes.test.ts
@@ -10,25 +10,35 @@ type RouteEntry = {
   route?: {
     path: string;
     methods: Record<string, boolean>;
+    stack: Array<{ handle: { name: string } }>;
   };
 };
 
 describe('ai route wiring', () => {
-  const routeEntries = (
+  const routeLayers = (
     aiRouter as unknown as {
       stack: RouteEntry[];
     }
-  ).stack
-    .filter((layer) => layer.route)
-    .map((layer) => ({
-      path: layer.route?.path,
-      methods: Object.keys(layer.route?.methods ?? {}).sort(),
-    }));
+  ).stack.filter((layer) => layer.route);
+
+  const routeEntries = routeLayers.map((layer) => ({
+    path: layer.route?.path,
+    methods: Object.keys(layer.route?.methods ?? {}).sort(),
+  }));
 
   it('registers the OpenRouter key rotation route', () => {
     expect(routeEntries).toContainEqual({
       path: '/:provider/api-key/rotate',
       methods: ['post'],
     });
+  });
+
+  it('guards the rotation route with verifyAdmin', () => {
+    const rotateRoute = routeLayers.find(
+      (layer) => layer.route?.path === '/:provider/api-key/rotate'
+    );
+
+    const handlerNames = rotateRoute?.route?.stack.map((handler) => handler.handle.name) ?? [];
+    expect(handlerNames).toContain('verifyAdmin');
   });
 });

--- a/backend/tests/unit/ai-routes.test.ts
+++ b/backend/tests/unit/ai-routes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+import { aiRouter } from '../../src/api/routes/ai/index.routes';
+
+type RouteEntry = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+  };
+};
+
+describe('ai route wiring', () => {
+  const routeEntries = (
+    aiRouter as unknown as {
+      stack: RouteEntry[];
+    }
+  ).stack
+    .filter((layer) => layer.route)
+    .map((layer) => ({
+      path: layer.route?.path,
+      methods: Object.keys(layer.route?.methods ?? {}).sort(),
+    }));
+
+  it('registers the OpenRouter key rotation route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/:provider/api-key/rotate',
+      methods: ['post'],
+    });
+  });
+});

--- a/backend/tests/unit/openrouter-auth-errors.test.ts
+++ b/backend/tests/unit/openrouter-auth-errors.test.ts
@@ -1,10 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import OpenAI from 'openai';
 
-const { mockGetApiKeyWithSource, mockGetClient, mockRenewCloudApiKey } = vi.hoisted(() => ({
+const { mockGetApiKeyWithSource, mockGetClient } = vi.hoisted(() => ({
   mockGetApiKeyWithSource: vi.fn(),
   mockGetClient: vi.fn(),
-  mockRenewCloudApiKey: vi.fn(),
 }));
 
 vi.mock('../../src/utils/environment.js', () => ({
@@ -34,7 +33,34 @@ describe('OpenRouterProvider authentication error handling', () => {
     const p = provider as Record<string, any>;
     p.getApiKeyWithSource = mockGetApiKeyWithSource;
     p.getClient = mockGetClient.mockResolvedValue(new OpenAI({ apiKey: 'test' }));
-    p.renewCloudApiKey = mockRenewCloudApiKey;
+  });
+
+  it('throws AppError with BILLING_INSUFFICIENT_BALANCE for cloud key 402 without renewing', async () => {
+    mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'cloud-key', source: 'cloud' });
+
+    await expect(
+      provider.sendRequest(() => {
+        throw createAPIError(402, 'Insufficient credits');
+      })
+    ).rejects.toMatchObject({
+      statusCode: 402,
+      code: ERROR_CODES.BILLING_INSUFFICIENT_BALANCE,
+      nextActions: expect.stringContaining('Upgrade your plan'),
+    });
+  });
+
+  it('throws AppError with BILLING_INSUFFICIENT_BALANCE for env key 402', async () => {
+    mockGetApiKeyWithSource.mockResolvedValue({ apiKey: 'env-key', source: 'env' });
+
+    await expect(
+      provider.sendRequest(() => {
+        throw createAPIError(402, 'Insufficient credits');
+      })
+    ).rejects.toMatchObject({
+      statusCode: 402,
+      code: ERROR_CODES.BILLING_INSUFFICIENT_BALANCE,
+      nextActions: expect.stringContaining('OpenRouter account'),
+    });
   });
 
   it('throws AppError with AI_INVALID_API_KEY for env key 401', async () => {

--- a/backend/tests/unit/openrouter-rotate.test.ts
+++ b/backend/tests/unit/openrouter-rotate.test.ts
@@ -21,7 +21,6 @@ type ProviderState = OpenRouterProvider & {
   cloudCredentials?: unknown;
   openRouterClient: unknown | null;
   currentApiKey?: string;
-  renewalPromise: Promise<string> | null;
   fetchPromise: Promise<string> | null;
   rotationPromise: Promise<string> | null;
 };
@@ -31,7 +30,6 @@ function resetProviderState(provider: OpenRouterProvider) {
   state.cloudCredentials = undefined;
   state.openRouterClient = null;
   state.currentApiKey = undefined;
-  state.renewalPromise = null;
   state.fetchPromise = null;
   state.rotationPromise = null;
 }
@@ -137,12 +135,12 @@ describe('OpenRouterProvider.rotateManagedApiKey', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('waits for an in-flight renewal to settle before rotating', async () => {
+  it('waits for an in-flight credentials fetch to settle before rotating', async () => {
     const rotatedKey = 'sk-or-rotated-1234567890';
     const state = provider as unknown as ProviderState;
-    let resolveRenewal!: (value: string) => void;
-    state.renewalPromise = new Promise<string>((resolve) => {
-      resolveRenewal = resolve;
+    let resolveInFlightFetch!: (value: string) => void;
+    state.fetchPromise = new Promise<string>((resolve) => {
+      resolveInFlightFetch = resolve;
     });
 
     fetchMock.mockResolvedValueOnce({
@@ -157,17 +155,17 @@ describe('OpenRouterProvider.rotateManagedApiKey', () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
 
-    resolveRenewal('sk-or-stale-pre-rotation-key');
+    resolveInFlightFetch('sk-or-stale-pre-rotation-key');
     await expect(rotation).resolves.toMatchObject({ apiKey: rotatedKey });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('returns the in-flight rotation result instead of renewing concurrently', async () => {
+  it('resolves key lookups from the in-flight rotation instead of fetching concurrently', async () => {
     const rotatedKey = 'sk-or-rotated-1234567890';
     const state = provider as unknown as ProviderState;
     state.rotationPromise = Promise.resolve(rotatedKey);
 
-    await expect(provider.renewCloudApiKey()).resolves.toBe(rotatedKey);
+    await expect(provider.getApiKey()).resolves.toBe(rotatedKey);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/backend/tests/unit/openrouter-rotate.test.ts
+++ b/backend/tests/unit/openrouter-rotate.test.ts
@@ -91,18 +91,84 @@ describe('OpenRouterProvider.rotateManagedApiKey', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('propagates upstream rotation failures as AppError with the upstream status', async () => {
+  it('surfaces the cloud JSON message on rotation failure but remaps the status to 502', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({ error: 'INTERNAL_ERROR', message: 'Failed to rotate credentials' })
+        ),
+    });
+
+    await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
+      statusCode: 502,
+      code: ERROR_CODES.AI_UPSTREAM_UNAVAILABLE,
+      message: 'Failed to rotate credentials',
+    });
+  });
+
+  it('remaps a cloud 401 to 502 so the dashboard does not treat it as session expiry', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: () =>
+        Promise.resolve(JSON.stringify({ error: 'INVALID_TOKEN', message: 'Invalid token' })),
+    });
+
+    await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
+      statusCode: 502,
+      code: ERROR_CODES.AI_UPSTREAM_UNAVAILABLE,
+      message: 'Invalid token',
+    });
+  });
+
+  it('passes a cloud 429 through as RATE_LIMITED with its message', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: () =>
+        Promise.resolve(JSON.stringify({ message: 'Too many rotate requests for this project' })),
+    });
+
+    await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
+      statusCode: 429,
+      code: ERROR_CODES.RATE_LIMITED,
+      message: 'Too many rotate requests for this project',
+    });
+  });
+
+  it('keeps non-JSON upstream bodies out of the client-facing message', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 503,
       statusText: 'Service Unavailable',
-      text: () => Promise.resolve('rotation backend down'),
+      text: () => Promise.resolve('<html>nginx stack trace</html>'),
     });
 
     await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
-      statusCode: 503,
+      statusCode: 502,
       code: ERROR_CODES.AI_UPSTREAM_UNAVAILABLE,
-      message: 'rotation backend down',
+      message: 'Failed to rotate cloud OpenRouter credentials (upstream status 503)',
+    });
+  });
+
+  it('remaps a cloud 401 on credentials fetch to 502 as well', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: () =>
+        Promise.resolve(JSON.stringify({ error: 'INVALID_TOKEN', message: 'Invalid token' })),
+    });
+
+    await expect(provider.getApiKey()).rejects.toMatchObject({
+      statusCode: 502,
+      code: ERROR_CODES.AI_UPSTREAM_UNAVAILABLE,
+      message: 'Invalid token',
     });
   });
 

--- a/backend/tests/unit/openrouter-rotate.test.ts
+++ b/backend/tests/unit/openrouter-rotate.test.ts
@@ -93,6 +93,84 @@ describe('OpenRouterProvider.rotateManagedApiKey', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('propagates upstream rotation failures as AppError with the upstream status', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: () => Promise.resolve('rotation backend down'),
+    });
+
+    await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
+      statusCode: 503,
+      code: ERROR_CODES.AI_UPSTREAM_UNAVAILABLE,
+      message: 'rotation backend down',
+    });
+  });
+
+  it('dedupes concurrent rotation requests into a single cloud call', async () => {
+    const rotatedKey = 'sk-or-rotated-1234567890';
+    let resolveFetch!: (value: unknown) => void;
+    fetchMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const first = provider.rotateManagedApiKey();
+    const second = provider.rotateManagedApiKey();
+
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          openrouter: { api_key: rotatedKey, limit_remaining: 42 },
+        }),
+    });
+
+    const expected = {
+      apiKey: rotatedKey,
+      maskedKey: `${rotatedKey.slice(0, 8)}••••••••${rotatedKey.slice(-4)}`,
+    };
+    await expect(first).resolves.toEqual(expected);
+    await expect(second).resolves.toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an in-flight renewal to settle before rotating', async () => {
+    const rotatedKey = 'sk-or-rotated-1234567890';
+    const state = provider as unknown as ProviderState;
+    let resolveRenewal!: (value: string) => void;
+    state.renewalPromise = new Promise<string>((resolve) => {
+      resolveRenewal = resolve;
+    });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          openrouter: { api_key: rotatedKey, limit_remaining: 42 },
+        }),
+    });
+
+    const rotation = provider.rotateManagedApiKey();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    resolveRenewal('sk-or-stale-pre-rotation-key');
+    await expect(rotation).resolves.toMatchObject({ apiKey: rotatedKey });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the in-flight rotation result instead of renewing concurrently', async () => {
+    const rotatedKey = 'sk-or-rotated-1234567890';
+    const state = provider as unknown as ProviderState;
+    state.rotationPromise = Promise.resolve(rotatedKey);
+
+    await expect(provider.renewCloudApiKey()).resolves.toBe(rotatedKey);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('rejects rotation for self-hosted environment keys', async () => {
     environmentMock.isCloud = false;
 

--- a/backend/tests/unit/openrouter-rotate.test.ts
+++ b/backend/tests/unit/openrouter-rotate.test.ts
@@ -1,0 +1,106 @@
+import jwt from 'jsonwebtoken';
+import type { JwtPayload } from 'jsonwebtoken';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const environmentMock = vi.hoisted(() => ({
+  isCloud: true,
+}));
+
+vi.mock('../../src/utils/environment.js', () => ({
+  isCloudEnvironment: () => environmentMock.isCloud,
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { OpenRouterProvider } from '../../src/providers/ai/openrouter.provider.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+type ProviderState = OpenRouterProvider & {
+  cloudCredentials?: unknown;
+  openRouterClient: unknown | null;
+  currentApiKey?: string;
+  renewalPromise: Promise<string> | null;
+  fetchPromise: Promise<string> | null;
+  rotationPromise: Promise<string> | null;
+};
+
+function resetProviderState(provider: OpenRouterProvider) {
+  const state = provider as unknown as ProviderState;
+  state.cloudCredentials = undefined;
+  state.openRouterClient = null;
+  state.currentApiKey = undefined;
+  state.renewalPromise = null;
+  state.fetchPromise = null;
+  state.rotationPromise = null;
+}
+
+describe('OpenRouterProvider.rotateManagedApiKey', () => {
+  const jwtSecret = 'test-secret-long-enough-for-signing-32chars';
+  let provider: OpenRouterProvider;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    environmentMock.isCloud = true;
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubEnv('PROJECT_ID', 'project_123');
+    vi.stubEnv('JWT_SECRET', jwtSecret);
+    vi.stubEnv('CLOUD_API_HOST', 'https://cloud.example');
+    provider = OpenRouterProvider.getInstance();
+    resetProviderState(provider);
+  });
+
+  afterEach(() => {
+    resetProviderState(provider);
+  });
+
+  it('posts to the cloud rotate endpoint, caches the new key, and returns a masked key', async () => {
+    const rotatedKey = 'sk-or-rotated-1234567890';
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          openrouter: {
+            api_key: rotatedKey,
+            limit_remaining: 42,
+          },
+        }),
+    });
+
+    const result = await provider.rotateManagedApiKey();
+
+    expect(result).toEqual({
+      apiKey: rotatedKey,
+      maskedKey: `${rotatedKey.slice(0, 8)}••••••••${rotatedKey.slice(-4)}`,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://cloud.example/ai/v1/credentials/project_123/rotate');
+    expect(options.method).toBe('POST');
+    expect(options.headers).toEqual({ 'Content-Type': 'application/json' });
+
+    const body = JSON.parse(String(options.body)) as { sign: string };
+    const payload = jwt.verify(body.sign, jwtSecret) as JwtPayload;
+    expect(payload.projectId).toBe('project_123');
+
+    await expect(provider.getMaskedApiKey()).resolves.toMatchObject({
+      apiKey: rotatedKey,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects rotation for self-hosted environment keys', async () => {
+    environmentMock.isCloud = false;
+
+    await expect(provider.rotateManagedApiKey()).rejects.toMatchObject({
+      statusCode: 400,
+      code: ERROR_CODES.INVALID_INPUT,
+      message: expect.stringContaining('Cloud-managed keys'),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/ai/hooks/useAIOverview.ts
+++ b/packages/dashboard/src/features/ai/hooks/useAIOverview.ts
@@ -2,9 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { aiService } from '#features/ai/services/ai.service';
 import type { AIOverview } from '@insforge/shared-schemas';
 
+export const AI_OVERVIEW_QUERY_KEY = ['ai-overview'] as const;
+
 export function useAIOverview() {
   return useQuery<AIOverview>({
-    queryKey: ['ai-overview'],
+    queryKey: AI_OVERVIEW_QUERY_KEY,
     queryFn: () => aiService.getOverview(),
     staleTime: 60 * 1000,
     retry: false,

--- a/packages/dashboard/src/features/ai/hooks/useOpenRouterKey.ts
+++ b/packages/dashboard/src/features/ai/hooks/useOpenRouterKey.ts
@@ -1,12 +1,33 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { aiService } from '#features/ai/services/ai.service';
+import { AI_OVERVIEW_QUERY_KEY } from '#features/ai/hooks/useAIOverview';
+import { useToast } from '#lib/hooks/useToast';
 import type { OpenRouterKey } from '@insforge/shared-schemas';
+
+export const OPENROUTER_KEY_QUERY_KEY = ['openrouter-key'] as const;
 
 export function useOpenRouterKey() {
   return useQuery<OpenRouterKey>({
-    queryKey: ['openrouter-key'],
+    queryKey: OPENROUTER_KEY_QUERY_KEY,
     queryFn: () => aiService.getProviderApiKey('openrouter'),
     staleTime: 60 * 1000,
     retry: false,
+  });
+}
+
+export function useRotateOpenRouterKey() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation<OpenRouterKey, Error>({
+    mutationFn: () => aiService.rotateProviderApiKey('openrouter'),
+    onSuccess: (key) => {
+      queryClient.setQueryData(OPENROUTER_KEY_QUERY_KEY, key);
+      void queryClient.invalidateQueries({ queryKey: AI_OVERVIEW_QUERY_KEY });
+      showToast('OpenRouter API key rotated successfully', 'success');
+    },
+    onError: (error) => {
+      showToast(error.message || 'Failed to rotate OpenRouter API key', 'error');
+    },
   });
 }

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowUpCircle, Loader2, StopCircle } from 'lucide-react';
+import { ArrowUpCircle, Loader2, RotateCcw, StopCircle } from 'lucide-react';
 import {
   Button,
+  ConfirmDialog,
   CopyButton,
   Tab,
   Tabs,
@@ -15,8 +16,9 @@ import type { AIOverviewMetricPoint } from '@insforge/shared-schemas';
 import { CodeEditor } from '#components';
 import { useAIModelCredits } from '#features/ai/hooks/useAIModelCredits';
 import { useAIOverview } from '#features/ai/hooks/useAIOverview';
-import { useOpenRouterKey } from '#features/ai/hooks/useOpenRouterKey';
+import { useOpenRouterKey, useRotateOpenRouterKey } from '#features/ai/hooks/useOpenRouterKey';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
+import { useConfirm } from '#lib/hooks/useConfirm';
 import { useToast } from '#lib/hooks/useToast';
 import type { DashboardModelCreditUsage } from '#types';
 import {
@@ -474,6 +476,7 @@ export default function AIOverviewPage() {
   const [selectedModelId, setSelectedModelId] = useState<
     (typeof OVERVIEW_QUICK_START_MODELS)[number]['id']
   >(OVERVIEW_QUICK_START_MODELS[0].id);
+  const { confirm, confirmDialogProps } = useConfirm();
   const {
     data: usageData,
     isLoading: isUsageLoading,
@@ -485,13 +488,36 @@ export default function AIOverviewPage() {
     isLoading: isOpenRouterKeyLoading,
     error: openRouterKeyError,
   } = useOpenRouterKey();
+  const rotateOpenRouterKey = useRotateOpenRouterKey();
   const {
     data: modelCredits,
     isLoading: isModelCreditsLoading,
     error: modelCreditsError,
   } = useAIModelCredits();
   const shouldShowModelCredits = host.mode === 'cloud-hosting' && !!host.onRequestModelCredits;
+  const canRotateOpenRouterKey = host.mode === 'cloud-hosting';
   const codeSnippets = useMemo(() => getOverviewCodeSnippets(selectedModelId), [selectedModelId]);
+
+  const handleRotateOpenRouterKey = async () => {
+    const confirmed = await confirm({
+      title: 'Rotate OpenRouter key?',
+      description:
+        'The current API key will stop working immediately. Update any apps or services that use it as soon as the new key appears.',
+      confirmText: 'Rotate key',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await rotateOpenRouterKey.mutateAsync();
+    } catch {
+      // Toast feedback is handled by the mutation hook.
+    }
+  };
 
   const totals = useMemo(
     () => ({
@@ -537,12 +563,37 @@ export default function AIOverviewPage() {
                 <span className="text-[12px] leading-4 text-muted-foreground">
                   Active OpenRouter key
                 </span>
-                <OpenRouterKeyBox
-                  apiKey={openRouterKey?.apiKey}
-                  maskedKey={openRouterKey?.maskedKey}
-                  isLoading={isOpenRouterKeyLoading}
-                  error={openRouterKeyError}
-                />
+                <div className="flex min-w-0 items-center gap-2">
+                  <div className="min-w-0 flex-1">
+                    <OpenRouterKeyBox
+                      apiKey={openRouterKey?.apiKey}
+                      maskedKey={openRouterKey?.maskedKey}
+                      isLoading={isOpenRouterKeyLoading}
+                      error={openRouterKeyError}
+                    />
+                  </div>
+                  {canRotateOpenRouterKey && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      className="h-8 shrink-0 px-2.5"
+                      onClick={() => {
+                        void handleRotateOpenRouterKey();
+                      }}
+                      disabled={
+                        isOpenRouterKeyLoading || rotateOpenRouterKey.isPending || !openRouterKey
+                      }
+                    >
+                      {rotateOpenRouterKey.isPending ? (
+                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <RotateCcw className="size-4" aria-hidden="true" />
+                      )}
+                      <span>Rotate</span>
+                    </Button>
+                  )}
+                </div>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -658,6 +709,7 @@ export default function AIOverviewPage() {
           )}
         </section>
       </div>
+      <ConfirmDialog {...confirmDialogProps} isLoading={rotateOpenRouterKey.isPending} />
     </div>
   );
 }

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -548,8 +548,8 @@ export default function AIOverviewPage() {
         </div>
 
         <section className="grid min-h-[280px] grid-cols-[360px_1fr] overflow-hidden rounded border border-[var(--alpha-8)] bg-card">
-          <div className="grid grid-rows-[1fr_32px] p-5">
-            <div className="flex flex-col gap-5">
+          <div className="grid min-w-0 grid-rows-[1fr_32px] p-5">
+            <div className="flex min-w-0 flex-col gap-5">
               <div className="flex flex-col gap-3">
                 <h2 className="text-base font-medium leading-6 text-foreground">
                   Start using Model Gateway

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -709,7 +709,7 @@ export default function AIOverviewPage() {
           )}
         </section>
       </div>
-      <ConfirmDialog {...confirmDialogProps} isLoading={rotateOpenRouterKey.isPending} />
+      <ConfirmDialog {...confirmDialogProps} />
     </div>
   );
 }

--- a/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
+++ b/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookMocks = vi.hoisted(() => ({
+  rotateOpenRouterKey: vi.fn(),
+  isRotating: false,
+}));
+
+vi.mock('#components', () => ({
+  CodeEditor: ({ code }: { code: string }) => <pre data-testid="code-editor">{code}</pre>,
+}));
+
+vi.mock('#features/ai/hooks/useAIOverview', () => ({
+  useAIOverview: () => ({
+    data: {
+      key: {
+        limit: null,
+        limitRemaining: null,
+        usage: 0,
+        usageDaily: 0,
+        usageWeekly: 0,
+        usageMonthly: 0,
+        observabilityAvailable: false,
+      },
+      charts: {
+        spend: [],
+        requests: [],
+        tokens: [],
+      },
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock('#features/ai/hooks/useAIModelCredits', () => ({
+  useAIModelCredits: () => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('#features/ai/hooks/useOpenRouterKey', () => ({
+  useOpenRouterKey: () => ({
+    data: {
+      apiKey: 'sk-or-current-key',
+      maskedKey: 'sk-or-cu••••••••-key',
+    },
+    isLoading: false,
+    error: null,
+  }),
+  useRotateOpenRouterKey: () => ({
+    mutateAsync: hookMocks.rotateOpenRouterKey,
+    isPending: hookMocks.isRotating,
+  }),
+}));
+
+vi.mock('#features/ai/constants', () => {
+  const TestModelIcon = ({ className }: { className?: string }) => (
+    <span data-testid="model-icon" className={className} />
+  );
+
+  return {
+    CODE_TAB_LANGUAGE: {
+      sdk: 'javascript',
+      python: 'python',
+      http: 'http',
+    },
+    OVERVIEW_QUICK_START_MODELS: [
+      {
+        id: 'openai/gpt-test',
+        label: 'GPT Test',
+        icon: TestModelIcon,
+      },
+    ],
+    getOverviewCodeSnippets: () => ({
+      sdk: 'const client = new OpenAI();',
+      python: 'client = OpenAI()',
+      http: 'POST /chat/completions',
+    }),
+  };
+});
+
+vi.mock('#lib/config/DashboardHostContext', () => ({
+  useDashboardHost: () => ({
+    mode: 'cloud-hosting',
+  }),
+}));
+
+import AIOverviewPage from '#features/ai/pages/AIOverviewPage';
+
+describe('AIOverviewPage OpenRouter key rotation', () => {
+  beforeEach(() => {
+    hookMocks.rotateOpenRouterKey.mockReset();
+    hookMocks.rotateOpenRouterKey.mockResolvedValue({
+      apiKey: 'sk-or-rotated-key',
+      maskedKey: 'sk-or-ro••••••••-key',
+    });
+    hookMocks.isRotating = false;
+  });
+
+  it('confirms before rotating the active OpenRouter key', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Rotate$/ }));
+
+    expect(screen.getByText('Rotate OpenRouter key?')).toBeInTheDocument();
+    expect(screen.getByText(/current API key will stop working immediately/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Rotate key' }));
+
+    await waitFor(() => {
+      expect(hookMocks.rotateOpenRouterKey).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('does not rotate when the confirmation is cancelled', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Rotate$/ }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(hookMocks.rotateOpenRouterKey).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/ai/services/__tests__/ai.service.test.ts
+++ b/packages/dashboard/src/features/ai/services/__tests__/ai.service.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiClientMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+}));
+
+vi.mock('#lib/api/client', () => ({
+  apiClient: apiClientMock,
+}));
+
+import { AIService } from '#features/ai/services/ai.service';
+
+describe('AIService', () => {
+  let service: AIService;
+
+  beforeEach(() => {
+    apiClientMock.request.mockReset();
+    apiClientMock.withAccessToken.mockClear();
+    service = new AIService();
+  });
+
+  it('rotates the provider API key with an authenticated POST request', async () => {
+    const rotatedKey = {
+      apiKey: 'sk-or-rotated',
+      maskedKey: 'sk-or-ro••••••••ated',
+    };
+    apiClientMock.request.mockResolvedValue(rotatedKey);
+
+    await expect(service.rotateProviderApiKey('openrouter')).resolves.toEqual(rotatedKey);
+
+    expect(apiClientMock.request).toHaveBeenCalledWith('/ai/openrouter/api-key/rotate', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+});

--- a/packages/dashboard/src/features/ai/services/ai.service.ts
+++ b/packages/dashboard/src/features/ai/services/ai.service.ts
@@ -21,6 +21,13 @@ export class AIService {
       headers: apiClient.withAccessToken(),
     });
   }
+
+  rotateProviderApiKey(provider: AIProvider): Promise<OpenRouterKey> {
+    return apiClient.request(`/ai/${provider}/api-key/rotate`, {
+      method: 'POST',
+      headers: apiClient.withAccessToken(),
+    });
+  }
 }
 
 export const aiService = new AIService();


### PR DESCRIPTION
## What changed

- Added an admin-only backend route to rotate the cloud-managed OpenRouter key: `POST /api/ai/:provider/api-key/rotate`.
- Added `OpenRouterProvider.rotateManagedApiKey()` to call the cloud backend rotate endpoint, update cached credentials, and return the new masked key payload.
- Added dashboard service/hook support for rotating the OpenRouter key and refreshing cached key/overview data.
- Added a Rotate button beside the active OpenRouter key in the AI overview page, guarded by a destructive confirmation dialog that warns the current key stops working immediately.
- Added focused backend and dashboard tests for route wiring, provider behavior, service request shape, and confirmation flow.

## Why

InsForge Cloud backend now supports rotating OpenRouter keys, and the dashboard needs a corresponding admin action so users can rotate the active Model Gateway key without leaving the dashboard.

## Validation

- `npx prettier --check backend/src/api/routes/ai/index.routes.ts backend/src/providers/ai/openrouter.provider.ts backend/tests/unit/ai-routes.test.ts backend/tests/unit/openrouter-rotate.test.ts packages/dashboard/src/features/ai/hooks/useAIOverview.ts packages/dashboard/src/features/ai/hooks/useOpenRouterKey.ts packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx packages/dashboard/src/features/ai/services/ai.service.ts packages/dashboard/src/features/ai/services/__tests__/ai.service.test.ts`
- `npx turbo run typecheck`
- `npx turbo run lint`
- `npx turbo run test`
- `npx turbo run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add admin-only rotation of the cloud-managed OpenRouter API key from the dashboard, with client-safe error mapping that avoids session/logout loops. Implements INS-325.

- New Features
  - Backend: `POST /api/ai/:provider/api-key/rotate` (admin-only) calls `OpenRouterProvider.rotateManagedApiKey()`, dedupes concurrent rotations, waits for any in-flight fetch before rotating, returns the rotated key to fetch requests started during rotation, updates cached credentials, returns the masked key, and uses consistent `AppError` codes/status; rejects with 400 in self-hosted mode.
  - Cloud credentials error handling: 402 maps to `BILLING_INSUFFICIENT_BALANCE` (with clear next steps for cloud vs. env keys); for rotate/fetch, 429 passes through as `RATE_LIMITED`, 403/409 keep their status, and 401/others remap to 502 `AI_UPSTREAM_UNAVAILABLE` with the cloud JSON message surfaced (raw bodies are only logged).
  - Dashboard: `aiService.rotateProviderApiKey('openrouter')` and `useRotateOpenRouterKey` update `OPENROUTER_KEY_QUERY_KEY`, invalidate `AI_OVERVIEW_QUERY_KEY`, and show toasts; a cloud-only Rotate button on the AI Overview uses `ConfirmDialog` and shows a spinner while pending.

- Bug Fixes
  - Kept the Rotate button inside the card by adding `min-w-0` so key text truncates instead of overflowing.

<sup>Written for commit 2bdb91fa9620e949fa26dc29aede05a1155826a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenRouter API key rotation for cloud-hosted deployments
> - Adds a `POST /ai/:provider/api-key/rotate` admin endpoint in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1499/files#diff-015e9a6c428e339cf6c588de3994e4cc5d43d8e8d2e150f83b0dc6b299a51c4b) that dispatches to `OpenRouterProvider.rotateCloudApiKey()`, which calls the InsForge Cloud API and returns the new raw and masked key.
> - Concurrent rotation calls are deduplicated via an in-flight promise memoized on `rotationPromise` in [openrouter.provider.ts](https://github.com/InsForge/InsForge/pull/1499/files#diff-1ea9372136fec62382bde369bc189a8bbbc2547db2eaaa9dcf6f88c208dd66d1).
> - Adds a `useRotateOpenRouterKey` mutation hook in [useOpenRouterKey.ts](https://github.com/InsForge/InsForge/pull/1499/files#diff-00e894732f14b46e7a81c21174c4cd2df3d733542191887e3dba48db675237d9) that updates query caches and shows toast feedback on success or failure.
> - The `AIOverviewPage` shows a Rotate button (cloud-hosted mode only) with a destructive confirmation dialog before triggering the mutation.
> - Risk: rotation is rejected with 400 `INVALID_INPUT` in self-hosted environments; upstream failures surface as `AI_UPSTREAM_UNAVAILABLE`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1499 opened
>
> - Added serialization logic to `OpenRouterProvider.rotateCloudApiKey` to wait for in-flight `fetchPromise` or `renewalPromise` to settle via `Promise.allSettled` before initiating rotation, and added early returns in `OpenRouterProvider.fetchCloudApiKey` and `OpenRouterProvider.renewCloudApiKey` to return the in-flight rotation result when `rotationPromise` exists [db8cef2]
> - Replaced generic `Error` throws with `AppError` instances in `OpenRouterProvider.createCloudProjectToken`, `OpenRouterProvider.applyCloudCredentials`, `OpenRouterProvider.fetchCloudApiKey`, `OpenRouterProvider.renewCloudApiKey`, and `OpenRouterProvider.rotateCloudApiKey` [db8cef2]
> - Added test assertions validating that upstream rotation failures propagate as `AppError` with upstream status and message, concurrent rotation requests are deduplicated into a single cloud call, rotation waits for in-flight renewal to settle, and `renewCloudApiKey` returns the rotation result when `rotationPromise` exists [db8cef2]
> - Added test assertion verifying that the `/:provider/api-key/rotate` route is guarded by `verifyAdmin` middleware [db8cef2]
> - Removed the `isLoading` prop assignment to `ConfirmDialog` in the `AIOverviewPage` component [db8cef2]
> - Removed automatic API key renewal flow for 402/403 responses in `OpenRouterProvider` [6a80e79]
> - Changed 402 and 401/403 error handling in `OpenRouterProvider.sendRequest` to surface specific error codes without retry [6a80e79]
> - Updated `OpenRouterProvider.rotateCloudApiKey` to wait only for in-flight credentials fetch before rotation [6a80e79]
> - Updated comments in `ChatCompletionService`, `EmbeddingService`, and `ImageGenerationService` to reflect upstream error mapping [6a80e79]
> - Added test cases for 402 error handling and updated rotation tests to remove renewal flow validation [6a80e79]
> - Implemented standardized error handling for cloud credentials operations in `OpenRouterProvider` [2bdb91f]
> - Added comprehensive test coverage for cloud credentials error handling in OpenRouter provider [2bdb91f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f83ea4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only API to rotate provider API keys (cloud-managed) and client API/mutation to trigger rotation.
  * Dashboard: “Rotate” button on AI Overview (cloud-hosting only) with confirmation, spinner/disabled states, toasts, and automatic overview refresh.

* **Tests**
  * Unit and UI tests covering route wiring, provider rotation behavior (including concurrency and error remapping), and the confirmation/interaction flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->