### PR TITLE
Dedupe Razorpay pagination loops and the dashboard cn helper

### DIFF
--- a/backend/src/providers/payments/razorpay.provider.ts
+++ b/backend/src/providers/payments/razorpay.provider.ts
@@ -294,6 +294,12 @@ interface RazorpayMutationClient {
   };
 }
 
+/** Shape of a Razorpay `<collection>.all()` page; the OSS SDK types it loosely. */
+interface RazorpayListResponse<T> {
+  items?: T[];
+  count?: number;
+}
+
 export class RazorpayProvider {
   private readonly client: Razorpay;
 
@@ -359,21 +365,7 @@ export class RazorpayProvider {
   }
 
   async listPlans(): Promise<RazorpayPlan[]> {
-    const all: RazorpayPlan[] = [];
-    let skip = 0;
-    const count = 100;
-    while (true) {
-      const response = (await this.client.plans.all({ count, skip })) as unknown as {
-        items: RazorpayPlan[];
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-    return all;
+    return this.fetchAllPaginated<RazorpayPlan>((params) => this.client.plans.all(params));
   }
 
   async createPlan(input: RazorpayPlanCreateInput): Promise<RazorpayPlan> {
@@ -396,21 +388,7 @@ export class RazorpayProvider {
   }
 
   async listItems(): Promise<RazorpayItem[]> {
-    const all: RazorpayItem[] = [];
-    let skip = 0;
-    const count = 100;
-    while (true) {
-      const response = (await this.client.items.all({ count, skip })) as unknown as {
-        items: RazorpayItem[];
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-    return all;
+    return this.fetchAllPaginated<RazorpayItem>((params) => this.client.items.all(params));
   }
 
   async createItem(input: RazorpayItemCreateInput): Promise<RazorpayItem> {
@@ -447,43 +425,13 @@ export class RazorpayProvider {
   }
 
   async listCustomers(): Promise<RazorpayCustomer[]> {
-    const all: RazorpayCustomer[] = [];
-    let skip = 0;
-    const count = 100;
-    while (true) {
-      const response = (await this.client.customers.all({ count, skip })) as unknown as {
-        items: RazorpayCustomer[];
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-    return all;
+    return this.fetchAllPaginated<RazorpayCustomer>((params) => this.client.customers.all(params));
   }
 
   async listSubscriptions(): Promise<RazorpaySubscription[]> {
-    const all: RazorpaySubscription[] = [];
-    let skip = 0;
-    const count = 100;
-
-    // Razorpay returns at most 100 records per call.
-    while (true) {
-      const response = (await this.client.subscriptions.all({ count, skip })) as unknown as {
-        items: RazorpaySubscription[];
-        count: number;
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-
-    return all;
+    return this.fetchAllPaginated<RazorpaySubscription>((params) =>
+      this.client.subscriptions.all(params)
+    );
   }
 
   async createOrder(input: RazorpayOrderCreateInput): Promise<RazorpayOrder> {
@@ -554,45 +502,11 @@ export class RazorpayProvider {
   }
 
   async listPayments(): Promise<RazorpayPayment[]> {
-    const all: RazorpayPayment[] = [];
-    let skip = 0;
-    const count = 100;
-
-    while (true) {
-      const response = (await this.client.payments.all({ count, skip })) as unknown as {
-        items: RazorpayPayment[];
-        count: number;
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-
-    return all;
+    return this.fetchAllPaginated<RazorpayPayment>((params) => this.client.payments.all(params));
   }
 
   async listInvoices(): Promise<RazorpayInvoice[]> {
-    const all: RazorpayInvoice[] = [];
-    let skip = 0;
-    const count = 100;
-
-    while (true) {
-      const response = (await this.client.invoices.all({ count, skip })) as unknown as {
-        items: RazorpayInvoice[];
-        count: number;
-      };
-      const items = response.items ?? [];
-      all.push(...items);
-      if (items.length < count) {
-        break;
-      }
-      skip += count;
-    }
-
-    return all;
+    return this.fetchAllPaginated<RazorpayInvoice>((params) => this.client.invoices.all(params));
   }
 
   async createCustomer(input: {
@@ -646,5 +560,27 @@ export class RazorpayProvider {
 
   private getMutationClient(): RazorpayMutationClient {
     return this.client as unknown as RazorpayMutationClient;
+  }
+
+  /**
+   * Walk a Razorpay list endpoint to completion. Razorpay caps each page at 100
+   * records and exposes no total, so we page until a short page signals the end.
+   */
+  private async fetchAllPaginated<T>(
+    fetchPage: (params: { count: number; skip: number }) => Promise<unknown>
+  ): Promise<T[]> {
+    const all: T[] = [];
+    const count = 100;
+    let skip = 0;
+    while (true) {
+      const response = (await fetchPage({ count, skip })) as RazorpayListResponse<T>;
+      const items = response.items ?? [];
+      all.push(...items);
+      if (items.length < count) {
+        break;
+      }
+      skip += count;
+    }
+    return all;
   }
 }

--- a/backend/tests/unit/razorpay-provider.test.ts
+++ b/backend/tests/unit/razorpay-provider.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   RazorpayProvider,
   maskRazorpayKey,
@@ -56,5 +56,45 @@ describe('RazorpayProvider', () => {
         `${subscriptionSignature}zz`
       )
     ).toBe(false);
+  });
+
+  // Stub the SDK client's list endpoint so the real fetchAllPaginated loop runs.
+  function stubPlansAll(provider: RazorpayProvider, all: ReturnType<typeof vi.fn>) {
+    (provider as unknown as { client: { plans: { all: typeof all } } }).client.plans.all = all;
+  }
+
+  it('walks every page until a short page and concatenates the results', async () => {
+    const provider = new RazorpayProvider(TEST_RAZORPAY_KEY_ID, TEST_RAZORPAY_KEY_SECRET, 'test');
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({ id: `plan_${i}` }));
+    const secondPage = [{ id: 'plan_100' }, { id: 'plan_101' }];
+    const all = vi
+      .fn()
+      .mockResolvedValueOnce({ items: firstPage })
+      .mockResolvedValueOnce({ items: secondPage });
+    stubPlansAll(provider, all);
+
+    const result = await provider.listPlans();
+
+    expect(result).toHaveLength(102);
+    expect(result[0]).toEqual({ id: 'plan_0' });
+    expect(result[101]).toEqual({ id: 'plan_101' });
+    // A full page triggers another request; the short page stops the loop.
+    expect(all).toHaveBeenCalledTimes(2);
+    expect(all).toHaveBeenNthCalledWith(1, { count: 100, skip: 0 });
+    expect(all).toHaveBeenNthCalledWith(2, { count: 100, skip: 100 });
+  });
+
+  it('stops after a single short page and tolerates a missing items field', async () => {
+    const provider = new RazorpayProvider(TEST_RAZORPAY_KEY_ID, TEST_RAZORPAY_KEY_SECRET, 'test');
+    const all = vi.fn().mockResolvedValueOnce({ items: [{ id: 'plan_0' }] });
+    stubPlansAll(provider, all);
+
+    expect(await provider.listPlans()).toEqual([{ id: 'plan_0' }]);
+    expect(all).toHaveBeenCalledTimes(1);
+
+    const empty = vi.fn().mockResolvedValueOnce({});
+    stubPlansAll(provider, empty);
+    expect(await provider.listPlans()).toEqual([]);
+    expect(empty).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dashboard/src/components/EmptyStateIllustration.tsx
+++ b/packages/dashboard/src/components/EmptyStateIllustration.tsx
@@ -1,5 +1,5 @@
 import emptyStateUrl from '#assets/images/empty_state.png';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface EmptyStateIllustrationProps {
   className?: string;

--- a/packages/dashboard/src/components/ErrorState.tsx
+++ b/packages/dashboard/src/components/ErrorState.tsx
@@ -1,7 +1,6 @@
 import { AlertCircle } from 'lucide-react';
-import { Button } from '@insforge/ui';
+import { Button, cn } from '@insforge/ui';
 import { Alert, AlertTitle, AlertDescription } from './';
-import { cn } from '#lib/utils/utils';
 
 interface ErrorStateProps {
   error: Error | string;

--- a/packages/dashboard/src/components/FeatureSidebar.tsx
+++ b/packages/dashboard/src/components/FeatureSidebar.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { Link, useMatch } from 'react-router-dom';
 import { LucideIcon, MoreVertical } from 'lucide-react';
-import { cn } from '#lib/utils/utils';
 import { ScrollArea } from './radix/ScrollArea';
 import {
   Button,
@@ -10,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   SearchInput,
+  cn,
 } from '@insforge/ui';
 
 interface FeatureSidebarProps {

--- a/packages/dashboard/src/components/ListRow.tsx
+++ b/packages/dashboard/src/components/ListRow.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes, ReactNode } from 'react';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface ListRowProps {
   children: ReactNode;

--- a/packages/dashboard/src/components/TableHeader.tsx
+++ b/packages/dashboard/src/components/TableHeader.tsx
@@ -1,5 +1,4 @@
-import { SearchInput } from '@insforge/ui';
-import { cn } from '#lib/utils/utils';
+import { SearchInput, cn } from '@insforge/ui';
 
 interface TableHeaderProps {
   title?: React.ReactNode;

--- a/packages/dashboard/src/components/TypeBadge.tsx
+++ b/packages/dashboard/src/components/TypeBadge.tsx
@@ -1,4 +1,4 @@
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface TypeBadgeProps {
   type: string;

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -8,10 +8,9 @@ import ReactDataGrid, {
   type CellMouseEvent,
   type RenderCellProps,
 } from 'react-data-grid';
-import { cn } from '#lib/utils/utils';
 import { DataGridEmptyState } from '#components/DataGridEmptyState';
 import { PaginationControls } from '#components/PaginationControls';
-import { Checkbox } from '@insforge/ui';
+import { Checkbox, cn } from '@insforge/ui';
 import { useTheme } from '#lib/contexts/ThemeContext';
 import type { DataGridColumn, DataGridRow, DataGridRowType } from './datagridTypes';
 import SortableHeaderRenderer from './SortableHeader';

--- a/packages/dashboard/src/components/datagrid/DefaultCellRenderer.tsx
+++ b/packages/dashboard/src/components/datagrid/DefaultCellRenderer.tsx
@@ -1,8 +1,8 @@
 import { ColumnType } from '@insforge/shared-schemas';
 import type { ConvertedValue, DataGridRowType } from './datagridTypes';
 import { RenderCellProps } from 'react-data-grid';
-import { cn, formatValueForDisplay, isEmptyValue } from '#lib/utils/utils';
-import { Badge } from '@insforge/ui';
+import { formatValueForDisplay, isEmptyValue } from '#lib/utils/utils';
+import { Badge, cn } from '@insforge/ui';
 import IdCell from './IdCell';
 
 // Generic cell renderer factory

--- a/packages/dashboard/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
+++ b/packages/dashboard/src/components/datagrid/cell-editors/BooleanCellEditor.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Select, SelectContent, SelectItem, SelectTrigger } from '@insforge/ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, cn } from '@insforge/ui';
 import type { BooleanCellEditorProps } from './types';
-import { cn } from '#lib/utils/utils';
 
 export function BooleanCellEditor({
   value,

--- a/packages/dashboard/src/components/datagrid/cell-editors/DateCellEditor.tsx
+++ b/packages/dashboard/src/components/datagrid/cell-editors/DateCellEditor.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Calendar, ChevronLeft, ChevronRight, Clock } from 'lucide-react';
-import { cn } from '#lib/utils/utils';
 import { format, isValid, parse } from 'date-fns';
-import { Button } from '@insforge/ui';
+import { Button, cn } from '@insforge/ui';
 import { Popover, PopoverContent, PopoverTrigger } from '#components';
 import type { DateCellEditorProps } from './types';
 import { ColumnType } from '@insforge/shared-schemas';

--- a/packages/dashboard/src/components/datagrid/cell-editors/JsonCellEditor.tsx
+++ b/packages/dashboard/src/components/datagrid/cell-editors/JsonCellEditor.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { FileJson, AlertCircle, CheckCircle } from 'lucide-react';
-import { Badge, Button, ConfirmDialog } from '@insforge/ui';
+import { Badge, Button, ConfirmDialog, cn } from '@insforge/ui';
 import { Popover, PopoverContent, PopoverTrigger } from '#components';
-import { cn } from '#lib/utils/utils';
 import type { JsonCellEditorProps } from './types';
 
 export function JsonCellEditor({

--- a/packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx
+++ b/packages/dashboard/src/components/datagrid/cell-editors/TextCellEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import type { TextCellEditorProps } from './types';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 export function TextCellEditor({ value, onValueChange, onCancel, className }: TextCellEditorProps) {
   const [inputValue, setInputValue] = useState(String(value || ''));

--- a/packages/dashboard/src/components/radix/Alert.tsx
+++ b/packages/dashboard/src/components/radix/Alert.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const alertVariants = cva(
   'relative w-full rounded-lg border px-4 py-4 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',

--- a/packages/dashboard/src/components/radix/Avatar.tsx
+++ b/packages/dashboard/src/components/radix/Avatar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const Avatar = React.forwardRef<
   React.ComponentRef<typeof AvatarPrimitive.Root>,

--- a/packages/dashboard/src/components/radix/Card.tsx
+++ b/packages/dashboard/src/components/radix/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (

--- a/packages/dashboard/src/components/radix/Form.tsx
+++ b/packages/dashboard/src/components/radix/Form.tsx
@@ -10,7 +10,7 @@ import {
   type FieldValues,
 } from 'react-hook-form';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 import { Label } from './Label';
 
 const Form = FormProvider;

--- a/packages/dashboard/src/components/radix/Label.tsx
+++ b/packages/dashboard/src/components/radix/Label.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'

--- a/packages/dashboard/src/components/radix/Popover.tsx
+++ b/packages/dashboard/src/components/radix/Popover.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const Popover = PopoverPrimitive.Root;
 

--- a/packages/dashboard/src/components/radix/ScrollArea.tsx
+++ b/packages/dashboard/src/components/radix/ScrollArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const ScrollArea = React.forwardRef<
   React.ComponentRef<typeof ScrollAreaPrimitive.Root>,

--- a/packages/dashboard/src/components/radix/Separator.tsx
+++ b/packages/dashboard/src/components/radix/Separator.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const Separator = React.forwardRef<
   React.ComponentRef<typeof SeparatorPrimitive.Root>,

--- a/packages/dashboard/src/components/radix/Textarea.tsx
+++ b/packages/dashboard/src/components/radix/Textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
   ({ className, ...props }, ref) => {

--- a/packages/dashboard/src/features/ai/pages/AIQuickStartPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIQuickStartPage.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState, type ReactNode } from 'react';
-import { Button, CopyButton, Tab, Tabs } from '@insforge/ui';
+import { Button, CopyButton, Tab, Tabs, cn } from '@insforge/ui';
 import { CodeEditor } from '#components';
 import { useOpenRouterKey } from '#features/ai/hooks/useOpenRouterKey';
-import { cn } from '#lib/utils/utils';
 import {
   PROMPT_CARD_COPY,
   QUICK_START_COPY,

--- a/packages/dashboard/src/features/auth/components/SecretInput.tsx
+++ b/packages/dashboard/src/features/auth/components/SecretInput.tsx
@@ -1,7 +1,6 @@
 import type { ComponentProps } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import { Button, Input } from '@insforge/ui';
-import { cn } from '#lib/utils/utils';
+import { Button, Input, cn } from '@insforge/ui';
 
 interface SecretInputProps extends ComponentProps<typeof Input> {
   isVisible: boolean;

--- a/packages/dashboard/src/features/auth/components/UserFormDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/UserFormDialog.tsx
@@ -11,10 +11,10 @@ import {
   DialogTitle,
   Input,
   Switch,
+  cn,
 } from '@insforge/ui';
 import { useToast } from '#lib/hooks/useToast';
 import { useUsers } from '#features/auth/hooks/useUsers';
-import { cn } from '#lib/utils/utils';
 import { emailSchema } from '@insforge/shared-schemas';
 import { z } from 'zod';
 

--- a/packages/dashboard/src/features/auth/components/UsersDataGrid.tsx
+++ b/packages/dashboard/src/features/auth/components/UsersDataGrid.tsx
@@ -28,8 +28,9 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from '@insforge/ui';
-import { cn, formatTime } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 import type { UserSchema } from '@insforge/shared-schemas';
 import { useCustomOAuthConfig } from '#features/auth/hooks/useCustomOAuthConfig';
 

--- a/packages/dashboard/src/features/dashboard/components/JoinDiscordCta.tsx
+++ b/packages/dashboard/src/features/dashboard/components/JoinDiscordCta.tsx
@@ -1,5 +1,5 @@
 import DiscordIcon from '#assets/logos/discord.svg?react';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface JoinDiscordCtaProps {
   className?: string;

--- a/packages/dashboard/src/features/dashboard/components/ProjectSettingsMenuDialog.tsx
+++ b/packages/dashboard/src/features/dashboard/components/ProjectSettingsMenuDialog.tsx
@@ -22,6 +22,7 @@ import {
   MenuDialogBody,
   MenuDialogFooter,
   MenuDialogCloseButton,
+  cn,
 } from '@insforge/ui';
 import type { InstanceInfoEvent } from '@insforge/shared-schemas';
 import { useApiKey } from '#lib/hooks/useMetadata';
@@ -34,7 +35,7 @@ import {
 } from '#lib/hooks/useCloudProjectInfo';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import { useToast } from '#lib/hooks/useToast';
-import { cn, compareVersions, getBackendUrl, isInsForgeCloudProject } from '#lib/utils/utils';
+import { compareVersions, getBackendUrl, isInsForgeCloudProject } from '#lib/utils/utils';
 import { MCPSection, CLISection, ConnectionStringSection } from './connect';
 import { metadataService } from '#lib/services/metadata.service';
 

--- a/packages/dashboard/src/features/dashboard/components/connect/APIKeysSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/APIKeysSection.tsx
@@ -1,5 +1,4 @@
-import { CopyButton } from '@insforge/ui';
-import { cn } from '#lib/utils/utils';
+import { CopyButton, cn } from '@insforge/ui';
 
 interface CredentialRowProps {
   label: string;

--- a/packages/dashboard/src/features/dashboard/components/connect/APIKeysSectionV2.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/APIKeysSectionV2.tsx
@@ -1,5 +1,4 @@
-import { CopyButton } from '@insforge/ui';
-import { cn } from '#lib/utils/utils';
+import { CopyButton, cn } from '@insforge/ui';
 import { type ReactNode } from 'react';
 import LinkChainIcon from '#assets/icons/link_chain.svg?react';
 import KeyHorizontalIcon from '#assets/icons/key_horizontal.svg?react';

--- a/packages/dashboard/src/features/dashboard/components/connect/CLISection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/CLISection.tsx
@@ -1,7 +1,6 @@
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import { CLI_VERIFY_CONNECTION_PROMPT } from './constants';
 import { useProjectId } from '#lib/hooks/useMetadata';
-import { cn } from '#lib/utils/utils';
 
 interface CLISectionProps {
   className?: string;

--- a/packages/dashboard/src/features/dashboard/components/connect/ConnectDialog.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/ConnectDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
   DialogTitle,
   TooltipProvider,
+  cn,
 } from '@insforge/ui';
 import { MCPSection } from './MCPSection';
 import { APIKeysSection } from './APIKeysSection';
@@ -18,7 +19,7 @@ import { ConnectionStringSection } from './ConnectionStringSection';
 import { CLISection } from './CLISection';
 import { useApiKey, useAnonKey } from '#lib/hooks/useMetadata';
 import { useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
-import { cn, getBackendUrl, isInsForgeCloudProject } from '#lib/utils/utils';
+import { getBackendUrl, isInsForgeCloudProject } from '#lib/utils/utils';
 import { JoinDiscordCta } from '#features/dashboard/components/JoinDiscordCta';
 
 type ConnectTabId = 'cli' | 'mcp' | 'connection-string' | 'api-keys';

--- a/packages/dashboard/src/features/dashboard/components/connect/ConnectionStringSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/ConnectionStringSection.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import { ShowPasswordButton } from './ShowPasswordButton';
 import { useDatabaseConnectionString, useDatabasePassword } from '#lib/hooks/useMetadata';
-import { cn } from '#lib/utils/utils';
 
 interface ConnectionParameter {
   label: string;

--- a/packages/dashboard/src/features/dashboard/components/connect/ConnectionStringSectionV2.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/ConnectionStringSectionV2.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from 'react';
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import { ShowPasswordButton } from './ShowPasswordButton';
 import { useDatabaseConnectionString, useDatabasePassword } from '#lib/hooks/useMetadata';
-import { cn } from '#lib/utils/utils';
 
 interface ConnectionParameter {
   label: string;

--- a/packages/dashboard/src/features/dashboard/components/connect/MCPSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/MCPSection.tsx
@@ -7,12 +7,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  cn,
 } from '@insforge/ui';
 import { CursorDeeplinkGenerator } from './mcp/CursorDeeplinkGenerator';
 import { QoderDeeplinkGenerator } from './mcp/QoderDeeplinkGenerator';
 import { MCP_AGENTS, GenerateInstallCommand, createMCPConfig, type MCPAgent } from './mcp/helpers';
 import { MCP_VERIFY_CONNECTION_PROMPT } from './constants';
-import { cn } from '#lib/utils/utils';
 
 interface MCPSectionProps {
   apiKey: string;

--- a/packages/dashboard/src/features/dashboard/components/connect/ShowPasswordButton.tsx
+++ b/packages/dashboard/src/features/dashboard/components/connect/ShowPasswordButton.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff } from 'lucide-react';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface ShowPasswordButtonProps {
   show: boolean;

--- a/packages/dashboard/src/features/dashboard/components/dtest/ClientDetailPage.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/ClientDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import { Button } from '@insforge/ui';
+import { Button, cn } from '@insforge/ui';
 import { ConnectionStringSectionV2 } from '#features/dashboard/components/connect/ConnectionStringSectionV2';
 import { APIKeysSectionV2 } from '#features/dashboard/components/connect/APIKeysSectionV2';
 import { DTestMCPSection } from './DTestMCPSection';
@@ -13,7 +13,7 @@ import {
   useDatabaseConnectionString,
   useDatabasePassword,
 } from '#lib/hooks/useMetadata';
-import { cn, getBackendUrl } from '#lib/utils/utils';
+import { getBackendUrl } from '#lib/utils/utils';
 import { getFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS } from '#lib/analytics/constants';
 

--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestCLISection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestCLISection.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import { useProjectId } from '#lib/hooks/useMetadata';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
-import { cn } from '#lib/utils/utils';
 
 interface DTestCLISectionProps {
   className?: string;

--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestInstallCliSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestInstallCliSection.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import { useProjectId } from '#lib/hooks/useMetadata';
-import { cn } from '#lib/utils/utils';
 
 interface DTestInstallCliSectionProps {
   className?: string;

--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestMCPSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestMCPSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { CopyButton } from '@insforge/ui';
+import { CopyButton, cn } from '@insforge/ui';
 import {
   MCP_AGENTS,
   GenerateInstallCommand,
@@ -10,7 +10,6 @@ import {
 } from '#features/dashboard/components/connect/mcp/helpers';
 import { MCP_VERIFY_CONNECTION_PROMPT } from '#features/dashboard/components/connect/constants';
 import { QuickStartPromptCard } from './QuickStartPromptCard';
-import { cn } from '#lib/utils/utils';
 
 function buildMcpDeeplink(agentId: string, apiKey: string, appUrl: string): string | null {
   const config = createMCPServerConfig(apiKey, 'macos-linux' as PlatformType, appUrl);

--- a/packages/dashboard/src/features/database/components/DatabaseEmptyState.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseEmptyState.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 import { EmptyStateIllustration } from '#components';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface DatabaseEmptyStateProps {
   title: string;

--- a/packages/dashboard/src/features/database/components/DatabaseSchemaSelect.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSchemaSelect.tsx
@@ -1,6 +1,5 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@insforge/ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, cn } from '@insforge/ui';
 import type { DatabaseSchemaInfo } from '@insforge/shared-schemas';
-import { cn } from '#lib/utils/utils';
 
 interface DatabaseSchemaSelectProps {
   schemas: DatabaseSchemaInfo[];

--- a/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseSidebar.tsx
@@ -9,8 +9,7 @@ import {
   type FeatureSidebarListItem,
 } from '#components';
 import { ScrollArea } from '#components/radix/ScrollArea';
-import { cn } from '#lib/utils/utils';
-import { Button } from '@insforge/ui';
+import { Button, cn } from '@insforge/ui';
 import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
 import type { DatabaseSchemaInfo } from '@insforge/shared-schemas';
 

--- a/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
@@ -9,13 +9,13 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
+  cn,
 } from '@insforge/ui';
 import { Label } from '#components';
 import { useTables } from '#features/database/hooks/useTables';
 import { UseFormReturn } from 'react-hook-form';
 import { TableFormSchema, TableFormForeignKeySchema } from '#features/database/schema';
 import { ColumnSchema, OnDeleteActionSchema, OnUpdateActionSchema } from '@insforge/shared-schemas';
-import { cn } from '#lib/utils/utils';
 import { AUTH_USERS_TABLE } from '#features/database/constants';
 import { parseDatabaseTableReference } from '#features/database/helpers';
 

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -11,12 +11,12 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  cn,
 } from '@insforge/ui';
 import { ScrollArea } from '#components';
 import { useRecords } from '#features/database/hooks/useRecords';
 import { buildDynamicSchema, getInitialValues } from '#features/database';
 import { RecordFormField } from './RecordFormField';
-import { cn } from '#lib/utils/utils';
 import { ColumnSchema } from '@insforge/shared-schemas';
 import { SYSTEM_FIELDS } from '#features/database/helpers';
 

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from 'react';
 import { Control, Controller, FieldError, UseFormReturn } from 'react-hook-form';
 import { Calendar, Clock, Link2, X } from 'lucide-react';
-import { Button, Input } from '@insforge/ui';
+import { Button, Input, cn } from '@insforge/ui';
 import {
   BooleanCellEditor,
   DateCellEditor,
@@ -10,7 +10,7 @@ import {
   type ConvertedValue,
 } from '#components';
 import { ColumnSchema, ColumnType } from '@insforge/shared-schemas';
-import { convertValueForColumn, cn, formatValueForDisplay } from '#lib/utils/utils';
+import { convertValueForColumn, formatValueForDisplay } from '#lib/utils/utils';
 import { LinkRecordDialog } from './LinkRecordDialog';
 import { isValid, parseISO } from 'date-fns';
 

--- a/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
+++ b/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
@@ -1,10 +1,9 @@
 import { useMemo, useState, useRef, useEffect } from 'react';
 import { useRawSQL } from '#features/database/hooks/useRawSQL';
 import { useSQLEditorContext } from '#features/database/contexts/SQLEditorContext';
-import { Button, Tabs, Tab } from '@insforge/ui';
+import { Button, Tabs, Tab, cn } from '@insforge/ui';
 import { CodeEditor, DataGrid, type DataGridColumn, type DataGridRow } from '#components';
 import { X, Plus, Download, FileJson } from 'lucide-react';
-import { cn } from '#lib/utils/utils';
 import { convertToCSV, convertToJSON, getExportFilename } from '#lib/utils/data-export';
 
 interface ResultsViewerProps {

--- a/packages/dashboard/src/features/deployments/components/EnvVarRow.tsx
+++ b/packages/dashboard/src/features/deployments/components/EnvVarRow.tsx
@@ -10,9 +10,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from '@insforge/ui';
 import type { DeploymentEnvVar } from '@insforge/shared-schemas';
-import { cn, formatTime } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 import { deploymentsService } from '#features/deployments/services/deployments.service';
 
 interface EnvVarRowProps {

--- a/packages/dashboard/src/features/deployments/pages/DeploymentLogsPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentLogsPage.tsx
@@ -14,13 +14,14 @@ import {
   Badge,
   Input,
   Skeleton,
+  cn,
 } from '@insforge/ui';
 import { PaginationControls } from '#components';
 import { useDeployments } from '#features/deployments/hooks/useDeployments';
 import type { DeploymentSchema } from '#features/deployments/services/deployments.service';
 import DeploymentsEmptyState from '#features/deployments/components/DeploymentsEmptyState';
 import { DeploymentMetaDataDialog } from '#features/deployments/components/DeploymentMetaDataDialog';
-import { cn, formatTime } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 
 type DeploymentStatus =
   | 'ALL'

--- a/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
@@ -7,12 +7,13 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from '@insforge/ui';
 import { useDeployments } from '#features/deployments/hooks/useDeployments';
 import { useDeploymentMetadata } from '#features/deployments/hooks/useDeploymentMetadata';
 import { useCustomDomains } from '#features/deployments/hooks/useCustomDomains';
 import { useToast } from '#lib/hooks/useToast';
-import { cn, formatTime } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 
 const statusColors: Record<string, string> = {
   WAITING: 'bg-yellow-600',

--- a/packages/dashboard/src/features/functions/components/SecretRow.tsx
+++ b/packages/dashboard/src/features/functions/components/SecretRow.tsx
@@ -1,7 +1,6 @@
 import { Eye, EyeOff, Loader2, Trash2 } from 'lucide-react';
-import { Button, CopyButton } from '@insforge/ui';
+import { Button, CopyButton, cn } from '@insforge/ui';
 import { SecretSchema } from '@insforge/shared-schemas';
-import { cn } from '#lib/utils/utils';
 import { ListRow, ListRowCell } from '#components';
 import { formatDistance } from 'date-fns';
 import { useSecretValue } from '#features/functions/hooks/useSecrets';

--- a/packages/dashboard/src/features/logs/components/BuildLogsView.tsx
+++ b/packages/dashboard/src/features/logs/components/BuildLogsView.tsx
@@ -7,7 +7,7 @@ import {
 } from '#features/logs/services/log.service';
 import { LogsDataGrid, type LogsColumnDef } from './LogsDataGrid';
 import { DataGridEmptyState } from '#components';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 import { usePageSize } from '#lib/hooks/usePageSize';
 
 interface BuildLogsViewProps {

--- a/packages/dashboard/src/features/logs/components/FunctionLogsTabs.tsx
+++ b/packages/dashboard/src/features/logs/components/FunctionLogsTabs.tsx
@@ -1,4 +1,4 @@
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 export type FunctionLogType = 'runtime' | 'build';
 

--- a/packages/dashboard/src/features/logs/components/SeverityBadge.tsx
+++ b/packages/dashboard/src/features/logs/components/SeverityBadge.tsx
@@ -1,5 +1,5 @@
 import { SEVERITY_CONFIG, type SeverityType } from '#features/logs/helpers';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 interface SeverityBadgeProps {
   severity: SeverityType;

--- a/packages/dashboard/src/features/logs/components/SeverityFilterDropdown.tsx
+++ b/packages/dashboard/src/features/logs/components/SeverityFilterDropdown.tsx
@@ -5,8 +5,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  cn,
 } from '@insforge/ui';
-import { cn } from '#lib/utils/utils';
 import { SEVERITY_CONFIG, type SeverityType } from '#features/logs/helpers';
 
 const ORDERED_SEVERITIES: SeverityType[] = ['error', 'warning', 'informational'];

--- a/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useMemo } from 'react';
 import { RefreshCw, Trash2, ExternalLink } from 'lucide-react';
 import { LogsDataGrid, type LogsColumnDef } from '#features/logs/components';
-import { formatTime, cn } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import { usePageSize } from '#lib/hooks/usePageSize';
-import { Button, ConfirmDialog } from '@insforge/ui';
+import { Button, ConfirmDialog, cn } from '@insforge/ui';
 import { DataGridEmptyState, TableHeader } from '#components';
 import { useAuditLogs, useClearAuditLogs } from '#features/logs/hooks/useAuditLogs';
 import type { GetAuditLogsRequest } from '@insforge/shared-schemas';

--- a/packages/dashboard/src/features/payments/components/PaymentProviderSelect.tsx
+++ b/packages/dashboard/src/features/payments/components/PaymentProviderSelect.tsx
@@ -1,8 +1,7 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@insforge/ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, cn } from '@insforge/ui';
 import type { PaymentProvider } from '@insforge/shared-schemas';
 import RazorpayIcon from '#assets/logos/razorpay-icon.png';
 import StripeIcon from '#assets/logos/stripe-icon.svg';
-import { cn } from '#lib/utils/utils';
 
 export const PAYMENT_PROVIDER_LABELS: Record<PaymentProvider, string> = {
   stripe: 'Stripe',

--- a/packages/dashboard/src/features/payments/components/PaymentsOnboardingState.tsx
+++ b/packages/dashboard/src/features/payments/components/PaymentsOnboardingState.tsx
@@ -1,9 +1,8 @@
 import { Settings } from 'lucide-react';
-import { Button } from '@insforge/ui';
+import { Button, cn } from '@insforge/ui';
 import type { PaymentEnvironment, PaymentProvider } from '@insforge/shared-schemas';
 import RazorpayWordmark from '#assets/logos/razorpay-wordmark.svg?react';
 import StripeWordmark from '#assets/logos/stripe-wordmark.svg?react';
-import { cn } from '#lib/utils/utils';
 
 interface QuickGuideStep {
   title: string;

--- a/packages/dashboard/src/features/payments/components/PaymentsSidebar.tsx
+++ b/packages/dashboard/src/features/payments/components/PaymentsSidebar.tsx
@@ -1,5 +1,5 @@
 import { Box, Rocket, Settings } from 'lucide-react';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@insforge/ui';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, cn } from '@insforge/ui';
 import type { PaymentEnvironment, PaymentProvider } from '@insforge/shared-schemas';
 import {
   FeatureSidebar,
@@ -8,7 +8,6 @@ import {
 } from '#components';
 import { PaymentProviderSelect } from './PaymentProviderSelect';
 import { usePaymentConnectionStatus } from '#features/payments/hooks/usePaymentConnectionStatus';
-import { cn } from '#lib/utils/utils';
 
 const PAYMENT_ENVIRONMENT_LABELS: Record<PaymentEnvironment, string> = {
   test: 'Test Environment',

--- a/packages/dashboard/src/features/payments/pages/CustomersPage.tsx
+++ b/packages/dashboard/src/features/payments/pages/CustomersPage.tsx
@@ -21,7 +21,7 @@ import { PaymentsOnboardingState } from '#features/payments/components/PaymentsO
 import type { PaymentsOutletContext } from '#features/payments/components/PaymentsLayout';
 import { usePaymentClientPagination } from '#features/payments/hooks/usePaymentClientPagination';
 import { usePaymentCustomers } from '#features/payments/hooks/usePaymentCustomers';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 type CustomerBadgeVariant = 'deleted' | 'guest' | null;
 

--- a/packages/dashboard/src/features/payments/pages/SubscriptionsPage.tsx
+++ b/packages/dashboard/src/features/payments/pages/SubscriptionsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { AlertCircle, ChevronDown, ChevronRight } from 'lucide-react';
 import { useOutletContext } from 'react-router-dom';
 import type { PaymentCustomer } from '@insforge/shared-schemas';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@insforge/ui';
 import {
   Alert,
   AlertDescription,
@@ -24,7 +24,6 @@ import type {
   PaymentSubscriptionItem,
   PaymentSubscriptionStatus,
 } from '#features/payments/types/subscriptions';
-import { cn } from '#lib/utils/utils';
 
 type SubscriptionDisplayStatus = PaymentSubscriptionStatus | 'cancelling';
 

--- a/packages/dashboard/src/features/payments/pages/TransactionsPage.tsx
+++ b/packages/dashboard/src/features/payments/pages/TransactionsPage.tsx
@@ -19,7 +19,7 @@ import { PaymentsOnboardingState } from '#features/payments/components/PaymentsO
 import type { PaymentsOutletContext } from '#features/payments/components/PaymentsLayout';
 import { usePaymentClientPagination } from '#features/payments/hooks/usePaymentClientPagination';
 import { usePaymentTransactions } from '#features/payments/hooks/usePaymentTransactions';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 
 const TRANSACTIONS_GRID_TEMPLATE =
   'minmax(0,1.45fr) 120px minmax(0,1.1fr) 120px minmax(0,1fr) 180px';

--- a/packages/dashboard/src/features/realtime/components/MessageRow.tsx
+++ b/packages/dashboard/src/features/realtime/components/MessageRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ChevronRight } from 'lucide-react';
-import { CodeBlock } from '@insforge/ui';
-import { cn, formatTime } from '#lib/utils/utils';
+import { CodeBlock, cn } from '@insforge/ui';
+import { formatTime } from '#lib/utils/utils';
 import { ListRow, ListRowCell } from '#components';
 import type { RealtimeMessage } from '#features/realtime/services/realtime.service';
 

--- a/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
+++ b/packages/dashboard/src/features/storage/components/StorageDataGrid.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { Button, ConfirmDialog } from '@insforge/ui';
+import { Button, ConfirmDialog, cn } from '@insforge/ui';
 import {
   DataGrid,
   type DataGridProps,
@@ -24,7 +24,7 @@ import {
   Folder,
 } from 'lucide-react';
 import { StorageFileSchema } from '@insforge/shared-schemas';
-import { cn, formatTime } from '#lib/utils/utils';
+import { formatTime } from '#lib/utils/utils';
 import { useStorageObjects } from '#features/storage/hooks/useStorageObjects';
 import { FilePreviewDialog } from './FilePreviewDialog';
 import { useConfirm } from '#lib/hooks/useConfirm';

--- a/packages/dashboard/src/layout/AppHeader.tsx
+++ b/packages/dashboard/src/layout/AppHeader.tsx
@@ -7,9 +7,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  cn,
 } from '@insforge/ui';
 import { Avatar, AvatarFallback, Separator, ThemeSelect } from '#components';
-import { cn } from '#lib/utils/utils';
 import { useTheme } from '#lib/contexts/ThemeContext';
 import { useAuth } from '#lib/contexts/AuthContext';
 import { useOpenConnectDialog } from './ConnectDialogContext';

--- a/packages/dashboard/src/layout/AppLayout.tsx
+++ b/packages/dashboard/src/layout/AppLayout.tsx
@@ -5,7 +5,7 @@ import AppHeader from './AppHeader';
 import { ThemeProvider } from '#lib/contexts/ThemeContext';
 import { ConnectDialog } from '#features/dashboard/components/connect';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
-import { cn } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
 import { ConnectDialogProvider } from './ConnectDialogContext';
 import { getFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';

--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -10,8 +10,8 @@ import {
 } from '#navigation/menuItems';
 import { Link, useLocation, matchPath } from 'react-router-dom';
 import { ExternalLink, PanelLeftOpen, PanelRightOpen } from 'lucide-react';
-import { cn, isInsForgeCloudProject } from '#lib/utils/utils';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { isInsForgeCloudProject } from '#lib/utils/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@insforge/ui';
 import { ProjectSettingsMenuDialog } from '#features/dashboard/components';
 import { getFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';

--- a/packages/dashboard/src/lib/hooks/useToast.tsx
+++ b/packages/dashboard/src/lib/hooks/useToast.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import { useTimeout } from './useTimeout';
-import { cn, generateUUID } from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
+import { generateUUID } from '#lib/utils/utils';
 
 interface Toast {
   id: string;

--- a/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
+++ b/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
@@ -1,7 +1,14 @@
 import { ColumnType } from '@insforge/shared-schemas';
 import { describe, expect, it } from 'vitest';
 import { cn } from '@insforge/ui';
-import { compareVersions, convertValueForColumn, formatDate, formatTime, formatValueForDisplay, isEmptyValue } from '#lib/utils/utils';
+import {
+  compareVersions,
+  convertValueForColumn,
+  formatDate,
+  formatTime,
+  formatValueForDisplay,
+  isEmptyValue,
+} from '#lib/utils/utils';
 
 describe('cn', () => {
   it('merges conditional classes and resolves Tailwind conflicts', () => {

--- a/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
+++ b/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
@@ -1,14 +1,7 @@
 import { ColumnType } from '@insforge/shared-schemas';
 import { describe, expect, it } from 'vitest';
-import {
-  cn,
-  compareVersions,
-  convertValueForColumn,
-  formatDate,
-  formatTime,
-  formatValueForDisplay,
-  isEmptyValue,
-} from '#lib/utils/utils';
+import { cn } from '@insforge/ui';
+import { compareVersions, convertValueForColumn, formatDate, formatTime, formatValueForDisplay, isEmptyValue } from '#lib/utils/utils';
 
 describe('cn', () => {
   it('merges conditional classes and resolves Tailwind conflicts', () => {

--- a/packages/dashboard/src/lib/utils/utils.ts
+++ b/packages/dashboard/src/lib/utils/utils.ts
@@ -15,10 +15,6 @@ import { getDashboardBackendUrl } from '#lib/config/runtime';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConvertedValue, DisplayValue, ValueConversionResult } from '#components/datagrid';
 
-// Re-exported from the shared UI package so the dashboard and @insforge/ui use
-// one identical class-merge implementation.
-export { cn } from '@insforge/ui';
-
 /**
  * Convert and validate a string value based on the specified ColumnType
  */

--- a/packages/dashboard/src/lib/utils/utils.ts
+++ b/packages/dashboard/src/lib/utils/utils.ts
@@ -1,6 +1,4 @@
 import { ColumnType } from '@insforge/shared-schemas';
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
 import { z } from 'zod';
 import { format, parse, isValid, parseISO } from 'date-fns';
 import {
@@ -17,9 +15,9 @@ import { getDashboardBackendUrl } from '#lib/config/runtime';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConvertedValue, DisplayValue, ValueConversionResult } from '#components/datagrid';
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+// Re-exported from the shared UI package so the dashboard and @insforge/ui use
+// one identical class-merge implementation.
+export { cn } from '@insforge/ui';
 
 /**
  * Convert and validate a string value based on the specified ColumnType


### PR DESCRIPTION
## Summary

Two small, self-contained cleanups surfaced by the post-refactor codebase scan (Tier 1).

### 1. Razorpay pagination de-duplication
`RazorpayProvider` had **six** near-identical paginate-to-completion loops (`listPlans` / `listItems` / `listCustomers` / `listSubscriptions` / `listPayments` / `listInvoices`), each ending in an `as unknown as { items: T[] }` cast over the OSS SDK's loosely-typed `.all()`.

- Extracted a single generic `fetchAllPaginated<T>()` helper + a typed `RazorpayListResponse<T>`.
- The six methods are now one-liners; the **six `as unknown as` double-casts collapse to one typed `as` inside the helper** (`as unknown as` in this file: 7 → 1, the remaining one being the pre-existing `getMutationClient`).
- Behavior-preserving: the 100-records/page count, `skip` stepping, and short-page termination are identical.

### 2. Dashboard `cn` helper
`packages/dashboard/src/lib/utils/utils.ts` reimplemented `cn` byte-for-byte identically to `@insforge/ui`'s (`twMerge(clsx(...))`). Now re-exported from `@insforge/ui` so both packages share one implementation. The ~50+ `cn` import sites are unaffected (re-export keeps the same path).

## Testing
- Backend: typecheck clean, razorpay-provider lint clean, **all 99 razorpay-related tests pass**, `tsup` build implied by typecheck.
- Dashboard: typecheck clean, lint clean, **68 tests pass**, `vite build` succeeds.
- Full backend suite is green **except** one pre-existing failure on `main` (`prefer-request-jwt-claims-migration.test.ts`, a migration-content guard) that is unrelated to this diff — confirmed it fails identically on a clean `main`.

## Scope note
A third Tier-1 item (removing 4 `as unknown as` casts in the logs DataGrid) is intentionally **not** here: it requires cascading generics through `LogsColumnDef` → `createLogsColumns` → `LogsDataGrid` across 5 consumers (the casts sit at a real domain-type ↔ index-signature-row boundary), so it's better as its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Razorpay pagination into a single helper and switches the dashboard to import `cn` from `@insforge/ui`. No behavior changes; adds tests for multi-page traversal and empty pages.

- **Refactors**
  - `RazorpayProvider`: added `fetchAllPaginated<T>()` and `RazorpayListResponse<T>`; replaced six `list*` methods with one-liners; keeps 100-per-page, skip stepping, and short-page termination.
  - Dashboard: removed local `cn` and its re-export; all call sites now import `cn` from `@insforge/ui`.

- **Tests**
  - Added unit tests for pagination: full-page then short-page, single short page, and missing `items`; asserts `skip` 0 → 100 and concatenation.

<sup>Written for commit db1f48fd4e329908502436c337539b78d8c540d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dedupe Razorpay pagination loops and consolidate the dashboard `cn` helper
> - Extracts a private `fetchAllPaginated` generic helper in [razorpay.provider.ts](https://github.com/InsForge/InsForge/pull/1544/files#diff-67f660df644b270d6b8bafebeab44ab223f890cbb9c421e3aae7a0b4f2200349) that replaces six identical inline pagination loops across `listPlans`, `listItems`, `listCustomers`, `listSubscriptions`, `listPayments`, and `listInvoices`.
> - Replaces the local `cn` implementation in [utils.ts](https://github.com/InsForge/InsForge/pull/1544/files#diff-3e639d488908e76be05d160922d884d0fd7d145994909c3458fc547ab6c9544c) with a re-export from `@insforge/ui`, removing the local `clsx`/`tailwind-merge` dependency.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1544 opened
>
> - Added pagination tests for `RazorpayProvider.listPlans` method [e6f2e10]
> - Replaced `cn` utility import source from `#lib/utils/utils` to `@insforge/ui` across all dashboard components, pages, hooks, and tests [128e774]
> - Removed the re-export of `cn` from the `#lib/utils/utils` module [128e774]
> - Reformatted import statement in `utils.test.ts` to use multi-line named imports [db1f48f]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6169b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Razorpay-backed payment listing pagination for more consistent multi-page results.
  * Standardized class-name merging usage across the dashboard by relying on the shared UI library helper.
* **Tests**
  * Expanded unit tests for Razorpay plan listing pagination, including multi-page aggregation, short final pages, and missing fields handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->