### PR TITLE
Type the s3-gateway request instead of casting in every command

### DIFF
--- a/backend/src/api/routes/s3-gateway/commands/abort-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/abort-multipart-upload.ts
@@ -1,11 +1,11 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const uploadIdRaw = req.query.uploadId;
   const uploadId = typeof uploadIdRaw === 'string' ? uploadIdRaw : '';
   if (!uploadId) {

--- a/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { parseXml, toXml } from '../xml.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
 const partSchema = z.object({
   PartNumber: z.coerce.number().int().positive().max(10_000),
@@ -16,9 +16,9 @@ const bodySchema = z.object({
   }),
 });
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const uploadIdRaw = req.query.uploadId;
   const uploadId = typeof uploadIdRaw === 'string' ? uploadIdRaw : '';
   if (!uploadId) {

--- a/backend/src/api/routes/s3-gateway/commands/copy-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/copy-object.ts
@@ -2,11 +2,11 @@ import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
 import { toXml } from '../xml.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const dstBucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const dstKey = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const dstBucket = getS3Bucket(req);
+  const dstKey = getS3Key(req);
 
   const source = req.headers['x-amz-copy-source'] as string | undefined;
   if (!source) {

--- a/backend/src/api/routes/s3-gateway/commands/create-bucket.ts
+++ b/backend/src/api/routes/s3-gateway/commands/create-bucket.ts
@@ -1,12 +1,12 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket } from '../request.js';
 
 const BUCKET_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
   if (!BUCKET_NAME_RE.test(bucket)) {
     sendS3Error(res, 'InvalidBucketName', `Invalid bucket name ${bucket}`, {
       resource: req.path,

--- a/backend/src/api/routes/s3-gateway/commands/create-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/create-multipart-upload.ts
@@ -1,11 +1,11 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { toXml } from '../xml.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const contentType = (req.headers['content-type'] as string) ?? 'application/octet-stream';
   const { uploadId } = await StorageService.getInstance()
     .getProvider()

--- a/backend/src/api/routes/s3-gateway/commands/delete-bucket.ts
+++ b/backend/src/api/routes/s3-gateway/commands/delete-bucket.ts
@@ -1,10 +1,10 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
   const svc = StorageService.getInstance();
   if (!(await svc.bucketExists(bucket))) {
     sendS3Error(res, 'NoSuchBucket', `Bucket ${bucket} does not exist`, {

--- a/backend/src/api/routes/s3-gateway/commands/delete-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/delete-object.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
 function isNotFound(err: unknown): boolean {
   const e = err as { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } };
@@ -12,9 +12,9 @@ function isNotFound(err: unknown): boolean {
   );
 }
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const svc = StorageService.getInstance();
   // S3 DeleteObject is idempotent for missing keys. Real provider failures
   // (network, permission, etc.) must propagate so the outer handler maps them

--- a/backend/src/api/routes/s3-gateway/commands/delete-objects.ts
+++ b/backend/src/api/routes/s3-gateway/commands/delete-objects.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { parseXml, toXml } from '../xml.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket } from '../request.js';
 
 interface ParsedDelete {
   Delete?: {
@@ -26,7 +26,7 @@ function isNotFound(err: unknown): boolean {
 // unbounded body into memory before we can reject it.
 const MAX_DELETE_BODY_BYTES = 1024 * 1024;
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
   const chunks: Buffer[] = [];
   let received = 0;
   for await (const c of req) {
@@ -71,7 +71,7 @@ export async function handle(req: S3AuthenticatedRequest, res: Response): Promis
   }
   const keys = items.map((i) => i.Key).filter((k): k is string => !!k);
 
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
+  const bucket = getS3Bucket(req);
   const svc = StorageService.getInstance();
 
   const deleted: Array<{ Key: string }> = [];

--- a/backend/src/api/routes/s3-gateway/commands/get-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/get-object.ts
@@ -1,11 +1,11 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const svc = StorageService.getInstance();
   if (!(await svc.bucketExists(bucket))) {
     sendS3Error(res, 'NoSuchBucket', 'Bucket does not exist', {

--- a/backend/src/api/routes/s3-gateway/commands/head-bucket.ts
+++ b/backend/src/api/routes/s3-gateway/commands/head-bucket.ts
@@ -1,10 +1,10 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
   const exists = await StorageService.getInstance().bucketExists(bucket);
   if (!exists) {
     sendS3Error(res, 'NoSuchBucket', `Bucket ${bucket} does not exist`, {

--- a/backend/src/api/routes/s3-gateway/commands/head-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/head-object.ts
@@ -1,11 +1,11 @@
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const svc = StorageService.getInstance();
   if (!(await svc.bucketExists(bucket))) {
     sendS3Error(res, 'NoSuchBucket', 'Bucket does not exist', {

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error } from '../errors.js';
 import { toXml } from '../xml.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket } from '../request.js';
 
 const MAX_KEYS_DEFAULT = 1000;
 const MAX_KEYS_LIMIT = 1000;
@@ -23,8 +23,8 @@ function decodeContinuation(token: string | undefined): string | undefined {
   return Buffer.from(token, 'base64url').toString('utf8');
 }
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
   const svc = StorageService.getInstance();
   if (!(await svc.bucketExists(bucket))) {
     sendS3Error(res, 'NoSuchBucket', `Bucket ${bucket} does not exist`, {

--- a/backend/src/api/routes/s3-gateway/commands/list-parts.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-parts.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { toXml } from '../xml.js';
 import { sendS3Error } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
 const MAX_PART_NUMBER = 10_000;
 
@@ -16,9 +16,9 @@ const querySchema = z.object({
   'part-number-marker': z.coerce.number().int().min(0).max(MAX_PART_NUMBER).optional(),
 });
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
 
   const parsed = querySchema.safeParse(req.query);
   if (!parsed.success) {

--- a/backend/src/api/routes/s3-gateway/commands/put-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/put-object.ts
@@ -3,7 +3,7 @@ import { Readable, Transform, TransformCallback } from 'stream';
 import crypto from 'crypto';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { sendS3Error, S3ProtocolError } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 import {
   AwsChunkedPayloadParser,
   ChunkSignatureV4Parser,
@@ -95,9 +95,9 @@ function parseDecodedLength(raw: unknown): number | null {
   return Number(raw);
 }
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
   const svc = StorageService.getInstance();
   if (!(await svc.bucketExists(bucket))) {
     sendS3Error(res, 'NoSuchBucket', 'Bucket does not exist', {

--- a/backend/src/api/routes/s3-gateway/commands/upload-part.ts
+++ b/backend/src/api/routes/s3-gateway/commands/upload-part.ts
@@ -6,7 +6,7 @@ import {
   ChunkSignatureV4Parser,
 } from '@/services/storage/s3-signature.js';
 import { sendS3Error, S3ProtocolError } from '../errors.js';
-import { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
 const MAX_PART_BYTES = 5 * 1024 * 1024 * 1024;
 const MAX_PART_NUMBER = 10_000;
@@ -69,9 +69,9 @@ function parseDecodedLength(raw: unknown): number | null {
   return Number(raw);
 }
 
-export async function handle(req: S3AuthenticatedRequest, res: Response): Promise<void> {
-  const bucket = (req as unknown as { s3Bucket: string }).s3Bucket;
-  const key = (req as unknown as { s3Key: string }).s3Key;
+export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
+  const bucket = getS3Bucket(req);
+  const key = getS3Key(req);
 
   const partNumberRaw = req.query.partNumber;
   const uploadIdRaw = req.query.uploadId;

--- a/backend/src/api/routes/s3-gateway/index.routes.ts
+++ b/backend/src/api/routes/s3-gateway/index.routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { s3Sigv4Middleware, S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
 import { dispatchOp, parseBucketAndKey, S3Op } from './dispatch.js';
+import { S3GatewayRequest } from './request.js';
 import { sendS3Error, S3ProtocolError } from './errors.js';
 import { StorageService } from '@/services/storage/storage.service.js';
 import logger from '@/utils/logger.js';
@@ -67,12 +68,11 @@ s3GatewayRouter.use(async (req: Request, res: Response) => {
     return;
   }
   const { bucket, key } = parseBucketAndKey(req.path);
-  (req as Request & { s3Op?: S3Op; s3Bucket?: string | null; s3Key?: string | null }).s3Op = op;
-  (req as Request & { s3Bucket?: string | null }).s3Bucket = bucket;
-  (req as Request & { s3Key?: string | null }).s3Key = key;
+  const authed = req as S3GatewayRequest;
+  authed.s3Op = op;
+  authed.s3Bucket = bucket;
+  authed.s3Key = key;
   logger.debug('S3 gateway dispatch', { op, bucket, key });
-
-  const authed = req as S3AuthenticatedRequest;
   try {
     switch (op) {
       case 'ListBuckets':

--- a/backend/src/api/routes/s3-gateway/request.ts
+++ b/backend/src/api/routes/s3-gateway/request.ts
@@ -1,0 +1,32 @@
+import type { S3Op } from './dispatch.js';
+import { S3ProtocolError } from './errors.js';
+import type { S3AuthenticatedRequest } from '@/api/middlewares/s3-sigv4.js';
+
+/**
+ * A SigV4-authenticated request after the gateway dispatch middleware has
+ * resolved the operation and parsed bucket/key from the path. `s3Bucket` and
+ * `s3Key` are null for operations that don't address them (ListBuckets has
+ * neither; bucket-level ops have no key), so command handlers read them through
+ * the accessors below rather than asserting non-null at each call site.
+ */
+export interface S3GatewayRequest extends S3AuthenticatedRequest {
+  s3Op: S3Op;
+  s3Bucket: string | null;
+  s3Key: string | null;
+}
+
+/** The target bucket for a bucket/object operation. */
+export function getS3Bucket(req: S3GatewayRequest): string {
+  if (req.s3Bucket === null) {
+    throw new S3ProtocolError('InvalidRequest', 'Missing bucket in request path');
+  }
+  return req.s3Bucket;
+}
+
+/** The target object key for an object operation. */
+export function getS3Key(req: S3GatewayRequest): string {
+  if (req.s3Key === null) {
+    throw new S3ProtocolError('InvalidRequest', 'Missing object key in request path');
+  }
+  return req.s3Key;
+}

--- a/backend/tests/unit/s3-gateway-request.test.ts
+++ b/backend/tests/unit/s3-gateway-request.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getS3Bucket,
+  getS3Key,
+  type S3GatewayRequest,
+} from '../../src/api/routes/s3-gateway/request';
+import { S3ProtocolError } from '../../src/api/routes/s3-gateway/errors';
+
+function makeReq(over: Partial<S3GatewayRequest>): S3GatewayRequest {
+  return { s3Bucket: null, s3Key: null, ...over } as S3GatewayRequest;
+}
+
+describe('s3-gateway request accessors', () => {
+  it('returns the bucket when present', () => {
+    expect(getS3Bucket(makeReq({ s3Bucket: 'my-bucket' }))).toBe('my-bucket');
+  });
+
+  it('throws an S3 protocol error when the bucket is missing', () => {
+    expect(() => getS3Bucket(makeReq({ s3Bucket: null }))).toThrow(S3ProtocolError);
+  });
+
+  it('returns the key when present', () => {
+    expect(getS3Key(makeReq({ s3Key: 'path/to/object' }))).toBe('path/to/object');
+  });
+
+  it('throws an S3 protocol error when the key is missing', () => {
+    expect(() => getS3Key(makeReq({ s3Key: null }))).toThrow(S3ProtocolError);
+  });
+});


### PR DESCRIPTION
## Summary

The 15 S3 command handlers each read `s3Bucket`/`s3Key` off the request via `(req as unknown as { s3Bucket: string }).s3Bucket` — **25 `as unknown as` double-casts** that defeat type checking and re-declare the augmented-request shape inline.

- New [`request.ts`](backend/src/api/routes/s3-gateway/request.ts): an `S3GatewayRequest` type (the authenticated request + the dispatch-added `s3Op`/`s3Bucket`/`s3Key`) and `getS3Bucket`/`getS3Key` accessors that narrow `string | null` → `string`.
- The dispatch middleware in `index.routes.ts` now sets the fields through one typed reference instead of three inline `as Request & {…}` casts.
- Every command reads via the accessors; `as unknown as` count in `s3-gateway/` is now **0**.

## Behavior

Behavior-preserving. The accessors throw `S3ProtocolError('InvalidRequest', …)` only when `s3Bucket`/`s3Key` is unexpectedly null — a state the router can't produce (bucket/object operations always parse a target from the path), so valid requests are unchanged. The dispatch error handler already maps `S3ProtocolError` to a proper S3 error response, so an impossible state now surfaces cleanly instead of as a downstream crash. This is the same defensive-guard pattern accepted in #1529.

## Scope

This is the s3-gateway half of the "backend hygiene" cleanup. The big-service splits (`deployment.service.ts`, `auth.service.ts`, etc.) are intentionally **not** included — each is a larger, higher-risk refactor better done one service per PR.

## Testing

- New `s3-gateway-request.test.ts` covers both accessors (present → value, absent → `S3ProtocolError`).
- Typecheck clean, `s3-gateway/` lint clean, full backend unit suite **1531 passed / 4 skipped** (the existing 26 s3-gateway command tests exercise the accessors' happy path end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed the S3 gateway request to remove unsafe double-casts and centralize bucket/key access. Adds `S3GatewayRequest` with `getS3Bucket`/`getS3Key`, updates the router to set typed fields, and keeps behavior unchanged; missing bucket/key now surface as clean S3 errors.

- **Refactors**
  - Added `S3GatewayRequest` and accessors that narrow `string | null` to `string` and throw `S3ProtocolError` on invalid states.
  - Router now sets `s3Op`, `s3Bucket`, and `s3Key` on the typed request instead of using inline casts.
  - Updated all 15 command handlers to use the accessors; removed 25 `as unknown as` casts.
  - Added unit tests for the accessors.

<sup>Written for commit 7f612ce7ad8aaf91ec1b7a1fc27a47afc5cb27fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Type s3-gateway requests with `S3GatewayRequest` instead of casting in each command handler
> - Adds a new `S3GatewayRequest` interface in [request.ts](https://github.com/InsForge/InsForge/pull/1530/files#diff-21df2a47ea770415a58f147d2f70742d439f4c834fbe51f49bd8bea927bb3593) that extends `S3AuthenticatedRequest` with typed `s3Op`, `s3Bucket`, and `s3Key` fields, eliminating per-command type casts.
> - Adds `getS3Bucket` and `getS3Key` accessor functions that throw `S3ProtocolError` (InvalidRequest) when the respective path parameter is missing.
> - Updates all 15 command handlers to accept `S3GatewayRequest` and use the new accessors instead of direct property casts.
> - Behavioral Change: missing bucket or key now throws an explicit `S3ProtocolError` (InvalidRequest) rather than passing `null` through to downstream logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f612ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for S3 gateway request handling to use centralized request parsing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->