### PR TITLE
Feat/prev next for bucket

### DIFF
--- a/packages/dashboard/src/features/storage/components/FilePreviewDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/FilePreviewDialog.tsx
@@ -101,6 +101,13 @@ export function FilePreviewDialog({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const target = e.target;
+      if (
+        target instanceof Element &&
+        target.closest('input, textarea, select, button, video, audio, iframe, [contenteditable]')
+      ) {
+        return;
+      }
       if (e.key === 'ArrowLeft' && hasPrevious && onPrevious) {
         e.preventDefault();
         onPrevious();

--- a/packages/dashboard/src/features/storage/components/FilePreviewDialog.tsx
+++ b/packages/dashboard/src/features/storage/components/FilePreviewDialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Download, ExternalLink } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight, Download, ExternalLink } from 'lucide-react';
 import { Button, Dialog, DialogContent, DialogDescription, DialogTitle } from '@insforge/ui';
 import { LoadingState, TypeBadge } from '#components';
 import { useStorageObjects } from '#features/storage/hooks/useStorageObjects';
@@ -10,9 +10,22 @@ interface FilePreviewDialogProps {
   onOpenChange: (open: boolean) => void;
   file: StorageFileSchema | null;
   bucket: string;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
 }
 
-export function FilePreviewDialog({ open, onOpenChange, file, bucket }: FilePreviewDialogProps) {
+export function FilePreviewDialog({
+  open,
+  onOpenChange,
+  file,
+  bucket,
+  onPrevious,
+  onNext,
+  hasPrevious = false,
+  hasNext = false,
+}: FilePreviewDialogProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -85,6 +98,26 @@ export function FilePreviewDialog({ open, onOpenChange, file, bucket }: FilePrev
       window.open(previewUrl, '_blank');
     }
   };
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' && hasPrevious && onPrevious) {
+        e.preventDefault();
+        onPrevious();
+      } else if (e.key === 'ArrowRight' && hasNext && onNext) {
+        e.preventDefault();
+        onNext();
+      }
+    },
+    [hasPrevious, hasNext, onPrevious, onNext]
+  );
+
+  useEffect(() => {
+    if (open) {
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [open, handleKeyDown]);
 
   const isPreviewable = (mimeType?: string): boolean => {
     if (!mimeType) {
@@ -205,7 +238,9 @@ export function FilePreviewDialog({ open, onOpenChange, file, bucket }: FilePrev
           {/* Header */}
           <div className="px-6 py-3">
             <div className="flex flex-col items-start gap-1">
-              <h2 className="text-lg font-semibold text-zinc-950 dark:text-white">{fileName}</h2>
+              <h2 className="text-lg font-semibold text-zinc-950 dark:text-white truncate">
+                {fileName}
+              </h2>
               <div className="flex items-center gap-1.5">
                 <span className="text-xs font-medium text-zinc-500 dark:text-neutral-400">
                   {formatFileSize(file.size)}
@@ -218,21 +253,47 @@ export function FilePreviewDialog({ open, onOpenChange, file, bucket }: FilePrev
           </div>
 
           {/* Preview Content */}
-          <div className="flex flex-1 min-h-0 overflow-hidden p-6 border-y border-zinc-200 dark:border-neutral-600">
-            {isLoading ? (
-              <div className="flex items-center justify-center w-full h-full min-h-0">
-                <LoadingState />
-              </div>
-            ) : error ? (
-              <div
-                className="flex w-full h-full items-center justify-center rounded bg-neutral-100 dark:bg-neutral-700 px-4 text-center"
-                role="alert"
-                aria-live="polite"
-              >
-                <p className="text-sm text-zinc-600 dark:text-neutral-200">{error}</p>
-              </div>
-            ) : (
-              renderPreview()
+          <div className="relative flex flex-1 min-h-0 overflow-hidden border-y border-zinc-200 dark:border-neutral-600">
+            <div className="flex flex-1 p-6">
+              {isLoading ? (
+                <div className="flex items-center justify-center w-full h-full min-h-0">
+                  <LoadingState />
+                </div>
+              ) : error ? (
+                <div
+                  className="flex w-full h-full items-center justify-center rounded bg-neutral-100 dark:bg-neutral-700 px-4 text-center"
+                  role="alert"
+                  aria-live="polite"
+                >
+                  <p className="text-sm text-zinc-600 dark:text-neutral-200">{error}</p>
+                </div>
+              ) : (
+                renderPreview()
+              )}
+            </div>
+            {(onPrevious || onNext) && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute left-2 top-1/2 -translate-y-1/2 h-10 w-10 rounded-full bg-black/40 text-white hover:bg-black/60 hover:text-white disabled:opacity-0"
+                  onClick={onPrevious}
+                  disabled={!hasPrevious}
+                  aria-label="Previous file"
+                >
+                  <ChevronLeft className="h-6 w-6" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10 rounded-full bg-black/40 text-white hover:bg-black/60 hover:text-white disabled:opacity-0"
+                  onClick={onNext}
+                  disabled={!hasNext}
+                  aria-label="Next file"
+                >
+                  <ChevronRight className="h-6 w-6" />
+                </Button>
+              </>
             )}
           </div>
 

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -390,6 +390,26 @@ export function StorageDataGrid({
     setShowPreviewDialog(true);
   }, []);
 
+  const previewFileIndex = useMemo(() => {
+    if (!previewFile) return -1;
+    return processedFiles.findIndex((f) => f.key === previewFile.key);
+  }, [previewFile, processedFiles]);
+
+  const handlePrevious = useCallback(() => {
+    if (previewFileIndex > 0) {
+      setPreviewFile(processedFiles[previewFileIndex - 1]);
+    }
+  }, [previewFileIndex, processedFiles]);
+
+  const handleNext = useCallback(() => {
+    if (previewFileIndex >= 0 && previewFileIndex < processedFiles.length - 1) {
+      setPreviewFile(processedFiles[previewFileIndex + 1]);
+    }
+  }, [previewFileIndex, processedFiles]);
+
+  const hasPrevious = previewFileIndex > 0;
+  const hasNext = previewFileIndex >= 0 && previewFileIndex < processedFiles.length - 1;
+
   const handleDelete = useCallback(
     async (file: StorageFileSchema) => {
       const confirmOptions = {
@@ -483,6 +503,10 @@ export function StorageDataGrid({
         onOpenChange={setShowPreviewDialog}
         file={previewFile}
         bucket={bucketName}
+        onPrevious={handlePrevious}
+        onNext={handleNext}
+        hasPrevious={hasPrevious}
+        hasNext={hasNext}
       />
     </div>
   );

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -391,7 +391,9 @@ export function StorageDataGrid({
   }, []);
 
   const previewFileIndex = useMemo(() => {
-    if (!previewFile) return -1;
+    if (!previewFile) {
+      return -1;
+    }
     return processedFiles.findIndex((f) => f.key === previewFile.key);
   }, [previewFile, processedFiles]);
 

--- a/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
@@ -48,14 +48,7 @@ describe('FilePreviewDialog', () => {
   });
 
   it('hides navigation buttons when no callbacks are provided', () => {
-    render(
-      <FilePreviewDialog
-        open
-        onOpenChange={vi.fn()}
-        file={fileA}
-        bucket="test-bucket"
-      />
-    );
+    render(<FilePreviewDialog open onOpenChange={vi.fn()} file={fileA} bucket="test-bucket" />);
 
     expect(screen.queryByRole('button', { name: 'Previous file' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Next file' })).not.toBeInTheDocument();

--- a/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
@@ -132,9 +132,8 @@ describe('FilePreviewDialog', () => {
     expect(onPrevious).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates with ArrowRight key when open and hasNext', async () => {
+  it('navigates with ArrowRight key when open and hasNext', () => {
     const onNext = vi.fn();
-    const user = userEvent.setup();
 
     render(
       <FilePreviewDialog
@@ -149,13 +148,12 @@ describe('FilePreviewDialog', () => {
       />
     );
 
-    await user.keyboard('{ArrowRight}');
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates with ArrowLeft key when open and hasPrevious', async () => {
+  it('navigates with ArrowLeft key when open and hasPrevious', () => {
     const onPrevious = vi.fn();
-    const user = userEvent.setup();
 
     render(
       <FilePreviewDialog
@@ -170,13 +168,12 @@ describe('FilePreviewDialog', () => {
       />
     );
 
-    await user.keyboard('{ArrowLeft}');
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
     expect(onPrevious).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call onNext on ArrowRight when hasNext is false', async () => {
+  it('does not call onNext on ArrowRight when hasNext is false', () => {
     const onNext = vi.fn();
-    const user = userEvent.setup();
 
     render(
       <FilePreviewDialog
@@ -191,13 +188,12 @@ describe('FilePreviewDialog', () => {
       />
     );
 
-    await user.keyboard('{ArrowRight}');
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     expect(onNext).not.toHaveBeenCalled();
   });
 
-  it('does not call onPrevious on ArrowLeft when hasPrevious is false', async () => {
+  it('does not call onPrevious on ArrowLeft when hasPrevious is false', () => {
     const onPrevious = vi.fn();
-    const user = userEvent.setup();
 
     render(
       <FilePreviewDialog
@@ -212,7 +208,7 @@ describe('FilePreviewDialog', () => {
       />
     );
 
-    await user.keyboard('{ArrowLeft}');
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
     expect(onPrevious).not.toHaveBeenCalled();
   });
 
@@ -234,9 +230,8 @@ describe('FilePreviewDialog', () => {
     expect(screen.getByRole('button', { name: 'Next file' })).toBeDisabled();
   });
 
-  it('does not respond to keyboard navigation when dialog is closed', async () => {
+  it('does not respond to keyboard navigation when dialog is closed', () => {
     const onNext = vi.fn();
-    const user = userEvent.setup();
 
     render(
       <FilePreviewDialog
@@ -251,7 +246,7 @@ describe('FilePreviewDialog', () => {
       />
     );
 
-    await user.keyboard('{ArrowRight}');
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     expect(onNext).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { FilePreviewDialog } from '#features/storage/components/FilePreviewDialog';
+import type { StorageFileSchema } from '@insforge/shared-schemas';
+
+const fileA: StorageFileSchema = {
+  key: 'images/a.png',
+  bucket: 'test-bucket',
+  size: 1024,
+  mimeType: 'image/png',
+  uploadedAt: '2026-06-16T00:00:00.000Z',
+  url: 'https://example.test/api/storage/buckets/test-bucket/objects/images%2Fa.png',
+};
+
+const fileB: StorageFileSchema = {
+  key: 'docs/b.pdf',
+  bucket: 'test-bucket',
+  size: 2048,
+  mimeType: 'application/pdf',
+  uploadedAt: '2026-06-16T00:00:00.000Z',
+  url: 'https://example.test/api/storage/buckets/test-bucket/objects/docs%2Fb.pdf',
+};
+
+vi.mock('#features/storage/hooks/useStorageObjects', () => ({
+  useStorageObjects: () => ({
+    downloadObject: vi.fn().mockResolvedValue(new Blob(['mock'])),
+  }),
+}));
+
+describe('FilePreviewDialog', () => {
+  it('renders previous and next buttons when callbacks are provided', () => {
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Previous file' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next file' })).toBeInTheDocument();
+  });
+
+  it('hides navigation buttons when no callbacks are provided', () => {
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Previous file' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next file' })).not.toBeInTheDocument();
+  });
+
+  it('disables previous button at the first file', () => {
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        hasPrevious={false}
+        hasNext
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Previous file' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next file' })).not.toBeDisabled();
+  });
+
+  it('disables next button at the last file', () => {
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileB}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        hasPrevious
+        hasNext={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Next file' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Previous file' })).not.toBeDisabled();
+  });
+
+  it('calls onNext when next button is clicked', async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={onNext}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Next file' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPrevious when previous button is clicked', async () => {
+    const onPrevious = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileB}
+        bucket="test-bucket"
+        onPrevious={onPrevious}
+        onNext={vi.fn()}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Previous file' }));
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates with ArrowRight key when open and hasNext', async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={onNext}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    await user.keyboard('{ArrowRight}');
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates with ArrowLeft key when open and hasPrevious', async () => {
+    const onPrevious = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileB}
+        bucket="test-bucket"
+        onPrevious={onPrevious}
+        onNext={vi.fn()}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onNext on ArrowRight when hasNext is false', async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileB}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={onNext}
+        hasPrevious
+        hasNext={false}
+      />
+    );
+
+    await user.keyboard('{ArrowRight}');
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it('does not call onPrevious on ArrowLeft when hasPrevious is false', async () => {
+    const onPrevious = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={onPrevious}
+        onNext={vi.fn()}
+        hasPrevious={false}
+        hasNext
+      />
+    );
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onPrevious).not.toHaveBeenCalled();
+  });
+
+  it('disables both buttons when only one file (no previous and no next)', () => {
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={vi.fn()}
+        hasPrevious={false}
+        hasNext={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Previous file' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next file' })).toBeDisabled();
+  });
+
+  it('does not respond to keyboard navigation when dialog is closed', async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <FilePreviewDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        file={fileA}
+        bucket="test-bucket"
+        onPrevious={vi.fn()}
+        onNext={onNext}
+        hasPrevious
+        hasNext
+      />
+    );
+
+    await user.keyboard('{ArrowRight}');
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

#closes #1537 

[screen-capture.webm](https://github.com/user-attachments/assets/8222e921-ef77-4dd0-949e-874ab93499c9)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds previous/next navigation to the bucket file preview dialog with Arrow key support, so you can browse files without closing it. Implements #1537.

- **New Features**
  - `FilePreviewDialog` adds previous/next buttons and `ArrowLeft`/`ArrowRight` shortcuts when open; ignores keys when focus is on inputs or other controls.
  - `StorageDataGrid` computes the current index and passes `onPrevious`/`onNext` plus `hasPrevious`/`hasNext`.
  - Buttons disable at the ends and hide when callbacks aren’t provided; accessible labels; long file names are truncated.
  - Tests cover button visibility, disabled states, click/keyboard navigation, boundary cases, and no input when the dialog is closed.

<sup>Written for commit 49d7e8d9d7173cb78c9606e7b89ace80fbd6867c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add previous/next file navigation to the storage `FilePreviewDialog`
> - Adds `onPrevious`, `onNext`, `hasPrevious`, and `hasNext` props to [`FilePreviewDialog`](https://github.com/InsForge/InsForge/pull/1538/files#diff-40aeb6c59d27c3110ed40b47081f1c5487763aabde985d867adb20f5c61be063); renders Previous/Next buttons when callbacks are provided and disables them at bounds.
> - Adds ArrowLeft/ArrowRight keyboard navigation via a `window` keydown listener scoped to when the dialog is open; ignores events from interactive elements.
> - [`StorageDataGrid`](https://github.com/InsForge/InsForge/pull/1538/files#diff-f5c251283c300026dd32af087f5ae243441ae1e5c94be61350cfda9e18a75480) wires up the navigation by tracking the previewed file's index in `processedFiles` and passing adjacent-file callbacks to the dialog.
> - New tests in [`FilePreviewDialog.test.tsx`](https://github.com/InsForge/InsForge/pull/1538/files#diff-72b38e9f39120f3e3d0b6b501ec18e900fbf9e22f43586d1177a54f539691ad8) cover button rendering, disabled states, click handlers, and keyboard navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49d7e8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Previous/Next navigation to the file preview dialog.
  * Enabled ArrowLeft/ArrowRight keyboard navigation while the dialog is open.
  * Added grid-level support to move between adjacent files in the preview sequence.
* **UI Improvements**
  * Updated the dialog header file name rendering to use truncation styling.
  * Added conditional left/right chevron controls with disabled states at boundaries.
* **Tests**
  * Added React Testing Library coverage for navigation visibility, disabled states, click handling, and keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->