### PR TITLE
Fix/database table search

### DIFF
--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -52,8 +52,7 @@ export default function TablesPage() {
   const [isTableFormDirty, setIsTableFormDirty] = useState(false);
   const [showTableForm, setShowTableForm] = useState(false);
   const [editingTable, setEditingTable] = useState<string | null>(null);
-  const [searchValue, setSearchValue] = useState('');
-  const searchQuery = searchValue.trim();
+  const [searchByTable, setSearchByTable] = useState<Record<string, string>>({});
   const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
   const [sortColumns, setSortColumns] = useState<SortColumn[]>([]);
   const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-table');
@@ -83,6 +82,15 @@ export default function TablesPage() {
 
     return tables[0];
   }, [isLoadingTables, tables, selectedTableFromQuery]);
+  const tableKey = `${selectedSchema}.${selectedTable ?? ''}`;
+  const searchValue = searchByTable[tableKey] ?? '';
+  const searchQuery = searchValue.trim();
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchByTable((prev) => ({ ...prev, [tableKey]: value }));
+    },
+    [tableKey]
+  );
   const selectTable = useCallback(
     (tableName: string | null, replace: boolean = false) => {
       const nextSearchParams = new URLSearchParams(searchParams);
@@ -306,7 +314,7 @@ export default function TablesPage() {
       // Reset all state
       setSelectedRows(new Set());
       setSortColumns([]);
-      setSearchValue('');
+      setSearchByTable((prev) => ({ ...prev, [tableKey]: '' }));
       setIsSorting(false);
 
       // Refresh current table data (if table is selected)
@@ -628,7 +636,7 @@ export default function TablesPage() {
                   )
                 }
                 searchValue={searchValue}
-                onSearchChange={setSearchValue}
+                onSearchChange={handleSearchChange}
                 searchDebounceTime={300}
                 searchPlaceholder="Search records"
               />

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -82,7 +82,7 @@ export default function TablesPage() {
 
     return tables[0];
   }, [isLoadingTables, tables, selectedTableFromQuery]);
-  const tableKey = `${selectedSchema}.${selectedTable ?? ''}`;
+  const tableKey = `${selectedSchema}\x00${selectedTable ?? ''}`;
   const searchValue = searchByTable[tableKey] ?? '';
   const searchQuery = searchValue.trim();
   const handleSearchChange = useCallback(
@@ -528,6 +528,7 @@ export default function TablesPage() {
           <>
             {selectedTable && (
               <TableHeader
+                key={tableKey}
                 leftContent={
                   selectedRows.size > 0 ? (
                     <div className="flex items-center gap-2">

--- a/packages/dashboard/src/features/database/pages/__tests__/TablesPage.test.tsx
+++ b/packages/dashboard/src/features/database/pages/__tests__/TablesPage.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookMocks = vi.hoisted(() => ({
+  useTableRecords: vi.fn(),
+  useTableSchema: vi.fn(),
+  setSelectedSchema: vi.fn(),
+}));
+
+vi.mock('#features/database/hooks/useDatabaseSchemaSelection', () => ({
+  useDatabaseSchemaSelection: () => ({
+    selectedSchema: 'public',
+    setSelectedSchema: hookMocks.setSelectedSchema,
+  }),
+}));
+
+vi.mock('#features/database/hooks/useDatabase', () => ({
+  useDatabaseSchemas: () => ({
+    schemas: [{ name: 'public', isProtected: false }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('#features/database/hooks/useTables', () => ({
+  useTables: () => ({
+    tables: ['tableA', 'tableB'],
+    isLoadingTables: false,
+    tablesError: null,
+    deleteTable: vi.fn(),
+    useTableSchema: hookMocks.useTableSchema,
+    refetchTables: vi.fn(),
+  }),
+}));
+
+vi.mock('#features/database/hooks/useRecords', () => ({
+  useRecords: () => ({
+    useTableRecords: hookMocks.useTableRecords,
+    createRecord: vi.fn(),
+    updateRecord: vi.fn(),
+    deleteRecords: vi.fn(),
+    isCreating: false,
+    isUpdating: false,
+    isDeleting: false,
+  }),
+}));
+
+vi.mock('#features/database/hooks/useTablePreferences', () => ({
+  useTablePreferences: () => ({
+    columnOrder: [],
+    columnWidths: {},
+    reorderColumns: vi.fn(),
+    setColumnWidth: vi.fn(),
+  }),
+}));
+
+vi.mock('#features/database/hooks/useCSVImport', () => ({
+  useCSVImport: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('#features/database/hooks/useCSVExport', () => ({
+  useCSVExport: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('#lib/hooks/usePageSize', () => ({
+  usePageSize: () => ({
+    pageSize: 50,
+    pageSizeOptions: [10, 20, 50, 100],
+    onPageSizeChange: vi.fn(),
+  }),
+}));
+
+vi.mock('#lib/hooks/useConfirm', () => ({
+  useConfirm: () => ({
+    confirm: vi.fn(),
+    confirmDialogProps: {},
+  }),
+}));
+
+vi.mock('#lib/hooks/useToast', () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+vi.mock('#features/database/components/DatabaseSidebar', () => ({
+  DatabaseSidebar: (props: { onTableSelect?: (tableName: string) => void }) => (
+    <div data-testid="database-sidebar">
+      <button onClick={() => props.onTableSelect?.('tableA')}>Switch to Table A</button>
+      <button onClick={() => props.onTableSelect?.('tableB')}>Switch to Table B</button>
+    </div>
+  ),
+}));
+
+vi.mock('#features/database/components/DatabaseDataGrid', () => ({
+  DatabaseDataGrid: () => <div data-testid="datagrid" />,
+}));
+
+vi.mock('#features/database/components/RecordFormDialog', () => ({
+  RecordFormDialog: () => null,
+}));
+
+vi.mock('#features/database/components/TableForm', () => ({
+  TableForm: () => null,
+}));
+
+vi.mock('#features/database/components/TablesEmptyState', () => ({
+  TablesEmptyState: () => null,
+}));
+
+vi.mock('#features/database/components/TemplatePreview', () => ({
+  TemplatePreview: () => null,
+}));
+
+vi.mock('#components', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div data-testid="alert">{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TableHeader: (props: { searchValue?: string; onSearchChange?: (value: string) => void }) => (
+    <div data-testid="table-header">
+      <input
+        data-testid="search-input"
+        value={props.searchValue ?? ''}
+        onChange={(e) => props.onSearchChange?.(e.target.value)}
+      />
+      <span data-testid="search-value-display">{props.searchValue ?? ''}</span>
+    </div>
+  ),
+  EmptyState: ({ title }: { title?: string }) => <div data-testid="empty-state">{title}</div>,
+  EmptyStateIllustration: () => null,
+  SelectionClearButton: () => null,
+  DeleteActionButton: () => null,
+}));
+
+vi.mock('@insforge/ui', () => ({
+  Button: (props: React.ComponentProps<'button'> & { variant?: string; size?: string }) => (
+    <button
+      {...props}
+      onClick={props.onClick as React.MouseEventHandler<HTMLButtonElement> | undefined}
+    >
+      {props.children}
+    </button>
+  ),
+  ConfirmDialog: () => null,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('#assets/icons/pencil.svg?react', () => ({
+  default: () => null,
+}));
+
+vi.mock('#assets/icons/refresh.svg?react', () => ({
+  default: () => null,
+}));
+
+import TablesPage from '#features/database/pages/TablesPage';
+
+describe('TablesPage table-switch search behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    hookMocks.useTableRecords.mockReturnValue({
+      data: { records: [], pagination: { total: 0 } },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    hookMocks.useTableSchema.mockReturnValue({
+      data: {
+        columns: [
+          {
+            columnName: 'id',
+            type: 'int4',
+            isPrimaryKey: true,
+            isNullable: false,
+            defaultValue: null,
+          },
+        ],
+        recordCount: 0,
+      },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('clears search input and does not use previous search term when switching tables', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/?table=tableA']}>
+        <TablesPage />
+      </MemoryRouter>
+    );
+
+    const searchInput = screen.getByTestId('search-input');
+    await user.type(searchInput, 'test query');
+
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('test query');
+
+    // useTableRecords should have been called with the search term for tableA
+    expect(hookMocks.useTableRecords).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      'test query',
+      expect.any(Array),
+      expect.any(Boolean)
+    );
+
+    // Switch to table B
+    await user.click(screen.getByRole('button', { name: 'Switch to Table B' }));
+
+    // Search input should be empty
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('');
+
+    // useTableRecords should have been called without the previous search term
+    expect(hookMocks.useTableRecords).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      '',
+      expect.any(Array),
+      expect.any(Boolean)
+    );
+  });
+
+  it('restores previous search value when switching back to a previously searched table', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/?table=tableA']}>
+        <TablesPage />
+      </MemoryRouter>
+    );
+
+    // Search in table A
+    const searchInput = screen.getByTestId('search-input');
+    await user.type(searchInput, 'tableA query');
+
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('tableA query');
+
+    // Switch to table B — search should clear
+    await user.click(screen.getByRole('button', { name: 'Switch to Table B' }));
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('');
+
+    // Search in table B
+    await user.type(screen.getByTestId('search-input'), 'tableB query');
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('tableB query');
+
+    // Switch back to table A
+    await user.click(screen.getByRole('button', { name: 'Switch to Table A' }));
+
+    // Should restore tableA's own search value
+    await waitFor(() => {
+      expect(screen.getByTestId('search-value-display')).toHaveTextContent('tableA query');
+    });
+
+    // Records query should use tableA's restored search term
+    expect(hookMocks.useTableRecords).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      'tableA query',
+      expect.any(Array),
+      expect.any(Boolean)
+    );
+  });
+
+  it('shows an empty search input for a table with no prior search', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/?table=tableA']}>
+        <TablesPage />
+      </MemoryRouter>
+    );
+
+    // Initially empty
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('');
+
+    // Search in table A
+    await user.type(screen.getByTestId('search-input'), 'a query');
+
+    // Switch to table B (never searched)
+    await user.click(screen.getByRole('button', { name: 'Switch to Table B' }));
+
+    // Table B should show empty search
+    expect(screen.getByTestId('search-value-display')).toHaveTextContent('');
+  });
+});


### PR DESCRIPTION
## Summary
#closes #1528
##Fix:
 Scoped search state by schema.table key using a Record<string, string> map, so each table preserves its own search independently.

[screen-capture.webm](https://github.com/user-attachments/assets/47627ec0-3cb6-47ef-9629-c67f94f68d0e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes table search leaking across tables by scoping search per table with a unique `schema\0table` key, so each table keeps its own query when you switch. Prevents stale filters and inconsistent results when navigating.

- **Bug Fixes**
  - Replaced global `searchValue` with `searchByTable: Record<string, string>` keyed by `${selectedSchema}\x00${selectedTable}`; added `handleSearchChange` and reset only the active table on refresh.
  - Derived `searchValue` from the map and set `key={tableKey}` on `TableHeader` to ensure the input resets correctly on table changes.
  - Added tests covering: clearing on switch, restoring previous search when returning, and empty state for tables without prior searches.

<sup>Written for commit b61c36946658ccf58f6e5dbb9f48280c291392bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix database table search to maintain independent search state per table
> - Replaces a single global `searchValue` state with a per-(schema, table) search map (`searchByTable`) in [TablesPage.tsx](https://github.com/InsForge/InsForge/pull/1531/files#diff-103425128d3b3dbb3753e98cf56e8154344e2dfa8a374af1d97af4e65decb4d6).
> - Switching tables now shows an empty search input for tables with no prior search, and restores previous search terms when switching back.
> - Refreshing clears only the active table's search rather than all search state.
> - Adds a `key={tableKey}` prop to `TableHeader` so it remounts on table/schema change.
> - Adds Vitest tests in [TablesPage.test.tsx](https://github.com/InsForge/InsForge/pull/1531/files#diff-c0a6be32a7a1ad16e0852f350da6968e7add14faf2cc206373118026fddab0d6) covering search clear-on-switch, restore-on-return, and empty-search behaviors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b61c369.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Record search is now tracked independently per table, keyed to the currently selected schema/table.
  * Switching tables clears the active table’s search term, and returning to a previously searched table restores its prior search, keeping results consistent.
* **Tests**
  * Added automated coverage to verify search clearing/restoration when changing tables via URL and sidebar controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->