### PR TITLE
feat(database): add self-hosted database backup and restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,11 @@ RUN npm ci --omit=dev && npm cache clean --force
 FROM node:20-alpine AS runner
 
 # tini: proper PID 1 for signal forwarding and zombie reaping
-RUN apk add --no-cache tini
+# postgresql16-client: pg_dump/pg_restore for database backups. Keep the
+# client major at 16 while the bundled postgres image is on 15 — pg_dump 17+
+# emits settings (e.g. transaction_timeout) that a 15 server rejects, which
+# would make every restore fail.
+RUN apk add --no-cache tini postgresql16-client
 
 WORKDIR /app
 
@@ -161,6 +165,10 @@ CMD ["sh", "-c", "cd backend && npm run migrate:up && cd .. && exec npm start"]
 FROM node:20-alpine AS dev
 
 COPY --from=deno-bin /bin/deno /usr/local/bin/deno
+
+# pg_dump/pg_restore for database backups (see runner stage for the
+# version-pinning rationale)
+RUN apk add --no-cache postgresql16-client
 
 WORKDIR /app
 

--- a/backend/src/api/routes/database/backups.routes.ts
+++ b/backend/src/api/routes/database/backups.routes.ts
@@ -1,0 +1,169 @@
+import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import {
+  ERROR_CODES,
+  createDatabaseBackupRequestSchema,
+  renameDatabaseBackupRequestSchema,
+  type CreateDatabaseBackupResponse,
+  type DatabaseBackupsResponse,
+  type DeleteDatabaseBackupResponse,
+  type RestoreDatabaseBackupResponse,
+  type UpdateDatabaseBackupResponse,
+} from '@insforge/shared-schemas';
+import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { AppError } from '@/utils/errors.js';
+import { DatabaseBackupService } from '@/services/database/database-backup.service.js';
+import { AuditService } from '@/services/logs/audit.service.js';
+import { SocketManager } from '@/infra/socket/socket.manager.js';
+import { successResponse } from '@/utils/response.js';
+import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
+import { type DatabaseResourceUpdate } from '@/utils/sql-parser.js';
+
+const router = Router();
+const backupService = DatabaseBackupService.getInstance();
+const auditService = AuditService.getInstance();
+const uuidParamSchema = z.string().uuid();
+
+// 22P02 (invalid uuid text) is not mapped by POSTGRES_ERROR_HANDLERS, so an
+// unvalidated :id would surface as a 500 instead of a 400.
+function parseBackupId(value: string): string {
+  const validation = uuidParamSchema.safeParse(value);
+  if (!validation.success) {
+    throw new AppError('Invalid backup ID', 400, ERROR_CODES.INVALID_INPUT);
+  }
+  return validation.data;
+}
+
+function getValidationMessage(error: z.ZodError): string {
+  return error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+}
+
+router.get(
+  '/',
+  verifyAdmin,
+  async (_req: AuthRequest, res: Response<DatabaseBackupsResponse>, next: NextFunction) => {
+    try {
+      const response = await backupService.listBackups();
+      successResponse(res, response);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.post(
+  '/',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response<CreateDatabaseBackupResponse>, next: NextFunction) => {
+    try {
+      const validation = createDatabaseBackupRequestSchema.safeParse(req.body ?? {});
+      if (!validation.success) {
+        throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+      }
+
+      const actor = req.hasApiKey ? 'api-key' : (req.user?.id ?? null);
+      const backup = await backupService.createBackup(validation.data, actor);
+
+      await auditService.log({
+        actor: actor ?? undefined,
+        action: 'CREATE_DATABASE_BACKUP',
+        module: 'DATABASE',
+        details: { id: backup.id, name: backup.name },
+        ip_address: req.ip,
+      });
+
+      successResponse(res, backup, 201);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.patch(
+  '/:id',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response<UpdateDatabaseBackupResponse>, next: NextFunction) => {
+    try {
+      const backupId = parseBackupId(req.params.id);
+      const validation = renameDatabaseBackupRequestSchema.safeParse(req.body ?? {});
+      if (!validation.success) {
+        throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+      }
+
+      const backup = await backupService.renameBackup(backupId, validation.data.name);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'RENAME_DATABASE_BACKUP',
+        module: 'DATABASE',
+        details: { id: backup.id, name: backup.name },
+        ip_address: req.ip,
+      });
+
+      successResponse(res, backup);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.delete(
+  '/:id',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response<DeleteDatabaseBackupResponse>, next: NextFunction) => {
+    try {
+      const backupId = parseBackupId(req.params.id);
+      await backupService.deleteBackup(backupId);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'DELETE_DATABASE_BACKUP',
+        module: 'DATABASE',
+        details: { id: backupId },
+        ip_address: req.ip,
+      });
+
+      successResponse(res, { message: 'Backup deleted successfully' });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.post(
+  '/:id/restore',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response<RestoreDatabaseBackupResponse>, next: NextFunction) => {
+    try {
+      const backupId = parseBackupId(req.params.id);
+      await backupService.restoreBackup(backupId);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'RESTORE_DATABASE_BACKUP',
+        module: 'DATABASE',
+        details: { id: backupId },
+        ip_address: req.ip,
+      });
+
+      const socket = SocketManager.getInstance();
+      socket.broadcastToRoom(
+        'role:project_admin',
+        ServerEvents.DATA_UPDATE,
+        {
+          resource: DataUpdateResourceType.DATABASE,
+          data: {
+            changes: [{ type: 'tables' }, { type: 'records' }] as DatabaseResourceUpdate[],
+          },
+        },
+        'system'
+      );
+
+      successResponse(res, { message: 'Database restored successfully' });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export { router as databaseBackupsRouter };

--- a/backend/src/api/routes/database/index.routes.ts
+++ b/backend/src/api/routes/database/index.routes.ts
@@ -4,12 +4,14 @@ import { databaseRecordsRouter } from './records.routes.js';
 import { databaseRpcRouter } from './rpc.routes.js';
 import databaseAdvanceRouter from './advance.routes.js';
 import { databaseMigrationsRouter } from './migrations.routes.js';
+import { databaseBackupsRouter } from './backups.routes.js';
 import { databaseAdminRouter } from './admin.routes.js';
 import { DatabaseService } from '@/services/database/database.service.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { successResponse } from '@/utils/response.js';
 import logger from '@/utils/logger.js';
 import { normalizeDatabaseSchemaName } from '@/services/database/helpers.js';
+import { isCloudEnvironment } from '@/utils/environment.js';
 
 const router = Router();
 const databaseService = DatabaseService.getInstance();
@@ -20,6 +22,9 @@ router.use('/records', databaseRecordsRouter);
 router.use('/rpc', databaseRpcRouter);
 router.use('/advance', databaseAdvanceRouter);
 router.use('/migrations', databaseMigrationsRouter);
+if (!isCloudEnvironment()) {
+  router.use('/backups', databaseBackupsRouter);
+}
 router.use('/admin', databaseAdminRouter);
 
 router.get(

--- a/backend/src/infra/database/migrations/051_create-database-backups.sql
+++ b/backend/src/infra/database/migrations/051_create-database-backups.sql
@@ -1,0 +1,30 @@
+-- Database Backups: metadata for self-hosted pg_dump backups.
+-- Backup archives are persisted through the storage provider (local STORAGE_DIR
+-- or S3 when AWS_S3_BUCKET is configured); this table only tracks metadata.
+
+CREATE TABLE IF NOT EXISTS system.database_backups (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            TEXT,
+  trigger_source  TEXT NOT NULL DEFAULT 'manual'
+                  CHECK (trigger_source IN ('manual', 'scheduled')),
+  status          TEXT NOT NULL DEFAULT 'running'
+                  CHECK (status IN ('running', 'completed', 'failed')),
+  storage_key     TEXT,
+  size_bytes      BIGINT,
+  error_message   TEXT,
+  created_by      TEXT,
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_database_backups_name
+  ON system.database_backups(name)
+  WHERE name IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_database_backups_status ON system.database_backups(status);
+
+DROP TRIGGER IF EXISTS update_database_backups_updated_at ON system.database_backups;
+CREATE TRIGGER update_database_backups_updated_at
+  BEFORE UPDATE ON system.database_backups
+  FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();

--- a/backend/src/services/database/database-backup.service.ts
+++ b/backend/src/services/database/database-backup.service.ts
@@ -68,6 +68,7 @@ export class DatabaseBackupService {
   // overlapping requests cannot both pass the concurrency guard.
   private backupInFlight = false;
   private restoreInProgress = false;
+  private metadataMutationsInFlight = 0;
 
   private constructor() {
     if (appConfig.storage.s3Bucket) {
@@ -154,6 +155,7 @@ export class DatabaseBackupService {
 
   async renameBackup(id: string, name: string | null): Promise<DatabaseBackup> {
     this.assertNoRestoreInProgress();
+    this.metadataMutationsInFlight += 1;
     try {
       const result = await this.dbManager.getPool().query(
         `
@@ -179,35 +181,42 @@ export class DatabaseBackupService {
         );
       }
       throw error;
+    } finally {
+      this.metadataMutationsInFlight -= 1;
     }
   }
 
   async deleteBackup(id: string): Promise<void> {
     this.assertNoRestoreInProgress();
-    const backup = await this.getBackupRow(id);
+    this.metadataMutationsInFlight += 1;
+    try {
+      const backup = await this.getBackupRow(id);
 
-    if (backup.status === 'running' && backup.id === this.activeBackupId) {
-      throw new AppError(
-        'This backup is still running and cannot be deleted yet.',
-        409,
-        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
-      );
-    }
-
-    // Remove the row first: a leaked artifact (logged below) is preferable to
-    // a row that survives an artifact delete and points at a missing file.
-    await this.dbManager.getPool().query(`DELETE FROM system.database_backups WHERE id = $1`, [id]);
-
-    if (backup.storageKey) {
-      try {
-        await this.deleteArtifact(backup.storageKey);
-      } catch (error) {
-        logger.warn('Failed to delete backup artifact', {
-          backupId: id,
-          storageKey: backup.storageKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
+      if (backup.status === 'running' && backup.id === this.activeBackupId) {
+        throw new AppError(
+          'This backup is still running and cannot be deleted yet.',
+          409,
+          ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+        );
       }
+
+      await this.dbManager
+        .getPool()
+        .query(`DELETE FROM system.database_backups WHERE id = $1`, [id]);
+
+      if (backup.storageKey) {
+        try {
+          await this.deleteArtifact(backup.storageKey);
+        } catch (error) {
+          logger.warn('Failed to delete backup artifact', {
+            backupId: id,
+            storageKey: backup.storageKey,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } finally {
+      this.metadataMutationsInFlight -= 1;
     }
   }
 
@@ -233,6 +242,13 @@ export class DatabaseBackupService {
     if (this.backupInFlight) {
       throw new AppError(
         'A backup is currently running. Try again once it finishes.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+    if (this.metadataMutationsInFlight > 0) {
+      throw new AppError(
+        'A backup is being renamed or deleted. Try again in a moment.',
         409,
         ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
       );
@@ -503,6 +519,32 @@ export class DatabaseBackupService {
       `,
       [this.activeBackupId]
     );
+    await this.cleanupStaleTmpDirs();
+  }
+
+  /**
+   * A backup interrupted by a process exit never reaches its finally-cleanup,
+   * leaving a partial dump in a `.backup-tmp-*` dir. Sweep dirs older than an
+   * hour — age-based so an in-flight backup's temp dir is never touched.
+   */
+  private async cleanupStaleTmpDirs(): Promise<void> {
+    const maxAgeMs = 60 * 60 * 1000;
+    try {
+      const entries = await fs.readdir(appConfig.storage.storageDir);
+      await Promise.all(
+        entries
+          .filter((name) => name.startsWith('.backup-tmp-'))
+          .map(async (name) => {
+            const dirPath = path.join(appConfig.storage.storageDir, name);
+            const stats = await fs.stat(dirPath).catch(() => null);
+            if (stats && Date.now() - stats.mtimeMs > maxAgeMs) {
+              await fs.rm(dirPath, { recursive: true, force: true }).catch(() => {});
+            }
+          })
+      );
+    } catch {
+      // The storage dir may not exist yet on a fresh install.
+    }
   }
 
   private localArtifactPath(key: string): string {

--- a/backend/src/services/database/database-backup.service.ts
+++ b/backend/src/services/database/database-backup.service.ts
@@ -1,0 +1,525 @@
+import { spawn } from 'node:child_process';
+import { createReadStream, createWriteStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import {
+  ERROR_CODES,
+  type CreateDatabaseBackupRequest,
+  type DatabaseBackup,
+  type DatabaseBackupsResponse,
+} from '@insforge/shared-schemas';
+import { AppError, isPgErrorLike } from '@/utils/errors.js';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { appConfig } from '@/infra/config/app.config.js';
+import { S3StorageProvider } from '@/providers/storage/s3.provider.js';
+import logger from '@/utils/logger.js';
+
+// Internal artifact bucket, mirroring the `_deployments` convention. With S3
+// configured the archive lands under `<appKey>/_database_backups/<key>`;
+// otherwise it is written to `<STORAGE_DIR>/_database_backups/<key>`.
+const BACKUP_BUCKET = '_database_backups';
+const MAX_STDERR_LENGTH = 4000;
+
+const BACKUP_COLUMNS = `
+  id,
+  name,
+  trigger_source AS "triggerSource",
+  status,
+  size_bytes::float8 AS "sizeBytes",
+  error_message AS "errorMessage",
+  created_at AS "createdAt",
+  completed_at AS "completedAt",
+  created_by AS "createdBy"
+`;
+
+interface BackupRow extends DatabaseBackup {
+  storageKey?: string | null;
+}
+
+function toIsoString(value: unknown): string | null {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return typeof value === 'string' ? value : null;
+}
+
+function serializeBackup(row: BackupRow): DatabaseBackup {
+  return {
+    id: row.id,
+    name: row.name,
+    triggerSource: row.triggerSource,
+    status: row.status,
+    sizeBytes: row.sizeBytes,
+    errorMessage: row.errorMessage,
+    createdAt: toIsoString(row.createdAt) ?? row.createdAt,
+    completedAt: toIsoString(row.completedAt),
+    createdBy: row.createdBy,
+  };
+}
+
+export class DatabaseBackupService {
+  private static instance: DatabaseBackupService;
+  private dbManager = DatabaseManager.getInstance();
+  private s3Provider: S3StorageProvider | null = null;
+  private activeBackupId: string | null = null;
+  private restoreInProgress = false;
+
+  private constructor() {
+    if (appConfig.storage.s3Bucket) {
+      this.s3Provider = new S3StorageProvider(
+        appConfig.storage.s3Bucket,
+        appConfig.storage.appKey,
+        appConfig.storage.awsRegion
+      );
+      void this.s3Provider.initialize();
+    }
+  }
+
+  public static getInstance(): DatabaseBackupService {
+    if (!DatabaseBackupService.instance) {
+      DatabaseBackupService.instance = new DatabaseBackupService();
+    }
+    return DatabaseBackupService.instance;
+  }
+
+  async listBackups(): Promise<DatabaseBackupsResponse> {
+    await this.failInterruptedBackups();
+
+    const result = await this.dbManager.getPool().query(`
+      SELECT ${BACKUP_COLUMNS}
+      FROM system.database_backups
+      ORDER BY created_at DESC
+    `);
+
+    return { backups: (result.rows as BackupRow[]).map(serializeBackup) };
+  }
+
+  async createBackup(
+    input: CreateDatabaseBackupRequest,
+    createdBy: string | null
+  ): Promise<DatabaseBackup> {
+    if (this.restoreInProgress) {
+      throw new AppError(
+        'A restore is currently in progress. Try again once it finishes.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+    if (this.activeBackupId) {
+      throw new AppError(
+        'Another backup is already running. Try again once it finishes.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+
+    let row: BackupRow;
+    try {
+      const result = await this.dbManager.getPool().query(
+        `
+          INSERT INTO system.database_backups (name, trigger_source, status, created_by)
+          VALUES ($1, 'manual', 'running', $2)
+          RETURNING ${BACKUP_COLUMNS}
+        `,
+        [input.name ?? null, createdBy]
+      );
+      row = result.rows[0] as BackupRow;
+    } catch (error) {
+      if (isPgErrorLike(error) && error.code === '23505') {
+        throw new AppError(
+          'A backup with this name already exists.',
+          409,
+          ERROR_CODES.DATABASE_DUPLICATE
+        );
+      }
+      throw error;
+    }
+
+    this.activeBackupId = row.id;
+    void this.runBackup(row.id)
+      .catch((error: unknown) => {
+        logger.error('Database backup failed', {
+          backupId: row.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        this.activeBackupId = null;
+      });
+
+    return serializeBackup(row);
+  }
+
+  async renameBackup(id: string, name: string | null): Promise<DatabaseBackup> {
+    try {
+      const result = await this.dbManager.getPool().query(
+        `
+          UPDATE system.database_backups
+          SET name = $2
+          WHERE id = $1
+          RETURNING ${BACKUP_COLUMNS}
+        `,
+        [id, name]
+      );
+
+      if (result.rows.length === 0) {
+        throw new AppError('Backup not found.', 404, ERROR_CODES.DATABASE_NOT_FOUND);
+      }
+
+      return serializeBackup(result.rows[0] as BackupRow);
+    } catch (error) {
+      if (isPgErrorLike(error) && error.code === '23505') {
+        throw new AppError(
+          'A backup with this name already exists.',
+          409,
+          ERROR_CODES.DATABASE_DUPLICATE
+        );
+      }
+      throw error;
+    }
+  }
+
+  async deleteBackup(id: string): Promise<void> {
+    const backup = await this.getBackupRow(id);
+
+    if (backup.status === 'running' && backup.id === this.activeBackupId) {
+      throw new AppError(
+        'This backup is still running and cannot be deleted yet.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+
+    if (backup.storageKey) {
+      try {
+        await this.deleteArtifact(backup.storageKey);
+      } catch (error) {
+        // Keep the metadata row consistent with reality: losing an orphaned
+        // file is preferable to a row that points at nothing, so log and
+        // continue with the row delete.
+        logger.warn('Failed to delete backup artifact', {
+          backupId: id,
+          storageKey: backup.storageKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    await this.dbManager.getPool().query(`DELETE FROM system.database_backups WHERE id = $1`, [id]);
+  }
+
+  /**
+   * Restores the database from a completed backup archive.
+   *
+   * The dump contains every schema, including system.database_backups itself,
+   * so the current metadata rows are snapshotted first and written back after
+   * the restore — otherwise restoring an old backup would resurrect deleted
+   * backups and drop newer ones while their archives still exist.
+   *
+   * pg_restore runs with --single-transaction so a failed restore rolls back
+   * and leaves the database untouched.
+   */
+  async restoreBackup(id: string): Promise<void> {
+    if (this.restoreInProgress) {
+      throw new AppError(
+        'Another restore is already in progress.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+    if (this.activeBackupId) {
+      throw new AppError(
+        'A backup is currently running. Try again once it finishes.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+
+    const backup = await this.getBackupRow(id);
+    if (backup.status !== 'completed' || !backup.storageKey) {
+      throw new AppError(
+        'This backup is not restorable. Only completed backups can be restored.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
+
+    this.restoreInProgress = true;
+    try {
+      const pool = this.dbManager.getPool();
+      const snapshot = await pool.query(
+        `SELECT id, name, trigger_source, status, storage_key, size_bytes,
+                error_message, created_by, completed_at, created_at, updated_at
+         FROM system.database_backups`
+      );
+
+      // Do NOT pg_terminate_backend other sessions here: that kills the
+      // backend's own long-lived clients (realtime LISTEN, pool) and crashes
+      // the process. Idle connections hold no table locks, so pg_restore can
+      // acquire what it needs; if something does hold a lock, the
+      // single-transaction restore fails and rolls back instead.
+      const artifact = await this.openArtifactStream(backup.storageKey);
+      await this.runPgTool(
+        'pg_restore',
+        ['--clean', '--if-exists', '--single-transaction', '-d', appConfig.database.name],
+        artifact
+      );
+
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query('TRUNCATE system.database_backups');
+        for (const row of snapshot.rows as Record<string, unknown>[]) {
+          await client.query(
+            `INSERT INTO system.database_backups
+               (id, name, trigger_source, status, storage_key, size_bytes,
+                error_message, created_by, completed_at, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+            [
+              row.id,
+              row.name,
+              row.trigger_source,
+              row.status,
+              row.storage_key,
+              row.size_bytes,
+              row.error_message,
+              row.created_by,
+              row.completed_at,
+              row.created_at,
+              row.updated_at,
+            ]
+          );
+        }
+        await client.query(`NOTIFY pgrst, 'reload schema';`);
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw error;
+      } finally {
+        client.release();
+      }
+
+      DatabaseManager.clearColumnTypeCache();
+      logger.info('Database restore completed', { backupId: id });
+    } finally {
+      this.restoreInProgress = false;
+    }
+  }
+
+  private async runBackup(id: string): Promise<void> {
+    const storageKey = `${formatTimestamp(new Date())}.dump`;
+    const tmpDir = await fs.mkdtemp(path.join(appConfig.storage.storageDir, '.backup-tmp-'));
+    const tmpPath = path.join(tmpDir, storageKey);
+
+    try {
+      const out = createWriteStream(tmpPath);
+      await this.runPgTool(
+        'pg_dump',
+        ['--format=custom', '-d', appConfig.database.name],
+        undefined,
+        out
+      );
+
+      const { size } = await fs.stat(tmpPath);
+      await this.persistArtifact(tmpPath, storageKey, size);
+
+      await this.dbManager.getPool().query(
+        `
+          UPDATE system.database_backups
+          SET status = 'completed', storage_key = $2, size_bytes = $3, completed_at = NOW()
+          WHERE id = $1
+        `,
+        [id, storageKey, size]
+      );
+      logger.info('Database backup completed', { backupId: id, storageKey, sizeBytes: size });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await this.dbManager
+        .getPool()
+        .query(
+          `UPDATE system.database_backups
+           SET status = 'failed', error_message = $2
+           WHERE id = $1`,
+          [id, message.slice(0, MAX_STDERR_LENGTH)]
+        )
+        .catch(() => {});
+      throw error;
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  private runPgTool(
+    tool: 'pg_dump' | 'pg_restore',
+    extraArgs: string[],
+    stdin?: Readable,
+    stdout?: NodeJS.WritableStream
+  ): Promise<void> {
+    const { host, port, user, password } = appConfig.database;
+    const args = ['-h', host, '-p', String(port), '-U', user, '--no-password', ...extraArgs];
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(tool, args, {
+        env: { ...process.env, PGPASSWORD: password },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stderr = '';
+      child.stderr.on('data', (chunk: Buffer) => {
+        if (stderr.length < MAX_STDERR_LENGTH) {
+          stderr += chunk.toString();
+        }
+      });
+
+      child.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') {
+          reject(
+            new AppError(
+              `${tool} is not available in the backend environment. Install the PostgreSQL client tools to enable database backups.`,
+              500,
+              ERROR_CODES.DATABASE_INTERNAL_ERROR
+            )
+          );
+          return;
+        }
+        reject(error);
+      });
+
+      // Settle only after the process exits AND every pipe has flushed, so a
+      // resolved promise guarantees the output stream is fully written. Pipe
+      // failures are captured (not awaited) so a spawn failure — where 'close'
+      // never fires — cannot leave an unhandled rejection.
+      let exited = false;
+      let exitCode: number | null = null;
+      let pendingPipes = 0;
+      let pipeError: unknown = null;
+
+      const settle = () => {
+        if (!exited || pendingPipes > 0) {
+          return;
+        }
+        if (exitCode !== 0) {
+          reject(
+            new AppError(
+              `${tool} exited with code ${exitCode ?? 'unknown'}: ${stderr.trim().slice(0, MAX_STDERR_LENGTH)}`,
+              500,
+              ERROR_CODES.DATABASE_INTERNAL_ERROR
+            )
+          );
+          return;
+        }
+        if (pipeError) {
+          reject(pipeError instanceof Error ? pipeError : new Error(String(pipeError)));
+          return;
+        }
+        resolve();
+      };
+
+      const trackPipe = (pipe: Promise<void>) => {
+        pendingPipes += 1;
+        pipe
+          .catch((error: unknown) => {
+            pipeError = pipeError ?? error;
+          })
+          .finally(() => {
+            pendingPipes -= 1;
+            settle();
+          });
+      };
+
+      if (stdin) {
+        trackPipe(pipeline(stdin, child.stdin));
+      } else {
+        child.stdin.end();
+      }
+      if (stdout) {
+        trackPipe(pipeline(child.stdout, stdout));
+      } else {
+        child.stdout.resume();
+      }
+
+      child.on('close', (code) => {
+        exited = true;
+        exitCode = code;
+        settle();
+      });
+    });
+  }
+
+  private async getBackupRow(id: string): Promise<BackupRow> {
+    const result = await this.dbManager.getPool().query(
+      `
+        SELECT ${BACKUP_COLUMNS}, storage_key AS "storageKey"
+        FROM system.database_backups
+        WHERE id = $1
+      `,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      throw new AppError('Backup not found.', 404, ERROR_CODES.DATABASE_NOT_FOUND);
+    }
+
+    return result.rows[0] as BackupRow;
+  }
+
+  /**
+   * Backups left in 'running' state with no in-memory operation were
+   * interrupted by a server restart; surface them as failed.
+   */
+  private async failInterruptedBackups(): Promise<void> {
+    await this.dbManager.getPool().query(
+      `
+        UPDATE system.database_backups
+        SET status = 'failed', error_message = 'Interrupted by a server restart.'
+        WHERE status = 'running' AND id IS DISTINCT FROM $1
+      `,
+      [this.activeBackupId]
+    );
+  }
+
+  private localArtifactPath(key: string): string {
+    return path.join(appConfig.storage.storageDir, BACKUP_BUCKET, key);
+  }
+
+  private async persistArtifact(tmpPath: string, key: string, size: number): Promise<void> {
+    if (this.s3Provider) {
+      await this.s3Provider.putObjectStream(BACKUP_BUCKET, key, createReadStream(tmpPath), {
+        contentType: 'application/octet-stream',
+        contentLength: size,
+      });
+      return;
+    }
+
+    const target = this.localArtifactPath(key);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    // The temp dir lives on the same volume as STORAGE_DIR, so rename is atomic.
+    await fs.rename(tmpPath, target);
+  }
+
+  private async openArtifactStream(key: string): Promise<Readable> {
+    if (this.s3Provider) {
+      const result = await this.s3Provider.getObjectStream(BACKUP_BUCKET, key);
+      return result.body;
+    }
+    return createReadStream(this.localArtifactPath(key));
+  }
+
+  private async deleteArtifact(key: string): Promise<void> {
+    if (this.s3Provider) {
+      await this.s3Provider.deleteObject(BACKUP_BUCKET, key);
+      return;
+    }
+    await fs.rm(this.localArtifactPath(key), { force: true });
+  }
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `_${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
+  );
+}

--- a/backend/src/services/database/database-backup.service.ts
+++ b/backend/src/services/database/database-backup.service.ts
@@ -64,6 +64,9 @@ export class DatabaseBackupService {
   private dbManager = DatabaseManager.getInstance();
   private s3Provider: S3StorageProvider | null = null;
   private activeBackupId: string | null = null;
+  // Reserved synchronously before the first await in createBackup so two
+  // overlapping requests cannot both pass the concurrency guard.
+  private backupInFlight = false;
   private restoreInProgress = false;
 
   private constructor() {
@@ -100,20 +103,15 @@ export class DatabaseBackupService {
     input: CreateDatabaseBackupRequest,
     createdBy: string | null
   ): Promise<DatabaseBackup> {
-    if (this.restoreInProgress) {
-      throw new AppError(
-        'A restore is currently in progress. Try again once it finishes.',
-        409,
-        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
-      );
-    }
-    if (this.activeBackupId) {
+    this.assertNoRestoreInProgress();
+    if (this.backupInFlight) {
       throw new AppError(
         'Another backup is already running. Try again once it finishes.',
         409,
         ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
       );
     }
+    this.backupInFlight = true;
 
     let row: BackupRow;
     try {
@@ -127,6 +125,7 @@ export class DatabaseBackupService {
       );
       row = result.rows[0] as BackupRow;
     } catch (error) {
+      this.backupInFlight = false;
       if (isPgErrorLike(error) && error.code === '23505') {
         throw new AppError(
           'A backup with this name already exists.',
@@ -147,12 +146,14 @@ export class DatabaseBackupService {
       })
       .finally(() => {
         this.activeBackupId = null;
+        this.backupInFlight = false;
       });
 
     return serializeBackup(row);
   }
 
   async renameBackup(id: string, name: string | null): Promise<DatabaseBackup> {
+    this.assertNoRestoreInProgress();
     try {
       const result = await this.dbManager.getPool().query(
         `
@@ -182,6 +183,7 @@ export class DatabaseBackupService {
   }
 
   async deleteBackup(id: string): Promise<void> {
+    this.assertNoRestoreInProgress();
     const backup = await this.getBackupRow(id);
 
     if (backup.status === 'running' && backup.id === this.activeBackupId) {
@@ -192,13 +194,14 @@ export class DatabaseBackupService {
       );
     }
 
+    // Remove the row first: a leaked artifact (logged below) is preferable to
+    // a row that survives an artifact delete and points at a missing file.
+    await this.dbManager.getPool().query(`DELETE FROM system.database_backups WHERE id = $1`, [id]);
+
     if (backup.storageKey) {
       try {
         await this.deleteArtifact(backup.storageKey);
       } catch (error) {
-        // Keep the metadata row consistent with reality: losing an orphaned
-        // file is preferable to a row that points at nothing, so log and
-        // continue with the row delete.
         logger.warn('Failed to delete backup artifact', {
           backupId: id,
           storageKey: backup.storageKey,
@@ -206,8 +209,6 @@ export class DatabaseBackupService {
         });
       }
     }
-
-    await this.dbManager.getPool().query(`DELETE FROM system.database_backups WHERE id = $1`, [id]);
   }
 
   /**
@@ -229,7 +230,7 @@ export class DatabaseBackupService {
         ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
       );
     }
-    if (this.activeBackupId) {
+    if (this.backupInFlight) {
       throw new AppError(
         'A backup is currently running. Try again once it finishes.',
         409,
@@ -237,17 +238,19 @@ export class DatabaseBackupService {
       );
     }
 
-    const backup = await this.getBackupRow(id);
-    if (backup.status !== 'completed' || !backup.storageKey) {
-      throw new AppError(
-        'This backup is not restorable. Only completed backups can be restored.',
-        409,
-        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
-      );
-    }
-
+    // Reserve synchronously, before any await, so two overlapping restore
+    // requests cannot both pass the guards above.
     this.restoreInProgress = true;
     try {
+      const backup = await this.getBackupRow(id);
+      if (backup.status !== 'completed' || !backup.storageKey) {
+        throw new AppError(
+          'This backup is not restorable. Only completed backups can be restored.',
+          409,
+          ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+        );
+      }
+
       const pool = this.dbManager.getPool();
       const snapshot = await pool.query(
         `SELECT id, name, trigger_source, status, storage_key, size_bytes,
@@ -309,7 +312,10 @@ export class DatabaseBackupService {
   }
 
   private async runBackup(id: string): Promise<void> {
-    const storageKey = `${formatTimestamp(new Date())}.dump`;
+    // Suffix with the backup id: the timestamp alone has second resolution,
+    // so two quick successive backups would otherwise share a key and the
+    // second archive would overwrite the first.
+    const storageKey = `${formatTimestamp(new Date())}_${id}.dump`;
     const tmpDir = await fs.mkdtemp(path.join(appConfig.storage.storageDir, '.backup-tmp-'));
     const tmpPath = path.join(tmpDir, storageKey);
 
@@ -335,6 +341,11 @@ export class DatabaseBackupService {
       );
       logger.info('Database backup completed', { backupId: id, storageKey, sizeBytes: size });
     } catch (error) {
+      // A failed row never gets a storage_key, so an artifact persisted just
+      // before a late failure (e.g. the completed-status update) would be
+      // orphaned — remove it best-effort.
+      await this.deleteArtifact(storageKey).catch(() => {});
+
       const message = error instanceof Error ? error.message : String(error);
       await this.dbManager
         .getPool()
@@ -446,6 +457,20 @@ export class DatabaseBackupService {
         settle();
       });
     });
+  }
+
+  /**
+   * Mutating backup metadata while a restore is running would be clobbered
+   * (or, for deletes, resurrected) by the post-restore snapshot write-back.
+   */
+  private assertNoRestoreInProgress(): void {
+    if (this.restoreInProgress) {
+      throw new AppError(
+        'A restore is currently in progress. Try again once it finishes.',
+        409,
+        ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+      );
+    }
   }
 
   private async getBackupRow(id: string): Promise<BackupRow> {

--- a/backend/src/services/database/database-backup.service.ts
+++ b/backend/src/services/database/database-backup.service.ts
@@ -21,6 +21,9 @@ import logger from '@/utils/logger.js';
 // otherwise it is written to `<STORAGE_DIR>/_database_backups/<key>`.
 const BACKUP_BUCKET = '_database_backups';
 const MAX_STDERR_LENGTH = 4000;
+const RESTORE_APPLICATION_NAME = 'insforge-backup-restore';
+const RESTORE_LOCK_POLL_INTERVAL_MS = 5_000;
+const RESTORE_LOCK_WAIT_TIMEOUT_MS = 30_000;
 
 const BACKUP_COLUMNS = `
   id,
@@ -280,17 +283,113 @@ export class DatabaseBackupService {
       // acquire what it needs; if something does hold a lock, the
       // single-transaction restore fails and rolls back instead.
       const artifact = await this.openArtifactStream(backup.storageKey);
-      await this.runPgTool(
-        'pg_restore',
-        ['--clean', '--if-exists', '--single-transaction', '-d', appConfig.database.name],
-        artifact
-      );
+      const watchdog = this.startRestoreLockWatchdog();
+      try {
+        await this.runPgTool(
+          'pg_restore',
+          ['--clean', '--if-exists', '--single-transaction', '-d', appConfig.database.name],
+          artifact
+        );
+      } catch (error) {
+        if (watchdog.wasTriggered()) {
+          throw new AppError(
+            `Restore aborted after waiting more than ${RESTORE_LOCK_WAIT_TIMEOUT_MS / 1000}s for a database lock. Close open transactions and long-running queries, then retry.`,
+            409,
+            ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION
+          );
+        }
+        throw error;
+      } finally {
+        watchdog.stop();
+      }
 
-      const client = await pool.connect();
+      await this.writeBackMetadataSnapshot(snapshot.rows as Record<string, unknown>[]);
+      await pool.query(`NOTIFY pgrst, 'reload schema';`).catch((error: unknown) => {
+        logger.warn('Failed to notify PostgREST after restore', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+      DatabaseManager.clearColumnTypeCache();
+      logger.info('Database restore completed', { backupId: id });
+    } finally {
+      this.restoreInProgress = false;
+    }
+  }
+
+  /**
+   * Bounds how long a restore may wait on a database lock. The dump preamble
+   * replays `SET lock_timeout = 0`, overriding any client-side setting, so
+   * this polls pg_stat_activity instead and terminates the restore session
+   * once it has been continuously lock-waiting past the timeout — the
+   * single-transaction restore then rolls back cleanly.
+   */
+  private startRestoreLockWatchdog(): { stop: () => void; wasTriggered: () => boolean } {
+    let lockWaitStartedAt: number | null = null;
+    let triggered = false;
+
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const result = await this.dbManager
+            .getPool()
+            .query(
+              `SELECT pid, wait_event_type AS "waitEventType" FROM pg_stat_activity WHERE application_name = $1`,
+              [RESTORE_APPLICATION_NAME]
+            );
+          const session = result.rows[0] as
+            | { pid: number; waitEventType: string | null }
+            | undefined;
+
+          if (!session || session.waitEventType !== 'Lock') {
+            lockWaitStartedAt = null;
+            return;
+          }
+
+          lockWaitStartedAt = lockWaitStartedAt ?? Date.now();
+          if (!triggered && Date.now() - lockWaitStartedAt > RESTORE_LOCK_WAIT_TIMEOUT_MS) {
+            triggered = true;
+            logger.warn('Terminating restore stuck waiting on a database lock', {
+              pid: session.pid,
+              waitedMs: Date.now() - lockWaitStartedAt,
+            });
+            await this.dbManager.getPool().query('SELECT pg_terminate_backend($1)', [session.pid]);
+          }
+        } catch {
+          // Transient monitoring failures must never break the restore.
+        }
+      })();
+    }, RESTORE_LOCK_POLL_INTERVAL_MS);
+    timer.unref();
+
+    return {
+      stop: () => clearInterval(timer),
+      wasTriggered: () => triggered,
+    };
+  }
+
+  /**
+   * Rewrites system.database_backups with the pre-restore snapshot. Retried
+   * because the table was just recreated by pg_restore; on final failure the
+   * restore is still reported as successful and the stale list is logged for
+   * the operator (it self-corrects on the next backup mutation).
+   */
+  private async writeBackMetadataSnapshot(rows: Record<string, unknown>[]): Promise<void> {
+    const pool = this.dbManager.getPool();
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const client = await pool.connect().catch((error: unknown) => {
+        lastError = error;
+        return null;
+      });
+      if (!client) {
+        continue;
+      }
       try {
         await client.query('BEGIN');
         await client.query('TRUNCATE system.database_backups');
-        for (const row of snapshot.rows as Record<string, unknown>[]) {
+        for (const row of rows) {
           await client.query(
             `INSERT INTO system.database_backups
                (id, name, trigger_source, status, storage_key, size_bytes,
@@ -311,20 +410,20 @@ export class DatabaseBackupService {
             ]
           );
         }
-        await client.query(`NOTIFY pgrst, 'reload schema';`);
         await client.query('COMMIT');
+        return;
       } catch (error) {
+        lastError = error;
         await client.query('ROLLBACK').catch(() => {});
-        throw error;
       } finally {
         client.release();
       }
-
-      DatabaseManager.clearColumnTypeCache();
-      logger.info('Database restore completed', { backupId: id });
-    } finally {
-      this.restoreInProgress = false;
     }
+
+    logger.error(
+      'Failed to write back backup metadata after restore; the backups list reflects the archived state until the next backup operation.',
+      { error: lastError instanceof Error ? lastError.message : String(lastError) }
+    );
   }
 
   private async runBackup(id: string): Promise<void> {
@@ -387,9 +486,14 @@ export class DatabaseBackupService {
     const { host, port, user, password } = appConfig.database;
     const args = ['-h', host, '-p', String(port), '-U', user, '--no-password', ...extraArgs];
 
+    const env: NodeJS.ProcessEnv = { ...process.env, PGPASSWORD: password };
+    if (tool === 'pg_restore') {
+      env.PGAPPNAME = RESTORE_APPLICATION_NAME;
+    }
+
     return new Promise((resolve, reject) => {
       const child = spawn(tool, args, {
-        env: { ...process.env, PGPASSWORD: password },
+        env,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
@@ -524,24 +628,26 @@ export class DatabaseBackupService {
 
   /**
    * A backup interrupted by a process exit never reaches its finally-cleanup,
-   * leaving a partial dump in a `.backup-tmp-*` dir. Sweep dirs older than an
-   * hour — age-based so an in-flight backup's temp dir is never touched.
+   * leaving a partial dump in a `.backup-tmp-*` dir. With no backup in flight
+   * on this single-instance server, any such dir is an orphan. Directory
+   * mtime is NOT a safe liveness signal (appending to the dump file never
+   * touches it), so the guard is the in-memory flag, checked again before
+   * each removal in case a backup starts mid-sweep.
    */
   private async cleanupStaleTmpDirs(): Promise<void> {
-    const maxAgeMs = 60 * 60 * 1000;
+    if (this.backupInFlight) {
+      return;
+    }
     try {
       const entries = await fs.readdir(appConfig.storage.storageDir);
-      await Promise.all(
-        entries
-          .filter((name) => name.startsWith('.backup-tmp-'))
-          .map(async (name) => {
-            const dirPath = path.join(appConfig.storage.storageDir, name);
-            const stats = await fs.stat(dirPath).catch(() => null);
-            if (stats && Date.now() - stats.mtimeMs > maxAgeMs) {
-              await fs.rm(dirPath, { recursive: true, force: true }).catch(() => {});
-            }
-          })
-      );
+      for (const name of entries.filter((n) => n.startsWith('.backup-tmp-'))) {
+        if (this.backupInFlight) {
+          return;
+        }
+        await fs
+          .rm(path.join(appConfig.storage.storageDir, name), { recursive: true, force: true })
+          .catch(() => {});
+      }
     } catch {
       // The storage dir may not exist yet on a fresh install.
     }

--- a/backend/tests/unit/database-backup.service.test.ts
+++ b/backend/tests/unit/database-backup.service.test.ts
@@ -142,6 +142,23 @@ describe('DatabaseBackupService', () => {
   });
 
   describe('listBackups', () => {
+    it('sweeps stale backup temp dirs but keeps recent ones', async () => {
+      const staleDir = path.join(STORAGE_DIR, '.backup-tmp-stale');
+      const freshDir = path.join(STORAGE_DIR, '.backup-tmp-fresh');
+      await fs.mkdir(staleDir, { recursive: true });
+      await fs.mkdir(freshDir, { recursive: true });
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      await fs.utimes(staleDir, twoHoursAgo, twoHoursAgo);
+
+      queryMock.mockResolvedValue({ rows: [] });
+      const service = DatabaseBackupService.getInstance();
+      await service.listBackups();
+
+      await expect(fs.stat(staleDir)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.stat(freshDir)).resolves.toBeTruthy();
+      await fs.rm(freshDir, { recursive: true, force: true });
+    });
+
     it('fails interrupted running rows, then returns serialized backups', async () => {
       queryMock.mockImplementation((sql: string) => {
         if (sql.includes("SET status = 'failed'")) {
@@ -321,6 +338,33 @@ describe('DatabaseBackupService', () => {
         statusCode: 409,
         code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
       });
+    });
+
+    it('blocks a restore while a rename or delete is in flight', async () => {
+      let releaseDelete!: (value: { rows: unknown[] }) => void;
+      const gatedRow = new Promise<{ rows: unknown[] }>((resolve) => {
+        releaseDelete = resolve;
+      });
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('storage_key AS "storageKey"')) {
+          return gatedRow;
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const service = DatabaseBackupService.getInstance();
+      const deletion = service.deleteBackup('some-id');
+
+      // The delete has passed its guard but is still awaiting the row lookup;
+      // a restore starting now would snapshot metadata the delete is about to
+      // change, so it must be rejected.
+      await expect(service.restoreBackup('some-id')).rejects.toMatchObject({
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
+      });
+
+      releaseDelete({ rows: [backupRow({ status: 'completed', storageKey: 'gone.dump' })] });
+      await deletion;
     });
 
     it('blocks concurrent restores and metadata mutations while a restore runs', async () => {

--- a/backend/tests/unit/database-backup.service.test.ts
+++ b/backend/tests/unit/database-backup.service.test.ts
@@ -7,15 +7,21 @@ import { ERROR_CODES } from '@insforge/shared-schemas';
 
 const STORAGE_DIR = '/tmp/insforge-backup-service-tests';
 
-const { queryMock, connectMock, clientQueryMock, releaseMock, spawnMock, clearColumnTypeCacheMock } =
-  vi.hoisted(() => ({
-    queryMock: vi.fn(),
-    connectMock: vi.fn(),
-    clientQueryMock: vi.fn(),
-    releaseMock: vi.fn(),
-    spawnMock: vi.fn(),
-    clearColumnTypeCacheMock: vi.fn(),
-  }));
+const {
+  queryMock,
+  connectMock,
+  clientQueryMock,
+  releaseMock,
+  spawnMock,
+  clearColumnTypeCacheMock,
+} = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  connectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  releaseMock: vi.fn(),
+  spawnMock: vi.fn(),
+  clearColumnTypeCacheMock: vi.fn(),
+}));
 
 vi.mock('../../src/infra/database/database.manager', () => ({
   DatabaseManager: {

--- a/backend/tests/unit/database-backup.service.test.ts
+++ b/backend/tests/unit/database-backup.service.test.ts
@@ -1,0 +1,353 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough, Writable } from 'node:stream';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+const STORAGE_DIR = '/tmp/insforge-backup-service-tests';
+
+const { queryMock, connectMock, clientQueryMock, releaseMock, spawnMock, clearColumnTypeCacheMock } =
+  vi.hoisted(() => ({
+    queryMock: vi.fn(),
+    connectMock: vi.fn(),
+    clientQueryMock: vi.fn(),
+    releaseMock: vi.fn(),
+    spawnMock: vi.fn(),
+    clearColumnTypeCacheMock: vi.fn(),
+  }));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        query: queryMock,
+        connect: connectMock,
+      })),
+    })),
+    clearColumnTypeCache: clearColumnTypeCacheMock,
+  },
+}));
+
+vi.mock('../../src/infra/config/app.config', () => ({
+  appConfig: {
+    storage: {
+      s3Bucket: undefined,
+      appKey: 'local',
+      awsRegion: 'us-east-2',
+      storageDir: '/tmp/insforge-backup-service-tests',
+    },
+    database: {
+      host: 'localhost',
+      port: 5432,
+      name: 'insforge',
+      user: 'postgres',
+      password: 'postgres',
+    },
+  },
+}));
+
+vi.mock('../../src/providers/storage/s3.provider', () => ({
+  S3StorageProvider: vi.fn(),
+}));
+
+vi.mock('../../src/utils/logger', () => {
+  const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { default: noopLogger, logger: noopLogger };
+});
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+import { DatabaseBackupService } from '../../src/services/database/database-backup.service';
+
+interface FakeChildOptions {
+  exitCode?: number;
+  stdoutData?: Buffer | null;
+  stderrData?: string;
+  autoClose?: boolean;
+}
+
+function makeFakeChild(options: FakeChildOptions = {}) {
+  const { exitCode = 0, stdoutData = Buffer.from('dump-bytes'), stderrData = '' } = options;
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    stdin: Writable;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+
+  const finish = () => {
+    if (stderrData) {
+      child.stderr.write(stderrData);
+    }
+    child.stderr.end();
+    if (stdoutData) {
+      child.stdout.write(stdoutData);
+    }
+    child.stdout.end();
+    setImmediate(() => child.emit('close', exitCode));
+  };
+
+  if (options.autoClose !== false) {
+    setImmediate(finish);
+  }
+
+  return { child, finish };
+}
+
+async function waitForIdle(service: DatabaseBackupService) {
+  await vi.waitFor(() => {
+    expect((service as unknown as { activeBackupId: string | null }).activeBackupId).toBeNull();
+  });
+}
+
+function backupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    name: null,
+    triggerSource: 'manual',
+    status: 'running',
+    sizeBytes: null,
+    errorMessage: null,
+    createdAt: new Date('2026-06-10T00:00:00Z'),
+    completedAt: null,
+    createdBy: 'admin',
+    ...overrides,
+  };
+}
+
+describe('DatabaseBackupService', () => {
+  beforeAll(async () => {
+    await fs.mkdir(STORAGE_DIR, { recursive: true });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue({ query: clientQueryMock, release: releaseMock });
+    clientQueryMock.mockResolvedValue({ rows: [] });
+  });
+
+  describe('listBackups', () => {
+    it('fails interrupted running rows, then returns serialized backups', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes("SET status = 'failed'")) {
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.resolve({
+          rows: [backupRow({ status: 'completed', sizeBytes: 1234 })],
+        });
+      });
+
+      const service = DatabaseBackupService.getInstance();
+      const result = await service.listBackups();
+
+      expect(queryMock.mock.calls[0][0]).toContain('Interrupted by a server restart.');
+      expect(result.backups).toEqual([
+        expect.objectContaining({
+          id: '00000000-0000-4000-8000-000000000001',
+          status: 'completed',
+          sizeBytes: 1234,
+          createdAt: '2026-06-10T00:00:00.000Z',
+          completedAt: null,
+        }),
+      ]);
+    });
+  });
+
+  describe('createBackup', () => {
+    it('creates a backup and marks it completed once pg_dump succeeds', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO system.database_backups')) {
+          return Promise.resolve({ rows: [backupRow({ name: 'before-upgrade' })] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      spawnMock.mockImplementation(() => makeFakeChild().child);
+
+      const service = DatabaseBackupService.getInstance();
+      const backup = await service.createBackup({ name: 'before-upgrade' }, 'admin');
+
+      expect(backup).toMatchObject({ name: 'before-upgrade', status: 'running' });
+
+      // The dump runs asynchronously after createBackup returns, so wait for
+      // the terminal status update before asserting on the side effects.
+      await vi.waitFor(() => {
+        const completedCall = queryMock.mock.calls.find(([sql]) =>
+          (sql as string).includes("SET status = 'completed'")
+        );
+        expect(completedCall).toBeDefined();
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'pg_dump',
+        expect.arrayContaining(['--format=custom', '-d', 'insforge']),
+        expect.objectContaining({ env: expect.objectContaining({ PGPASSWORD: 'postgres' }) })
+      );
+
+      const completedCall = queryMock.mock.calls.find(([sql]) =>
+        (sql as string).includes("SET status = 'completed'")
+      );
+      const [, params] = completedCall as [string, unknown[]];
+      const storageKey = params[1] as string;
+      expect(storageKey).toMatch(/^\d{8}_\d{6}\.dump$/);
+      expect(params[2]).toBe(Buffer.from('dump-bytes').length);
+
+      const artifact = await fs.readFile(
+        path.join(STORAGE_DIR, '_database_backups', storageKey),
+        'utf8'
+      );
+      expect(artifact).toBe('dump-bytes');
+
+      await waitForIdle(service);
+    });
+
+    it('marks the backup failed when pg_dump exits nonzero', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO system.database_backups')) {
+          return Promise.resolve({ rows: [backupRow()] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      spawnMock.mockImplementation(
+        () => makeFakeChild({ exitCode: 1, stderrData: 'connection refused' }).child
+      );
+
+      const service = DatabaseBackupService.getInstance();
+      await service.createBackup({}, 'admin');
+
+      await vi.waitFor(() => {
+        const failedCall = queryMock.mock.calls.find(([sql]) =>
+          (sql as string).includes("SET status = 'failed'")
+        );
+        expect(failedCall).toBeDefined();
+      });
+
+      const failedCall = queryMock.mock.calls.find(([sql]) =>
+        (sql as string).includes("SET status = 'failed'")
+      );
+      const [, params] = failedCall as [string, unknown[]];
+      expect(params[1]).toContain('pg_dump exited with code 1');
+      expect(params[1]).toContain('connection refused');
+
+      await waitForIdle(service);
+    });
+
+    it('rejects a duplicate backup name with a 409', async () => {
+      queryMock.mockRejectedValueOnce(
+        Object.assign(new Error('duplicate key value'), { code: '23505' })
+      );
+
+      const service = DatabaseBackupService.getInstance();
+      await expect(service.createBackup({ name: 'dup' }, 'admin')).rejects.toMatchObject({
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_DUPLICATE,
+      });
+    });
+
+    it('rejects concurrent backups while one is still running', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO system.database_backups')) {
+          return Promise.resolve({ rows: [backupRow()] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      const pending = makeFakeChild({ autoClose: false });
+      spawnMock.mockImplementation(() => pending.child);
+
+      const service = DatabaseBackupService.getInstance();
+      await service.createBackup({}, 'admin');
+
+      await expect(service.createBackup({}, 'admin')).rejects.toMatchObject({
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
+      });
+
+      // Let the running dump finish only after the service has wired up the
+      // child process, otherwise the 'close' event fires with no listener.
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+      pending.finish();
+      await waitForIdle(service);
+    });
+  });
+
+  describe('restoreBackup', () => {
+    it('refuses to restore a backup that is not completed', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('WHERE id = $1')) {
+          return Promise.resolve({ rows: [backupRow({ status: 'failed' })] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const service = DatabaseBackupService.getInstance();
+      await expect(service.restoreBackup('some-id')).rejects.toMatchObject({
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
+      });
+    });
+
+    it('restores the archive and reinstates the backup metadata snapshot', async () => {
+      const storageKey = '20260610_010203.dump';
+      const artifactDir = path.join(STORAGE_DIR, '_database_backups');
+      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.writeFile(path.join(artifactDir, storageKey), 'archive-bytes');
+
+      const snapshotRow = {
+        id: '00000000-0000-4000-8000-000000000002',
+        name: 'kept',
+        trigger_source: 'manual',
+        status: 'completed',
+        storage_key: storageKey,
+        size_bytes: 42,
+        error_message: null,
+        created_by: 'admin',
+        completed_at: new Date('2026-06-09T00:00:00Z'),
+        created_at: new Date('2026-06-09T00:00:00Z'),
+        updated_at: new Date('2026-06-09T00:00:00Z'),
+      };
+
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('WHERE id = $1')) {
+          return Promise.resolve({
+            rows: [backupRow({ status: 'completed', storageKey })],
+          });
+        }
+        return Promise.resolve({ rows: [snapshotRow] });
+      });
+      spawnMock.mockImplementation(() => makeFakeChild({ stdoutData: null }).child);
+
+      const service = DatabaseBackupService.getInstance();
+      await service.restoreBackup('some-id');
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'pg_restore',
+        expect.arrayContaining(['--clean', '--if-exists', '--single-transaction']),
+        expect.anything()
+      );
+      // Terminating other sessions would crash the backend's own long-lived
+      // clients (realtime LISTEN), so the restore flow must never do it.
+      expect(
+        queryMock.mock.calls.some(([sql]) => (sql as string).includes('pg_terminate_backend'))
+      ).toBe(false);
+
+      const clientSql = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+      expect(clientSql).toContain('BEGIN');
+      expect(clientSql.some((sql) => sql.includes('TRUNCATE system.database_backups'))).toBe(true);
+      expect(clientSql.some((sql) => sql.includes('INSERT INTO system.database_backups'))).toBe(
+        true
+      );
+      expect(clientSql.some((sql) => sql.includes('NOTIFY pgrst'))).toBe(true);
+      expect(clientSql).toContain('COMMIT');
+      expect(clearColumnTypeCacheMock).toHaveBeenCalled();
+      expect(releaseMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/unit/database-backup.service.test.ts
+++ b/backend/tests/unit/database-backup.service.test.ts
@@ -203,7 +203,7 @@ describe('DatabaseBackupService', () => {
       );
       const [, params] = completedCall as [string, unknown[]];
       const storageKey = params[1] as string;
-      expect(storageKey).toMatch(/^\d{8}_\d{6}\.dump$/);
+      expect(storageKey).toMatch(/^\d{8}_\d{6}_[0-9a-f-]{36}\.dump$/);
       expect(params[2]).toBe(Buffer.from('dump-bytes').length);
 
       const artifact = await fs.readFile(
@@ -282,6 +282,29 @@ describe('DatabaseBackupService', () => {
       pending.finish();
       await waitForIdle(service);
     });
+
+    it('reserves the concurrency guard before the first await', async () => {
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO system.database_backups')) {
+          return Promise.resolve({ rows: [backupRow()] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      spawnMock.mockImplementation(() => makeFakeChild().child);
+
+      const service = DatabaseBackupService.getInstance();
+      // Fire both before either INSERT resolves; without a synchronous
+      // reservation both would pass the guard.
+      const first = service.createBackup({}, 'admin');
+      const second = service.createBackup({}, 'admin');
+
+      await expect(second).rejects.toMatchObject({
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
+      });
+      await first;
+      await waitForIdle(service);
+    });
   });
 
   describe('restoreBackup', () => {
@@ -298,6 +321,40 @@ describe('DatabaseBackupService', () => {
         statusCode: 409,
         code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
       });
+    });
+
+    it('blocks concurrent restores and metadata mutations while a restore runs', async () => {
+      const storageKey = '20260610_040506.dump';
+      const artifactDir = path.join(STORAGE_DIR, '_database_backups');
+      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.writeFile(path.join(artifactDir, storageKey), 'archive-bytes');
+
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('WHERE id = $1')) {
+          return Promise.resolve({
+            rows: [backupRow({ status: 'completed', storageKey })],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      const pending = makeFakeChild({ stdoutData: null, autoClose: false });
+      spawnMock.mockImplementation(() => pending.child);
+
+      const service = DatabaseBackupService.getInstance();
+      const restore = service.restoreBackup('some-id');
+
+      const conflict = {
+        statusCode: 409,
+        code: ERROR_CODES.DATABASE_CONSTRAINT_VIOLATION,
+      };
+      await expect(service.restoreBackup('some-id')).rejects.toMatchObject(conflict);
+      await expect(service.deleteBackup('some-id')).rejects.toMatchObject(conflict);
+      await expect(service.renameBackup('some-id', 'x')).rejects.toMatchObject(conflict);
+      await expect(service.createBackup({}, 'admin')).rejects.toMatchObject(conflict);
+
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+      pending.finish();
+      await restore;
     });
 
     it('restores the archive and reinstates the backup metadata snapshot', async () => {

--- a/backend/tests/unit/database-backup.service.test.ts
+++ b/backend/tests/unit/database-backup.service.test.ts
@@ -57,10 +57,11 @@ vi.mock('../../src/providers/storage/s3.provider', () => ({
   S3StorageProvider: vi.fn(),
 }));
 
-vi.mock('../../src/utils/logger', () => {
-  const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-  return { default: noopLogger, logger: noopLogger };
-});
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/utils/logger', () => ({ default: loggerMock, logger: loggerMock }));
 
 vi.mock('node:child_process', () => ({
   spawn: spawnMock,
@@ -142,21 +143,40 @@ describe('DatabaseBackupService', () => {
   });
 
   describe('listBackups', () => {
-    it('sweeps stale backup temp dirs but keeps recent ones', async () => {
-      const staleDir = path.join(STORAGE_DIR, '.backup-tmp-stale');
-      const freshDir = path.join(STORAGE_DIR, '.backup-tmp-fresh');
-      await fs.mkdir(staleDir, { recursive: true });
-      await fs.mkdir(freshDir, { recursive: true });
-      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
-      await fs.utimes(staleDir, twoHoursAgo, twoHoursAgo);
+    it('sweeps orphaned backup temp dirs when no backup is in flight', async () => {
+      const orphanDir = path.join(STORAGE_DIR, '.backup-tmp-orphan');
+      await fs.mkdir(orphanDir, { recursive: true });
 
       queryMock.mockResolvedValue({ rows: [] });
       const service = DatabaseBackupService.getInstance();
       await service.listBackups();
 
-      await expect(fs.stat(staleDir)).rejects.toMatchObject({ code: 'ENOENT' });
-      await expect(fs.stat(freshDir)).resolves.toBeTruthy();
-      await fs.rm(freshDir, { recursive: true, force: true });
+      await expect(fs.stat(orphanDir)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('never sweeps temp dirs while a backup is in flight', async () => {
+      const liveDir = path.join(STORAGE_DIR, '.backup-tmp-live');
+      await fs.mkdir(liveDir, { recursive: true });
+
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('INSERT INTO system.database_backups')) {
+          return Promise.resolve({ rows: [backupRow()] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      const pending = makeFakeChild({ autoClose: false });
+      spawnMock.mockImplementation(() => pending.child);
+
+      const service = DatabaseBackupService.getInstance();
+      await service.createBackup({}, 'admin');
+
+      await service.listBackups();
+      await expect(fs.stat(liveDir)).resolves.toBeTruthy();
+
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled());
+      pending.finish();
+      await waitForIdle(service);
+      await fs.rm(liveDir, { recursive: true, force: true });
     });
 
     it('fails interrupted running rows, then returns serialized backups', async () => {
@@ -437,7 +457,9 @@ describe('DatabaseBackupService', () => {
       expect(spawnMock).toHaveBeenCalledWith(
         'pg_restore',
         expect.arrayContaining(['--clean', '--if-exists', '--single-transaction']),
-        expect.anything()
+        expect.objectContaining({
+          env: expect.objectContaining({ PGAPPNAME: 'insforge-backup-restore' }),
+        })
       );
       // Terminating other sessions would crash the backend's own long-lived
       // clients (realtime LISTEN), so the restore flow must never do it.
@@ -451,10 +473,109 @@ describe('DatabaseBackupService', () => {
       expect(clientSql.some((sql) => sql.includes('INSERT INTO system.database_backups'))).toBe(
         true
       );
-      expect(clientSql.some((sql) => sql.includes('NOTIFY pgrst'))).toBe(true);
       expect(clientSql).toContain('COMMIT');
+      // The PostgREST reload runs outside the write-back transaction so a
+      // write-back failure cannot leave PostgREST on a stale schema.
+      expect(queryMock.mock.calls.some(([sql]) => (sql as string).includes('NOTIFY pgrst'))).toBe(
+        true
+      );
       expect(clearColumnTypeCacheMock).toHaveBeenCalled();
       expect(releaseMock).toHaveBeenCalled();
+    });
+
+    it('terminates a restore stuck waiting on a database lock', async () => {
+      const storageKey = '20260611_050607.dump';
+      const artifactDir = path.join(STORAGE_DIR, '_database_backups');
+      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.writeFile(path.join(artifactDir, storageKey), 'archive-bytes');
+
+      const terminateCalls: unknown[][] = [];
+      queryMock.mockImplementation((sql: string, params?: unknown[]) => {
+        if (sql.includes('WHERE id = $1') && !sql.includes('pg_terminate_backend')) {
+          return Promise.resolve({
+            rows: [backupRow({ status: 'completed', storageKey })],
+          });
+        }
+        if (sql.includes('pg_stat_activity')) {
+          return Promise.resolve({ rows: [{ pid: 4242, waitEventType: 'Lock' }] });
+        }
+        if (sql.includes('pg_terminate_backend')) {
+          terminateCalls.push(params ?? []);
+          return Promise.resolve({ rows: [] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      const pending = makeFakeChild({
+        stdoutData: null,
+        autoClose: false,
+        exitCode: 1,
+        stderrData: 'FATAL: terminating connection due to administrator command',
+      });
+      spawnMock.mockImplementation(() => pending.child);
+
+      vi.useFakeTimers();
+      try {
+        const service = DatabaseBackupService.getInstance();
+        const restore = service.restoreBackup('some-id');
+        restore.catch(() => {});
+
+        // 5s polls; the session reports Lock-waiting every tick, so the
+        // watchdog should terminate it once 30s of continuous waiting passes.
+        await vi.advanceTimersByTimeAsync(45_000);
+        expect(terminateCalls).toHaveLength(1);
+        expect(terminateCalls[0]).toEqual([4242]);
+
+        vi.useRealTimers();
+        // The terminated pg_restore exits nonzero; the service maps it to a
+        // clear lock-timeout error instead of the raw stderr.
+        pending.finish();
+        await expect(restore).rejects.toMatchObject({
+          statusCode: 409,
+          message: expect.stringContaining('waiting more than 30s for a database lock'),
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('still reports success when the metadata write-back fails after retries', async () => {
+      const storageKey = '20260611_010203.dump';
+      const artifactDir = path.join(STORAGE_DIR, '_database_backups');
+      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.writeFile(path.join(artifactDir, storageKey), 'archive-bytes');
+
+      queryMock.mockImplementation((sql: string) => {
+        if (sql.includes('WHERE id = $1')) {
+          return Promise.resolve({
+            rows: [backupRow({ status: 'completed', storageKey })],
+          });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      clientQueryMock.mockImplementation((sql: string) => {
+        if (sql.includes('TRUNCATE')) {
+          return Promise.reject(new Error('deadlock detected'));
+        }
+        return Promise.resolve({ rows: [] });
+      });
+      spawnMock.mockImplementation(() => makeFakeChild({ stdoutData: null }).child);
+
+      const service = DatabaseBackupService.getInstance();
+      await expect(service.restoreBackup('some-id')).resolves.toBeUndefined();
+
+      // Three attempts, each rolled back.
+      const truncates = clientQueryMock.mock.calls.filter(([sql]) =>
+        (sql as string).includes('TRUNCATE')
+      );
+      expect(truncates).toHaveLength(3);
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to write back backup metadata'),
+        expect.objectContaining({ error: 'deadlock detected' })
+      );
+      // PostgREST is still reloaded even though the write-back failed.
+      expect(queryMock.mock.calls.some(([sql]) => (sql as string).includes('NOTIFY pgrst'))).toBe(
+        true
+      );
     });
   });
 });

--- a/backend/tests/unit/database-backups-migration.test.ts
+++ b/backend/tests/unit/database-backups-migration.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDir,
+  '../../src/infra/database/migrations/051_create-database-backups.sql'
+);
+
+describe('051_create-database-backups migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  // ── Idempotency guards ───────────────────────────────────────────────
+  it('creates the table with IF NOT EXISTS', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS system\.database_backups/i);
+  });
+
+  it('creates indexes with IF NOT EXISTS', () => {
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS idx_database_backups_name/i);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS idx_database_backups_status/i);
+  });
+
+  it('drops the updated_at trigger before creating it', () => {
+    const dropIndex = sql.search(
+      /DROP TRIGGER IF EXISTS update_database_backups_updated_at ON system\.database_backups/i
+    );
+    const createIndex = sql.search(/CREATE TRIGGER update_database_backups_updated_at/i);
+    expect(dropIndex).toBeGreaterThanOrEqual(0);
+    expect(createIndex).toBeGreaterThan(dropIndex);
+  });
+
+  // ── Structure ────────────────────────────────────────────────────────
+  it('constrains status to the supported lifecycle values', () => {
+    expect(sql).toMatch(/CHECK \(status IN \('running', 'completed', 'failed'\)\)/i);
+  });
+
+  it('constrains trigger_source to manual or scheduled', () => {
+    expect(sql).toMatch(/CHECK \(trigger_source IN \('manual', 'scheduled'\)\)/i);
+  });
+
+  it('enforces unique backup names only when a name is set', () => {
+    expect(sql).toMatch(/ON system\.database_backups\(name\)\s+WHERE name IS NOT NULL/i);
+  });
+
+  it('uses the shared system.update_updated_at trigger function', () => {
+    expect(sql).toMatch(/EXECUTE FUNCTION system\.update_updated_at\(\)/i);
+  });
+});

--- a/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
@@ -9,7 +9,6 @@ import {
   type FeatureSidebarListItem,
 } from '#components';
 import { ScrollArea } from '#components/radix/ScrollArea';
-import { useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
 import { cn } from '#lib/utils/utils';
 import { Button } from '@insforge/ui';
 import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
@@ -113,8 +112,6 @@ function DatabaseStudioSidebarItem({ label, href, sectionEnd }: DatabaseStudioSi
 const STUDIO_MENU_TRANSITION_MS = 260;
 
 export function DatabaseStudioSidebarPanel({ onBack }: DatabaseStudioSidebarPanelProps) {
-  const isCloudHostingMode = useIsCloudHostingMode();
-
   return (
     <aside className="h-full w-60 flex flex-col border-r border-border bg-semantic-1 flex-shrink-0">
       <div className="p-3">
@@ -130,17 +127,14 @@ export function DatabaseStudioSidebarPanel({ onBack }: DatabaseStudioSidebarPane
 
       <ScrollArea className="flex-1 px-3 pb-2">
         <div className="flex flex-col gap-1.5">
-          {(isCloudHostingMode
-            ? [
-                ...DATABASE_STUDIO_SIDEBAR_BASE_ITEMS,
-                {
-                  id: 'backups',
-                  label: 'Backup & Restore',
-                  href: '/dashboard/database/backups',
-                },
-              ]
-            : DATABASE_STUDIO_SIDEBAR_BASE_ITEMS
-          ).map((item) => (
+          {[
+            ...DATABASE_STUDIO_SIDEBAR_BASE_ITEMS,
+            {
+              id: 'backups',
+              label: 'Backup & Restore',
+              href: '/dashboard/database/backups',
+            },
+          ].map((item) => (
             <DatabaseStudioSidebarItem
               key={item.id}
               label={item.label}

--- a/packages/dashboard/src/features/database/hooks/__tests__/useDatabaseBackup.test.tsx
+++ b/packages/dashboard/src/features/database/hooks/__tests__/useDatabaseBackup.test.tsx
@@ -1,0 +1,138 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DashboardHostProvider } from '#lib/config/DashboardHostContext';
+import {
+  useDatabaseBackupActions,
+  useDatabaseBackupInfo,
+} from '#features/database/hooks/useDatabaseBackup';
+import { backupService } from '#features/database/services/backup.service';
+
+vi.mock('#features/database/services/backup.service', () => ({
+  backupService: {
+    listBackups: vi.fn(),
+    createBackup: vi.fn(),
+    renameBackup: vi.fn(),
+    deleteBackup: vi.fn(),
+    restoreBackup: vi.fn(),
+  },
+}));
+
+const listBackupsMock = vi.mocked(backupService.listBackups);
+const createBackupMock = vi.mocked(backupService.createBackup);
+const restoreBackupMock = vi.mocked(backupService.restoreBackup);
+
+function makeBackup(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'backup-1',
+    name: 'nightly',
+    triggerSource: 'manual' as const,
+    status: 'completed' as const,
+    sizeBytes: 100,
+    errorMessage: null,
+    createdAt: '2026-06-10T00:00:00.000Z',
+    completedAt: '2026-06-10T00:01:00.000Z',
+    createdBy: 'admin',
+    ...overrides,
+  };
+}
+
+function createWrapper(hostValue: Parameters<typeof DashboardHostProvider>[0]['value']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <DashboardHostProvider value={hostValue}>{children}</DashboardHostProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useDatabaseBackupInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches backups from the OSS backend in self-hosting mode', async () => {
+    listBackupsMock.mockResolvedValue({
+      backups: [
+        makeBackup(),
+        makeBackup({ id: 'backup-2', name: null, triggerSource: 'scheduled' }),
+      ],
+    });
+
+    const { result } = renderHook(() => useDatabaseBackupInfo(), {
+      wrapper: createWrapper({ mode: 'self-hosting' }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backupInfo).not.toBeNull();
+    });
+
+    expect(result.current.backupInfo?.manualBackups).toEqual([
+      expect.objectContaining({ id: 'backup-1', name: 'nightly', triggerSource: 'manual' }),
+    ]);
+    expect(result.current.backupInfo?.scheduledBackups).toEqual([
+      expect.objectContaining({ id: 'backup-2', triggerSource: 'scheduled' }),
+    ]);
+  });
+
+  it('uses the host callback in cloud-hosting mode', async () => {
+    const onRequestBackupInfo = vi.fn().mockResolvedValue({
+      manualBackups: [],
+      scheduledBackups: [],
+    });
+
+    const { result } = renderHook(() => useDatabaseBackupInfo(), {
+      wrapper: createWrapper({ mode: 'cloud-hosting', onRequestBackupInfo }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backupInfo).toEqual({ manualBackups: [], scheduledBackups: [] });
+    });
+
+    expect(onRequestBackupInfo).toHaveBeenCalled();
+    expect(listBackupsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDatabaseBackupActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls the OSS backend in self-hosting mode and omits empty names', async () => {
+    createBackupMock.mockResolvedValue(makeBackup());
+    restoreBackupMock.mockResolvedValue({ message: 'ok' });
+
+    const { result } = renderHook(() => useDatabaseBackupActions(), {
+      wrapper: createWrapper({ mode: 'self-hosting' }),
+    });
+
+    await result.current.createBackup?.('  my backup  ');
+    expect(createBackupMock).toHaveBeenCalledWith('my backup');
+
+    await result.current.createBackup?.('   ');
+    expect(createBackupMock).toHaveBeenLastCalledWith(undefined);
+
+    await result.current.restoreBackup?.('backup-1');
+    expect(restoreBackupMock).toHaveBeenCalledWith('backup-1');
+  });
+
+  it('returns the host callbacks in cloud-hosting mode', () => {
+    const onCreateBackup = vi.fn();
+    const onRestoreBackup = vi.fn();
+
+    const { result } = renderHook(() => useDatabaseBackupActions(), {
+      wrapper: createWrapper({ mode: 'cloud-hosting', onCreateBackup, onRestoreBackup }),
+    });
+
+    expect(result.current.createBackup).toBe(onCreateBackup);
+    expect(result.current.restoreBackup).toBe(onRestoreBackup);
+    expect(result.current.renameBackup).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/features/database/hooks/__tests__/useDatabaseBackup.test.tsx
+++ b/packages/dashboard/src/features/database/hooks/__tests__/useDatabaseBackup.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DashboardHostProvider } from '#lib/config/DashboardHostContext';
 import {
+  hasRunningBackup,
   useDatabaseBackupActions,
   useDatabaseBackupInfo,
 } from '#features/database/hooks/useDatabaseBackup';
@@ -97,6 +98,34 @@ describe('useDatabaseBackupInfo', () => {
 
     expect(onRequestBackupInfo).toHaveBeenCalled();
     expect(listBackupsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hasRunningBackup', () => {
+  it('drives the polling interval from backup statuses', () => {
+    expect(hasRunningBackup(null)).toBe(false);
+    expect(hasRunningBackup(undefined)).toBe(false);
+    expect(
+      hasRunningBackup({
+        manualBackups: [
+          { ...makeBackup(), status: 'completed' },
+          { ...makeBackup(), status: 'failed' },
+        ],
+        scheduledBackups: [],
+      })
+    ).toBe(false);
+    expect(
+      hasRunningBackup({
+        manualBackups: [{ ...makeBackup(), status: 'running' }],
+        scheduledBackups: [],
+      })
+    ).toBe(true);
+    expect(
+      hasRunningBackup({
+        manualBackups: [],
+        scheduledBackups: [{ ...makeBackup(), status: 'running' }],
+      })
+    ).toBe(true);
   });
 });
 

--- a/packages/dashboard/src/features/database/hooks/useDatabaseBackup.ts
+++ b/packages/dashboard/src/features/database/hooks/useDatabaseBackup.ts
@@ -1,16 +1,43 @@
 import { useQuery } from '@tanstack/react-query';
+import type { DatabaseBackup } from '@insforge/shared-schemas';
+import { backupService } from '#features/database/services/backup.service';
 import { useDashboardHost, useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
-import type { DashboardBackupInfo, DashboardInstanceInfo } from '#types';
+import type { DashboardBackup, DashboardBackupInfo, DashboardInstanceInfo } from '#types';
+
+function toDashboardBackup(backup: DatabaseBackup): DashboardBackup {
+  return {
+    id: backup.id,
+    name: backup.name,
+    triggerSource: backup.triggerSource,
+    status: backup.status,
+    sizeBytes: backup.sizeBytes,
+    createdAt: backup.createdAt,
+    createdBy: backup.createdBy,
+  };
+}
+
+async function fetchSelfHostingBackupInfo(): Promise<DashboardBackupInfo> {
+  const { backups } = await backupService.listBackups();
+
+  return {
+    manualBackups: backups.filter((b) => b.triggerSource === 'manual').map(toDashboardBackup),
+    scheduledBackups: backups.filter((b) => b.triggerSource === 'scheduled').map(toDashboardBackup),
+  };
+}
 
 export function useDatabaseBackupInfo() {
   const host = useDashboardHost();
   const isCloudHostingMode = useIsCloudHostingMode();
   const onRequestBackupInfo = host.mode === 'cloud-hosting' ? host.onRequestBackupInfo : undefined;
-  const isBackupInfoQueryEnabled = isCloudHostingMode && !!onRequestBackupInfo;
+  const isBackupInfoQueryEnabled = !isCloudHostingMode || !!onRequestBackupInfo;
 
   const query = useQuery({
     queryKey: ['database-backup', 'backup-info'],
     queryFn: (): Promise<DashboardBackupInfo | null> => {
+      if (!isCloudHostingMode) {
+        return fetchSelfHostingBackupInfo();
+      }
+
       if (!onRequestBackupInfo) {
         return Promise.resolve(null);
       }
@@ -26,6 +53,40 @@ export function useDatabaseBackupInfo() {
     isLoading: query.isLoading,
     error: query.error,
     refetch: query.refetch,
+  };
+}
+
+/**
+ * Mode-aware backup mutations: cloud-hosting delegates to the host callbacks
+ * (the cloud control plane owns backups there), self-hosting calls the OSS
+ * backend directly.
+ */
+export function useDatabaseBackupActions() {
+  const host = useDashboardHost();
+  const isCloudHostingMode = useIsCloudHostingMode();
+
+  if (!isCloudHostingMode) {
+    return {
+      createBackup: async (name: string) => {
+        await backupService.createBackup(name.trim() ? name.trim() : undefined);
+      },
+      renameBackup: async (backupId: string, name: string | null) => {
+        await backupService.renameBackup(backupId, name);
+      },
+      deleteBackup: async (backupId: string) => {
+        await backupService.deleteBackup(backupId);
+      },
+      restoreBackup: async (backupId: string) => {
+        await backupService.restoreBackup(backupId);
+      },
+    };
+  }
+
+  return {
+    createBackup: host.onCreateBackup,
+    renameBackup: host.onRenameBackup,
+    deleteBackup: host.onDeleteBackup,
+    restoreBackup: host.onRestoreBackup,
   };
 }
 

--- a/packages/dashboard/src/features/database/hooks/useDatabaseBackup.ts
+++ b/packages/dashboard/src/features/database/hooks/useDatabaseBackup.ts
@@ -11,9 +11,17 @@ function toDashboardBackup(backup: DatabaseBackup): DashboardBackup {
     triggerSource: backup.triggerSource,
     status: backup.status,
     sizeBytes: backup.sizeBytes,
+    errorMessage: backup.errorMessage,
     createdAt: backup.createdAt,
     createdBy: backup.createdBy,
   };
+}
+
+export function hasRunningBackup(info: DashboardBackupInfo | null | undefined): boolean {
+  if (!info) {
+    return false;
+  }
+  return [...info.manualBackups, ...info.scheduledBackups].some((b) => b.status === 'running');
 }
 
 async function fetchSelfHostingBackupInfo(): Promise<DashboardBackupInfo> {
@@ -46,6 +54,7 @@ export function useDatabaseBackupInfo() {
     },
     enabled: isBackupInfoQueryEnabled,
     staleTime: 5 * 60 * 1000,
+    refetchInterval: (q) => (hasRunningBackup(q.state.data) ? 5000 : false),
   });
 
   return {

--- a/packages/dashboard/src/features/database/pages/BackupsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/BackupsPage.tsx
@@ -95,7 +95,19 @@ export default function BackupsPage() {
       return;
     }
 
-    await backupActions.restoreBackup(backupId);
+    try {
+      await backupActions.restoreBackup(backupId);
+    } catch (error) {
+      // Rethrow so ConfirmRestoreDialog stays open; the cloud host surfaces
+      // its own restore error notifications.
+      if (!isCloudHostingMode) {
+        showToast(
+          error instanceof Error ? error.message : 'Failed to restore the backup.',
+          'error'
+        );
+      }
+      throw error;
+    }
 
     if (!isCloudHostingMode) {
       // The cloud host surfaces its own restore notifications.
@@ -116,7 +128,17 @@ export default function BackupsPage() {
       throw new Error('Backup creation is not available in the current dashboard mode.');
     }
 
-    await backupActions.createBackup(backupName);
+    try {
+      await backupActions.createBackup(backupName);
+    } catch (error) {
+      // Rethrow so CreateBackupDialog stays open; the cloud host surfaces its
+      // own error notifications.
+      if (!isCloudHostingMode) {
+        showToast(error instanceof Error ? error.message : 'Failed to create the backup.', 'error');
+      }
+      throw error;
+    }
+
     await refetch();
   };
 
@@ -412,9 +434,21 @@ export default function BackupsPage() {
             );
           }
 
-          return renameBackup(renameBackupDialogState.id, backupName).then(async () => {
-            await refetch();
-          });
+          return renameBackup(renameBackupDialogState.id, backupName)
+            .then(async () => {
+              await refetch();
+            })
+            .catch((error: unknown) => {
+              // Rethrow so RenameBackupDialog stays open; the cloud host
+              // surfaces its own error notifications.
+              if (!isCloudHostingMode) {
+                showToast(
+                  error instanceof Error ? error.message : 'Failed to rename the backup.',
+                  'error'
+                );
+              }
+              throw error;
+            });
         }}
       />
       <ConfirmRestoreDialog

--- a/packages/dashboard/src/features/database/pages/BackupsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/BackupsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Info, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { CircleAlert, Info, Loader2, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Button,
@@ -241,6 +241,8 @@ export default function BackupsPage() {
                   {manualBackups.map((backup) => {
                     const savedOnLabel = formatBackupTimestamp(backup.createdAt);
                     const backupLabel = backup.name?.trim() || `${savedOnLabel} (Manual)`;
+                    const showStatus = !isCloudHostingMode && backup.status !== 'completed';
+                    const isRestorable = isCloudHostingMode || backup.status === 'completed';
 
                     return (
                       <div
@@ -260,9 +262,32 @@ export default function BackupsPage() {
                             >
                               <Pencil className="h-4 w-4" />
                             </button>
+                            {showStatus && backup.status === 'running' && (
+                              <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                                Backing up…
+                              </span>
+                            )}
+                            {showStatus && backup.status === 'failed' && (
+                              <span
+                                className="flex shrink-0 items-center gap-1 text-xs text-destructive"
+                                title={backup.errorMessage ?? undefined}
+                              >
+                                <CircleAlert className="h-3 w-3" />
+                                Failed
+                              </span>
+                            )}
                           </div>
                           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs leading-4 text-muted-foreground">
                             <span>Saved on: {savedOnLabel}</span>
+                            {showStatus && backup.status === 'failed' && backup.errorMessage && (
+                              <span
+                                className="truncate text-destructive"
+                                title={backup.errorMessage}
+                              >
+                                {backup.errorMessage}
+                              </span>
+                            )}
                           </div>
                         </div>
 
@@ -271,6 +296,7 @@ export default function BackupsPage() {
                             type="button"
                             variant="secondary"
                             size="sm"
+                            disabled={!isRestorable}
                             className="h-7 rounded border-[var(--alpha-8)] px-2 text-sm font-medium text-foreground"
                             onClick={() => {
                               handleOpenRestoreBackupDialog(

--- a/packages/dashboard/src/features/database/pages/BackupsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/BackupsPage.tsx
@@ -15,10 +15,11 @@ import { DatabaseEmptyState } from '#features/database/components/DatabaseEmptyS
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { RenameBackupDialog } from '#features/database/components/RenameBackupDialog';
 import {
+  useDatabaseBackupActions,
   useDatabaseBackupInfo,
   useDatabaseBackupInstanceInfo,
 } from '#features/database/hooks/useDatabaseBackup';
-import { useDashboardHost } from '#lib/config/DashboardHostContext';
+import { useDashboardHost, useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import { useToast } from '#lib/hooks/useToast';
 
@@ -43,10 +44,12 @@ export default function BackupsPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const host = useDashboardHost();
+  const isCloudHostingMode = useIsCloudHostingMode();
   const { showToast } = useToast();
   const { confirm, confirmDialogProps } = useConfirm();
   const { backupInfo, refetch } = useDatabaseBackupInfo();
   const { instanceInfo } = useDatabaseBackupInstanceInfo();
+  const backupActions = useDatabaseBackupActions();
   const [createBackupDialogOpen, setCreateBackupDialogOpen] = useState(false);
   const [renameBackupDialogState, setRenameBackupDialogState] = useState<{
     id: string;
@@ -57,7 +60,12 @@ export default function BackupsPage() {
     timestampLabel: string;
   } | null>(null);
 
-  const isFreePlan = (instanceInfo?.planName?.toLowerCase() ?? 'free') === 'free';
+  // Self-hosting has no plans, quotas, or backup scheduler — only the
+  // cloud-hosting control plane does.
+  const isFreePlan =
+    isCloudHostingMode && (instanceInfo?.planName?.toLowerCase() ?? 'free') === 'free';
+  const hasManualBackupQuota = isCloudHostingMode;
+  const showScheduledBackups = isCloudHostingMode && !isFreePlan;
   const manualBackups = backupInfo?.manualBackups ?? [];
   const scheduledBackups = backupInfo?.scheduledBackups ?? [];
 
@@ -82,12 +90,18 @@ export default function BackupsPage() {
   };
 
   const handleRestoreBackupClick = async (backupId: string) => {
-    if (!host.onRestoreBackup) {
+    if (!backupActions.restoreBackup) {
       showToast('Backup restore is not available in the current dashboard mode.', 'info');
       return;
     }
 
-    await host.onRestoreBackup(backupId);
+    await backupActions.restoreBackup(backupId);
+
+    if (!isCloudHostingMode) {
+      // The cloud host surfaces its own restore notifications.
+      showToast('Database restored successfully.', 'success');
+      await refetch();
+    }
   };
 
   const handleRenameBackupClick = (backupId: string, backupLabel: string) => {
@@ -98,11 +112,11 @@ export default function BackupsPage() {
   };
 
   const handleCreateBackup = async (backupName: string) => {
-    if (!host.onCreateBackup) {
+    if (!backupActions.createBackup) {
       throw new Error('Backup creation is not available in the current dashboard mode.');
     }
 
-    await host.onCreateBackup(backupName);
+    await backupActions.createBackup(backupName);
     await refetch();
   };
 
@@ -119,16 +133,19 @@ export default function BackupsPage() {
       return;
     }
 
-    if (!host.onDeleteBackup) {
+    if (!backupActions.deleteBackup) {
       showToast('Backup deletion is not available in the current dashboard mode.', 'info');
       return;
     }
 
     try {
-      await host.onDeleteBackup(backupId);
+      await backupActions.deleteBackup(backupId);
       await refetch();
-    } catch {
+    } catch (error) {
       // The cloud host is responsible for delete failure toasts.
+      if (!isCloudHostingMode) {
+        showToast(error instanceof Error ? error.message : 'Failed to delete the backup.', 'error');
+      }
     }
   };
 
@@ -158,12 +175,16 @@ export default function BackupsPage() {
               >
                 <div className="min-w-0">
                   <h2 className="text-xl font-medium leading-7 text-foreground">
-                    Manual Backups ({manualBackups.length}/{isFreePlan ? 1 : 5})
+                    {hasManualBackupQuota
+                      ? `Manual Backups (${manualBackups.length}/${isFreePlan ? 1 : 5})`
+                      : `Manual Backups (${manualBackups.length})`}
                   </h2>
                   <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                    {isFreePlan && manualBackups.length === 0
-                      ? 'Create a manual backup. Free plan allows 1 manual backup.'
-                      : 'You can create up to 5 backups manually and can be restored at any time.'}
+                    {!hasManualBackupQuota
+                      ? 'Create manual backups of your database and restore them at any time.'
+                      : isFreePlan && manualBackups.length === 0
+                        ? 'Create a manual backup. Free plan allows 1 manual backup.'
+                        : 'You can create up to 5 backups manually and can be restored at any time.'}
                   </p>
                 </div>
                 {isFreePlan && manualBackups.length >= 1 ? (
@@ -271,7 +292,7 @@ export default function BackupsPage() {
               )}
             </div>
 
-            {!isFreePlan && (
+            {showScheduledBackups && (
               <div className="overflow-hidden rounded-lg border border-[var(--alpha-8)] bg-card">
                 <div className="px-6 py-6">
                   <div className="min-w-0">
@@ -384,13 +405,14 @@ export default function BackupsPage() {
             return Promise.resolve();
           }
 
-          if (!host.onRenameBackup) {
+          const renameBackup = backupActions.renameBackup;
+          if (!renameBackup) {
             return Promise.reject(
               new Error('Backup rename is not available in the current dashboard mode.')
             );
           }
 
-          return host.onRenameBackup(renameBackupDialogState.id, backupName).then(async () => {
+          return renameBackup(renameBackupDialogState.id, backupName).then(async () => {
             await refetch();
           });
         }}

--- a/packages/dashboard/src/features/database/services/backup.service.ts
+++ b/packages/dashboard/src/features/database/services/backup.service.ts
@@ -1,0 +1,59 @@
+import { apiClient } from '#lib/api/client';
+import type {
+  CreateDatabaseBackupRequest,
+  CreateDatabaseBackupResponse,
+  DatabaseBackupsResponse,
+  DeleteDatabaseBackupResponse,
+  RenameDatabaseBackupRequest,
+  RestoreDatabaseBackupResponse,
+  UpdateDatabaseBackupResponse,
+} from '@insforge/shared-schemas';
+
+export class BackupService {
+  async listBackups(): Promise<DatabaseBackupsResponse> {
+    return apiClient.request('/database/backups', {
+      method: 'GET',
+      headers: apiClient.withAccessToken({}),
+    });
+  }
+
+  async createBackup(name?: string): Promise<CreateDatabaseBackupResponse> {
+    const body: CreateDatabaseBackupRequest = name ? { name } : {};
+
+    return apiClient.request('/database/backups', {
+      method: 'POST',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(body),
+    });
+  }
+
+  async renameBackup(backupId: string, name: string | null): Promise<UpdateDatabaseBackupResponse> {
+    const body: RenameDatabaseBackupRequest = { name };
+
+    return apiClient.request(`/database/backups/${backupId}`, {
+      method: 'PATCH',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(body),
+    });
+  }
+
+  async deleteBackup(backupId: string): Promise<DeleteDatabaseBackupResponse> {
+    return apiClient.request(`/database/backups/${backupId}`, {
+      method: 'DELETE',
+      headers: apiClient.withAccessToken({}),
+    });
+  }
+
+  async restoreBackup(backupId: string): Promise<RestoreDatabaseBackupResponse> {
+    return apiClient.request(`/database/backups/${backupId}/restore`, {
+      method: 'POST',
+      headers: apiClient.withAccessToken({}),
+    });
+  }
+}
+
+export const backupService = new BackupService();

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -23,6 +23,7 @@ export interface DashboardBackup {
   triggerSource: 'manual' | 'scheduled';
   status: 'running' | 'completed' | string;
   sizeBytes: number | null;
+  errorMessage?: string | null;
   expiresAt?: string | null;
   createdAt: string;
   createdBy: string | null;

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -9,6 +9,7 @@ import {
   databasePolicySchema,
   databaseTriggerSchema,
   migrationSchema,
+  databaseBackupSchema,
 } from './database.schema.js';
 
 export const createTableRequestSchema = tableSchema
@@ -403,6 +404,41 @@ export const databaseMigrationsResponseSchema = z.object({
   migrations: z.array(migrationSchema),
 });
 
+// Database Backup Schemas
+export const createDatabaseBackupRequestSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Backup name cannot be empty')
+    .max(64, 'Backup name must be less than 64 characters')
+    .optional(),
+});
+
+export const renameDatabaseBackupRequestSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Backup name cannot be empty')
+    .max(64, 'Backup name must be less than 64 characters')
+    .nullable(),
+});
+
+export const databaseBackupsResponseSchema = z.object({
+  backups: z.array(databaseBackupSchema),
+});
+
+export const createDatabaseBackupResponseSchema = databaseBackupSchema;
+
+export const updateDatabaseBackupResponseSchema = databaseBackupSchema;
+
+export const deleteDatabaseBackupResponseSchema = z.object({
+  message: z.string(),
+});
+
+export const restoreDatabaseBackupResponseSchema = z.object({
+  message: z.string(),
+});
+
 // Database Metadata Response Types
 export type DatabaseFunctionsResponse = z.infer<typeof databaseFunctionsResponseSchema>;
 export type DatabaseSchemasResponse = z.infer<typeof databaseSchemasResponseSchema>;
@@ -410,3 +446,12 @@ export type DatabaseIndexesResponse = z.infer<typeof databaseIndexesResponseSche
 export type DatabasePoliciesResponse = z.infer<typeof databasePoliciesResponseSchema>;
 export type DatabaseTriggersResponse = z.infer<typeof databaseTriggersResponseSchema>;
 export type DatabaseMigrationsResponse = z.infer<typeof databaseMigrationsResponseSchema>;
+
+// Database Backup Types
+export type CreateDatabaseBackupRequest = z.infer<typeof createDatabaseBackupRequestSchema>;
+export type RenameDatabaseBackupRequest = z.infer<typeof renameDatabaseBackupRequestSchema>;
+export type DatabaseBackupsResponse = z.infer<typeof databaseBackupsResponseSchema>;
+export type CreateDatabaseBackupResponse = z.infer<typeof createDatabaseBackupResponseSchema>;
+export type UpdateDatabaseBackupResponse = z.infer<typeof updateDatabaseBackupResponseSchema>;
+export type DeleteDatabaseBackupResponse = z.infer<typeof deleteDatabaseBackupResponseSchema>;
+export type RestoreDatabaseBackupResponse = z.infer<typeof restoreDatabaseBackupResponseSchema>;

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -122,8 +122,21 @@ export const migrationSchema = z.object({
   createdAt: z.string(),
 });
 
+export const databaseBackupSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  triggerSource: z.enum(['manual', 'scheduled']),
+  status: z.enum(['running', 'completed', 'failed']),
+  sizeBytes: z.number().nullable(),
+  errorMessage: z.string().nullable(),
+  createdAt: z.string(),
+  completedAt: z.string().nullable(),
+  createdBy: z.string().nullable(),
+});
+
 export type DatabaseFunction = z.infer<typeof databaseFunctionSchema>;
 export type DatabaseIndex = z.infer<typeof databaseIndexSchema>;
 export type DatabasePolicy = z.infer<typeof databasePolicySchema>;
 export type DatabaseTrigger = z.infer<typeof databaseTriggerSchema>;
 export type Migration = z.infer<typeof migrationSchema>;
+export type DatabaseBackup = z.infer<typeof databaseBackupSchema>;


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->
Test local and OSS tag: [v2.2.2-backup](https://github.com/InsForge/InsForge/tree/refs/tags/v2.2.2-backup)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-hosted database backup and restore using `pg_dump`/`pg_restore`, storing archives on local disk or S3, with a dashboard to create, list, rename, delete, and restore. Now includes a restore lock-wait watchdog and resilient metadata write-back for safer restores.

- **New Features**
  - Backend (self-hosted only): `/database/backups` routes (list/create/rename/delete/restore); dumps with `pg_dump --format=custom`, restores with `pg_restore --clean --if-exists --single-transaction`; stores under `_database_backups` in `STORAGE_DIR` or S3; validates UUIDs/bodies, writes audit logs, issues `NOTIFY pgrst`, and broadcasts DB refresh.
  - Concurrency & safety: single-flight backup/restore with synchronous guards; blocks rename/delete during restore; marks interrupted “running” backups as failed on restart and sweeps stale `.backup-tmp-*` dirs; restore watchdog aborts after 30s of continuous lock waiting with a clear error and does not preemptively kill other sessions; snapshots and retries post-restore metadata write-back (logged and non‑fatal on final failure).
  - Dashboard: Backup & Restore page and sidebar in both modes; self-hosting uses a `backupService` to call the OSS API with success/error toasts and trims empty names; quotas and the scheduler remain cloud-only; tests for hooks.
  - Schemas: `@insforge/shared-schemas` adds backup objects and request/response schemas; unit tests cover the service, watchdog behavior, and migration.

- **Migration**
  - Apply `051_create-database-backups.sql` (adds `system.database_backups`).
  - Rebuild the backend image; `postgresql16-client` is installed (pinned to 16) so `pg_dump`/`pg_restore` are available in runner/dev images.
  - Ensure storage is configured: writable `STORAGE_DIR` for local, or S3 via `AWS_S3_BUCKET` and related settings.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
> 
> <!-- Briefly describe what this PR does -->
> 
> ## How did you test this change?
> 
> <!-- Describe how you tested this PR -->
> Test local and OSS tag: [v2.2.2-backup](https://github.com/InsForge/InsForge/tree/refs/tags/v2.2.2-backup)
> 
> <!-- This is an auto-generated description by cubic. -->
> ---
> ## Summary by cubic
> Adds self-hosted database backup and restore using `pg_dump`/`pg_restore`, storing archives on local disk or S3, with a dashboard to create, list, rename, delete, and restore. Now includes a restore lock-wait watchdog and resilient metadata write-back for safer restores.
> 
> - **New Features**
>   - Backend (self-hosted only): `/database/backups` routes (list/create/rename/delete/restore); dumps with `pg_dump --format=custom`, restores with `pg_restore --clean --if-exists --single-transaction`; stores under `_database_backups` in `STORAGE_DIR` or S3; validates UUIDs/bodies, writes audit logs, issues `NOTIFY pgrst`, and broadcasts DB refresh.
>   - Concurrency & safety: single-flight backup/restore with synchronous guards; blocks rename/delete during restore; marks interrupted “running” backups as failed on restart and sweeps stale `.backup-tmp-*` dirs; restore watchdog aborts after 30s of continuous lock waiting with a clear error and does not preemptively kill other sessions; snapshots and retries post-restore metadata write-back (logged and non‑fatal on final failure).
>   - Dashboard: Backup & Restore page and sidebar in both modes; self-hosting uses a `backupService` to call the OSS API with success/error toasts and trims empty names; quotas and the scheduler remain cloud-only; tests for hooks.
>   - Schemas: `@insforge/shared-schemas` adds backup objects and request/response schemas; unit tests cover the service, watchdog behavior, and migration.
> 
> - **Migration**
>   - Apply `051_create-database-backups.sql` (adds `system.database_backups`).
>   - Rebuild the backend image; `postgresql16-client` is installed (pinned to 16) so `pg_dump`/`pg_restore` are available in runner/dev images.
>   - Ensure storage is configured: writable `STORAGE_DIR` for local, or S3 via `AWS_S3_BUCKET` and related settings.<!-- Macroscope's changelog starts here -->
> #### Changes since #1506 opened
>
> - Added visual status indicators and conditional restore functionality for self-hosted database backups [f123ca8]
> - Implemented automatic polling mechanism for database backup status updates [f123ca8]
> - Added error message support to database backup data structures [f123ca8]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->