### PR TITLE
fix(functions): register worker onmessage before top-level await to fix 504 race

### DIFF
--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -62,16 +62,12 @@ try {
 // take >200ms), the request message was silently dropped -> 504 timeout.
 //
 // Fix: register a synchronous handler BEFORE any top-level await. It buffers
-// any early message(s). Once imports finish, we drain the buffer through the
-// real handler and swap `self.onmessage` to point at it directly.
-let __readyHandler = null;
+// any early message(s). Once imports finish, we swap `self.onmessage` to the
+// real handler and drain the buffer through it. Single-threaded execution
+// guarantees no message can slip between the swap and the drain.
 const __earlyMessages = [];
 self.onmessage = (e) => {
-  if (__readyHandler) {
-    __readyHandler(e);
-  } else {
-    __earlyMessages.push(e);
-  }
+  __earlyMessages.push(e);
 };
 
 // ----------------------------
@@ -80,30 +76,35 @@ self.onmessage = (e) => {
 // We use dynamic imports AFTER the environment is shadowed.
 //
 // If an import fails (e.g. npm registry unreachable under restricted egress),
-// the worker can never produce a real handler. Without this guard the buffered
-// message would hang until the runtime's 60s timeout -> slow, undiagnosable 504.
-// Instead: respond to the buffered message AND any future message with an
-// explicit 500 (same {success,error,status} shape server.ts onmessage expects),
-// then terminate.
+// the worker can never produce a real handler. Answer the request with an
+// explicit 500 (same {success,error,status} shape server.ts onmessage expects)
+// instead of hanging to the runtime's 60s timeout.
+//
+// The request message may NOT have been delivered yet when the import rejects:
+// literal dynamic imports are prefetched with the module graph, so a failed
+// import rejects before the first event-loop turn. Closing the worker at that
+// point would drop the undelivered request and reproduce the silent 504, so we
+// only close() after a message has been answered (with a deadline as backstop).
 let createClient, encodeBase64, decodeBase64;
+let __importFailed = false;
 try {
   ({ createClient } = await import('npm:@insforge/sdk'));
   ({ encodeBase64, decodeBase64 } =
     await import('https://deno.land/std@0.224.0/encoding/base64.ts'));
 } catch (importError) {
+  __importFailed = true;
   const failMsg = 'SDK import failed: ' + (importError?.message || importError);
   console.error(failMsg);
-  const importFailureHandler = () => {
+  const answerAndClose = () => {
     self.postMessage({ success: false, error: failMsg, status: 500 });
+    self.close();
   };
-  // Register fallback for any future message, and answer buffered ones now.
-  __readyHandler = importFailureHandler;
-  self.onmessage = importFailureHandler;
-  for (const e of __earlyMessages.splice(0)) {
-    importFailureHandler(e);
+  if (__earlyMessages.splice(0).length > 0) {
+    answerAndClose();
+  } else {
+    self.onmessage = answerAndClose;
+    setTimeout(() => self.close(), 10000);
   }
-  self.close();
-  throw new Error(failMsg);
 }
 
 // Handle the single message with code, request data, and secrets
@@ -213,8 +214,9 @@ const handleMessage = async (e) => {
 };
 
 // Activate the real handler and drain any messages that arrived during import.
-__readyHandler = handleMessage;
-self.onmessage = handleMessage;
-for (const e of __earlyMessages.splice(0)) {
-  handleMessage(e);
+if (!__importFailed) {
+  self.onmessage = handleMessage;
+  for (const e of __earlyMessages.splice(0)) {
+    await handleMessage(e);
+  }
 }

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -53,15 +53,61 @@ try {
 // ----------------------------
 
 // ----------------------------
+// EARLY MESSAGE BUFFERING (Race Fix)
+// ----------------------------
+// The runtime (server.ts -> executeInWorker) calls worker.postMessage()
+// immediately after `new Worker()`. Web Workers do NOT queue messages that
+// arrive before an `onmessage` handler is registered, so if we only attached
+// the handler AFTER the top-level `await import(...)` below (cold import can
+// take >200ms), the request message was silently dropped -> 504 timeout.
+//
+// Fix: register a synchronous handler BEFORE any top-level await. It buffers
+// any early message(s). Once imports finish, we drain the buffer through the
+// real handler and swap `self.onmessage` to point at it directly.
+let __readyHandler = null;
+const __earlyMessages = [];
+self.onmessage = (e) => {
+  if (__readyHandler) {
+    __readyHandler(e);
+  } else {
+    __earlyMessages.push(e);
+  }
+};
+
+// ----------------------------
 // LATE IMPORTS (Pre-emptive Mocking)
 // ----------------------------
 // We use dynamic imports AFTER the environment is shadowed.
-const { createClient } = await import('npm:@insforge/sdk');
-const { encodeBase64, decodeBase64 } =
-  await import('https://deno.land/std@0.224.0/encoding/base64.ts');
+//
+// If an import fails (e.g. npm registry unreachable under restricted egress),
+// the worker can never produce a real handler. Without this guard the buffered
+// message would hang until the runtime's 60s timeout -> slow, undiagnosable 504.
+// Instead: respond to the buffered message AND any future message with an
+// explicit 500 (same {success,error,status} shape server.ts onmessage expects),
+// then terminate.
+let createClient, encodeBase64, decodeBase64;
+try {
+  ({ createClient } = await import('npm:@insforge/sdk'));
+  ({ encodeBase64, decodeBase64 } =
+    await import('https://deno.land/std@0.224.0/encoding/base64.ts'));
+} catch (importError) {
+  const failMsg = 'SDK import failed: ' + (importError?.message || importError);
+  console.error(failMsg);
+  const importFailureHandler = () => {
+    self.postMessage({ success: false, error: failMsg, status: 500 });
+  };
+  // Register fallback for any future message, and answer buffered ones now.
+  __readyHandler = importFailureHandler;
+  self.onmessage = importFailureHandler;
+  for (const e of __earlyMessages.splice(0)) {
+    importFailureHandler(e);
+  }
+  self.close();
+  throw new Error(failMsg);
+}
 
 // Handle the single message with code, request data, and secrets
-self.onmessage = async (e) => {
+const handleMessage = async (e) => {
   const { code, requestData, secrets = {} } = e.data;
 
   try {
@@ -165,3 +211,10 @@ self.onmessage = async (e) => {
     }
   }
 };
+
+// Activate the real handler and drain any messages that arrived during import.
+__readyHandler = handleMessage;
+self.onmessage = handleMessage;
+for (const e of __earlyMessages.splice(0)) {
+  handleMessage(e);
+}


### PR DESCRIPTION
Fixes #1510

### Problem
After #1482 (deno-migration), all self-hosted edge functions return `504 Function timeout`. The runtime posts the request message synchronously right after `new Worker()` (`functions/server.ts:164` → `:246`), but `functions/worker-template.js` only attached `self.onmessage` **after** a top-level `await import("npm:@insforge/sdk")` (`:59` → `:64`). Web Workers do not queue messages that arrive before an `onmessage` handler is registered, so the >200 ms cold import means the request is dropped and the worker idles until the timeout. Full analysis in #1510.

### Fix (single file: `functions/worker-template.js`)
- Register a **synchronous** `self.onmessage` before any top-level `await`. It buffers early messages in an array.
- After the imports resolve, swap in the real handler (`handleMessage`) and drain the buffer.
- Wrap the dynamic imports in `try/catch`: on failure, answer buffered + future messages with an explicit `{ success: false, error, status: 500 }` (the shape `server.ts`'s `onmessage` already expects) and `self.close()`, instead of hanging to the 504.

### Testing
- Verified on a self-hosted instance: functions that previously timed out now respond normally.
- Import-failure path returns a fast 500 rather than a timeout.

No API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a worker message race that caused 504 timeouts in self-hosted edge functions. We now register `self.onmessage` before any top-level await, buffer early messages, drain them after imports, and reply with a structured 500 before closing the worker if `@insforge/sdk` cannot load (fixes #1510).

- **Bug Fixes**
  - Add synchronous `self.onmessage` to buffer messages before imports; after imports, attach the real handler and drain the buffer.
  - On import failure, respond with `{ success: false, error, status: 500 }` to buffered and future messages, then `close()`; if no message arrived yet, install a respond-and-close handler and add a 10s backstop close.

<sup>Written for commit 41e5b4c0127367ab2ecab4f689e29b1778cb5ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 504 race in worker by buffering messages before top-level awaits complete
> - Defines a temporary `self.onmessage` in [worker-template.js](https://github.com/InsForge/InsForge/pull/1511/files#diff-5b15d90fa8b813623248c82a78beb07550e9132da22b19301aeb63579a8629a6) that buffers incoming messages into `__earlyMessages` before dynamic imports run, preventing messages from being dropped during startup.
> - After imports succeed, reassigns `self.onmessage` to the real `handleMessage` handler and drains the buffer in order.
> - On import failure, responds immediately with `{success: false, status: 500}` and closes the worker, or waits up to 10s for the first message before force-closing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41e5b4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition during worker startup that could drop early messages — incoming messages are now buffered and processed once initialization completes, with graceful error responses and safe shutdown if initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->