### PR TITLE
fix(ai): cap maxTokens at 16384 and prevent model-catalog cache stampede

### DIFF
--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -11,6 +11,8 @@ let modelsCache: {
   models: AIModelSchema[];
 } | null = null;
 
+let fetchInFlight: Promise<AIModelSchema[]> | null = null;
+
 export class AIModelService {
   /**
    * Get all available AI models
@@ -22,6 +24,19 @@ export class AIModelService {
       return modelsCache.models;
     }
 
+    if (fetchInFlight) {
+      return fetchInFlight;
+    }
+
+    fetchInFlight = AIModelService.fetchAndCacheModels();
+    try {
+      return await fetchInFlight;
+    } finally {
+      fetchInFlight = null;
+    }
+  }
+
+  private static async fetchAndCacheModels(): Promise<AIModelSchema[]> {
     const response = await fetch(OPENROUTER_MODELS_URL);
 
     if (!response.ok) {
@@ -68,6 +83,7 @@ export class AIModelService {
         return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
       });
 
+    const now = Date.now();
     modelsCache = {
       expiresAt: now + MODELS_CACHE_TTL_MS,
       models,

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -6,11 +6,10 @@ const { mockFetch } = vi.hoisted(() => ({
 
 vi.stubGlobal('fetch', mockFetch);
 
-import { AIModelService } from '../../src/services/ai/ai-model.service';
-
 describe('AIModelService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
   });
 
   it('fetches the public OpenRouter catalog with all output modalities and caches it', async () => {
@@ -61,6 +60,8 @@ describe('AIModelService', () => {
         }),
     });
 
+    const { AIModelService } = await import('../../src/services/ai/ai-model.service');
+
     const firstResult = await AIModelService.getModels();
     const secondResult = await AIModelService.getModels();
 
@@ -107,5 +108,47 @@ describe('AIModelService', () => {
         outputPriceLabel: undefined,
       },
     ]);
+  });
+
+  it('deduplicates concurrent cache-miss fetches (stampede prevention)', async () => {
+    mockFetch.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: () =>
+                  Promise.resolve({
+                    data: [
+                      {
+                        id: 'openai/gpt-4o',
+                        created: 1714608000,
+                        architecture: {
+                          input_modalities: ['text'],
+                          output_modalities: ['text'],
+                        },
+                        pricing: {
+                          prompt: '0.000005',
+                          completion: '0.000015',
+                        },
+                      },
+                    ],
+                  }),
+              }),
+            10
+          )
+        )
+    );
+
+    const { AIModelService } = await import('../../src/services/ai/ai-model.service');
+
+    const [firstResult, secondResult] = await Promise.all([
+      AIModelService.getModels(),
+      AIModelService.getModels(),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(firstResult).toEqual(secondResult);
   });
 });

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -128,7 +128,7 @@ export const chatCompletionRequestSchema = z.object({
   model: z.string(),
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
-  maxTokens: z.number().positive().max(16384).optional(),
+  maxTokens: z.number().int().positive().max(16384).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -128,7 +128,7 @@ export const chatCompletionRequestSchema = z.object({
   model: z.string(),
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
-  maxTokens: z.number().positive().optional(),
+  maxTokens: z.number().positive().max(16384).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response


### PR DESCRIPTION
Closes #1525
 Two AI-path safeguards:

  1. **Financial guard** — `maxTokens` in `chatCompletionRequestSchema` now has a
     strict `.max(16384)` upper bound, rejecting oversized output-token requests at
     validation time before they reach OpenRouter.
  2. **Stability guard** — `AIModelService.getModels()` collapses concurrent
     cache-miss callers onto a single in-flight `fetch` via a `fetchInFlight`
     tracker (cleared on settle), eliminating the thundering-herd hit on the
     OpenRouter models endpoint on cold/expired caches.

  ## Why
  - No upper bound on `maxTokens` left per-request cost uncapped.
  - Check-then-fetch in `getModels()` let every concurrent cold-cache request issue
    its own upstream fetch, risking 429s and cascading 500s.

  ## Changes
  - `packages/shared-schemas/src/ai-api.schema.ts` — `.max(16384)` on `maxTokens`.
  - `backend/src/services/ai/ai-model.service.ts` — in-flight promise dedupe;
    extracted `fetchAndCacheModels()`; preserved stale-cache fallback on `!ok`.
  - `backend/tests/unit/ai-model.service.test.ts` — per-test module isolation +
    concurrency regression test (asserts a single fetch for concurrent calls).

  ## Testing
  - Full backend suite: 1536 passed, 4 skipped.
  - `turbo run typecheck` green across all packages; shared-schemas build green.
  - Runtime boundary check: 16384 allowed, 16385 / 200000 rejected.

  ## Notes
  - The 16384 cap may constrain very large reasoning (`thinking`) outputs; chosen
    deliberately as a safety ceiling.
  - Dedupe is per-process (module-level cache); multi-instance deployments fetch
    once per instance, as before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `maxTokens` at 16384, requires it be an integer, and deduplicates model-catalog fetches on cache misses to stop request stampedes and avoid upstream 429s.

- **Bug Fixes**
  - `packages/shared-schemas`: `chatCompletionRequestSchema.maxTokens` now validates as a positive integer ≤ 16384.
  - `backend`: `AIModelService.getModels()` collapses concurrent cache-miss requests to a single in-flight fetch; stale-cache fallback kept.

<sup>Written for commit b0915d4682a7edf8cf709659a48fcecb71f5be04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant network requests by reusing an in-flight AI model catalog fetch during concurrent calls.
  * Tightened validation for chat completion requests by limiting `maxTokens` to a maximum of 16,384 (still optional and positive).

* **Tests**
  * Improved unit test isolation and added coverage to confirm only a single fetch occurs when requests are made concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap `maxTokens` at 16384 and prevent `AIModelService.getModels` cache stampede
> - Adds a module-scoped `fetchInFlight` promise in [`ai-model.service.ts`](https://github.com/InsForge/InsForge/pull/1535/files#diff-745b6cc8df215e75fc9d0984af6ba2b02356571c136e8e8d04d1cec69176fd35) so concurrent cache-miss calls share a single upstream fetch instead of each triggering a separate request.
> - Tightens `maxTokens` validation in [`ai-api.schema.ts`](https://github.com/InsForge/InsForge/pull/1535/files#diff-b337ceae5cba47edcb003641f623c0fda08c1249dd6b57720f960f0af21fc78c) to require a positive integer no greater than 16384.
> - Risk: chat completion requests with a non-integer or out-of-range `maxTokens` will now be rejected at validation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0915d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->