### PR TITLE
fix(ai): implement token cost caps and prevent cache stampede (#1525)

### DIFF
--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -11,68 +11,92 @@ let modelsCache: {
   models: AIModelSchema[];
 } | null = null;
 
+/**
+ * Tracks an in-flight request to the OpenRouter model catalog.
+ * Used to deduplicate concurrent cache-miss requests and prevent cache stampedes.
+ */
+let fetchInFlight: Promise<AIModelSchema[]> | null = null;
+
 export class AIModelService {
   /**
-   * Get all available AI models
-   * Fetches the public OpenRouter catalog directly.
+   * Retrieves the catalog of available AI models from OpenRouter.
+   * Utilizes a time-based cache and coalesces concurrent fetches to prevent rate limiting.
+   * * @returns {Promise<AIModelSchema[]>} A promise resolving to an array of available models.
    */
   static async getModels(): Promise<AIModelSchema[]> {
-    const now = Date.now();
-    if (modelsCache && modelsCache.expiresAt > now) {
+    if (modelsCache && modelsCache.expiresAt > Date.now()) {
       return modelsCache.models;
     }
 
-    const response = await fetch(OPENROUTER_MODELS_URL);
-
-    if (!response.ok) {
-      if (modelsCache) {
-        return modelsCache.models;
-      }
-      throw new AppError(
-        `Failed to fetch models: ${response.statusText}`,
-        500,
-        ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
-      );
+    if (fetchInFlight) {
+      return fetchInFlight;
     }
 
-    const data = (await response.json()) as { data: RawOpenRouterModel[] };
-    const rawModels = data.data || [];
+    fetchInFlight = (async () => {
+      const response = await fetch(OPENROUTER_MODELS_URL);
 
-    const models: AIModelSchema[] = rawModels
-      .map((rawModel) => {
-        const inputModality = normalizeModalities(rawModel.architecture?.input_modalities || []);
-        const outputModality = normalizeModalities(rawModel.architecture?.output_modalities || []);
-        const { inputPrice, outputPrice, inputPriceLabel, outputPriceLabel } = calculateTokenPrices(
-          rawModel.pricing,
-          inputModality,
-          outputModality
+      if (!response.ok) {
+        if (modelsCache) {
+          return modelsCache.models;
+        }
+        throw new AppError(
+          `Failed to fetch models: ${response.statusText}`,
+          500,
+          ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
         );
-        return {
-          id: rawModel.id, // OpenRouter provided model ID
-          created: rawModel.created,
-          modelId: rawModel.id,
-          provider: 'openrouter',
-          inputModality,
-          outputModality,
-          inputPrice,
-          outputPrice,
-          inputPriceLabel,
-          outputPriceLabel,
-        };
-      })
-      .filter((model) => model.inputModality.length > 0 && model.outputModality.length > 0)
-      .sort((a, b) => {
-        const [aCompany = '', bCompany = ''] = [a.id.split('/')[0], b.id.split('/')[0]];
+      }
 
-        const orderDiff = getProviderOrder(aCompany) - getProviderOrder(bCompany);
-        return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
-      });
+      const data = (await response.json()) as { data: RawOpenRouterModel[] };
+      const rawModels = data.data || [];
 
-    modelsCache = {
-      expiresAt: now + MODELS_CACHE_TTL_MS,
-      models,
-    };
+      const models: AIModelSchema[] = rawModels
+        .map((rawModel) => {
+          const inputModality = normalizeModalities(rawModel.architecture?.input_modalities || []);
+          const outputModality = normalizeModalities(
+            rawModel.architecture?.output_modalities || []
+          );
+          const { inputPrice, outputPrice, inputPriceLabel, outputPriceLabel } =
+            calculateTokenPrices(rawModel.pricing, inputModality, outputModality);
+          return {
+            id: rawModel.id, // OpenRouter provided model ID
+            created: rawModel.created,
+            modelId: rawModel.id,
+            provider: 'openrouter',
+            inputModality,
+            outputModality,
+            inputPrice,
+            outputPrice,
+            inputPriceLabel,
+            outputPriceLabel,
+          };
+        })
+        .filter((model) => model.inputModality.length > 0 && model.outputModality.length > 0)
+        .sort((a, b) => {
+          const [aCompany = '', bCompany = ''] = [a.id.split('/')[0], b.id.split('/')[0]];
 
-    return models || [];
+          const orderDiff = getProviderOrder(aCompany) - getProviderOrder(bCompany);
+          return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
+        });
+
+      modelsCache = {
+        expiresAt: Date.now() + MODELS_CACHE_TTL_MS,
+        models,
+      };
+
+      return models;
+    })().finally(() => {
+      fetchInFlight = null;
+    });
+
+    return fetchInFlight;
   }
+}
+
+/**
+ * Test helper to reset module-level cache and in-flight tracking state.
+ * Strictly for use in unit test isolation.
+ */
+export function _resetCacheForTesting() {
+  modelsCache = null;
+  fetchInFlight = null;
 }

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -6,11 +6,12 @@ const { mockFetch } = vi.hoisted(() => ({
 
 vi.stubGlobal('fetch', mockFetch);
 
-import { AIModelService } from '../../src/services/ai/ai-model.service';
+import { AIModelService, _resetCacheForTesting } from '../../src/services/ai/ai-model.service';
 
 describe('AIModelService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetCacheForTesting();
   });
 
   it('fetches the public OpenRouter catalog with all output modalities and caches it', async () => {
@@ -61,8 +62,10 @@ describe('AIModelService', () => {
         }),
     });
 
-    const firstResult = await AIModelService.getModels();
-    const secondResult = await AIModelService.getModels();
+    const [firstResult, secondResult] = await Promise.all([
+      AIModelService.getModels(),
+      AIModelService.getModels(),
+    ]);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -107,5 +110,31 @@ describe('AIModelService', () => {
         outputPriceLabel: undefined,
       },
     ]);
+  });
+
+  it('clears in-flight state after a failed fetch so a later call retries', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Too Many Requests',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [],
+          }),
+      });
+
+    // 1. First batch of concurrent calls should reject
+    await expect(
+      Promise.all([AIModelService.getModels(), AIModelService.getModels()])
+    ).rejects.toThrow();
+
+    // 2. The next call should trigger a fresh fetch
+    await AIModelService.getModels();
+
+    // 3. Since the first two shared a fetch, and the third triggered a new one, the total should be 2.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -128,7 +128,8 @@ export const chatCompletionRequestSchema = z.object({
   model: z.string(),
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
-  maxTokens: z.number().positive().optional(),
+  // Max cap set to 16,384 (standard max output for flagship models) to prevent financial abuse
+  maxTokens: z.number().int().positive().max(16384).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response


### PR DESCRIPTION
## Overview
This PR resolves #1525 by introducing two critical safeguards to protect the AI endpoint from financial abuse and concurrency crashes.

---

## Proposed Changes

### 1. Financial Safeguard: Token Cost Cap
- **Problem**: The Zod validation schema for chat completion requests (`chatCompletionRequestSchema` in `packages/shared-schemas/src/ai-api.schema.ts`) did not enforce an upper bound on `maxTokens`. A malicious or misconfigured client could request hundreds of thousands of tokens, draining the OpenRouter API budget.
- **Fix**: Added a strict `.max(16384)` constraint to the `maxTokens` property in Zod schema.

### 2. Stability Safeguard: Cache Stampede (Thundering Herd) Prevention
- **Problem**: Under heavy load, when the 1-hour models cache expired, multiple concurrent requests entering `getModels()` in `backend/src/services/ai/ai-model.service.ts` would all bypass the cache check and call the external OpenRouter URL simultaneously. This "thundering herd" causes downstream 429 rate limits and 500 server crashes.
- **Fix**: Declared a module-scoped `fetchInFlight: Promise<AIModelSchema[]> | null` tracking variable. Multiple concurrent cache-miss requests now wait on the same in-flight fetch promise, collapsing them into a single outbound request. The tracker is reset to `null` inside a `finally` block once resolved or rejected.

---

## Verification & Testing

### 1. Automated Tests
- Updated `backend/tests/unit/ai-model.service.test.ts` to execute `Promise.all` concurrently instead of sequentially.
- Verified that `mockFetch` is called **exactly once** for parallel requests, asserting that concurrent requests collapse correctly.
- Ran backend unit tests successfully:
  ```bash
  npx vitest run tests/unit/ai-model.service.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `maxTokens` cap and deduplicate concurrent model fetches to reduce token spend and prevent cache stampedes. Aligns with Linear #1525.

- **Bug Fixes**
  - Enforce `maxTokens` as a positive integer capped at 16,384 in `chatCompletionRequestSchema`.
  - Deduplicate concurrent `AIModelService.getModels()` calls via module-scoped `fetchInFlight`, cleared in `finally`.
  - On upstream errors, serve cached models when available and allow retry; added `_resetCacheForTesting()` and tests for concurrency and post-failure retry behavior.

<sup>Written for commit cb41cfe564f356602bf502d47840c229fee3bac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cache stampede prevention and cap `maxTokens` at 16384 in AI service
> - Introduces a module-level in-flight promise (`fetchInFlight`) in [`ai-model.service.ts`](https://github.com/InsForge/InsForge/pull/1526/files#diff-745b6cc8df215e75fc9d0984af6ba2b02356571c136e8e8d04d1cec69176fd35) so concurrent cache-miss calls share a single upstream fetch instead of each triggering their own request.
> - Clears the in-flight state in a `finally` block so failures allow retries on subsequent calls.
> - Tightens `maxTokens` validation in [`ai-api.schema.ts`](https://github.com/InsForge/InsForge/pull/1526/files#diff-b337ceae5cba47edcb003641f623c0fda08c1249dd6b57720f960f0af21fc78c) to reject non-integer values and values above 16384.
> - Behavioral Change: requests with `maxTokens > 16384` or non-integer `maxTokens` now fail schema validation at the API boundary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb41cfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Concurrent AI model catalog fetches are now deduplicated to reuse a single in-flight upstream request.
* **Bug Fixes**
  * `maxTokens` validation now enforces a positive integer with an optional cap of 16,384.
  * If the upstream AI service is unavailable, previously cached models are used when available.
  * Shared in-flight fetch state is cleared after failures to ensure subsequent calls retry.
* **Tests**
  * Updated unit tests to validate concurrent deduplication and retry behavior after a failed shared fetch.
  * Tests now reset cached/in-flight state between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->