### PR TITLE
feat(auth): implement shared-keys fallback for Microsoft OAuth

### DIFF
--- a/backend/src/providers/oauth/microsoft.provider.ts
+++ b/backend/src/providers/oauth/microsoft.provider.ts
@@ -69,7 +69,12 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
       if (!sharedAuthUrl) {
         throw new Error('Shared Microsoft OAuth did not return an authorization URL');
       }
-      const authUrl = new URL(sharedAuthUrl);
+      let authUrl: URL;
+      try {
+        authUrl = new URL(sharedAuthUrl);
+      } catch {
+        throw new Error(`Shared Microsoft OAuth returned an invalid URL: ${sharedAuthUrl}`);
+      }
       Object.entries(additionalParams ?? {}).forEach(([key, value]) => {
         if (!authUrl.searchParams.has(key)) {
           authUrl.searchParams.set(key, value);
@@ -224,6 +229,9 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
     }
 
     const email = typeof payloadData.email === 'string' ? payloadData.email : '';
+    if (!email) {
+      throw new Error('Shared Microsoft callback missing required email');
+    }
     const name = typeof payloadData.name === 'string' ? payloadData.name : '';
     const avatar = typeof payloadData.avatar === 'string' ? payloadData.avatar : '';
 
@@ -231,7 +239,7 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
       provider: 'microsoft',
       providerId,
       email,
-      userName: name || email.split('@')[0],
+      userName: name || email.split('@')[0] || 'user',
       avatarUrl: avatar,
       identityData: payloadData,
     };

--- a/backend/src/providers/oauth/microsoft.provider.ts
+++ b/backend/src/providers/oauth/microsoft.provider.ts
@@ -46,7 +46,7 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
       // Use shared keys if configured
       const cloudBaseUrl = process.env.CLOUD_API_HOST || 'https://api.insforge.dev';
       const redirectUri = `${selfBaseUrl}/api/auth/oauth/shared/callback/${encodeURIComponent(state)}`;
-      
+
       let sharedAuthUrl: string;
       try {
         const response = await axios.get(
@@ -61,7 +61,9 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
         sharedAuthUrl = response.data.auth_url || response.data.url;
       } catch (error) {
         logger.error('Failed to get shared Microsoft OAuth URL:', error);
-        throw new Error(`Failed to initialize shared Microsoft OAuth: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        throw new Error(
+          `Failed to initialize shared Microsoft OAuth: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
       }
 
       if (!sharedAuthUrl) {
@@ -217,6 +219,10 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
    */
   handleSharedCallback(payloadData: Record<string, unknown>): OAuthUserData {
     const providerId = typeof payloadData.providerId === 'string' ? payloadData.providerId : '';
+    if (!providerId) {
+      throw new Error('Missing providerId from Microsoft shared callback payload');
+    }
+
     const email = typeof payloadData.email === 'string' ? payloadData.email : '';
     const name = typeof payloadData.name === 'string' ? payloadData.name : '';
     const avatar = typeof payloadData.avatar === 'string' ? payloadData.avatar : '';

--- a/backend/src/providers/oauth/microsoft.provider.ts
+++ b/backend/src/providers/oauth/microsoft.provider.ts
@@ -38,11 +38,39 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
 
     const selfBaseUrl = getApiBaseUrl();
 
+    if (config?.useSharedKey) {
+      if (!state) {
+        logger.warn('Shared Microsoft OAuth called without state parameter');
+        throw new Error('State parameter is required for shared Microsoft OAuth');
+      }
+      // Use shared keys if configured
+      const cloudBaseUrl = process.env.CLOUD_API_HOST || 'https://api.insforge.dev';
+      const redirectUri = `${selfBaseUrl}/api/auth/oauth/shared/callback/${state}`;
+      const response = await axios.get(
+        `${cloudBaseUrl}/auth/v1/shared/microsoft?redirect_uri=${encodeURIComponent(redirectUri)}`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      const sharedAuthUrl = response.data.auth_url || response.data.url;
+      if (!sharedAuthUrl) {
+        throw new Error('Shared Microsoft OAuth did not return an authorization URL');
+      }
+      const authUrl = new URL(sharedAuthUrl);
+      Object.entries(additionalParams ?? {}).forEach(([key, value]) => {
+        if (!authUrl.searchParams.has(key)) {
+          authUrl.searchParams.set(key, value);
+        }
+      });
+      return authUrl.toString();
+    }
+
     logger.debug('Microsoft OAuth Config (fresh from DB):', {
       clientId: config.clientId ? 'SET' : 'NOT SET',
     });
 
-    // Note: shared-keys path not implemented for Microsoft; configure local keys
     const authUrl = new URL('https://login.microsoftonline.com/common/oauth2/v2.0/authorize');
     authUrl.searchParams.set('client_id', config.clientId ?? '');
     authUrl.searchParams.set('response_type', 'code');
@@ -172,6 +200,25 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
       userName,
       avatarUrl: '', // Microsoft doesn't provide avatar in basic profile
       identityData: microsoftUserInfo,
+    };
+  }
+
+  /**
+   * Handle shared callback payload transformation
+   */
+  handleSharedCallback(payloadData: Record<string, unknown>): OAuthUserData {
+    const providerId = String(payloadData.providerId ?? '');
+    const email = String(payloadData.email ?? '');
+    const name = String(payloadData.name ?? '');
+    const avatar = String(payloadData.avatar ?? '');
+
+    return {
+      provider: 'microsoft',
+      providerId,
+      email,
+      userName: name || email.split('@')[0],
+      avatarUrl: avatar,
+      identityData: payloadData,
     };
   }
 }

--- a/backend/src/providers/oauth/microsoft.provider.ts
+++ b/backend/src/providers/oauth/microsoft.provider.ts
@@ -45,16 +45,25 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
       }
       // Use shared keys if configured
       const cloudBaseUrl = process.env.CLOUD_API_HOST || 'https://api.insforge.dev';
-      const redirectUri = `${selfBaseUrl}/api/auth/oauth/shared/callback/${state}`;
-      const response = await axios.get(
-        `${cloudBaseUrl}/auth/v1/shared/microsoft?redirect_uri=${encodeURIComponent(redirectUri)}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-      const sharedAuthUrl = response.data.auth_url || response.data.url;
+      const redirectUri = `${selfBaseUrl}/api/auth/oauth/shared/callback/${encodeURIComponent(state)}`;
+      
+      let sharedAuthUrl: string;
+      try {
+        const response = await axios.get(
+          `${cloudBaseUrl}/auth/v1/shared/microsoft?redirect_uri=${encodeURIComponent(redirectUri)}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            timeout: 5000,
+          }
+        );
+        sharedAuthUrl = response.data.auth_url || response.data.url;
+      } catch (error) {
+        logger.error('Failed to get shared Microsoft OAuth URL:', error);
+        throw new Error(`Failed to initialize shared Microsoft OAuth: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
       if (!sharedAuthUrl) {
         throw new Error('Shared Microsoft OAuth did not return an authorization URL');
       }
@@ -207,10 +216,10 @@ export class MicrosoftOAuthProvider implements OAuthProvider {
    * Handle shared callback payload transformation
    */
   handleSharedCallback(payloadData: Record<string, unknown>): OAuthUserData {
-    const providerId = String(payloadData.providerId ?? '');
-    const email = String(payloadData.email ?? '');
-    const name = String(payloadData.name ?? '');
-    const avatar = String(payloadData.avatar ?? '');
+    const providerId = typeof payloadData.providerId === 'string' ? payloadData.providerId : '';
+    const email = typeof payloadData.email === 'string' ? payloadData.email : '';
+    const name = typeof payloadData.name === 'string' ? payloadData.name : '';
+    const avatar = typeof payloadData.avatar === 'string' ? payloadData.avatar : '';
 
     return {
       provider: 'microsoft',

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -1075,6 +1075,9 @@ export class AuthService {
       case 'apple':
         userData = this.appleOAuthProvider.handleSharedCallback(payloadData);
         break;
+      case 'microsoft':
+        userData = this.microsoftOAuthProvider.handleSharedCallback(payloadData);
+        break;
       default:
         throw new AppError(
           `OAuth provider '${provider}' is not supported for shared callback.`,

--- a/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
@@ -80,6 +80,7 @@ export function OAuthConfigDialog({
     'linkedin',
     'facebook',
     'apple',
+    'microsoft',
   ] satisfies readonly OAuthProvidersSchema[];
   const isSharedKeysAvailable =
     isInsForgeCloudProject() && provider?.id && sharedKeyProviders.includes(provider.id);

--- a/packages/shared-schemas/package.json
+++ b/packages/shared-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/shared-schemas",
-  "version": "1.1.59",
+  "version": "1.2.0",
   "author": "Insforge",
   "description": "Shared TypeScript schemas for InsForge frontend and backend",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Currently, `microsoft.provider.ts` is the only OAuth provider missing the shared-keys fallback implementation. This forces developers testing the platform to manually create their own Microsoft Azure OAuth apps.

This PR brings Microsoft to parity with the other providers (Google, Apple, GitHub, etc.) by implementing the shared keys flow.

## Changes:
- Added the `config?.useSharedKey` fallback in `generateOAuthUrl` to fetch the authorization URL from the InsForge cloud API (`/auth/v1/shared/microsoft`).
- Added `handleSharedCallback` to correctly parse the Microsoft user payload.
- Removed the outdated `// Note: shared-keys path not implemented` comment.

## ⚠️ Note for Core Team
This client-side code is fully complete, but it requires a corresponding backend route in the cloud infrastructure before it becomes fully functional.

When reviewing/merging this, please ensure that the `/shared/microsoft` endpoint is added to the `api.insforge.dev` cloud server to handle the redirect generation and token exchange!

Fixes #1520 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared-keys fallback for Microsoft OAuth so environments can use InsForge-managed credentials when `useSharedKey` is enabled. Requires the cloud route for Microsoft shared auth to generate redirects and exchange tokens.

- **New Features**
  - `generateOAuthUrl`: when `config.useSharedKey` is true, builds a shared callback redirect (`/api/auth/oauth/shared/callback/{state}`), fetches the auth URL from `${CLOUD_API_HOST || https://api.insforge.dev}/auth/v1/shared/microsoft` with a 5s timeout, only appends missing `additionalParams`, and validates/throws on bad responses or URLs.
  - `handleSharedCallback`: maps the shared payload to `OAuthUserData`, validates `providerId` and `email`, and sets `userName` to the name or email local-part.
  - `AuthService`: routes the `microsoft` provider to the new shared-callback handler.
  - Dashboard: adds `microsoft` to `sharedKeyProviders` in `OAuthConfigDialog`.

- **Dependencies**
  - Bumps `@insforge/shared-schemas` to `1.2.0`.

<sup>Written for commit 16808b2d1ea8162bde3917a06c6d72c782c60ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared-keys fallback for Microsoft OAuth provider
> - Adds a `useSharedKey` path to `MicrosoftOAuthProvider.generateOAuthUrl` that fetches an authorization URL from the InsForge Cloud API (`https://api.insforge.dev`) and merges any `additionalParams` before returning it; throws on missing state, request failure, or invalid URL.
> - Adds `MicrosoftOAuthProvider.handleSharedCallback` to parse shared callback payloads into `OAuthUserData`, validating `providerId` and `email`.
> - Extends the shared OAuth callback switch in `AuthService` with a `microsoft` case delegating to the new handler.
> - Enables the shared-keys UI option for Microsoft in `OAuthConfigDialog` for Cloud projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16808b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an alternative Microsoft shared OAuth callback flow for sign-in.
  * Enhanced shared-callback handling to populate user profile details (provider, email, display name, avatar).
  * Updated the dashboard’s OAuth configuration dialog to treat Microsoft as eligible for Shared Keys.
* **Bug Fixes**
  * Microsoft OAuth URL generation now uses the implemented shared-auth flow when enabled, removing the previous “not supported” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->