### PR TITLE
INS-359 Add realtime message clear endpoint

### DIFF
--- a/backend/src/api/routes/realtime/messages.routes.ts
+++ b/backend/src/api/routes/realtime/messages.routes.ts
@@ -4,6 +4,7 @@ import { RealtimeMessageService } from '@/services/realtime/realtime-message.ser
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
 import {
+  clearRealtimeMessagesResponseSchema,
   ERROR_CODES,
   listMessagesRequestSchema,
   messageStatsRequestSchema,
@@ -25,6 +26,17 @@ router.get('/', verifyAdmin, async (req: AuthRequest, res: Response, next: NextF
     }
     const messages = await messageService.list(validation.data);
     successResponse(res, messages);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Clear all messages
+router.delete('/', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const deleted = await messageService.clearAllMessages();
+    const response = clearRealtimeMessagesResponseSchema.parse({ deleted });
+    successResponse(res, response);
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/realtime/realtime-message.service.ts
+++ b/backend/src/services/realtime/realtime-message.service.ts
@@ -6,6 +6,8 @@ import { RealtimeChannelService } from './realtime-channel.service.js';
 import type { UserContext } from '@/api/middlewares/auth.js';
 import { withUserContext } from '@/services/database/user-context.service.js';
 
+const DEFAULT_CLEAR_BATCH_SIZE = 1000;
+
 export class RealtimeMessageService {
   private static instance: RealtimeMessageService;
   private pool: Pool | null = null;
@@ -174,6 +176,51 @@ export class RealtimeMessageService {
 
     const result = await this.getPool().query(query, params);
     return result.rows;
+  }
+
+  async clearAllMessages(batchSize = DEFAULT_CLEAR_BATCH_SIZE): Promise<number> {
+    if (batchSize <= 0) {
+      logger.warn('Invalid realtime message clear batch size', { batchSize });
+      return 0;
+    }
+
+    const pool = this.getPool();
+    const cutoffResult = await pool.query('SELECT NOW() as cutoff_time');
+    const cutoffTime = cutoffResult.rows[0]?.cutoff_time;
+    let totalDeleted = 0;
+    let batches = 0;
+
+    while (true) {
+      const result = await pool.query(
+        `WITH deleted AS (
+          DELETE FROM realtime.messages
+          WHERE id IN (
+            SELECT id FROM realtime.messages
+            WHERE created_at <= $2
+            ORDER BY created_at ASC
+            LIMIT $1
+          )
+          RETURNING id
+        )
+        SELECT COUNT(*)::int as deleted_count FROM deleted`,
+        [batchSize, cutoffTime]
+      );
+      const deletedCount = Number(result.rows[0]?.deleted_count ?? 0);
+      totalDeleted += deletedCount;
+
+      if (deletedCount === 0) {
+        break;
+      }
+
+      batches += 1;
+
+      if (deletedCount < batchSize) {
+        break;
+      }
+    }
+
+    logger.info('Realtime messages cleared', { deletedCount: totalDeleted, batches });
+    return totalDeleted;
   }
 
   /**

--- a/backend/tests/unit/realtime-message.service.test.ts
+++ b/backend/tests/unit/realtime-message.service.test.ts
@@ -1,14 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockClient, mockPool, mockGetByName } = vi.hoisted(() => ({
+const { mockClient, mockPool, mockGetByName, mockLogger } = vi.hoisted(() => ({
   mockClient: {
     query: vi.fn(),
     release: vi.fn(),
   },
   mockPool: {
     connect: vi.fn(),
+    query: vi.fn(),
   },
   mockGetByName: vi.fn(),
+  mockLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock('../../src/infra/database/database.manager', () => ({
@@ -28,12 +35,7 @@ vi.mock('../../src/services/realtime/realtime-channel.service', () => ({
 }));
 
 vi.mock('../../src/utils/logger', () => ({
-  default: {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
+  default: mockLogger,
 }));
 
 import { RealtimeMessageService } from '../../src/services/realtime/realtime-message.service';
@@ -51,9 +53,14 @@ describe('RealtimeMessageService', () => {
     vi.clearAllMocks();
     mockClient.query.mockReset();
     mockClient.release.mockReset();
+    mockPool.query.mockReset();
+    mockLogger.debug.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.warn.mockReset();
     mockPool.connect.mockResolvedValue(mockClient);
     mockGetByName.mockResolvedValue({ id: '11111111-1111-1111-1111-111111111111' });
     mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
   });
 
   it('stores project admin websocket publishes as system messages without a UUID sender', async () => {
@@ -96,5 +103,52 @@ describe('RealtimeMessageService', () => {
       userId,
     ]);
     expect(result?.senderId).toBe(userId);
+  });
+
+  it('clears every realtime message in batches and returns the deleted count', async () => {
+    const cutoffTime = new Date('2026-06-15T00:00:00.000Z');
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ cutoff_time: cutoffTime }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ deleted_count: 1000 }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ deleted_count: 42 }], rowCount: 1 });
+
+    const deleted = await RealtimeMessageService.getInstance().clearAllMessages();
+
+    expect(deleted).toBe(1042);
+    expect(mockPool.query).toHaveBeenCalledTimes(3);
+    expect(String(mockPool.query.mock.calls[0][0])).toContain('SELECT NOW()');
+    expect(String(mockPool.query.mock.calls[1][0])).toContain('WHERE created_at <= $2');
+    expect(String(mockPool.query.mock.calls[1][0])).toContain('LIMIT $1');
+    expect(mockPool.query.mock.calls[1][1]).toEqual([1000, cutoffTime]);
+    expect(mockLogger.info).toHaveBeenCalledWith('Realtime messages cleared', {
+      deletedCount: 1042,
+      batches: 2,
+    });
+  });
+
+  it('returns zero when there are no realtime messages to clear', async () => {
+    const cutoffTime = new Date('2026-06-15T00:00:00.000Z');
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ cutoff_time: cutoffTime }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ deleted_count: 0 }], rowCount: 1 });
+
+    const deleted = await RealtimeMessageService.getInstance().clearAllMessages();
+
+    expect(deleted).toBe(0);
+    expect(mockPool.query).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledWith('Realtime messages cleared', {
+      deletedCount: 0,
+      batches: 0,
+    });
+  });
+
+  it('skips clearing when the batch size is invalid', async () => {
+    const deleted = await RealtimeMessageService.getInstance().clearAllMessages(0);
+
+    expect(deleted).toBe(0);
+    expect(mockPool.query).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith('Invalid realtime message clear batch size', {
+      batchSize: 0,
+    });
   });
 });

--- a/docs/agent-docs/real-time.md
+++ b/docs/agent-docs/real-time.md
@@ -261,6 +261,7 @@ REST endpoints:
 | `PUT /api/realtime/channels/{id}` | Update channel |
 | `DELETE /api/realtime/channels/{id}` | Delete channel |
 | `GET /api/realtime/messages` | List message history |
+| `DELETE /api/realtime/messages` | Clear all message history |
 | `GET /api/realtime/messages/stats` | Message stats |
 | `GET /api/realtime/permissions` | Realtime RLS policies |
 | `GET /api/realtime/config` | Retention config |

--- a/openapi/realtime.yaml
+++ b/openapi/realtime.yaml
@@ -312,6 +312,23 @@ paths:
                 error: "INVALID_INPUT"
                 message: "channelId: Invalid uuid"
                 statusCode: 400
+    delete:
+      summary: Clear Messages
+      description: Permanently delete all stored realtime messages
+      tags:
+        - Messages
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      responses:
+        '200':
+          description: Messages cleared
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClearMessagesResponse'
+              example:
+                deleted: 42
 
   /api/realtime/messages/stats:
     get:
@@ -647,6 +664,17 @@ components:
           format: date-time
           description: Timestamp when the message was created
           example: "2024-01-15T10:30:00Z"
+
+    ClearMessagesResponse:
+      type: object
+      required:
+        - deleted
+      properties:
+        deleted:
+          type: integer
+          minimum: 0
+          description: Number of realtime messages deleted
+          example: 42
 
     MessageStats:
       type: object

--- a/packages/dashboard/src/features/realtime/hooks/__tests__/useRealtimeMessages.test.tsx
+++ b/packages/dashboard/src/features/realtime/hooks/__tests__/useRealtimeMessages.test.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRealtimeMessages } from '#features/realtime/hooks/useRealtimeMessages';
+import { realtimeService } from '#features/realtime/services/realtime.service';
+
+vi.mock('#features/realtime/services/realtime.service', () => ({
+  realtimeService: {
+    listMessages: vi.fn(),
+    getMessageStats: vi.fn(),
+    clearMessages: vi.fn(),
+  },
+}));
+
+vi.mock('#lib/hooks/useToast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+const listMessagesMock = vi.mocked(realtimeService.listMessages);
+const getMessageStatsMock = vi.mocked(realtimeService.getMessageStats);
+const clearMessagesMock = vi.mocked(realtimeService.clearMessages);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useRealtimeMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listMessagesMock.mockResolvedValue([]);
+    getMessageStatsMock.mockResolvedValue({
+      totalMessages: 300,
+      whDeliveryRate: 0,
+      topEvents: [],
+      retentionDays: null,
+    });
+    clearMessagesMock.mockResolvedValue({ deleted: 300 });
+  });
+
+  it('resets the messages page offset after clearing messages', async () => {
+    const { result } = renderHook(() => useRealtimeMessages(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.messagesTotalCount).toBe(300);
+    });
+
+    act(() => {
+      result.current.setMessagesPage(3);
+    });
+
+    expect(result.current.messagesParams.offset).toBe(200);
+
+    await act(async () => {
+      await result.current.clearMessages();
+    });
+
+    await waitFor(() => {
+      expect(result.current.messagesParams.offset).toBe(0);
+    });
+    expect(clearMessagesMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/dashboard/src/features/realtime/hooks/useRealtimeMessages.ts
+++ b/packages/dashboard/src/features/realtime/hooks/useRealtimeMessages.ts
@@ -1,9 +1,12 @@
 import { useState, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { realtimeService } from '#features/realtime/services/realtime.service';
 import type { ListMessagesRequest } from '@insforge/shared-schemas';
+import { useToast } from '#lib/hooks/useToast';
 
 export function useRealtimeMessages() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const [messagesParams, setMessagesParams] = useState<ListMessagesRequest>({
     limit: 100,
     offset: 0,
@@ -28,6 +31,24 @@ export function useRealtimeMessages() {
     queryKey: ['realtime', 'stats'],
     queryFn: () => realtimeService.getMessageStats(),
     staleTime: 60 * 1000,
+  });
+
+  const clearMessagesMutation = useMutation({
+    mutationFn: () => realtimeService.clearMessages(),
+    onSuccess: async (data) => {
+      setMessagesParams((previousParams) => ({
+        ...previousParams,
+        offset: 0,
+      }));
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['realtime', 'messages'] }),
+        queryClient.invalidateQueries({ queryKey: ['realtime', 'stats'] }),
+      ]);
+      showToast(`Cleared ${data.deleted} realtime messages.`, 'success');
+    },
+    onError: (mutationError: Error) => {
+      showToast(mutationError.message || 'Failed to clear realtime messages.', 'error');
+    },
   });
 
   const filterMessages = useCallback((params: Partial<ListMessagesRequest>) => {
@@ -65,6 +86,8 @@ export function useRealtimeMessages() {
     messagesTotalPages,
     setMessagesPage,
     filterMessages,
+    clearMessages: clearMessagesMutation.mutateAsync,
+    isClearingMessages: clearMessagesMutation.isPending,
     refetchMessages,
     refetchStats,
     refetch,

--- a/packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx
+++ b/packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, useRef } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Trash2 } from 'lucide-react';
 import RefreshIcon from '#assets/icons/refresh.svg?react';
 import {
   Button,
+  ConfirmDialog,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -14,6 +15,7 @@ import { useRealtimeMessages } from '#features/realtime/hooks/useRealtimeMessage
 import { MessageRow } from '#features/realtime/components/MessageRow';
 import RealtimeEmptyState from '#features/realtime/components/RealtimeEmptyState';
 import type { RealtimeMessage } from '#features/realtime/services/realtime.service';
+import { useConfirm } from '#lib/hooks/useConfirm';
 
 export default function RealtimeMessagesPage() {
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -21,6 +23,7 @@ export default function RealtimeMessagesPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isScrolled, setIsScrolled] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const { confirm, confirmDialogProps } = useConfirm();
 
   const handleScroll = useCallback(() => {
     if (scrollRef.current) {
@@ -37,6 +40,8 @@ export default function RealtimeMessagesPage() {
     messagesTotalCount,
     messagesPageSize,
     setMessagesPage,
+    clearMessages,
+    isClearingMessages,
   } = useRealtimeMessages();
 
   const handleSearchChange = useCallback((value: string) => {
@@ -57,6 +62,26 @@ export default function RealtimeMessagesPage() {
       await refetchMessages();
     } finally {
       setIsRefreshing(false);
+    }
+  };
+
+  const handleClearMessages = async () => {
+    const shouldClear = await confirm({
+      title: 'Clear Realtime Messages',
+      description:
+        'This will permanently delete every stored realtime message. This action cannot be undone.',
+      confirmText: 'Clear Messages',
+      destructive: true,
+    });
+
+    if (!shouldClear) {
+      return;
+    }
+
+    try {
+      await clearMessages();
+    } catch {
+      // The mutation hook already handles error toasts; swallow here to avoid an unhandled rejection.
     }
   };
 
@@ -150,6 +175,25 @@ export default function RealtimeMessagesPage() {
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Clear messages"
+                    onClick={() => void handleClearMessages()}
+                    disabled={isClearingMessages}
+                    className="h-8 w-8 rounded p-1.5 text-muted-foreground hover:bg-[var(--alpha-4)] active:bg-[var(--alpha-8)]"
+                  >
+                    <Trash2 className="h-5 w-5 text-[#717A7A]" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" align="center">
+                  <p>{isClearingMessages ? 'Clearing...' : 'Clear messages'}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         }
         searchValue={searchQuery}
@@ -229,6 +273,7 @@ export default function RealtimeMessagesPage() {
           />
         </div>
       )}
+      <ConfirmDialog {...confirmDialogProps} />
     </div>
   );
 }

--- a/packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx
+++ b/packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RealtimeMessagesPage from '#features/realtime/pages/RealtimeMessagesPage';
+
+const { mockUseRealtimeMessages } = vi.hoisted(() => ({
+  mockUseRealtimeMessages: vi.fn(),
+}));
+
+vi.mock('#assets/icons/refresh.svg?react', () => ({
+  default: () => <svg aria-hidden="true" />,
+}));
+
+vi.mock('#features/realtime/hooks/useRealtimeMessages', () => ({
+  useRealtimeMessages: () => mockUseRealtimeMessages(),
+}));
+
+function mockMessagesPageState(
+  overrides: Partial<ReturnType<typeof mockUseRealtimeMessages>> = {}
+) {
+  mockUseRealtimeMessages.mockReturnValue({
+    messages: [],
+    messagesCount: 0,
+    messagesParams: { limit: 100, offset: 0 },
+    isLoadingMessages: false,
+    messagesError: null,
+    stats: undefined,
+    isLoadingStats: false,
+    messagesPageSize: 100,
+    messagesCurrentPage: 1,
+    messagesTotalCount: 0,
+    messagesTotalPages: 1,
+    setMessagesPage: vi.fn(),
+    filterMessages: vi.fn(),
+    clearMessages: vi.fn().mockResolvedValue({ deleted: 0 }),
+    isClearingMessages: false,
+    refetchMessages: vi.fn().mockResolvedValue(undefined),
+    refetchStats: vi.fn().mockResolvedValue(undefined),
+    refetch: vi.fn(),
+    ...overrides,
+  });
+}
+
+describe('RealtimeMessagesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('confirms before clearing all realtime messages from the messages toolbar', async () => {
+    const user = userEvent.setup();
+    const clearMessages = vi.fn().mockResolvedValue({ deleted: 3 });
+    mockMessagesPageState({ clearMessages });
+
+    render(<RealtimeMessagesPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Clear messages' }));
+
+    const confirmDialog = screen.getByRole('dialog', { name: 'Clear Realtime Messages' });
+    expect(confirmDialog).toBeInTheDocument();
+    expect(clearMessages).not.toHaveBeenCalled();
+
+    await user.click(within(confirmDialog).getByRole('button', { name: 'Clear Messages' }));
+
+    await waitFor(() => {
+      expect(clearMessages).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('does not clear realtime messages when confirmation is cancelled', async () => {
+    const user = userEvent.setup();
+    const clearMessages = vi.fn().mockResolvedValue({ deleted: 3 });
+    mockMessagesPageState({ clearMessages });
+
+    render(<RealtimeMessagesPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Clear messages' }));
+
+    const confirmDialog = screen.getByRole('dialog', { name: 'Clear Realtime Messages' });
+    await user.click(within(confirmDialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(confirmDialog).not.toBeInTheDocument();
+    });
+    expect(clearMessages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/realtime/services/realtime.service.ts
+++ b/packages/dashboard/src/features/realtime/services/realtime.service.ts
@@ -4,6 +4,7 @@ import type {
   RealtimeMessage,
   CreateChannelRequest,
   UpdateChannelRequest,
+  ClearRealtimeMessagesResponse,
   ListMessagesRequest,
   MessageStatsResponse,
   GetRealtimeConfigResponse,
@@ -77,6 +78,13 @@ export class RealtimeService {
     const endpoint = `/realtime/messages${query ? `?${query}` : ''}`;
 
     return apiClient.request(endpoint, {
+      headers: apiClient.withAccessToken(),
+    });
+  }
+
+  async clearMessages(): Promise<ClearRealtimeMessagesResponse> {
+    return apiClient.request('/realtime/messages', {
+      method: 'DELETE',
       headers: apiClient.withAccessToken(),
     });
   }

--- a/packages/shared-schemas/src/realtime-api.schema.ts
+++ b/packages/shared-schemas/src/realtime-api.schema.ts
@@ -69,6 +69,13 @@ export const listMessagesResponseSchema = z.array(realtimeMessageSchema);
 export type ListMessagesRequest = z.infer<typeof listMessagesRequestSchema>;
 export type ListMessagesResponse = z.infer<typeof listMessagesResponseSchema>;
 
+// Clear Messages
+export const clearRealtimeMessagesResponseSchema = z.object({
+  deleted: z.number().int().min(0),
+});
+
+export type ClearRealtimeMessagesResponse = z.infer<typeof clearRealtimeMessagesResponseSchema>;
+
 // Message Stats
 export const messageStatsRequestSchema = z.object({
   channelId: z.string().uuid().optional(),


### PR DESCRIPTION
## Summary

- Add an admin `DELETE /api/realtime/messages` endpoint that clears all stored realtime messages and returns the deleted count.
- Clear messages in batches and log the destructive operation with deleted count and batch count.
- Add a destructive Clear Messages button next to Refresh on the realtime messages page, with confirmation and cancel coverage.
- Update shared schema, OpenAPI, and realtime agent endpoint docs.

## Validation

- `npx prettier --write packages/dashboard/src/features/realtime/hooks/useRealtimeConfig.ts packages/dashboard/src/features/realtime/hooks/useRealtimeMessages.ts packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx`
- `npm --workspace @insforge/dashboard run test:component -- src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx`
- `npm --workspace @insforge/dashboard run typecheck`
- `cd backend && npm test -- tests/unit/realtime-message.service.test.ts`
- `npx eslint backend/src/services/realtime/realtime-message.service.ts backend/tests/unit/realtime-message.service.test.ts packages/dashboard/src/features/realtime/services/realtime.service.ts packages/dashboard/src/features/realtime/hooks/useRealtimeConfig.ts packages/dashboard/src/features/realtime/hooks/useRealtimeMessages.ts packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx`
- `cd backend && npm run typecheck`
- `npm --workspace @insforge/shared-schemas run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add DELETE /api/realtime/messages endpoint to clear all realtime messages
> - Adds `RealtimeMessageService.clearAllMessages()` in [realtime-message.service.ts](https://github.com/InsForge/InsForge/pull/1522/files#diff-a2d728faf1381417078822c3959529299ecedbf9ff257c3bc46dafc6f4451f63) that deletes rows in batches of 1000 up to a fixed cutoff timestamp, returning the total deleted count.
> - Adds an admin-protected `DELETE /api/realtime/messages` route and a `ClearRealtimeMessagesResponse` Zod schema in shared-schemas.
> - Adds a "Clear messages" toolbar button in [RealtimeMessagesPage.tsx](https://github.com/InsForge/InsForge/pull/1522/files#diff-7c078be6bccffbae9303320b9fa6c5ae00e17c0335cd29a6fb8a03de4b89be84) with a confirmation dialog; on confirm, resets pagination offset to 0 and invalidates message and stats queries.
> - Updates [realtime.yaml](https://github.com/InsForge/InsForge/pull/1522/files#diff-d5555b7daa2047a3e8fc617f99d8b0834c5bb240b3334a8fb00a3a1067631bb6) and [real-time.md](https://github.com/InsForge/InsForge/pull/1522/files#diff-a09ea6545a30ce6f5dcb461c639e63c75d1ccaf4dc6dc56aa8f514025d5fad2a) to document the new endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59c9d69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a destructive “Clear messages” button to the realtime messages interface, with a confirmation dialog to prevent accidental deletion
  * Implemented an authenticated “Clear messages” action that permanently removes all realtime messages and reports the deleted count on success (with error feedback on failure)

* **Documentation**
  * Updated API documentation to include the new endpoint for clearing realtime messages and its response format

* **Tests**
  * Added unit and UI tests covering the new message-clearing behavior and deletion result aggregation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->