### PR TITLE
feat(database): add RLS policy simulator endpoint

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -229,7 +229,7 @@ export const verifyOTPLimiter = [verifyOTPRateLimiter];
  * an explicit named flag (not `NODE_ENV`) so unit tests still exercise the
  * limiter and prod can never accidentally bypass via test envs.
  */
-export type WriteLimiterCategory = 'functions' | 'deployments' | 'compute';
+export type WriteLimiterCategory = 'functions' | 'deployments' | 'compute' | 'database';
 
 function isWriteRateLimitDisabled(): boolean {
   return process.env.INSFORGE_DISABLE_WRITE_RATE_LIMIT === '1';
@@ -245,6 +245,7 @@ export const DEFAULT_WRITE_ENDPOINT_LIMITS: Readonly<Record<WriteLimiterCategory
     functions: 15,
     deployments: 25,
     compute: 15,
+    database: 30,
   });
 
 /**
@@ -448,3 +449,4 @@ function createWriteEndpointLimiter(category: WriteLimiterCategory) {
 export const functionsWriteLimiter = createWriteEndpointLimiter('functions');
 export const deploymentsWriteLimiter = createWriteEndpointLimiter('deployments');
 export const computeWriteLimiter = createWriteEndpointLimiter('compute');
+export const databaseWriteLimiter = createWriteEndpointLimiter('database');

--- a/backend/src/api/routes/database/index.routes.ts
+++ b/backend/src/api/routes/database/index.routes.ts
@@ -10,6 +10,7 @@ import { DatabaseService } from '@/services/database/database.service.js';
 import { PolicySimulatorService } from '@/services/database/policy-simulator.service.js';
 import { AuditService } from '@/services/logs/audit.service.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { databaseWriteLimiter } from '@/api/middlewares/rate-limiters.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES, simulatePolicyRequestSchema } from '@insforge/shared-schemas';
@@ -111,6 +112,7 @@ router.get(
 router.post(
   '/policies/simulate',
   verifyAdmin,
+  databaseWriteLimiter,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validation = simulatePolicyRequestSchema.safeParse(req.body);
@@ -124,19 +126,25 @@ router.post(
 
       const response = await policySimulatorService.simulate(validation.data);
 
-      await auditService.log({
-        actor: req.hasApiKey ? 'api-key' : req.user?.id,
-        action: 'SIMULATE_RLS_POLICY',
-        module: 'DATABASE',
-        details: {
-          schema: response.schema,
-          table: response.table,
-          operation: response.operation,
-          role: response.role,
-          decision: response.decision,
-        },
-        ip_address: req.ip,
-      });
+      // Audit logging must not turn a successful, side-effect-free simulation
+      // into a 500. Log failures are recorded but never propagated.
+      try {
+        await auditService.log({
+          actor: req.hasApiKey ? 'api-key' : req.user?.id,
+          action: 'SIMULATE_RLS_POLICY',
+          module: 'DATABASE',
+          details: {
+            schema: response.schema,
+            table: response.table,
+            operation: response.operation,
+            role: response.role,
+            decision: response.decision,
+          },
+          ip_address: req.ip,
+        });
+      } catch (auditError) {
+        logger.warn('RLS policy simulation audit log failed:', auditError);
+      }
 
       successResponse(res, response);
     } catch (error: unknown) {

--- a/backend/src/api/routes/database/index.routes.ts
+++ b/backend/src/api/routes/database/index.routes.ts
@@ -7,14 +7,20 @@ import { databaseMigrationsRouter } from './migrations.routes.js';
 import { databaseBackupsRouter } from './backups.routes.js';
 import { databaseAdminRouter } from './admin.routes.js';
 import { DatabaseService } from '@/services/database/database.service.js';
+import { PolicySimulatorService } from '@/services/database/policy-simulator.service.js';
+import { AuditService } from '@/services/logs/audit.service.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { successResponse } from '@/utils/response.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES, simulatePolicyRequestSchema } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { normalizeDatabaseSchemaName } from '@/services/database/helpers.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 
 const router = Router();
 const databaseService = DatabaseService.getInstance();
+const policySimulatorService = PolicySimulatorService.getInstance();
+const auditService = AuditService.getInstance();
 
 // Mount database sub-routes
 router.use('/tables', databaseTablesRouter);
@@ -89,6 +95,52 @@ router.get(
       successResponse(res, response);
     } catch (error: unknown) {
       logger.warn('Get policies error:', error);
+      next(error);
+    }
+  }
+);
+
+/**
+ * Simulate an RLS policy decision for a table operation.
+ * POST /api/database/policies/simulate
+ *
+ * Runs the operation as the chosen role + JWT claims inside a rolled-back
+ * transaction (no side effects) and reports allow/deny plus the applicable
+ * policies. Admin-only; strictly less powerful than /advance/rawsql.
+ */
+router.post(
+  '/policies/simulate',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const validation = simulatePolicyRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const response = await policySimulatorService.simulate(validation.data);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'SIMULATE_RLS_POLICY',
+        module: 'DATABASE',
+        details: {
+          schema: response.schema,
+          table: response.table,
+          operation: response.operation,
+          role: response.role,
+          decision: response.decision,
+        },
+        ip_address: req.ip,
+      });
+
+      successResponse(res, response);
+    } catch (error: unknown) {
+      logger.warn('RLS policy simulation error:', error);
       next(error);
     }
   }

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -196,7 +196,13 @@ export class PolicySimulatorService {
       throw toSimulationError(error);
     }
 
-    const decision = classifySelect({ rowsVisible, rowsTotal, bypassRls: base.bypassRls });
+    const decision = classifySelect({
+      rowsVisible,
+      rowsTotal,
+      bypassRls: base.bypassRls,
+      rlsEnabled: base.rlsEnabled,
+      applicablePermissiveCount: countPermissivePolicies(base.applicablePolicies),
+    });
 
     return finalize({
       ...base,
@@ -316,6 +322,8 @@ export class PolicySimulatorService {
         rowsAffected,
         rowsTotal,
         bypassRls: base.bypassRls,
+        rlsEnabled: base.rlsEnabled,
+        applicablePermissiveCount: countPermissivePolicies(base.applicablePolicies),
       });
       return finalize({
         ...base,
@@ -399,10 +407,21 @@ export function buildWhereClause(
   return { sql: `WHERE ${clauses.join(' AND ')}`, params };
 }
 
+/**
+ * Count applicable PERMISSIVE policies. RLS is permissive-OR: a non-bypass role
+ * sees a row only if at least one permissive policy passes, so zero permissive
+ * policies means deny-all regardless of how many restrictive policies exist.
+ */
+function countPermissivePolicies(policies: SimulatorPolicy[]): number {
+  return policies.filter((p) => p.permissive).length;
+}
+
 export function classifySelect(args: {
   rowsVisible: number;
   rowsTotal: number | null;
   bypassRls: boolean;
+  rlsEnabled: boolean;
+  applicablePermissiveCount: number;
 }): PolicySimulatorDecision {
   if (args.bypassRls) {
     return 'bypass';
@@ -412,7 +431,20 @@ export function classifySelect(args: {
     return args.rowsVisible > 0 ? 'allowed' : 'denied';
   }
   if (args.rowsTotal === 0) {
-    return 'allowed'; // nothing to read; RLS can't be observed but didn't block
+    // No row existed to test, so RLS could not be observed.
+    // If RLS is not enforced on the table, no policy can deny — access is governed
+    // by table GRANTs (the role's read already succeeded), so an empty read is
+    // allowed, consistent with a populated RLS-disabled table that reads every row.
+    if (!args.rlsEnabled) {
+      return 'allowed';
+    }
+    // RLS enforced: apply Postgres's deterministic default-deny instead of
+    // pretending certainty. With no applicable PERMISSIVE policy, RLS lets no row
+    // through for a non-bypass role (permissive-OR), so the role would be denied
+    // once rows exist — the same outcome a populated table gives (rowsVisible
+    // 0 < rowsTotal => denied). A permissive policy means the real outcome is
+    // genuinely unobserved, so don't infer a denial.
+    return args.applicablePermissiveCount === 0 ? 'denied' : 'allowed';
   }
   if (args.rowsVisible === 0) {
     return 'denied';
@@ -427,6 +459,8 @@ export function classifyMutation(args: {
   rowsAffected: number;
   rowsTotal: number | null;
   bypassRls: boolean;
+  rlsEnabled: boolean;
+  applicablePermissiveCount: number;
 }): PolicySimulatorDecision {
   if (args.bypassRls) {
     return 'bypass';
@@ -436,7 +470,13 @@ export function classifyMutation(args: {
     return args.rowsAffected > 0 ? 'allowed' : 'denied';
   }
   if (args.rowsTotal === 0) {
-    return 'allowed'; // no matching rows to act on
+    // No matching row to act on, so RLS could not be observed. Mirror
+    // classifySelect: RLS-disabled => allowed (GRANT-governed); RLS-enforced with
+    // no applicable permissive policy => denied by default; with one => unobserved.
+    if (!args.rlsEnabled) {
+      return 'allowed';
+    }
+    return args.applicablePermissiveCount === 0 ? 'denied' : 'allowed';
   }
   if (args.rowsAffected === 0) {
     return 'denied';
@@ -464,7 +504,7 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
   }
 
   const policyCount = result.applicablePolicies.length;
-  const permissiveCount = result.applicablePolicies.filter((p) => p.permissive).length;
+  const permissiveCount = countPermissivePolicies(result.applicablePolicies);
   const policySummary =
     policyCount === 0
       ? `No RLS policy applies to ${operation} for role "${role}", so it is blocked by default.`
@@ -482,19 +522,24 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
     ? ' (Admin baseline unavailable: project_admin lacks SELECT on this table, so visible vs total rows were not compared.)'
     : '';
 
+  // Empty result (empty table, or a filter that matched nothing): no row existed
+  // to test, so RLS could not be *observed*. Report the deterministic outcome
+  // instead of pretending certainty. With no applicable permissive policy, RLS
+  // lets no row through for a non-bypass role (permissive-OR), so access is denied
+  // by default — the same outcome a populated table gives, and what
+  // classifySelect/classifyMutation return here. With a permissive policy present
+  // the real outcome is genuinely unobserved, so the decision stays 'allowed' and
+  // we say so. (rowsTotal is null, not 0, when the admin baseline is unavailable,
+  // so this never collides with baselineNote.)
+  if (result.rowsTotal === 0) {
+    if (permissiveCount === 0) {
+      return `${operation} as "${role}" on ${table} matched no rows, and no applicable permissive RLS policy grants row access to ${operation} for role "${role}", so access is denied by default.`;
+    }
+    return `${operation} as "${role}" on ${table} matched no rows, so row level security could not be observed: nothing was denied, but whether any future row would pass is not proven (the applicable policy may still evaluate false, e.g. for unmet claims). ${policySummary}`;
+  }
+
   switch (decision) {
     case 'allowed':
-      if (result.rowsTotal === 0) {
-        // Empty table (or a filter that matched nothing): the operation was not
-        // denied, but with no rows present RLS could not actually be observed.
-        // Say so honestly instead of appending the default policy summary, which
-        // would read "is allowed ... blocked by default" and contradict itself.
-        const consequence =
-          policyCount === 0
-            ? `No RLS policy currently applies to ${operation} for role "${role}", so once matching rows exist they would be denied by default.`
-            : policySummary;
-        return `${operation} as "${role}" on ${table} matched no rows, so row level security could not be observed (nothing was denied, but whether future rows would pass is not proven). ${consequence}`;
-      }
       return `${operation} as "${role}" on ${table} is allowed. ${policySummary}${baselineNote}`;
     case 'partial':
       return `${operation} as "${role}" on ${table} is partially allowed: ${result.rowsVisible ?? result.rowsAffected} of ${result.rowsTotal} rows pass RLS. ${policySummary}`;

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -580,19 +580,32 @@ async function countAsAdmin(
 }
 
 async function assertTableExists(pool: Pool, schema: string, table: string): Promise<void> {
+  // Use pg_class.relkind so we can tell "missing" apart from "exists but is not
+  // a base table". RLS policies only apply to ordinary ('r') and partitioned
+  // ('p') tables; views/matviews/foreign tables have no pg_policies, so
+  // simulating against them would silently produce empty, misleading results.
   const result = await pool.query(
-    `SELECT EXISTS (
-       SELECT 1 FROM information_schema.tables
-       WHERE table_schema = $1 AND table_name = $2
-     ) AS present`,
+    `SELECT c.relkind
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = $1 AND c.relname = $2`,
     [schema, table]
   );
-  if (!result.rows[0].present) {
+  if (result.rows.length === 0) {
     throw new AppError(
       `Table "${schema}.${table}" does not exist.`,
       404,
       ERROR_CODES.DATABASE_NOT_FOUND,
       NEXT_ACTIONS.CHECK_TABLE_EXISTS
+    );
+  }
+  const relkind = result.rows[0].relkind as string;
+  if (relkind !== 'r' && relkind !== 'p') {
+    throw new AppError(
+      `"${schema}.${table}" is not a base table, so it has no row level security policies to simulate.`,
+      400,
+      ERROR_CODES.INVALID_INPUT,
+      'Simulate against a base table. Views, materialized views, and foreign tables are not supported.'
     );
   }
 }

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -140,6 +140,11 @@ export class PolicySimulatorService {
     const where = buildWhereClause(input.match);
     const sampleLimit = input.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
 
+    // Snapshot the admin baseline BEFORE the role's read so SELECT and mutation
+    // simulations share the same race window relative to concurrent writes
+    // (simulateMutation also counts before it runs).
+    const rowsTotal = await countAsAdmin(pool, qualifiedName, where);
+
     let rowsVisible: number;
     let sampleRows: ColumnMap[] | null;
 
@@ -170,7 +175,10 @@ export class PolicySimulatorService {
       ));
     } catch (error) {
       if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
-        // No SELECT privilege at all — the role can't read the table.
+        // No SELECT privilege at all — the role can't read the table. Keep
+        // rowsTotal null here (not the admin baseline) so a privilege-denied
+        // read returns the same shape it always has — the baseline is only
+        // meaningful for the visible-vs-total comparison, which never runs.
         const reason = (error as DatabaseError).message;
         return finalize({
           ...base,
@@ -182,12 +190,12 @@ export class PolicySimulatorService {
           denialReason: reason,
           qualifiedName,
           whereSql: where.sql,
+          request: input,
         });
       }
       throw toSimulationError(error);
     }
 
-    const rowsTotal = await countAsAdmin(pool, qualifiedName, where);
     const decision = classifySelect({ rowsVisible, rowsTotal, bypassRls: base.bypassRls });
 
     return finalize({
@@ -200,6 +208,7 @@ export class PolicySimulatorService {
       denialReason: null,
       qualifiedName,
       whereSql: where.sql,
+      request: input,
     });
   }
 
@@ -239,6 +248,7 @@ export class PolicySimulatorService {
         denialReason: null,
         qualifiedName,
         whereSql: '',
+        request: input,
       });
     } catch (error) {
       if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
@@ -252,6 +262,7 @@ export class PolicySimulatorService {
           denialReason: (error as DatabaseError).message,
           qualifiedName,
           whereSql: '',
+          request: input,
         });
       }
       throw toSimulationError(error);
@@ -316,6 +327,7 @@ export class PolicySimulatorService {
         denialReason: null,
         qualifiedName,
         whereSql: where.sql,
+        request: input,
       });
     } catch (error) {
       if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
@@ -329,6 +341,7 @@ export class PolicySimulatorService {
           denialReason: (error as DatabaseError).message,
           qualifiedName,
           whereSql: where.sql,
+          request: input,
         });
       }
       throw toSimulationError(error);
@@ -471,6 +484,17 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
 
   switch (decision) {
     case 'allowed':
+      if (result.rowsTotal === 0) {
+        // Empty table (or a filter that matched nothing): the operation was not
+        // denied, but with no rows present RLS could not actually be observed.
+        // Say so honestly instead of appending the default policy summary, which
+        // would read "is allowed ... blocked by default" and contradict itself.
+        const consequence =
+          policyCount === 0
+            ? `No RLS policy currently applies to ${operation} for role "${role}", so once matching rows exist they would be denied by default.`
+            : policySummary;
+        return `${operation} as "${role}" on ${table} matched no rows, so row level security could not be observed (nothing was denied, but whether future rows would pass is not proven). ${consequence}`;
+      }
       return `${operation} as "${role}" on ${table} is allowed. ${policySummary}${baselineNote}`;
     case 'partial':
       return `${operation} as "${role}" on ${table} is partially allowed: ${result.rowsVisible ?? result.rowsAffected} of ${result.rowsTotal} rows pass RLS. ${policySummary}`;
@@ -492,29 +516,157 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
   }
 }
 
-export function buildExampleQuery(result: SimulatePolicyResponse, qualifiedName: string): string {
-  const claims = JSON.stringify(result.effectiveClaims).replace(/'/g, "''");
+/**
+ * A faithful, copy-pasteable reproduction of the simulated session: the same
+ * role, the same JWT claims, and the same data statement the simulator actually
+ * ran — the filter from `match`, the values from `row`, and the SELECT sample
+ * limit — wrapped in BEGIN/ROLLBACK so running it persists nothing.
+ *
+ * This text is display-only (the backend never executes it), but it must be
+ * unambiguous and safe to paste: identifiers are quoted, and values render as
+ * SQL literals with strings/JSON dollar-quoted using a collision-free tag, so
+ * single quotes and backslashes are safe regardless of the server's
+ * `standard_conforming_strings` setting.
+ */
+export function buildExampleQuery(
+  result: SimulatePolicyResponse,
+  qualifiedName: string,
+  request?: Pick<SimulatePolicyRequest, 'match' | 'row' | 'sampleLimit'>
+): string {
   const lines = [
     'BEGIN;',
-    `SET LOCAL ROLE ${result.role};`,
-    `SELECT set_config('request.jwt.claims', '${claims}', true);`,
+    // Reuse the same role allowlist the simulator executes with, so the snippet
+    // can never render a role outside {anon, authenticated, project_admin}.
+    `${ROLE_SQL[result.role]};`,
+    `SELECT set_config('request.jwt.claims', ${dollarQuote(
+      JSON.stringify(result.effectiveClaims)
+    )}, true);`,
   ];
+
+  const row = request?.row;
+  const where = renderExampleWhere(request?.match);
+
   switch (result.operation) {
-    case 'SELECT':
-      lines.push(`SELECT * FROM ${qualifiedName};`);
+    case 'SELECT': {
+      const sampleLimit = request?.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
+      if (Number.isInteger(sampleLimit) && sampleLimit > 0) {
+        lines.push(`SELECT * FROM ${qualifiedName}${where} LIMIT ${sampleLimit};`);
+      } else {
+        // sampleLimit 0: the simulator only counted visible rows (no sample
+        // read), so reproduce the count rather than an unbounded SELECT *.
+        lines.push(`SELECT count(*) FROM ${qualifiedName}${where};`);
+      }
       break;
-    case 'INSERT':
-      lines.push(`INSERT INTO ${qualifiedName} (...) VALUES (...);`);
+    }
+    case 'INSERT': {
+      const columns = row ? Object.keys(row) : [];
+      if (columns.length === 0) {
+        lines.push(`INSERT INTO ${qualifiedName} DEFAULT VALUES;`);
+      } else {
+        const cols = columns.map(quoteIdentifier).join(', ');
+        const vals = columns.map((c) => toSqlLiteral((row as ColumnMap)[c])).join(', ');
+        lines.push(`INSERT INTO ${qualifiedName} (${cols}) VALUES (${vals});`);
+      }
       break;
-    case 'UPDATE':
-      lines.push(`UPDATE ${qualifiedName} SET ... WHERE ...;`);
+    }
+    case 'UPDATE': {
+      const columns = row ? Object.keys(row) : [];
+      if (columns.length === 0) {
+        // Unreachable in practice: simulateMutation rejects an UPDATE without a
+        // `row` before finalize runs. Emit a comment, never a non-runnable
+        // statement, so the snippet always pastes cleanly.
+        lines.push(`-- UPDATE ${qualifiedName}: provide a row payload (SET values) to simulate.`);
+      } else {
+        const setSql = columns
+          .map((c) => `${quoteIdentifier(c)} = ${toSqlLiteral((row as ColumnMap)[c])}`)
+          .join(', ');
+        lines.push(`UPDATE ${qualifiedName} SET ${setSql}${where};`);
+      }
       break;
-    case 'DELETE':
-      lines.push(`DELETE FROM ${qualifiedName} WHERE ...;`);
+    }
+    case 'DELETE': {
+      lines.push(`DELETE FROM ${qualifiedName}${where};`);
       break;
+    }
   }
+
   lines.push('ROLLBACK;');
   return lines.join('\n');
+}
+
+/** Render a `match` map as a literal WHERE clause (empty string when absent). */
+function renderExampleWhere(match: Record<string, unknown> | undefined): string {
+  if (!match) {
+    return '';
+  }
+  const keys = Object.keys(match);
+  if (keys.length === 0) {
+    return '';
+  }
+  const clauses = keys.map((key) => {
+    const value = match[key];
+    return value === null
+      ? `${quoteIdentifier(key)} IS NULL`
+      : `${quoteIdentifier(key)} = ${toSqlLiteral(value)}`;
+  });
+  return ` WHERE ${clauses.join(' AND ')}`;
+}
+
+/**
+ * Render a JS value as a SQL literal for the example query. Primitives render
+ * bare; null/undefined render as NULL; strings and JSON (objects/arrays) are
+ * dollar-quoted so embedded quotes and backslashes never need escaping.
+ */
+function toSqlLiteral(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number') {
+    // Non-finite numbers cannot come from a JSON request body, but guard anyway
+    // so the display path can never emit an invalid literal.
+    return Number.isFinite(value) ? String(value) : 'NULL';
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (typeof value === 'string') {
+    return dollarQuote(value);
+  }
+  // Objects/arrays render as a JSON string literal Postgres can coerce. We do
+  // not add a ::type cast: the simulator does not introspect column types, and
+  // a wrong cast (e.g. ::jsonb on a text column) would be less faithful than a
+  // plain literal. JSON.stringify can return undefined (functions, symbols) or
+  // throw (circular refs, nested BigInt) for exotic values a JSON request can't
+  // contain; either way, fall back to NULL so the display path never fails the
+  // simulation it is only annotating.
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    return 'NULL';
+  }
+  return json === undefined ? 'NULL' : dollarQuote(json);
+}
+
+/**
+ * Wrap `text` in a dollar-quoted SQL string literal, so the value needs no
+ * escaping and is safe under any `standard_conforming_strings` setting. We pick
+ * a tag whose closing delimiter first appears in `text + delimiter` exactly at
+ * the join. That rules out not just a delimiter embedded in the body, but also
+ * boundary merges — e.g. a value ending in `$` ("SAVE20$") would otherwise fuse
+ * with a bare `$$` delimiter into `$$SAVE20$$$` and terminate early. `$$` is
+ * tried first (clean for the common case), then `$q1$`, `$q2$`, …
+ */
+function dollarQuote(text: string): string {
+  for (let i = 0; ; i += 1) {
+    const delim = i === 0 ? '$$' : `$q${i}$`;
+    if ((text + delim).indexOf(delim) === text.length) {
+      return `${delim}${text}${delim}`;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -541,6 +693,9 @@ interface FinalizeArgs extends SimulationBase {
   denialReason: string | null;
   qualifiedName: string;
   whereSql: string;
+  // The original request, so the example query can faithfully reproduce the
+  // exact filter (`match`), values (`row`), and SELECT sample limit.
+  request: SimulatePolicyRequest;
 }
 
 function finalize(args: FinalizeArgs): SimulatePolicyResponse {
@@ -563,7 +718,7 @@ function finalize(args: FinalizeArgs): SimulatePolicyResponse {
     exampleQuery: '',
   };
   response.explanation = buildExplanation(response);
-  response.exampleQuery = buildExampleQuery(response, args.qualifiedName);
+  response.exampleQuery = buildExampleQuery(response, args.qualifiedName, args.request);
   return response;
 }
 

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -457,14 +457,17 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
       ? `No RLS policy applies to ${operation} for role "${role}", so it is blocked by default.`
       : `${policyCount} polic${policyCount === 1 ? 'y' : 'ies'} apply (${permissiveCount} permissive). Permissive policies are combined with OR, restrictive with AND.`;
 
-  // A 42501 denial can be a missing table GRANT or an RLS policy block. Both look
-  // identical in the decision, so call out the GRANT case (different fix).
-  const isGrantDenial = !!result.denialReason && /permission denied/i.test(result.denialReason);
-  // When the admin baseline could not be computed, the counts were not compared.
-  const baselineNote =
-    result.rowsTotal === null
-      ? ' (Admin baseline unavailable: project_admin lacks SELECT on this table, so visible vs total rows were not compared.)'
-      : '';
+  // A 42501 denial can be a missing table GRANT or an RLS policy block. Both
+  // share the error code, so we read the Postgres message (best-effort, English
+  // defaults). Check the definitive RLS phrase first; only then treat a generic
+  // "permission denied" as a missing GRANT. The raw message is always shown too.
+  const denialReason = result.denialReason;
+  const looksLikeRls = !!denialReason && /row.?level security/i.test(denialReason);
+  const looksLikeGrant = !!denialReason && !looksLikeRls && /permission denied/i.test(denialReason);
+  const baselineUnavailable = result.rowsTotal === null;
+  const baselineNote = baselineUnavailable
+    ? ' (Admin baseline unavailable: project_admin lacks SELECT on this table, so visible vs total rows were not compared.)'
+    : '';
 
   switch (decision) {
     case 'allowed':
@@ -472,12 +475,18 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
     case 'partial':
       return `${operation} as "${role}" on ${table} is partially allowed: ${result.rowsVisible ?? result.rowsAffected} of ${result.rowsTotal} rows pass RLS. ${policySummary}`;
     case 'denied':
-      if (isGrantDenial) {
-        return `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. This is a missing table privilege (GRANT), not an RLS policy.`;
+      if (looksLikeGrant) {
+        return `${operation} as "${role}" on ${table} is denied: ${denialReason}. This is a missing table privilege (GRANT), not an RLS policy.`;
       }
-      return result.denialReason
-        ? `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. ${policySummary}${baselineNote}`
-        : `${operation} as "${role}" on ${table} is denied by RLS (no rows pass). ${policySummary}${baselineNote}`;
+      if (denialReason) {
+        return `${operation} as "${role}" on ${table} is denied: ${denialReason}. ${policySummary}`;
+      }
+      if (baselineUnavailable) {
+        // The role saw 0 rows, but with no admin baseline we cannot prove the
+        // table is non-empty, so this is not necessarily an RLS denial.
+        return `${operation} as "${role}" on ${table} returned no rows for "${role}". The admin baseline was unavailable (project_admin lacks SELECT), so this may be an empty table rather than an RLS denial. ${policySummary}`;
+      }
+      return `${operation} as "${role}" on ${table} is denied by RLS (no rows pass). ${policySummary}`;
     default:
       return policySummary;
   }

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -13,6 +13,7 @@ import {
 import { NEXT_ACTIONS } from '@/utils/next-actions.js';
 import { normalizeDatabaseSchemaName, quoteIdentifier, quoteQualifiedName } from './helpers.js';
 import { validateIdentifier, validateTableName } from '@/utils/validations.js';
+import logger from '@/utils/logger.js';
 
 /**
  * RLS Policy Simulator
@@ -149,8 +150,9 @@ export class PolicySimulatorService {
         base.effectiveClaims,
         async (client) => {
           const countResult = await client.query(
-            // count(*) is bigint; keep it as bigint (pg returns it as a string)
-            // and parse in JS so a table with >2^31 rows can't overflow an int4.
+            // count(*) is bigint (pg returns it as a string); parse in JS to avoid
+            // an int4 overflow. A Postgres table cannot physically hold 2^53 rows,
+            // so Number() stays within JS safe-integer range.
             `SELECT count(*) AS n FROM ${qualifiedName} ${where.sql}`,
             where.params
           );
@@ -386,11 +388,15 @@ export function buildWhereClause(
 
 export function classifySelect(args: {
   rowsVisible: number;
-  rowsTotal: number;
+  rowsTotal: number | null;
   bypassRls: boolean;
 }): PolicySimulatorDecision {
   if (args.bypassRls) {
     return 'bypass';
+  }
+  if (args.rowsTotal === null) {
+    // Admin baseline unavailable: decide on the role's own visibility alone.
+    return args.rowsVisible > 0 ? 'allowed' : 'denied';
   }
   if (args.rowsTotal === 0) {
     return 'allowed'; // nothing to read; RLS can't be observed but didn't block
@@ -406,11 +412,15 @@ export function classifySelect(args: {
 
 export function classifyMutation(args: {
   rowsAffected: number;
-  rowsTotal: number;
+  rowsTotal: number | null;
   bypassRls: boolean;
 }): PolicySimulatorDecision {
   if (args.bypassRls) {
     return 'bypass';
+  }
+  if (args.rowsTotal === null) {
+    // Admin baseline unavailable: decide on what the role actually affected.
+    return args.rowsAffected > 0 ? 'allowed' : 'denied';
   }
   if (args.rowsTotal === 0) {
     return 'allowed'; // no matching rows to act on
@@ -447,15 +457,27 @@ export function buildExplanation(result: SimulatePolicyResponse): string {
       ? `No RLS policy applies to ${operation} for role "${role}", so it is blocked by default.`
       : `${policyCount} polic${policyCount === 1 ? 'y' : 'ies'} apply (${permissiveCount} permissive). Permissive policies are combined with OR, restrictive with AND.`;
 
+  // A 42501 denial can be a missing table GRANT or an RLS policy block. Both look
+  // identical in the decision, so call out the GRANT case (different fix).
+  const isGrantDenial = !!result.denialReason && /permission denied/i.test(result.denialReason);
+  // When the admin baseline could not be computed, the counts were not compared.
+  const baselineNote =
+    result.rowsTotal === null
+      ? ' (Admin baseline unavailable: project_admin lacks SELECT on this table, so visible vs total rows were not compared.)'
+      : '';
+
   switch (decision) {
     case 'allowed':
-      return `${operation} as "${role}" on ${table} is allowed. ${policySummary}`;
+      return `${operation} as "${role}" on ${table} is allowed. ${policySummary}${baselineNote}`;
     case 'partial':
       return `${operation} as "${role}" on ${table} is partially allowed: ${result.rowsVisible ?? result.rowsAffected} of ${result.rowsTotal} rows pass RLS. ${policySummary}`;
     case 'denied':
+      if (isGrantDenial) {
+        return `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. This is a missing table privilege (GRANT), not an RLS policy.`;
+      }
       return result.denialReason
-        ? `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. ${policySummary}`
-        : `${operation} as "${role}" on ${table} is denied by RLS (no rows pass). ${policySummary}`;
+        ? `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. ${policySummary}${baselineNote}`
+        : `${operation} as "${role}" on ${table} is denied by RLS (no rows pass). ${policySummary}${baselineNote}`;
     default:
       return policySummary;
   }
@@ -560,26 +582,57 @@ async function runSimulated<T>(
     return await fn(client);
   } finally {
     // Roll back unconditionally: the simulator must never persist rows.
-    await client.query('ROLLBACK').catch(() => {});
-    await client.query('RESET ROLE').catch(() => {});
-    client.release();
+    // (statement_timeout does not apply to ROLLBACK/RESET — they are not
+    // ordinary statements.) Surface cleanup failures instead of swallowing
+    // them, and evict any connection we could not cleanly reset so a session
+    // with leftover role/claims state never returns to the pool.
+    let cleanupError: Error | undefined;
+    try {
+      await client.query('ROLLBACK');
+      await client.query('RESET ROLE');
+    } catch (error) {
+      cleanupError = error instanceof Error ? error : new Error(String(error));
+      logger.warn('Policy simulator transaction cleanup failed:', cleanupError);
+    }
+    client.release(cleanupError);
   }
 }
 
-/** Count matching rows with RLS bypassed (the project_admin "total" baseline). */
+/**
+ * Count matching rows with RLS bypassed (the project_admin "total" baseline).
+ *
+ * Returns null when the baseline cannot be computed because project_admin lacks
+ * SELECT on the table (a table created outside the dashboard may not have been
+ * granted to project_admin). The simulation still returns a structured result;
+ * the decision then falls back to the simulated role's own visibility.
+ */
 async function countAsAdmin(
   pool: Pool,
   qualifiedName: string,
   where: { sql: string; params: unknown[] }
-): Promise<number> {
-  return runSimulated(pool, 'project_admin', { role: 'project_admin' }, async (client) => {
-    const result = await client.query(
-      // bigint count parsed in JS — avoids an int4 overflow on very large tables.
-      `SELECT count(*) AS n FROM ${qualifiedName} ${where.sql}`,
-      where.params
-    );
-    return Number(result.rows[0].n);
-  });
+): Promise<number | null> {
+  try {
+    return await runSimulated(pool, 'project_admin', { role: 'project_admin' }, async (client) => {
+      const result = await client.query(
+        // count(*) is bigint (pg returns it as a string); parse in JS to avoid an
+        // int4 overflow. A Postgres table cannot physically hold 2^53 rows, so
+        // Number() stays within JS safe-integer range.
+        `SELECT count(*) AS n FROM ${qualifiedName} ${where.sql}`,
+        where.params
+      );
+      return Number(result.rows[0].n);
+    });
+  } catch (error) {
+    if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
+      logger.warn(
+        `Policy simulator admin baseline unavailable for ${qualifiedName}: ${
+          (error as DatabaseError).message
+        }`
+      );
+      return null;
+    }
+    throw error;
+  }
 }
 
 async function assertTableExists(pool: Pool, schema: string, table: string): Promise<void> {
@@ -670,11 +723,13 @@ async function getApplicablePolicies(
  */
 function toSimulationError(error: unknown): AppError {
   if (hasPgErrorCode(error, STATEMENT_TIMEOUT_CODE)) {
+    // A statement timeout is a server-side resource limit, not bad client input.
+    // 503 (retryable) lets clients distinguish it from a 400 validation error.
     return new AppError(
-      'Simulation timed out. The policy or query was too expensive to evaluate.',
-      400,
-      ERROR_CODES.DATABASE_VALIDATION_ERROR,
-      'Narrow the simulation with a "match" filter, or simplify the policy predicate.'
+      'Policy simulation timed out before it could complete.',
+      503,
+      ERROR_CODES.DATABASE_INTERNAL_ERROR,
+      'The policy or query was too expensive to evaluate within the simulation budget. Narrow it with a "match" filter, or simplify the policy predicate, and retry.'
     );
   }
   if (error instanceof DatabaseError) {

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -149,10 +149,12 @@ export class PolicySimulatorService {
         base.effectiveClaims,
         async (client) => {
           const countResult = await client.query(
-            `SELECT count(*)::int AS n FROM ${qualifiedName} ${where.sql}`,
+            // count(*) is bigint; keep it as bigint (pg returns it as a string)
+            // and parse in JS so a table with >2^31 rows can't overflow an int4.
+            `SELECT count(*) AS n FROM ${qualifiedName} ${where.sql}`,
             where.params
           );
-          const visible = countResult.rows[0].n as number;
+          const visible = Number(countResult.rows[0].n);
           let sample: ColumnMap[] | null = null;
           if (sampleLimit > 0) {
             const sampleResult = await client.query(
@@ -572,10 +574,11 @@ async function countAsAdmin(
 ): Promise<number> {
   return runSimulated(pool, 'project_admin', { role: 'project_admin' }, async (client) => {
     const result = await client.query(
-      `SELECT count(*)::int AS n FROM ${qualifiedName} ${where.sql}`,
+      // bigint count parsed in JS — avoids an int4 overflow on very large tables.
+      `SELECT count(*) AS n FROM ${qualifiedName} ${where.sql}`,
       where.params
     );
-    return result.rows[0].n as number;
+    return Number(result.rows[0].n);
   });
 }
 

--- a/backend/src/services/database/policy-simulator.service.ts
+++ b/backend/src/services/database/policy-simulator.service.ts
@@ -1,0 +1,679 @@
+import { Pool, PoolClient, DatabaseError } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { AppError, getDatabaseErrorDetails, hasPgErrorCode } from '@/utils/errors.js';
+import {
+  ERROR_CODES,
+  type RoleSchema,
+  type PolicySimulatorOperation,
+  type PolicySimulatorDecision,
+  type SimulatePolicyRequest,
+  type SimulatePolicyResponse,
+  type SimulatorPolicy,
+} from '@insforge/shared-schemas';
+import { NEXT_ACTIONS } from '@/utils/next-actions.js';
+import { normalizeDatabaseSchemaName, quoteIdentifier, quoteQualifiedName } from './helpers.js';
+import { validateIdentifier, validateTableName } from '@/utils/validations.js';
+
+/**
+ * RLS Policy Simulator
+ * ====================
+ *
+ * Run a data operation AS a chosen role + JWT identity without persisting any
+ * rows, and report whether row level security allows or denies it.
+ *
+ * Design principle: Postgres is the oracle. We never re-implement RLS's
+ * permissive-OR / restrictive-AND combination logic. We run the real query
+ * inside a rolled-back transaction and report what actually happened, then list
+ * the policies Postgres *would* consider so the developer can see why.
+ *
+ *   request ─► validate (schema/table/role/op, identifiers)
+ *           ─► introspect: rlsEnabled (pg_class), applicablePolicies (pg_policies)
+ *           ─► run op in a transaction:
+ *                BEGIN
+ *                SET LOCAL statement_timeout = 5s
+ *                SET LOCAL ROLE <allowlisted: anon|authenticated|project_admin>
+ *                set_config('request.jwt.claims', <merged claims as jsonb>, true)
+ *                <SELECT count|sample | INSERT | UPDATE | DELETE>   (parameterized)
+ *                ROLLBACK            ◄── always, success or failure
+ *           ─► classify decision (Postgres outcome + admin baseline)
+ *           ─► explain + example query
+ *
+ * Decision semantics (Postgres is authoritative):
+ *   bypass   role is project_admin (BYPASSRLS) — policies are NOT evaluated
+ *   denied   op raised 42501 (no privilege / WITH CHECK), or RLS hides every row
+ *   partial  RLS hides some but not all of the rows the op would otherwise touch
+ *   allowed  the role can perform the op on all matching rows
+ *
+ * This endpoint is admin-only. It is strictly less powerful than the existing
+ * /database/advance/rawsql/unrestricted route (which already lets an admin run
+ * arbitrary SQL), because every statement here runs under a downgraded role and
+ * is always rolled back.
+ */
+
+const SIMULATION_STATEMENT_TIMEOUT_MS = 5000;
+const DEFAULT_SAMPLE_LIMIT = 5;
+const REQUEST_JWT_CLAIMS_SETTING = 'request.jwt.claims';
+const RLS_VIOLATION_CODE = '42501';
+const STATEMENT_TIMEOUT_CODE = '57014';
+
+// Postgres roles the simulator is allowed to assume. Kept as a literal allowlist
+// (never interpolated from input) so a future caller can't smuggle SQL into
+// `SET LOCAL ROLE`.
+const ROLE_SQL: Record<RoleSchema, string> = {
+  anon: 'SET LOCAL ROLE anon',
+  authenticated: 'SET LOCAL ROLE authenticated',
+  project_admin: 'SET LOCAL ROLE project_admin',
+};
+
+type ColumnMap = Record<string, unknown>;
+
+export class PolicySimulatorService {
+  private static instance: PolicySimulatorService;
+  private dbManager = DatabaseManager.getInstance();
+
+  private constructor() {}
+
+  public static getInstance(): PolicySimulatorService {
+    if (!PolicySimulatorService.instance) {
+      PolicySimulatorService.instance = new PolicySimulatorService();
+    }
+    return PolicySimulatorService.instance;
+  }
+
+  /**
+   * Simulate `input` and return the access decision. `pool` is injectable so
+   * integration tests can target an isolated test database.
+   */
+  async simulate(
+    input: SimulatePolicyRequest,
+    pool: Pool = this.dbManager.getPool()
+  ): Promise<SimulatePolicyResponse> {
+    try {
+      const schema = normalizeDatabaseSchemaName(input.schema);
+      validateTableName(input.table);
+      const table = input.table;
+      const { role, operation } = input;
+
+      await assertTableExists(pool, schema, table);
+
+      const rlsEnabled = await getTableRlsEnabled(pool, schema, table);
+      const applicablePolicies = await getApplicablePolicies(pool, schema, table, operation, role);
+
+      const effectiveClaims = mergeClaims(role, input.claims);
+      const bypassRls = role === 'project_admin';
+      const qualifiedName = quoteQualifiedName(schema, table);
+
+      const base = {
+        schema,
+        table,
+        operation,
+        role,
+        effectiveClaims,
+        rlsEnabled,
+        bypassRls,
+        applicablePolicies,
+      };
+
+      if (operation === 'SELECT') {
+        return await this.simulateSelect(pool, input, base, qualifiedName);
+      }
+      if (operation === 'INSERT') {
+        return await this.simulateInsert(pool, input, base, qualifiedName);
+      }
+      // UPDATE | DELETE
+      return await this.simulateMutation(pool, input, base, qualifiedName);
+    } catch (error) {
+      // AppErrors (validation, table-not-found, RLS-denial-as-error) pass
+      // through unchanged; raw Postgres failures (bad column/type, timeout)
+      // become clean 4xx instead of a 500 from any query in the flow.
+      throw toSimulationError(error);
+    }
+  }
+
+  private async simulateSelect(
+    pool: Pool,
+    input: SimulatePolicyRequest,
+    base: SimulationBase,
+    qualifiedName: string
+  ): Promise<SimulatePolicyResponse> {
+    const where = buildWhereClause(input.match);
+    const sampleLimit = input.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
+
+    let rowsVisible: number;
+    let sampleRows: ColumnMap[] | null;
+
+    try {
+      ({ rowsVisible, sampleRows } = await runSimulated(
+        pool,
+        base.role,
+        base.effectiveClaims,
+        async (client) => {
+          const countResult = await client.query(
+            `SELECT count(*)::int AS n FROM ${qualifiedName} ${where.sql}`,
+            where.params
+          );
+          const visible = countResult.rows[0].n as number;
+          let sample: ColumnMap[] | null = null;
+          if (sampleLimit > 0) {
+            const sampleResult = await client.query(
+              `SELECT * FROM ${qualifiedName} ${where.sql} LIMIT $${where.params.length + 1}`,
+              [...where.params, sampleLimit]
+            );
+            sample = sampleResult.rows as ColumnMap[];
+          }
+          return { rowsVisible: visible, sampleRows: sample };
+        }
+      ));
+    } catch (error) {
+      if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
+        // No SELECT privilege at all — the role can't read the table.
+        const reason = (error as DatabaseError).message;
+        return finalize({
+          ...base,
+          decision: 'denied',
+          rowsVisible: 0,
+          rowsTotal: null,
+          rowsAffected: null,
+          sampleRows: null,
+          denialReason: reason,
+          qualifiedName,
+          whereSql: where.sql,
+        });
+      }
+      throw toSimulationError(error);
+    }
+
+    const rowsTotal = await countAsAdmin(pool, qualifiedName, where);
+    const decision = classifySelect({ rowsVisible, rowsTotal, bypassRls: base.bypassRls });
+
+    return finalize({
+      ...base,
+      decision,
+      rowsVisible,
+      rowsTotal,
+      rowsAffected: null,
+      sampleRows,
+      denialReason: null,
+      qualifiedName,
+      whereSql: where.sql,
+    });
+  }
+
+  private async simulateInsert(
+    pool: Pool,
+    input: SimulatePolicyRequest,
+    base: SimulationBase,
+    qualifiedName: string
+  ): Promise<SimulatePolicyResponse> {
+    const columns = input.row ? Object.keys(input.row) : [];
+    columns.forEach((c) => validateIdentifier(c, 'column'));
+
+    const sql =
+      columns.length === 0
+        ? `INSERT INTO ${qualifiedName} DEFAULT VALUES`
+        : `INSERT INTO ${qualifiedName} (${columns.map(quoteIdentifier).join(', ')}) ` +
+          `VALUES (${columns.map((_, i) => `$${i + 1}`).join(', ')})`;
+    const params = columns.map((c) => (input.row as ColumnMap)[c]);
+
+    try {
+      const rowsAffected = await runSimulated(
+        pool,
+        base.role,
+        base.effectiveClaims,
+        async (client) => {
+          const result = await client.query(sql, params);
+          return result.rowCount ?? 0;
+        }
+      );
+      return finalize({
+        ...base,
+        decision: base.bypassRls ? 'bypass' : 'allowed',
+        rowsVisible: null,
+        rowsTotal: null,
+        rowsAffected,
+        sampleRows: null,
+        denialReason: null,
+        qualifiedName,
+        whereSql: '',
+      });
+    } catch (error) {
+      if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
+        return finalize({
+          ...base,
+          decision: 'denied',
+          rowsVisible: null,
+          rowsTotal: null,
+          rowsAffected: 0,
+          sampleRows: null,
+          denialReason: (error as DatabaseError).message,
+          qualifiedName,
+          whereSql: '',
+        });
+      }
+      throw toSimulationError(error);
+    }
+  }
+
+  private async simulateMutation(
+    pool: Pool,
+    input: SimulatePolicyRequest,
+    base: SimulationBase,
+    qualifiedName: string
+  ): Promise<SimulatePolicyResponse> {
+    const where = buildWhereClause(input.match);
+    const rowsTotal = await countAsAdmin(pool, qualifiedName, where);
+
+    let sql: string;
+    let params: unknown[];
+
+    if (base.operation === 'UPDATE') {
+      if (!input.row || Object.keys(input.row).length === 0) {
+        throw new AppError(
+          'UPDATE simulation requires a "row" payload (the SET values).',
+          400,
+          ERROR_CODES.INVALID_INPUT,
+          'Provide a row object mapping columns to the values you want to write.'
+        );
+      }
+      const setColumns = Object.keys(input.row);
+      setColumns.forEach((c) => validateIdentifier(c, 'column'));
+      const setSql = setColumns.map((c, i) => `${quoteIdentifier(c)} = $${i + 1}`).join(', ');
+      const setParams = setColumns.map((c) => (input.row as ColumnMap)[c]);
+      const reWhere = buildWhereClause(input.match, setParams.length + 1);
+      sql = `UPDATE ${qualifiedName} SET ${setSql} ${reWhere.sql}`;
+      params = [...setParams, ...reWhere.params];
+    } else {
+      sql = `DELETE FROM ${qualifiedName} ${where.sql}`;
+      params = where.params;
+    }
+
+    try {
+      const rowsAffected = await runSimulated(
+        pool,
+        base.role,
+        base.effectiveClaims,
+        async (client) => {
+          const result = await client.query(sql, params);
+          return result.rowCount ?? 0;
+        }
+      );
+      const decision = classifyMutation({
+        rowsAffected,
+        rowsTotal,
+        bypassRls: base.bypassRls,
+      });
+      return finalize({
+        ...base,
+        decision,
+        rowsVisible: null,
+        rowsTotal,
+        rowsAffected,
+        sampleRows: null,
+        denialReason: null,
+        qualifiedName,
+        whereSql: where.sql,
+      });
+    } catch (error) {
+      if (hasPgErrorCode(error, RLS_VIOLATION_CODE)) {
+        return finalize({
+          ...base,
+          decision: 'denied',
+          rowsVisible: null,
+          rowsTotal,
+          rowsAffected: 0,
+          sampleRows: null,
+          denialReason: (error as DatabaseError).message,
+          qualifiedName,
+          whereSql: where.sql,
+        });
+      }
+      throw toSimulationError(error);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no DB) — unit tested directly.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the request.jwt.claims object. The simulated role is always authoritative
+ * for `role`, so a custom `role` claim can't desync auth.role() from SET ROLE.
+ */
+export function mergeClaims(
+  role: RoleSchema,
+  claims: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  return { ...(claims ?? {}), role };
+}
+
+/**
+ * Build a parameterized WHERE clause from a column->value map. null values
+ * become "IS NULL". Identifiers are validated; values are always parameters.
+ */
+export function buildWhereClause(
+  match: Record<string, unknown> | undefined,
+  startIndex = 1
+): { sql: string; params: unknown[] } {
+  if (!match) {
+    return { sql: '', params: [] };
+  }
+  const keys = Object.keys(match);
+  if (keys.length === 0) {
+    return { sql: '', params: [] };
+  }
+
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+  let index = startIndex;
+
+  for (const key of keys) {
+    validateIdentifier(key, 'column');
+    const value = match[key];
+    if (value === null) {
+      clauses.push(`${quoteIdentifier(key)} IS NULL`);
+    } else {
+      clauses.push(`${quoteIdentifier(key)} = $${index}`);
+      params.push(value);
+      index += 1;
+    }
+  }
+
+  return { sql: `WHERE ${clauses.join(' AND ')}`, params };
+}
+
+export function classifySelect(args: {
+  rowsVisible: number;
+  rowsTotal: number;
+  bypassRls: boolean;
+}): PolicySimulatorDecision {
+  if (args.bypassRls) {
+    return 'bypass';
+  }
+  if (args.rowsTotal === 0) {
+    return 'allowed'; // nothing to read; RLS can't be observed but didn't block
+  }
+  if (args.rowsVisible === 0) {
+    return 'denied';
+  }
+  if (args.rowsVisible < args.rowsTotal) {
+    return 'partial';
+  }
+  return 'allowed';
+}
+
+export function classifyMutation(args: {
+  rowsAffected: number;
+  rowsTotal: number;
+  bypassRls: boolean;
+}): PolicySimulatorDecision {
+  if (args.bypassRls) {
+    return 'bypass';
+  }
+  if (args.rowsTotal === 0) {
+    return 'allowed'; // no matching rows to act on
+  }
+  if (args.rowsAffected === 0) {
+    return 'denied';
+  }
+  if (args.rowsAffected < args.rowsTotal) {
+    return 'partial';
+  }
+  return 'allowed';
+}
+
+export function buildExplanation(result: SimulatePolicyResponse): string {
+  const { role, operation, table, decision } = result;
+  if (result.bypassRls) {
+    if (decision === 'denied') {
+      // BYPASSRLS skips policies, so a denial here is a missing table GRANT,
+      // not a policy block.
+      return `${operation} as "${role}" was denied despite BYPASSRLS${
+        result.denialReason ? `: ${result.denialReason}` : ''
+      }. Row level security was bypassed, so this is a missing table privilege (GRANT), not a policy.`;
+    }
+    return `Role "${role}" has BYPASSRLS, so row level security policies are not evaluated for ${operation} on ${table}. The operation runs with full table access, subject to table GRANTs.`;
+  }
+  if (!result.rlsEnabled) {
+    return `Row level security is not enabled on ${table}, so policies are not enforced. Access for ${operation} as "${role}" is governed only by table GRANTs. Decision: ${decision}.`;
+  }
+
+  const policyCount = result.applicablePolicies.length;
+  const permissiveCount = result.applicablePolicies.filter((p) => p.permissive).length;
+  const policySummary =
+    policyCount === 0
+      ? `No RLS policy applies to ${operation} for role "${role}", so it is blocked by default.`
+      : `${policyCount} polic${policyCount === 1 ? 'y' : 'ies'} apply (${permissiveCount} permissive). Permissive policies are combined with OR, restrictive with AND.`;
+
+  switch (decision) {
+    case 'allowed':
+      return `${operation} as "${role}" on ${table} is allowed. ${policySummary}`;
+    case 'partial':
+      return `${operation} as "${role}" on ${table} is partially allowed: ${result.rowsVisible ?? result.rowsAffected} of ${result.rowsTotal} rows pass RLS. ${policySummary}`;
+    case 'denied':
+      return result.denialReason
+        ? `${operation} as "${role}" on ${table} is denied: ${result.denialReason}. ${policySummary}`
+        : `${operation} as "${role}" on ${table} is denied by RLS (no rows pass). ${policySummary}`;
+    default:
+      return policySummary;
+  }
+}
+
+export function buildExampleQuery(result: SimulatePolicyResponse, qualifiedName: string): string {
+  const claims = JSON.stringify(result.effectiveClaims).replace(/'/g, "''");
+  const lines = [
+    'BEGIN;',
+    `SET LOCAL ROLE ${result.role};`,
+    `SELECT set_config('request.jwt.claims', '${claims}', true);`,
+  ];
+  switch (result.operation) {
+    case 'SELECT':
+      lines.push(`SELECT * FROM ${qualifiedName};`);
+      break;
+    case 'INSERT':
+      lines.push(`INSERT INTO ${qualifiedName} (...) VALUES (...);`);
+      break;
+    case 'UPDATE':
+      lines.push(`UPDATE ${qualifiedName} SET ... WHERE ...;`);
+      break;
+    case 'DELETE':
+      lines.push(`DELETE FROM ${qualifiedName} WHERE ...;`);
+      break;
+  }
+  lines.push('ROLLBACK;');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+interface SimulationBase {
+  schema: string;
+  table: string;
+  operation: PolicySimulatorOperation;
+  role: RoleSchema;
+  effectiveClaims: Record<string, unknown>;
+  rlsEnabled: boolean;
+  bypassRls: boolean;
+  applicablePolicies: SimulatorPolicy[];
+}
+
+interface FinalizeArgs extends SimulationBase {
+  decision: PolicySimulatorDecision;
+  rowsVisible: number | null;
+  rowsTotal: number | null;
+  rowsAffected: number | null;
+  sampleRows: ColumnMap[] | null;
+  denialReason: string | null;
+  qualifiedName: string;
+  whereSql: string;
+}
+
+function finalize(args: FinalizeArgs): SimulatePolicyResponse {
+  const response: SimulatePolicyResponse = {
+    schema: args.schema,
+    table: args.table,
+    operation: args.operation,
+    role: args.role,
+    effectiveClaims: args.effectiveClaims,
+    rlsEnabled: args.rlsEnabled,
+    bypassRls: args.bypassRls,
+    decision: args.decision,
+    rowsVisible: args.rowsVisible,
+    rowsTotal: args.rowsTotal,
+    rowsAffected: args.rowsAffected,
+    sampleRows: args.sampleRows,
+    denialReason: args.denialReason,
+    applicablePolicies: args.applicablePolicies,
+    explanation: '',
+    exampleQuery: '',
+  };
+  response.explanation = buildExplanation(response);
+  response.exampleQuery = buildExampleQuery(response, args.qualifiedName);
+  return response;
+}
+
+/**
+ * Run `fn` inside a transaction as `role` with the given JWT claims, then ALWAYS
+ * ROLLBACK. Mirrors the role/claims pattern of withUserContext but never commits,
+ * so no rows persist. (Sequence values a statement consumes are not rolled back,
+ * as in any Postgres transaction.)
+ */
+async function runSimulated<T>(
+  pool: Pool,
+  role: RoleSchema,
+  claims: Record<string, unknown>,
+  fn: (client: PoolClient) => Promise<T>
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`SET LOCAL statement_timeout = ${SIMULATION_STATEMENT_TIMEOUT_MS}`);
+    await client.query(ROLE_SQL[role]);
+    await client.query('SELECT set_config($1, $2, true)', [
+      REQUEST_JWT_CLAIMS_SETTING,
+      JSON.stringify(claims),
+    ]);
+    return await fn(client);
+  } finally {
+    // Roll back unconditionally: the simulator must never persist rows.
+    await client.query('ROLLBACK').catch(() => {});
+    await client.query('RESET ROLE').catch(() => {});
+    client.release();
+  }
+}
+
+/** Count matching rows with RLS bypassed (the project_admin "total" baseline). */
+async function countAsAdmin(
+  pool: Pool,
+  qualifiedName: string,
+  where: { sql: string; params: unknown[] }
+): Promise<number> {
+  return runSimulated(pool, 'project_admin', { role: 'project_admin' }, async (client) => {
+    const result = await client.query(
+      `SELECT count(*)::int AS n FROM ${qualifiedName} ${where.sql}`,
+      where.params
+    );
+    return result.rows[0].n as number;
+  });
+}
+
+async function assertTableExists(pool: Pool, schema: string, table: string): Promise<void> {
+  const result = await pool.query(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = $1 AND table_name = $2
+     ) AS present`,
+    [schema, table]
+  );
+  if (!result.rows[0].present) {
+    throw new AppError(
+      `Table "${schema}.${table}" does not exist.`,
+      404,
+      ERROR_CODES.DATABASE_NOT_FOUND,
+      NEXT_ACTIONS.CHECK_TABLE_EXISTS
+    );
+  }
+}
+
+async function getTableRlsEnabled(pool: Pool, schema: string, table: string): Promise<boolean> {
+  const result = await pool.query(
+    `SELECT c.relrowsecurity AS enabled
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = $1 AND c.relname = $2`,
+    [schema, table]
+  );
+  return result.rows.length > 0 ? Boolean(result.rows[0].enabled) : false;
+}
+
+/**
+ * Policies Postgres would consider for this (table, operation, role).
+ *
+ * A policy applies when its command is ALL or matches the operation, and the
+ * simulated role is in the policy's roles or the policy targets PUBLIC.
+ */
+async function getApplicablePolicies(
+  pool: Pool,
+  schema: string,
+  table: string,
+  operation: PolicySimulatorOperation,
+  role: RoleSchema
+): Promise<SimulatorPolicy[]> {
+  const result = await pool.query(
+    `SELECT
+        tablename AS "tableName",
+        policyname AS "policyName",
+        cmd,
+        roles,
+        qual,
+        with_check AS "withCheck",
+        (permissive = 'PERMISSIVE') AS permissive
+       FROM pg_policies
+      WHERE schemaname = $1
+        AND tablename = $2
+        AND (cmd = 'ALL' OR cmd = $3)
+        AND EXISTS (
+          SELECT 1 FROM unnest(roles) AS pol_role
+          WHERE CASE
+            WHEN pol_role = 'public' THEN true
+            ELSE pg_has_role($4, pol_role, 'MEMBER')
+          END
+        )
+      ORDER BY permissive DESC, policyname`,
+    [schema, table, operation, role]
+  );
+  return result.rows as SimulatorPolicy[];
+}
+
+/**
+ * Translate a non-RLS Postgres failure into a clean 4xx. Bad column/type input
+ * is the caller's mistake (400); a statement timeout means the policy/query was
+ * too expensive to evaluate within the simulation budget.
+ */
+function toSimulationError(error: unknown): AppError {
+  if (hasPgErrorCode(error, STATEMENT_TIMEOUT_CODE)) {
+    return new AppError(
+      'Simulation timed out. The policy or query was too expensive to evaluate.',
+      400,
+      ERROR_CODES.DATABASE_VALIDATION_ERROR,
+      'Narrow the simulation with a "match" filter, or simplify the policy predicate.'
+    );
+  }
+  if (error instanceof DatabaseError) {
+    const details = getDatabaseErrorDetails(error);
+    if (details) {
+      return new AppError(details.message, details.statusCode, details.code, details.nextActions);
+    }
+    return new AppError(error.message, 400, ERROR_CODES.DATABASE_VALIDATION_ERROR);
+  }
+  if (error instanceof AppError) {
+    return error;
+  }
+  return new AppError(
+    error instanceof Error ? error.message : 'Policy simulation failed.',
+    500,
+    ERROR_CODES.INTERNAL_ERROR
+  );
+}

--- a/backend/tests/integration/policy-simulator.test.ts
+++ b/backend/tests/integration/policy-simulator.test.ts
@@ -62,6 +62,19 @@ beforeAll(async () => {
     -- A view to prove the simulator rejects non-base-table relations.
     CREATE VIEW todos_view AS SELECT * FROM todos;
     GRANT SELECT ON todos_view TO authenticated;
+
+    -- A table project_admin cannot read, to prove the admin baseline degrades
+    -- gracefully (rowsTotal=null) instead of failing the whole simulation.
+    CREATE TABLE no_admin_grant (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL,
+      title TEXT NOT NULL
+    );
+    ALTER TABLE no_admin_grant ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY owner_select ON no_admin_grant FOR SELECT TO authenticated USING (auth.uid() = user_id);
+    GRANT SELECT ON no_admin_grant TO authenticated;
+    REVOKE ALL ON no_admin_grant FROM project_admin;
+    INSERT INTO no_admin_grant (user_id, title) VALUES ('${USER_A}', 'private');
   `);
 
   await db.publish();
@@ -301,5 +314,22 @@ describe('validation', () => {
     await expect(
       simulator.simulate({ table: 'todos_view', operation: 'SELECT', role: 'authenticated' }, pool)
     ).rejects.toThrow(/not a base table/i);
+  });
+
+  it('degrades gracefully when project_admin cannot read the table (null baseline)', async () => {
+    // The owner can see their own row, but the admin baseline cannot be computed.
+    const res = await simulator.simulate(
+      {
+        table: 'no_admin_grant',
+        operation: 'SELECT',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+      },
+      pool
+    );
+    expect(res.rowsTotal).toBeNull();
+    expect(res.rowsVisible).toBe(1);
+    expect(res.decision).toBe('allowed');
+    expect(res.explanation).toMatch(/baseline unavailable/i);
   });
 });

--- a/backend/tests/integration/policy-simulator.test.ts
+++ b/backend/tests/integration/policy-simulator.test.ts
@@ -1,0 +1,295 @@
+import { Pool } from 'pg';
+import type { PgTestClient } from 'insforge-test';
+import { getConnections } from './utils';
+import { PolicySimulatorService } from '@/services/database/policy-simulator.service.js';
+
+/**
+ * Integration coverage for the RLS policy simulator.
+ *
+ * The simulator runs its operations on a SEPARATE pool connection (so its
+ * BEGIN/ROLLBACK never touches the test harness transaction). We seed the
+ * fixture through `db`, then `db.publish()` to commit so that separate pool
+ * connection can see the table, policies, and rows.
+ */
+
+const USER_A = '550e8400-e29b-41d4-a716-446655440001';
+const USER_B = '550e8400-e29b-41d4-a716-446655440002';
+
+const simulator = PolicySimulatorService.getInstance();
+
+let db: PgTestClient;
+let pool: Pool;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  const conn = await getConnections();
+  db = conn.db;
+  teardown = conn.teardown;
+  pool = conn.manager.getPool(db.config);
+
+  await db.query(`
+    CREATE TABLE todos (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL,
+      title TEXT NOT NULL,
+      done BOOLEAN NOT NULL DEFAULT false
+    );
+    ALTER TABLE todos ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY owner_select ON todos FOR SELECT TO authenticated USING (auth.uid() = user_id);
+    CREATE POLICY owner_insert ON todos FOR INSERT TO authenticated WITH CHECK (auth.uid() = user_id);
+    CREATE POLICY owner_update ON todos FOR UPDATE TO authenticated USING (auth.uid() = user_id);
+    CREATE POLICY owner_delete ON todos FOR DELETE TO authenticated USING (auth.uid() = user_id);
+    GRANT ALL ON todos TO authenticated, project_admin;
+    -- anon can reach the table but has no policy, so RLS denies every row.
+    GRANT SELECT ON todos TO anon;
+    INSERT INTO todos (user_id, title) VALUES
+      ('${USER_A}', 'a-one'),
+      ('${USER_A}', 'a-two'),
+      ('${USER_B}', 'b-one');
+
+    -- Custom-claim table: visibility scoped by an org_id JWT claim.
+    CREATE TABLE docs (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      org_id TEXT NOT NULL,
+      title TEXT NOT NULL
+    );
+    ALTER TABLE docs ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY org_select ON docs FOR SELECT TO authenticated
+      USING ((current_setting('request.jwt.claims', true)::jsonb ->> 'org_id') = org_id);
+    GRANT SELECT ON docs TO authenticated, project_admin;
+    INSERT INTO docs (org_id, title) VALUES ('acme', 'acme-doc'), ('globex', 'globex-doc');
+  `);
+
+  await db.publish();
+});
+
+afterAll(async () => {
+  await teardown();
+});
+
+describe('SELECT simulation', () => {
+  it('reports the owner sees only their rows (partial)', async () => {
+    const res = await simulator.simulate(
+      { table: 'todos', operation: 'SELECT', role: 'authenticated', claims: { sub: USER_A } },
+      pool
+    );
+    expect(res.decision).toBe('partial');
+    expect(res.rowsVisible).toBe(2);
+    expect(res.rowsTotal).toBe(3);
+    expect(res.rlsEnabled).toBe(true);
+    expect(res.bypassRls).toBe(false);
+    expect(res.sampleRows).toHaveLength(2);
+  });
+
+  it('denies anon (table privilege but no policy)', async () => {
+    const res = await simulator.simulate(
+      { table: 'todos', operation: 'SELECT', role: 'anon' },
+      pool
+    );
+    expect(res.decision).toBe('denied');
+    expect(res.rowsVisible).toBe(0);
+    expect(res.rowsTotal).toBe(3);
+    expect(res.applicablePolicies).toHaveLength(0); // owner_* policies target authenticated
+  });
+
+  it('reports project_admin as bypass, not allowed-by-policy', async () => {
+    const res = await simulator.simulate(
+      { table: 'todos', operation: 'SELECT', role: 'project_admin' },
+      pool
+    );
+    expect(res.decision).toBe('bypass');
+    expect(res.bypassRls).toBe(true);
+    expect(res.rowsVisible).toBe(3);
+    expect(res.explanation).toContain('BYPASSRLS');
+  });
+
+  it('lists the applicable policy for an authenticated SELECT', async () => {
+    const res = await simulator.simulate(
+      { table: 'todos', operation: 'SELECT', role: 'authenticated', claims: { sub: USER_A } },
+      pool
+    );
+    const names = res.applicablePolicies.map((p) => p.policyName);
+    expect(names).toContain('owner_select');
+    const policy = res.applicablePolicies.find((p) => p.policyName === 'owner_select');
+    expect(policy?.permissive).toBe(true);
+    expect(policy?.cmd).toBe('SELECT');
+  });
+
+  it('honors custom JWT claims (org_id scoping)', async () => {
+    const acme = await simulator.simulate(
+      {
+        table: 'docs',
+        operation: 'SELECT',
+        role: 'authenticated',
+        claims: { sub: USER_A, org_id: 'acme' },
+      },
+      pool
+    );
+    expect(acme.rowsVisible).toBe(1);
+    expect(acme.effectiveClaims.org_id).toBe('acme');
+
+    const globex = await simulator.simulate(
+      {
+        table: 'docs',
+        operation: 'SELECT',
+        role: 'authenticated',
+        claims: { sub: USER_A, org_id: 'globex' },
+      },
+      pool
+    );
+    expect(globex.rowsVisible).toBe(1);
+  });
+});
+
+describe('INSERT simulation', () => {
+  it('allows an owner to insert their own row', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'INSERT',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        row: { user_id: USER_A, title: 'new' },
+      },
+      pool
+    );
+    expect(res.decision).toBe('allowed');
+    expect(res.rowsAffected).toBe(1);
+  });
+
+  it('denies inserting a row owned by someone else (WITH CHECK)', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'INSERT',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        row: { user_id: USER_B, title: 'spoof' },
+      },
+      pool
+    );
+    expect(res.decision).toBe('denied');
+    expect(res.denialReason).toMatch(/row-level security/i);
+  });
+
+  it('has no side effects: the inserted row is rolled back', async () => {
+    const before = await pool.query('SELECT count(*)::int AS n FROM todos');
+    await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'INSERT',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        row: { user_id: USER_A, title: 'ephemeral' },
+      },
+      pool
+    );
+    const after = await pool.query('SELECT count(*)::int AS n FROM todos');
+    expect(after.rows[0].n).toBe(before.rows[0].n);
+  });
+});
+
+describe('UPDATE / DELETE simulation', () => {
+  it('allows an owner to update their own rows', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'UPDATE',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        row: { done: true },
+        match: { user_id: USER_A },
+      },
+      pool
+    );
+    expect(res.decision).toBe('allowed');
+    expect(res.rowsAffected).toBe(2);
+    expect(res.rowsTotal).toBe(2);
+  });
+
+  it('denies updating another users rows (USING hides them)', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'UPDATE',
+        role: 'authenticated',
+        claims: { sub: USER_B },
+        row: { title: 'hacked' },
+        match: { user_id: USER_A },
+      },
+      pool
+    );
+    expect(res.decision).toBe('denied');
+    expect(res.rowsAffected).toBe(0);
+    expect(res.rowsTotal).toBe(2);
+  });
+
+  it('denies an UPDATE that would reassign ownership (WITH CHECK)', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'UPDATE',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        row: { user_id: USER_B },
+        match: { user_id: USER_A },
+      },
+      pool
+    );
+    expect(res.decision).toBe('denied');
+    expect(res.denialReason).toMatch(/row-level security/i);
+  });
+
+  it('requires a row payload for UPDATE', async () => {
+    await expect(
+      simulator.simulate(
+        { table: 'todos', operation: 'UPDATE', role: 'authenticated', claims: { sub: USER_A } },
+        pool
+      )
+    ).rejects.toThrow(/row/i);
+  });
+
+  it('denies deleting another users rows', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'DELETE',
+        role: 'authenticated',
+        claims: { sub: USER_B },
+        match: { user_id: USER_A },
+      },
+      pool
+    );
+    expect(res.decision).toBe('denied');
+    expect(res.rowsAffected).toBe(0);
+  });
+
+  it('allows an owner to delete their own rows (rolled back)', async () => {
+    const res = await simulator.simulate(
+      {
+        table: 'todos',
+        operation: 'DELETE',
+        role: 'authenticated',
+        claims: { sub: USER_A },
+        match: { user_id: USER_A },
+      },
+      pool
+    );
+    expect(res.decision).toBe('allowed');
+    expect(res.rowsAffected).toBe(2);
+
+    const after = await pool.query('SELECT count(*)::int AS n FROM todos');
+    expect(after.rows[0].n).toBe(3); // delete was rolled back
+  });
+});
+
+describe('validation', () => {
+  it('rejects an unknown table', async () => {
+    await expect(
+      simulator.simulate(
+        { table: 'does_not_exist', operation: 'SELECT', role: 'authenticated' },
+        pool
+      )
+    ).rejects.toThrow(/does not exist/i);
+  });
+});

--- a/backend/tests/integration/policy-simulator.test.ts
+++ b/backend/tests/integration/policy-simulator.test.ts
@@ -58,6 +58,10 @@ beforeAll(async () => {
       USING ((current_setting('request.jwt.claims', true)::jsonb ->> 'org_id') = org_id);
     GRANT SELECT ON docs TO authenticated, project_admin;
     INSERT INTO docs (org_id, title) VALUES ('acme', 'acme-doc'), ('globex', 'globex-doc');
+
+    -- A view to prove the simulator rejects non-base-table relations.
+    CREATE VIEW todos_view AS SELECT * FROM todos;
+    GRANT SELECT ON todos_view TO authenticated;
   `);
 
   await db.publish();
@@ -291,5 +295,11 @@ describe('validation', () => {
         pool
       )
     ).rejects.toThrow(/does not exist/i);
+  });
+
+  it('rejects a view (not a base table)', async () => {
+    await expect(
+      simulator.simulate({ table: 'todos_view', operation: 'SELECT', role: 'authenticated' }, pool)
+    ).rejects.toThrow(/not a base table/i);
   });
 });

--- a/backend/tests/integration/policy-simulator.test.ts
+++ b/backend/tests/integration/policy-simulator.test.ts
@@ -75,6 +75,29 @@ beforeAll(async () => {
     GRANT SELECT ON no_admin_grant TO authenticated;
     REVOKE ALL ON no_admin_grant FROM project_admin;
     INSERT INTO no_admin_grant (user_id, title) VALUES ('${USER_A}', 'private');
+
+    -- An empty RLS table to prove the empty-result default-deny: with no rows to
+    -- observe, the decision must follow Postgres's default-deny — denied when no
+    -- permissive policy applies, unobserved-but-allowed when one does.
+    CREATE TABLE empty_todos (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id UUID NOT NULL,
+      title TEXT NOT NULL
+    );
+    ALTER TABLE empty_todos ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY owner_select ON empty_todos FOR SELECT TO authenticated USING (auth.uid() = user_id);
+    GRANT SELECT ON empty_todos TO anon, authenticated, project_admin;
+    -- intentionally no rows inserted
+
+    -- An empty table with RLS DISABLED: access is GRANT-governed, so an empty read
+    -- is allowed (no policy can deny). Proves the empty-result default-deny does
+    -- NOT fire when RLS is off.
+    CREATE TABLE empty_no_rls (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      title TEXT NOT NULL
+    );
+    GRANT SELECT ON empty_no_rls TO anon, authenticated, project_admin;
+    -- RLS intentionally NOT enabled; no rows inserted
   `);
 
   await db.publish();
@@ -331,5 +354,44 @@ describe('validation', () => {
     expect(res.rowsVisible).toBe(1);
     expect(res.decision).toBe('allowed');
     expect(res.explanation).toMatch(/baseline unavailable/i);
+  });
+});
+
+describe('empty-table default-deny', () => {
+  it('denies a role with no applicable permissive policy on an empty table', async () => {
+    // anon can reach empty_todos (table GRANT) but owner_select targets
+    // authenticated, so no permissive policy applies. With zero rows to observe,
+    // the simulator must still report the default-deny, not a misleading 'allowed'.
+    const res = await simulator.simulate(
+      { table: 'empty_todos', operation: 'SELECT', role: 'anon' },
+      pool
+    );
+    expect(res.rowsTotal).toBe(0);
+    expect(res.rowsVisible).toBe(0);
+    expect(res.applicablePolicies).toHaveLength(0);
+    expect(res.decision).toBe('denied');
+    expect(res.explanation).toMatch(/no applicable permissive/i);
+  });
+
+  it('reports allowed-but-unobserved when a permissive policy applies on an empty table', async () => {
+    const res = await simulator.simulate(
+      { table: 'empty_todos', operation: 'SELECT', role: 'authenticated', claims: { sub: USER_A } },
+      pool
+    );
+    expect(res.rowsTotal).toBe(0);
+    expect(res.decision).toBe('allowed');
+    expect(res.applicablePolicies.map((p) => p.policyName)).toContain('owner_select');
+    expect(res.explanation).toMatch(/could not be observed/i);
+  });
+
+  it('reports allowed on an empty table with RLS disabled (GRANT-governed, no policy can deny)', async () => {
+    const res = await simulator.simulate(
+      { table: 'empty_no_rls', operation: 'SELECT', role: 'anon' },
+      pool
+    );
+    expect(res.rlsEnabled).toBe(false);
+    expect(res.rowsTotal).toBe(0);
+    expect(res.decision).toBe('allowed');
+    expect(res.explanation).toMatch(/not enabled/i);
   });
 });

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -317,26 +317,135 @@ describe('buildExplanation', () => {
     );
     expect(text).not.toContain('missing table privilege (GRANT)');
   });
+
+  it('does not contradict itself on an empty table (allowed + no rows + no policy)', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'allowed',
+        rowsVisible: 0,
+        rowsTotal: 0,
+        applicablePolicies: [],
+      })
+    );
+    expect(text).toMatch(/matched no rows/i);
+    expect(text).not.toContain('is allowed');
+    expect(text).toContain('denied by default');
+  });
+
+  it('explains an empty table with a policy without claiming a proven allow', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'allowed',
+        rowsVisible: 0,
+        rowsTotal: 0,
+        applicablePolicies: [ownerSelect],
+      })
+    );
+    expect(text).toMatch(/matched no rows/i);
+    expect(text).toContain('OR'); // the permissive/restrictive combination rule still surfaces
+  });
 });
 
 describe('buildExampleQuery', () => {
-  it('produces a runnable, rolled-back snippet with role and claims', () => {
+  it('produces a runnable, rolled-back session scaffold with role and claims', () => {
     const snippet = buildExampleQuery(
       baseResult({ role: 'authenticated', effectiveClaims: { role: 'authenticated', sub: 'u1' } }),
       '"public"."todos"'
     );
+    expect(snippet.startsWith('BEGIN;')).toBe(true);
     expect(snippet).toContain('SET LOCAL ROLE authenticated;');
     expect(snippet).toContain("set_config('request.jwt.claims'");
     expect(snippet).toContain('"public"."todos"');
-    expect(snippet.startsWith('BEGIN;')).toBe(true);
     expect(snippet.trimEnd().endsWith('ROLLBACK;')).toBe(true);
   });
 
-  it('escapes single quotes in the claims JSON', () => {
+  it('dollar-quotes claims so single quotes are not doubled (no escaping needed)', () => {
     const snippet = buildExampleQuery(
       baseResult({ effectiveClaims: { role: 'authenticated', note: "o'brien" } }),
       '"public"."todos"'
     );
-    expect(snippet).toContain("o''brien");
+    expect(snippet).toContain("o'brien"); // verbatim, inside a dollar-quoted literal
+    expect(snippet).not.toContain("o''brien");
+    expect(snippet).toMatch(/set_config\('request\.jwt\.claims', \$\$.*\$\$, true\)/);
+  });
+
+  it('falls back to a collision-free dollar tag when a value contains $$', () => {
+    const snippet = buildExampleQuery(
+      baseResult({ effectiveClaims: { role: 'authenticated', x: 'a$$b' } }),
+      '"public"."todos"'
+    );
+    expect(snippet).toContain('$q1$');
+    expect(snippet).toContain('a$$b');
+  });
+
+  it('backfills the SELECT filter and sample limit', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'SELECT' }), '"public"."todos"', {
+      match: { user_id: 'u1', done: true },
+      sampleLimit: 3,
+    });
+    expect(snippet).toContain(
+      'SELECT * FROM "public"."todos" WHERE "user_id" = $$u1$$ AND "done" = true LIMIT 3;'
+    );
+  });
+
+  it('renders a real INSERT with columns and literal values', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'INSERT' }), '"public"."todos"', {
+      row: { user_id: 'u1', title: 'hi', done: false },
+    });
+    expect(snippet).toContain(
+      'INSERT INTO "public"."todos" ("user_id", "title", "done") VALUES ($$u1$$, $$hi$$, false);'
+    );
+  });
+
+  it('renders a real UPDATE with SET and WHERE', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'UPDATE' }), '"public"."todos"', {
+      row: { done: true },
+      match: { user_id: 'u1' },
+    });
+    expect(snippet).toContain(
+      'UPDATE "public"."todos" SET "done" = true WHERE "user_id" = $$u1$$;'
+    );
+  });
+
+  it('renders a real DELETE with WHERE, and null match as IS NULL', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'DELETE' }), '"public"."todos"', {
+      match: { archived_at: null },
+    });
+    expect(snippet).toContain('DELETE FROM "public"."todos" WHERE "archived_at" IS NULL;');
+  });
+
+  it('never emits an invalid literal for a non-finite value (defensive)', () => {
+    // A non-finite number cannot arrive via a JSON request body; this guards the
+    // display path so it renders NULL instead of a broken literal or a throw.
+    const snippet = buildExampleQuery(baseResult({ operation: 'SELECT' }), '"public"."todos"', {
+      match: { score: Number.POSITIVE_INFINITY } as Record<string, unknown>,
+    });
+    expect(snippet).toContain('"score" = NULL');
+  });
+
+  it('escapes a value ending in $ without breaking the dollar-quote (boundary)', () => {
+    // A bare $$ tag would fuse with the trailing $ into $$SAVE20$$$ and close
+    // early; the tag must escalate to a non-empty delimiter. Assert the FULL
+    // literal so a malformed surrounding quote can't pass on a fragment match.
+    const snippet = buildExampleQuery(baseResult({ operation: 'DELETE' }), '"public"."orders"', {
+      match: { promo_code: 'SAVE20$' },
+    });
+    expect(snippet).toContain('WHERE "promo_code" = $q1$SAVE20$$q1$;');
+  });
+
+  it('escapes a lone $ value', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'DELETE' }), '"public"."orders"', {
+      match: { code: '$' },
+    });
+    expect(snippet).toContain('WHERE "code" = $q1$$$q1$;');
+  });
+
+  it('reproduces a count(*) when sampling is disabled (sampleLimit 0)', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'SELECT' }), '"public"."todos"', {
+      match: { user_id: 'u1' },
+      sampleLimit: 0,
+    });
+    expect(snippet).toContain('SELECT count(*) FROM "public"."todos" WHERE "user_id" = $$u1$$;');
+    expect(snippet).not.toContain('SELECT *');
   });
 });

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -148,6 +148,10 @@ describe('classifySelect', () => {
   it('allowed (not denied) when the table is empty', () => {
     expect(classifySelect({ rowsVisible: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
   });
+  it('falls back to the role visibility when the admin baseline is null', () => {
+    expect(classifySelect({ rowsVisible: 2, rowsTotal: null, bypassRls: false })).toBe('allowed');
+    expect(classifySelect({ rowsVisible: 0, rowsTotal: null, bypassRls: false })).toBe('denied');
+  });
 });
 
 describe('classifyMutation', () => {
@@ -165,6 +169,12 @@ describe('classifyMutation', () => {
   });
   it('allowed when there are no matching rows to act on', () => {
     expect(classifyMutation({ rowsAffected: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
+  });
+  it('falls back to rows affected when the admin baseline is null', () => {
+    expect(classifyMutation({ rowsAffected: 1, rowsTotal: null, bypassRls: false })).toBe(
+      'allowed'
+    );
+    expect(classifyMutation({ rowsAffected: 0, rowsTotal: null, bypassRls: false })).toBe('denied');
   });
 });
 
@@ -253,6 +263,32 @@ describe('buildExplanation', () => {
       })
     );
     expect(text).toContain('violates row-level security');
+  });
+
+  it('distinguishes a missing GRANT denial from an RLS policy denial', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'denied',
+        rowsVisible: 0,
+        rowsTotal: 3,
+        denialReason: 'permission denied for table todos',
+        applicablePolicies: [],
+      })
+    );
+    expect(text).toContain('GRANT');
+    expect(text).not.toContain('blocked by default');
+  });
+
+  it('notes when the admin baseline was unavailable', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'allowed',
+        rowsVisible: 2,
+        rowsTotal: null,
+        applicablePolicies: [ownerSelect],
+      })
+    );
+    expect(text).toContain('Admin baseline unavailable');
   });
 });
 

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -290,6 +290,33 @@ describe('buildExplanation', () => {
     );
     expect(text).toContain('Admin baseline unavailable');
   });
+
+  it('does not claim a proven RLS denial when 0 rows + no baseline', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'denied',
+        rowsVisible: 0,
+        rowsTotal: null,
+        denialReason: null,
+        applicablePolicies: [ownerSelect],
+      })
+    );
+    expect(text).toMatch(/may be an empty table/i);
+    expect(text).not.toContain('denied by RLS (no rows pass)');
+  });
+
+  it('prefers the RLS phrase over "permission denied" when both could match', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'denied',
+        rowsVisible: 0,
+        rowsTotal: 3,
+        denialReason: 'new row violates row-level security policy for table "todos"',
+        applicablePolicies: [ownerSelect],
+      })
+    );
+    expect(text).not.toContain('missing table privilege (GRANT)');
+  });
 });
 
 describe('buildExampleQuery', () => {

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import type { SimulatePolicyResponse, SimulatorPolicy } from '@insforge/shared-schemas';
+import {
+  simulatePolicyRequestSchema,
+  type SimulatePolicyResponse,
+  type SimulatorPolicy,
+} from '@insforge/shared-schemas';
 import {
   mergeClaims,
   buildWhereClause,
@@ -8,6 +12,68 @@ import {
   buildExplanation,
   buildExampleQuery,
 } from '@/services/database/policy-simulator.service.js';
+
+describe('simulatePolicyRequestSchema', () => {
+  it('accepts a minimal valid request', () => {
+    const parsed = simulatePolicyRequestSchema.safeParse({
+      table: 'todos',
+      operation: 'SELECT',
+      role: 'authenticated',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts custom claims, row, match, and sampleLimit', () => {
+    const parsed = simulatePolicyRequestSchema.safeParse({
+      schema: 'public',
+      table: 'todos',
+      operation: 'UPDATE',
+      role: 'authenticated',
+      claims: { sub: 'u1', org_id: 'acme' },
+      row: { done: true },
+      match: { user_id: 'u1' },
+      sampleLimit: 10,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects an unknown operation', () => {
+    expect(
+      simulatePolicyRequestSchema.safeParse({
+        table: 'todos',
+        operation: 'TRUNCATE',
+        role: 'authenticated',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects an unknown role', () => {
+    expect(
+      simulatePolicyRequestSchema.safeParse({
+        table: 'todos',
+        operation: 'SELECT',
+        role: 'superuser',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects a missing table', () => {
+    expect(
+      simulatePolicyRequestSchema.safeParse({ operation: 'SELECT', role: 'anon' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a sampleLimit above the cap', () => {
+    expect(
+      simulatePolicyRequestSchema.safeParse({
+        table: 'todos',
+        operation: 'SELECT',
+        role: 'anon',
+        sampleLimit: 1000,
+      }).success
+    ).toBe(false);
+  });
+});
 
 describe('mergeClaims', () => {
   it('injects the simulated role', () => {

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -134,47 +134,201 @@ describe('buildWhereClause', () => {
 
 describe('classifySelect', () => {
   it('reports bypass for BYPASSRLS roles', () => {
-    expect(classifySelect({ rowsVisible: 3, rowsTotal: 3, bypassRls: true })).toBe('bypass');
+    expect(
+      classifySelect({
+        rowsVisible: 3,
+        rowsTotal: 3,
+        bypassRls: true,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('bypass');
   });
   it('allowed when the role sees every row', () => {
-    expect(classifySelect({ rowsVisible: 3, rowsTotal: 3, bypassRls: false })).toBe('allowed');
+    expect(
+      classifySelect({
+        rowsVisible: 3,
+        rowsTotal: 3,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
   });
   it('partial when the role sees some rows', () => {
-    expect(classifySelect({ rowsVisible: 1, rowsTotal: 3, bypassRls: false })).toBe('partial');
+    expect(
+      classifySelect({
+        rowsVisible: 1,
+        rowsTotal: 3,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('partial');
   });
   it('denied when the role sees no rows but rows exist', () => {
-    expect(classifySelect({ rowsVisible: 0, rowsTotal: 3, bypassRls: false })).toBe('denied');
+    expect(
+      classifySelect({
+        rowsVisible: 0,
+        rowsTotal: 3,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
   });
-  it('allowed (not denied) when the table is empty', () => {
-    expect(classifySelect({ rowsVisible: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
+  it('denied (default-deny) on an empty table when no permissive policy applies', () => {
+    expect(
+      classifySelect({
+        rowsVisible: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
+  });
+  it('allowed (outcome unobserved) on an empty table when a permissive policy applies', () => {
+    expect(
+      classifySelect({
+        rowsVisible: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
+  });
+  it('allowed on an empty table when RLS is disabled (no policy can deny)', () => {
+    expect(
+      classifySelect({
+        rowsVisible: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: false,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('allowed');
   });
   it('falls back to the role visibility when the admin baseline is null', () => {
-    expect(classifySelect({ rowsVisible: 2, rowsTotal: null, bypassRls: false })).toBe('allowed');
-    expect(classifySelect({ rowsVisible: 0, rowsTotal: null, bypassRls: false })).toBe('denied');
+    expect(
+      classifySelect({
+        rowsVisible: 2,
+        rowsTotal: null,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
+    expect(
+      classifySelect({
+        rowsVisible: 0,
+        rowsTotal: null,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
   });
 });
 
 describe('classifyMutation', () => {
   it('reports bypass for BYPASSRLS roles', () => {
-    expect(classifyMutation({ rowsAffected: 2, rowsTotal: 2, bypassRls: true })).toBe('bypass');
+    expect(
+      classifyMutation({
+        rowsAffected: 2,
+        rowsTotal: 2,
+        bypassRls: true,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('bypass');
   });
   it('allowed when every matching row is affected', () => {
-    expect(classifyMutation({ rowsAffected: 2, rowsTotal: 2, bypassRls: false })).toBe('allowed');
+    expect(
+      classifyMutation({
+        rowsAffected: 2,
+        rowsTotal: 2,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
   });
   it('partial when only some matching rows are affected', () => {
-    expect(classifyMutation({ rowsAffected: 1, rowsTotal: 2, bypassRls: false })).toBe('partial');
+    expect(
+      classifyMutation({
+        rowsAffected: 1,
+        rowsTotal: 2,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('partial');
   });
   it('denied when matching rows exist but none are affected', () => {
-    expect(classifyMutation({ rowsAffected: 0, rowsTotal: 2, bypassRls: false })).toBe('denied');
+    expect(
+      classifyMutation({
+        rowsAffected: 0,
+        rowsTotal: 2,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
   });
-  it('allowed when there are no matching rows to act on', () => {
-    expect(classifyMutation({ rowsAffected: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
+  it('denied (default-deny) on an empty match when no permissive policy applies', () => {
+    expect(
+      classifyMutation({
+        rowsAffected: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
+  });
+  it('allowed (outcome unobserved) on an empty match when a permissive policy applies', () => {
+    expect(
+      classifyMutation({
+        rowsAffected: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
+  });
+  it('allowed on an empty match when RLS is disabled (no policy can deny)', () => {
+    expect(
+      classifyMutation({
+        rowsAffected: 0,
+        rowsTotal: 0,
+        bypassRls: false,
+        rlsEnabled: false,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('allowed');
   });
   it('falls back to rows affected when the admin baseline is null', () => {
-    expect(classifyMutation({ rowsAffected: 1, rowsTotal: null, bypassRls: false })).toBe(
-      'allowed'
-    );
-    expect(classifyMutation({ rowsAffected: 0, rowsTotal: null, bypassRls: false })).toBe('denied');
+    expect(
+      classifyMutation({
+        rowsAffected: 1,
+        rowsTotal: null,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 1,
+      })
+    ).toBe('allowed');
+    expect(
+      classifyMutation({
+        rowsAffected: 0,
+        rowsTotal: null,
+        bypassRls: false,
+        rlsEnabled: true,
+        applicablePermissiveCount: 0,
+      })
+    ).toBe('denied');
   });
 });
 
@@ -208,6 +362,18 @@ const ownerSelect: SimulatorPolicy = {
   qual: '(auth.uid() = user_id)',
   withCheck: null,
   permissive: true,
+};
+
+// A restrictive policy with NO accompanying permissive policy: RLS is
+// permissive-OR, so this configuration denies every row for the role.
+const restrictiveSelect: SimulatorPolicy = {
+  tableName: 'todos',
+  policyName: 'tenant_restrict',
+  cmd: 'SELECT',
+  roles: ['authenticated'],
+  qual: "(tenant_id = current_setting('app.tenant', true))",
+  withCheck: null,
+  permissive: false,
 };
 
 describe('buildExplanation', () => {
@@ -318,10 +484,10 @@ describe('buildExplanation', () => {
     expect(text).not.toContain('missing table privilege (GRANT)');
   });
 
-  it('does not contradict itself on an empty table (allowed + no rows + no policy)', () => {
+  it('reports default-deny on an empty table when no permissive policy applies', () => {
     const text = buildExplanation(
       baseResult({
-        decision: 'allowed',
+        decision: 'denied',
         rowsVisible: 0,
         rowsTotal: 0,
         applicablePolicies: [],
@@ -329,10 +495,25 @@ describe('buildExplanation', () => {
     );
     expect(text).toMatch(/matched no rows/i);
     expect(text).not.toContain('is allowed');
+    expect(text).toMatch(/no applicable permissive/i);
     expect(text).toContain('denied by default');
   });
 
-  it('explains an empty table with a policy without claiming a proven allow', () => {
+  it('reports default-deny on an empty table with only a restrictive policy', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'denied',
+        rowsVisible: 0,
+        rowsTotal: 0,
+        applicablePolicies: [restrictiveSelect],
+      })
+    );
+    expect(text).toMatch(/matched no rows/i);
+    expect(text).toMatch(/no applicable permissive/i);
+    expect(text).toContain('denied by default');
+  });
+
+  it('explains an empty table with a permissive policy without claiming a proven allow', () => {
     const text = buildExplanation(
       baseResult({
         decision: 'allowed',
@@ -342,6 +523,7 @@ describe('buildExplanation', () => {
       })
     );
     expect(text).toMatch(/matched no rows/i);
+    expect(text).toMatch(/could not be observed/i);
     expect(text).toContain('OR'); // the permissive/restrictive combination rule still surfaces
   });
 });
@@ -447,5 +629,23 @@ describe('buildExampleQuery', () => {
     });
     expect(snippet).toContain('SELECT count(*) FROM "public"."todos" WHERE "user_id" = $$u1$$;');
     expect(snippet).not.toContain('SELECT *');
+  });
+
+  it('renders DEFAULT VALUES for an INSERT with no row payload', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'INSERT' }), '"public"."todos"');
+    expect(snippet).toContain('INSERT INTO "public"."todos" DEFAULT VALUES;');
+  });
+
+  it('emits a comment, never a broken statement, for an UPDATE with no row payload', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'UPDATE' }), '"public"."todos"');
+    expect(snippet).toContain('-- UPDATE "public"."todos"');
+    expect(snippet).not.toMatch(/UPDATE "public"\."todos" SET/);
+  });
+
+  it('renders an object value as a dollar-quoted JSON literal', () => {
+    const snippet = buildExampleQuery(baseResult({ operation: 'INSERT' }), '"public"."todos"', {
+      row: { meta: { a: 1, b: "it's" } },
+    });
+    expect(snippet).toContain('VALUES ($${"a":1,"b":"it\'s"}$$);');
   });
 });

--- a/backend/tests/unit/policy-simulator.service.test.ts
+++ b/backend/tests/unit/policy-simulator.service.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import type { SimulatePolicyResponse, SimulatorPolicy } from '@insforge/shared-schemas';
+import {
+  mergeClaims,
+  buildWhereClause,
+  classifySelect,
+  classifyMutation,
+  buildExplanation,
+  buildExampleQuery,
+} from '@/services/database/policy-simulator.service.js';
+
+describe('mergeClaims', () => {
+  it('injects the simulated role', () => {
+    expect(mergeClaims('authenticated', { sub: 'u1' })).toEqual({
+      sub: 'u1',
+      role: 'authenticated',
+    });
+  });
+
+  it('keeps custom claims like org_id', () => {
+    expect(mergeClaims('authenticated', { sub: 'u1', org_id: 'acme' })).toEqual({
+      sub: 'u1',
+      org_id: 'acme',
+      role: 'authenticated',
+    });
+  });
+
+  it('never lets a custom role claim override the simulated role', () => {
+    expect(mergeClaims('anon', { role: 'project_admin', sub: 'u1' })).toEqual({
+      role: 'anon',
+      sub: 'u1',
+    });
+  });
+
+  it('handles missing claims', () => {
+    expect(mergeClaims('project_admin', undefined)).toEqual({ role: 'project_admin' });
+  });
+});
+
+describe('buildWhereClause', () => {
+  it('returns empty for no match', () => {
+    expect(buildWhereClause(undefined)).toEqual({ sql: '', params: [] });
+    expect(buildWhereClause({})).toEqual({ sql: '', params: [] });
+  });
+
+  it('parameterizes values and quotes identifiers', () => {
+    const { sql, params } = buildWhereClause({ user_id: 'u1', done: true });
+    expect(sql).toBe('WHERE "user_id" = $1 AND "done" = $2');
+    expect(params).toEqual(['u1', true]);
+  });
+
+  it('renders null as IS NULL without a parameter', () => {
+    const { sql, params } = buildWhereClause({ deleted_at: null, id: 5 });
+    expect(sql).toBe('WHERE "deleted_at" IS NULL AND "id" = $1');
+    expect(params).toEqual([5]);
+  });
+
+  it('honors a custom start index (for combining with a SET clause)', () => {
+    const { sql, params } = buildWhereClause({ user_id: 'u1' }, 3);
+    expect(sql).toBe('WHERE "user_id" = $3');
+    expect(params).toEqual(['u1']);
+  });
+
+  it('rejects identifiers with quotes or control characters', () => {
+    expect(() => buildWhereClause({ 'evil"col': 1 })).toThrow();
+  });
+});
+
+describe('classifySelect', () => {
+  it('reports bypass for BYPASSRLS roles', () => {
+    expect(classifySelect({ rowsVisible: 3, rowsTotal: 3, bypassRls: true })).toBe('bypass');
+  });
+  it('allowed when the role sees every row', () => {
+    expect(classifySelect({ rowsVisible: 3, rowsTotal: 3, bypassRls: false })).toBe('allowed');
+  });
+  it('partial when the role sees some rows', () => {
+    expect(classifySelect({ rowsVisible: 1, rowsTotal: 3, bypassRls: false })).toBe('partial');
+  });
+  it('denied when the role sees no rows but rows exist', () => {
+    expect(classifySelect({ rowsVisible: 0, rowsTotal: 3, bypassRls: false })).toBe('denied');
+  });
+  it('allowed (not denied) when the table is empty', () => {
+    expect(classifySelect({ rowsVisible: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
+  });
+});
+
+describe('classifyMutation', () => {
+  it('reports bypass for BYPASSRLS roles', () => {
+    expect(classifyMutation({ rowsAffected: 2, rowsTotal: 2, bypassRls: true })).toBe('bypass');
+  });
+  it('allowed when every matching row is affected', () => {
+    expect(classifyMutation({ rowsAffected: 2, rowsTotal: 2, bypassRls: false })).toBe('allowed');
+  });
+  it('partial when only some matching rows are affected', () => {
+    expect(classifyMutation({ rowsAffected: 1, rowsTotal: 2, bypassRls: false })).toBe('partial');
+  });
+  it('denied when matching rows exist but none are affected', () => {
+    expect(classifyMutation({ rowsAffected: 0, rowsTotal: 2, bypassRls: false })).toBe('denied');
+  });
+  it('allowed when there are no matching rows to act on', () => {
+    expect(classifyMutation({ rowsAffected: 0, rowsTotal: 0, bypassRls: false })).toBe('allowed');
+  });
+});
+
+function baseResult(overrides: Partial<SimulatePolicyResponse>): SimulatePolicyResponse {
+  return {
+    schema: 'public',
+    table: 'todos',
+    operation: 'SELECT',
+    role: 'authenticated',
+    effectiveClaims: { role: 'authenticated', sub: 'u1' },
+    rlsEnabled: true,
+    bypassRls: false,
+    decision: 'allowed',
+    rowsVisible: 1,
+    rowsTotal: 1,
+    rowsAffected: null,
+    sampleRows: null,
+    denialReason: null,
+    applicablePolicies: [],
+    explanation: '',
+    exampleQuery: '',
+    ...overrides,
+  };
+}
+
+const ownerSelect: SimulatorPolicy = {
+  tableName: 'todos',
+  policyName: 'owner_select',
+  cmd: 'SELECT',
+  roles: ['authenticated'],
+  qual: '(auth.uid() = user_id)',
+  withCheck: null,
+  permissive: true,
+};
+
+describe('buildExplanation', () => {
+  it('explains BYPASSRLS for project_admin', () => {
+    const text = buildExplanation(
+      baseResult({ role: 'project_admin', bypassRls: true, decision: 'bypass' })
+    );
+    expect(text).toContain('BYPASSRLS');
+  });
+
+  it('explains a denied BYPASSRLS role as a missing GRANT, not full access', () => {
+    const text = buildExplanation(
+      baseResult({
+        role: 'project_admin',
+        bypassRls: true,
+        decision: 'denied',
+        denialReason: 'permission denied for table todos',
+      })
+    );
+    expect(text).toContain('GRANT');
+    expect(text).not.toContain('full table access');
+  });
+
+  it('notes when RLS is not enabled', () => {
+    const text = buildExplanation(baseResult({ rlsEnabled: false }));
+    expect(text).toContain('not enabled');
+    expect(text).toContain('GRANT');
+  });
+
+  it('flags default-deny when no policy applies', () => {
+    const text = buildExplanation(
+      baseResult({ decision: 'denied', rowsVisible: 0, rowsTotal: 3, applicablePolicies: [] })
+    );
+    expect(text).toContain('No RLS policy');
+  });
+
+  it('summarizes permissive policy combination on allow', () => {
+    const text = buildExplanation(
+      baseResult({ decision: 'allowed', applicablePolicies: [ownerSelect] })
+    );
+    expect(text).toContain('allowed');
+    expect(text).toContain('OR');
+  });
+
+  it('reports the denial reason when present', () => {
+    const text = buildExplanation(
+      baseResult({
+        decision: 'denied',
+        rowsVisible: 0,
+        rowsTotal: 3,
+        denialReason: 'new row violates row-level security policy',
+        applicablePolicies: [ownerSelect],
+      })
+    );
+    expect(text).toContain('violates row-level security');
+  });
+});
+
+describe('buildExampleQuery', () => {
+  it('produces a runnable, rolled-back snippet with role and claims', () => {
+    const snippet = buildExampleQuery(
+      baseResult({ role: 'authenticated', effectiveClaims: { role: 'authenticated', sub: 'u1' } }),
+      '"public"."todos"'
+    );
+    expect(snippet).toContain('SET LOCAL ROLE authenticated;');
+    expect(snippet).toContain("set_config('request.jwt.claims'");
+    expect(snippet).toContain('"public"."todos"');
+    expect(snippet.startsWith('BEGIN;')).toBe(true);
+    expect(snippet.trimEnd().endsWith('ROLLBACK;')).toBe(true);
+  });
+
+  it('escapes single quotes in the claims JSON', () => {
+    const snippet = buildExampleQuery(
+      baseResult({ effectiveClaims: { role: 'authenticated', note: "o'brien" } }),
+      '"public"."todos"'
+    );
+    expect(snippet).toContain("o''brien");
+  });
+});

--- a/docs/agent-native/diagnostics.mdx
+++ b/docs/agent-native/diagnostics.mdx
@@ -1,13 +1,16 @@
 ---
-title: "Diagnostics & advisor"
-sidebarTitle: "Diagnostics & advisor"
-description: "The agent reads backend health, advisor findings, and error logs, then applies the fix."
+title: 'Diagnostics & advisor'
+sidebarTitle: 'Diagnostics & advisor'
+description: 'The agent reads backend health, advisor findings, and error logs, then applies the fix.'
 ---
 
 When something breaks, an agent should not have to guess. `npx @insforge/cli diagnose` turns the backend's own signals into something an agent can fetch and act on directly: advisor findings with remediations, database health checks, instance metrics, and aggregated error logs. Each finding comes with a fix, so "what is wrong" and "what to do about it" arrive together. The agent pulls all of this itself, with no dashboard in the loop, which is what lets it close security gaps like a permissive RLS policy before they leak data.
 
 <Frame caption="A Backend Advisor finding: the problem, the affected table, and a remediation the agent can copy and apply.">
-  <img src="/images/backend-advisor.png" alt="Backend Advisor finding: a permissive RLS policy on public.messages with a Copy Remediation button" />
+  <img
+    src="/images/backend-advisor.png"
+    alt="Backend Advisor finding: a permissive RLS policy on public.messages with a Copy Remediation button"
+  />
 </Frame>
 
 ## Full health report
@@ -36,12 +39,12 @@ A typical finding is a permissive RLS policy that exposes a table to anonymous u
 
 Each part of the report is also available on its own:
 
-| Command | What it checks |
-|---------|----------------|
+| Command            | What it checks                                                |
+| ------------------ | ------------------------------------------------------------- |
 | `diagnose advisor` | Latest advisor scan: security, performance, and health issues |
-| `diagnose db` | Database health: connections, table bloat, index usage |
-| `diagnose metrics` | Instance metrics: CPU, memory, disk, and network |
-| `diagnose logs` | Error-level logs aggregated across every backend source |
+| `diagnose db`      | Database health: connections, table bloat, index usage        |
+| `diagnose metrics` | Instance metrics: CPU, memory, disk, and network              |
+| `diagnose logs`    | Error-level logs aggregated across every backend source       |
 
 For raw logs from a single source, use the top-level command:
 
@@ -54,7 +57,7 @@ Sources include `insforge.logs`, `postgREST.logs`, `postgres.logs`, `function.lo
 
 ## Policy simulator
 
-The advisor tells you a policy looks wrong. The policy simulator tells you what a specific identity can actually do, before you deploy. Send a table, an operation, a role, and the JWT claims to test, and the backend runs that exact operation as that identity inside a transaction it always rolls back, then reports whether row level security allowed or denied it and which policies applied.
+The advisor tells you a policy looks wrong. The policy simulator tells you what a specific identity can actually do, before you deploy. Send a table, an operation, a role, and the JWT claims to test, and the backend runs that exact operation as that identity inside a transaction it always rolls back, then reports whether row-level security allowed or denied it and which policies applied. This endpoint is admin-protected.
 
 ```http
 POST /api/database/policies/simulate

--- a/docs/agent-native/diagnostics.mdx
+++ b/docs/agent-native/diagnostics.mdx
@@ -52,6 +52,24 @@ npx @insforge/cli logs postgres.logs
 
 Sources include `insforge.logs`, `postgREST.logs`, `postgres.logs`, `function.logs`, and `function-deploy.logs`.
 
+## Policy simulator
+
+The advisor tells you a policy looks wrong. The policy simulator tells you what a specific identity can actually do, before you deploy. Send a table, an operation, a role, and the JWT claims to test, and the backend runs that exact operation as that identity inside a transaction it always rolls back, then reports whether row level security allowed or denied it and which policies applied.
+
+```http
+POST /api/database/policies/simulate
+{
+  "table": "todos",
+  "operation": "SELECT",
+  "role": "authenticated",
+  "claims": { "sub": "550e8400-e29b-41d4-a716-446655440001" }
+}
+```
+
+The response gives the decision (`allowed`, `denied`, `partial`, or `bypass`), how many rows the role can see versus how many exist, the policies Postgres considered with their `USING` and `WITH CHECK` expressions, and a plain-language explanation. `project_admin` is reported as `bypass` because it has `BYPASSRLS`. No rows are persisted: every simulated statement runs under a downgraded role and is rolled back. See the [policies API spec](https://github.com/InsForge/InsForge/blob/main/openapi/policies.yaml) for the full request and response shape.
+
+This sits between the advisor and [branching](/agent-native/branching): the advisor finds a bad policy, the simulator confirms exactly how it allows or denies a given user, and branching lets you rehearse the fix in isolation.
+
 ## Let the agent interpret it
 
 `diagnose --ai` hands the collected diagnostic data to a model and returns a plain-language analysis:

--- a/openapi/policies.yaml
+++ b/openapi/policies.yaml
@@ -1,0 +1,260 @@
+openapi: 3.0.3
+info:
+  title: Insforge RLS Policies API
+  version: 1.0.0
+
+paths:
+  /api/database/policies:
+    get:
+      summary: List RLS Policies
+      description: List row level security policies for a schema.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - in: query
+          name: schema
+          schema:
+            type: string
+            default: public
+          description: Schema to list policies for. Defaults to "public".
+      responses:
+        '200':
+          description: Policies for the schema
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - policies
+                properties:
+                  policies:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Policy'
+
+  /api/database/policies/simulate:
+    post:
+      summary: Simulate RLS Policy Decision
+      description: >
+        Simulate a data operation (SELECT/INSERT/UPDATE/DELETE) on a table as a
+        chosen role and JWT identity, with no side effects, and report whether
+        row level security allows or denies it and which policies apply. The
+        operation runs under a downgraded role inside a transaction that is
+        always rolled back. Admin only.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulatePolicyRequest'
+            example:
+              table: todos
+              operation: SELECT
+              role: authenticated
+              claims:
+                sub: 550e8400-e29b-41d4-a716-446655440001
+      responses:
+        '200':
+          description: Simulation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulatePolicyResponse'
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Admin access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Table not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  schemas:
+    Policy:
+      type: object
+      required:
+        - tableName
+        - policyName
+        - cmd
+        - roles
+      properties:
+        tableName:
+          type: string
+        policyName:
+          type: string
+        cmd:
+          type: string
+          description: SELECT, INSERT, UPDATE, DELETE, or ALL
+        roles:
+          type: array
+          items:
+            type: string
+        qual:
+          type: string
+          nullable: true
+          description: The USING expression, if any
+        withCheck:
+          type: string
+          nullable: true
+          description: The WITH CHECK expression, if any
+
+    ApplicablePolicy:
+      allOf:
+        - $ref: '#/components/schemas/Policy'
+        - type: object
+          required:
+            - permissive
+          properties:
+            permissive:
+              type: boolean
+              description: true for PERMISSIVE (combined with OR), false for RESTRICTIVE (AND)
+
+    SimulatePolicyRequest:
+      type: object
+      required:
+        - table
+        - operation
+        - role
+      properties:
+        schema:
+          type: string
+          default: public
+        table:
+          type: string
+        operation:
+          type: string
+          enum: [SELECT, INSERT, UPDATE, DELETE]
+        role:
+          type: string
+          enum: [anon, authenticated, project_admin]
+        claims:
+          type: object
+          additionalProperties: true
+          description: >
+            Custom JWT claims injected as request.jwt.claims (e.g. sub, email,
+            org_id). The simulated role always overrides any role claim here.
+        row:
+          type: object
+          additionalProperties: true
+          description: >
+            Column to value map. INSERT row (optional) or UPDATE SET payload
+            (required for UPDATE).
+        match:
+          type: object
+          additionalProperties: true
+          description: Column to value map building a parameterized WHERE (AND-ed).
+        sampleLimit:
+          type: integer
+          minimum: 0
+          maximum: 50
+          description: Number of visible rows to return as a sample for SELECT.
+
+    SimulatePolicyResponse:
+      type: object
+      required:
+        - schema
+        - table
+        - operation
+        - role
+        - effectiveClaims
+        - rlsEnabled
+        - bypassRls
+        - decision
+        - applicablePolicies
+        - explanation
+        - exampleQuery
+      properties:
+        schema:
+          type: string
+        table:
+          type: string
+        operation:
+          type: string
+          enum: [SELECT, INSERT, UPDATE, DELETE]
+        role:
+          type: string
+          enum: [anon, authenticated, project_admin]
+        effectiveClaims:
+          type: object
+          additionalProperties: true
+        rlsEnabled:
+          type: boolean
+        bypassRls:
+          type: boolean
+        decision:
+          type: string
+          enum: [allowed, denied, partial, bypass]
+        rowsVisible:
+          type: integer
+          nullable: true
+        rowsTotal:
+          type: integer
+          nullable: true
+        rowsAffected:
+          type: integer
+          nullable: true
+        sampleRows:
+          type: array
+          nullable: true
+          items:
+            type: object
+            additionalProperties: true
+        denialReason:
+          type: string
+          nullable: true
+        applicablePolicies:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicablePolicy'
+        explanation:
+          type: string
+        exampleQuery:
+          type: string
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+          description: Error code for programmatic handling
+        message:
+          type: string
+          description: Human-readable error message
+        statusCode:
+          type: integer
+          description: HTTP status code
+        nextActions:
+          type: string
+          description: Suggested action to resolve the error

--- a/openapi/policies.yaml
+++ b/openapi/policies.yaml
@@ -159,8 +159,12 @@ components:
         schema:
           type: string
           default: public
+          minLength: 1
+          maxLength: 64
         table:
           type: string
+          minLength: 1
+          maxLength: 64
         operation:
           type: string
           enum: [SELECT, INSERT, UPDATE, DELETE]

--- a/openapi/policies.yaml
+++ b/openapi/policies.yaml
@@ -92,6 +92,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Simulation timed out (server-side resource limit, retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   securitySchemes:
@@ -194,6 +200,11 @@ components:
         - rlsEnabled
         - bypassRls
         - decision
+        - rowsVisible
+        - rowsTotal
+        - rowsAffected
+        - sampleRows
+        - denialReason
         - applicablePolicies
         - explanation
         - exampleQuery

--- a/openapi/policies.yaml
+++ b/openapi/policies.yaml
@@ -86,6 +86,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too many requests (rate limited)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   securitySchemes:

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -11,6 +11,7 @@ import {
   migrationSchema,
   databaseBackupSchema,
 } from './database.schema.js';
+import { roleSchema } from './auth.schema.js';
 
 export const createTableRequestSchema = tableSchema
   .pick({
@@ -396,6 +397,68 @@ export const databasePoliciesResponseSchema = z.object({
   policies: z.array(databasePolicySchema),
 });
 
+// RLS Policy Simulator Schemas
+//
+// Simulate a data operation as a given role + JWT identity without persisting
+// any rows, and report whether RLS allows or denies it and which policies apply.
+// Roles map 1:1 to the Postgres roles the runtime uses (anon / authenticated /
+// project_admin), so the same `roleSchema` gates this request.
+export const policySimulatorOperationSchema = z.enum(['SELECT', 'INSERT', 'UPDATE', 'DELETE']);
+
+export const simulatePolicyRequestSchema = z.object({
+  // Defaults to "public" on the backend. Internal schemas are rejected there.
+  schema: z.string().min(1).max(64).optional(),
+  table: z.string().min(1).max(64),
+  operation: policySimulatorOperationSchema,
+  role: roleSchema,
+  // Custom JWT claims to inject as request.jwt.claims (e.g. { sub, email, org_id }).
+  // The simulated `role` is always written into the claims, overriding any role key here.
+  claims: z.record(z.string(), z.unknown()).optional(),
+  // Column -> value map. INSERT: the row to insert (optional; omit for DEFAULT VALUES).
+  // UPDATE: the SET payload (required for UPDATE).
+  row: z.record(z.string(), z.unknown()).optional(),
+  // Column -> value map building a parameterized WHERE (AND-ed) to scope which
+  // rows SELECT/UPDATE/DELETE target. null values become "IS NULL".
+  match: z.record(z.string(), z.unknown()).optional(),
+  // Number of visible rows to return as a sample for SELECT (0 disables).
+  sampleLimit: z.number().int().min(0).max(50).optional(),
+});
+
+// A policy that Postgres would consider for this (table, operation, role),
+// surfaced with its permissive/restrictive flag and predicate text.
+export const simulatorPolicySchema = databasePolicySchema.extend({
+  permissive: z.boolean(),
+});
+
+export const policySimulatorDecisionSchema = z.enum(['allowed', 'denied', 'partial', 'bypass']);
+
+export const simulatePolicyResponseSchema = z.object({
+  schema: z.string(),
+  table: z.string(),
+  operation: policySimulatorOperationSchema,
+  role: roleSchema,
+  // The exact claims written into request.jwt.claims for the simulated session.
+  effectiveClaims: z.record(z.string(), z.unknown()),
+  rlsEnabled: z.boolean(),
+  bypassRls: z.boolean(),
+  decision: policySimulatorDecisionSchema,
+  // SELECT: rows visible to the role. UPDATE/DELETE/INSERT: null.
+  rowsVisible: z.number().nullable(),
+  // Baseline rows matched with RLS bypassed (admin view). SELECT/UPDATE/DELETE; null for INSERT.
+  rowsTotal: z.number().nullable(),
+  // INSERT/UPDATE/DELETE: rows the operation would have affected. null for SELECT.
+  rowsAffected: z.number().nullable(),
+  // SELECT: a small sample of rows the role can see. null otherwise.
+  sampleRows: z.array(z.record(z.string(), z.unknown())).nullable(),
+  // Postgres message when the operation was denied by RLS (error 42501).
+  denialReason: z.string().nullable(),
+  applicablePolicies: z.array(simulatorPolicySchema),
+  // Plain-English summary of the decision and why.
+  explanation: z.string(),
+  // A copy-pasteable SQL snippet reproducing the simulated session.
+  exampleQuery: z.string(),
+});
+
 export const databaseTriggersResponseSchema = z.object({
   triggers: z.array(databaseTriggerSchema),
 });
@@ -444,6 +507,11 @@ export type DatabaseFunctionsResponse = z.infer<typeof databaseFunctionsResponse
 export type DatabaseSchemasResponse = z.infer<typeof databaseSchemasResponseSchema>;
 export type DatabaseIndexesResponse = z.infer<typeof databaseIndexesResponseSchema>;
 export type DatabasePoliciesResponse = z.infer<typeof databasePoliciesResponseSchema>;
+export type PolicySimulatorOperation = z.infer<typeof policySimulatorOperationSchema>;
+export type PolicySimulatorDecision = z.infer<typeof policySimulatorDecisionSchema>;
+export type SimulatorPolicy = z.infer<typeof simulatorPolicySchema>;
+export type SimulatePolicyRequest = z.infer<typeof simulatePolicyRequestSchema>;
+export type SimulatePolicyResponse = z.infer<typeof simulatePolicyResponseSchema>;
 export type DatabaseTriggersResponse = z.infer<typeof databaseTriggersResponseSchema>;
 export type DatabaseMigrationsResponse = z.infer<typeof databaseMigrationsResponseSchema>;
 

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -443,11 +443,12 @@ export const simulatePolicyResponseSchema = z.object({
   bypassRls: z.boolean(),
   decision: policySimulatorDecisionSchema,
   // SELECT: rows visible to the role. UPDATE/DELETE/INSERT: null.
-  rowsVisible: z.number().nullable(),
-  // Baseline rows matched with RLS bypassed (admin view). SELECT/UPDATE/DELETE; null for INSERT.
-  rowsTotal: z.number().nullable(),
+  rowsVisible: z.number().int().min(0).nullable(),
+  // Baseline rows matched with RLS bypassed (admin view). null for INSERT, or
+  // when project_admin lacks SELECT on the table (baseline unavailable).
+  rowsTotal: z.number().int().min(0).nullable(),
   // INSERT/UPDATE/DELETE: rows the operation would have affected. null for SELECT.
-  rowsAffected: z.number().nullable(),
+  rowsAffected: z.number().int().min(0).nullable(),
   // SELECT: a small sample of rows the role can see. null otherwise.
   sampleRows: z.array(z.record(z.string(), z.unknown())).nullable(),
   // Postgres message when the operation was denied by RLS (error 42501).

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -456,7 +456,8 @@ export const simulatePolicyResponseSchema = z.object({
   applicablePolicies: z.array(simulatorPolicySchema),
   // Plain-English summary of the decision and why.
   explanation: z.string(),
-  // A copy-pasteable SQL snippet reproducing the simulated session.
+  // A copy-pasteable SQL snippet that reproduces the exact simulated operation
+  // — same role, claims, filter, and values — wrapped in BEGIN/ROLLBACK.
   exampleQuery: z.string(),
 });
 


### PR DESCRIPTION
## what

adds an admin-only RLS policy simulator so you can test access before deploy.

`POST /api/database/policies/simulate` takes a table, an operation (select/insert/update/delete), a role, and the JWT claims to test. it runs that exact operation as that identity inside a transaction it always rolls back, then reports whether row level security allowed or denied it, how many rows the role sees vs how many exist, which policies applied, and a plain-language explanation.

this is PR 1 of 2: the backend engine + API + tests. the dashboard page (the UX the issue describes) is the fast-follow. happy to combine them if you'd rather.

Refs #1428

## how it works

postgres is the oracle. i don't re-implement the permissive-OR / restrictive-AND policy math, that's a footgun. the real operation runs under a downgraded role (`SET LOCAL ROLE` + `set_config('request.jwt.claims', ...)`, same pattern as `withUserContext`) and the result is whatever postgres actually did, rolled back so nothing persists.

- decision is `allowed`, `denied`, `partial`, or `bypass`. `project_admin` is reported as `bypass` because it has BYPASSRLS, not "allowed by policy".
- "which policy" = the policies postgres would consider, pulled from `pg_policies` filtered by command and role (using `pg_has_role` so member roles and PUBLIC are handled), each with its `USING` / `WITH CHECK` text and permissive flag.
- a 42501 means denied (no privilege, or WITH CHECK failed); other postgres errors come back as a clean 4xx, not a 500.
- all identifiers are validated and quoted, all values are parameterized, statement_timeout is set, and the work runs on its own pooled connection that always rolls back and resets role.

it slots between the advisor and branching: the advisor finds a bad policy, this tells you exactly how it allows or denies a given user, branching lets you rehearse the fix.

## tests

- unit: 33 tests over the pure logic (claims merge, where builder, decision classifiers, explanation, example query, request schema validation).
- integration (`backend/tests/integration/policy-simulator.test.ts`): mirrors `tests/integration/rls.test.ts`. owner / cross-user / anon / project_admin across all four ops, WITH CHECK denials, custom `org_id` claim scoping, no-rows-persisted, unknown-table rejection.
- full backend unit suite stays green (1539 passing).

## also

- shared zod request/response schemas in `@insforge/shared-schemas`.
- openapi spec at `openapi/policies.yaml`.
- short note in `docs/agent-native/diagnostics.mdx`.

## design notes (a couple of choices worth flagging)

- the simulator runs in its own always-rolled-back transaction via a small `runSimulated` helper rather than reusing `withUserContext`. that one commits and only builds the standard `{ role, sub, email }` claims, whereas the simulator needs the opposite: never persist, and inject arbitrary custom claims (e.g. `org_id`). i kept it separate so the shared production path's behavior doesn't change. happy to extract a lower-level `withRoleAndClaims({ rollback })` primitive that both share if you'd rather.
- "which policy applies" uses `pg_has_role(role, policy_role, 'MEMBER')` against `pg_policies`, so PUBLIC and role membership resolve the same way postgres would. the allow/deny decision itself always comes from running the real op (postgres is the oracle); the policy list is for the explanation, not the decision.
- the engine never reimplements RLS combination (permissive OR / restrictive AND). it runs the op as the downgraded role and reports what postgres actually did.

## open questions (would like your read before the dashboard PR)

1. ok to land backend first then dashboard, or do you want both in one PR?
2. want an agent-native surface too (a `diagnose simulate --json` style command, or an MCP tool)?
3. for v1, is "actual outcome + applicable policies" enough, or should it also try to pin the single deciding policy?


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RLS policy simulator endpoint at `POST /api/database/policies/simulate`
> - Adds [`PolicySimulatorService`](https://github.com/InsForge/InsForge/pull/1523/files#diff-ab337d2fea58c41c6454564124559c6a6bb6e89376fe61624b00818232bbbbff) that simulates RLS decisions for SELECT, INSERT, UPDATE, and DELETE without persisting any changes — operations run in rolled-back transactions with `SET LOCAL ROLE` and a configurable JWT claims context.
> - Returns structured responses with `decision` (allowed/denied/partial/bypass), `rowsVisible`, `rowsTotal` (admin baseline), `denialReason`, `applicablePolicies`, and a copy-paste example query.
> - Adds the route in [`index.routes.ts`](https://github.com/InsForge/InsForge/pull/1523/files#diff-23065b21bfcd628bfab00c377c421159213bede84f5ff30e5d4bfd5676b05bee) guarded by `verifyAdmin` and a new `databaseWriteLimiter` (30 req/IP default); audit logging failures do not affect the 200 response.
> - Adds Zod schemas in [`database-api.schema.ts`](https://github.com/InsForge/InsForge/pull/1523/files#diff-b36b10da732a6923ba4ff08476bd3df82a78720ab4015b38906da55567b904ff) and an OpenAPI spec in [`openapi/policies.yaml`](https://github.com/InsForge/InsForge/pull/1523/files#diff-8e82bd6c96772ed5989163a6a226c8732576ad5f4798b387e783c1a16a073230).
> - Risk: each simulation acquires a DB connection and runs real queries against `pg_class`/`pg_policies`; under load this could add connection pressure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 975e480.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin-protected **Policy simulator** endpoints:
    * `POST /api/database/policies/simulate` to evaluate RLS outcomes (allowed/denied/partial/bypass) with explanations and row metrics.
    * `GET /api/database/policies` to list RLS policies (schema default: `public`).
  * Added **database** write rate limiting (30 requests per period).
* **Bug Fixes**
  * Improved simulator resilience and validation; audit logging failures no longer block simulation.
* **Documentation**
  * Updated diagnostics docs and OpenAPI spec for the policy simulator API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->