### PR TITLE
fix(payments): drop unregistered invoice.payment_succeeded handler case

### DIFF
--- a/backend/src/services/payments/stripe/webhook.service.ts
+++ b/backend/src/services/payments/stripe/webhook.service.ts
@@ -440,7 +440,6 @@ export class StripeWebhookService {
           )
         );
       case 'invoice.paid':
-      case 'invoice.payment_succeeded':
         await this.stripeTransactionService.upsertInvoiceTransaction(
           environment,
           event.data.object as StripeInvoice,


### PR DESCRIPTION
## Summary

`applyStripeWebhookEvent` in `backend/src/services/payments/stripe/webhook.service.ts` handled `invoice.payment_succeeded`, but the managed Stripe webhook endpoint is created with exactly `STRIPE_MANAGED_WEBHOOK_EVENTS` as its `enabled_events` (`config.service.ts`), and that list never included `invoice.payment_succeeded` — so the case was unreachable dead code. This removes it, making the handler consistent with the registered event list.

## Why drop the case instead of registering the event

- Every successful invoice payment fires **both** `invoice.paid` and `invoice.payment_succeeded` with the same invoice data. Registering both would double-deliver every paid invoice for no extra coverage.
- `invoice.paid` is strictly broader: it also fires for out-of-band payments, which `invoice.payment_succeeded` misses. [Stripe's docs](https://docs.stripe.com/invoicing/integration) recommend listening to `invoice.paid` for this reason.
- Git history shows the divergence was never intentional: the handler had both cases since the original commit (38b1e7ff), while the registered list only ever had `invoice.paid`.

## Testing

- `npx tsc --noEmit` passes
- `npx vitest run tests/unit/stripe-webhook.service.test.ts tests/unit/stripe-webhook-routes.test.ts` passes
- `invoice.payment_succeeded` has no other references in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unreachable `invoice.payment_succeeded` handling from the Stripe webhook service to align with `STRIPE_MANAGED_WEBHOOK_EVENTS`. `invoice.paid` already covers all successful invoice payments (including out-of-band), so behavior is unchanged while the handler now matches the enabled events.

<sup>Written for commit fbdc15c5f3c5394a9b6d55fd8a8e0f7979e717c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `invoice.payment_succeeded` case from `StripeWebhookService.handleStripeWebhook`
> The `invoice.payment_succeeded` event type is not a registered Stripe webhook event, so handling it alongside `invoice.paid` was dead code. This change removes the case so only `invoice.paid` triggers `upsertInvoiceTransaction` with status `succeeded`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbdc15c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment webhook event handling to correctly process invoice payments and ensure transactions are properly recorded when invoices are marked as paid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->