### PR TITLE
Harden production deployment secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,10 @@ MAX_URLENCODED_BODY_SIZE=10mb
 # -----------------------------------------------------------------------------
 # PostgreSQL Configuration
 # -----------------------------------------------------------------------------
-# These are optional - defaults are shown below
-# In production, use strong passwords and consider external database services
+# Development compose can use defaults, but production compose requires a
+# unique POSTGRES_PASSWORD. Generate one before deploying.
+POSTGRES_PASSWORD=
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
 POSTGRES_DB=insforge
 
 # -----------------------------------------------------------------------------
@@ -59,16 +59,17 @@ VITE_API_BASE_URL=http://localhost:7130
 # -----------------------------------------------------------------------------
 # JWT_SECRET: Must be at least 32 characters. Use a secure random generator!
 # Example: openssl rand -base64 32
-JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
+JWT_SECRET=
 
 # Root admin credentials - CHANGE THESE IN PRODUCTION!
+ROOT_ADMIN_PASSWORD=
 ROOT_ADMIN_USERNAME=admin
-ROOT_ADMIN_PASSWORD=change-this-password
 
 # Encryption key for secrets and database encryption
 # IMPORTANT: Set this to a separate 32+ character secret from JWT_SECRET.
-# If not set, JWT_SECRET is used as fallback — but rotating JWT_SECRET will
-# permanently corrupt all stored secrets (API keys, OAuth tokens, etc.).
+# Production compose requires this value. Local development can fall back to
+# JWT_SECRET, but rotating JWT_SECRET later would permanently corrupt all stored
+# secrets (API keys, OAuth tokens, etc.).
 # Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ ENV STORAGE_DIR=/insforge-storage
 ENV LOGS_DIR=/insforge-logs
 ENV MAX_JSON_BODY_SIZE=100mb
 ENV MAX_URLENCODED_BODY_SIZE=10mb
+ENV NODE_ENV=production
 
 RUN mkdir -p /data /insforge-storage /insforge-logs && \
     chown node:node /data /insforge-storage /insforge-logs

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Or run from source:
 git clone https://github.com/InsForge/InsForge.git
 cd insforge
 cp .env.example .env
+# Edit .env and set unique JWT_SECRET, ENCRYPTION_KEY, ROOT_ADMIN_PASSWORD,
+# and POSTGRES_PASSWORD before starting the production compose file.
 docker compose -f docker-compose.prod.yml up
 ```
 
@@ -158,7 +160,7 @@ cp .env.example .env.project1
 cp .env.example .env.project2
 ```
 
-Edit `.env.project2` with different ports:
+Edit each env file with its own `JWT_SECRET`, `ENCRYPTION_KEY`, `ROOT_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD`. Then edit `.env.project2` with different ports:
 ```
 POSTGRES_PORT=5442
 POSTGREST_PORT=5440

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -20,6 +20,18 @@ if (envPath) {
   dotenv.config();
 }
 
+const INSECURE_JWT_SECRETS = new Set([
+  'dev-secret-please-change-in-production',
+  'your-secret-key-here-must-be-32-char-or-above',
+  'change-this-jwt-secret-min-32-characters',
+]);
+
+const INSECURE_ROOT_ADMIN_PASSWORDS = new Set(['change-this-password', 'changeme123']);
+const INSECURE_POSTGRES_PASSWORDS = new Set(['postgres', 'change-this-password']);
+const INSECURE_ENCRYPTION_KEYS = new Set(['change-this-encryption-key-32chars']);
+const MIN_SECRET_LENGTH = 32;
+const MIN_PASSWORD_LENGTH = 16;
+
 export interface AppConfig {
   app: {
     port: number;
@@ -107,6 +119,10 @@ function parseEnvInt(val: string | undefined, fallback: number): number {
     return fallback;
   }
   return parsed;
+}
+
+function valueIsOneOf(value: string | undefined, values: Set<string>): boolean {
+  return value !== undefined && values.has(value.trim());
 }
 
 export function loadConfig(): AppConfig {
@@ -206,3 +222,82 @@ export function loadConfig(): AppConfig {
 }
 
 export const appConfig: AppConfig = loadConfig();
+
+export function shouldEnforceDeploymentSecurity(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.INSFORGE_ALLOW_INSECURE_DEFAULTS === 'true') {
+    return false;
+  }
+
+  return env.NODE_ENV === 'production' || env.INSFORGE_ENFORCE_SECURE_CONFIG === 'true';
+}
+
+export function getDeploymentSecurityErrors(
+  config: AppConfig,
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const errors: string[] = [];
+  const jwtSecret = config.app.jwtSecret.trim();
+  const rootAdminPassword = config.auth.rootAdminPassword.trim();
+  const postgresPassword = config.database.password.trim();
+  const encryptionKey = env.ENCRYPTION_KEY?.trim() ?? '';
+
+  if (!jwtSecret) {
+    errors.push('JWT_SECRET is required.');
+  } else if (
+    jwtSecret.length < MIN_SECRET_LENGTH ||
+    valueIsOneOf(jwtSecret, INSECURE_JWT_SECRETS)
+  ) {
+    errors.push('JWT_SECRET must be a unique random value with at least 32 characters.');
+  }
+
+  if (!rootAdminPassword) {
+    errors.push('ROOT_ADMIN_PASSWORD is required.');
+  } else if (
+    rootAdminPassword.length < MIN_PASSWORD_LENGTH ||
+    valueIsOneOf(rootAdminPassword, INSECURE_ROOT_ADMIN_PASSWORDS)
+  ) {
+    errors.push('ROOT_ADMIN_PASSWORD must be a unique strong value with at least 16 characters.');
+  }
+
+  if (!postgresPassword) {
+    errors.push('POSTGRES_PASSWORD is required.');
+  } else if (
+    postgresPassword.length < MIN_PASSWORD_LENGTH ||
+    valueIsOneOf(postgresPassword, INSECURE_POSTGRES_PASSWORDS)
+  ) {
+    errors.push('POSTGRES_PASSWORD must be a unique strong value with at least 16 characters.');
+  }
+
+  if (!encryptionKey) {
+    errors.push('ENCRYPTION_KEY is required.');
+  } else if (
+    encryptionKey.length < MIN_SECRET_LENGTH ||
+    valueIsOneOf(encryptionKey, INSECURE_ENCRYPTION_KEYS)
+  ) {
+    errors.push('ENCRYPTION_KEY must be a unique random value with at least 32 characters.');
+  } else if (jwtSecret && encryptionKey === jwtSecret) {
+    errors.push('ENCRYPTION_KEY must be different from JWT_SECRET.');
+  }
+
+  return errors;
+}
+
+export function assertSecureDeploymentConfig(
+  config: AppConfig = appConfig,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  if (!shouldEnforceDeploymentSecurity(env)) {
+    return;
+  }
+
+  const errors = getDeploymentSecurityErrors(config, env);
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        'Refusing to start InsForge with insecure production configuration:',
+        ...errors.map((error) => `- ${error}`),
+        'Set unique secrets or set INSFORGE_ALLOW_INSECURE_DEFAULTS=true only for isolated local development.',
+      ].join('\n')
+    );
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -40,7 +40,7 @@ import packageJson from '../../package.json';
 import { schedulesRouter } from '@/api/routes/schedules/index.routes.js';
 import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
-import { appConfig } from '@/infra/config/app.config.js';
+import { appConfig, assertSecureDeploymentConfig } from '@/infra/config/app.config.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -307,6 +307,8 @@ const PORT = appConfig.app.port;
 
 async function initializeServer() {
   try {
+    assertSecureDeploymentConfig();
+
     const app = await createApp();
     const server = app.listen(PORT, () => {
       logger.info(`Backend API service listening on port ${PORT}`);

--- a/backend/tests/unit/app.config.test.ts
+++ b/backend/tests/unit/app.config.test.ts
@@ -22,7 +22,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadConfig } from '../../src/infra/config/app.config';
+import {
+  assertSecureDeploymentConfig,
+  getDeploymentSecurityErrors,
+  loadConfig,
+  shouldEnforceDeploymentSecurity,
+} from '../../src/infra/config/app.config';
 
 // ---------------------------------------------------------------------------
 // Helper — save / restore process.env around each test
@@ -378,6 +383,123 @@ describe('config.auth', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 // Section: storage
 // ═══════════════════════════════════════════════════════════════════════════
+
+describe('deployment security validation', () => {
+  it('does not enforce production secret checks during local development by default', () => {
+    unsetEnvKeys('NODE_ENV', 'INSFORGE_ENFORCE_SECURE_CONFIG');
+
+    expect(shouldEnforceDeploymentSecurity()).toBe(false);
+  });
+
+  it('enforces production secret checks when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(shouldEnforceDeploymentSecurity()).toBe(true);
+  });
+
+  it('enforces production secret checks when explicitly requested', () => {
+    unsetEnvKeys('NODE_ENV');
+    process.env.INSFORGE_ENFORCE_SECURE_CONFIG = 'true';
+
+    expect(shouldEnforceDeploymentSecurity()).toBe(true);
+  });
+
+  it('allows an explicit local escape hatch for isolated development', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.INSFORGE_ALLOW_INSECURE_DEFAULTS = 'true';
+
+    expect(shouldEnforceDeploymentSecurity()).toBe(false);
+  });
+
+  it('rejects known production placeholder credentials', () => {
+    process.env.JWT_SECRET = 'dev-secret-please-change-in-production';
+    process.env.ENCRYPTION_KEY = 'change-this-encryption-key-32chars';
+    process.env.ROOT_ADMIN_PASSWORD = 'change-this-password';
+    process.env.POSTGRES_PASSWORD = 'postgres';
+
+    const errors = getDeploymentSecurityErrors(loadConfig());
+
+    expect(errors).toContain(
+      'JWT_SECRET must be a unique random value with at least 32 characters.'
+    );
+    expect(errors).toContain(
+      'ENCRYPTION_KEY must be a unique random value with at least 32 characters.'
+    );
+    expect(errors).toContain(
+      'ROOT_ADMIN_PASSWORD must be a unique strong value with at least 16 characters.'
+    );
+    expect(errors).toContain(
+      'POSTGRES_PASSWORD must be a unique strong value with at least 16 characters.'
+    );
+  });
+
+  it('rejects short production passwords', () => {
+    process.env.JWT_SECRET = 'u53-strong-random-jwt-secret-for-prod';
+    process.env.ENCRYPTION_KEY = 'u53-strong-random-encryption-key-for-prod';
+    process.env.ROOT_ADMIN_PASSWORD = 'short';
+    process.env.POSTGRES_PASSWORD = 'weak';
+
+    const errors = getDeploymentSecurityErrors(loadConfig());
+
+    expect(errors).toContain(
+      'ROOT_ADMIN_PASSWORD must be a unique strong value with at least 16 characters.'
+    );
+    expect(errors).toContain(
+      'POSTGRES_PASSWORD must be a unique strong value with at least 16 characters.'
+    );
+  });
+
+  it('uses the caller-provided env when asserting deployment security', () => {
+    unsetEnvKeys('NODE_ENV', 'INSFORGE_ENFORCE_SECURE_CONFIG', 'ENCRYPTION_KEY');
+
+    const baseConfig = loadConfig();
+    const config = {
+      ...baseConfig,
+      app: {
+        ...baseConfig.app,
+        jwtSecret: 'u53-strong-random-jwt-secret-for-prod',
+      },
+      auth: {
+        ...baseConfig.auth,
+        rootAdminPassword: 'correct-horse-admin-password-2026',
+      },
+      database: {
+        ...baseConfig.database,
+        password: 'correct-horse-postgres-password-2026',
+      },
+    };
+
+    expect(() =>
+      assertSecureDeploymentConfig(config, {
+        NODE_ENV: 'production',
+        ENCRYPTION_KEY: 'u53-strong-random-encryption-key-for-prod',
+      })
+    ).not.toThrow();
+  });
+
+  it('throws before startup when production credentials are insecure', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'your-secret-key-here-must-be-32-char-or-above';
+    process.env.ENCRYPTION_KEY = 'your-secret-key-here-must-be-32-char-or-above';
+    process.env.ROOT_ADMIN_PASSWORD = 'change-this-password';
+    process.env.POSTGRES_PASSWORD = 'postgres';
+
+    expect(() => assertSecureDeploymentConfig(loadConfig())).toThrow(
+      /Refusing to start InsForge with insecure production configuration/
+    );
+  });
+
+  it('accepts unique production credentials', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.JWT_SECRET = 'u53-strong-random-jwt-secret-for-prod';
+    process.env.ENCRYPTION_KEY = 'u53-strong-random-encryption-key-for-prod';
+    process.env.ROOT_ADMIN_PASSWORD = 'correct-horse-admin-password-2026';
+    process.env.POSTGRES_PASSWORD = 'correct-horse-postgres-password-2026';
+
+    expect(getDeploymentSecurityErrors(loadConfig())).toEqual([]);
+    expect(() => assertSecureDeploymentConfig(loadConfig())).not.toThrow();
+  });
+});
 
 describe('config.storage', () => {
   it('uses defaults when no env vars are set', () => {

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -1,6 +1,6 @@
 # PostgreSQL Configuration (optional - defaults shown)
+POSTGRES_PASSWORD=
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
 POSTGRES_DB=insforge
 
 # Port Configuration
@@ -15,11 +15,12 @@ API_BASE_URL=http://localhost:7130
 VITE_API_BASE_URL=http://localhost:7130
 
 # Authentication
-JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
+JWT_SECRET=
+ROOT_ADMIN_PASSWORD=
 ROOT_ADMIN_USERNAME=admin
-ROOT_ADMIN_PASSWORD=change-this-password
 
-# Encryption key for secrets and database encryption (will use JWT_SECRET if not provided)
+# Encryption key for secrets and database encryption
+# Production compose requires a value different from JWT_SECRET.
 ENCRYPTION_KEY=
 
 # Worker timeout in milliseconds (default: 60000 ms) 

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -4,9 +4,9 @@ services:
 
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
@@ -24,11 +24,11 @@ services:
 
     restart: unless-stopped
     environment:
-      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-please-change-in-production}
+      PGRST_JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst
@@ -60,22 +60,23 @@ services:
       - "${AUTH_PORT:-7131}:7131"
     environment:
       - PORT=7130
+      - NODE_ENV=production
       - PROJECT_ROOT=/app
       - API_BASE_URL=${API_BASE_URL:-}
       - VITE_API_BASE_URL=${VITE_API_BASE_URL:-}
-      - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+      - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
       - ROOT_ADMIN_USERNAME=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}
+      - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       - ADMIN_EMAIL=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      - ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}
+      - ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       # PostgreSQL connection
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
@@ -124,20 +125,20 @@ services:
       - "${DENO_PORT:-7133}:7133"
     environment:
       - PORT=7133
-      - DENO_ENV=development
+      - DENO_ENV=production
       - DENO_DIR=/deno-dir
       # PostgreSQL connection
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Worker timeout (60 seconds default)
       - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-60000}
       # Encryption keys for decrypting function secrets
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
-      - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
+      - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
     volumes:
       - deno_cache:/deno-dir
     healthcheck:

--- a/deploy/docker-deploy.md
+++ b/deploy/docker-deploy.md
@@ -39,7 +39,9 @@ cp .env.example .env.project1
 cp .env.example .env.project2
 ```
 
-### Step 2: Edit each env file with unique ports
+### Step 2: Edit each env file with unique secrets and ports
+
+Set a different `JWT_SECRET`, `ENCRYPTION_KEY`, `ROOT_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD` in each env file. Do not reuse `.env.example` placeholders in production.
 
 **.env.project1** (default ports):
 ```

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -19,7 +19,15 @@ spec:
         - key: ROOT_ADMIN_PASSWORD
           type: STRING
           name: Root Admin Password
-          description: Password for the root admin. Must be at least 8 characters.
+          description: Password for the root admin. Must be at least 16 characters.
+        - key: JWT_SECRET
+          type: STRING
+          name: JWT Secret
+          description: Random 32+ character secret used to sign auth tokens.
+        - key: ENCRYPTION_KEY
+          type: STRING
+          name: Encryption Key
+          description: Random 32+ character secret for stored secrets. Use a different value from JWT Secret.
         - key: OPENROUTER_API_KEY
           type: STRING
           name: OpenRouter API Key
@@ -139,7 +147,7 @@ spec:
                     default: postgres
                     expose: true
                 JWT_SECRET:
-                    default: ${PASSWORD}
+                    default: ${JWT_SECRET}
                     expose: true
                     readonly: true
                 JWT_EXP:
@@ -350,7 +358,7 @@ spec:
                 PORT:
                     default: "7133"
                 DENO_ENV:
-                    default: development
+                    default: production
                 DENO_DIR:
                     default: /deno-dir
                 POSTGRES_HOST:
@@ -368,7 +376,7 @@ spec:
                 WORKER_TIMEOUT_MS:
                     default: "60000"
                 ENCRYPTION_KEY:
-                    default: ${PASSWORD}
+                    default: ${ENCRYPTION_KEY}
                 JWT_SECRET:
                     default: ${PGRST_JWT_SECRET}
             configs:
@@ -889,10 +897,14 @@ spec:
                     default: ${ZEABUR_WEB_URL}
                 JWT_SECRET:
                     default: ${PGRST_JWT_SECRET}
+                ENCRYPTION_KEY:
+                    default: ${ENCRYPTION_KEY}
                 ROOT_ADMIN_USERNAME:
                     default: ${ROOT_ADMIN_USERNAME}
                 ROOT_ADMIN_PASSWORD:
                     default: ${ROOT_ADMIN_PASSWORD}
+                NODE_ENV:
+                    default: production
                 # PostgreSQL connection
                 POSTGRES_HOST:
                     default: postgres
@@ -902,7 +914,7 @@ spec:
                     default: insforge
                 POSTGRES_USER:
                     default: postgres
-                POSTGRESDB_PASSWORD:
+                POSTGRES_PASSWORD:
                     default: ${PGPASSWORD}
                 DATABASE_URL:
                     default: postgres://postgres:${PGPASSWORD}@postgres:5432/insforge

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -4,9 +4,9 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -21,11 +21,11 @@ services:
     image: postgrest/postgrest:v12.2.12
     restart: unless-stopped
     environment:
-      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: ${POSTGREST_OPENAPI_SERVER_PROXY_URI:-http://localhost:3000}
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
+      PGRST_JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
       PGRST_DB_CHANNEL_ENABLED: "true"
       PGRST_DB_CHANNEL: pgrst
     depends_on:
@@ -51,21 +51,22 @@ services:
         condition: service_started
     environment:
       PORT: "7130"
+      NODE_ENV: production
       PROJECT_ROOT: /app
       API_BASE_URL: ${API_BASE_URL:-http://localhost:7130}
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:7130}
-      JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
       ROOT_ADMIN_USERNAME: ${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      ROOT_ADMIN_PASSWORD: ${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-changeme123}}
+      ROOT_ADMIN_PASSWORD: ${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       ADMIN_EMAIL: ${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      ADMIN_PASSWORD: ${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-changeme123}}
+      ADMIN_PASSWORD: ${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       POSTGRES_HOST: postgres
       POSTGRES_PORT: "5432"
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       POSTGREST_BASE_URL: http://postgrest:3000
       DENO_RUNTIME_URL: http://deno:7133
       LOGS_DIR: /insforge-logs
@@ -108,11 +109,11 @@ services:
       POSTGRES_PORT: "5432"
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       POSTGREST_BASE_URL: http://postgrest:3000
       WORKER_TIMEOUT_MS: ${WORKER_TIMEOUT_MS:-60000}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
-      JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_S3_BUCKET: ${AWS_S3_BUCKET:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,10 +2,10 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -31,14 +31,11 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      #POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      #POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      #POSTGRES_DB: ${POSTGRES_DB:-insforge}
-      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
-      PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-please-change-in-production}
+      PGRST_JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
     ports:
       - "${POSTGREST_PORT:-5430}:3000"
     depends_on:
@@ -64,14 +61,15 @@ services:
       - "${AUTH_PORT:-7131}:7131"
     environment:
       - PORT=7130
+      - NODE_ENV=production
       - PROJECT_ROOT=/app
       - API_BASE_URL=${API_BASE_URL:-}
-      - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
+      - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
       - ROOT_ADMIN_USERNAME=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}
+      - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       - ADMIN_EMAIL=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
-      - ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}
+      - ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:?Set ROOT_ADMIN_PASSWORD to a unique strong password}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       # PostgreSQL connection
@@ -79,8 +77,8 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Deno Runtime URL for serverless functions
       - DENO_RUNTIME_URL=http://deno:7133
@@ -159,13 +157,13 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD to a unique strong password}
       - POSTGREST_BASE_URL=http://postgrest:3000
       # Worker timeout (60 seconds default)
       - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-60000}
       # Encryption keys for decrypting function secrets
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
-      - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?Set ENCRYPTION_KEY to a unique 32+ character secret}
+      - JWT_SECRET=${JWT_SECRET:?Set JWT_SECRET to a unique 32+ character secret}
     volumes:
       - ./functions:/app/functions
       - deno_cache:/deno-dir

--- a/docs/deployment/deploy-to-aws-ec2.md
+++ b/docs/deployment/deploy-to-aws-ec2.md
@@ -128,13 +128,11 @@ The full template lives at `deploy/docker-compose/.env.example`. These are the v
 
 ```env
 # Required
-JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
+JWT_SECRET=<output-of-openssl-rand-base64-32>
+ENCRYPTION_KEY=<different-output-of-openssl-rand-base64-32>
 ROOT_ADMIN_USERNAME=admin
-ROOT_ADMIN_PASSWORD=change-this-password
-POSTGRES_PASSWORD=change-this-password
-
-# Optional: falls back to JWT_SECRET if left blank
-ENCRYPTION_KEY=
+ROOT_ADMIN_PASSWORD=<strong-unique-admin-password>
+POSTGRES_PASSWORD=<strong-unique-database-password>
 
 # Optional: enables AI features
 OPENROUTER_API_KEY=

--- a/docs/deployment/deploy-to-azure-virtual-machines.md
+++ b/docs/deployment/deploy-to-azure-virtual-machines.md
@@ -103,24 +103,23 @@ This guide provides comprehensive, step-by-step instructions for deploying, mana
 
     ```ini
     # Required
-    JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
+    JWT_SECRET=<output-of-openssl-rand-base64-32>
+    ENCRYPTION_KEY=<different-output-of-openssl-rand-base64-32>
     ROOT_ADMIN_USERNAME=admin
-    ROOT_ADMIN_PASSWORD=change-this-password
-    POSTGRES_PASSWORD=change-this-password
+    ROOT_ADMIN_PASSWORD=<strong-unique-admin-password>
+    POSTGRES_PASSWORD=<strong-unique-database-password>
 
     # API URLs (replace with your VM public IP or domain)
     API_BASE_URL=http://<your-vm-public-ip>:7130
     VITE_API_BASE_URL=http://<your-vm-public-ip>:7130
 
     # Optional
-    # ENCRYPTION_KEY falls back to JWT_SECRET if left empty
-    ENCRYPTION_KEY=
     # OPENROUTER_API_KEY=
     # VERCEL_TOKEN=
     # GOOGLE_CLIENT_ID=
     ```
     The rest of `.env.example` covers optional features (OpenRouter, Vercel deployments, OAuth providers). Leave those blank unless you need them.
-    > **Generate a Secure JWT Secret:** Run this on your VM and paste the result into `JWT_SECRET`:
+    > **Generate Secure Secrets:** Run this twice on your VM and paste different values into `JWT_SECRET` and `ENCRYPTION_KEY`:
     > ```bash
     > openssl rand -base64 32
     > ```

--- a/docs/deployment/deploy-to-google-cloud-compute-engine.md
+++ b/docs/deployment/deploy-to-google-cloud-compute-engine.md
@@ -169,23 +169,20 @@ At a minimum, set these values:
 ```env
 # Authentication (required)
 # IMPORTANT: Generate a strong random secret for production (32+ characters)
-JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
+JWT_SECRET=<output-of-openssl-rand-base64-32>
+ENCRYPTION_KEY=<different-output-of-openssl-rand-base64-32>
 
 # Admin account (used for initial setup)
 ROOT_ADMIN_USERNAME=admin
-ROOT_ADMIN_PASSWORD=change-this-password
+ROOT_ADMIN_PASSWORD=<strong-unique-admin-password>
 
 # Database (required)
-POSTGRES_PASSWORD=your-secure-postgres-password
+POSTGRES_PASSWORD=<strong-unique-database-password>
 ```
 
 Optional values you may want to set:
 
 ```env
-# Encryption key for secrets and database encryption.
-# Falls back to JWT_SECRET if left empty.
-ENCRYPTION_KEY=
-
 # AI/LLM (get a key from https://openrouter.ai/keys)
 OPENROUTER_API_KEY=
 


### PR DESCRIPTION
Closes #1552

## Summary

This hardens production/self-hosted deployments so InsForge no longer starts with documented default or placeholder secrets.

Production deployment paths previously allowed fallback values for JWT, admin, database, and encryption secrets. In a copied `.env.example` or unset-env deployment, that can leave production instances with predictable credentials or token-signing material.

## Changes

- Refuse production startup when `JWT_SECRET`, `ENCRYPTION_KEY`, `ROOT_ADMIN_PASSWORD`, or `POSTGRES_PASSWORD` are missing or known placeholder/default values.
- Require `ENCRYPTION_KEY` to be separate from `JWT_SECRET` in production.
- Require 32+ character JWT/encryption secrets and 16+ character root admin/Postgres passwords.
- Set production `NODE_ENV` in Docker deployment paths.
- Remove unsafe default secrets from production compose files and env examples.
- Update README and deployment docs to require generated unique secrets.
- Update Zeabur deployment env wiring for separate JWT/encryption secrets and backend `POSTGRES_PASSWORD`.
- Add unit tests for production secret validation.

## How did you test this change?

- `npm.cmd test -- app.config.test.ts`
- `npm.cmd run build`
- `docker compose -f docker-compose.prod.yml config --quiet`
- `docker compose -f deploy/docker-compose/docker-compose.yml config --quiet`
- `docker compose -f docker-compose.dokploy.yml config --quiet`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden production deployment secrets by enforcing secure configuration at startup
> - Adds `assertSecureDeploymentConfig` in [app.config.ts](https://github.com/InsForge/InsForge/pull/1551/files#diff-24b06be8fbc5ad753cf4ae7c1e6d9c70c7740c17331319f8eb0fc50b559527fb), called at server startup, which validates `JWT_SECRET`, `ENCRYPTION_KEY`, `ROOT_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD` — rejecting known placeholders, short values, and identical JWT/encryption keys.
> - All production Docker Compose files replace insecure default fallbacks with required parameter expansions, so containers fail to start if secrets are missing.
> - Sets `NODE_ENV=production` explicitly in the Dockerfile runner stage and across Compose service definitions.
> - Updates `.env.example` files and deployment guides (AWS, Azure, GCE) to require unique secrets and remove the suggestion that `ENCRYPTION_KEY` can fall back to `JWT_SECRET`.
> - Risk: existing deployments using placeholder or reused secrets (e.g. `ENCRYPTION_KEY` == `JWT_SECRET`) will fail to start until secrets are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a3284c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added production deployment security checks to block startup when secrets and passwords are missing, too short, or left as known insecure defaults.

* **Documentation**
  * Updated deployment and quickstart guides to require unique values for `JWT_SECRET`, `ENCRYPTION_KEY`, `ROOT_ADMIN_PASSWORD`, and `POSTGRES_PASSWORD`.
  * Clarified that `ENCRYPTION_KEY` must be different from `JWT_SECRET`.

* **Chores**
  * Hardened Docker Compose production configs to require required secrets via explicit environment-variable checks.
  * Updated the example environment files to remove hard-coded example secret values.
  * Set the runtime container to production mode by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->