### PR TITLE
Share the payment webhook-event store and normalize Razorpay errors

### DIFF
--- a/backend/src/api/routes/payments/razorpay/catalog.routes.ts
+++ b/backend/src/api/routes/payments/razorpay/catalog.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type Response, type NextFunction } from 'express';
+import { normalizeRazorpayError } from '@/providers/payments/razorpay-errors.js';
 import { type AuthRequest } from '@/api/middlewares/auth.js';
 import { RazorpayCatalogService } from '@/services/payments/razorpay/catalog.service.js';
 import { getPaymentEnvironment } from '@/services/payments/helpers.js';
@@ -20,7 +21,7 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction) => {
     const catalog = await catalogService.listCatalog(environment);
     successResponse(res, catalog);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -34,7 +35,7 @@ router.post('/items', async (req: AuthRequest, res: Response, next: NextFunction
     });
     successResponse(res, item, 201);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -49,7 +50,7 @@ router.patch('/items/:itemId', async (req: AuthRequest, res: Response, next: Nex
     });
     successResponse(res, item);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -63,7 +64,7 @@ router.post('/plans', async (req: AuthRequest, res: Response, next: NextFunction
     });
     successResponse(res, plan, 201);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 

--- a/backend/src/api/routes/payments/razorpay/config.routes.ts
+++ b/backend/src/api/routes/payments/razorpay/config.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type Response, type NextFunction } from 'express';
+import { normalizeRazorpayError } from '@/providers/payments/razorpay-errors.js';
 import { type AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
@@ -33,7 +34,7 @@ router.put('/config', async (req: AuthRequest, res: Response, next: NextFunction
     const keys = await configService.getKeyConfig();
     successResponse(res, { keys });
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -51,7 +52,7 @@ router.delete('/config', async (req: AuthRequest, res: Response, next: NextFunct
     const keys = await configService.getKeyConfig();
     successResponse(res, { keys });
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -61,7 +62,7 @@ router.post('/sync', async (req: AuthRequest, res: Response, next: NextFunction)
     const result = await syncService.syncAll(environment);
     successResponse(res, result);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -71,7 +72,7 @@ router.get('/webhook', async (req: AuthRequest, res: Response, next: NextFunctio
     const result = await configService.getWebhookSetup(environment);
     successResponse(res, result);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -83,7 +84,7 @@ router.post(
       const result = await configService.rotateWebhookSecret(environment);
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );

--- a/backend/src/api/routes/payments/razorpay/index.routes.ts
+++ b/backend/src/api/routes/payments/razorpay/index.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type Response, type NextFunction } from 'express';
+import { normalizeRazorpayError } from '@/providers/payments/razorpay-errors.js';
 import { verifyAdmin, verifyUser, type AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
@@ -41,7 +42,7 @@ router.get('/status', verifyAdmin, async (_req: AuthRequest, res: Response, next
     const connections = await configService.getRazorpayStatus();
     successResponse(res, { razorpayConnections: connections });
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -50,7 +51,7 @@ router.get('/config', verifyAdmin, async (_req: AuthRequest, res: Response, next
     const keys = await configService.getKeyConfig();
     successResponse(res, { keys });
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -59,7 +60,7 @@ router.post('/sync', verifyAdmin, async (_req: AuthRequest, res: Response, next:
     const result = await syncService.syncAll('all');
     successResponse(res, result);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -88,7 +89,7 @@ environmentRouter.post(
       );
       successResponse(res, order, 201);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -115,7 +116,7 @@ environmentRouter.post(
       });
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -145,7 +146,7 @@ environmentRouter.post(
       );
       successResponse(res, subscription, 201);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -172,7 +173,7 @@ environmentRouter.post(
       });
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -202,7 +203,7 @@ environmentRouter.post(
       );
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -226,7 +227,7 @@ environmentRouter.post(
       const result = await subscriptionService.pauseSubscription(params, req.user);
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -250,7 +251,7 @@ environmentRouter.post(
       const result = await subscriptionService.resumeSubscription(params, req.user);
       successResponse(res, result);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -266,7 +267,7 @@ environmentRouter.get('/customers', async (req: AuthRequest, res: Response, next
     const customers = await customerService.listCustomers({ environment, ...query }, 'razorpay');
     successResponse(res, customers);
   } catch (error) {
-    next(error);
+    next(normalizeRazorpayError(error));
   }
 });
 
@@ -285,7 +286,7 @@ environmentRouter.get(
       );
       successResponse(res, transactions);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );
@@ -299,7 +300,7 @@ environmentRouter.get(
       const subscriptions = await subscriptionService.listSubscriptions({ environment, ...query });
       successResponse(res, subscriptions);
     } catch (error) {
-      next(error);
+      next(normalizeRazorpayError(error));
     }
   }
 );

--- a/backend/src/providers/payments/razorpay-errors.ts
+++ b/backend/src/providers/payments/razorpay-errors.ts
@@ -1,0 +1,63 @@
+import { AppError, UpstreamError, getUpstreamStatus } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { RazorpayKeyValidationError } from './razorpay.provider.js';
+
+interface RazorpayErrorLike {
+  statusCode?: unknown;
+  error?: unknown;
+  message?: unknown;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Razorpay SDK API errors reject with a plain object carrying a numeric
+ * `statusCode` and a nested `error` object (`{ code, description, ... }`),
+ * rather than an `Error` subclass like Stripe's.
+ */
+function isRazorpayError(error: unknown): error is RazorpayErrorLike {
+  if (!isObject(error)) {
+    return false;
+  }
+  const inner = error.error;
+  return (
+    typeof error.statusCode === 'number' &&
+    isObject(inner) &&
+    (typeof inner.code === 'string' || typeof inner.description === 'string')
+  );
+}
+
+/** The human-readable message lives in `error.error.description`. */
+function getRazorpayErrorMessage(error: RazorpayErrorLike, fallbackMessage: string): string {
+  const inner = error.error;
+  if (isObject(inner) && typeof inner.description === 'string' && inner.description.trim()) {
+    return inner.description;
+  }
+  if (typeof error.message === 'string' && error.message.trim()) {
+    return error.message;
+  }
+  return fallbackMessage;
+}
+
+export function normalizeRazorpayError(error: unknown): unknown {
+  if (error instanceof RazorpayKeyValidationError) {
+    return new AppError(error.message, 400, ERROR_CODES.PAYMENT_CONFIG_INVALID);
+  }
+  if (error instanceof AppError || !isRazorpayError(error)) {
+    return error;
+  }
+
+  const status = getUpstreamStatus(error);
+  const message = getRazorpayErrorMessage(error, 'Razorpay request failed');
+
+  if (status === 429) {
+    return new AppError(message, 429, ERROR_CODES.RATE_LIMITED);
+  }
+  if (status === 401 || status === 403) {
+    return new AppError(message, status, ERROR_CODES.PAYMENT_CONFIG_INVALID);
+  }
+
+  return new UpstreamError(error, message);
+}

--- a/backend/src/providers/payments/razorpay-errors.ts
+++ b/backend/src/providers/payments/razorpay-errors.ts
@@ -59,5 +59,10 @@ export function normalizeRazorpayError(error: unknown): unknown {
     return new AppError(message, status, ERROR_CODES.PAYMENT_CONFIG_INVALID);
   }
 
+  // `UpstreamError` re-derives its message via `getUpstreamErrorMessage`, which
+  // reads a top-level `error.message` but not Razorpay's nested
+  // `error.error.description`. We pass our extracted description as the fallback
+  // so it surfaces — Razorpay SDK errors carry no top-level `message`, so the
+  // fallback always wins and this stays consistent with the branches above.
   return new UpstreamError(error, message);
 }

--- a/backend/src/services/payments/razorpay/webhook.service.ts
+++ b/backend/src/services/payments/razorpay/webhook.service.ts
@@ -2,6 +2,7 @@ import type { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { getBillingSubjectFromProviderAttributes } from '@/services/payments/helpers.js';
 import { RazorpayConfigService } from '@/services/payments/razorpay/config.service.js';
+import { PaymentWebhookEventStore } from '@/services/payments/webhook-event-store.js';
 import {
   RazorpayTransactionService,
   type RazorpayTransactionStatus,
@@ -28,8 +29,8 @@ export interface RazorpayWebhookEventRow {
   processingStatus: RazorpayWebhookProcessingStatus;
   attemptCount: number;
   lastError: string | null;
-  receivedAt: string;
-  processedAt: string | null;
+  receivedAt: Date | string;
+  processedAt: Date | string | null;
 }
 
 interface ShouldProcessResult {
@@ -47,6 +48,7 @@ export class RazorpayWebhookService {
   private pool: Pool | null = null;
   private readonly configService = RazorpayConfigService.getInstance();
   private readonly transactionService = RazorpayTransactionService.getInstance();
+  private readonly eventStore = PaymentWebhookEventStore.getInstance();
 
   static getInstance(): RazorpayWebhookService {
     if (!RazorpayWebhookService.instance) {
@@ -156,91 +158,24 @@ export class RazorpayWebhookService {
     eventType: string,
     payload: RazorpayWebhookPayload
   ): Promise<ShouldProcessResult> {
-    const pendingReclaimCutoff = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes
-
-    const insertResult = await this.getPool().query<RazorpayWebhookEventRow>(
-      `INSERT INTO payments.webhook_events
-         (provider, environment, provider_event_id, event_type, livemode,
-          processing_status, attempt_count, received_at, payload)
-       VALUES ('razorpay', $1, $2, $3, $4, 'pending', 1, NOW(), $5)
-       ON CONFLICT (provider, environment, provider_event_id) DO NOTHING
-       RETURNING
-         id,
-         environment,
-         provider_event_id  AS "eventId",
-         event_type         AS "eventType",
-         processing_status  AS "processingStatus",
-         attempt_count      AS "attemptCount",
-         last_error         AS "lastError",
-         received_at        AS "receivedAt",
-         processed_at       AS "processedAt"`,
-      [environment, eventId, eventType, environment === 'live', payload]
-    );
-
-    const inserted = insertResult.rows[0];
-    if (inserted) {
-      return { row: inserted, shouldProcess: true };
-    }
-
-    const retryResult = await this.getPool().query<RazorpayWebhookEventRow>(
-      `UPDATE payments.webhook_events
-       SET processing_status = 'pending',
-           attempt_count = attempt_count + 1,
-           last_error = NULL,
-           processed_at = NULL,
-           payload = $4,
-           updated_at = NOW()
-       WHERE environment = $1
-         AND provider = 'razorpay'
-         AND provider_event_id = $2
-         AND (
-           processing_status = 'failed'
-           OR (processing_status = 'pending' AND updated_at < $3)
-         )
-       RETURNING
-         id,
-         environment,
-         provider_event_id  AS "eventId",
-         event_type         AS "eventType",
-         processing_status  AS "processingStatus",
-         attempt_count      AS "attemptCount",
-         last_error         AS "lastError",
-         received_at        AS "receivedAt",
-         processed_at       AS "processedAt"`,
-      [environment, eventId, pendingReclaimCutoff, payload]
-    );
-
-    const retried = retryResult.rows[0];
-    if (retried) {
-      return { row: retried, shouldProcess: true };
-    }
-
-    const existingResult = await this.getPool().query<RazorpayWebhookEventRow>(
-      `SELECT
-         id,
-         environment,
-         provider_event_id  AS "eventId",
-         event_type         AS "eventType",
-         processing_status  AS "processingStatus",
-         attempt_count      AS "attemptCount",
-         last_error         AS "lastError",
-         received_at        AS "receivedAt",
-         processed_at       AS "processedAt"
-       FROM payments.webhook_events
-       WHERE provider = 'razorpay'
-         AND environment = $1
-         AND provider_event_id = $2`,
-      [environment, eventId]
-    );
-
-    const row = existingResult.rows[0] as RazorpayWebhookEventRow;
-    logger.info('Razorpay webhook event already processed or currently processing; skipping', {
+    const result = await this.eventStore.recordStart({
+      provider: 'razorpay',
       environment,
       eventId,
       eventType,
+      livemode: environment === 'live',
+      payload,
     });
 
-    return { shouldProcess: false, row };
+    if (!result.shouldProcess) {
+      logger.info('Razorpay webhook event already processed or currently processing; skipping', {
+        environment,
+        eventId,
+        eventType,
+      });
+    }
+
+    return result;
   }
 
   async markWebhookEvent(
@@ -249,29 +184,7 @@ export class RazorpayWebhookService {
     status: RazorpayWebhookProcessingStatus,
     error: string | null
   ): Promise<RazorpayWebhookEventRow> {
-    const result = await this.getPool().query<RazorpayWebhookEventRow>(
-      `UPDATE payments.webhook_events
-       SET processing_status = $3,
-           last_error        = $4,
-           processed_at      = CASE WHEN $3 IN ('processed', 'ignored') THEN NOW() ELSE processed_at END,
-           updated_at        = NOW()
-       WHERE provider = 'razorpay'
-         AND environment = $1
-         AND provider_event_id = $2
-       RETURNING
-         id,
-         environment,
-         provider_event_id  AS "eventId",
-         event_type         AS "eventType",
-         processing_status  AS "processingStatus",
-         attempt_count      AS "attemptCount",
-         last_error         AS "lastError",
-         received_at        AS "receivedAt",
-         processed_at       AS "processedAt"`,
-      [environment, eventId, status, error]
-    );
-
-    return result.rows[0] as RazorpayWebhookEventRow;
+    return this.eventStore.mark('razorpay', environment, eventId, status, error);
   }
 
   private parseWebhookPayload(rawBody: string): RazorpayWebhookPayload {

--- a/backend/src/services/payments/razorpay/webhook.service.ts
+++ b/backend/src/services/payments/razorpay/webhook.service.ts
@@ -2,7 +2,7 @@ import type { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { getBillingSubjectFromProviderAttributes } from '@/services/payments/helpers.js';
 import { RazorpayConfigService } from '@/services/payments/razorpay/config.service.js';
-import { PaymentWebhookEventStore } from '@/services/payments/webhook-event-store.js';
+import { WebhookStoreService } from '@/services/payments/webhook-store.service.js';
 import {
   RazorpayTransactionService,
   type RazorpayTransactionStatus,
@@ -48,7 +48,7 @@ export class RazorpayWebhookService {
   private pool: Pool | null = null;
   private readonly configService = RazorpayConfigService.getInstance();
   private readonly transactionService = RazorpayTransactionService.getInstance();
-  private readonly eventStore = PaymentWebhookEventStore.getInstance();
+  private readonly webhookStore = WebhookStoreService.getInstance();
 
   static getInstance(): RazorpayWebhookService {
     if (!RazorpayWebhookService.instance) {
@@ -158,7 +158,7 @@ export class RazorpayWebhookService {
     eventType: string,
     payload: RazorpayWebhookPayload
   ): Promise<ShouldProcessResult> {
-    const result = await this.eventStore.recordStart({
+    const result = await this.webhookStore.recordStart({
       provider: 'razorpay',
       environment,
       eventId,
@@ -184,7 +184,7 @@ export class RazorpayWebhookService {
     status: RazorpayWebhookProcessingStatus,
     error: string | null
   ): Promise<RazorpayWebhookEventRow> {
-    return this.eventStore.mark('razorpay', environment, eventId, status, error);
+    return this.webhookStore.mark('razorpay', environment, eventId, status, error);
   }
 
   private parseWebhookPayload(rawBody: string): RazorpayWebhookPayload {

--- a/backend/src/services/payments/stripe/webhook.service.ts
+++ b/backend/src/services/payments/stripe/webhook.service.ts
@@ -7,7 +7,7 @@ import { PaymentCustomerService } from '@/services/payments/payment-customer.ser
 import { StripeTransactionService } from '@/services/payments/stripe/transaction.service.js';
 import { StripeSubscriptionService } from '@/services/payments/stripe/subscription.service.js';
 import { getStripeWebhookSecretName } from '@/services/payments/stripe/constants.js';
-import { PaymentWebhookEventStore } from '@/services/payments/webhook-event-store.js';
+import { WebhookStoreService } from '@/services/payments/webhook-store.service.js';
 import {
   fromStripeTimestamp,
   getBillingSubjectFromProviderAttributes,
@@ -41,7 +41,7 @@ export class StripeWebhookService {
   private readonly customerService = PaymentCustomerService.getInstance();
   private readonly stripeTransactionService = StripeTransactionService.getInstance();
   private readonly subscriptionService = StripeSubscriptionService.getInstance();
-  private readonly eventStore = PaymentWebhookEventStore.getInstance();
+  private readonly webhookStore = WebhookStoreService.getInstance();
 
   static getInstance(): StripeWebhookService {
     if (!StripeWebhookService.instance) {
@@ -131,7 +131,7 @@ export class StripeWebhookService {
     event: StripeEvent
   ): Promise<{ row: StripeWebhookEventRow; shouldProcess: boolean }> {
     const object = event.data.object as unknown;
-    return this.eventStore.recordStart({
+    return this.webhookStore.recordStart({
       provider: 'stripe',
       environment,
       eventId: event.id,
@@ -150,7 +150,7 @@ export class StripeWebhookService {
     processingStatus: 'processed' | 'failed' | 'ignored',
     error: string | null
   ): Promise<StripeWebhookEventRow> {
-    return this.eventStore.mark('stripe', environment, eventId, processingStatus, error);
+    return this.webhookStore.mark('stripe', environment, eventId, processingStatus, error);
   }
 
   normalizeWebhookEventRow(row: StripeWebhookEventRow): StripeWebhookEvent {

--- a/backend/src/services/payments/stripe/webhook.service.ts
+++ b/backend/src/services/payments/stripe/webhook.service.ts
@@ -7,6 +7,7 @@ import { PaymentCustomerService } from '@/services/payments/payment-customer.ser
 import { StripeTransactionService } from '@/services/payments/stripe/transaction.service.js';
 import { StripeSubscriptionService } from '@/services/payments/stripe/subscription.service.js';
 import { getStripeWebhookSecretName } from '@/services/payments/stripe/constants.js';
+import { PaymentWebhookEventStore } from '@/services/payments/webhook-event-store.js';
 import {
   fromStripeTimestamp,
   getBillingSubjectFromProviderAttributes,
@@ -32,8 +33,6 @@ import {
   type StripeWebhookResponse,
 } from '@insforge/shared-schemas';
 
-const WEBHOOK_PENDING_RECLAIM_WINDOW_MS = 5 * 60 * 1000;
-
 export class StripeWebhookService {
   private static instance: StripeWebhookService;
   private pool: Pool | null = null;
@@ -42,6 +41,7 @@ export class StripeWebhookService {
   private readonly customerService = PaymentCustomerService.getInstance();
   private readonly stripeTransactionService = StripeTransactionService.getInstance();
   private readonly subscriptionService = StripeSubscriptionService.getInstance();
+  private readonly eventStore = PaymentWebhookEventStore.getInstance();
 
   static getInstance(): StripeWebhookService {
     if (!StripeWebhookService.instance) {
@@ -131,118 +131,17 @@ export class StripeWebhookService {
     event: StripeEvent
   ): Promise<{ row: StripeWebhookEventRow; shouldProcess: boolean }> {
     const object = event.data.object as unknown;
-    const objectType = this.getStripeObjectType(object);
-    const objectId = getStripeObjectId(object);
-    const accountId = typeof event.account === 'string' ? event.account : null;
-    const pendingReclaimCutoff = new Date(Date.now() - WEBHOOK_PENDING_RECLAIM_WINDOW_MS);
-
-    const insertResult = await this.getPool().query(
-      `INSERT INTO payments.webhook_events (
-         provider,
-         environment,
-         provider_event_id,
-         event_type,
-         livemode,
-         provider_account_id,
-         object_type,
-         object_id,
-         processing_status,
-         attempt_count,
-         payload
-       )
-       VALUES ('stripe', $1, $2, $3, $4, $5, $6, $7, 'pending', 1, $8)
-       ON CONFLICT (provider, environment, provider_event_id) DO NOTHING
-       RETURNING
-         environment,
-         provider,
-         provider_event_id AS "eventId",
-         event_type AS "eventType",
-         livemode,
-         provider_account_id AS "accountId",
-         object_type AS "objectType",
-         object_id AS "objectId",
-         processing_status AS "processingStatus",
-         attempt_count AS "attemptCount",
-         last_error AS "lastError",
-         received_at AS "receivedAt",
-         processed_at AS "processedAt",
-         created_at AS "createdAt",
-         updated_at AS "updatedAt"`,
-      [environment, event.id, event.type, event.livemode, accountId, objectType, objectId, event]
-    );
-
-    const inserted = insertResult.rows[0] as StripeWebhookEventRow | undefined;
-    if (inserted) {
-      return { row: inserted, shouldProcess: true };
-    }
-
-    const retryResult = await this.getPool().query(
-      `UPDATE payments.webhook_events
-       SET processing_status = 'pending',
-           attempt_count = attempt_count + 1,
-           last_error = NULL,
-           processed_at = NULL,
-           payload = $3,
-           updated_at = NOW()
-       WHERE environment = $1
-         AND provider = 'stripe'
-         AND provider_event_id = $2
-         AND (
-           processing_status = 'failed'
-           OR (processing_status = 'pending' AND updated_at < $4)
-         )
-       RETURNING
-         environment,
-         provider,
-         provider_event_id AS "eventId",
-         event_type AS "eventType",
-         livemode,
-         provider_account_id AS "accountId",
-         object_type AS "objectType",
-         object_id AS "objectId",
-         processing_status AS "processingStatus",
-         attempt_count AS "attemptCount",
-         last_error AS "lastError",
-         received_at AS "receivedAt",
-         processed_at AS "processedAt",
-         created_at AS "createdAt",
-         updated_at AS "updatedAt"`,
-      [environment, event.id, event, pendingReclaimCutoff]
-    );
-
-    const retried = retryResult.rows[0] as StripeWebhookEventRow | undefined;
-    if (retried) {
-      return { row: retried, shouldProcess: true };
-    }
-
-    const existingResult = await this.getPool().query(
-      `SELECT
-         environment,
-         provider,
-         provider_event_id AS "eventId",
-         event_type AS "eventType",
-         livemode,
-         provider_account_id AS "accountId",
-         object_type AS "objectType",
-         object_id AS "objectId",
-         processing_status AS "processingStatus",
-         attempt_count AS "attemptCount",
-         last_error AS "lastError",
-         received_at AS "receivedAt",
-         processed_at AS "processedAt",
-         created_at AS "createdAt",
-         updated_at AS "updatedAt"
-       FROM payments.webhook_events
-       WHERE environment = $1
-         AND provider = 'stripe'
-         AND provider_event_id = $2`,
-      [environment, event.id]
-    );
-
-    return {
-      row: existingResult.rows[0] as StripeWebhookEventRow,
-      shouldProcess: false,
-    };
+    return this.eventStore.recordStart({
+      provider: 'stripe',
+      environment,
+      eventId: event.id,
+      eventType: event.type,
+      livemode: event.livemode,
+      accountId: typeof event.account === 'string' ? event.account : null,
+      objectType: this.getStripeObjectType(object),
+      objectId: getStripeObjectId(object),
+      payload: event,
+    });
   }
 
   async markWebhookEvent(
@@ -251,35 +150,7 @@ export class StripeWebhookService {
     processingStatus: 'processed' | 'failed' | 'ignored',
     error: string | null
   ): Promise<StripeWebhookEventRow> {
-    const result = await this.getPool().query(
-      `UPDATE payments.webhook_events
-       SET processing_status = $3,
-           last_error = $4,
-           processed_at = CASE WHEN $3 IN ('processed', 'ignored') THEN NOW() ELSE processed_at END,
-           updated_at = NOW()
-       WHERE environment = $1
-         AND provider = 'stripe'
-         AND provider_event_id = $2
-       RETURNING
-         environment,
-         provider,
-         provider_event_id AS "eventId",
-         event_type AS "eventType",
-         livemode,
-         provider_account_id AS "accountId",
-         object_type AS "objectType",
-         object_id AS "objectId",
-         processing_status AS "processingStatus",
-         attempt_count AS "attemptCount",
-         last_error AS "lastError",
-         received_at AS "receivedAt",
-         processed_at AS "processedAt",
-         created_at AS "createdAt",
-         updated_at AS "updatedAt"`,
-      [environment, eventId, processingStatus, error]
-    );
-
-    return result.rows[0] as StripeWebhookEventRow;
+    return this.eventStore.mark('stripe', environment, eventId, processingStatus, error);
   }
 
   normalizeWebhookEventRow(row: StripeWebhookEventRow): StripeWebhookEvent {

--- a/backend/src/services/payments/webhook-event-store.ts
+++ b/backend/src/services/payments/webhook-event-store.ts
@@ -1,0 +1,213 @@
+import type { Pool } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import type { PaymentEnvironment, PaymentProvider } from '@/types/payments.js';
+
+/**
+ * How long a row may sit in `pending` before another delivery of the same event
+ * is allowed to reclaim and retry it. Guards against a crashed handler wedging
+ * an event as permanently pending.
+ */
+const WEBHOOK_PENDING_RECLAIM_WINDOW_MS = 5 * 60 * 1000;
+
+export type PaymentWebhookProcessingStatus = 'pending' | 'processed' | 'failed' | 'ignored';
+
+/**
+ * A row from `payments.webhook_events`. The table is provider-scoped, so this is
+ * the superset of columns both Stripe and Razorpay use; columns a given provider
+ * doesn't populate (e.g. Razorpay leaves `accountId`/`objectType`/`objectId`
+ * null) come back null.
+ */
+export interface PaymentWebhookEventRow {
+  id: string;
+  environment: PaymentEnvironment;
+  provider: PaymentProvider;
+  eventId: string;
+  eventType: string;
+  livemode: boolean;
+  accountId: string | null;
+  objectType: string | null;
+  objectId: string | null;
+  processingStatus: PaymentWebhookProcessingStatus;
+  attemptCount: number;
+  lastError: string | null;
+  receivedAt: Date | string;
+  processedAt: Date | string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+export interface RecordWebhookEventInput {
+  provider: PaymentProvider;
+  environment: PaymentEnvironment;
+  eventId: string;
+  eventType: string;
+  livemode: boolean;
+  /** Full provider event/payload, stored verbatim in the `payload` jsonb column. */
+  payload: unknown;
+  /** Stripe-only; left null for providers that don't record them. */
+  accountId?: string | null;
+  objectType?: string | null;
+  objectId?: string | null;
+}
+
+export interface RecordWebhookEventResult {
+  row: PaymentWebhookEventRow;
+  shouldProcess: boolean;
+}
+
+const RETURNING_COLUMNS = `
+  id,
+  environment,
+  provider,
+  provider_event_id    AS "eventId",
+  event_type           AS "eventType",
+  livemode,
+  provider_account_id  AS "accountId",
+  object_type          AS "objectType",
+  object_id            AS "objectId",
+  processing_status    AS "processingStatus",
+  attempt_count        AS "attemptCount",
+  last_error           AS "lastError",
+  received_at          AS "receivedAt",
+  processed_at         AS "processedAt",
+  created_at           AS "createdAt",
+  updated_at           AS "updatedAt"`;
+
+/**
+ * Shared idempotent store for inbound payment webhook events. Owns the
+ * `payments.webhook_events` lifecycle (record-with-idempotency, retry reclaim,
+ * status marking) that Stripe and Razorpay previously duplicated. Provider
+ * specifics — signature verification, event-id derivation, and event-type
+ * dispatch — stay in each provider's webhook service.
+ */
+export class PaymentWebhookEventStore {
+  private static instance: PaymentWebhookEventStore;
+  private pool: Pool | null = null;
+
+  static getInstance(): PaymentWebhookEventStore {
+    if (!PaymentWebhookEventStore.instance) {
+      PaymentWebhookEventStore.instance = new PaymentWebhookEventStore();
+    }
+    return PaymentWebhookEventStore.instance;
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  /**
+   * Record the arrival of an event and decide whether it should be processed.
+   * Returns `shouldProcess: false` when the event is a duplicate that's already
+   * been processed (or is being processed within the reclaim window).
+   *
+   * Three steps, all keyed on `(provider, environment, provider_event_id)`:
+   *   1. INSERT … ON CONFLICT DO NOTHING — wins for a brand-new event.
+   *   2. UPDATE … WHERE failed OR stale-pending — reclaims for a retry.
+   *   3. SELECT — the event is already terminal/in-flight, so skip it.
+   */
+  async recordStart(input: RecordWebhookEventInput): Promise<RecordWebhookEventResult> {
+    const pool = this.getPool();
+    const pendingReclaimCutoff = new Date(Date.now() - WEBHOOK_PENDING_RECLAIM_WINDOW_MS);
+    const { provider, environment, eventId, eventType, livemode, payload } = input;
+    const accountId = input.accountId ?? null;
+    const objectType = input.objectType ?? null;
+    const objectId = input.objectId ?? null;
+
+    const insertResult = await pool.query<PaymentWebhookEventRow>(
+      `INSERT INTO payments.webhook_events (
+         provider,
+         environment,
+         provider_event_id,
+         event_type,
+         livemode,
+         provider_account_id,
+         object_type,
+         object_id,
+         processing_status,
+         attempt_count,
+         payload
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', 1, $9)
+       ON CONFLICT (provider, environment, provider_event_id) DO NOTHING
+       RETURNING ${RETURNING_COLUMNS}`,
+      [
+        provider,
+        environment,
+        eventId,
+        eventType,
+        livemode,
+        accountId,
+        objectType,
+        objectId,
+        payload,
+      ]
+    );
+
+    const inserted = insertResult.rows[0];
+    if (inserted) {
+      return { row: inserted, shouldProcess: true };
+    }
+
+    const retryResult = await pool.query<PaymentWebhookEventRow>(
+      `UPDATE payments.webhook_events
+       SET processing_status = 'pending',
+           attempt_count = attempt_count + 1,
+           last_error = NULL,
+           processed_at = NULL,
+           payload = $4,
+           updated_at = NOW()
+       WHERE provider = $1
+         AND environment = $2
+         AND provider_event_id = $3
+         AND (
+           processing_status = 'failed'
+           OR (processing_status = 'pending' AND updated_at < $5)
+         )
+       RETURNING ${RETURNING_COLUMNS}`,
+      [provider, environment, eventId, payload, pendingReclaimCutoff]
+    );
+
+    const retried = retryResult.rows[0];
+    if (retried) {
+      return { row: retried, shouldProcess: true };
+    }
+
+    const existingResult = await pool.query<PaymentWebhookEventRow>(
+      `SELECT ${RETURNING_COLUMNS}
+       FROM payments.webhook_events
+       WHERE provider = $1
+         AND environment = $2
+         AND provider_event_id = $3`,
+      [provider, environment, eventId]
+    );
+
+    return { row: existingResult.rows[0], shouldProcess: false };
+  }
+
+  /** Transition an event to a terminal status, stamping `processed_at` on success. */
+  async mark(
+    provider: PaymentProvider,
+    environment: PaymentEnvironment,
+    eventId: string,
+    status: PaymentWebhookProcessingStatus,
+    error: string | null
+  ): Promise<PaymentWebhookEventRow> {
+    const result = await this.getPool().query<PaymentWebhookEventRow>(
+      `UPDATE payments.webhook_events
+       SET processing_status = $4,
+           last_error = $5,
+           processed_at = CASE WHEN $4 IN ('processed', 'ignored') THEN NOW() ELSE processed_at END,
+           updated_at = NOW()
+       WHERE provider = $1
+         AND environment = $2
+         AND provider_event_id = $3
+       RETURNING ${RETURNING_COLUMNS}`,
+      [provider, environment, eventId, status, error]
+    );
+
+    return result.rows[0];
+  }
+}

--- a/backend/src/services/payments/webhook-store.service.ts
+++ b/backend/src/services/payments/webhook-store.service.ts
@@ -1,6 +1,8 @@
 import type { Pool } from 'pg';
+import { AppError } from '@/utils/errors.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import type { PaymentEnvironment, PaymentProvider } from '@/types/payments.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
 
 /**
  * How long a row may sit in `pending` before another delivery of the same event
@@ -80,15 +82,15 @@ const RETURNING_COLUMNS = `
  * specifics — signature verification, event-id derivation, and event-type
  * dispatch — stay in each provider's webhook service.
  */
-export class PaymentWebhookEventStore {
-  private static instance: PaymentWebhookEventStore;
+export class WebhookStoreService {
+  private static instance: WebhookStoreService;
   private pool: Pool | null = null;
 
-  static getInstance(): PaymentWebhookEventStore {
-    if (!PaymentWebhookEventStore.instance) {
-      PaymentWebhookEventStore.instance = new PaymentWebhookEventStore();
+  static getInstance(): WebhookStoreService {
+    if (!WebhookStoreService.instance) {
+      WebhookStoreService.instance = new WebhookStoreService();
     }
-    return PaymentWebhookEventStore.instance;
+    return WebhookStoreService.instance;
   }
 
   private getPool(): Pool {
@@ -184,7 +186,18 @@ export class PaymentWebhookEventStore {
       [provider, environment, eventId]
     );
 
-    return { row: existingResult.rows[0], shouldProcess: false };
+    const existing = existingResult.rows[0];
+    if (!existing) {
+      // The conflicting row that blocked the INSERT/reclaim should still be
+      // here; if it isn't, it was deleted concurrently and we can't proceed.
+      throw new AppError(
+        `Webhook event ${provider}/${environment}/${eventId} vanished during recording`,
+        500,
+        ERROR_CODES.INTERNAL_ERROR
+      );
+    }
+
+    return { row: existing, shouldProcess: false };
   }
 
   /** Transition an event to a terminal status, stamping `processed_at` on success. */
@@ -208,6 +221,17 @@ export class PaymentWebhookEventStore {
       [provider, environment, eventId, status, error]
     );
 
-    return result.rows[0];
+    const row = result.rows[0];
+    if (!row) {
+      // The event is marked only after it was recorded, so the row must exist;
+      // a no-op UPDATE means it was deleted out from under us.
+      throw new AppError(
+        `Webhook event ${provider}/${environment}/${eventId} not found while marking ${status}`,
+        500,
+        ERROR_CODES.INTERNAL_ERROR
+      );
+    }
+
+    return row;
   }
 }

--- a/backend/tests/unit/razorpay-errors.test.ts
+++ b/backend/tests/unit/razorpay-errors.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { AppError } from '../../src/utils/errors';
+import { RazorpayKeyValidationError } from '../../src/providers/payments/razorpay.provider';
+import { normalizeRazorpayError } from '../../src/providers/payments/razorpay-errors';
+
+describe('normalizeRazorpayError', () => {
+  it('maps local Razorpay key validation errors to payment config errors', () => {
+    const normalized = normalizeRazorpayError(new RazorpayKeyValidationError('bad key'));
+
+    expect(normalized).toMatchObject({
+      statusCode: 400,
+      code: ERROR_CODES.PAYMENT_CONFIG_INVALID,
+      message: 'bad key',
+    });
+  });
+
+  it('preserves existing AppError instances', () => {
+    const appError = new AppError('configured', 400, ERROR_CODES.PAYMENT_CONFIG_INVALID);
+
+    expect(normalizeRazorpayError(appError)).toBe(appError);
+  });
+
+  it('passes through errors that are not Razorpay SDK errors', () => {
+    const plain = new Error('boom');
+
+    expect(normalizeRazorpayError(plain)).toBe(plain);
+  });
+
+  it('maps Razorpay rate limits to RATE_LIMITED', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 429,
+      error: { code: 'BAD_REQUEST_ERROR', description: 'Too many requests' },
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 429,
+      code: ERROR_CODES.RATE_LIMITED,
+      message: 'Too many requests',
+    });
+  });
+
+  it('maps Razorpay auth errors to payment config errors', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 401,
+      error: { code: 'BAD_REQUEST_ERROR', description: 'Authentication failed' },
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 401,
+      code: ERROR_CODES.PAYMENT_CONFIG_INVALID,
+      message: 'Authentication failed',
+    });
+  });
+
+  it('maps generic Razorpay API errors to upstream failures using the nested description', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 500,
+      error: { code: 'SERVER_ERROR', description: 'Razorpay is unavailable' },
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 500,
+      code: ERROR_CODES.UPSTREAM_FAILURE,
+      message: 'Razorpay is unavailable',
+    });
+  });
+});

--- a/backend/tests/unit/razorpay-errors.test.ts
+++ b/backend/tests/unit/razorpay-errors.test.ts
@@ -53,6 +53,19 @@ describe('normalizeRazorpayError', () => {
     });
   });
 
+  it('maps Razorpay forbidden errors to payment config errors', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 403,
+      error: { code: 'BAD_REQUEST_ERROR', description: 'Forbidden' },
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 403,
+      code: ERROR_CODES.PAYMENT_CONFIG_INVALID,
+      message: 'Forbidden',
+    });
+  });
+
   it('maps generic Razorpay API errors to upstream failures using the nested description', () => {
     const normalized = normalizeRazorpayError({
       statusCode: 500,
@@ -63,6 +76,33 @@ describe('normalizeRazorpayError', () => {
       statusCode: 500,
       code: ERROR_CODES.UPSTREAM_FAILURE,
       message: 'Razorpay is unavailable',
+    });
+  });
+
+  it('falls back to the top-level message when the nested description is blank', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 500,
+      error: { code: 'SERVER_ERROR', description: '   ' },
+      message: 'top-level failure',
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 500,
+      code: ERROR_CODES.UPSTREAM_FAILURE,
+      message: 'top-level failure',
+    });
+  });
+
+  it('falls back to a literal message when neither description nor message is usable', () => {
+    const normalized = normalizeRazorpayError({
+      statusCode: 500,
+      error: { code: 'SERVER_ERROR' },
+    });
+
+    expect(normalized).toMatchObject({
+      statusCode: 500,
+      code: ERROR_CODES.UPSTREAM_FAILURE,
+      message: 'Razorpay request failed',
     });
   });
 });

--- a/backend/tests/unit/razorpay-webhook.service.test.ts
+++ b/backend/tests/unit/razorpay-webhook.service.test.ts
@@ -200,10 +200,14 @@ describe('RazorpayWebhookService', () => {
         /INSERT INTO payments\.webhook_events[\s\S]*ON CONFLICT \(provider, environment, provider_event_id\) DO NOTHING/i
       ),
       [
+        'razorpay',
         'test',
         'evt_new_123',
         'payment.captured',
         false,
+        null,
+        null,
+        null,
         expect.objectContaining({
           event: 'payment.captured',
         }),
@@ -245,15 +249,16 @@ describe('RazorpayWebhookService', () => {
     expect(mockPool.query).toHaveBeenNthCalledWith(
       2,
       expect.stringMatching(
-        /UPDATE payments\.webhook_events[\s\S]*processing_status = 'failed'[\s\S]*OR \(processing_status = 'pending' AND updated_at < \$3\)/i
+        /UPDATE payments\.webhook_events[\s\S]*processing_status = 'failed'[\s\S]*OR \(processing_status = 'pending' AND updated_at < \$5\)/i
       ),
       [
+        'razorpay',
         'test',
         'evt_pending_123',
-        expect.any(Date),
         expect.objectContaining({
           event: 'payment.captured',
         }),
+        expect.any(Date),
       ]
     );
   });

--- a/backend/tests/unit/stripe-services.test.ts
+++ b/backend/tests/unit/stripe-services.test.ts
@@ -2697,7 +2697,7 @@ describe('Stripe payment services', () => {
 
     expect(mockPool.query).toHaveBeenLastCalledWith(
       expect.stringMatching(/UPDATE payments\.webhook_events/i),
-      ['test', 'evt_apply_fail_123', 'failed', 'activity write failed']
+      ['stripe', 'test', 'evt_apply_fail_123', 'failed', 'activity write failed']
     );
   });
 

--- a/backend/tests/unit/stripe-webhook.service.test.ts
+++ b/backend/tests/unit/stripe-webhook.service.test.ts
@@ -78,9 +78,9 @@ describe('StripeWebhookService', () => {
     expect(mockPool.query).toHaveBeenNthCalledWith(
       2,
       expect.stringMatching(
-        /UPDATE payments\.webhook_events[\s\S]*processing_status = 'failed'[\s\S]*OR \(processing_status = 'pending' AND updated_at < \$4\)/i
+        /UPDATE payments\.webhook_events[\s\S]*processing_status = 'failed'[\s\S]*OR \(processing_status = 'pending' AND updated_at < \$5\)/i
       ),
-      ['test', 'evt_123', expect.any(Object), expect.any(Date)]
+      ['stripe', 'test', 'evt_123', expect.any(Object), expect.any(Date)]
     );
   });
 

--- a/backend/tests/unit/webhook-store.service.test.ts
+++ b/backend/tests/unit/webhook-store.service.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PaymentWebhookEventRow, RecordWebhookEventInput } from '../../src/services/payments/webhook-store.service';
+
+const { mockPool } = vi.hoisted(() => ({
+  mockPool: {
+    query: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+import { WebhookStoreService } from '../../src/services/payments/webhook-store.service';
+
+function makeRow(overrides: Partial<PaymentWebhookEventRow> = {}): PaymentWebhookEventRow {
+  return {
+    id: 'whe_1',
+    environment: 'test',
+    provider: 'stripe',
+    eventId: 'evt_1',
+    eventType: 'checkout.session.completed',
+    livemode: false,
+    accountId: null,
+    objectType: 'checkout.session',
+    objectId: 'cs_test_1',
+    processingStatus: 'pending',
+    attemptCount: 1,
+    lastError: null,
+    receivedAt: new Date('2026-06-15T00:00:00.000Z'),
+    processedAt: null,
+    createdAt: new Date('2026-06-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-15T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const input: RecordWebhookEventInput = {
+  provider: 'stripe',
+  environment: 'test',
+  eventId: 'evt_1',
+  eventType: 'checkout.session.completed',
+  livemode: false,
+  payload: { id: 'evt_1' },
+  accountId: null,
+  objectType: 'checkout.session',
+  objectId: 'cs_test_1',
+};
+
+describe('WebhookStoreService.recordStart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.query.mockReset();
+  });
+
+  it('processes a brand-new event when the INSERT wins', async () => {
+    const row = makeRow();
+    mockPool.query.mockResolvedValueOnce({ rows: [row] });
+
+    const result = await WebhookStoreService.getInstance().recordStart(input);
+
+    expect(result).toEqual({ row, shouldProcess: true });
+    // Only the INSERT runs; no reclaim/select needed.
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockPool.query.mock.calls[0];
+    expect(sql).toContain('INSERT INTO payments.webhook_events');
+    expect(params).toEqual([
+      'stripe',
+      'test',
+      'evt_1',
+      'checkout.session.completed',
+      false,
+      null,
+      'checkout.session',
+      'cs_test_1',
+      { id: 'evt_1' },
+    ]);
+  });
+
+  it('reclaims and reprocesses a failed/stale-pending event via the UPDATE', async () => {
+    const row = makeRow({ attemptCount: 2 });
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // INSERT no-op (conflict)
+      .mockResolvedValueOnce({ rows: [row] }); // UPDATE reclaim wins
+
+    const result = await WebhookStoreService.getInstance().recordStart(input);
+
+    expect(result).toEqual({ row, shouldProcess: true });
+    expect(mockPool.query).toHaveBeenCalledTimes(2);
+    expect(mockPool.query.mock.calls[1][0]).toContain('UPDATE payments.webhook_events');
+  });
+
+  it('skips an event that is already terminal/in-flight via the SELECT', async () => {
+    const row = makeRow({ processingStatus: 'processed' });
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // INSERT no-op
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE no-op (not failed/stale)
+      .mockResolvedValueOnce({ rows: [row] }); // SELECT existing
+
+    const result = await WebhookStoreService.getInstance().recordStart(input);
+
+    expect(result).toEqual({ row, shouldProcess: false });
+    expect(mockPool.query).toHaveBeenCalledTimes(3);
+    expect(mockPool.query.mock.calls[2][0]).toContain('SELECT');
+  });
+
+  it('throws when the conflicting row vanishes before the SELECT', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(WebhookStoreService.getInstance().recordStart(input)).rejects.toThrow(
+      /vanished during recording/
+    );
+  });
+});
+
+describe('WebhookStoreService.mark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.query.mockReset();
+  });
+
+  it('returns the updated row on success', async () => {
+    const row = makeRow({ processingStatus: 'processed' });
+    mockPool.query.mockResolvedValueOnce({ rows: [row] });
+
+    const result = await WebhookStoreService.getInstance().mark(
+      'stripe',
+      'test',
+      'evt_1',
+      'processed',
+      null
+    );
+
+    expect(result).toEqual(row);
+    const [sql, params] = mockPool.query.mock.calls[0];
+    expect(sql).toContain('UPDATE payments.webhook_events');
+    expect(params).toEqual(['stripe', 'test', 'evt_1', 'processed', null]);
+  });
+
+  it('throws when the event row is missing', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      WebhookStoreService.getInstance().mark('stripe', 'test', 'evt_1', 'processed', null)
+    ).rejects.toThrow(/not found while marking/);
+  });
+});

--- a/backend/tests/unit/webhook-store.service.test.ts
+++ b/backend/tests/unit/webhook-store.service.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { PaymentWebhookEventRow, RecordWebhookEventInput } from '../../src/services/payments/webhook-store.service';
+import type {
+  PaymentWebhookEventRow,
+  RecordWebhookEventInput,
+} from '../../src/services/payments/webhook-store.service';
 
 const { mockPool } = vi.hoisted(() => ({
   mockPool: {


### PR DESCRIPTION
## Summary

Two parity-focused backend payment refactors. (The originally-scoped `PaymentProvider` class interface was dropped — see below.)

### 1. Shared webhook-event store
The webhook-event lifecycle was duplicated near-verbatim across `stripe/webhook.service.ts` and `razorpay/webhook.service.ts`: the idempotent record (`INSERT … ON CONFLICT DO NOTHING` → reclaim-stale `UPDATE` → `SELECT`), the 5-minute pending-reclaim window, and the status-marking `UPDATE`. These now live in a new `PaymentWebhookEventStore`, keyed on `(provider, environment, provider_event_id)`.

- Each service keeps its **public methods and row types** intact and delegates the SQL to the store.
- Provider-specific logic — signature verification, event-id derivation, event-type dispatch — stays in each service.
- The table (`payments.webhook_events`) is already provider-scoped; the store records the Stripe-only columns (`provider_account_id`/`object_type`/`object_id`) as explicit nulls for Razorpay.

### 2. Razorpay error normalization
Razorpay routes previously passed raw SDK errors through `next(error)`, while Stripe routes normalize via `normalizeStripeError`. New `razorpay-errors.ts` mirrors the Stripe template for the Razorpay SDK error shape (`{ statusCode, error: { code, description } }`): key-validation → 400, rate-limit → 429, auth (401/403) → `PAYMENT_CONFIG_INVALID`, else `UpstreamError`, surfacing the nested `error.description` as the message. Wired into all 22 catch handlers across the three Razorpay route files.

### Dropped: `PaymentProvider` class interface
The third originally-planned item. Nothing consumes the provider classes polymorphically (every `new StripeProvider`/`new RazorpayProvider` is used immediately by its own service), the name `PaymentProvider` is already the `'stripe' | 'razorpay'` type, and the two providers' signatures genuinely diverge (webhook verify returns a typed event vs. a boolean; products+prices vs. items+plans; Stripe-only portal/endpoints; Razorpay-only orders/pause/resume). A class interface would have been a documentation-only abstraction with no caller, so it was intentionally skipped.

## Behavior

Behavior-preserving. The unified store binds `provider` as the first parameter and records Stripe-only columns as nulls for Razorpay, so four unit tests that asserted the old per-provider SQL param shape are updated to match the new shape — idempotency semantics, call counts, and returned rows are unchanged.

## Testing

- New `razorpay-errors.test.ts` (6 cases, parallel to `stripe-errors.test.ts`).
- Backend typecheck clean, touched files lint clean, `tsup` build succeeds.
- **Full backend unit suite: 1522 passed, 4 skipped** — including all 223 payment tests.

Note: behavior preservation rests on the unit suite (which mocks the pool); no live-DB integration run is included in this PR. The store's SQL is a faithful merge of the two originals (same table, columns, idempotency key, and reclaim window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes webhook event persistence in a shared `WebhookStoreService` and normalizes Razorpay SDK errors so Stripe and Razorpay behave consistently. Improves idempotency handling and returns clearer, mapped errors from Razorpay routes.

- **Refactors**
  - Introduced `WebhookStoreService` (INSERT with conflict handling → reclaim stale pending after 5 min → SELECT; status marking). Stripe and Razorpay webhook services now call `recordStart`/`mark`.
  - Behavior unchanged; provider is now the first SQL param and Stripe-only columns are null for Razorpay. Updated affected tests and added store tests.

- **Bug Fixes**
  - Added `normalizeRazorpayError` and wired it into all Razorpay routes. Maps key-validation → 400, 401/403 → PAYMENT_CONFIG_INVALID, 429 → RATE_LIMITED, else `UpstreamError` using the nested description (with sensible fallbacks).
  - Hardened `WebhookStoreService`: throw INTERNAL_ERROR when the conflicting row vanishes during `recordStart` or when `mark` targets a missing row. Added unit tests for these paths.

<sup>Written for commit 9c2456a67c9a872cc3e173ef6ede6ee0622fedd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share the payment webhook-event store and normalize Razorpay SDK errors
> - Introduces [`PaymentWebhookEventStore`](https://github.com/InsForge/InsForge/pull/1529/files#diff-47dd8ce9fcad5b59469ecdc67834d9137874dc6e1ca0c3bba544ac433f607e28), a shared class that handles idempotent webhook event persistence (INSERT with conflict handling, 5-minute stale-pending reclaim, and status marking) for both Stripe and Razorpay.
> - Refactors [`StripeWebhookService`](https://github.com/InsForge/InsForge/pull/1529/files#diff-54e047b52344dda95db90c77a26cf6f4bec748fe3060b51df7a764955359d7a4) and [`RazorpayWebhookService`](https://github.com/InsForge/InsForge/pull/1529/files#diff-65a65c463ee8bbb12d488cc84368566f051bd8cb107b1f934ebb85fde185bfdf) to delegate all `webhook_events` SQL to the shared store instead of managing it inline.
> - Adds [`normalizeRazorpayError`](https://github.com/InsForge/InsForge/pull/1529/files#diff-416c4a859c20db30772e84628caa5321fe5487be69e4e01763d7ffdc2295985b), which maps Razorpay SDK errors to `AppError`/`UpstreamError` (key validation → 400 `PAYMENT_CONFIG_INVALID`, 429 → `RATE_LIMITED`, 401/403 → `PAYMENT_CONFIG_INVALID`, other shaped errors → `UpstreamError`). All Razorpay route handlers now call this before forwarding to error middleware.
> - Behavioral Change: Razorpay SDK errors that previously reached error middleware as raw SDK objects now arrive as typed `AppError` or `UpstreamError` instances, which may change HTTP status codes and error codes returned to clients.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1529 opened
>
> - Added error handling to `WebhookStoreService.recordStart` and `WebhookStoreService.mark` methods to throw `AppError` with 500 status and `INTERNAL_ERROR` code when webhook event rows cannot be found or vanish during processing [4eb4507]
> - Renamed `PaymentWebhookEventStore` class to `WebhookStoreService` and updated all references across `RazorpayWebhookService` and `StripeWebhookService` [4eb4507]
> - Added unit tests for `WebhookStoreService` covering `recordStart` behaviors including insert success, reclaim via update, skip via select, and throw on vanished row, and `mark` behaviors including successful update and throw when missing [4eb4507]
> - Added unit tests for `normalizeRazorpayError` function covering 403 forbidden mapping to `PAYMENT_CONFIG_INVALID`, fallback to top-level message when nested description is blank, and fallback to literal default message when neither description nor message is usable [4eb4507]
> - Added inline comment to `normalizeRazorpayError` function clarifying why the extracted Razorpay nested error description is passed as the fallback message to `UpstreamError` [4eb4507]
> - Reformatted type-only import statement [9c2456a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d9cd6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for payment gateway operations with improved error classification and normalization
  * Strengthened webhook event processing for better consistency and idempotency across payment providers

* **Refactor**
  * Centralized webhook event state management for improved reliability

* **Tests**
  * Expanded test coverage for payment error scenarios and webhook event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->