### PR TITLE
fix: add overflow-y-auto to sidebar so self-hosted MCP steps are fully scrollable

### DIFF
--- a/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
@@ -550,7 +550,7 @@ export default function DashboardPage() {
       <div
         className={`flex min-w-0 flex-col lg:flex-row${isCloudHostingMode ? '' : ' min-h-full lg:h-full lg:min-h-0'}`}
       >
-        <section className="insforge-dashboard-home-sidebar min-w-0 shrink-0 border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
+        <section className="insforge-dashboard-home-sidebar min-w-0 shrink-0 overflow-y-auto border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
           <div className="mx-auto flex w-full max-w-[400px] flex-col gap-12">
             <div className="flex flex-col gap-12">
               <div className="flex items-center gap-2">

--- a/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
@@ -550,7 +550,7 @@ export default function DashboardPage() {
       <div
         className={`flex min-w-0 flex-col lg:flex-row${isCloudHostingMode ? '' : ' min-h-full lg:h-full lg:min-h-0'}`}
       >
-        <section className="insforge-dashboard-home-sidebar h-full min-w-0 shrink-0 overflow-y-auto border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
+        <section className="insforge-dashboard-home-sidebar lg:h-full min-w-0 shrink-0 lg:overflow-y-auto border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
           <div className="mx-auto flex w-full max-w-[400px] flex-col gap-12">
             <div className="flex flex-col gap-12">
               <div className="flex items-center gap-2">

--- a/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DashboardPage.tsx
@@ -550,7 +550,7 @@ export default function DashboardPage() {
       <div
         className={`flex min-w-0 flex-col lg:flex-row${isCloudHostingMode ? '' : ' min-h-full lg:h-full lg:min-h-0'}`}
       >
-        <section className="insforge-dashboard-home-sidebar min-w-0 shrink-0 overflow-y-auto border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
+        <section className="insforge-dashboard-home-sidebar h-full min-w-0 shrink-0 overflow-y-auto border-b border-[var(--alpha-8)] px-10 py-10 lg:border-r lg:border-b-0">
           <div className="mx-auto flex w-full max-w-[400px] flex-col gap-12">
             <div className="flex flex-col gap-12">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

In self-hosted mode, DashboardPage.tsx applies lg:overflow-hidden to the <main> element to lock the layout to full viewport height. The left sidebar <section> had no overflow-y-auto, so when its content exceeded the viewport (e.g. when the Antigravity client is selected in the Getting Started steps), the overflow was silently clipped with no scrollbar.
Added overflow-y-auto to the sidebar <section> so it scrolls independently. This doesn't affect the full-height layout or the ReactFlow canvas on the right.

Fixes #1513 

## How did you test this change?

Before:
https://github.com/user-attachments/assets/84b072e6-9e4c-456c-a133-7cce92500a58

After:
https://github.com/user-attachments/assets/f02a8636-a50e-4adf-b6bf-5d5b4bfbf639

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the self-hosted dashboard’s sidebar scrollable with lg:overflow-y-auto and lg:h-full, so long Getting Started steps aren’t clipped. Only on large screens to keep mobile responsive; full-height layout and ReactFlow canvas unchanged.

<sup>Written for commit f350099250f47dee1c054285c7ba2be081914abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make dashboard sidebar fully scrollable on large screens
> Adds `lg:h-full` and `lg:overflow-y-auto` to the sidebar `<section>` in [DashboardPage.tsx](https://github.com/InsForge/InsForge/pull/1514/files#diff-78f1eb74c12a1df7ac1a1d02f35195a0f8ad51c0c85b21b545ecc255223831a9), so the sidebar fills available height and scrolls vertically when content overflows. This fixes truncated self-hosted MCP setup steps on large screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f350099.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard sidebar now properly spans the full height and supports independent vertical scrolling on large screens, improving navigation and usability when sidebar content exceeds the visible area—scrolling and layout remain consistent across viewports, reducing overlap and making options easier to access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->