### PR TITLE
Make the logs DataGrid generic over its row type

### DIFF
--- a/packages/dashboard/src/features/logs/components/BuildLogsView.tsx
+++ b/packages/dashboard/src/features/logs/components/BuildLogsView.tsx
@@ -110,14 +110,14 @@ export function BuildLogsView({ className }: BuildLogsViewProps) {
   }, [currentPage, logsWithIds, pageSize]);
 
   // Column definitions for build logs
-  const columns: LogsColumnDef[] = useMemo(
+  const columns: LogsColumnDef<BuildLogRow>[] = useMemo(
     () => [
       {
         key: 'level',
         name: 'Level',
         width: '100px',
         renderCell: ({ row }) => {
-          const level = (row as unknown as BuildLogRow).level;
+          const level = row.level;
           return <span className={cn('text-sm font-medium', getLevelColor(level))}>{level}</span>;
         },
       },
@@ -126,7 +126,7 @@ export function BuildLogsView({ className }: BuildLogsViewProps) {
         name: 'Message',
         width: '1fr',
         renderCell: ({ row }) => {
-          const message = (row as unknown as BuildLogRow).message;
+          const message = row.message;
           return (
             <p className="text-sm text-gray-900 dark:text-white font-normal leading-6 truncate">
               {message}

--- a/packages/dashboard/src/features/logs/components/LogsDataGrid.tsx
+++ b/packages/dashboard/src/features/logs/components/LogsDataGrid.tsx
@@ -12,10 +12,12 @@ import type { CellClickArgs, CellMouseEvent } from 'react-data-grid';
 // Cell props exposed to a column's renderCell, with the row narrowed to the
 // consumer's row type T. The grid itself operates on the loose DataGridRowType
 // (it needs the index signature); createLogsColumns bridges the two.
-export type LogsCellProps<T> = Omit<RenderCellProps<DataGridRowType>, 'row'> & { row: T };
+export type LogsCellProps<T extends object> = Omit<RenderCellProps<DataGridRowType>, 'row'> & {
+  row: T;
+};
 
 // Column definition type for LogsDataGrid
-export interface LogsColumnDef<T = DataGridRowType> {
+export interface LogsColumnDef<T extends object = DataGridRowType> {
   key: string;
   name: string;
   width?: string;
@@ -27,7 +29,7 @@ export interface LogsColumnDef<T = DataGridRowType> {
 }
 
 // Convert logs data to DataGrid columns with custom renderers
-export function createLogsColumns<T = DataGridRowType>(
+export function createLogsColumns<T extends object = DataGridRowType>(
   columnDefs: LogsColumnDef<T>[]
 ): DataGridColumn<DataGridRowType>[] {
   return columnDefs.map((def) => {
@@ -73,7 +75,7 @@ export function createLogsColumns<T = DataGridRowType>(
 }
 
 // Logs-specific DataGrid props - generic to accept any object type
-export interface LogsDataGridProps<T = Record<string, unknown>> extends Omit<
+export interface LogsDataGridProps<T extends object = Record<string, unknown>> extends Omit<
   DataGridProps<DataGridRowType>,
   'columns' | 'data'
 > {
@@ -86,7 +88,7 @@ export interface LogsDataGridProps<T = Record<string, unknown>> extends Omit<
 }
 
 // Specialized DataGrid for logs
-export function LogsDataGrid<T = Record<string, unknown>>({
+export function LogsDataGrid<T extends object = Record<string, unknown>>({
   columnDefs,
   data,
   noPadding,

--- a/packages/dashboard/src/features/logs/components/LogsDataGrid.tsx
+++ b/packages/dashboard/src/features/logs/components/LogsDataGrid.tsx
@@ -9,32 +9,40 @@ import {
 } from '#components/datagrid';
 import type { CellClickArgs, CellMouseEvent } from 'react-data-grid';
 
+// Cell props exposed to a column's renderCell, with the row narrowed to the
+// consumer's row type T. The grid itself operates on the loose DataGridRowType
+// (it needs the index signature); createLogsColumns bridges the two.
+export type LogsCellProps<T> = Omit<RenderCellProps<DataGridRowType>, 'row'> & { row: T };
+
 // Column definition type for LogsDataGrid
-export interface LogsColumnDef {
+export interface LogsColumnDef<T = DataGridRowType> {
   key: string;
   name: string;
   width?: string;
   minWidth?: number;
   maxWidth?: number;
   sortable?: boolean;
-  renderCell?: (props: RenderCellProps<DataGridRowType>) => React.ReactNode;
+  renderCell?: (props: LogsCellProps<T>) => React.ReactNode;
   renderHeaderCell?: (props: RenderHeaderCellProps<DataGridRowType>) => React.ReactNode;
 }
 
 // Convert logs data to DataGrid columns with custom renderers
-export function createLogsColumns(columnDefs: LogsColumnDef[]): DataGridColumn<DataGridRowType>[] {
+export function createLogsColumns<T = DataGridRowType>(
+  columnDefs: LogsColumnDef<T>[]
+): DataGridColumn<DataGridRowType>[] {
   return columnDefs.map((def) => {
-    const baseCellRenderer =
-      def.renderCell ||
-      (({ row, column }: RenderCellProps<DataGridRowType>) => {
-        const value = row[column.key];
-        const displayValue = String(value ?? '');
-        return (
-          <span className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
-            {displayValue}
-          </span>
-        );
-      });
+    const renderCell = (props: RenderCellProps<DataGridRowType>) => {
+      if (def.renderCell) {
+        // Single boundary cast: the grid's rows are the consumer's T at runtime.
+        return def.renderCell({ ...props, row: props.row as unknown as T });
+      }
+      const value = props.row[props.column.key];
+      return (
+        <span className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
+          {String(value ?? '')}
+        </span>
+      );
+    };
 
     const baseHeaderRenderer =
       def.renderHeaderCell ||
@@ -55,7 +63,7 @@ export function createLogsColumns(columnDefs: LogsColumnDef[]): DataGridColumn<D
       maxWidth: def.maxWidth,
       resizable: true,
       sortable: false,
-      renderCell: (props: RenderCellProps<DataGridRowType>) => baseCellRenderer(props),
+      renderCell,
       renderHeaderCell: (props: RenderHeaderCellProps<DataGridRowType>) =>
         baseHeaderRenderer(props),
     };
@@ -69,7 +77,7 @@ export interface LogsDataGridProps<T = Record<string, unknown>> extends Omit<
   DataGridProps<DataGridRowType>,
   'columns' | 'data'
 > {
-  columnDefs: LogsColumnDef[];
+  columnDefs: LogsColumnDef<T>[];
   data: T[];
   noPadding?: boolean;
   selectedRowId?: string | null;
@@ -88,7 +96,7 @@ export function LogsDataGrid<T = Record<string, unknown>>({
   ...restProps
 }: LogsDataGridProps<T>) {
   const columns = useMemo(() => {
-    return createLogsColumns(columnDefs);
+    return createLogsColumns<T>(columnDefs);
   }, [columnDefs]);
 
   // Ensure each row has an id for DataGrid compatibility

--- a/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
@@ -7,7 +7,7 @@ import { usePageSize } from '#lib/hooks/usePageSize';
 import { Button, ConfirmDialog } from '@insforge/ui';
 import { DataGridEmptyState, TableHeader } from '#components';
 import { useAuditLogs, useClearAuditLogs } from '#features/logs/hooks/useAuditLogs';
-import type { GetAuditLogsRequest } from '@insforge/shared-schemas';
+import type { AuditLogSchema, GetAuditLogsRequest } from '@insforge/shared-schemas';
 
 function ModuleBadge({ module }: { module?: string | null }) {
   return (
@@ -73,7 +73,7 @@ export default function AuditsPage() {
   const logsData = logsResponse?.data || [];
   const totalRecords = logsResponse?.pagination?.total || 0;
 
-  const columns: LogsColumnDef[] = useMemo(
+  const columns: LogsColumnDef<AuditLogSchema>[] = useMemo(
     () => [
       {
         key: 'actor',

--- a/packages/dashboard/src/features/logs/pages/FunctionLogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/FunctionLogsPage.tsx
@@ -63,7 +63,7 @@ export default function FunctionLogsPage() {
     setSelectedLog(null);
   }, []);
 
-  const logsColumns: LogsColumnDef[] = useMemo(
+  const logsColumns: LogsColumnDef<LogSchema>[] = useMemo(
     () => [
       {
         key: 'timestamp',
@@ -79,9 +79,7 @@ export default function FunctionLogsPage() {
         key: 'severity',
         name: 'Type',
         width: '160px',
-        renderCell: ({ row }) => (
-          <SeverityBadge severity={getSeverity(row as unknown as LogSchema)} />
-        ),
+        renderCell: ({ row }) => <SeverityBadge severity={getSeverity(row)} />,
       },
       {
         key: 'event_message',

--- a/packages/dashboard/src/features/logs/pages/LogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/LogsPage.tsx
@@ -55,7 +55,7 @@ export default function LogsPage() {
     setSelectedLog(null);
   }, []);
 
-  const logsColumns: LogsColumnDef[] = useMemo(
+  const logsColumns: LogsColumnDef<LogSchema>[] = useMemo(
     () => [
       {
         key: 'timestamp',
@@ -71,9 +71,7 @@ export default function LogsPage() {
         key: 'severity',
         name: 'Type',
         width: '160px',
-        renderCell: ({ row }) => (
-          <SeverityBadge severity={getSeverity(row as unknown as LogSchema)} />
-        ),
+        renderCell: ({ row }) => <SeverityBadge severity={getSeverity(row)} />,
       },
       {
         key: 'event_message',

--- a/packages/dashboard/src/features/logs/pages/MCPLogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/MCPLogsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { DataGridEmptyState, EmptyState, TableHeader } from '#components';
 import { LogsDataGrid, type LogsColumnDef } from '#features/logs/components';
 import { useMcpUsage } from '#features/logs/hooks/useMcpUsage';
+import type { McpUsageRecord } from '#features/logs/services/usage.service';
 import { formatTime } from '#lib/utils/utils';
 import { usePageSize } from '#lib/hooks/usePageSize';
 
@@ -24,7 +25,7 @@ export default function MCPLogsPage() {
     error: mcpError,
   } = useMcpUsage({ successFilter: null, pageSize });
 
-  const mcpColumns: LogsColumnDef[] = useMemo(
+  const mcpColumns: LogsColumnDef<McpUsageRecord>[] = useMemo(
     () => [
       {
         key: 'tool_name',


### PR DESCRIPTION
## Summary
`LogsColumnDef` / `createLogsColumns` / `LogsDataGrid` were fixed to the grid's loose `DataGridRowType`, forcing every consumer to cast the row to its concrete type — **four `as unknown as` casts** across `BuildLogsView`, `FunctionLogsPage`, and `LogsPage`.

These are now generic over the row type `T`:
- Consumers declare `LogsColumnDef<BuildLogRow>` / `<LogSchema>` / `<McpUsageRecord>` / `<AuditLogSchema>` and get a properly-typed `row` in `renderCell`.
- The genuinely-unavoidable boundary cast (the grid stores rows as the index-signature `DataGridRowType`; the data is `T` at runtime) collapses to **a single, documented `as unknown as T` inside `createLogsColumns`** — 4 call-site casts → 1 adapter cast.
- Verified each consumer's `renderCell` field accesses (`level`/`message`, `eventMessage`/`timestamp`/`body`, `tool_name`/`created_at`, `module`/`details`/`createdAt`) all exist on its row type, so typing them surfaces no loose-access breakage.

## Behavior
Behavior-preserving — pure typing change; runtime row data and rendering are unchanged.

## Testing
Typecheck clean, lint clean, 68 dashboard tests pass, `vite build` succeeds. `as unknown as` in `features/logs/`: 4 → 1 (the centralized adapter cast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `LogsDataGrid`, `LogsColumnDef`, and `createLogsColumns` generic over the row type to give `renderCell` a typed `row` and remove unsafe casts. Constrained the generic to objects; behavior is unchanged.

- **Refactors**
  - Added a type parameter `T extends object`; `renderCell` now receives `row: T`.
  - Centralized the single adapter cast inside `createLogsColumns`; removed call-site casts in `BuildLogsView`, `LogsPage`, `FunctionLogsPage`, `MCPLogsPage`, and `AuditsPage`.
  - Constrained `T` to object types to reject primitive rows while supporting interface-based rows.
  - Columns now type-check against `BuildLogRow`, `LogSchema`, `McpUsageRecord`, and `AuditLogSchema`.

<sup>Written for commit f08e5687a721b4ad16499243af38ae6703fb6c0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `LogsDataGrid` and `LogsColumnDef` generic over their row type
> - Introduces a generic `LogsColumnDef<T>` interface and `LogsCellProps<T>` type in [LogsDataGrid.tsx](https://github.com/InsForge/InsForge/pull/1546/files#diff-1f02b86eb048404931a8cd78169a26aca1bfb60747084eb7b6bbc61586848f5b), so column renderers receive a strongly-typed `row` without manual casts.
> - Updates `createLogsColumns` and `LogsDataGrid` to propagate the generic `T`, preserving type safety through the full column definition pipeline.
> - Each page (`LogsPage`, `FunctionLogsPage`, `AuditsPage`, `MCPLogsPage`, `BuildLogsView`) now declares its columns as `LogsColumnDef<SpecificRowType>[]`, removing all unsafe `row as SomeType` casts in `renderCell` functions.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1546 opened
>
> - Added generic constraint requiring type parameter extends object [f08e568]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab0bec9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Strengthened type safety and consistency across logs display features to improve code maintainability and reduce potential runtime errors during future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->