### PR TITLE
chore(ai): add test coverage for maxTokens and externalize cap configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,11 @@ LOGS_DIR=
 # Used for AI-powered features and model gateway
 OPENROUTER_API_KEY=
 
+# Maximum output tokens per chat completion request (default: 16384).
+# Increase this for models with larger output windows (e.g. 32768 for 32K-output models).
+# Must be a positive integer. Invalid values are silently ignored and the default is used.
+MAX_COMPLETION_TOKENS=16384
+
 # -----------------------------------------------------------------------------
 # Stripe Payments Configuration (Optional)
 # -----------------------------------------------------------------------------

--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -27,7 +27,11 @@ export class AIModelService {
    */
   static async getModels(): Promise<AIModelSchema[]> {
     if (Date.now() < circuitBreakerUntil) {
-      throw new Error('Upstream AI models catalog is temporarily unavailable.');
+      throw new AppError(
+        'Upstream AI models catalog is temporarily unavailable.',
+        500,
+        ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+      );
     }
 
     if (modelsCache && modelsCache.expiresAt > Date.now()) {
@@ -42,13 +46,17 @@ export class AIModelService {
       let response;
       try {
         response = await fetch(OPENROUTER_MODELS_URL);
-      } catch (error) {
+      } catch {
         if (modelsCache) {
           modelsCache.expiresAt = Date.now() + 5000;
           return modelsCache.models;
         }
         circuitBreakerUntil = Date.now() + 5000;
-        throw error;
+        throw new AppError(
+          'Upstream AI models catalog is temporarily unavailable.',
+          500,
+          ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+        );
       }
 
       if (!response.ok) {

--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -2,6 +2,7 @@ import type { RawOpenRouterModel } from '@/types/ai.js';
 import { ERROR_CODES, type AIModelSchema } from '@insforge/shared-schemas';
 import { calculateTokenPrices, normalizeModalities, getProviderOrder } from './helpers.js';
 import { AppError } from '@/utils/errors.js';
+import { logger } from '@/utils/logger.js';
 
 const MODELS_CACHE_TTL_MS = 60 * 60 * 1000;
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models?output_modalities=all';
@@ -29,7 +30,7 @@ export class AIModelService {
     if (Date.now() < circuitBreakerUntil) {
       throw new AppError(
         'Upstream AI models catalog is temporarily unavailable.',
-        500,
+        503,
         ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
       );
     }
@@ -43,73 +44,73 @@ export class AIModelService {
     }
 
     fetchInFlight = (async () => {
-      let response;
       try {
-        response = await fetch(OPENROUTER_MODELS_URL);
-      } catch {
-        if (modelsCache) {
-          modelsCache.expiresAt = Date.now() + 5000;
-          return modelsCache.models;
-        }
-        circuitBreakerUntil = Date.now() + 5000;
-        throw new AppError(
-          'Upstream AI models catalog is temporarily unavailable.',
-          500,
-          ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
-        );
-      }
+        const response = await fetch(OPENROUTER_MODELS_URL);
 
-      if (!response.ok) {
-        if (modelsCache) {
-          modelsCache.expiresAt = Date.now() + 5000;
-          return modelsCache.models;
-        }
-        circuitBreakerUntil = Date.now() + 5000;
-        throw new AppError(
-          `Failed to fetch models: ${response.statusText}`,
-          500,
-          ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
-        );
-      }
-
-      const data = (await response.json()) as { data: RawOpenRouterModel[] };
-      const rawModels = data.data || [];
-
-      const models: AIModelSchema[] = rawModels
-        .map((rawModel) => {
-          const inputModality = normalizeModalities(rawModel.architecture?.input_modalities || []);
-          const outputModality = normalizeModalities(
-            rawModel.architecture?.output_modalities || []
+        if (!response.ok) {
+          throw new AppError(
+            `Failed to fetch models: ${response.statusText}`,
+            503,
+            ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
           );
-          const { inputPrice, outputPrice, inputPriceLabel, outputPriceLabel } =
-            calculateTokenPrices(rawModel.pricing, inputModality, outputModality);
-          return {
-            id: rawModel.id, // OpenRouter provided model ID
-            created: rawModel.created,
-            modelId: rawModel.id,
-            provider: 'openrouter',
-            inputModality,
-            outputModality,
-            inputPrice,
-            outputPrice,
-            inputPriceLabel,
-            outputPriceLabel,
-          };
-        })
-        .filter((model) => model.inputModality.length > 0 && model.outputModality.length > 0)
-        .sort((a, b) => {
-          const [aCompany = '', bCompany = ''] = [a.id.split('/')[0], b.id.split('/')[0]];
+        }
 
-          const orderDiff = getProviderOrder(aCompany) - getProviderOrder(bCompany);
-          return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
-        });
+        const data = (await response.json()) as { data: RawOpenRouterModel[] };
+        const rawModels = data.data || [];
 
-      modelsCache = {
-        expiresAt: Date.now() + MODELS_CACHE_TTL_MS,
-        models,
-      };
+        const models: AIModelSchema[] = rawModels
+          .map((rawModel) => {
+            const inputModality = normalizeModalities(
+              rawModel.architecture?.input_modalities || []
+            );
+            const outputModality = normalizeModalities(
+              rawModel.architecture?.output_modalities || []
+            );
+            const { inputPrice, outputPrice, inputPriceLabel, outputPriceLabel } =
+              calculateTokenPrices(rawModel.pricing, inputModality, outputModality);
+            return {
+              id: rawModel.id, // OpenRouter provided model ID
+              created: rawModel.created,
+              modelId: rawModel.id,
+              provider: 'openrouter',
+              inputModality,
+              outputModality,
+              inputPrice,
+              outputPrice,
+              inputPriceLabel,
+              outputPriceLabel,
+            };
+          })
+          .filter((model) => model.inputModality.length > 0 && model.outputModality.length > 0)
+          .sort((a, b) => {
+            const [aCompany = '', bCompany = ''] = [a.id.split('/')[0], b.id.split('/')[0]];
 
-      return models;
+            const orderDiff = getProviderOrder(aCompany) - getProviderOrder(bCompany);
+            return orderDiff !== 0 ? orderDiff : a.id.localeCompare(b.id);
+          });
+
+        modelsCache = {
+          expiresAt: Date.now() + MODELS_CACHE_TTL_MS,
+          models,
+        };
+
+        return models;
+      } catch (err) {
+        if (modelsCache) {
+          logger.warn('OpenRouter catalog fetch failed; serving stale cache.', { err });
+          modelsCache.expiresAt = Date.now() + 5000;
+          return modelsCache.models;
+        }
+        logger.warn('OpenRouter catalog fetch failed; opening circuit breaker.', { err });
+        circuitBreakerUntil = Date.now() + 5000;
+        throw err instanceof AppError
+          ? err
+          : new AppError(
+              'Upstream AI models catalog is temporarily unavailable.',
+              503,
+              ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+            );
+      }
     })().finally(() => {
       fetchInFlight = null;
     });

--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -21,7 +21,7 @@ export class AIModelService {
   /**
    * Retrieves the catalog of available AI models from OpenRouter.
    * Utilizes a time-based cache and coalesces concurrent fetches to prevent rate limiting.
-   * * @returns {Promise<AIModelSchema[]>} A promise resolving to an array of available models.
+   * @returns {Promise<AIModelSchema[]>} A promise resolving to an array of available models.
    */
   static async getModels(): Promise<AIModelSchema[]> {
     if (modelsCache && modelsCache.expiresAt > Date.now()) {
@@ -33,12 +33,30 @@ export class AIModelService {
     }
 
     fetchInFlight = (async () => {
-      const response = await fetch(OPENROUTER_MODELS_URL);
+      let response;
+      try {
+        response = await fetch(OPENROUTER_MODELS_URL);
+      } catch (error) {
+        if (modelsCache) {
+          modelsCache.expiresAt = Date.now() + 5000;
+          return modelsCache.models;
+        }
+        modelsCache = {
+          expiresAt: Date.now() + 5000,
+          models: [],
+        };
+        throw error;
+      }
 
       if (!response.ok) {
         if (modelsCache) {
+          modelsCache.expiresAt = Date.now() + 5000;
           return modelsCache.models;
         }
+        modelsCache = {
+          expiresAt: Date.now() + 5000,
+          models: [],
+        };
         throw new AppError(
           `Failed to fetch models: ${response.statusText}`,
           500,

--- a/backend/src/services/ai/ai-model.service.ts
+++ b/backend/src/services/ai/ai-model.service.ts
@@ -17,6 +17,8 @@ let modelsCache: {
  */
 let fetchInFlight: Promise<AIModelSchema[]> | null = null;
 
+let circuitBreakerUntil = 0;
+
 export class AIModelService {
   /**
    * Retrieves the catalog of available AI models from OpenRouter.
@@ -24,6 +26,10 @@ export class AIModelService {
    * @returns {Promise<AIModelSchema[]>} A promise resolving to an array of available models.
    */
   static async getModels(): Promise<AIModelSchema[]> {
+    if (Date.now() < circuitBreakerUntil) {
+      throw new Error('Upstream AI models catalog is temporarily unavailable.');
+    }
+
     if (modelsCache && modelsCache.expiresAt > Date.now()) {
       return modelsCache.models;
     }
@@ -41,10 +47,7 @@ export class AIModelService {
           modelsCache.expiresAt = Date.now() + 5000;
           return modelsCache.models;
         }
-        modelsCache = {
-          expiresAt: Date.now() + 5000,
-          models: [],
-        };
+        circuitBreakerUntil = Date.now() + 5000;
         throw error;
       }
 
@@ -53,10 +56,7 @@ export class AIModelService {
           modelsCache.expiresAt = Date.now() + 5000;
           return modelsCache.models;
         }
-        modelsCache = {
-          expiresAt: Date.now() + 5000,
-          models: [],
-        };
+        circuitBreakerUntil = Date.now() + 5000;
         throw new AppError(
           `Failed to fetch models: ${response.statusText}`,
           500,
@@ -117,4 +117,5 @@ export class AIModelService {
 export function _resetCacheForTesting() {
   modelsCache = null;
   fetchInFlight = null;
+  circuitBreakerUntil = 0;
 }

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -10,7 +10,7 @@ import { AIModelService, _resetCacheForTesting } from '../../src/services/ai/ai-
 
 describe('AIModelService', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockFetch.mockReset();
     _resetCacheForTesting();
   });
 
@@ -131,10 +131,61 @@ describe('AIModelService', () => {
       Promise.all([AIModelService.getModels(), AIModelService.getModels()])
     ).rejects.toThrow();
 
-    // 2. The next call should trigger a fresh fetch
+    // 2. Advance time by 6 seconds so the 5s negative cache expires
+    const baseTime = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 6000);
+
+    // 3. The next call should trigger a fresh fetch
     await AIModelService.getModels();
 
-    // 3. Since the first two shared a fetch, and the third triggered a new one, the total should be 2.
+    // 4. Since the first two shared a fetch, and the third triggered a new one, the total should be 2.
     expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    dateSpy.mockRestore();
+  });
+
+  it('serves stale cache on upstream failure and updates cache expiration to avoid pounding', async () => {
+    // 1. Populate the cache with a successful fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'openai/gpt-image',
+              created: 1767225600,
+              architecture: {
+                input_modalities: ['image', 'text'],
+                output_modalities: ['video', 'text', 'embeddings'],
+              },
+              pricing: {
+                prompt: '0.000001',
+                completion: '0.000002',
+              },
+            },
+          ],
+        }),
+    });
+
+    const initialResult = await AIModelService.getModels();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // 2. Advance time by 2 hours so cache becomes stale (TTL is 1 hour)
+    const baseTime = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 2 * 60 * 60 * 1000);
+
+    // 3. Mock fetch failure for subsequent request
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Internal Server Error',
+    });
+
+    // 4. Retrieve models again - should return stale cache instead of throwing
+    const staleResult = await AIModelService.getModels();
+    expect(staleResult).toEqual(initialResult);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore Date.now mock
+    dateSpy.mockRestore();
   });
 });

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -188,4 +188,46 @@ describe('AIModelService', () => {
     // Restore Date.now mock
     dateSpy.mockRestore();
   });
+
+  it('serves stale cache on genuine network rejection, extends cache expiry, and does not throw', async () => {
+    // 1. Populate the cache with a successful fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'openai/gpt-image',
+              created: 1767225600,
+              architecture: {
+                input_modalities: ['image', 'text'],
+                output_modalities: ['video', 'text', 'embeddings'],
+              },
+              pricing: {
+                prompt: '0.000001',
+                completion: '0.000002',
+              },
+            },
+          ],
+        }),
+    });
+
+    const initialResult = await AIModelService.getModels();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // 2. Advance time by 2 hours so cache becomes stale (TTL is 1 hour)
+    const baseTime = Date.now();
+    const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 2 * 60 * 60 * 1000);
+
+    // 3. Mock genuine network rejection for subsequent request
+    mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
+
+    // 4. Retrieve models again - should return stale cache instead of throwing
+    const staleResult = await AIModelService.getModels();
+    expect(staleResult).toEqual(initialResult);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Restore Date.now mock
+    dateSpy.mockRestore();
+  });
 });

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -135,13 +135,15 @@ describe('AIModelService', () => {
     const baseTime = Date.now();
     const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 6000);
 
-    // 3. The next call should trigger a fresh fetch
-    await AIModelService.getModels();
+    try {
+      // 3. The next call should trigger a fresh fetch
+      await AIModelService.getModels();
 
-    // 4. Since the first two shared a fetch, and the third triggered a new one, the total should be 2.
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    dateSpy.mockRestore();
+      // 4. Since the first two shared a fetch, and the third triggered a new one, the total should be 2.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      dateSpy.mockRestore();
+    }
   });
 
   it('serves stale cache on upstream failure and updates cache expiration to avoid pounding', async () => {
@@ -174,19 +176,21 @@ describe('AIModelService', () => {
     const baseTime = Date.now();
     const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 2 * 60 * 60 * 1000);
 
-    // 3. Mock fetch failure for subsequent request
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      statusText: 'Internal Server Error',
-    });
+    try {
+      // 3. Mock fetch failure for subsequent request
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Internal Server Error',
+      });
 
-    // 4. Retrieve models again - should return stale cache instead of throwing
-    const staleResult = await AIModelService.getModels();
-    expect(staleResult).toEqual(initialResult);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore Date.now mock
-    dateSpy.mockRestore();
+      // 4. Retrieve models again - should return stale cache instead of throwing
+      const staleResult = await AIModelService.getModels();
+      expect(staleResult).toEqual(initialResult);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      // Restore Date.now mock
+      dateSpy.mockRestore();
+    }
   });
 
   it('serves stale cache on genuine network rejection, extends cache expiry, and does not throw', async () => {
@@ -219,15 +223,17 @@ describe('AIModelService', () => {
     const baseTime = Date.now();
     const dateSpy = vi.spyOn(Date, 'now').mockImplementation(() => baseTime + 2 * 60 * 60 * 1000);
 
-    // 3. Mock genuine network rejection for subsequent request
-    mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
+    try {
+      // 3. Mock genuine network rejection for subsequent request
+      mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
 
-    // 4. Retrieve models again - should return stale cache instead of throwing
-    const staleResult = await AIModelService.getModels();
-    expect(staleResult).toEqual(initialResult);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // Restore Date.now mock
-    dateSpy.mockRestore();
+      // 4. Retrieve models again - should return stale cache instead of throwing
+      const staleResult = await AIModelService.getModels();
+      expect(staleResult).toEqual(initialResult);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      // Restore Date.now mock
+      dateSpy.mockRestore();
+    }
   });
 });

--- a/backend/tests/unit/ai-tool-calling-schemas.test.ts
+++ b/backend/tests/unit/ai-tool-calling-schemas.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   toolFunctionSchema,
   toolSchema,
@@ -7,7 +7,7 @@ import {
   chatMessageSchema,
   chatCompletionRequestSchema,
   chatCompletionResponseSchema,
-  CONFIGURED_MAX_TOKENS,
+  DEFAULT_MAX_TOKENS_CAP,
 } from '@insforge/shared-schemas';
 
 describe('Tool Calling Schemas', () => {
@@ -188,10 +188,14 @@ describe('Tool Calling Schemas', () => {
       messages: [{ role: 'user' as const, content: 'Hello' }],
     };
 
+    afterEach(() => {
+      delete process.env.MAX_COMPLETION_TOKENS;
+    });
+
     it('accepts maxTokens at the maximum boundary cap', () => {
       const result = chatCompletionRequestSchema.safeParse({
         ...baseRequest,
-        maxTokens: CONFIGURED_MAX_TOKENS,
+        maxTokens: DEFAULT_MAX_TOKENS_CAP,
       });
       expect(result.success).toBe(true);
     });
@@ -199,7 +203,7 @@ describe('Tool Calling Schemas', () => {
     it('rejects maxTokens exceeding the maximum boundary cap', () => {
       const result = chatCompletionRequestSchema.safeParse({
         ...baseRequest,
-        maxTokens: CONFIGURED_MAX_TOKENS + 1,
+        maxTokens: DEFAULT_MAX_TOKENS_CAP + 1,
       });
       expect(result.success).toBe(false);
     });
@@ -210,6 +214,22 @@ describe('Tool Calling Schemas', () => {
         maxTokens: 100.5,
       });
       expect(result.success).toBe(false);
+    });
+
+    it('respects MAX_COMPLETION_TOKENS env var when set', () => {
+      process.env.MAX_COMPLETION_TOKENS = '1000';
+
+      const rejected = chatCompletionRequestSchema.safeParse({
+        ...baseRequest,
+        maxTokens: 1001,
+      });
+      expect(rejected.success).toBe(false);
+
+      const accepted = chatCompletionRequestSchema.safeParse({
+        ...baseRequest,
+        maxTokens: 1000,
+      });
+      expect(accepted.success).toBe(true);
     });
   });
 

--- a/backend/tests/unit/ai-tool-calling-schemas.test.ts
+++ b/backend/tests/unit/ai-tool-calling-schemas.test.ts
@@ -7,7 +7,7 @@ import {
   chatMessageSchema,
   chatCompletionRequestSchema,
   chatCompletionResponseSchema,
-  DEFAULT_MAX_TOKENS_CAP,
+  CONFIGURED_MAX_TOKENS,
 } from '@insforge/shared-schemas';
 
 describe('Tool Calling Schemas', () => {
@@ -191,7 +191,7 @@ describe('Tool Calling Schemas', () => {
     it('accepts maxTokens at the maximum boundary cap', () => {
       const result = chatCompletionRequestSchema.safeParse({
         ...baseRequest,
-        maxTokens: DEFAULT_MAX_TOKENS_CAP,
+        maxTokens: CONFIGURED_MAX_TOKENS,
       });
       expect(result.success).toBe(true);
     });
@@ -199,7 +199,7 @@ describe('Tool Calling Schemas', () => {
     it('rejects maxTokens exceeding the maximum boundary cap', () => {
       const result = chatCompletionRequestSchema.safeParse({
         ...baseRequest,
-        maxTokens: DEFAULT_MAX_TOKENS_CAP + 1,
+        maxTokens: CONFIGURED_MAX_TOKENS + 1,
       });
       expect(result.success).toBe(false);
     });

--- a/backend/tests/unit/ai-tool-calling-schemas.test.ts
+++ b/backend/tests/unit/ai-tool-calling-schemas.test.ts
@@ -7,6 +7,7 @@ import {
   chatMessageSchema,
   chatCompletionRequestSchema,
   chatCompletionResponseSchema,
+  DEFAULT_MAX_TOKENS_CAP,
 } from '@insforge/shared-schemas';
 
 describe('Tool Calling Schemas', () => {
@@ -178,6 +179,37 @@ describe('Tool Calling Schemas', () => {
     it('accepts request without any tool fields (backward compatible)', () => {
       const result = chatCompletionRequestSchema.safeParse(baseRequest);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('chatCompletionRequestSchema - maxTokens validation', () => {
+    const baseRequest = {
+      model: 'openai/gpt-4',
+      messages: [{ role: 'user' as const, content: 'Hello' }],
+    };
+
+    it('accepts maxTokens at the maximum boundary cap', () => {
+      const result = chatCompletionRequestSchema.safeParse({
+        ...baseRequest,
+        maxTokens: DEFAULT_MAX_TOKENS_CAP,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects maxTokens exceeding the maximum boundary cap', () => {
+      const result = chatCompletionRequestSchema.safeParse({
+        ...baseRequest,
+        maxTokens: DEFAULT_MAX_TOKENS_CAP + 1,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-integer maxTokens values', () => {
+      const result = chatCompletionRequestSchema.safeParse({
+        ...baseRequest,
+        maxTokens: 100.5,
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
       "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1298,6 +1299,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1719,6 +1721,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
       "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1823,6 +1826,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1871,6 +1875,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1899,7 +1904,8 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -2773,6 +2779,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6419,6 +6426,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6975,8 +6983,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7195,6 +7202,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -7297,6 +7305,7 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -7492,6 +7501,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -8008,6 +8018,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8522,6 +8533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9337,6 +9349,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9681,8 +9694,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -10103,6 +10115,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10172,6 +10185,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10232,6 +10246,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10473,6 +10488,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -11452,6 +11468,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -12024,6 +12041,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12722,7 +12740,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13492,6 +13509,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -13810,6 +13828,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13954,6 +13973,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13983,7 +14003,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13999,7 +14018,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14012,8 +14030,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -14149,6 +14166,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14171,6 +14189,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14183,6 +14202,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14206,6 +14226,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14416,7 +14437,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15694,7 +15716,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -16036,6 +16059,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -16197,6 +16221,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16439,6 +16464,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16940,6 +16966,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17121,6 +17148,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
       "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1299,7 +1298,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1721,7 +1719,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
       "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1826,7 +1823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1875,7 +1871,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1904,8 +1899,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@databases/sql/-/sql-3.3.0.tgz",
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -2779,7 +2773,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6426,7 +6419,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6983,7 +6975,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7202,7 +7195,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -7305,7 +7297,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -7501,7 +7492,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -8018,7 +8008,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8533,7 +8522,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9349,7 +9337,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9694,7 +9681,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -10115,7 +10103,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10185,7 +10172,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10246,7 +10232,6 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10488,7 +10473,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -11468,7 +11452,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -12041,7 +12024,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12740,6 +12722,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13509,7 +13492,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -13828,7 +13810,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13973,7 +13954,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14003,6 +13983,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -14018,6 +13999,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14030,7 +14012,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -14166,7 +14149,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14189,7 +14171,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14202,7 +14183,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
       "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14226,7 +14206,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14437,8 +14416,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15716,8 +15694,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -16059,7 +16036,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -16221,7 +16197,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16464,7 +16439,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16966,7 +16940,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17148,7 +17121,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
 import { modalitySchema } from './ai.schema.js';
 
+export const DEFAULT_MAX_TOKENS_CAP = 16384;
+
+const getMaxTokensCap = () => {
+  const g = (typeof globalThis !== 'undefined' ? globalThis : {}) as {
+    process?: { env?: Record<string, string> };
+  };
+  const env = (g.process && g.process.env) || {};
+  return env.MAX_COMPLETION_TOKENS
+    ? parseInt(env.MAX_COMPLETION_TOKENS, 10)
+    : DEFAULT_MAX_TOKENS_CAP;
+};
+
 // ============= Chat Completion Schemas =============
 
 // OpenAI-compatible content schemas
@@ -128,8 +140,8 @@ export const chatCompletionRequestSchema = z.object({
   model: z.string(),
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
-  // Max cap set to 16,384 (standard max output for flagship models) to prevent financial abuse
-  maxTokens: z.number().int().positive().max(16384).optional(),
+  // Cap output tokens to prevent abuse. Configurable via MAX_COMPLETION_TOKENS, defaults to 16,384.
+  maxTokens: z.number().int().positive().max(getMaxTokensCap()).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -1,17 +1,20 @@
 import { z } from 'zod';
 import { modalitySchema } from './ai.schema.js';
 
+declare const process: any;
+
 export const DEFAULT_MAX_TOKENS_CAP = 16384;
 
 const getMaxTokensCap = () => {
-  const g = (typeof globalThis !== 'undefined' ? globalThis : {}) as {
-    process?: { env?: Record<string, string> };
-  };
-  const env = (g.process && g.process.env) || {};
-  return env.MAX_COMPLETION_TOKENS
-    ? parseInt(env.MAX_COMPLETION_TOKENS, 10)
-    : DEFAULT_MAX_TOKENS_CAP;
+  if (typeof process !== 'undefined' && process.env && process.env.MAX_COMPLETION_TOKENS) {
+    const parsed = parseInt(process.env.MAX_COMPLETION_TOKENS, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_MAX_TOKENS_CAP;
 };
+
+// This cap is evaluated once at module load time.
+export const CONFIGURED_MAX_TOKENS = getMaxTokensCap();
 
 // ============= Chat Completion Schemas =============
 
@@ -141,7 +144,7 @@ export const chatCompletionRequestSchema = z.object({
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
   // Cap output tokens to prevent abuse. Configurable via MAX_COMPLETION_TOKENS, defaults to 16,384.
-  maxTokens: z.number().int().positive().max(getMaxTokensCap()).optional(),
+  maxTokens: z.number().int().positive().max(CONFIGURED_MAX_TOKENS).optional(),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -13,9 +13,6 @@ const getMaxTokensCap = () => {
   return DEFAULT_MAX_TOKENS_CAP;
 };
 
-// This cap is evaluated once at module load time.
-export const CONFIGURED_MAX_TOKENS = getMaxTokensCap();
-
 // ============= Chat Completion Schemas =============
 
 // OpenAI-compatible content schemas
@@ -143,8 +140,16 @@ export const chatCompletionRequestSchema = z.object({
   model: z.string(),
   messages: z.array(chatMessageSchema),
   temperature: z.number().min(0).max(2).optional(),
-  // Cap output tokens to prevent abuse. Configurable via MAX_COMPLETION_TOKENS, defaults to 16,384.
-  maxTokens: z.number().int().positive().max(CONFIGURED_MAX_TOKENS).optional(),
+  // Cap output tokens to prevent abuse. Configurable via MAX_COMPLETION_TOKENS env var, defaults to 16,384.
+  // Evaluated lazily per-request so dotenv loading order does not affect the cap.
+  maxTokens: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .refine((val) => val === undefined || val <= getMaxTokensCap(), {
+      message: 'Exceeds configured maximum token cap.',
+    }),
   topP: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
   // Web Search: Incorporate relevant web search results into the response

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { modalitySchema } from './ai.schema.js';
 
-declare const process: any;
+declare const process: { env?: Record<string, string> };
 
 export const DEFAULT_MAX_TOKENS_CAP = 16384;
 

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -7,8 +7,8 @@ export const DEFAULT_MAX_TOKENS_CAP = 16384;
 
 const getMaxTokensCap = () => {
   if (typeof process !== 'undefined' && process.env && process.env.MAX_COMPLETION_TOKENS) {
-    const parsed = parseInt(process.env.MAX_COMPLETION_TOKENS, 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    const parsed = Number(process.env.MAX_COMPLETION_TOKENS);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
   }
   return DEFAULT_MAX_TOKENS_CAP;
 };


### PR DESCRIPTION
## Overview
This PR resolves #1540 by addressing post-merge architectural feedback from PR #1526. It externalizes token cap configurations, adds rigorous security boundary validation tests, and implements outage backoff resilience (circuit breaker) for upstream catalog caching.

---

## Changes Made

### 1. Architectural: Configuration Externalization
- **Removed Magic Literal**: Decoupled the hardcoded `16384` token ceiling from Zod validation.
- **Environment Driven**: Bound the token cap validation to `process.env.MAX_COMPLETION_TOKENS`, falling back to `DEFAULT_MAX_TOKENS_CAP = 16384`.
- **Browser-Safe Cross-Compilation**: Implemented `getMaxTokensCap()` accessing the environment variables dynamically via `globalThis`. This prevents bundler-level errors when executing in the browser (dashboard/frontend) while maintaining absolute type safety under the `shared-schemas` compiler context.

### 2. Security: TDD Schema Validation Coverage
- Added automated boundary checks to `backend/tests/unit/ai-tool-calling-schemas.test.ts`:
  - **Floats/Rejection**: Asserts strict validation failure on fractional tokens (e.g. `100.5`) to enforce integer validation.
  - **Upper Bounds/Rejection**: Asserts rejection of payloads exceeding boundary limit constraints (e.g. `getMaxTokensCap() + 1`).
  - **Boundary Accept**: Asserts success when processing exact limits (e.g. `getMaxTokensCap()`).

### 3. Resilience: Negative Caching & Outage Backoff
- Fixed the JSDoc syntax typo (`* * @returns` -> `* @returns`) on `AIModelService.getModels()`.
- **Circuit Breaker Implementation**: Wrapped the OpenRouter endpoint fetch in a `try/catch` block inside `backend/src/services/ai/ai-model.service.ts`:
  - Under a sustained outage, if a stale cache is present, we return it but temporarily push its expiration out by `5000ms` (5 seconds).
  - If no cache is present, we store a temporary negative cache with an empty model list for 5 seconds to act as a backoff circuit breaker.
  - This avoids pounding the upstream catalog endpoints on every request when they are experiencing downtime.
- **TDD Coverage**: Added test coverage in `backend/tests/unit/ai-model.service.test.ts` to assert that stale cache data is correctly returned upon API rejections.
- **Test Optimization**: Standardized setups by replacing `vi.clearAllMocks()` with `mockFetch.mockReset()` to prevent state pollution, and updated the retry test to mock fake timer progression.

---

## Verification Results

### 1. Unit Tests
All unit tests compile and run successfully:
```bash
npx vitest run tests/unit/ai-model.service.test.ts tests/unit/ai-tool-calling-schemas.test.ts
```

**Results:**
- tests/unit/ai-model.service.test.ts (3/3 passed)
- tests/unit/ai-tool-calling-schemas.test.ts (23/23 passed)
### 2. Quality & Compilation Checks

- Shared schemas compilation succeeded with npm run build.
- Formatting and ESLint rules verified clean on all modified files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Externalized the `maxTokens` cap with lazy, env‑driven validation and added boundary tests. Added a 5s circuit breaker with stale‑cache fallback, warning logs, and standardized 503 errors for the model catalog. Addresses Linear #1540.

- **New Features**
  - Env‑driven `maxTokens` cap via `MAX_COMPLETION_TOKENS` with lazy per‑parse validation (defaults to `DEFAULT_MAX_TOKENS_CAP`); ignores invalid env values.
  - Circuit breaker on `AIModelService.getModels`: on failure, serve stale and extend TTL by 5s; if no cache, open a 5s breaker and return `AI_UPSTREAM_UNAVAILABLE` (503); logs warnings and covers non‑2xx, network, and JSON parse errors.

- **Refactors**
  - Tests cover cap boundaries and env override, stale‑cache paths, and breaker expiry; use `mockFetch.mockReset()` and restore `Date.now` to avoid clock leaks.
  - Standardized 503 `AppError`, typed `process` in `@insforge/shared-schemas`, and documented `MAX_COMPLETION_TOKENS` in `.env.example`.

<sup>Written for commit ba025494d8b4fde6f24a8337724f1f3d9af7835b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `MAX_COMPLETION_TOKENS` cap and circuit breaker to AI model service
> - Replaces the hardcoded `maxTokens` limit of 16384 in `chatCompletionRequestSchema` with a runtime-configurable cap read from the `MAX_COMPLETION_TOKENS` env var, falling back to 16384 when unset or invalid.
> - Adds a 5-second circuit breaker to `AIModelService.getModels`: when no cache exists and an upstream fetch fails, subsequent calls immediately return 503 for 5 seconds instead of retrying.
> - When a stale cache exists and the upstream fetch fails, the cache TTL is shortened to 5 seconds and the stale data is returned rather than throwing.
> - Non-ok upstream HTTP responses are now surfaced as 503 `AI_UPSTREAM_UNAVAILABLE` instead of 500.
> - Adds unit test coverage for the new `maxTokens` cap behavior and the stale-cache/circuit-breaker paths in the model service.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba02549.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI completion `maxTokens` limits are now configurable via `MAX_COMPLETION_TOKENS` (default fallback applied when invalid).
* **Bug Fixes**
  * Improved resilience when fetching AI models: temporary outage handling avoids repeated upstream calls and serves recently cached results when failures occur.
* **Tests**
  * Added/updated unit coverage for stale-cache behavior, outage timing/retry logic, and `maxTokens` validation (including env-driven boundaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->