### PR TITLE
fix(payments): backfill Stripe customer mappings from webhook event metadata

### DIFF
--- a/backend/src/services/payments/payment-customer.service.ts
+++ b/backend/src/services/payments/payment-customer.service.ts
@@ -12,6 +12,7 @@ import type {
   StripeEnvironment,
 } from '@/types/payments.js';
 import type {
+  BillingSubject,
   ListPaymentCustomersRequest,
   ListPaymentCustomersResponse,
   PaymentCustomer,
@@ -285,6 +286,29 @@ export class PaymentCustomerService {
     } finally {
       client.release();
     }
+  }
+
+  async backfillCustomerMapping(
+    provider: PaymentProvider,
+    environment: StripeEnvironment,
+    subject: BillingSubject,
+    providerCustomerId: string
+  ): Promise<void> {
+    // ON CONFLICT DO NOTHING covers both unique constraints (subject and
+    // provider_customer_id): backfill fills missing mappings from webhook
+    // event metadata but never overrides a checkout-written mapping.
+    await this.getPool().query(
+      `INSERT INTO payments.customer_mappings (
+         provider,
+         environment,
+         subject_type,
+         subject_id,
+         provider_customer_id
+       )
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT DO NOTHING`,
+      [provider, environment, subject.type, subject.id, providerCustomerId]
+    );
   }
 
   async upsertCustomerProjection(

--- a/backend/src/services/payments/stripe/subscription.service.ts
+++ b/backend/src/services/payments/stripe/subscription.service.ts
@@ -1,5 +1,6 @@
 import type { Pool, PoolClient } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { PaymentCustomerService } from '@/services/payments/payment-customer.service.js';
 import type { StripeProvider } from '@/providers/payments/stripe.provider.js';
 import {
   fromStripeTimestamp,
@@ -29,6 +30,7 @@ export interface SubscriptionProjectionResult {
 export class StripeSubscriptionService {
   private static instance: StripeSubscriptionService;
   private pool: Pool | null = null;
+  private readonly customerService = PaymentCustomerService.getInstance();
 
   static getInstance(): StripeSubscriptionService {
     if (!StripeSubscriptionService.instance) {
@@ -170,7 +172,9 @@ export class StripeSubscriptionService {
       return { synced: false, unmapped: false };
     }
 
-    const subject = await this.resolveSubscriptionSubject(environment, subscription, customerId);
+    const metadataSubject = getBillingSubjectFromProviderAttributes(subscription.metadata);
+    const subject =
+      metadataSubject ?? (await this.resolveSubjectFromCustomerMapping(environment, customerId));
 
     const subscriptionItems = await this.resolveSubscriptionItems(subscription, provider);
     const client = await this.getPool().connect();
@@ -252,13 +256,26 @@ export class StripeSubscriptionService {
       );
 
       await client.query('COMMIT');
-      return { synced: true, unmapped: !subject };
     } catch (error) {
       await client.query('ROLLBACK');
       throw error;
     } finally {
       client.release();
     }
+
+    if (metadataSubject) {
+      // Stripe delivers customer.subscription.* and checkout.session.completed
+      // in no guaranteed order; backfill the mapping so fulfillment triggers
+      // on this event can resolve the subject regardless of arrival order.
+      await this.customerService.backfillCustomerMapping(
+        'stripe',
+        environment,
+        metadataSubject,
+        customerId
+      );
+    }
+
+    return { synced: true, unmapped: !subject };
   }
 
   private async deleteMissingSyncedSubscriptions(
@@ -344,17 +361,6 @@ export class StripeSubscriptionService {
     }
 
     return provider.listSubscriptionItems(subscription.id);
-  }
-
-  private async resolveSubscriptionSubject(
-    environment: StripeEnvironment,
-    subscription: StripeSubscription,
-    customerId: string
-  ): Promise<BillingSubject | null> {
-    return (
-      getBillingSubjectFromProviderAttributes(subscription.metadata) ??
-      (await this.resolveSubjectFromCustomerMapping(environment, customerId))
-    );
   }
 
   private async findStripeCustomerMappingByCustomerId(

--- a/backend/src/services/payments/stripe/transaction.service.ts
+++ b/backend/src/services/payments/stripe/transaction.service.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { PaymentCustomerService } from '@/services/payments/payment-customer.service.js';
 import { STRIPE_CHECKOUT_MODE_METADATA_KEY } from '@/services/payments/stripe/constants.js';
 import {
   fromStripeTimestamp,
@@ -78,6 +79,7 @@ type RefundStripeContextLoader = () => Promise<RefundStripeContext>;
 export class StripeTransactionService {
   private static instance: StripeTransactionService;
   private pool: Pool | null = null;
+  private readonly customerService = PaymentCustomerService.getInstance();
 
   static getInstance(): StripeTransactionService {
     if (!StripeTransactionService.instance) {
@@ -121,7 +123,22 @@ export class StripeTransactionService {
   ): Promise<void> {
     const customerId = getStripeObjectId(invoice.customer);
     const subscriptionId = this.getInvoiceSubscriptionId(invoice);
-    const subject = await this.resolveInvoiceSubject(environment, invoice, customerId);
+    const metadataSubject = this.getInvoiceMetadataSubject(invoice);
+    const subject =
+      metadataSubject ??
+      (customerId ? await this.findSubjectForStripeCustomer(environment, customerId) : null);
+
+    if (metadataSubject && customerId) {
+      // Stripe delivers invoice.* and checkout.session.completed in no
+      // guaranteed order; backfill the mapping so fulfillment triggers on
+      // this event can resolve the subject regardless of arrival order.
+      await this.customerService.backfillCustomerMapping(
+        'stripe',
+        environment,
+        metadataSubject,
+        customerId
+      );
+    }
     const paymentIntentId = this.getInvoicePaymentIntentId(invoice);
     const firstLine = invoice.lines?.data?.[0] ?? null;
     const productId = this.getInvoiceLineItemProductId(firstLine);
@@ -769,16 +786,20 @@ export class StripeTransactionService {
     return { type: mapping.subjectType, id: mapping.subjectId };
   }
 
+  private getInvoiceMetadataSubject(invoice: StripeInvoice): BillingSubject | null {
+    return (
+      getBillingSubjectFromProviderAttributes(invoice.parent?.subscription_details?.metadata) ??
+      getBillingSubjectFromProviderAttributes(invoice.metadata)
+    );
+  }
+
   private async resolveInvoiceSubject(
     environment: StripeEnvironment,
     invoice: StripeInvoice,
     customerId: string | null
   ): Promise<BillingSubject | null> {
-    const parentMetadata = invoice.parent?.subscription_details?.metadata;
-
     return (
-      getBillingSubjectFromProviderAttributes(parentMetadata) ??
-      getBillingSubjectFromProviderAttributes(invoice.metadata) ??
+      this.getInvoiceMetadataSubject(invoice) ??
       (customerId ? await this.findSubjectForStripeCustomer(environment, customerId) : null)
     );
   }

--- a/backend/src/services/payments/stripe/transaction.service.ts
+++ b/backend/src/services/payments/stripe/transaction.service.ts
@@ -127,18 +127,6 @@ export class StripeTransactionService {
     const subject =
       metadataSubject ??
       (customerId ? await this.findSubjectForStripeCustomer(environment, customerId) : null);
-
-    if (metadataSubject && customerId) {
-      // Stripe delivers invoice.* and checkout.session.completed in no
-      // guaranteed order; backfill the mapping so fulfillment triggers on
-      // this event can resolve the subject regardless of arrival order.
-      await this.customerService.backfillCustomerMapping(
-        'stripe',
-        environment,
-        metadataSubject,
-        customerId
-      );
-    }
     const paymentIntentId = this.getInvoicePaymentIntentId(invoice);
     const firstLine = invoice.lines?.data?.[0] ?? null;
     const productId = this.getInvoiceLineItemProductId(firstLine);
@@ -182,6 +170,18 @@ export class StripeTransactionService {
         { type: 'payment_intent', id: paymentIntentId },
       ],
     });
+
+    if (metadataSubject && customerId) {
+      // Stripe delivers invoice.* and checkout.session.completed in no
+      // guaranteed order; backfill the mapping so fulfillment triggers on
+      // this event can resolve the subject regardless of arrival order.
+      await this.customerService.backfillCustomerMapping(
+        'stripe',
+        environment,
+        metadataSubject,
+        customerId
+      );
+    }
 
     if (status === 'succeeded') {
       await this.refreshOriginalTransactionRefundState(environment, paymentIntentId, null);

--- a/backend/tests/unit/stripe-services.test.ts
+++ b/backend/tests/unit/stripe-services.test.ts
@@ -3079,6 +3079,7 @@ describe('Stripe payment services', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
@@ -3132,6 +3133,119 @@ describe('Stripe payment services', () => {
       expect.stringMatching(
         /related_object_ids = tx\.related_object_ids \|\| EXCLUDED\.related_object_ids/i
       ),
+      expect.any(Array)
+    );
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i),
+      ['stripe', 'test', 'organization', 'org_123', 'cus_123']
+    );
+  });
+
+  it('resolves invoice subjects from existing customer mappings without backfilling', async () => {
+    mockGetSecretByKey
+      .mockResolvedValueOnce('whsec_test_123')
+      .mockResolvedValueOnce('sk_test_1234567890');
+    mockProvider.constructWebhookEvent.mockReturnValueOnce({
+      id: 'evt_invoice_456',
+      type: 'invoice.paid',
+      livemode: false,
+      data: {
+        object: {
+          id: 'in_456',
+          object: 'invoice',
+          amount_due: 9900,
+          amount_paid: 9900,
+          currency: 'usd',
+          created: 1777334400,
+          customer: 'cus_456',
+          customer_email: 'buyer@example.com',
+          description: 'Subscription invoice',
+          number: 'INV-456',
+          metadata: {},
+          status_transitions: { paid_at: 1777334500 },
+          parent: {
+            type: 'subscription_details',
+            quote_details: null,
+            subscription_details: {
+              subscription: 'sub_456',
+              metadata: {},
+            },
+          },
+          payments: {
+            data: [
+              {
+                payment: {
+                  type: 'payment_intent',
+                  payment_intent: 'pi_invoice_456',
+                },
+              },
+            ],
+          },
+          lines: { data: [] },
+        },
+      },
+    });
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            environment: 'test',
+            eventId: 'evt_invoice_456',
+            eventType: 'invoice.paid',
+            livemode: false,
+            accountId: null,
+            objectType: 'invoice',
+            objectId: 'in_456',
+            processingStatus: 'pending',
+            attemptCount: 1,
+            lastError: null,
+            receivedAt: new Date('2026-04-28T00:00:00.000Z'),
+            processedAt: null,
+            createdAt: new Date('2026-04-28T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-28T00:00:00.000Z'),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ subjectType: 'user', subjectId: 'user_456' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            environment: 'test',
+            eventId: 'evt_invoice_456',
+            eventType: 'invoice.paid',
+            livemode: false,
+            accountId: null,
+            objectType: 'invoice',
+            objectId: 'in_456',
+            processingStatus: 'processed',
+            attemptCount: 1,
+            lastError: null,
+            receivedAt: new Date('2026-04-28T00:00:00.000Z'),
+            processedAt: new Date('2026-04-28T00:00:01.000Z'),
+            createdAt: new Date('2026-04-28T00:00:00.000Z'),
+            updatedAt: new Date('2026-04-28T00:00:01.000Z'),
+          },
+        ],
+      });
+
+    await expect(
+      stripeServices.handleStripeWebhook('test', Buffer.from('{"id":"evt_invoice_456"}'), 'sig_123')
+    ).resolves.toMatchObject({ received: true, handled: true });
+
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/FROM payments\.customer_mappings/i),
+      ['test', 'cus_456']
+    );
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /INSERT INTO payments\.transactions[\s\S]*ON CONFLICT \(provider, environment, provider_object_type, provider_object_id\)/i
+      ),
+      expect.arrayContaining(['test', 'payment_intent', 'pi_invoice_456', 'user', 'user_456'])
+    );
+    expect(mockPool.query).not.toHaveBeenCalledWith(
+      expect.stringMatching(/INSERT INTO payments\.customer_mappings/i),
       expect.any(Array)
     );
   });
@@ -3753,6 +3867,7 @@ describe('Stripe payment services', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -3888,6 +4003,7 @@ describe('Stripe payment services', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -3926,6 +4042,10 @@ describe('Stripe payment services', () => {
       expect.arrayContaining(['test', 'si_123', 'sub_123', 'prod_123', 'price_123', 1])
     );
     expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringMatching(/INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i),
+      ['stripe', 'test', 'organization', 'org_123', 'cus_123']
+    );
   });
 
   it('syncs existing Stripe subscriptions as unmapped when no billing subject exists', async () => {

--- a/backend/tests/unit/stripe-services.test.ts
+++ b/backend/tests/unit/stripe-services.test.ts
@@ -3136,7 +3136,9 @@ describe('Stripe payment services', () => {
       expect.any(Array)
     );
     expect(mockPool.query).toHaveBeenCalledWith(
-      expect.stringMatching(/INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i),
+      expect.stringMatching(
+        /INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i
+      ),
       ['stripe', 'test', 'organization', 'org_123', 'cus_123']
     );
   });
@@ -4043,7 +4045,9 @@ describe('Stripe payment services', () => {
     );
     expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
     expect(mockPool.query).toHaveBeenCalledWith(
-      expect.stringMatching(/INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i),
+      expect.stringMatching(
+        /INSERT INTO payments\.customer_mappings[\s\S]*ON CONFLICT DO NOTHING/i
+      ),
       ['stripe', 'test', 'organization', 'org_123', 'cus_123']
     );
   });

--- a/docs/agent-docs/payments-razorpay.md
+++ b/docs/agent-docs/payments-razorpay.md
@@ -166,17 +166,20 @@ For subscriptions, resolve the billing subject from the subscription entity's `n
 CREATE OR REPLACE FUNCTION public.grant_razorpay_subscription_access()
 RETURNS TRIGGER AS $$
 DECLARE
+  v_subject_type TEXT;
   v_subject_id TEXT;
 BEGIN
   IF NEW.provider = 'razorpay'
      AND NEW.event_type = 'subscription.charged'
      AND NEW.processing_status = 'processed' THEN
+    v_subject_type := NEW.payload -> 'payload' -> 'subscription' -> 'entity'
+                      -> 'notes' ->> 'insforge_subject_type';
     v_subject_id := NEW.payload -> 'payload' -> 'subscription' -> 'entity'
                     -> 'notes' ->> 'insforge_subject_id';
 
     IF v_subject_id IS NULL THEN
-      SELECT m.subject_id
-      INTO v_subject_id
+      SELECT m.subject_type, m.subject_id
+      INTO v_subject_type, v_subject_id
       FROM payments.customer_mappings m
       WHERE m.provider = NEW.provider
         AND m.environment = NEW.environment
@@ -189,13 +192,16 @@ BEGIN
       RETURN NEW;
     END IF;
 
-    -- team_id is a UUID here; match the type of the subject id sent at creation
-    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
-    VALUES (v_subject_id::uuid, 'pro', true, NOW())
-    ON CONFLICT (team_id) DO UPDATE SET
-      plan = EXCLUDED.plan,
-      active = true,
-      updated_at = NOW();
+    -- Branch on the subject type sent at creation; team_id is a UUID here,
+    -- so the type check also guards the cast.
+    IF v_subject_type = 'team' THEN
+      INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+      VALUES (v_subject_id::uuid, 'pro', true, NOW())
+      ON CONFLICT (team_id) DO UPDATE SET
+        plan = EXCLUDED.plan,
+        active = true,
+        updated_at = NOW();
+    END IF;
   END IF;
 
   RETURN NEW;

--- a/docs/agent-docs/payments-razorpay.md
+++ b/docs/agent-docs/payments-razorpay.md
@@ -160,6 +160,56 @@ CREATE TRIGGER fulfill_razorpay_order_from_webhook
   EXECUTE FUNCTION public.fulfill_razorpay_order();
 ```
 
+For subscriptions, resolve the billing subject from the subscription entity's `notes` in the event payload — InsForge stamps `insforge_subject_type` and `insforge_subject_id` into notes at subscription creation (and creates the `payments.customer_mappings` row at the same time, so the mapping is also a safe fallback):
+
+```sql
+CREATE OR REPLACE FUNCTION public.grant_razorpay_subscription_access()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_subject_id TEXT;
+BEGIN
+  IF NEW.provider = 'razorpay'
+     AND NEW.event_type = 'subscription.charged'
+     AND NEW.processing_status = 'processed' THEN
+    v_subject_id := NEW.payload -> 'payload' -> 'subscription' -> 'entity'
+                    -> 'notes' ->> 'insforge_subject_id';
+
+    IF v_subject_id IS NULL THEN
+      SELECT m.subject_id
+      INTO v_subject_id
+      FROM payments.customer_mappings m
+      WHERE m.provider = NEW.provider
+        AND m.environment = NEW.environment
+        AND m.provider_customer_id = NEW.payload -> 'payload' -> 'subscription'
+                                     -> 'entity' ->> 'customer_id';
+    END IF;
+
+    IF v_subject_id IS NULL THEN
+      RAISE WARNING 'Razorpay event % has no resolvable billing subject', NEW.provider_event_id;
+      RETURN NEW;
+    END IF;
+
+    -- team_id is a UUID here; match the type of the subject id sent at creation
+    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+    VALUES (v_subject_id::uuid, 'pro', true, NOW())
+    ON CONFLICT (team_id) DO UPDATE SET
+      plan = EXCLUDED.plan,
+      active = true,
+      updated_at = NOW();
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER grant_razorpay_subscription_access_from_webhook
+  AFTER INSERT OR UPDATE ON payments.webhook_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.grant_razorpay_subscription_access();
+```
+
+Handle revocation the same way from `subscription.cancelled`, `subscription.halted`, and `subscription.expired`.
+
 Adapt the payload lookup to the app schema and event shape. Protect app-owned billing tables with RLS. Use `payments.transactions` for dashboard/reporting only.
 
 ## Security

--- a/docs/agent-docs/payments-stripe.md
+++ b/docs/agent-docs/payments-stripe.md
@@ -193,13 +193,16 @@ BEGIN
       RETURN NEW;
     END IF;
 
-    -- team_id is a UUID here; match the type of the subject id sent at checkout
-    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
-    VALUES (v_subject_id::uuid, 'pro', true, NOW())
-    ON CONFLICT (team_id) DO UPDATE SET
-      plan = EXCLUDED.plan,
-      active = true,
-      updated_at = NOW();
+    -- Branch on the subject type sent at checkout; team_id is a UUID here,
+    -- so the type check also guards the cast.
+    IF v_subject_type = 'team' THEN
+      INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+      VALUES (v_subject_id::uuid, 'pro', true, NOW())
+      ON CONFLICT (team_id) DO UPDATE SET
+        plan = EXCLUDED.plan,
+        active = true,
+        updated_at = NOW();
+    END IF;
   END IF;
 
   RETURN NEW;

--- a/docs/agent-docs/payments-stripe.md
+++ b/docs/agent-docs/payments-stripe.md
@@ -156,7 +156,7 @@ CREATE TRIGGER fulfill_paid_order_from_stripe_webhook
 
 ### Subscriptions
 
-Subscription events do not carry your app's `metadata`. Resolve the billing subject from the subscription metadata embedded in the event payload (InsForge stamps `insforge_subject_type` and `insforge_subject_id` at checkout), then fall back to `payments.customer_mappings`:
+Subscription events do not carry your app's `metadata`. Resolve the billing subject from the subscription metadata embedded in the event payload — InsForge stamps `insforge_subject_type` and `insforge_subject_id` at checkout, and Stripe snapshots it onto subscription-generated invoices as `parent.subscription_details.metadata`. Check `invoice.metadata` next, then fall back to `payments.customer_mappings` (the same order InsForge uses internally):
 
 ```sql
 CREATE OR REPLACE FUNCTION public.grant_subscription_access()
@@ -168,10 +168,16 @@ BEGIN
   IF NEW.provider = 'stripe'
      AND NEW.event_type = 'invoice.paid'
      AND NEW.processing_status = 'processed' THEN
-    v_subject_type := NEW.payload -> 'data' -> 'object' -> 'parent'
-                      -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type';
-    v_subject_id := NEW.payload -> 'data' -> 'object' -> 'parent'
-                    -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id';
+    v_subject_type := COALESCE(
+      NEW.payload -> 'data' -> 'object' -> 'parent'
+        -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type',
+      NEW.payload -> 'data' -> 'object' -> 'metadata' ->> 'insforge_subject_type'
+    );
+    v_subject_id := COALESCE(
+      NEW.payload -> 'data' -> 'object' -> 'parent'
+        -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id',
+      NEW.payload -> 'data' -> 'object' -> 'metadata' ->> 'insforge_subject_id'
+    );
 
     IF v_subject_id IS NULL THEN
       SELECT m.subject_type, m.subject_id
@@ -187,6 +193,7 @@ BEGIN
       RETURN NEW;
     END IF;
 
+    -- team_id is a UUID here; match the type of the subject id sent at checkout
     INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
     VALUES (v_subject_id::uuid, 'pro', true, NOW())
     ON CONFLICT (team_id) DO UPDATE SET

--- a/docs/agent-docs/payments-stripe.md
+++ b/docs/agent-docs/payments-stripe.md
@@ -123,7 +123,11 @@ Portal creation requires an authenticated user and an existing `payments.custome
 
 ## Fulfillment
 
-Create triggers from verified Stripe webhook events into app-owned tables:
+Create triggers from verified Stripe webhook events into app-owned tables.
+
+Webhook events are verified and processed independently. InsForge commits all rows derived from an event before marking that event `processed`, but there is no ordering guarantee across events: Stripe can deliver `invoice.paid` before `checkout.session.completed`, so rows created by another event (such as `payments.customer_mappings`) may not exist yet when your trigger fires. Resolve the billing subject from the event payload first and use `payments.customer_mappings` as a fallback, exactly as the examples below do. Never let fulfillment skip silently: log or dead-letter events you cannot resolve.
+
+### One-time payments
 
 ```sql
 CREATE OR REPLACE FUNCTION public.fulfill_paid_order()
@@ -149,6 +153,59 @@ CREATE TRIGGER fulfill_paid_order_from_stripe_webhook
   FOR EACH ROW
   EXECUTE FUNCTION public.fulfill_paid_order();
 ```
+
+### Subscriptions
+
+Subscription events do not carry your app's `metadata`. Resolve the billing subject from the subscription metadata embedded in the event payload (InsForge stamps `insforge_subject_type` and `insforge_subject_id` at checkout), then fall back to `payments.customer_mappings`:
+
+```sql
+CREATE OR REPLACE FUNCTION public.grant_subscription_access()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_subject_type TEXT;
+  v_subject_id TEXT;
+BEGIN
+  IF NEW.provider = 'stripe'
+     AND NEW.event_type = 'invoice.paid'
+     AND NEW.processing_status = 'processed' THEN
+    v_subject_type := NEW.payload -> 'data' -> 'object' -> 'parent'
+                      -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type';
+    v_subject_id := NEW.payload -> 'data' -> 'object' -> 'parent'
+                    -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id';
+
+    IF v_subject_id IS NULL THEN
+      SELECT m.subject_type, m.subject_id
+      INTO v_subject_type, v_subject_id
+      FROM payments.customer_mappings m
+      WHERE m.provider = NEW.provider
+        AND m.environment = NEW.environment
+        AND m.provider_customer_id = NEW.payload -> 'data' -> 'object' ->> 'customer';
+    END IF;
+
+    IF v_subject_id IS NULL THEN
+      RAISE WARNING 'Stripe event % has no resolvable billing subject', NEW.provider_event_id;
+      RETURN NEW;
+    END IF;
+
+    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+    VALUES (v_subject_id::uuid, 'pro', true, NOW())
+    ON CONFLICT (team_id) DO UPDATE SET
+      plan = EXCLUDED.plan,
+      active = true,
+      updated_at = NOW();
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER grant_subscription_access_from_stripe_webhook
+  AFTER INSERT OR UPDATE ON payments.webhook_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.grant_subscription_access();
+```
+
+Adjust the trigger target to the app-owned entitlement table for the billing subject type used at checkout. Handle revocation the same way from `customer.subscription.deleted` and `customer.subscription.updated` events (`payload -> 'data' -> 'object' -> 'metadata'` holds the subject keys on subscription events).
 
 Use `payments.transactions` for dashboard/reporting only.
 

--- a/docs/agent-docs/payments.md
+++ b/docs/agent-docs/payments.md
@@ -15,6 +15,7 @@ Use a provider-specific guide before coding. Stripe and Razorpay have different 
 4. Fulfillment should run from verified rows in `payments.webhook_events`.
 5. Keep user-facing order, credit, and entitlement state in app-owned tables with app-owned RLS.
 6. Use `payments.transactions` for dashboard and reporting queries, not as the primary fulfillment contract.
+7. Webhook events are processed independently with no cross-event ordering guarantee. Rows derived from an event are committed before that event is marked `processed`, but rows derived from other events (such as `payments.customer_mappings` or provider mirrors) may not exist yet. Fulfillment triggers must resolve billing subjects from the event payload first and treat lookups into rows owned by other events as fallbacks.
 
 ## Shared tables
 

--- a/docs/core-concepts/payments/overview.mdx
+++ b/docs/core-concepts/payments/overview.mdx
@@ -63,6 +63,8 @@ CREATE TRIGGER fulfill_from_payment_webhook
 
 If your app accepts multiple providers, keep the trigger idempotent and branch on `NEW.provider` and `NEW.event_type`. Protect your app-owned fulfillment tables with your own RLS policies.
 
+Webhook events are processed independently and providers give no ordering guarantee across events. Rows derived from an event are committed before that event is marked `processed`, but rows owned by other events — such as `payments.customer_mappings`, which checkout completion creates — may not exist yet when your trigger fires. Resolve billing subjects from the event payload first and treat lookups into other tables as fallbacks. See the provider guides for subscription fulfillment examples.
+
 <Warning>
   Older Stripe-only `payments.payment_history` rows are migrated into
   `payments.transactions` for dashboard and reporting. Triggers on

--- a/docs/core-concepts/payments/stripe.mdx
+++ b/docs/core-concepts/payments/stripe.mdx
@@ -132,6 +132,61 @@ CREATE TRIGGER fulfill_stripe_order_from_webhook
   EXECUTE FUNCTION public.fulfill_stripe_order();
 ```
 
+### Event ordering
+
+Webhook events are verified and processed independently. InsForge commits every row derived from an event before marking that event `processed`, but Stripe gives no ordering guarantee across events: `invoice.paid` can be processed before `checkout.session.completed`, so rows created by another event (such as `payments.customer_mappings`) may not exist yet when your trigger fires.
+
+For subscription events, resolve the billing subject from the event payload first — InsForge stamps `insforge_subject_type` and `insforge_subject_id` into subscription metadata at checkout, and Stripe copies it onto every invoice — and fall back to `payments.customer_mappings`:
+
+```sql
+CREATE OR REPLACE FUNCTION public.grant_subscription_access()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_subject_type TEXT;
+  v_subject_id TEXT;
+BEGIN
+  IF NEW.provider = 'stripe'
+     AND NEW.event_type = 'invoice.paid'
+     AND NEW.processing_status = 'processed' THEN
+    v_subject_type := NEW.payload -> 'data' -> 'object' -> 'parent'
+                      -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type';
+    v_subject_id := NEW.payload -> 'data' -> 'object' -> 'parent'
+                    -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id';
+
+    IF v_subject_id IS NULL THEN
+      SELECT m.subject_type, m.subject_id
+      INTO v_subject_type, v_subject_id
+      FROM payments.customer_mappings m
+      WHERE m.provider = NEW.provider
+        AND m.environment = NEW.environment
+        AND m.provider_customer_id = NEW.payload -> 'data' -> 'object' ->> 'customer';
+    END IF;
+
+    IF v_subject_id IS NULL THEN
+      RAISE WARNING 'Stripe event % has no resolvable billing subject', NEW.provider_event_id;
+      RETURN NEW;
+    END IF;
+
+    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+    VALUES (v_subject_id::uuid, 'pro', true, NOW())
+    ON CONFLICT (team_id) DO UPDATE SET
+      plan = EXCLUDED.plan,
+      active = true,
+      updated_at = NOW();
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER grant_subscription_access_from_stripe_webhook
+  AFTER INSERT OR UPDATE ON payments.webhook_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.grant_subscription_access();
+```
+
+Never let fulfillment skip silently — log or dead-letter events you cannot resolve so they can be replayed.
+
 ## Sync and dashboard state
 
 Stripe sync mirrors Products, Prices, Customers, and Subscriptions. Webhooks maintain session, subscription, customer, refund, and transaction state as Stripe emits events.

--- a/docs/core-concepts/payments/stripe.mdx
+++ b/docs/core-concepts/payments/stripe.mdx
@@ -173,13 +173,16 @@ BEGIN
       RETURN NEW;
     END IF;
 
-    -- team_id is a UUID here; match the type of the subject id sent at checkout
-    INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
-    VALUES (v_subject_id::uuid, 'pro', true, NOW())
-    ON CONFLICT (team_id) DO UPDATE SET
-      plan = EXCLUDED.plan,
-      active = true,
-      updated_at = NOW();
+    -- Branch on the subject type sent at checkout; team_id is a UUID here,
+    -- so the type check also guards the cast.
+    IF v_subject_type = 'team' THEN
+      INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
+      VALUES (v_subject_id::uuid, 'pro', true, NOW())
+      ON CONFLICT (team_id) DO UPDATE SET
+        plan = EXCLUDED.plan,
+        active = true,
+        updated_at = NOW();
+    END IF;
   END IF;
 
   RETURN NEW;

--- a/docs/core-concepts/payments/stripe.mdx
+++ b/docs/core-concepts/payments/stripe.mdx
@@ -136,7 +136,7 @@ CREATE TRIGGER fulfill_stripe_order_from_webhook
 
 Webhook events are verified and processed independently. InsForge commits every row derived from an event before marking that event `processed`, but Stripe gives no ordering guarantee across events: `invoice.paid` can be processed before `checkout.session.completed`, so rows created by another event (such as `payments.customer_mappings`) may not exist yet when your trigger fires.
 
-For subscription events, resolve the billing subject from the event payload first — InsForge stamps `insforge_subject_type` and `insforge_subject_id` into subscription metadata at checkout, and Stripe copies it onto every invoice — and fall back to `payments.customer_mappings`:
+For subscription events, resolve the billing subject from the event payload first — InsForge stamps `insforge_subject_type` and `insforge_subject_id` into subscription metadata at checkout, and Stripe snapshots it onto subscription-generated invoices as `parent.subscription_details.metadata`. Check `invoice.metadata` next, then fall back to `payments.customer_mappings` (the same order InsForge uses internally):
 
 ```sql
 CREATE OR REPLACE FUNCTION public.grant_subscription_access()
@@ -148,10 +148,16 @@ BEGIN
   IF NEW.provider = 'stripe'
      AND NEW.event_type = 'invoice.paid'
      AND NEW.processing_status = 'processed' THEN
-    v_subject_type := NEW.payload -> 'data' -> 'object' -> 'parent'
-                      -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type';
-    v_subject_id := NEW.payload -> 'data' -> 'object' -> 'parent'
-                    -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id';
+    v_subject_type := COALESCE(
+      NEW.payload -> 'data' -> 'object' -> 'parent'
+        -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_type',
+      NEW.payload -> 'data' -> 'object' -> 'metadata' ->> 'insforge_subject_type'
+    );
+    v_subject_id := COALESCE(
+      NEW.payload -> 'data' -> 'object' -> 'parent'
+        -> 'subscription_details' -> 'metadata' ->> 'insforge_subject_id',
+      NEW.payload -> 'data' -> 'object' -> 'metadata' ->> 'insforge_subject_id'
+    );
 
     IF v_subject_id IS NULL THEN
       SELECT m.subject_type, m.subject_id
@@ -167,6 +173,7 @@ BEGIN
       RETURN NEW;
     END IF;
 
+    -- team_id is a UUID here; match the type of the subject id sent at checkout
     INSERT INTO public.team_entitlements (team_id, plan, active, updated_at)
     VALUES (v_subject_id::uuid, 'pro', true, NOW())
     ON CONFLICT (team_id) DO UPDATE SET


### PR DESCRIPTION
## Problem

Stripe delivers `checkout.session.completed`, `customer.subscription.*`, and `invoice.*` webhook events in no guaranteed order, but `payments.customer_mappings` was only ever written by the `checkout.session.completed` handler. When Stripe delivered `invoice.paid` first (observed ~800 ms ahead in testing), the event was marked `processed` with no mapping row in place, so app fulfillment triggers that resolve the billing subject via `customer_mappings` silently skipped fulfillment.

Razorpay already backfills mappings from subscription webhook events; Stripe did not.

## Fix

- Add `PaymentCustomerService.backfillCustomerMapping`, an `ON CONFLICT DO NOTHING` upsert that fills missing mappings without overriding checkout-written rows (covers both unique constraints on the table).
- Call it from `upsertInvoiceTransaction` and `upsertSubscriptionProjection` whenever the billing subject is resolvable from event metadata (`insforge_subject_*` stamped at checkout). Whichever event arrives first now creates the mapping, and it commits before that event flips to `processed` — restoring ordering for fulfillment triggers.

## Docs

- `docs/agent-docs/payments.md`: new shared rule stating the cross-event ordering contract.
- `docs/agent-docs/payments-stripe.md` and `docs/core-concepts/payments/stripe.mdx`: subscription fulfillment trigger example that resolves the subject payload-first with a `customer_mappings` fallback, plus guidance to never skip fulfillment silently.
- `docs/core-concepts/payments/overview.mdx`: ordering note in the fulfillment model.

Companion skill update: pushed to the open insforge-skills PR #93 branch.

## Tests

- Updated existing webhook tests for the new query and added assertions for the backfill insert.
- New test: invoice without metadata resolves via existing mapping and performs no backfill write.
- `vitest run tests/unit/stripe-services.test.ts` → 63 passed; all other payments unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills missing Stripe `payments.customer_mappings` from subscription and invoice webhook metadata so fulfillment doesn’t skip when events arrive out of order. Docs add payload‑first subscription fulfillment examples for Stripe and Razorpay, with subject type checks and clear ordering notes.

- **Bug Fixes**
  - Added `backfillCustomerMapping` upsert (`ON CONFLICT DO NOTHING`) to safely fill missing mappings.
  - Subject resolution now prefers event metadata (invoices: `parent.subscription_details.metadata`, then `invoice.metadata`; subscriptions: `subscription.metadata`) and falls back to `payments.customer_mappings`.
  - Backfill runs after the DB upsert (invoice) or commit (subscription) but before the event is marked processed.

- **Migration**
  - Update fulfillment to resolve the billing subject from the event payload first; use `payments.customer_mappings` only as a fallback.
  - Trigger examples now extract both `insforge_subject_type` and `insforge_subject_id`, branch on type, and warn or dead‑letter when unresolved.
  - New/updated Stripe and Razorpay subscription examples mirror the resolution order and document cross‑event ordering.

<sup>Written for commit 02024bf0e150a0bf17b22d3d8e972d7da0d64c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Backfill Stripe customer mappings from webhook event metadata in subscription and invoice processing
> - Adds `PaymentCustomerService.backfillCustomerMapping` which inserts a row into `payments.customer_mappings` using `ON CONFLICT DO NOTHING`, so existing mappings are never overwritten.
> - `StripeSubscriptionService.upsertSubscriptionProjection` and `StripeTransactionService.upsertInvoiceTransaction` now read the billing subject from event metadata first, fall back to `payments.customer_mappings`, and call `backfillCustomerMapping` after committing if a metadata subject was found.
> - Invoice metadata extraction is extracted into a new `getInvoiceMetadataSubject` helper that checks `parent.subscription_details.metadata` before `invoice.metadata`.
> - Adds documentation to `payments.md`, `stripe.mdx`, and `payments-stripe.md` explaining independent webhook event processing and demonstrating subject resolution patterns with fallback to `payments.customer_mappings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02024bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prefer webhook payload metadata for billing-subject resolution and persist provider→subject mappings to better handle out-of-order Stripe events.

* **Documentation**
  * Clarified webhook ordering and fulfillment rules; added subscription access provisioning examples and provider-specific guidance for Stripe and Razorpay.

* **Tests**
  * Updated unit tests to validate revised subject resolution, mapping persistence, and call ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->