### PR TITLE
refactor(payments): rename Razorpay webhook regenerate-secret endpoint to rotate-secret

### DIFF
--- a/backend/src/api/routes/payments/razorpay/config.routes.ts
+++ b/backend/src/api/routes/payments/razorpay/config.routes.ts
@@ -76,11 +76,11 @@ router.get('/webhook', async (req: AuthRequest, res: Response, next: NextFunctio
 });
 
 router.post(
-  '/webhook/regenerate-secret',
+  '/webhook/rotate-secret',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { environment } = parseZodSchema(razorpayEnvironmentParamsSchema, req.params);
-      const result = await configService.regenerateWebhookSecret(environment);
+      const result = await configService.rotateWebhookSecret(environment);
       successResponse(res, result);
     } catch (error) {
       next(error);

--- a/backend/src/services/payments/razorpay/config.service.ts
+++ b/backend/src/services/payments/razorpay/config.service.ts
@@ -561,7 +561,7 @@ export class RazorpayConfigService {
     };
   }
 
-  async regenerateWebhookSecret(
+  async rotateWebhookSecret(
     environment: RazorpayEnvironment
   ): Promise<GetRazorpayWebhookSetupResponse> {
     await this.createRazorpayProvider(environment);
@@ -572,7 +572,7 @@ export class RazorpayConfigService {
     const webhookUrl = this.getWebhookUrl(environment);
     await this.upsertManualWebhookConnection(environment, webhookUrl);
 
-    logger.info('Razorpay webhook secret regenerated', {
+    logger.info('Razorpay webhook secret rotated', {
       environment,
       webhookUrl,
     });

--- a/backend/tests/unit/payments-routes.test.ts
+++ b/backend/tests/unit/payments-routes.test.ts
@@ -241,7 +241,7 @@ describe('payments route schemas', () => {
     expect(paymentsApiSchemaSource).toContain('razorpayWebhookParamsSchema');
     expect(paymentsApiSchemaSource).toContain('upsertRazorpayConfigBodySchema');
     expect(paymentsApiSchemaSource).toContain('getRazorpayWebhookSetupResponseSchema');
-    expect(paymentsApiSchemaSource).toContain('regenerateRazorpayWebhookSecretResponseSchema');
+    expect(paymentsApiSchemaSource).toContain('rotateRazorpayWebhookSecretResponseSchema');
     expect(paymentsApiSchemaSource).toContain('getRazorpayStatusResponseSchema');
     expect(paymentsApiSchemaSource).toContain('getRazorpayConfigResponseSchema');
     expect(paymentsApiSchemaSource).toContain('syncRazorpayPaymentsResponseSchema');
@@ -337,10 +337,8 @@ describe('payments route schemas', () => {
     expect(razorpayConfigRouteSource).toMatch(/router\.post\(\s*'\/sync'/);
     expect(razorpayConfigRouteSource).toMatch(/router\.get\(\s*'\/webhook'/);
     expect(razorpayConfigRouteSource).toContain('configService.getWebhookSetup(environment)');
-    expect(razorpayConfigRouteSource).toMatch(/router\.post\(\s*'\/webhook\/regenerate-secret'/);
-    expect(razorpayConfigRouteSource).toContain(
-      'configService.regenerateWebhookSecret(environment)'
-    );
+    expect(razorpayConfigRouteSource).toMatch(/router\.post\(\s*'\/webhook\/rotate-secret'/);
+    expect(razorpayConfigRouteSource).toContain('configService.rotateWebhookSecret(environment)');
     expect(razorpayConfigRouteSource).not.toMatch(/router\.post\(\s*'\/webhook'/);
     expect(razorpayConfigRouteSource).toContain('successResponse(res, result)');
     expect(razorpayRouteSource).not.toContain('webhook-configure');
@@ -366,7 +364,7 @@ describe('payments route schemas', () => {
 
   it('keeps Razorpay webhooks manual rather than half-managed through a provider API', () => {
     expect(razorpayConfigRouteSource).toContain('getWebhookSetup(environment)');
-    expect(razorpayConfigRouteSource).toContain('regenerateWebhookSecret(environment)');
+    expect(razorpayConfigRouteSource).toContain('rotateWebhookSecret(environment)');
     expect(razorpayProviderSource).not.toContain('createWebhook(');
     expect(razorpayProviderSource).not.toContain('/v1/accounts/me/webhooks');
     expect(razorpayConfigServiceSource).toContain('manual');

--- a/docs/agent-docs/payments-razorpay.md
+++ b/docs/agent-docs/payments-razorpay.md
@@ -27,7 +27,7 @@ Use these backend routes for admin tooling:
 
 ```http
 GET /api/payments/razorpay/test/webhook
-POST /api/payments/razorpay/test/webhook/regenerate-secret
+POST /api/payments/razorpay/test/webhook/rotate-secret
 ```
 
 Recommended active events are the events InsForge handles:

--- a/openapi/payments.yaml
+++ b/openapi/payments.yaml
@@ -868,9 +868,9 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /api/payments/razorpay/{environment}/webhook/regenerate-secret:
+  /api/payments/razorpay/{environment}/webhook/rotate-secret:
     post:
-      summary: Regenerate Razorpay Webhook Secret
+      summary: Rotate Razorpay Webhook Secret
       description: Generate a new Razorpay webhook signing secret. Update the webhook secret in the Razorpay Dashboard after calling this endpoint.
       tags:
         - Razorpay Payments
@@ -881,11 +881,11 @@ paths:
         - $ref: '#/components/parameters/EnvironmentPath'
       responses:
         '200':
-          description: Razorpay webhook setup values with the regenerated secret
+          description: Razorpay webhook setup values with the rotated secret
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegenerateRazorpayWebhookSecretResponse'
+                $ref: '#/components/schemas/RotateRazorpayWebhookSecretResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -3675,7 +3675,7 @@ components:
           description: Raw signing secret to copy into the Razorpay Dashboard.
           example: "webhook_secret_xxx"
 
-    RegenerateRazorpayWebhookSecretResponse:
+    RotateRazorpayWebhookSecretResponse:
       allOf:
         - $ref: '#/components/schemas/GetRazorpayWebhookSetupResponse'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "@types/xml2js": "^0.4.14",
         "dotenv-cli": "^10.0.0",
         "insforge-test": "^0.2.0",
-        "pgsql-test": "^4.16.2",
         "supertest": "^7.2.2",
         "tsup": "^8.5.0",
         "tsx": "^4.7.1",
@@ -17237,7 +17236,7 @@
     },
     "packages/shared-schemas": {
       "name": "@insforge/shared-schemas",
-      "version": "1.1.58",
+      "version": "1.1.59",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.23.8"

--- a/packages/dashboard/src/features/payments/components/PaymentsSettingsDialog.tsx
+++ b/packages/dashboard/src/features/payments/components/PaymentsSettingsDialog.tsx
@@ -877,12 +877,12 @@ function StripeWebhookEnvironmentSection({
 
 function RazorpayWebhooksTabContent({
   keys,
-  regenerateWebhookSecret,
+  rotateWebhookSecret,
   isBusy,
   onGoToKeys,
 }: {
   keys: RazorpayKeyConfig[];
-  regenerateWebhookSecret: ReturnType<typeof useRazorpayWebhook>['regenerateWebhookSecret'];
+  rotateWebhookSecret: ReturnType<typeof useRazorpayWebhook>['rotateWebhookSecret'];
   isBusy: boolean;
   onGoToKeys: () => void;
 }) {
@@ -899,7 +899,7 @@ function RazorpayWebhooksTabContent({
           <RazorpayWebhookEnvironmentSection
             environment={environment}
             keys={keys}
-            regenerateWebhookSecret={regenerateWebhookSecret}
+            rotateWebhookSecret={rotateWebhookSecret}
             isBusy={isBusy}
             onGoToKeys={onGoToKeys}
           />
@@ -957,17 +957,17 @@ function RazorpayWebhookManualSetupGuidance() {
 function RazorpayWebhookEnvironmentSection({
   environment,
   keys,
-  regenerateWebhookSecret,
+  rotateWebhookSecret,
   isBusy,
   onGoToKeys,
 }: {
   environment: PaymentEnvironment;
   keys: RazorpayKeyConfig[];
-  regenerateWebhookSecret: ReturnType<typeof useRazorpayWebhook>['regenerateWebhookSecret'];
+  rotateWebhookSecret: ReturnType<typeof useRazorpayWebhook>['rotateWebhookSecret'];
   isBusy: boolean;
   onGoToKeys: () => void;
 }) {
-  const [isRegenerateConfirmOpen, setIsRegenerateConfirmOpen] = useState(false);
+  const [isRotateConfirmOpen, setIsRotateConfirmOpen] = useState(false);
   const environmentLabel = environment === 'test' ? 'Test mode' : 'Live mode';
   const hasKeyId = keys.some(
     (key) => key.environment === environment && key.keyType === 'api_key' && Boolean(key.value)
@@ -979,8 +979,7 @@ function RazorpayWebhookEnvironmentSection({
   const setupQuery = useRazorpayWebhookSetup(environment, isKeyConfigured);
   const setup = setupQuery.data ?? null;
   const isWebhookUrlPublic = setup ? isPublicHttpsWebhookUrl(setup.webhookUrl) : true;
-  const isRegenerating =
-    regenerateWebhookSecret.isPending && regenerateWebhookSecret.variables === environment;
+  const isRotating = rotateWebhookSecret.isPending && rotateWebhookSecret.variables === environment;
 
   return (
     <SettingRow
@@ -1036,26 +1035,26 @@ function RazorpayWebhookEnvironmentSection({
                   size="sm"
                   className="h-7 px-2"
                   disabled={isBusy}
-                  onClick={() => setIsRegenerateConfirmOpen(true)}
+                  onClick={() => setIsRotateConfirmOpen(true)}
                 >
-                  {isRegenerating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-                  Regenerate
+                  {isRotating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                  Rotate
                 </Button>
               </div>
             </div>
           </div>
 
           <ConfirmDialog
-            open={isRegenerateConfirmOpen}
-            onOpenChange={setIsRegenerateConfirmOpen}
-            title="Regenerate Razorpay webhook secret?"
-            description="Regenerating the webhook secret will break existing Razorpay webhook deliveries until you update the secret in Razorpay Dashboard."
+            open={isRotateConfirmOpen}
+            onOpenChange={setIsRotateConfirmOpen}
+            title="Rotate Razorpay webhook secret?"
+            description="Rotating the webhook secret will break existing Razorpay webhook deliveries until you update the secret in Razorpay Dashboard."
             cancelText="Cancel"
-            confirmText="Regenerate"
+            confirmText="Rotate"
             destructive
-            isLoading={isRegenerating}
+            isLoading={isRotating}
             onConfirm={async () => {
-              await regenerateWebhookSecret.mutateAsync(environment);
+              await rotateWebhookSecret.mutateAsync(environment);
             }}
           />
         </div>
@@ -1088,7 +1087,7 @@ export function PaymentsSettingsDialog({
     removeKey: rzpRemoveKey,
   } = useRazorpayConfig();
   const { syncPayments: rzpSyncPayments } = useRazorpaySync();
-  const { regenerateWebhookSecret } = useRazorpayWebhook();
+  const { rotateWebhookSecret } = useRazorpayWebhook();
 
   const [activeTab, setActiveTab] = useState<PaymentsSettingsTab>('keys');
 
@@ -1132,7 +1131,7 @@ export function PaymentsSettingsDialog({
     rzpSaveKey.isPending ||
     rzpRemoveKey.isPending ||
     rzpSyncPayments.isPending ||
-    regenerateWebhookSecret.isPending;
+    rotateWebhookSecret.isPending;
 
   const canClose = !isBusy;
   const configuredKeys = keys.filter((key) => Boolean(key.value));
@@ -1198,7 +1197,7 @@ export function PaymentsSettingsDialog({
       rzpSaveKey.reset();
       rzpRemoveKey.reset();
       rzpSyncPayments.reset();
-      regenerateWebhookSecret.reset();
+      rotateWebhookSecret.reset();
 
       setActiveTab('keys');
     }
@@ -1412,7 +1411,7 @@ export function PaymentsSettingsDialog({
               ) : (
                 <RazorpayWebhooksTabContent
                   keys={rzpKeys}
-                  regenerateWebhookSecret={regenerateWebhookSecret}
+                  rotateWebhookSecret={rotateWebhookSecret}
                   isBusy={isBusy}
                   onGoToKeys={() => setActiveTab('keys')}
                 />

--- a/packages/dashboard/src/features/payments/hooks/useRazorpayWebhook.ts
+++ b/packages/dashboard/src/features/payments/hooks/useRazorpayWebhook.ts
@@ -24,16 +24,16 @@ export function useRazorpayWebhook() {
     staleTime: 30 * 1000,
   });
 
-  const regenerateWebhookSecret = useMutation({
+  const rotateWebhookSecret = useMutation({
     mutationFn: (environment: RazorpayEnvironment) =>
-      razorpayService.regenerateWebhookSecret(environment),
+      razorpayService.rotateWebhookSecret(environment),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: RAZORPAY_STATUS_QUERY_KEY });
       await queryClient.invalidateQueries({ queryKey: ['payments', 'razorpay'] });
-      showToast('Razorpay webhook secret regenerated', 'success');
+      showToast('Razorpay webhook secret rotated', 'success');
     },
     onError: (err: Error) => {
-      showToast(err.message || 'Failed to regenerate Razorpay webhook secret', 'error');
+      showToast(err.message || 'Failed to rotate Razorpay webhook secret', 'error');
     },
   });
 
@@ -41,7 +41,7 @@ export function useRazorpayWebhook() {
     connections: data?.razorpayConnections ?? [],
     isLoading,
     error,
-    regenerateWebhookSecret,
+    rotateWebhookSecret,
   };
 }
 

--- a/packages/dashboard/src/features/payments/services/razorpay.service.ts
+++ b/packages/dashboard/src/features/payments/services/razorpay.service.ts
@@ -1,7 +1,7 @@
 import type {
   RazorpayEnvironment,
   GetRazorpayWebhookSetupResponse,
-  RegenerateRazorpayWebhookSecretResponse,
+  RotateRazorpayWebhookSecretResponse,
   GetRazorpayConfigResponse,
   GetRazorpayStatusResponse,
   ListRazorpayCatalogResponse,
@@ -19,7 +19,7 @@ import { apiClient } from '#lib/api/client';
 
 export type {
   GetRazorpayWebhookSetupResponse,
-  RegenerateRazorpayWebhookSecretResponse,
+  RotateRazorpayWebhookSecretResponse,
   GetRazorpayConfigResponse,
   GetRazorpayStatusResponse,
   ListRazorpayCatalogResponse,
@@ -74,10 +74,10 @@ export class RazorpayService {
     });
   }
 
-  async regenerateWebhookSecret(
+  async rotateWebhookSecret(
     environment: RazorpayEnvironment
-  ): Promise<RegenerateRazorpayWebhookSecretResponse> {
-    return apiClient.request(`/payments/razorpay/${environment}/webhook/regenerate-secret`, {
+  ): Promise<RotateRazorpayWebhookSecretResponse> {
+    return apiClient.request(`/payments/razorpay/${environment}/webhook/rotate-secret`, {
       method: 'POST',
       headers: apiClient.withAccessToken(),
     });

--- a/packages/shared-schemas/package.json
+++ b/packages/shared-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/shared-schemas",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "author": "Insforge",
   "description": "Shared TypeScript schemas for InsForge frontend and backend",
   "license": "Apache-2.0",

--- a/packages/shared-schemas/src/payments-api.schema.ts
+++ b/packages/shared-schemas/src/payments-api.schema.ts
@@ -817,7 +817,7 @@ export const getRazorpayWebhookSetupResponseSchema = z.object({
   webhookSecret: z.string().trim().min(1),
 });
 
-export const regenerateRazorpayWebhookSecretResponseSchema = getRazorpayWebhookSetupResponseSchema;
+export const rotateRazorpayWebhookSecretResponseSchema = getRazorpayWebhookSetupResponseSchema;
 
 export const razorpayWebhookResponseSchema = z.object({
   received: z.boolean(),
@@ -962,7 +962,7 @@ export type UpsertStripeConfigRequest = z.infer<typeof upsertStripeConfigRequest
 export type UpsertRazorpayConfigBody = z.infer<typeof upsertRazorpayConfigBodySchema>;
 export type UpsertRazorpayConfigRequest = z.infer<typeof upsertRazorpayConfigRequestSchema>;
 export type GetRazorpayWebhookSetupResponse = z.infer<typeof getRazorpayWebhookSetupResponseSchema>;
-export type RegenerateRazorpayWebhookSecretResponse = z.infer<
-  typeof regenerateRazorpayWebhookSecretResponseSchema
+export type RotateRazorpayWebhookSecretResponse = z.infer<
+  typeof rotateRazorpayWebhookSecretResponseSchema
 >;
 export type RazorpayWebhookResponse = z.infer<typeof razorpayWebhookResponseSchema>;


### PR DESCRIPTION
## Summary
- Rename the Razorpay webhook secret endpoint from `POST /api/payments/razorpay/{environment}/webhook/regenerate-secret` to `.../webhook/rotate-secret`
- Rename the surrounding identifiers for consistency: `rotateWebhookSecret` service methods (backend + dashboard), `rotateRazorpayWebhookSecretResponseSchema` / `RotateRazorpayWebhookSecretResponse` in shared-schemas, and the OpenAPI path/schema
- Update dashboard UI copy (button, confirm dialog, toasts) from "Regenerate" to "Rotate"
- Update agent docs (`docs/agent-docs/payments-razorpay.md`)

This is a breaking rename with no alias for the old path, since the Razorpay feature only recently merged (#1483).

## Validation
- `backend/tests/unit/payments-routes.test.ts` passes (31/31, assertions updated)
- Dashboard payments tests pass
- eslint clean on all changed files
- Dashboard and shared-schemas typecheck passes. Note: backend `typecheck` fails on `main` already (missing `lru-cache` declaration in `s3-access-key.service.ts`) — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Razorpay webhook secret endpoint from POST /api/payments/razorpay/{environment}/webhook/regenerate-secret to POST /api/payments/razorpay/{environment}/webhook/rotate-secret and switched all related names and UI copy to “rotate.” This is a breaking rename; the old path is removed.

- **Refactors**
  - Backend route and service method renamed to `rotateWebhookSecret`; log message updated.
  - Shared schemas and OpenAPI updated to `RotateRazorpayWebhookSecretResponse` and new path; bumped `@insforge/shared-schemas` to 1.1.59.
  - Dashboard: `useRazorpayWebhook` and `razorpay.service` renamed; UI copy now says “Rotate.”
  - Tests and docs updated to reflect the new endpoint and names.

- **Migration**
  - Update callers to POST /api/payments/razorpay/{environment}/webhook/rotate-secret.
  - Update code to use `rotateWebhookSecret` and `RotateRazorpayWebhookSecretResponse` from `packages/shared-schemas`.

<sup>Written for commit 359b67d3cc5e6d1f33856158c991f454e95411bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename Razorpay webhook `regenerate-secret` endpoint to `rotate-secret`
> Renames the Razorpay webhook secret endpoint and all associated identifiers from `regenerate` to `rotate` across the full stack: API route, service method, OpenAPI spec, shared schemas, dashboard hook, and UI copy. The button label in the payments settings dialog changes from 'Regenerate' to 'Rotate' and confirmation dialog text is updated accordingly.
>
> Risk: Any existing clients calling `POST /webhook/regenerate-secret` will receive 404s after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 359b67d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Razorpay webhook secret management terminology across the platform, renaming the operation from "regenerate" to "rotate" for clearer semantics and consistency.

* **UI**
  * Dashboard settings and dialogs now trigger and display webhook secret rotation flows and related loading/confirmation states.

* **Tests**
  * Updated tests and schema assertions to expect the rotation flow.

* **Documentation**
  * API spec and admin docs updated to reflect the webhook secret rotation endpoint and response schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->