### PR TITLE
Extract shared ListRow component for feature list rows

### DIFF
--- a/packages/dashboard/src/components/ListRow.tsx
+++ b/packages/dashboard/src/components/ListRow.tsx
@@ -1,0 +1,52 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '#lib/utils/utils';
+
+interface ListRowProps {
+  children: ReactNode;
+  /** Row click handler. When set, the card shows a pointer cursor. */
+  onClick?: () => void;
+  /** Overrides applied to the outer card. */
+  className?: string;
+  /** Overrides applied to the inner hover row (e.g. leading padding). */
+  contentClassName?: string;
+  /** Optional content rendered below the row, inside the card (e.g. an expanded panel). */
+  footer?: ReactNode;
+}
+
+/**
+ * The shared card-row shell used across feature list views: a bordered
+ * `bg-card` container with an inner hover surface. Pair with `ListRowCell` for
+ * the per-column cells. Centralizes the row design tokens so a design change
+ * lands in one place.
+ */
+export function ListRow({ children, onClick, className, contentClassName, footer }: ListRowProps) {
+  return (
+    <div className={cn('group rounded border border-[var(--alpha-8)] bg-card', className)}>
+      <div
+        className={cn(
+          'flex items-center rounded transition-colors hover:bg-[var(--alpha-8)]',
+          onClick && 'cursor-pointer',
+          contentClassName
+        )}
+        onClick={onClick}
+      >
+        {children}
+      </div>
+      {footer}
+    </div>
+  );
+}
+
+type ListRowCellProps = HTMLAttributes<HTMLDivElement>;
+
+/**
+ * A single fixed-height column within a `ListRow`. Sizing (`flex-1 min-w-0`,
+ * `w-[60px] shrink-0`, alignment, etc.) is supplied via `className`.
+ */
+export function ListRowCell({ className, children, ...props }: ListRowCellProps) {
+  return (
+    <div className={cn('flex h-12 items-center px-2.5', className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/__tests__/ListRow.test.tsx
+++ b/packages/dashboard/src/components/__tests__/ListRow.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ListRow, ListRowCell } from '#components';
+
+describe('ListRow', () => {
+  it('makes the inner row clickable with a pointer cursor when onClick is set', () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <ListRow onClick={onClick}>
+        <ListRowCell>Row content</ListRowCell>
+      </ListRow>
+    );
+
+    const outer = container.firstElementChild as HTMLElement;
+    const inner = outer.firstElementChild as HTMLElement;
+
+    // The cursor affordance lives on the inner row, not the outer card, so an
+    // optional footer (rendered as a sibling of the row) stays non-interactive.
+    expect(inner.className).toContain('cursor-pointer');
+    expect(outer.className).not.toContain('cursor-pointer');
+
+    fireEvent.click(inner);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not interactive when onClick is omitted', () => {
+    const { container } = render(
+      <ListRow>
+        <ListRowCell>Row content</ListRowCell>
+      </ListRow>
+    );
+
+    const inner = container.firstElementChild!.firstElementChild as HTMLElement;
+    expect(inner.className).not.toContain('cursor-pointer');
+  });
+
+  it('renders the footer below the row and outside the clickable area', () => {
+    const onClick = vi.fn();
+    render(
+      <ListRow onClick={onClick} footer={<button>Footer action</button>}>
+        <ListRowCell>Row content</ListRowCell>
+      </ListRow>
+    );
+
+    const footerButton = screen.getByRole('button', { name: 'Footer action' });
+    fireEvent.click(footerButton);
+
+    // Clicking the footer must not trigger the row's onClick.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('omits the footer node when footer is falsy', () => {
+    const { container } = render(
+      <ListRow footer={false}>
+        <ListRowCell>Row content</ListRowCell>
+      </ListRow>
+    );
+
+    // Only the inner row, no trailing footer sibling.
+    expect(container.firstElementChild!.children).toHaveLength(1);
+  });
+});
+
+describe('ListRowCell', () => {
+  it('applies the default cell padding', () => {
+    const { container } = render(<ListRowCell>cell</ListRowCell>);
+    expect((container.firstElementChild as HTMLElement).className).toContain('px-2.5');
+  });
+
+  it('lets a px override win over the default padding', () => {
+    const { container } = render(<ListRowCell className="w-12 px-0">cell</ListRowCell>);
+    const cell = container.firstElementChild as HTMLElement;
+
+    expect(cell.className).toContain('px-0');
+    expect(cell.className).not.toContain('px-2.5');
+  });
+});

--- a/packages/dashboard/src/components/index.ts
+++ b/packages/dashboard/src/components/index.ts
@@ -20,6 +20,7 @@ export { DeleteActionButton } from './DeleteActionButton';
 export { EmptyState, type EmptyStateProps } from '@insforge/ui';
 export { EmptyStateIllustration } from './EmptyStateIllustration';
 export { ErrorState } from './ErrorState';
+export { ListRow, ListRowCell } from './ListRow';
 export { LoadingState, type LoadingStateProps } from '@insforge/ui';
 export { PaginationControls, type PaginationControlsProps } from './PaginationControls';
 export { SelectionClearButton } from './SelectionClearButton';

--- a/packages/dashboard/src/features/functions/components/FunctionRow.tsx
+++ b/packages/dashboard/src/features/functions/components/FunctionRow.tsx
@@ -1,6 +1,7 @@
 import { CopyButton } from '@insforge/ui';
 import { FunctionSchema } from '@insforge/shared-schemas';
-import { cn, getBackendUrl } from '#lib/utils/utils';
+import { getBackendUrl } from '#lib/utils/utils';
+import { ListRow, ListRowCell } from '#components';
 import { format, formatDistance } from 'date-fns';
 interface FunctionRowProps {
   function: FunctionSchema;
@@ -21,54 +22,46 @@ export function FunctionRow({
     : `${getBackendUrl()}/functions/${func.slug}`;
 
   return (
-    <div
-      className={cn(
-        'group rounded border border-[var(--alpha-8)] bg-card cursor-pointer',
-        className
-      )}
-      onClick={onClick}
-    >
-      <div className="flex items-center pl-2 rounded hover:bg-[var(--alpha-8)] transition-colors">
-        {/* Name Column */}
-        <div className="flex-[1.5] min-w-0 h-12 flex items-center px-2.5">
-          <p className="text-sm leading-[18px] text-foreground truncate" title={func.name}>
-            {func.name}
-          </p>
-        </div>
+    <ListRow className={className} contentClassName="pl-2" onClick={onClick}>
+      {/* Name Column */}
+      <ListRowCell className="flex-[1.5] min-w-0">
+        <p className="text-sm leading-[18px] text-foreground truncate" title={func.name}>
+          {func.name}
+        </p>
+      </ListRowCell>
 
-        {/* URL Column */}
-        <div className="flex-[3] min-w-0 h-12 flex items-center px-2.5">
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="text-sm leading-[18px] text-foreground truncate" title={functionUrl}>
-              {functionUrl}
-            </span>
-            <CopyButton
-              showText={false}
-              text={functionUrl}
-              className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-            />
-          </div>
-        </div>
-
-        {/* Created Column */}
-        <div className="flex-[1.5] min-w-0 h-12 flex items-center px-2.5">
-          <span className="text-sm leading-[18px] text-foreground truncate" title={func.createdAt}>
-            {format(new Date(func.createdAt), 'MMM dd, yyyy, hh:mm a')}
+      {/* URL Column */}
+      <ListRowCell className="flex-[3] min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm leading-[18px] text-foreground truncate" title={functionUrl}>
+            {functionUrl}
           </span>
+          <CopyButton
+            showText={false}
+            text={functionUrl}
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+          />
         </div>
+      </ListRowCell>
 
-        {/* Last Update Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span
-            className="text-sm leading-[18px] text-foreground truncate"
-            title={func.deployedAt ?? ''}
-          >
-            {func.deployedAt
-              ? formatDistance(new Date(func.deployedAt), new Date(), { addSuffix: true })
-              : 'Never'}
-          </span>
-        </div>
-      </div>
-    </div>
+      {/* Created Column */}
+      <ListRowCell className="flex-[1.5] min-w-0">
+        <span className="text-sm leading-[18px] text-foreground truncate" title={func.createdAt}>
+          {format(new Date(func.createdAt), 'MMM dd, yyyy, hh:mm a')}
+        </span>
+      </ListRowCell>
+
+      {/* Last Update Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span
+          className="text-sm leading-[18px] text-foreground truncate"
+          title={func.deployedAt ?? ''}
+        >
+          {func.deployedAt
+            ? formatDistance(new Date(func.deployedAt), new Date(), { addSuffix: true })
+            : 'Never'}
+        </span>
+      </ListRowCell>
+    </ListRow>
   );
 }

--- a/packages/dashboard/src/features/functions/components/ScheduleRow.tsx
+++ b/packages/dashboard/src/features/functions/components/ScheduleRow.tsx
@@ -1,4 +1,3 @@
-import { cn } from '#lib/utils/utils';
 import type { ScheduleSchema } from '@insforge/shared-schemas';
 import { format } from 'date-fns';
 import { MoreVertical, Pencil, Trash2 } from 'lucide-react';
@@ -11,6 +10,7 @@ import {
   DropdownMenuItem,
   Switch,
 } from '@insforge/ui';
+import { ListRow, ListRowCell } from '#components';
 
 interface ScheduleRowProps {
   schedule: ScheduleSchema;
@@ -32,104 +32,90 @@ export function ScheduleRow({
   className,
 }: ScheduleRowProps) {
   return (
-    <div
-      className={cn(
-        'group rounded border border-[var(--alpha-8)] bg-card cursor-pointer',
-        className
-      )}
-      onClick={onClick}
-    >
-      <div className="flex items-center pl-2 rounded hover:bg-[var(--alpha-8)] transition-colors">
-        {/* Name Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <p className="text-sm text-foreground truncate" title={schedule.name}>
-            {schedule.name}
-          </p>
-        </div>
+    <ListRow className={className} contentClassName="pl-2" onClick={onClick}>
+      {/* Name Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <p className="text-sm text-foreground truncate" title={schedule.name}>
+          {schedule.name}
+        </p>
+      </ListRowCell>
 
-        {/* Function URL Column */}
-        <div className="flex-[2] min-w-0 h-12 flex items-center px-2.5">
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="text-sm text-foreground truncate" title={schedule.functionUrl}>
-              {schedule.functionUrl}
-            </span>
-            <CopyButton
-              showText={false}
-              text={schedule.functionUrl}
-              className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-            />
-          </div>
-        </div>
-
-        {/* Next Run Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground truncate" title={schedule.nextRun ?? ''}>
-            {schedule.isActive
-              ? schedule.nextRun
-                ? format(new Date(schedule.nextRun), 'MMM dd, yyyy HH:mm')
-                : 'Not scheduled'
-              : 'Inactive'}
+      {/* Function URL Column */}
+      <ListRowCell className="flex-[2] min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-sm text-foreground truncate" title={schedule.functionUrl}>
+            {schedule.functionUrl}
           </span>
-        </div>
-
-        {/* Last Run Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground truncate" title={schedule.lastExecutedAt ?? ''}>
-            {schedule.lastExecutedAt
-              ? format(new Date(schedule.lastExecutedAt), 'MMM dd, yyyy HH:mm')
-              : 'Never'}
-          </span>
-        </div>
-
-        {/* Created Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground truncate" title={schedule.createdAt}>
-            {format(new Date(schedule.createdAt), 'MMM dd, yyyy HH:mm')}
-          </span>
-        </div>
-
-        {/* Active Toggle Column */}
-        <div
-          className="w-[60px] shrink-0 h-12 flex items-center px-2.5"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Switch
-            checked={Boolean(schedule.isActive)}
-            onCheckedChange={(next) => onToggle(schedule.id, next)}
-            disabled={isLoading}
-            aria-label={`${schedule.name} active toggle`}
+          <CopyButton
+            showText={false}
+            text={schedule.functionUrl}
+            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
           />
         </div>
+      </ListRowCell>
 
-        {/* Actions Column */}
-        <div
-          className="w-12 shrink-0 h-12 flex items-center justify-end px-2.5"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-sm" title={`Actions for ${schedule.name}`}>
-                <MoreVertical className="w-4 h-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              sideOffset={6}
-              className="w-40"
-              onCloseAutoFocus={(e) => e.preventDefault()}
-            >
-              <DropdownMenuItem onSelect={() => onEdit(schedule.id)}>
-                <Pencil className="mr-2 h-4 w-4" />
-                <span>Edit</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => onDelete(schedule.id)} className="text-destructive">
-                <Trash2 className="mr-2 h-4 w-4" />
-                <span>Delete</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-    </div>
+      {/* Next Run Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground truncate" title={schedule.nextRun ?? ''}>
+          {schedule.isActive
+            ? schedule.nextRun
+              ? format(new Date(schedule.nextRun), 'MMM dd, yyyy HH:mm')
+              : 'Not scheduled'
+            : 'Inactive'}
+        </span>
+      </ListRowCell>
+
+      {/* Last Run Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground truncate" title={schedule.lastExecutedAt ?? ''}>
+          {schedule.lastExecutedAt
+            ? format(new Date(schedule.lastExecutedAt), 'MMM dd, yyyy HH:mm')
+            : 'Never'}
+        </span>
+      </ListRowCell>
+
+      {/* Created Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground truncate" title={schedule.createdAt}>
+          {format(new Date(schedule.createdAt), 'MMM dd, yyyy HH:mm')}
+        </span>
+      </ListRowCell>
+
+      {/* Active Toggle Column */}
+      <ListRowCell className="w-[60px] shrink-0" onClick={(e) => e.stopPropagation()}>
+        <Switch
+          checked={Boolean(schedule.isActive)}
+          onCheckedChange={(next) => onToggle(schedule.id, next)}
+          disabled={isLoading}
+          aria-label={`${schedule.name} active toggle`}
+        />
+      </ListRowCell>
+
+      {/* Actions Column */}
+      <ListRowCell className="w-12 shrink-0 justify-end" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-sm" title={`Actions for ${schedule.name}`}>
+              <MoreVertical className="w-4 h-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            sideOffset={6}
+            className="w-40"
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            <DropdownMenuItem onSelect={() => onEdit(schedule.id)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              <span>Edit</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onDelete(schedule.id)} className="text-destructive">
+              <Trash2 className="mr-2 h-4 w-4" />
+              <span>Delete</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </ListRowCell>
+    </ListRow>
   );
 }
 

--- a/packages/dashboard/src/features/functions/components/SecretRow.tsx
+++ b/packages/dashboard/src/features/functions/components/SecretRow.tsx
@@ -2,6 +2,7 @@ import { Eye, EyeOff, Loader2, Trash2 } from 'lucide-react';
 import { Button, CopyButton } from '@insforge/ui';
 import { SecretSchema } from '@insforge/shared-schemas';
 import { cn } from '#lib/utils/utils';
+import { ListRow, ListRowCell } from '#components';
 import { formatDistance } from 'date-fns';
 import { useSecretValue } from '#features/functions/hooks/useSecrets';
 
@@ -32,83 +33,81 @@ export function SecretRow({ secret, onDelete, className }: SecretRowProps) {
     isValueVisible && revealedSecret ? revealedSecret.value : (valueError ?? 'Reveal secret value');
 
   return (
-    <div className={cn('group rounded border border-[var(--alpha-8)] bg-card', className)}>
-      <div className="flex items-center pl-1.5 rounded hover:bg-[var(--alpha-8)] transition-colors">
-        {/* Name Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <p className="text-sm text-foreground truncate" title={secret.key}>
-            {secret.key}
-          </p>
-        </div>
+    <ListRow className={className} contentClassName="pl-1.5">
+      {/* Name Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <p className="text-sm text-foreground truncate" title={secret.key}>
+          {secret.key}
+        </p>
+      </ListRowCell>
 
-        {/* Value Column */}
-        <div className="flex-[1.5] min-w-0 h-12 flex items-center gap-2 px-2.5">
+      {/* Value Column */}
+      <ListRowCell className="flex-[1.5] min-w-0 gap-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={(e) => void handleToggleValue(e)}
+          disabled={isFetchingValue}
+          className="size-7 shrink-0 rounded text-muted-foreground hover:text-foreground"
+          title={isValueVisible ? 'Hide secret value' : 'Reveal secret value'}
+          aria-label={
+            isValueVisible ? `Hide value for ${secret.key}` : `Reveal value for ${secret.key}`
+          }
+        >
+          {isFetchingValue ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : isValueVisible ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </Button>
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-sm',
+            isValueVisible && revealedSecret
+              ? 'font-mono text-foreground'
+              : 'text-muted-foreground',
+            valueError && 'text-destructive'
+          )}
+          title={valueTitle}
+        >
+          {displayedValue}
+        </span>
+        {isValueVisible && revealedSecret ? (
+          <CopyButton
+            showText={false}
+            text={revealedSecret.value}
+            copyText="Copy secret value"
+            copiedText="Copied secret value"
+            className="size-6 shrink-0"
+          />
+        ) : null}
+      </ListRowCell>
+
+      {/* Updated at Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground truncate">
+          {secret.updatedAt
+            ? formatDistance(new Date(secret.updatedAt), new Date(), { addSuffix: true })
+            : 'Never'}
+        </span>
+      </ListRowCell>
+
+      {/* Delete Button Column */}
+      <ListRowCell className="w-12 justify-end">
+        {!secret.isReserved && (
           <Button
             variant="ghost"
-            size="icon-sm"
-            onClick={(e) => void handleToggleValue(e)}
-            disabled={isFetchingValue}
-            className="size-7 shrink-0 rounded text-muted-foreground hover:text-foreground"
-            title={isValueVisible ? 'Hide secret value' : 'Reveal secret value'}
-            aria-label={
-              isValueVisible ? `Hide value for ${secret.key}` : `Reveal value for ${secret.key}`
-            }
+            size="icon"
+            onClick={handleDeleteClick}
+            className="size-8 p-1.5 text-muted-foreground hover:text-foreground hover:bg-[var(--alpha-8)] opacity-0 group-hover:opacity-100 transition-opacity"
+            title="Delete secret"
           >
-            {isFetchingValue ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : isValueVisible ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
+            <Trash2 className="w-5 h-5" />
           </Button>
-          <span
-            className={cn(
-              'min-w-0 flex-1 truncate text-sm',
-              isValueVisible && revealedSecret
-                ? 'font-mono text-foreground'
-                : 'text-muted-foreground',
-              valueError && 'text-destructive'
-            )}
-            title={valueTitle}
-          >
-            {displayedValue}
-          </span>
-          {isValueVisible && revealedSecret ? (
-            <CopyButton
-              showText={false}
-              text={revealedSecret.value}
-              copyText="Copy secret value"
-              copiedText="Copied secret value"
-              className="size-6 shrink-0"
-            />
-          ) : null}
-        </div>
-
-        {/* Updated at Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground truncate">
-            {secret.updatedAt
-              ? formatDistance(new Date(secret.updatedAt), new Date(), { addSuffix: true })
-              : 'Never'}
-          </span>
-        </div>
-
-        {/* Delete Button Column */}
-        <div className="w-12 h-12 flex items-center justify-end px-2.5">
-          {!secret.isReserved && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleDeleteClick}
-              className="size-8 p-1.5 text-muted-foreground hover:text-foreground hover:bg-[var(--alpha-8)] opacity-0 group-hover:opacity-100 transition-opacity"
-              title="Delete secret"
-            >
-              <Trash2 className="w-5 h-5" />
-            </Button>
-          )}
-        </div>
-      </div>
-    </div>
+        )}
+      </ListRowCell>
+    </ListRow>
   );
 }

--- a/packages/dashboard/src/features/realtime/components/ChannelRow.tsx
+++ b/packages/dashboard/src/features/realtime/components/ChannelRow.tsx
@@ -1,6 +1,7 @@
-import { cn, formatDate } from '#lib/utils/utils';
+import { formatDate } from '#lib/utils/utils';
 import { Trash2 } from 'lucide-react';
 import { Switch } from '@insforge/ui';
+import { ListRow, ListRowCell } from '#components';
 import type { RealtimeChannel } from '#features/realtime/services/realtime.service';
 
 interface ChannelRowProps {
@@ -23,69 +24,57 @@ export function ChannelRow({
   className,
 }: ChannelRowProps) {
   return (
-    <div
-      className={cn(
-        'group rounded border border-[var(--alpha-8)] bg-card cursor-pointer',
-        className
-      )}
-      onClick={onClick}
-    >
-      {/* Inner state layer — hover overlays on top of bg-card */}
-      <div className="flex items-center pl-1.5 rounded hover:bg-[var(--alpha-8)] transition-colors">
-        {/* Toggle Switch */}
-        <div className="flex items-center w-[62px] shrink-0 h-12 px-2.5">
-          <Switch
-            checked={channel.enabled}
-            disabled={isUpdating}
-            onCheckedChange={(checked) => {
-              onToggleEnabled(checked);
-            }}
-            onClick={(e) => e.stopPropagation()}
-          />
-        </div>
+    <ListRow className={className} contentClassName="pl-1.5" onClick={onClick}>
+      {/* Toggle Switch */}
+      <ListRowCell className="w-[62px] shrink-0">
+        <Switch
+          checked={channel.enabled}
+          disabled={isUpdating}
+          onCheckedChange={(checked) => {
+            onToggleEnabled(checked);
+          }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </ListRowCell>
 
-        {/* Pattern Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <p className="text-sm leading-[18px] text-foreground truncate" title={channel.pattern}>
-            {channel.pattern}
-          </p>
-        </div>
+      {/* Pattern Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <p className="text-sm leading-[18px] text-foreground truncate" title={channel.pattern}>
+          {channel.pattern}
+        </p>
+      </ListRowCell>
 
-        {/* Description Column */}
-        <div className="flex-[2.5] min-w-0 h-12 flex items-center px-2.5">
-          <span
-            className="text-sm text-foreground leading-[18px] truncate block"
-            title={channel.description || ''}
-          >
-            {channel.description || '-'}
-          </span>
-        </div>
+      {/* Description Column */}
+      <ListRowCell className="flex-[2.5] min-w-0">
+        <span
+          className="text-sm text-foreground leading-[18px] truncate block"
+          title={channel.description || ''}
+        >
+          {channel.description || '-'}
+        </span>
+      </ListRowCell>
 
-        {/* Created Column */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span
-            className="text-sm text-foreground leading-[18px] truncate"
-            title={channel.createdAt}
-          >
-            {formatDate(channel.createdAt)}
-          </span>
-        </div>
+      {/* Created Column */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground leading-[18px] truncate" title={channel.createdAt}>
+          {formatDate(channel.createdAt)}
+        </span>
+      </ListRowCell>
 
-        {/* Delete Button - hidden by default, visible on hover */}
-        <div className="w-[52px] shrink-0 flex items-center justify-center h-12">
-          <button
-            className="flex items-center justify-center size-8 rounded opacity-0 group-hover:opacity-100 hover:bg-[var(--alpha-8)] transition-all disabled:opacity-50"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            disabled={isDeleting}
-            aria-label="Delete channel"
-          >
-            <Trash2 className="size-5 text-muted-foreground group-hover:text-foreground transition-colors" />
-          </button>
-        </div>
-      </div>
-    </div>
+      {/* Delete Button - hidden by default, visible on hover */}
+      <ListRowCell className="w-[52px] shrink-0 justify-center px-0">
+        <button
+          className="flex items-center justify-center size-8 rounded opacity-0 group-hover:opacity-100 hover:bg-[var(--alpha-8)] transition-all disabled:opacity-50"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          disabled={isDeleting}
+          aria-label="Delete channel"
+        >
+          <Trash2 className="size-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+        </button>
+      </ListRowCell>
+    </ListRow>
   );
 }

--- a/packages/dashboard/src/features/realtime/components/MessageRow.tsx
+++ b/packages/dashboard/src/features/realtime/components/MessageRow.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { CodeBlock } from '@insforge/ui';
 import { cn, formatTime } from '#lib/utils/utils';
+import { ListRow, ListRowCell } from '#components';
 import type { RealtimeMessage } from '#features/realtime/services/realtime.service';
 
 interface MessageRowProps {
@@ -13,84 +14,78 @@ export function MessageRow({ message, className }: MessageRowProps) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className={cn('rounded border border-[var(--alpha-8)] bg-card', className)}>
-      {/* Row */}
-      <div
-        className="flex items-center rounded cursor-pointer hover:bg-[var(--alpha-8)] transition-colors"
-        onClick={() => setExpanded((prev) => !prev)}
-      >
-        {/* Chevron */}
-        <div className="w-[30px] shrink-0 flex items-center justify-center">
-          <ChevronRight
-            className={cn(
-              'w-4 h-4 text-muted-foreground transition-transform',
-              expanded && 'rotate-90'
-            )}
-          />
-        </div>
+    <ListRow
+      className={className}
+      onClick={() => setExpanded((prev) => !prev)}
+      footer={
+        expanded && (
+          <div className="px-3 pb-3">
+            <CodeBlock
+              code={JSON.stringify(message.payload, null, 2)}
+              label="Payload"
+              variant="compact"
+            />
+          </div>
+        )
+      }
+    >
+      {/* Chevron */}
+      <ListRowCell className="w-[30px] shrink-0 justify-center px-0">
+        <ChevronRight
+          className={cn(
+            'w-4 h-4 text-muted-foreground transition-transform',
+            expanded && 'rotate-90'
+          )}
+        />
+      </ListRowCell>
 
-        {/* Event Name */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <p className="text-sm leading-[18px] text-foreground truncate" title={message.eventName}>
-            {message.eventName}
-          </p>
-        </div>
+      {/* Event Name */}
+      <ListRowCell className="flex-1 min-w-0">
+        <p className="text-sm leading-[18px] text-foreground truncate" title={message.eventName}>
+          {message.eventName}
+        </p>
+      </ListRowCell>
 
-        {/* Channel */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span
-            className="text-sm text-foreground leading-[18px] truncate block"
-            title={message.channelName}
-          >
-            {message.channelName}
-          </span>
-        </div>
+      {/* Channel */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span
+          className="text-sm text-foreground leading-[18px] truncate block"
+          title={message.channelName}
+        >
+          {message.channelName}
+        </span>
+      </ListRowCell>
 
-        {/* Sender Type */}
-        <div className="w-[80px] shrink-0 h-12 flex items-center px-2.5">
-          <span
-            className={cn(
-              'inline-flex items-center justify-center h-5 px-1.5 rounded-sm text-xs font-medium text-white capitalize',
-              message.senderType === 'system' ? 'bg-sky-800' : 'bg-teal-700'
-            )}
-          >
-            {message.senderType}
-          </span>
-        </div>
+      {/* Sender Type */}
+      <ListRowCell className="w-[80px] shrink-0">
+        <span
+          className={cn(
+            'inline-flex items-center justify-center h-5 px-1.5 rounded-sm text-xs font-medium text-white capitalize',
+            message.senderType === 'system' ? 'bg-sky-800' : 'bg-teal-700'
+          )}
+        >
+          {message.senderType}
+        </span>
+      </ListRowCell>
 
-        {/* WebSockets */}
-        <div className="w-[100px] shrink-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground leading-[18px]">{message.wsAudienceCount}</span>
-        </div>
+      {/* WebSockets */}
+      <ListRowCell className="w-[100px] shrink-0">
+        <span className="text-sm text-foreground leading-[18px]">{message.wsAudienceCount}</span>
+      </ListRowCell>
 
-        {/* Webhooks */}
-        <div className="w-[100px] shrink-0 h-12 flex items-center px-2.5">
-          <span className="text-sm text-foreground leading-[18px]">
-            {message.whDeliveredCount}/{message.whAudienceCount}
-          </span>
-        </div>
+      {/* Webhooks */}
+      <ListRowCell className="w-[100px] shrink-0">
+        <span className="text-sm text-foreground leading-[18px]">
+          {message.whDeliveredCount}/{message.whAudienceCount}
+        </span>
+      </ListRowCell>
 
-        {/* Sent At */}
-        <div className="flex-1 min-w-0 h-12 flex items-center px-2.5">
-          <span
-            className="text-sm text-foreground leading-[18px] truncate"
-            title={message.createdAt}
-          >
-            {formatTime(message.createdAt)}
-          </span>
-        </div>
-      </div>
-
-      {/* Expanded payload */}
-      {expanded && (
-        <div className="px-3 pb-3">
-          <CodeBlock
-            code={JSON.stringify(message.payload, null, 2)}
-            label="Payload"
-            variant="compact"
-          />
-        </div>
-      )}
-    </div>
+      {/* Sent At */}
+      <ListRowCell className="flex-1 min-w-0">
+        <span className="text-sm text-foreground leading-[18px] truncate" title={message.createdAt}>
+          {formatTime(message.createdAt)}
+        </span>
+      </ListRowCell>
+    </ListRow>
   );
 }

--- a/packages/dashboard/src/features/realtime/components/__tests__/MessageRow.test.tsx
+++ b/packages/dashboard/src/features/realtime/components/__tests__/MessageRow.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { RealtimeMessage } from '#features/realtime/services/realtime.service';
+import { MessageRow } from '#features/realtime/components/MessageRow';
+
+const message: RealtimeMessage = {
+  id: '11111111-1111-1111-1111-111111111111',
+  eventName: 'user.created',
+  channelId: null,
+  channelName: 'public',
+  payload: { hello: 'world' },
+  senderType: 'user',
+  senderId: null,
+  wsAudienceCount: 3,
+  whAudienceCount: 2,
+  whDeliveredCount: 1,
+  createdAt: '2026-06-15T10:00:00.000Z',
+};
+
+describe('MessageRow', () => {
+  it('toggles the payload panel when the row is clicked', () => {
+    render(<MessageRow message={message} />);
+
+    // Collapsed by default — the payload panel (CodeBlock labeled "Payload") is absent.
+    expect(screen.queryByText('Payload')).toBeNull();
+
+    const row = screen.getByText('user.created');
+
+    fireEvent.click(row);
+    expect(screen.getByText('Payload')).toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(screen.queryByText('Payload')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the duplicated card-row markup across feature list views into a shared `ListRow` + `ListRowCell` pair in `#components`, so the row design tokens (`border border-[var(--alpha-8)]`, `bg-card`, `hover:bg-[var(--alpha-8)]`, `h-12`/`px-2.5`) live in one place instead of being copy-pasted.

- **New**: `ListRow` (bordered `bg-card` shell + inner hover surface, optional `footer` slot) and `ListRowCell` (fixed-height column; sizing supplied via `className`).
- **Converted** the 5 components sharing this idiom: `SecretRow`, `FunctionRow`, `ScheduleRow`, `ChannelRow`, and `MessageRow` (uses the `footer` slot for its expandable payload panel).
- **Intentionally left alone**: `EnvVarRow` (legacy neutral-color + `grid-cols-12` styling) and `ModelRow` (borderless table row) — converting them would change their appearance. `EnvVarRow` is a reasonable follow-up modernization with design sign-off.

## Behavior

Behavior-preserving refactor — per-cell Tailwind classes are reproduced as-is. Notes on the deliberate equivalences:
- `cursor-pointer` sits on the inner row (not the outer card) so `MessageRow`'s expanded payload panel isn't given a pointer cursor; for the non-expandable rows the inner fills the card, so it's identical.
- Chevron/delete cells pass `px-0` to override `ListRowCell`'s default `px-2.5` (those cells had no padding originally; `tailwind-merge` resolves the conflict). Cells that *did* have `px-2.5` originally (e.g. `SecretRow`'s delete column) keep it via the default.
- Two benign, non-visual additions on `MessageRow` from routing through `ListRow`: its outer card now carries `group` (no `group-hover:` descendants, so inert) and its chevron cell picks up the default `h-12` (sibling cells already set the row height, so it's centered identically). The other four rows already had `group`.

## Testing

- New `ListRow.test.tsx` locks the shared contracts: `onClick` ⇒ inner row gets `cursor-pointer` (outer doesn't), footer renders outside the clickable area, and `ListRowCell`'s `px-0` override beats the default `px-2.5`.
- New `MessageRow.test.tsx` covers the chevron expand/collapse toggle of the payload panel — the one piece of real logic in the extraction.
- `typecheck`, `lint` (0 warnings), `build`, and `test` (67/67) all pass.

## Follow-up (not in this PR)

Clickable rows use a `div` + `onClick` with no keyboard affordance — a pre-existing gap across all 5 originals. Now that the click pattern lives in one place it's a good candidate to address, but a correct fix must distinguish purely-clickable rows from rows that contain nested interactive controls (`ChannelRow`/`ScheduleRow` have a `Switch`/dropdown), so it's deferred to its own scoped change rather than a blanket `role="button"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ## Summary
>
> Extracts the duplicated card-row markup across feature list views into a shared `ListRow` + `ListRowCell` pair in `#components`, so the row design tokens (`border border-[var(--alpha-8)]`, `bg-card`, `hover:bg-[var(--alpha-8)]`, `h-12`/`px-2.5`) live in one place instead of being copy-pasted.
>
> - **New**: `ListRow` (bordered `bg-card` shell + inner hover surface, optional `footer` slot) and `ListRowCell` (fixed-height column; sizing supplied via `className`).
> - **Converted** the 5 components sharing this idiom: `SecretRow`, `FunctionRow`, `ScheduleRow`, `ChannelRow`, and `MessageRow` (uses the `footer` slot for its expandable payload panel).
> - **Intentionally left alone**: `EnvVarRow` (legacy neutral-color + `grid-cols-12` styling) and `ModelRow` (borderless table row) — converting them would change their appearance. `EnvVarRow` is a reasonable follow-up modernization with design sign-off.
>
> ## Behavior
>
> Behavior-preserving refactor — per-cell Tailwind classes are reproduced as-is. Notes on the deliberate equivalences:
> - `cursor-pointer` sits on the inner row (not the outer card) so `MessageRow`'s expanded payload panel isn't given a pointer cursor; for the non-expandable rows the inner fills the card, so it's identical.
> - Chevron/delete cells pass `px-0` to override `ListRowCell`'s default `px-2.5` (those cells had no padding originally; `tailwind-merge` resolves the conflict). Cells that *did* have `px-2.5` originally (e.g. `SecretRow`'s delete column) keep it via the default.
> - Two benign, non-visual additions on `MessageRow` from routing through `ListRow`: its outer card now carries `group` (no `group-hover:` descendants, so inert) and its chevron cell picks up the default `h-12` (sibling cells already set the row height, so it's centered identically). The other four rows already had `group`.
>
> ## Testing
>
> - New `ListRow.test.tsx` locks the shared contracts: `onClick` ⇒ inner row gets `cursor-pointer` (outer doesn't), footer renders outside the clickable area, and `ListRowCell`'s `px-0` override beats the default `px-2.5`.
> - New `MessageRow.test.tsx` covers the chevron expand/collapse toggle of the payload panel — the one piece of real logic in the extraction.
> - `typecheck`, `lint` (0 warnings), `build`, and `test` (67/67) all pass.
>
> ## Follow-up (not in this PR)
>
> Clickable rows use a `div` + `onClick` with no keyboard affordance — a pre-existing gap across all 5 originals. Now that the click pattern lives in one place it's a good candidate to address, but a correct fix must distinguish purely-clickable rows from rows that contain nested interactive controls (`ChannelRow`/`ScheduleRow` have a `Switch`/dropdown), so it's deferred to its own scoped change rather than a blanket `role="button"`.
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #1527 opened
>
> - Added test suite for `ListRow` and `ListRowCell` components in `dashboard` package [900b666]
> - Added test for `MessageRow` component payload panel toggle behavior in `dashboard` package realtime feature [900b666]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard row-based screens (functions, schedules, secrets, channels, messages) to use standardized, bordered “row card” layouts via new shared row components.
* **New Features**
  * Added reusable `ListRow` and `ListRowCell` building blocks, including optional footer support and consistent cell padding/alignment.
* **Tests**
  * Added coverage for `ListRow` behavior and for message row expand/collapse functionality.
* **Chores**
  * Re-exported the new row components from the dashboard component index for easier use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->