### PR TITLE
perf(database): bound tableCountCache size to prevent memory leak

### DIFF
--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -93,13 +93,23 @@ export class DatabaseManager {
     }
   }
 
+  /**
+   * Inserts an entry into a bounded cache with FIFO eviction.
+   * When the cache reaches maxSize, the oldest entry (first insertion-order key) is removed
+   * before adding the new entry, preventing unbounded memory growth.
+   *
+   * @param cache - The Map to insert into
+   * @param maxSize - Maximum number of entries allowed
+   * @param key - Cache key
+   * @param entry - Value to cache
+   */
   private static setBoundedCache<V>(
     cache: Map<string, V>,
     maxSize: number,
     key: string,
     entry: V
   ): void {
-    if (cache.size >= maxSize) {
+    if (cache.size >= maxSize && !cache.has(key)) {
       const first = cache.keys().next().value;
       if (first !== undefined) {
         cache.delete(first);

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -24,6 +24,7 @@ export class DatabaseManager {
   private static readonly COLUMN_TYPE_CACHE_TTL = 5 * 60 * 1000;
   private static columnTypeCache = new Map<string, CacheEntry<Record<string, string>>>();
   private static readonly MAX_CACHE_SIZE = 100;
+  private static readonly MAX_TABLE_COUNT_CACHE_SIZE = 1000;
   private static readonly TABLE_COUNT_CACHE_TTL = 60 * 1000;
   private static tableCountCache = new Map<string, { count: number; timestamp: number }>();
 
@@ -96,6 +97,19 @@ export class DatabaseManager {
     });
   }
 
+  private static setTableCountCache(
+    cacheKey: string,
+    entry: { count: number; timestamp: number }
+  ): void {
+    if (DatabaseManager.tableCountCache.size >= DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE) {
+      const firstKey = DatabaseManager.tableCountCache.keys().next().value;
+      if (firstKey) {
+        DatabaseManager.tableCountCache.delete(firstKey);
+      }
+    }
+    DatabaseManager.tableCountCache.set(cacheKey, entry);
+  }
+
   static clearColumnTypeCache(
     tableName?: string,
     schemaName: string = DEFAULT_DATABASE_SCHEMA
@@ -159,7 +173,7 @@ export class DatabaseManager {
         const nowAfterQuery = Date.now();
         for (const row of queryResult.rows) {
           const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
-          DatabaseManager.tableCountCache.set(cacheKey, {
+          DatabaseManager.setTableCountCache(cacheKey, {
             count: Number(row.count),
             timestamp: nowAfterQuery,
           });

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -154,16 +154,18 @@ export class DatabaseManager {
     ]);
 
     const now = Date.now();
+    const requestCounts = new Map<string, number>();
     const missingOrExpired: string[] = [];
+
     for (const tableName of allTables) {
       const cacheKey = buildQualifiedTableKey(tableName, 'public');
       const cached = DatabaseManager.tableCountCache.get(cacheKey);
-      if (!cached || now - cached.timestamp >= DatabaseManager.TABLE_COUNT_CACHE_TTL) {
+      if (cached && now - cached.timestamp < DatabaseManager.TABLE_COUNT_CACHE_TTL) {
+        requestCounts.set(cacheKey, cached.count);
+      } else {
         missingOrExpired.push(tableName);
       }
     }
-
-    const freshCounts = new Map<string, number>();
 
     if (missingOrExpired.length > 0) {
       const client = await this.pool.connect();
@@ -184,7 +186,7 @@ export class DatabaseManager {
         for (const row of queryResult.rows) {
           const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
           const count = Number(row.count);
-          freshCounts.set(cacheKey, count);
+          requestCounts.set(cacheKey, count);
           DatabaseManager.setBoundedCache(
             DatabaseManager.tableCountCache,
             DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE,
@@ -201,18 +203,9 @@ export class DatabaseManager {
 
     const tableMetadatas = allTables.map((tableName) => {
       const cacheKey = buildQualifiedTableKey(tableName, 'public');
-
-      // 1. Prioritize freshly fetched counts from this request
-      const freshCount = freshCounts.get(cacheKey);
-      if (freshCount !== undefined) {
-        return { tableName, recordCount: freshCount };
-      }
-
-      // 2. Fallback to the bounded global cache
-      const cached = DatabaseManager.tableCountCache.get(cacheKey);
       return {
         tableName,
-        recordCount: cached ? cached.count : 0,
+        recordCount: requestCounts.get(cacheKey) ?? 0,
       };
     });
 

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -24,6 +24,10 @@ export class DatabaseManager {
   private static readonly COLUMN_TYPE_CACHE_TTL = 5 * 60 * 1000;
   private static columnTypeCache = new Map<string, CacheEntry<Record<string, string>>>();
   private static readonly MAX_CACHE_SIZE = 100;
+  /**
+   * Maximum entries for table row counts.
+   * Bounded at 1000 per workspace/process to prevent memory leaks in multi-tenant or multi-schema deployments.
+   */
   private static readonly MAX_TABLE_COUNT_CACHE_SIZE = 1000;
   private static readonly TABLE_COUNT_CACHE_TTL = 60 * 1000;
   private static tableCountCache = new Map<string, { count: number; timestamp: number }>();
@@ -77,37 +81,31 @@ export class DatabaseManager {
         map[row.column_name] = dataType === 'user-defined' ? row.udt_name.toLowerCase() : dataType;
       }
 
-      DatabaseManager.setColumnTypeCache(cacheKey, map);
+      DatabaseManager.setBoundedCache(
+        DatabaseManager.columnTypeCache,
+        DatabaseManager.MAX_CACHE_SIZE,
+        cacheKey,
+        { data: map, expiry: Date.now() + DatabaseManager.COLUMN_TYPE_CACHE_TTL }
+      );
       return map;
     } finally {
       client.release();
     }
   }
 
-  private static setColumnTypeCache(cacheKey: string, data: Record<string, string>): void {
-    if (DatabaseManager.columnTypeCache.size >= DatabaseManager.MAX_CACHE_SIZE) {
-      const firstKey = DatabaseManager.columnTypeCache.keys().next().value;
-      if (firstKey) {
-        DatabaseManager.columnTypeCache.delete(firstKey);
-      }
-    }
-    DatabaseManager.columnTypeCache.set(cacheKey, {
-      data,
-      expiry: Date.now() + DatabaseManager.COLUMN_TYPE_CACHE_TTL,
-    });
-  }
-
-  private static setTableCountCache(
-    cacheKey: string,
-    entry: { count: number; timestamp: number }
+  private static setBoundedCache<V>(
+    cache: Map<string, V>,
+    maxSize: number,
+    key: string,
+    entry: V
   ): void {
-    if (DatabaseManager.tableCountCache.size >= DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE) {
-      const firstKey = DatabaseManager.tableCountCache.keys().next().value;
-      if (firstKey) {
-        DatabaseManager.tableCountCache.delete(firstKey);
+    if (cache.size >= maxSize) {
+      const first = cache.keys().next().value;
+      if (first !== undefined) {
+        cache.delete(first);
       }
     }
-    DatabaseManager.tableCountCache.set(cacheKey, entry);
+    cache.set(key, entry);
   }
 
   static clearColumnTypeCache(
@@ -173,10 +171,12 @@ export class DatabaseManager {
         const nowAfterQuery = Date.now();
         for (const row of queryResult.rows) {
           const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
-          DatabaseManager.setTableCountCache(cacheKey, {
-            count: Number(row.count),
-            timestamp: nowAfterQuery,
-          });
+          DatabaseManager.setBoundedCache(
+            DatabaseManager.tableCountCache,
+            DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE,
+            cacheKey,
+            { count: Number(row.count), timestamp: nowAfterQuery }
+          );
         }
       } catch (error) {
         logger.error('Failed to batch query exact table counts:', { error });

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -163,6 +163,8 @@ export class DatabaseManager {
       }
     }
 
+    const freshCounts = new Map<string, number>();
+
     if (missingOrExpired.length > 0) {
       const client = await this.pool.connect();
       try {
@@ -181,11 +183,13 @@ export class DatabaseManager {
         const nowAfterQuery = Date.now();
         for (const row of queryResult.rows) {
           const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
+          const count = Number(row.count);
+          freshCounts.set(cacheKey, count);
           DatabaseManager.setBoundedCache(
             DatabaseManager.tableCountCache,
             DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE,
             cacheKey,
-            { count: Number(row.count), timestamp: nowAfterQuery }
+            { count, timestamp: nowAfterQuery }
           );
         }
       } catch (error) {
@@ -197,6 +201,14 @@ export class DatabaseManager {
 
     const tableMetadatas = allTables.map((tableName) => {
       const cacheKey = buildQualifiedTableKey(tableName, 'public');
+
+      // 1. Prioritize freshly fetched counts from this request
+      const freshCount = freshCounts.get(cacheKey);
+      if (freshCount !== undefined) {
+        return { tableName, recordCount: freshCount };
+      }
+
+      // 2. Fallback to the bounded global cache
       const cached = DatabaseManager.tableCountCache.get(cacheKey);
       return {
         tableName,

--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -183,10 +183,17 @@ export class DatabaseManager {
 
         const queryResult = await client.query(unionQuery);
         const nowAfterQuery = Date.now();
+
+        // 1. Resolve all database counts into the request-local map first
         for (const row of queryResult.rows) {
           const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
-          const count = Number(row.count);
-          requestCounts.set(cacheKey, count);
+          requestCounts.set(cacheKey, Number(row.count));
+        }
+
+        // 2. Perform all cache mutations second
+        for (const row of queryResult.rows) {
+          const cacheKey = buildQualifiedTableKey(row.table_name, 'public');
+          const count = requestCounts.get(cacheKey) ?? Number(row.count);
           DatabaseManager.setBoundedCache(
             DatabaseManager.tableCountCache,
             DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE,


### PR DESCRIPTION
Closes #1518 
## Problem
`tableCountCache` entries were inserted via a raw `Map.set()` call with no size check:
```ts
// BEFORE — no eviction guard
DatabaseManager.tableCountCache.set(cacheKey, {
  count: Number(row.count),
  timestamp: nowAfterQuery,
});
```

By contrast, `columnTypeCache` — declared in the same class — already handled this correctly through a dedicated private helper (`setColumnTypeCache`) that enforces `MAX_CACHE_SIZE = 100` using a FIFO eviction strategy before every write. `tableCountCache` had no equivalent.

---
## Fix
The change mirrors the exact engineering pattern already established for `columnTypeCache`:
### 1. New size constant
```ts
private static readonly MAX_TABLE_COUNT_CACHE_SIZE = 1000;
```
A ceiling of **1 000** is chosen (vs. 100 for column-type maps) because table-count entries are significantly smaller objects — just `{ count: number; timestamp: number }` — and a higher limit avoids unnecessary cache churn in large schemas.
### 2. New bounded-write helper
```ts
private static setTableCountCache(
  cacheKey: string,
  entry: { count: number; timestamp: number }
): void {
  if (DatabaseManager.tableCountCache.size >= DatabaseManager.MAX_TABLE_COUNT_CACHE_SIZE) {
    const firstKey = DatabaseManager.tableCountCache.keys().next().value;
    if (firstKey) {
      DatabaseManager.tableCountCache.delete(firstKey);
    }
  }
  DatabaseManager.tableCountCache.set(cacheKey, entry);
}
```
**Eviction behaviour:** When the map is at capacity, the _oldest_ key (insertion-order first, per JavaScript `Map` semantics) is removed before the new entry is written. This is the same FIFO strategy used by `setColumnTypeCache`. The evicted entry is typically the stalest in the set, making this a sensible default without requiring a full LRU structure.
### 3. Route all writes through the helper
```ts
// AFTER — bounded write
DatabaseManager.setTableCountCache(cacheKey, {
  count: Number(row.count),
  timestamp: nowAfterQuery,
});
```
---
## Diff Summary
| File | Change |
|---|---|
| `backend/src/infra/database/database.manager.ts` | +`MAX_TABLE_COUNT_CACHE_SIZE` constant, +`setTableCountCache()` helper, raw `.set()` → helper call, CRLF → LF (auto-fixed by Prettier) |
---
## Validation
| Check | Result | Notes |
|---|---|---|
| `npx eslint backend/src/infra/database/database.manager.ts --max-warnings=0` | ✅ **Clean** | 0 errors, 0 warnings after auto-fixing pre-existing CRLF line-endings across the file |
| `npx turbo run typecheck` | ⚠️ Pre-existing failure | `src/providers/payments/razorpay.provider.ts` — `Cannot find module 'razorpay'`. This error exists on `main` and is unrelated to this PR. |
> **Pre-existing debt note:** The `razorpay` type error is a missing `@types` declaration that predates this branch. It is not introduced or worsened by this change.
---
## No Breaking Changes
This is a pure internal refactor. No public API surface, exported types, route signatures, or database queries are modified. Callers of `getMetadata()` observe identical return values.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound `tableCountCache` to 1,000 entries with FIFO eviction via `setBoundedCache()` to stop memory growth. `getMetadata()` now resolves counts from a request-local `requestCounts` map populated before any cache writes, so results stay correct even if eviction happens mid-request.

- **Bug Fixes**
  - Enforced `MAX_TABLE_COUNT_CACHE_SIZE = 1000` via `setBoundedCache()`.
  - Prevented mid-request data loss with a strict two-phase flow: load all counts into `requestCounts` from valid cache hits and DB results first, then update the global cache; final mapping reads only from `requestCounts`.
  - Fixed eviction edge cases: evict empty-string keys and skip eviction when overwriting an existing key.
  - No public API changes.

- **Refactors**
  - Consolidated cache writes for `columnTypeCache` and `tableCountCache` through `setBoundedCache<V>()`; removed `setColumnTypeCache()`/`setTableCountCache()`.

<sup>Written for commit 6a04e52a1dc91096cc6bbf5fa775b1ea00b0e075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `tableCountCache` size to 1000 entries in `DatabaseManager` to prevent memory leak
> - Adds a private static `setBoundedCache` helper in [database.manager.ts](https://github.com/InsForge/InsForge/pull/1519/files#diff-87be7972af532e332149b821a1998be60387341564cef1030f7f2f3ff8337dc9) that inserts into a `Map` with FIFO eviction, only evicting the oldest entry when the cache is full and the key is new.
> - Applies this helper to `tableCountCache` (capped at 1000 entries) and refactors `columnTypeCache` to use the same helper, removing the bespoke `setColumnTypeCache` method.
> - `getMetadata` now collects table row counts into a request-local map, serving fresh cache hits without a query and batch-querying misses via `UNION ALL`, then updating the global cache after results are assembled.
> - Behavioral Change: column type cache no longer evicts the oldest entry on an overwrite of an existing key; eviction only occurs when inserting a new key beyond the cache size limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a04e52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved caching for table counts and column types by enforcing a bounded cache size with FIFO eviction to avoid unbounded memory growth.
  * Refreshed metadata now consistently uses newly queried table counts within the same request, rather than relying only on previously cached values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->