### PR TITLE
Make AnalyticsService a singleton like the other services

### DIFF
--- a/backend/src/api/routes/analytics/index.routes.ts
+++ b/backend/src/api/routes/analytics/index.routes.ts
@@ -10,7 +10,7 @@ import { AppError } from '@/utils/errors.js';
 import { AnalyticsService } from '@/services/analytics/analytics.service.js';
 
 export const analyticsRouter = Router();
-const service = new AnalyticsService();
+const service = AnalyticsService.getInstance();
 
 const MAX_LIMIT = 100;
 

--- a/backend/src/services/analytics/analytics.service.ts
+++ b/backend/src/services/analytics/analytics.service.ts
@@ -1,10 +1,18 @@
 import { PostHogProvider } from '@/providers/analytics/posthog.provider.js';
 
 export class AnalyticsService {
+  private static instance: AnalyticsService;
   private provider: PostHogProvider;
 
   constructor(provider: PostHogProvider = PostHogProvider.getInstance()) {
     this.provider = provider;
+  }
+
+  static getInstance(): AnalyticsService {
+    if (!AnalyticsService.instance) {
+      AnalyticsService.instance = new AnalyticsService();
+    }
+    return AnalyticsService.instance;
   }
 
   getConnection() {


### PR DESCRIPTION
## Summary
`AnalyticsService` was the only backend service instantiated with `new` (in the analytics route), while every other service uses a `getInstance()` singleton. This adds `getInstance()` and switches the route to it.

- The constructor is kept for DI/testing (`new AnalyticsService(mockProvider)`).
- Behavior-preserving: the route already held a single module-level instance, so this is purely a consistency fix.

## Testing
Backend typecheck clean, lint clean, 73 analytics-related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted `AnalyticsService` to a singleton via `getInstance()` and updated the analytics route to use it. The constructor stays for DI/testing; behavior is unchanged and this aligns the service with the rest of the backend.

<sup>Written for commit c8621ff23533874e65020ff7bbe8d6d7c8c22719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `AnalyticsService` a singleton via `getInstance()`
> Adds a private static `instance` field and a static `getInstance()` method to `AnalyticsService`, matching the pattern used by other services. Updates the analytics router in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1545/files#diff-e1a4f7b89c8c3afeff21d0290bb95fecfec2552b7286fd71a02dff289ef3127c) to use `getInstance()` instead of `new AnalyticsService()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8621ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal analytics service architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->