### PR TITLE
Feat/pagination db studio

### DIFF
--- a/packages/dashboard/src/features/database/pages/FunctionsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/FunctionsPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '#components';
 import { useDatabaseSchemas, useFunctions } from '#features/database/hooks/useDatabase';
 import { useDatabaseSchemaSelection } from '#features/database/hooks/useDatabaseSchemaSelection';
+import { usePageSize } from '#lib/hooks/usePageSize';
 import { SQLModal, SQLCellButton } from '#features/database/components/SQLModal';
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { type DatabaseFunctionsResponse } from '@insforge/shared-schemas';
@@ -58,6 +59,8 @@ export default function FunctionsPage() {
   const selectedSchemaInfo = getDatabaseSchemaInfo(schemas, selectedSchema);
   const { data, isLoading, error, refetch } = useFunctions(selectedSchema, true);
   const [sqlModal, setSqlModal] = useState({ open: false, title: '', value: '' });
+  const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-functions');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const allFunctions = useMemo(() => parseFunctionsFromResponse(data), [data]);
 
@@ -70,10 +73,23 @@ export default function FunctionsPage() {
     return allFunctions.filter((func) => func.functionName.toLowerCase().includes(query));
   }, [allFunctions, searchQuery]);
 
+  const totalPages = Math.ceil(filteredFunctions.length / pageSize);
+  const safeCurrentPage = Math.min(currentPage, Math.max(1, totalPages));
+
+  const paginatedFunctions = useMemo(() => {
+    const start = (safeCurrentPage - 1) * pageSize;
+    return filteredFunctions.slice(start, start + pageSize);
+  }, [filteredFunctions, safeCurrentPage, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedSchema, pageSize]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       setSearchQuery('');
+      setCurrentPage(1);
       await refetch();
     } finally {
       setIsRefreshing(false);
@@ -202,6 +218,7 @@ export default function FunctionsPage() {
                 value={selectedSchemaInfo.name}
                 onValueChange={(schemaName) => {
                   setSearchQuery('');
+                  setCurrentPage(1);
                   setSelectedSchema(schemaName, { replace: true });
                 }}
                 disabled={isLoadingSchemas}
@@ -220,10 +237,18 @@ export default function FunctionsPage() {
         ) : (
           <div className="min-h-0 flex-1 overflow-hidden">
             <DataGrid
-              data={filteredFunctions}
+              data={paginatedFunctions}
               columns={columns}
               showSelection={false}
-              showPagination={false}
+              showPagination={true}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              totalRecords={filteredFunctions.length}
+              paginationRecordLabel="functions"
+              onPageChange={setCurrentPage}
+              onPageSizeChange={onPageSizeChange}
               noPadding={true}
               className="h-full"
               isRefreshing={isRefreshing}

--- a/packages/dashboard/src/features/database/pages/IndexesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/IndexesPage.tsx
@@ -17,6 +17,7 @@ import { SQLModal, SQLCellButton } from '#features/database/components/SQLModal'
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { type DatabaseIndexesResponse } from '@insforge/shared-schemas';
 import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
+import { usePageSize } from '#lib/hooks/usePageSize';
 import { DEFAULT_DATABASE_SCHEMA, getDatabaseSchemaInfo } from '#features/database/helpers';
 
 interface IndexRow extends DataGridRowType {
@@ -60,6 +61,8 @@ export default function IndexesPage() {
   const selectedSchemaInfo = getDatabaseSchemaInfo(schemas, selectedSchema);
   const { data, isLoading, error, refetch } = useIndexes(selectedSchema, true);
   const [sqlModal, setSqlModal] = useState({ open: false, title: '', value: '' });
+  const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-indexes');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const allIndexes = useMemo(() => parseIndexesFromResponse(data), [data]);
 
@@ -76,10 +79,23 @@ export default function IndexesPage() {
     );
   }, [allIndexes, searchQuery]);
 
+  const totalPages = Math.ceil(filteredIndexes.length / pageSize);
+  const safeCurrentPage = Math.min(currentPage, Math.max(1, totalPages));
+
+  const paginatedIndexes = useMemo(() => {
+    const start = (safeCurrentPage - 1) * pageSize;
+    return filteredIndexes.slice(start, start + pageSize);
+  }, [filteredIndexes, safeCurrentPage, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedSchema, pageSize]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       setSearchQuery('');
+      setCurrentPage(1);
       await refetch();
     } finally {
       setIsRefreshing(false);
@@ -227,6 +243,7 @@ export default function IndexesPage() {
                 value={selectedSchemaInfo.name}
                 onValueChange={(schemaName) => {
                   setSearchQuery('');
+                  setCurrentPage(1);
                   setSelectedSchema(schemaName, { replace: true });
                 }}
                 disabled={isLoadingSchemas}
@@ -245,10 +262,18 @@ export default function IndexesPage() {
         ) : (
           <div className="min-h-0 flex-1 overflow-hidden">
             <DataGrid
-              data={filteredIndexes}
+              data={paginatedIndexes}
               columns={columns}
               showSelection={false}
-              showPagination={false}
+              showPagination={true}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              totalRecords={filteredIndexes.length}
+              paginationRecordLabel="indexes"
+              onPageChange={setCurrentPage}
+              onPageSizeChange={onPageSizeChange}
               noPadding={true}
               className="h-full"
               isRefreshing={isRefreshing}

--- a/packages/dashboard/src/features/database/pages/MigrationsPage.tsx
+++ b/packages/dashboard/src/features/database/pages/MigrationsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import RefreshIcon from '#assets/icons/refresh.svg?react';
 import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -11,6 +11,7 @@ import {
   type DataGridRowType,
 } from '#components';
 import { formatTime } from '#lib/utils/utils';
+import { usePageSize } from '#lib/hooks/usePageSize';
 import type { DatabaseMigrationsResponse } from '@insforge/shared-schemas';
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { SQLCellButton, SQLModal } from '#features/database/components/SQLModal';
@@ -55,6 +56,8 @@ export default function MigrationsPage() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [sqlModal, setSqlModal] = useState({ open: false, title: '', value: '' });
   const { data, isLoading, error, refetch } = useMigrations(true);
+  const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-migrations');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const allMigrations = useMemo(() => parseMigrationsFromResponse(data), [data]);
 
@@ -70,10 +73,23 @@ export default function MigrationsPage() {
     );
   }, [allMigrations, searchQuery]);
 
+  const totalPages = Math.ceil(filteredMigrations.length / pageSize);
+  const safeCurrentPage = Math.min(currentPage, Math.max(1, totalPages));
+
+  const paginatedMigrations = useMemo(() => {
+    const start = (safeCurrentPage - 1) * pageSize;
+    return filteredMigrations.slice(start, start + pageSize);
+  }, [filteredMigrations, safeCurrentPage, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, pageSize]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       setSearchQuery('');
+      setCurrentPage(1);
       await refetch();
     } finally {
       setIsRefreshing(false);
@@ -202,10 +218,18 @@ export default function MigrationsPage() {
         ) : (
           <div className="min-h-0 flex-1 overflow-hidden">
             <DataGrid
-              data={filteredMigrations}
+              data={paginatedMigrations}
               columns={columns}
               showSelection={false}
-              showPagination={false}
+              showPagination={true}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              totalRecords={filteredMigrations.length}
+              paginationRecordLabel="migrations"
+              onPageChange={setCurrentPage}
+              onPageSizeChange={onPageSizeChange}
               noPadding={true}
               className="h-full"
               isRefreshing={isRefreshing}

--- a/packages/dashboard/src/features/database/pages/PoliciesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/PoliciesPage.tsx
@@ -17,6 +17,7 @@ import { SQLModal, SQLCellButton } from '#features/database/components/SQLModal'
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { type DatabasePoliciesResponse } from '@insforge/shared-schemas';
 import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
+import { usePageSize } from '#lib/hooks/usePageSize';
 import { DEFAULT_DATABASE_SCHEMA, getDatabaseSchemaInfo } from '#features/database/helpers';
 
 interface PolicyRow extends DataGridRowType {
@@ -62,6 +63,8 @@ export default function PoliciesPage() {
   const selectedSchemaInfo = getDatabaseSchemaInfo(schemas, selectedSchema);
   const { data, isLoading, error, refetch } = usePolicies(selectedSchema, true);
   const [sqlModal, setSqlModal] = useState({ open: false, title: '', value: '' });
+  const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-policies');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const allPolicies = useMemo(() => parsePoliciesFromResponse(data), [data]);
 
@@ -78,10 +81,23 @@ export default function PoliciesPage() {
     );
   }, [allPolicies, searchQuery]);
 
+  const totalPages = Math.ceil(filteredPolicies.length / pageSize);
+  const safeCurrentPage = Math.min(currentPage, Math.max(1, totalPages));
+
+  const paginatedPolicies = useMemo(() => {
+    const start = (safeCurrentPage - 1) * pageSize;
+    return filteredPolicies.slice(start, start + pageSize);
+  }, [filteredPolicies, safeCurrentPage, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedSchema, pageSize]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       setSearchQuery('');
+      setCurrentPage(1);
       await refetch();
     } finally {
       setIsRefreshing(false);
@@ -236,6 +252,7 @@ export default function PoliciesPage() {
                 value={selectedSchemaInfo.name}
                 onValueChange={(schemaName) => {
                   setSearchQuery('');
+                  setCurrentPage(1);
                   setSelectedSchema(schemaName, { replace: true });
                 }}
                 disabled={isLoadingSchemas}
@@ -254,10 +271,18 @@ export default function PoliciesPage() {
         ) : (
           <div className="min-h-0 flex-1 overflow-hidden">
             <DataGrid
-              data={filteredPolicies}
+              data={paginatedPolicies}
               columns={columns}
               showSelection={false}
-              showPagination={false}
+              showPagination={true}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              totalRecords={filteredPolicies.length}
+              paginationRecordLabel="policies"
+              onPageChange={setCurrentPage}
+              onPageSizeChange={onPageSizeChange}
               noPadding={true}
               className="h-full"
               isRefreshing={isRefreshing}

--- a/packages/dashboard/src/features/database/pages/TriggersPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TriggersPage.tsx
@@ -17,6 +17,7 @@ import { SQLModal, SQLCellButton } from '#features/database/components/SQLModal'
 import { DatabaseStudioSidebarPanel } from '#features/database/components/DatabaseSidebar';
 import { type DatabaseTriggersResponse } from '@insforge/shared-schemas';
 import { DatabaseSchemaSelect } from '#features/database/components/DatabaseSchemaSelect';
+import { usePageSize } from '#lib/hooks/usePageSize';
 import { DEFAULT_DATABASE_SCHEMA, getDatabaseSchemaInfo } from '#features/database/helpers';
 
 interface TriggerRow extends DataGridRowType {
@@ -60,6 +61,8 @@ export default function TriggersPage() {
   const selectedSchemaInfo = getDatabaseSchemaInfo(schemas, selectedSchema);
   const { data, isLoading, error, refetch } = useTriggers(selectedSchema, true);
   const [sqlModal, setSqlModal] = useState({ open: false, title: '', value: '' });
+  const { pageSize, pageSizeOptions, onPageSizeChange } = usePageSize('db-triggers');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const allTriggers = useMemo(() => parseTriggersFromResponse(data), [data]);
 
@@ -76,10 +79,23 @@ export default function TriggersPage() {
     );
   }, [allTriggers, searchQuery]);
 
+  const totalPages = Math.ceil(filteredTriggers.length / pageSize);
+  const safeCurrentPage = Math.min(currentPage, Math.max(1, totalPages));
+
+  const paginatedTriggers = useMemo(() => {
+    const start = (safeCurrentPage - 1) * pageSize;
+    return filteredTriggers.slice(start, start + pageSize);
+  }, [filteredTriggers, safeCurrentPage, pageSize]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedSchema, pageSize]);
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       setSearchQuery('');
+      setCurrentPage(1);
       await refetch();
     } finally {
       setIsRefreshing(false);
@@ -229,6 +245,7 @@ export default function TriggersPage() {
                 value={selectedSchemaInfo.name}
                 onValueChange={(schemaName) => {
                   setSearchQuery('');
+                  setCurrentPage(1);
                   setSelectedSchema(schemaName, { replace: true });
                 }}
                 disabled={isLoadingSchemas}
@@ -247,10 +264,18 @@ export default function TriggersPage() {
         ) : (
           <div className="min-h-0 flex-1 overflow-hidden">
             <DataGrid
-              data={filteredTriggers}
+              data={paginatedTriggers}
               columns={columns}
               showSelection={false}
-              showPagination={false}
+              showPagination={true}
+              currentPage={currentPage}
+              totalPages={totalPages}
+              pageSize={pageSize}
+              pageSizeOptions={pageSizeOptions}
+              totalRecords={filteredTriggers.length}
+              paginationRecordLabel="triggers"
+              onPageChange={setCurrentPage}
+              onPageSizeChange={onPageSizeChange}
               noPadding={true}
               className="h-full"
               isRefreshing={isRefreshing}

--- a/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
+++ b/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider } from '#lib/contexts/ThemeContext';
+
+function createFunctions(num: number) {
+  return Array.from({ length: num }, (_, i) => ({
+    functionName: `func_${i}`,
+    kind: i % 2 === 0 ? 'f' : 'p',
+    functionDef: `CREATE FUNCTION func_${i}() RETURNS void LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;`,
+  }));
+}
+
+const hookMocks = vi.hoisted(() => ({
+  schemas: [{ name: 'public' }, { name: 'private' }],
+  functions: createFunctions(120),
+  searchQuery: '',
+  selectedSchema: 'public',
+  currentPage: 1,
+  pageSize: 50,
+  onPageSizeChange: vi.fn(),
+  setSelectedSchema: vi.fn(),
+  setSearchQuery: vi.fn(),
+  setCurrentPage: vi.fn(),
+}));
+
+vi.mock('#assets/icons/refresh.svg?react', () => ({
+  default: () => <svg data-testid="refresh-icon" />,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({ search: '' }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('#features/database/hooks/useDatabase', () => ({
+  useDatabaseSchemas: () => ({
+    schemas: hookMocks.schemas,
+    isLoading: false,
+  }),
+  useFunctions: () => ({
+    data: { functions: hookMocks.functions },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('#features/database/hooks/useDatabaseSchemaSelection', () => ({
+  useDatabaseSchemaSelection: () => ({
+    selectedSchema: hookMocks.selectedSchema,
+    setSelectedSchema: hookMocks.setSelectedSchema,
+  }),
+}));
+
+vi.mock('#lib/hooks/usePageSize', () => ({
+  usePageSize: () => ({
+    pageSize: hookMocks.pageSize,
+    pageSizeOptions: [50, 100, 250, 500],
+    onPageSizeChange: hookMocks.onPageSizeChange,
+  }),
+}));
+
+import FunctionsPage from '#features/database/pages/FunctionsPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider forcedTheme="light">
+        <FunctionsPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store.get(key) ?? null);
+  vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, value) => store.set(key, value));
+  vi.spyOn(Storage.prototype, 'clear').mockImplementation(() => store.clear());
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('FunctionsPage pagination', () => {
+  beforeEach(() => {
+    hookMocks.functions = createFunctions(120);
+    hookMocks.searchQuery = '';
+    hookMocks.selectedSchema = 'public';
+    hookMocks.currentPage = 1;
+    hookMocks.pageSize = 50;
+    hookMocks.onPageSizeChange = vi.fn();
+    hookMocks.setSelectedSchema = vi.fn();
+    hookMocks.setSearchQuery = vi.fn();
+    hookMocks.setCurrentPage = vi.fn();
+  });
+
+  it('renders pagination for 120 functions (3 pages with pageSize=50)', () => {
+    renderPage();
+    expect(screen.getByText(/of 120 functions/i)).toBeInTheDocument();
+  });
+
+  it('shows correct record count when all rows fit in one page', () => {
+    hookMocks.functions = createFunctions(30);
+    renderPage();
+    expect(screen.getByText(/of 30 functions/i)).toBeInTheDocument();
+  });
+
+  it('renders page navigation buttons', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Go to first page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to next page' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to last page' })).toBeInTheDocument();
+  });
+
+  it('disables previous and first page buttons on page 1', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Go to first page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Go to next page' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Go to last page' })).toBeEnabled();
+  });
+
+  it('renders empty state when no functions exist', () => {
+    hookMocks.functions = [];
+    renderPage();
+    expect(screen.getByText('No functions found')).toBeInTheDocument();
+  });
+
+  it('shows per-page selector', () => {
+    renderPage();
+    expect(screen.getByText(/Functions per page/i)).toBeInTheDocument();
+  });
+
+  it('clamps currentPage when data shrinks below current page', () => {
+    hookMocks.currentPage = 3;
+    hookMocks.functions = createFunctions(30);
+    renderPage();
+    expect(screen.getByText(/Showing 1 to 30 of 30/i)).toBeInTheDocument();
+  });
+
+  it('shows single page when data exactly equals pageSize', () => {
+    hookMocks.functions = createFunctions(50);
+    renderPage();
+    expect(screen.getByText(/of 50 functions/i)).toBeInTheDocument();
+  });
+
+  it('shows single-item last page when data is pageSize+1', () => {
+    hookMocks.functions = createFunctions(51);
+    renderPage();
+    expect(screen.getByText(/of 51 functions/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to next page' })).toBeEnabled();
+  });
+});

--- a/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
+++ b/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider } from '#lib/contexts/ThemeContext';
@@ -149,11 +150,15 @@ describe('FunctionsPage pagination', () => {
     expect(screen.getByText(/Functions per page/i)).toBeInTheDocument();
   });
 
-  it('clamps currentPage when data shrinks below current page', () => {
-    hookMocks.currentPage = 3;
-    hookMocks.functions = createFunctions(30);
+  it('navigates to page 2 when user clicks the page-2 button', async () => {
+    const user = userEvent.setup();
     renderPage();
-    expect(screen.getByText(/Showing 1 to 30 of 30/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Go to page 2' }));
+    expect(screen.getByText(/Showing 51 to 100 of 120/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to page 2' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
   });
 
   it('shows single page when data exactly equals pageSize', () => {

--- a/packages/ui/src/components/Pagination.tsx
+++ b/packages/ui/src/components/Pagination.tsx
@@ -65,7 +65,7 @@ export function Pagination({
   currentPage = 1,
   totalPages = 1,
   totalRecords = 0,
-  pageSize = 100,
+  pageSize = 50,
   pageSizeOptions,
   recordLabel = 'users',
   visiblePageCount = FIXED_CENTER_SLOT_COUNT,
@@ -79,12 +79,7 @@ export function Pagination({
   const endRecord =
     totalRecords === 0 ? 0 : Math.min(normalizedCurrentPage * pageSize, totalRecords);
 
-  // Keep pagination density consistent across the app:
-  // 2 fixed controls on the left + 5 center slots + 2 fixed controls on the right = 9 total items.
-  const enforcedCenterSlotCount = Math.max(
-    FIXED_CENTER_SLOT_COUNT,
-    Math.min(FIXED_CENTER_SLOT_COUNT, visiblePageCount)
-  );
+  const enforcedCenterSlotCount = Math.max(FIXED_CENTER_SLOT_COUNT, visiblePageCount);
 
   const items = React.useMemo(
     () => getVisibleItems(normalizedCurrentPage, normalizedTotalPages, enforcedCenterSlotCount),

--- a/packages/ui/src/components/Pagination.tsx
+++ b/packages/ui/src/components/Pagination.tsx
@@ -39,10 +39,6 @@ function getVisibleItems(
     return Array.from({ length: totalPages }, (_, index) => index + 1);
   }
 
-  // For 5 center slots:
-  // start: 1 2 3 4 ...
-  // middle: ... p-1 p p+1 ...
-  // end: ... n-3 n-2 n-1 n
   const edgePageCount = slots - 1;
   const endStartPage = totalPages - edgePageCount + 1;
 
@@ -57,7 +53,10 @@ function getVisibleItems(
     ];
   }
 
-  return ['ellipsis-left', currentPage - 1, currentPage, currentPage + 1, 'ellipsis-right'];
+  const half = Math.floor((slots - 2) / 2);
+  const rangeStart = currentPage - half;
+  const range = Array.from({ length: slots - 2 }, (_, index) => rangeStart + index);
+  return ['ellipsis-left', ...range, 'ellipsis-right'];
 }
 
 export function Pagination({


### PR DESCRIPTION
## Summary

#closes #1549

[screen-capture (1).webm](https://github.com/user-attachments/assets/552dcba8-0ceb-4018-b0ae-c20f086bc4ab)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client‑side pagination to Database Studio pages with per‑page persistence and smoother navigation for large lists. Implements the requirements from Linear #1549.

- **New Features**
  - Paginated views for Functions, Indexes, Migrations, Policies, and Triggers using `DataGrid`.
  - Remembers per‑page selection via `usePageSize` (keys: `db-functions`, `db-indexes`, `db-migrations`, `db-policies`, `db-triggers`).
  - Resets to page 1 on search, schema, page‑size changes, and manual refresh; clamps current page when data shrinks.
  - Updated `Pagination` default page size to 50 and expanded center page range when `visiblePageCount` is larger; added tests for Functions pagination.

<sup>Written for commit 8003f41fd2ea565d510a869c5926962e5ed2510a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add client-side pagination to Database studio pages
> - Adds paginated rendering to the Functions, Indexes, Migrations, Policies, and Triggers database pages, replacing full-list rendering in their `DataGrid` components.
> - Each page uses a `usePageSize` hook and local `currentPage` state, computing a sliced subset of filtered results to display. Page resets to 1 on search query, schema, or page size changes.
> - Updates [`Pagination.tsx`](https://github.com/InsForge/InsForge/pull/1553/files#diff-5c85d4dcc7dfbdaabe3308d6f5ed26f51dc8fbf59693c27672cee350b566fc43) to default `pageSize` to 50 (down from 100) and widens the sliding window of visible page buttons based on `visiblePageCount`.
> - Behavioral Change: the default page size across all paginated database pages is now 50 records instead of 100.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8003f41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled client-side pagination on database tables (functions, indexes, migrations, policies, and triggers) to better handle large datasets.
  * Pagination now resets to page 1 when changing search filters, switching schemas, page size, or refreshing.
  * Added pagination coverage for the functions table to verify counts, navigation, and empty states.
* **Bug Fixes**
  * Updated the pagination UI defaults to 50 items per page and refined the page-number/ellipsis display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->