### PR TITLE
[codex] fix storage object key display

### DIFF
--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -51,11 +51,10 @@ function formatFileSize(bytes: number) {
 
 // Custom cell renderers for storage files
 const FileNameRenderer = ({ row, column }: RenderCellProps<StorageDataGridRow>) => {
-  const fullPath = String(row[column.key] || '');
-  const fileName = fullPath.split('/').pop() || fullPath;
+  const objectKey = String(row[column.key] || '');
   return (
-    <span className="truncate text-[13px] leading-[18px] text-foreground" title={fullPath}>
-      {fileName}
+    <span className="truncate text-[13px] leading-[18px] text-foreground" title={objectKey}>
+      {objectKey}
     </span>
   );
 };

--- a/packages/dashboard/src/features/storage/components/__tests__/StorageDataGrid.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/StorageDataGrid.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { StorageFileSchema } from '@insforge/shared-schemas';
+import { createStorageColumns } from '#features/storage/components/StorageDataGrid';
+
+describe('createStorageColumns', () => {
+  it('renders the full storage object key in the name column', () => {
+    const columns = createStorageColumns();
+    const nameColumn = columns.find((column) => column.key === 'key');
+    const row: StorageFileSchema = {
+      key: 'avatars/user-1/profile.png',
+      bucket: 'images',
+      size: 128,
+      mimeType: 'image/png',
+      uploadedAt: '2026-06-16T00:00:00.000Z',
+      url: 'https://example.test/api/storage/buckets/images/objects/avatars%2Fuser-1%2Fprofile.png',
+    };
+
+    if (!nameColumn?.renderCell) {
+      throw new Error('Expected the storage name column to define a cell renderer');
+    }
+
+    const cell = nameColumn.renderCell({
+      row,
+      column: nameColumn,
+    } as Parameters<NonNullable<typeof nameColumn.renderCell>>[0]);
+
+    render(<>{cell}</>);
+
+    expect(screen.getByText('avatars/user-1/profile.png')).toBeInTheDocument();
+    expect(screen.queryByText('profile.png')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Render the full storage object key in the dashboard storage bucket file list instead of trimming to the basename.
- Add a regression test covering slash-containing object keys so the Name column stays aligned with the actual object URL/key.

## Root Cause

The storage Name cell read `row.key` but then displayed only `split('/').pop()`, so nested object keys such as `avatars/user-1/profile.png` appeared as `profile.png` even though downloads and generated URLs still used the full key.

## Validation

- `npx prettier --check packages/dashboard/src/features/storage/components/StorageDataGrid.tsx packages/dashboard/src/features/storage/components/__tests__/StorageDataGrid.test.tsx`
- `npm --workspace @insforge/dashboard run test:component -- StorageDataGrid.test.tsx`
- `npm --workspace @insforge/dashboard run test:component`
- `npm --workspace @insforge/dashboard run lint`
- `npm --workspace @insforge/dashboard run typecheck`
- `npm --workspace @insforge/dashboard run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the full storage object key in the dashboard file list so the Name column matches the actual object URL/key. This fixes confusing basename-only display for nested keys.

- **Bug Fixes**
  - Name column now renders the full `row.key` instead of only the basename.
  - Added a regression test for keys with slashes to keep display consistent with object URLs.

<sup>Written for commit 0ff391020b39082bfb413cae1eac08503c33f018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix storage object key display to show full key instead of basename
> The `FileNameRenderer` component in [StorageDataGrid.tsx](https://github.com/InsForge/InsForge/pull/1536/files#diff-f5c251283c300026dd32af087f5ae243441ae1e5c94be61350cfda9e18a75480) was splitting the object key on `/` and displaying only the last segment. It now renders the full object key as both the cell text and the `title` attribute. A test is added to verify the full key appears and the basename alone does not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ff3910.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Storage grid now displays complete object key paths instead of file names only, providing clearer file identification in the Name column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->