### PR TITLE
Add useCopyToClipboard hook and replace ad-hoc copy state

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/AdvisoryItem.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { Check, ChevronDown, ChevronUp, Copy } from 'lucide-react';
 import type { DashboardAdvisorIssue } from '#types';
 import { useToast } from '#lib/hooks/useToast';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import { formatRemediationPrompt } from './remediationPrompt';
 import CriticalIcon from '#assets/icons/severity_critical.svg?react';
 import InfoIcon from '#assets/icons/severity_info.svg?react';
@@ -27,18 +27,15 @@ const SEVERITY_TONE = {
 
 export function AdvisoryItem({ issue, expanded, onToggle }: AdvisoryItemProps) {
   const { showToast } = useToast();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const Icon = SEVERITY_ICON[issue.severity];
 
   const handleCopyRemediation = async () => {
     if (!issue.recommendation) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(formatRemediationPrompt(issue));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
+    const ok = await copy(formatRemediationPrompt(issue));
+    if (!ok) {
       showToast('Failed to copy remediation', 'error');
     }
   };

--- a/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
@@ -14,6 +14,7 @@ import type {
 } from '#types';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
 import { useToast } from '#lib/hooks/useToast';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import { EmptyState, PaginationControls } from '#components';
 import { AdvisoryItem } from './AdvisoryItem';
 import { AdvisoryTabs, type AdvisoryTabValue } from './AdvisoryTabs';
@@ -102,7 +103,7 @@ export function BackendAdvisorSection() {
   const queryClient = useQueryClient();
 
   const [isScanning, setIsScanning] = useState(false);
-  const [copiedAll, setCopiedAll] = useState(false);
+  const { copied: copiedAll, copy } = useCopyToClipboard();
   const baselineScanIdRef = useRef<string | undefined>(undefined);
   const pollStartRef = useRef<number | null>(null);
   const refetchLatest = latest.refetch;
@@ -252,9 +253,10 @@ export function BackendAdvisorSection() {
         showToast('No remediations available', 'info');
         return;
       }
-      await navigator.clipboard.writeText(formatRemediationPromptBatch(actionable));
-      setCopiedAll(true);
-      setTimeout(() => setCopiedAll(false), 2000);
+      const copiedOk = await copy(formatRemediationPromptBatch(actionable));
+      if (!copiedOk) {
+        showToast('Failed to copy remediations', 'error');
+      }
     } catch {
       showToast('Failed to copy remediations', 'error');
     }

--- a/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/advisor/BackendAdvisorSection.tsx
@@ -258,6 +258,8 @@ export function BackendAdvisorSection() {
         showToast('Failed to copy remediations', 'error');
       }
     } catch {
+      // Guards the paginated advisor fetch above — `copy()` handles its own
+      // failure via the `copiedOk` check, so this only fires for fetch errors.
       showToast('Failed to copy remediations', 'error');
     }
   };

--- a/packages/dashboard/src/features/deployments/components/DeploymentMetaDataDialog.tsx
+++ b/packages/dashboard/src/features/deployments/components/DeploymentMetaDataDialog.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { Button, Dialog, DialogContent, DialogDescription, DialogTitle } from '@insforge/ui';
 import { ScrollArea } from '#components';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import type { DeploymentSchema } from '#features/deployments/services/deployments.service';
 
 interface DeploymentMetaDataDialogProps {
@@ -13,19 +13,13 @@ export function DeploymentMetaDataDialog({
   deployment,
   onOpenChange,
 }: DeploymentMetaDataDialogProps) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
 
   const handleCopyMetadata = async () => {
     if (!deployment?.metadata) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(JSON.stringify(deployment.metadata, null, 2));
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
-    }
+    await copy(JSON.stringify(deployment.metadata, null, 2));
   };
 
   const handleClose = () => {

--- a/packages/dashboard/src/features/deployments/components/EnvVarRow.tsx
+++ b/packages/dashboard/src/features/deployments/components/EnvVarRow.tsx
@@ -13,6 +13,7 @@ import {
 } from '@insforge/ui';
 import type { DeploymentEnvVar } from '@insforge/shared-schemas';
 import { cn, formatTime } from '#lib/utils/utils';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import { deploymentsService } from '#features/deployments/services/deployments.service';
 
 interface EnvVarRowProps {
@@ -27,7 +28,7 @@ export function EnvVarRow({ envVar, onEdit, onDelete, className }: EnvVarRowProp
   const [fetchedValue, setFetchedValue] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
 
   // Reset cached value when the env var is updated (e.g., after an edit)
   useEffect(() => {
@@ -76,13 +77,7 @@ export function EnvVarRow({ envVar, onEdit, onDelete, className }: EnvVarRowProp
     if (fetchedValue === null) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(fetchedValue);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
-    }
+    await copy(fetchedValue);
   };
 
   const maskedValue = '••••••••••••••';

--- a/packages/dashboard/src/features/deployments/pages/DeploymentDomainsPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentDomainsPage.tsx
@@ -25,6 +25,7 @@ import { useDeploymentSlug } from '#features/deployments/hooks/useDeploymentSlug
 import { useDeploymentMetadata } from '#features/deployments/hooks/useDeploymentMetadata';
 import { useCustomDomains } from '#features/deployments/hooks/useCustomDomains';
 import { useToast } from '#lib/hooks/useToast';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import type { CustomDomain } from '#features/deployments/services/deployments.service';
 
 /**
@@ -62,16 +63,10 @@ function StatusBadge({ verified, misconfigured }: { verified: boolean; misconfig
  * Small inline copy button used in DNS record tables.
  */
 function CopyIconButton({ value, label }: { value: string; label: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard(1500);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Keep this non-blocking inside the table UI.
-    }
+    await copy(value);
   };
 
   return (
@@ -304,8 +299,8 @@ function CustomDomainRow({
  * and user-owned custom domains with full DNS verification workflow.
  */
 export default function DeploymentDomainsPage() {
-  const [copiedDefault, setCopiedDefault] = useState(false);
-  const [copiedCustom, setCopiedCustom] = useState(false);
+  const { copied: copiedDefault, copy: copyDefault } = useCopyToClipboard();
+  const { copied: copiedCustom, copy: copyCustom } = useCopyToClipboard();
   const [isEditing, setIsEditing] = useState(false);
   const [customSlug, setCustomSlug] = useState('');
   const [isAddDomainOpen, setIsAddDomainOpen] = useState(false);
@@ -348,11 +343,7 @@ export default function DeploymentDomainsPage() {
     if (!defaultDomain) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(defaultDomain);
-      setCopiedDefault(true);
-      setTimeout(() => setCopiedDefault(false), 2000);
-    } catch {
+    if (!(await copyDefault(defaultDomain))) {
       showToast('Failed to copy to clipboard', 'error');
     }
   };
@@ -361,11 +352,7 @@ export default function DeploymentDomainsPage() {
     if (!customDomainUrl) {
       return;
     }
-    try {
-      await navigator.clipboard.writeText(customDomainUrl);
-      setCopiedCustom(true);
-      setTimeout(() => setCopiedCustom(false), 2000);
-    } catch {
+    if (!(await copyCustom(customDomainUrl))) {
       showToast('Failed to copy to clipboard', 'error');
     }
   };

--- a/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
+++ b/packages/dashboard/src/features/deployments/pages/DeploymentOverviewPage.tsx
@@ -10,6 +10,7 @@ import {
 } from '@insforge/ui';
 import { useDeployments } from '#features/deployments/hooks/useDeployments';
 import { useDeploymentMetadata } from '#features/deployments/hooks/useDeploymentMetadata';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
 import { useCustomDomains } from '#features/deployments/hooks/useCustomDomains';
 import { useToast } from '#lib/hooks/useToast';
 import { cn, formatTime } from '#lib/utils/utils';
@@ -28,7 +29,7 @@ const DEPLOY_PROMPT = 'Deploy my app to InsForge';
 
 export default function DeploymentOverviewPage() {
   const { showToast } = useToast();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [iframeKey, setIframeKey] = useState(0);
   const { deployments, isLoadingDeployments, refetchDeployments } = useDeployments();
@@ -87,11 +88,8 @@ export default function DeploymentOverviewPage() {
   };
 
   const handleCopyPrompt = async () => {
-    try {
-      await navigator.clipboard.writeText(DEPLOY_PROMPT);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
+    const ok = await copy(DEPLOY_PROMPT);
+    if (!ok) {
       showToast('Failed to copy to clipboard', 'error');
     }
   };

--- a/packages/dashboard/src/lib/hooks/__tests__/useCopyToClipboard.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useCopyToClipboard.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCopyToClipboard } from '#lib/hooks/useCopyToClipboard';
+
+function stubClipboard(writeText: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+describe('useCopyToClipboard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('copies the text, flips `copied`, and resets it after resetMs', async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+
+    const { result } = renderHook(() => useCopyToClipboard(1500));
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.copy('hello');
+    });
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(result.current.copied).toBe(true);
+
+    // Still set just before the window closes, cleared once it elapses.
+    act(() => vi.advanceTimersByTime(1499));
+    expect(result.current.copied).toBe(true);
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('returns false and leaves `copied` unset when the write fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    stubClipboard(writeText);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    let ok!: boolean;
+    await act(async () => {
+      ok = await result.current.copy('x');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.copied).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('clears the pending reset timer on unmount', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+    await act(async () => {
+      await result.current.copy('x');
+    });
+
+    // The first copy arms a timer without clearing one (ref starts null),
+    // so any clearTimeout after unmount must be the cleanup tearing it down.
+    clearSpy.mockClear();
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/lib/hooks/useCopyToClipboard.ts
+++ b/packages/dashboard/src/lib/hooks/useCopyToClipboard.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Copy text to the clipboard and expose a transient `copied` flag that resets
+ * after `resetMs`. `copy` resolves to whether the write succeeded so callers can
+ * surface their own error feedback (e.g. a toast). The reset timer is cleared on
+ * unmount.
+ */
+export function useCopyToClipboard(resetMs = 2000) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => setCopied(false), resetMs);
+        return true;
+      } catch (err) {
+        console.error('Failed to copy to clipboard:', err);
+        return false;
+      }
+    },
+    [resetMs]
+  );
+
+  return { copied, copy };
+}


### PR DESCRIPTION
## Summary
Six components hand-rolled the same copy pattern — a local `copied` `useState`, `navigator.clipboard.writeText`, `setCopied(true)`, and a `setTimeout` reset — none of which cleared the timer on unmount.

New `useCopyToClipboard(resetMs = 2000)` hook returns `{ copied, copy }`:
- `copy(text)` resolves to a success **boolean** so callers keep their own error feedback (toasts).
- The reset timer is cleared on unmount (a small leak the ad-hoc versions had).

Adopted in `AdvisoryItem`, `BackendAdvisorSection`, `DeploymentMetaDataDialog`, `EnvVarRow`, `DeploymentOverviewPage`, and `DeploymentDomainsPage` (its two domain copy buttons + the per-row `CopyIconButton`, which keeps its 1500ms reset).

## Scope
`DTestMCPSection` is intentionally left alone — it's a fire-and-forget copy with no `copied` state, so the hook adds nothing there.

## Behavior
Behavior-preserving: per-site reset timings (2000/1500ms) and error toasts are retained; the only functional delta is the added unmount cleanup.

## Testing
Typecheck clean, lint clean, dashboard tests pass, `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a `useCopyToClipboard` hook and replaced duplicate copy-to-clipboard logic across the dashboard. Simplifies code, preserves UX, fixes an unmount timer leak, and adds unit tests.

- **Refactors**
  - New `useCopyToClipboard(resetMs)` hook returns `{ copied, copy }`; `copy(text)` resolves to a boolean.
  - Clears the reset timer on unmount; tests cover success/failure, reset timing, and cleanup.
  - Adopted in `AdvisoryItem`, `BackendAdvisorSection`, `DeploymentMetaDataDialog`, `EnvVarRow`, `DeploymentOverviewPage`, and `DeploymentDomainsPage` (per-row `CopyIconButton` at 1500ms). Clarified the try/catch comment in `BackendAdvisorSection`.
  - Behavior preserved: same reset timings (2000ms/1500ms) and existing error toasts.

<sup>Written for commit e2342830f42d5e8a73e99a66cefbd336e4468152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `useCopyToClipboard` hook and replace ad-hoc copy state across dashboard components
> - Adds a new [`useCopyToClipboard`](https://github.com/InsForge/InsForge/pull/1548/files#diff-462e9b5806607251a33898fd74150dff4346622ca8df2422f89e1c7fad721f09) hook that exposes `{ copied, copy }`, where `copy` writes to the clipboard, returns a boolean success flag, and auto-resets `copied` after a configurable delay (default 2000ms).
> - Replaces local `copied` state and direct `navigator.clipboard` calls in six components: `AdvisoryItem`, `BackendAdvisorSection`, `DeploymentMetaDataDialog`, `EnvVarRow`, `DeploymentDomainsPage`, and `DeploymentOverviewPage`.
> - Each component now shows an error toast on copy failure instead of relying on try/catch with manual state cleanup.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1548 opened
>
> - Added test suite for `useCopyToClipboard` hook [ac0942d]
> - Added inline comment clarifying error handling in `BackendAdvisorSection` component [ac0942d]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e234283.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated copy-to-clipboard functionality across multiple dashboard pages and components into a shared, reusable hook for consistent “Copied” behavior and simplified clipboard handling.
* **New Features**
  * Added a shared `useCopyToClipboard` hook with transient copied-state management and boolean success/failure reporting.
* **Bug Fixes**
  * Improved failure handling for copy actions by relying on copy success results and showing error toasts when copying fails.
* **Tests**
  * Added unit tests covering success/failure paths, copied-state reset timing, and cleanup on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->