### PR TITLE
fix(mcp): resolve correct path for insforge-instructions-sdk.md in fetch-docs tool

### DIFF
--- a/backend/src/api/routes/docs/index.routes.ts
+++ b/backend/src/api/routes/docs/index.routes.ts
@@ -17,6 +17,11 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Resolve the documentation root once for the module.
+// PROJECT_ROOT is set in docker-compose.yml. Otherwise, fallback to the monorepo root.
+const PROJECT_ROOT = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../../..');
+const DOCS_ROOT = path.join(PROJECT_ROOT, 'docs');
+
 const router = Router();
 
 /**
@@ -164,14 +169,11 @@ router.get('/:docType', async (req: Request, res: Response, next: NextFunction) 
     const docFileName = LEGACY_DOCS_MAP[parsed.data];
 
     // Read the documentation file
-    // PROJECT_ROOT is set in the docker-compose.yml file to point to the InsForge directory
-    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../../..');
-    const docsRoot = path.join(projectRoot, 'docs');
-    const filePath = path.join(docsRoot, docFileName);
+    const filePath = path.join(DOCS_ROOT, docFileName);
     const rawContent = await readFile(filePath, 'utf-8');
 
     // Process snippet imports and replace component tags with actual content
-    const content = await processSnippets(rawContent, docsRoot);
+    const content = await processSnippets(rawContent, DOCS_ROOT);
 
     // Traditional REST: return documentation directly
     return successResponse(res, {
@@ -211,14 +213,11 @@ router.get('/:docFeature/:docLanguage', async (req: Request, res: Response, next
         : `${parsedFeature.data}-sdk-${parsedLanguage.data}`;
 
     // Read the documentation file
-    // PROJECT_ROOT is set in the docker-compose.yml file to point to the InsForge directory
-    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../../..');
-    const docsRoot = path.join(projectRoot, 'docs');
-    const filePath = path.join(docsRoot, docFileName);
+    const filePath = path.join(DOCS_ROOT, docFileName);
     const rawContent = await readFile(filePath, 'utf-8');
 
     // Process snippet imports and replace component tags with actual content
-    const content = await processSnippets(rawContent, docsRoot);
+    const content = await processSnippets(rawContent, DOCS_ROOT);
 
     // Traditional REST: return documentation directly
     return successResponse(res, {

--- a/backend/src/api/routes/docs/index.routes.ts
+++ b/backend/src/api/routes/docs/index.routes.ts
@@ -165,7 +165,7 @@ router.get('/:docType', async (req: Request, res: Response, next: NextFunction) 
 
     // Read the documentation file
     // PROJECT_ROOT is set in the docker-compose.yml file to point to the InsForge directory
-    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../..');
+    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../../..');
     const docsRoot = path.join(projectRoot, 'docs');
     const filePath = path.join(docsRoot, docFileName);
     const rawContent = await readFile(filePath, 'utf-8');
@@ -212,7 +212,7 @@ router.get('/:docFeature/:docLanguage', async (req: Request, res: Response, next
 
     // Read the documentation file
     // PROJECT_ROOT is set in the docker-compose.yml file to point to the InsForge directory
-    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../..');
+    const projectRoot = process.env.PROJECT_ROOT || path.resolve(__dirname, '../../../../..');
     const docsRoot = path.join(projectRoot, 'docs');
     const filePath = path.join(docsRoot, docFileName);
     const rawContent = await readFile(filePath, 'utf-8');


### PR DESCRIPTION
## Summary

The fetch-docs MCP tool was resolving insforge-instructions-sdk.md relative to backend/, resulting in an ENOENT error on self-hosted instances. The file actually lives at docs/insforge-instructions-sdk.md in the repo root.
This breaks the very first verification step for every new self-hoster calling fetch-docs to confirm MCP is working fails out of the box.
Fixed the path resolution to correctly point to docs/insforge-instructions-sdk.md from the repo root.

Fixes #1515 

## How did you test this change?

<img width="275" height="211" alt="Screenshot 2026-06-13 at 1 42 11 AM" src="https://github.com/user-attachments/assets/e121184d-0477-4ade-b83e-0da2d99675fe" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path resolution in the fetch-docs MCP routes to load docs from repo-root `docs/` (e.g., `insforge-instructions-sdk.md`) instead of `backend/`. Centralizes path logic with module-level project/docs roots and corrects the fallback to the repo root when PROJECT_ROOT is unset, preventing ENOENT errors and unblocking initial MCP verification for self-hosted instances.

<sup>Written for commit e4b05150f3ba7033ce5b5c515b0ad39d74e61d31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix docs root path resolution in `fetch-docs` tool handlers
> Centralizes the docs root path into module-level constants `PROJECT_ROOT` and `DOCS_ROOT` in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1516/files#diff-68ead628a2c6870c7f194ce84c9057bd1bda14b5fd93c2bfda832b7023e46629), replacing per-request computation in each handler. Risk: when `PROJECT_ROOT` env var is unset, the fallback now resolves one directory higher (`../../../../..` from `__dirname`), pointing `DOCS_ROOT` to a different `docs` directory than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4b0515.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation file path resolution so docs are reliably located and served through the API.
  * Reduced per-request overhead by computing doc roots once at startup, improving documentation request performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->