### PR TITLE
feat(ai): sync rotated OpenRouter key into the OPENROUTER_API_KEY secret

### DIFF
--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -7,6 +7,8 @@ import { AIModelService } from '@/services/ai/ai-model.service.js';
 import { AppError } from '@/utils/errors.js';
 import { errorResponse, successResponse } from '@/utils/response.js';
 import { OpenRouterProvider } from '@/providers/ai/openrouter.provider.js';
+import { SecretService } from '@/services/secrets/secret.service.js';
+import { FunctionService } from '@/services/functions/function.service.js';
 import logger from '@/utils/logger.js';
 import {
   ERROR_CODES,
@@ -91,6 +93,7 @@ router.post(
       const provider = parseAIProvider(req.params.provider);
       const openRouterProvider = OpenRouterProvider.getInstance();
       const key = await rotateProviderApiKey(provider, openRouterProvider);
+      await syncRotatedOpenRouterSecret(key.apiKey);
       successResponse(res, key);
     } catch (error) {
       next(error);
@@ -122,6 +125,34 @@ function getProviderApiKey(provider: AIProvider, openRouterProvider: OpenRouterP
         ERROR_CODES.INVALID_INPUT
       );
     }
+  }
+}
+
+const OPENROUTER_SECRET_KEY = 'OPENROUTER_API_KEY';
+
+/**
+ * Keep the OPENROUTER_API_KEY secret in sync after a rotation: secrets are
+ * injected into edge functions as env vars, so a stale copy keeps calling
+ * OpenRouter with the revoked key. Best-effort — the upstream key has already
+ * rotated, so a sync failure must not fail the request.
+ */
+async function syncRotatedOpenRouterSecret(apiKey: string): Promise<void> {
+  try {
+    const updated = await SecretService.getInstance().updateSecretByKey(OPENROUTER_SECRET_KEY, {
+      value: apiKey,
+    });
+    if (!updated) {
+      // No OPENROUTER_API_KEY secret configured; nothing to sync.
+      return;
+    }
+    const functionService = FunctionService.getInstance();
+    if (functionService.isSubhostingConfigured()) {
+      functionService.redeploy();
+    }
+  } catch (error) {
+    logger.error('Failed to sync rotated OpenRouter API key to secrets', {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 

--- a/backend/tests/unit/ai-rotate-secret-sync.test.ts
+++ b/backend/tests/unit/ai-rotate-secret-sync.test.ts
@@ -1,0 +1,136 @@
+import express, { type ErrorRequestHandler } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+const authMocks = vi.hoisted(() => ({
+  verifyAdmin: vi.fn((_req, _res, next) => next()),
+  verifyUser: vi.fn((_req, _res, next) => next()),
+}));
+
+const openRouterMocks = vi.hoisted(() => ({
+  rotateManagedApiKey: vi.fn(),
+}));
+
+const secretMocks = vi.hoisted(() => ({
+  updateSecretByKey: vi.fn(),
+}));
+
+const functionMocks = vi.hoisted(() => ({
+  isSubhostingConfigured: vi.fn(),
+  redeploy: vi.fn(),
+}));
+
+vi.mock('../../src/api/middlewares/auth.js', () => ({
+  verifyAdmin: authMocks.verifyAdmin,
+  verifyUser: authMocks.verifyUser,
+}));
+
+vi.mock('../../src/providers/ai/openrouter.provider.js', () => ({
+  OpenRouterProvider: {
+    getInstance: () => openRouterMocks,
+  },
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => secretMocks,
+  },
+}));
+
+vi.mock('../../src/services/functions/function.service.js', () => ({
+  FunctionService: {
+    getInstance: () => functionMocks,
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { aiRouter } from '../../src/api/routes/ai/index.routes';
+import { AppError } from '../../src/utils/errors';
+
+const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  void next;
+
+  const status = err instanceof AppError ? err.statusCode : 500;
+  res.status(status).json({ message: err instanceof Error ? err.message : 'error' });
+};
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/ai', aiRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('POST /api/ai/openrouter/api-key/rotate secret sync', () => {
+  const rotatedKey = 'sk-or-rotated-1234567890';
+  const maskedKey = 'sk-or-ro••••••••7890';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openRouterMocks.rotateManagedApiKey.mockResolvedValue({
+      apiKey: rotatedKey,
+      maskedKey,
+    });
+    secretMocks.updateSecretByKey.mockResolvedValue(true);
+    functionMocks.isSubhostingConfigured.mockReturnValue(true);
+  });
+
+  it('updates the OPENROUTER_API_KEY secret with the rotated key and redeploys functions', async () => {
+    const response = await request(createApp()).post('/api/ai/openrouter/api-key/rotate');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ apiKey: rotatedKey, maskedKey });
+    expect(secretMocks.updateSecretByKey).toHaveBeenCalledWith('OPENROUTER_API_KEY', {
+      value: rotatedKey,
+    });
+    expect(functionMocks.redeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips redeployment when no OPENROUTER_API_KEY secret exists', async () => {
+    secretMocks.updateSecretByKey.mockResolvedValue(false);
+
+    const response = await request(createApp()).post('/api/ai/openrouter/api-key/rotate');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ apiKey: rotatedKey });
+    expect(functionMocks.redeploy).not.toHaveBeenCalled();
+  });
+
+  it('skips redeployment when subhosting is not configured', async () => {
+    functionMocks.isSubhostingConfigured.mockReturnValue(false);
+
+    const response = await request(createApp()).post('/api/ai/openrouter/api-key/rotate');
+
+    expect(response.status).toBe(200);
+    expect(functionMocks.redeploy).not.toHaveBeenCalled();
+  });
+
+  it('still returns the rotated key when the secret sync fails', async () => {
+    secretMocks.updateSecretByKey.mockRejectedValue(new Error('db down'));
+
+    const response = await request(createApp()).post('/api/ai/openrouter/api-key/rotate');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ apiKey: rotatedKey, maskedKey });
+    expect(functionMocks.redeploy).not.toHaveBeenCalled();
+  });
+
+  it('does not touch secrets when rotation itself fails', async () => {
+    openRouterMocks.rotateManagedApiKey.mockRejectedValue(
+      new AppError('rotation failed', 502, 'AI_UPSTREAM_UNAVAILABLE')
+    );
+
+    const response = await request(createApp()).post('/api/ai/openrouter/api-key/rotate');
+
+    expect(response.status).toBe(502);
+    expect(secretMocks.updateSecretByKey).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Rotating the cloud-managed OpenRouter API key (`POST /api/ai/openrouter/api-key/rotate`) left a stale copy in the `OPENROUTER_API_KEY` secret. Deno Subhosting bakes secrets into deployments as env vars at deploy time, so edge functions kept calling OpenRouter with the revoked key until an unrelated redeploy happened.

## Change

After a successful rotation, the rotate route now:

1. Updates the `OPENROUTER_API_KEY` secret with the new key — **only if the secret already exists**; rotation never creates it. The secret's existence is the signal that functions consume it.
2. Triggers the same debounced `FunctionService.redeploy()` the secrets routes use, gated on `isSubhostingConfigured()`, so deployed functions pick up the new key.

The sync is **best-effort**: by the time we touch secrets the upstream key has already rotated, so a secret-store failure is logged but the request still returns the new key.

### Why the redeploy is needed

- **Cloud (Subhosting)**: secrets are passed as `envVars` in the deployment-creation request — deployment-time, not invocation-time. Rotation is cloud-only, so every real rotation hits this path.
- **Local OSS runtime**: `functions/server.ts` re-reads `system.secrets` on every invocation, so no redeploy is needed — and none fires, since `isSubhostingConfigured()` is false there.

## Tests

New `backend/tests/unit/ai-rotate-secret-sync.test.ts` (supertest against the AI router) covers:

- secret updated with the rotated key + redeploy triggered
- redeploy skipped when the secret doesn't exist
- redeploy skipped when subhosting isn't configured
- rotation still returns 200 with the new key when the secret sync throws
- a failed rotation never touches secrets

`tsc` and the backend unit suite pass apart from pre-existing `lru-cache`-related failures in the S3/storage tests (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotating the cloud-managed OpenRouter API key now updates the `OPENROUTER_API_KEY` secret and redeploys functions so edge deployments use the new key. This prevents calls to OpenRouter with revoked keys.

- **Bug Fixes**
  - After a successful rotation (`POST /api/ai/openrouter/api-key/rotate`), updates the `OPENROUTER_API_KEY` secret with the new key if the secret exists.
  - Triggers debounced `FunctionService.redeploy()` when `isSubhostingConfigured()` is true to propagate updated env vars; skipped locally and when the secret doesn’t exist.
  - Best-effort sync: logs secret-store failures but still returns the new key; failed rotations never touch secrets. Unit tests cover these paths.

<sup>Written for commit 73f0f26d21e49e5cf338fb7e78a22f152decae9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync rotated OpenRouter API key into the `OPENROUTER_API_KEY` secret after rotation
> - After a successful provider API key rotation, the `/:provider/api-key/rotate` route now calls `syncRotatedOpenRouterSecret` to update the `OPENROUTER_API_KEY` secret via `SecretService.updateSecretByKey`.
> - If the secret exists and subhosting is configured, a functions redeploy is triggered via `FunctionService`.
> - Failures in the sync/redeploy path are caught, logged, and suppressed so they do not affect the rotation API response.
> - Unit tests in [ai-rotate-secret-sync.test.ts](https://github.com/InsForge/InsForge/pull/1503/files#diff-a823c81aee0c3347a9ced26633997542f0302874f67f3f0cd6b5681a6997b865) cover sync, conditional redeploy, and failure isolation scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f0f26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved OpenRouter API key rotation with automatic synchronization of rotated keys to system storage and function redeployment for subhosting configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->