### PR TITLE
feat: add Go SDK for InsForge

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -1,0 +1,75 @@
+name: Go SDK
+
+on:
+  pull_request:
+    branches: [main, master, develop]
+    paths:
+      - 'sdks/go/**'
+  push:
+    branches: [main, master]
+    paths:
+      - 'sdks/go/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Go SDK Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version: ["1.21", "1.22"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: sdks/go/go.sum
+
+      - name: Download dependencies
+        working-directory: sdks/go
+        run: go mod download
+
+      - name: Run tests
+        working-directory: sdks/go
+        run: go test ./... -v -race
+
+  lint:
+    name: Go SDK Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: sdks/go
+          version: latest
+
+  vet:
+    name: Go SDK Vet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: go vet
+        working-directory: sdks/go
+        run: go vet ./...

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,0 +1,294 @@
+# InsForge Go SDK
+
+Official Go SDK for [InsForge](https://insforge.dev) — backend-as-a-service providing Database, Authentication, Storage, AI, Serverless Functions, and Realtime.
+
+## Installation
+
+```bash
+go get github.com/InsForge/InsForge/sdks/go/insforge@latest
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/InsForge/InsForge/sdks/go/insforge"
+)
+
+func main() {
+    client := insforge.CreateClient(insforge.Config{
+        BaseURL: "https://your-app.region.insforge.app",
+        AnonKey: "your-anon-key",
+    })
+
+    // Sign in
+    session, err := client.Auth.SignInWithPassword("user@example.com", "password")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println("Logged in as:", session.User.Email)
+
+    // Query the database
+    var todos []map[string]any
+    if err := client.DB.From("todos").Select("*").Execute(&todos); err != nil {
+        panic(err)
+    }
+    fmt.Printf("Found %d todos\n", len(todos))
+}
+```
+
+## Authentication
+
+```go
+// Sign up
+session, err := client.Auth.SignUp("user@example.com", "password", map[string]any{
+    "display_name": "Jane Doe",
+})
+
+// Sign in
+session, err := client.Auth.SignInWithPassword("user@example.com", "password")
+
+// OAuth — get redirect URL
+oauthURL, err := client.Auth.SignInWithOAuth("google", "https://myapp.com/callback", codeChallenge)
+// Redirect the user to oauthURL.URL
+
+// Exchange OAuth code after redirect
+session, err := client.Auth.ExchangeOAuthCode("google", code, codeVerifier)
+
+// Sign out
+err = client.Auth.SignOut()
+
+// Get current user
+user, err := client.Auth.GetCurrentUser()
+
+// Refresh token
+session, err = client.Auth.RefreshSession()
+
+// Profile management
+profile, err := client.Auth.GetProfile(userID)
+profile, err = client.Auth.SetProfile(userID, map[string]any{"bio": "Hello"})
+
+// Password reset flow
+err = client.Auth.SendResetPasswordEmail("user@example.com")
+session, err = client.Auth.ExchangeResetPasswordToken(token)
+err = client.Auth.ResetPassword("new-password")
+```
+
+## Database
+
+```go
+// Select rows
+var rows []map[string]any
+err := client.DB.From("todos").Select("*").Execute(&rows)
+
+// Select into typed structs
+type Todo struct {
+    ID    int    `json:"id"`
+    Title string `json:"title"`
+    Done  bool   `json:"done"`
+}
+var todos []Todo
+err = client.DB.From("todos").Select("*").Execute(&todos)
+
+// Filter
+err = client.DB.From("todos").
+    Select("*").
+    Eq("done", false).
+    Order("created_at", "desc").
+    Limit(10).
+    Execute(&todos)
+
+// Multiple filters
+err = client.DB.From("products").
+    Select("*").
+    Gte("price", 10).
+    Lte("price", 100).
+    In("category", []any{"electronics", "books"}).
+    Execute(&rows)
+
+// Insert
+err = client.DB.From("todos").
+    Insert([]map[string]any{{"title": "Buy groceries", "done": false}}).
+    Execute(&rows)
+
+// Update
+err = client.DB.From("todos").
+    Update(map[string]any{"done": true}).
+    Eq("id", 1).
+    Execute(&rows)
+
+// Delete
+err = client.DB.From("todos").Delete().Eq("id", 1).Execute(nil)
+
+// Upsert
+err = client.DB.From("todos").
+    Upsert([]map[string]any{{"id": 1, "title": "Updated", "done": true}}).
+    Execute(&rows)
+
+// Single row
+var todo Todo
+err = client.DB.From("todos").Select("*").Eq("id", 1).Single().Execute(&todo)
+
+// Call a Postgres function
+var result map[string]any
+err = client.DB.Rpc("my_function", map[string]any{"param": "value"}).Execute(&result)
+```
+
+## Storage
+
+```go
+import "os"
+
+// Upload a file
+data, _ := os.ReadFile("avatar.png")
+publicURL, err := client.Storage.From("avatars").Upload("user-123/avatar.png", data, "image/png")
+
+// Download a file
+fileData, err := client.Storage.From("avatars").Download("user-123/avatar.png")
+
+// List files
+objects, err := client.Storage.From("avatars").List("user-123/")
+for _, obj := range objects {
+    fmt.Printf("%s (%d bytes)\n", obj.Key, obj.Size)
+}
+
+// Delete a file
+err = client.Storage.From("avatars").Remove("user-123/avatar.png")
+```
+
+## AI
+
+```go
+// Chat completion
+resp, err := client.AI.Chat.Create(insforge.ChatCompletionRequest{
+    Model: "openai/gpt-4o",
+    Messages: []insforge.ChatMessage{
+        {Role: "system", Content: "You are a helpful assistant."},
+        {Role: "user", Content: "What is the capital of France?"},
+    },
+})
+fmt.Println(resp.Choices[0].Message.Content)
+
+// Streaming chat completion
+req := insforge.ChatCompletionRequest{
+    Model:    "openai/gpt-4o",
+    Messages: []insforge.ChatMessage{{Role: "user", Content: "Tell me a story"}},
+}
+chunks, errs := client.AI.Chat.CreateStream(req)
+for chunk := range chunks {
+    if len(chunk.Choices) > 0 {
+        fmt.Print(chunk.Choices[0].Delta.Content)
+    }
+}
+if err := <-errs; err != nil {
+    fmt.Println("stream error:", err)
+}
+
+// Embeddings
+embResp, err := client.AI.CreateEmbeddings(insforge.EmbeddingsRequest{
+    Model: "openai/text-embedding-3-small",
+    Input: []string{"Hello, world!"},
+})
+fmt.Println(embResp.Data[0].Embedding[:5])
+
+// Image generation
+imgResp, err := client.AI.GenerateImage(insforge.ImageGenerationRequest{
+    Prompt: "A serene mountain lake at sunrise",
+    Size:   "1024x1024",
+    N:      1,
+})
+fmt.Println(imgResp.Data[0].URL)
+```
+
+## Serverless Functions
+
+```go
+// Invoke a function
+result, err := client.Functions.Invoke("send-welcome-email", &insforge.InvokeOptions{
+    Body: map[string]any{
+        "to":   "user@example.com",
+        "name": "Jane",
+    },
+})
+fmt.Println(result.Data)
+
+// GET request
+result, err = client.Functions.Invoke("get-stats", &insforge.InvokeOptions{
+    Method: "GET",
+})
+
+// Custom headers
+result, err = client.Functions.Invoke("process-webhook", &insforge.InvokeOptions{
+    Headers: map[string]string{"X-Webhook-Secret": "secret"},
+    Body:    payload,
+})
+```
+
+## Realtime
+
+```go
+// Connect
+if err := client.Realtime.Connect(); err != nil {
+    panic(err)
+}
+defer client.Realtime.Disconnect()
+
+// Subscribe to a channel
+err = client.Realtime.Subscribe("todos", func(msg insforge.RealtimeMessage) {
+    fmt.Printf("Received on %s: %v\n", msg.Channel, msg.Payload)
+})
+
+// Publish a message
+err = client.Realtime.Publish("todos", map[string]any{
+    "action": "created",
+    "id":     42,
+})
+
+// One-time handler
+client.Realtime.Once("notifications", func(msg insforge.RealtimeMessage) {
+    fmt.Println("Got one notification:", msg.Payload)
+})
+
+// Check connection
+fmt.Println("Connected:", client.Realtime.IsConnected())
+fmt.Println("Subscribed channels:", client.Realtime.GetSubscribedChannels())
+
+// Unsubscribe
+err = client.Realtime.Unsubscribe("todos")
+```
+
+## Error Handling
+
+```go
+_, err := client.Auth.SignInWithPassword("bad@example.com", "wrong")
+if err != nil {
+    if insErr, ok := err.(*insforge.InsForgeError); ok {
+        fmt.Printf("API error [%s]: %s (HTTP %d)\n",
+            insErr.ErrorCode, insErr.Message, insErr.StatusCode)
+    } else {
+        fmt.Println("Network/other error:", err)
+    }
+}
+```
+
+## Configuration
+
+```go
+client := insforge.CreateClient(insforge.Config{
+    BaseURL:           "https://your-app.region.insforge.app",
+    AnonKey:           "your-anon-key",
+    // Optional: override bearer token (for use inside InsForge Functions)
+    EdgeFunctionToken: os.Getenv("INSFORGE_FUNCTION_TOKEN"),
+    // Optional: HTTP timeout in seconds (default: 30)
+    TimeoutSeconds:    60,
+})
+```
+
+## Running Tests
+
+```bash
+go test ./...
+```

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/InsForge/InsForge/sdks/go
+
+go 1.21
+
+require github.com/gorilla/websocket v1.4.2

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/sdks/go/insforge/ai.go
+++ b/sdks/go/insforge/ai.go
@@ -1,0 +1,197 @@
+package insforge
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+)
+
+// AIClient provides access to AI chat completions, embeddings, and image generation.
+type AIClient struct {
+	http *httpClient
+	Chat *chatCompletionsClient
+}
+
+func newAIClient(h *httpClient) *AIClient {
+	a := &AIClient{http: h}
+	a.Chat = &chatCompletionsClient{http: h}
+	return a
+}
+
+// -----------------------------------------------------------------------
+// Chat Completions
+// -----------------------------------------------------------------------
+
+// chatCompletionsClient mirrors the OpenAI chat.completions namespace.
+type chatCompletionsClient struct {
+	http *httpClient
+}
+
+// ChatMessage represents a single message in a chat conversation.
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatCompletionRequest is the request body for a chat completion.
+type ChatCompletionRequest struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	TopP        *float64      `json:"top_p,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+	// Extra fields (tool calls, response format, etc.) can be added as needed
+}
+
+// ChatCompletionResponse is a non-streaming chat completion response.
+type ChatCompletionResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int         `json:"index"`
+		Message ChatMessage `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// ChatCompletionChunk is a single chunk in a streaming response.
+type ChatCompletionChunk struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Role    string `json:"role,omitempty"`
+			Content string `json:"content,omitempty"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+// Create sends a chat completion request. Set req.Stream = false.
+func (c *chatCompletionsClient) Create(req ChatCompletionRequest) (*ChatCompletionResponse, error) {
+	req.Stream = false
+	var resp ChatCompletionResponse
+	if err := c.http.do("POST", "/api/ai/chat/completions", req, nil, &resp, nil); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateStream sends a streaming chat completion request.
+// It returns a channel that receives chunks and an error channel.
+// The caller should range over the chunks channel until it is closed.
+func (c *chatCompletionsClient) CreateStream(req ChatCompletionRequest) (<-chan ChatCompletionChunk, <-chan error) {
+	chunks := make(chan ChatCompletionChunk, 32)
+	errs := make(chan error, 1)
+
+	req.Stream = true
+	go func() {
+		defer close(chunks)
+		defer close(errs)
+
+		body, err := c.http.doStream("POST", "/api/ai/chat/completions", req)
+		if err != nil {
+			errs <- err
+			return
+		}
+		defer body.Close()
+
+		scanner := bufio.NewScanner(body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			if payload == "[DONE]" {
+				break
+			}
+			var chunk ChatCompletionChunk
+			if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+				errs <- err
+				return
+			}
+			chunks <- chunk
+		}
+		if err := scanner.Err(); err != nil {
+			errs <- err
+		}
+	}()
+
+	return chunks, errs
+}
+
+// -----------------------------------------------------------------------
+// Embeddings
+// -----------------------------------------------------------------------
+
+// EmbeddingsRequest is the request body for generating embeddings.
+type EmbeddingsRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// EmbeddingsResponse contains the generated embeddings.
+type EmbeddingsResponse struct {
+	Object string `json:"object"`
+	Data   []struct {
+		Object    string    `json:"object"`
+		Embedding []float64 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// CreateEmbeddings generates vector embeddings for the provided inputs.
+func (a *AIClient) CreateEmbeddings(req EmbeddingsRequest) (*EmbeddingsResponse, error) {
+	var resp EmbeddingsResponse
+	if err := a.http.do("POST", "/api/ai/embeddings", req, nil, &resp, nil); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// -----------------------------------------------------------------------
+// Image Generation
+// -----------------------------------------------------------------------
+
+// ImageGenerationRequest is the request body for generating images.
+type ImageGenerationRequest struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model,omitempty"`
+	N      int    `json:"n,omitempty"`
+	Size   string `json:"size,omitempty"`
+}
+
+// ImageGenerationResponse contains the generated image URLs.
+type ImageGenerationResponse struct {
+	Created int64 `json:"created"`
+	Data    []struct {
+		URL     string `json:"url"`
+		B64JSON string `json:"b64_json,omitempty"`
+	} `json:"data"`
+}
+
+// GenerateImage generates images from a text prompt.
+func (a *AIClient) GenerateImage(req ImageGenerationRequest) (*ImageGenerationResponse, error) {
+	var resp ImageGenerationResponse
+	if err := a.http.do("POST", "/api/ai/images/generate", req, nil, &resp, nil); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/sdks/go/insforge/auth.go
+++ b/sdks/go/insforge/auth.go
@@ -1,0 +1,202 @@
+package insforge
+
+import "net/url"
+
+// AuthClient handles authentication and user management.
+type AuthClient struct {
+	http *httpClient
+}
+
+func newAuthClient(h *httpClient) *AuthClient {
+	return &AuthClient{http: h}
+}
+
+// AuthUser represents a user object returned by the API.
+type AuthUser struct {
+	ID        string         `json:"id"`
+	Email     string         `json:"email"`
+	CreatedAt string         `json:"createdAt"`
+	UpdatedAt string         `json:"updatedAt"`
+	Profile   map[string]any `json:"profile,omitempty"`
+}
+
+// AuthSession is the response from sign-in / sign-up operations.
+type AuthSession struct {
+	AccessToken  string   `json:"accessToken"`
+	RefreshToken string   `json:"refreshToken"`
+	ExpiresIn    int      `json:"expiresIn"`
+	TokenType    string   `json:"tokenType"`
+	User         AuthUser `json:"user"`
+}
+
+// SignUp registers a new user with email and password.
+// Optional metadata can include display_name, avatar_url, etc.
+func (a *AuthClient) SignUp(email, password string, metadata map[string]any) (*AuthSession, error) {
+	body := map[string]any{
+		"email":       email,
+		"password":    password,
+		"client_type": "server",
+	}
+	if len(metadata) > 0 {
+		body["metadata"] = metadata
+	}
+	var session AuthSession
+	if err := a.http.do("POST", "/api/auth/users", body, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	a.http.state.setTokens(session.AccessToken, session.RefreshToken, "", nil)
+	return &session, nil
+}
+
+// SignInWithPassword authenticates using email and password.
+func (a *AuthClient) SignInWithPassword(email, password string) (*AuthSession, error) {
+	body := map[string]any{
+		"email":       email,
+		"password":    password,
+		"client_type": "server",
+	}
+	var session AuthSession
+	if err := a.http.do("POST", "/api/auth/sessions", body, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	a.http.state.setTokens(session.AccessToken, session.RefreshToken, "", nil)
+	return &session, nil
+}
+
+// OAuthURL holds the redirect URL for OAuth sign-in.
+type OAuthURL struct {
+	URL string `json:"url"`
+}
+
+// SignInWithOAuth returns the OAuth provider redirect URL.
+// provider is e.g. "google" or "github".
+func (a *AuthClient) SignInWithOAuth(provider, redirectURL, codeChallenge string) (*OAuthURL, error) {
+	params := url.Values{}
+	params.Set("redirect_uri", redirectURL)
+	params.Set("code_challenge", codeChallenge)
+	params.Set("client_type", "server")
+	var result OAuthURL
+	if err := a.http.do("GET", "/api/auth/oauth/"+provider, nil, params, &result, nil); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ExchangeOAuthCode exchanges an OAuth authorization code for a session.
+func (a *AuthClient) ExchangeOAuthCode(provider, code, codeVerifier string) (*AuthSession, error) {
+	body := map[string]any{
+		"provider":      provider,
+		"code":          code,
+		"code_verifier": codeVerifier,
+		"client_type":   "server",
+	}
+	var session AuthSession
+	if err := a.http.do("POST", "/api/auth/oauth/exchange", body, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	a.http.state.setTokens(session.AccessToken, session.RefreshToken, "", nil)
+	return &session, nil
+}
+
+// SignOut invalidates the current session.
+func (a *AuthClient) SignOut() error {
+	err := a.http.do("POST", "/api/auth/logout", map[string]any{}, nil, nil, nil)
+	a.http.state.clear()
+	return err
+}
+
+// GetCurrentSession returns the currently authenticated session from the server.
+func (a *AuthClient) GetCurrentSession() (*AuthSession, error) {
+	var session AuthSession
+	if err := a.http.do("GET", "/api/auth/sessions/current", nil, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+// GetCurrentUser returns the currently authenticated user.
+func (a *AuthClient) GetCurrentUser() (*AuthUser, error) {
+	session, err := a.GetCurrentSession()
+	if err != nil {
+		return nil, err
+	}
+	return &session.User, nil
+}
+
+// RefreshSession exchanges the stored refresh token for a new access token.
+func (a *AuthClient) RefreshSession() (*AuthSession, error) {
+	refreshToken := a.http.state.getRefreshToken()
+	if refreshToken == "" {
+		return nil, &InsForgeError{Message: "no refresh token available", StatusCode: 0}
+	}
+	body := map[string]any{"refreshToken": refreshToken}
+	var session AuthSession
+	if err := a.http.do("POST", "/api/auth/refresh", body, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	a.http.state.setTokens(session.AccessToken, session.RefreshToken, "", nil)
+	return &session, nil
+}
+
+// GetProfile returns the profile for the given user ID.
+func (a *AuthClient) GetProfile(userID string) (map[string]any, error) {
+	var profile map[string]any
+	if err := a.http.do("GET", "/api/auth/profiles/"+userID, nil, nil, &profile, nil); err != nil {
+		return nil, err
+	}
+	return profile, nil
+}
+
+// SetProfile updates the profile for the given user ID.
+func (a *AuthClient) SetProfile(userID string, updates map[string]any) (map[string]any, error) {
+	var profile map[string]any
+	if err := a.http.do("PATCH", "/api/auth/profiles/"+userID, updates, nil, &profile, nil); err != nil {
+		return nil, err
+	}
+	return profile, nil
+}
+
+// ResendVerificationEmail resends the email verification link.
+func (a *AuthClient) ResendVerificationEmail(email string) error {
+	return a.http.do("POST", "/api/auth/email/resend-verification", map[string]any{"email": email}, nil, nil, nil)
+}
+
+// VerifyEmail verifies an email using a token from the verification link.
+func (a *AuthClient) VerifyEmail(token string) error {
+	return a.http.do("POST", "/api/auth/email/verify", map[string]any{"token": token}, nil, nil, nil)
+}
+
+// SendResetPasswordEmail sends a password reset email.
+func (a *AuthClient) SendResetPasswordEmail(email string) error {
+	return a.http.do("POST", "/api/auth/email/reset-password", map[string]any{"email": email}, nil, nil, nil)
+}
+
+// ExchangeResetPasswordToken exchanges a password reset token for a session.
+func (a *AuthClient) ExchangeResetPasswordToken(token string) (*AuthSession, error) {
+	var session AuthSession
+	if err := a.http.do("POST", "/api/auth/email/exchange-reset-token", map[string]any{"token": token}, nil, &session, nil); err != nil {
+		return nil, err
+	}
+	a.http.state.setTokens(session.AccessToken, session.RefreshToken, "", nil)
+	return &session, nil
+}
+
+// ResetPassword sets a new password for the current user (after exchanging reset token).
+func (a *AuthClient) ResetPassword(newPassword string) error {
+	return a.http.do("POST", "/api/auth/email/change-password", map[string]any{"password": newPassword}, nil, nil, nil)
+}
+
+// PublicConfig holds public authentication configuration (enabled providers, etc.).
+type PublicConfig struct {
+	Providers []string       `json:"providers"`
+	Extra     map[string]any `json:"-"`
+}
+
+// GetPublicConfig returns the public auth configuration for this backend.
+func (a *AuthClient) GetPublicConfig() (map[string]any, error) {
+	var cfg map[string]any
+	if err := a.http.do("GET", "/api/auth/config/public", nil, nil, &cfg, nil); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/sdks/go/insforge/client.go
+++ b/sdks/go/insforge/client.go
@@ -1,0 +1,64 @@
+// Package insforge provides an official Go SDK for InsForge backend-as-a-service.
+//
+// Usage:
+//
+//	client := insforge.CreateClient(insforge.Config{
+//	    BaseURL: "https://your-app.region.insforge.app",
+//	    AnonKey: "your-anon-key",
+//	})
+//
+//	// Auth
+//	result, err := client.Auth.SignInWithPassword("user@example.com", "password")
+//
+//	// Database
+//	var rows []map[string]any
+//	err = client.DB.From("todos").Select("*").Execute(&rows)
+//
+//	// Storage
+//	url, err := client.Storage.From("avatars").Upload("path/to/file.png", data, "image/png")
+package insforge
+
+// Config holds the configuration for the InsForge client.
+type Config struct {
+	// BaseURL is your InsForge backend URL, e.g. "https://your-app.region.insforge.app"
+	BaseURL string
+	// AnonKey is the anonymous/public API key.
+	AnonKey string
+	// EdgeFunctionToken overrides the bearer token for serverless function calls.
+	// Useful when the SDK is used inside an InsForge Function.
+	EdgeFunctionToken string
+	// Timeout for HTTP requests in seconds. Defaults to 30.
+	TimeoutSeconds int
+}
+
+// InsForgeClient is the top-level client. Instantiate with CreateClient.
+type InsForgeClient struct {
+	Auth      *AuthClient
+	DB        *DatabaseClient
+	Storage   *StorageClient
+	AI        *AIClient
+	Functions *FunctionsClient
+	Realtime  *RealtimeClient
+
+	http *httpClient
+}
+
+// CreateClient creates and returns a new InsForgeClient.
+func CreateClient(cfg Config) *InsForgeClient {
+	if cfg.BaseURL == "" {
+		panic("insforge: Config.BaseURL is required")
+	}
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 30
+	}
+	h := newHTTPClient(cfg.BaseURL, cfg.AnonKey, cfg.EdgeFunctionToken, cfg.TimeoutSeconds)
+	return &InsForgeClient{
+		Auth:      newAuthClient(h),
+		DB:        newDatabaseClient(h),
+		Storage:   newStorageClient(h),
+		AI:        newAIClient(h),
+		Functions: newFunctionsClient(h),
+		Realtime:  newRealtimeClient(h),
+		http:      h,
+	}
+}

--- a/sdks/go/insforge/database.go
+++ b/sdks/go/insforge/database.go
@@ -1,0 +1,307 @@
+package insforge
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// DatabaseClient is the entry point for database operations.
+type DatabaseClient struct {
+	http *httpClient
+}
+
+func newDatabaseClient(h *httpClient) *DatabaseClient {
+	return &DatabaseClient{http: h}
+}
+
+// From starts a new query builder for the given table.
+func (d *DatabaseClient) From(table string) *QueryBuilder {
+	return &QueryBuilder{
+		http:      d.http,
+		table:     table,
+		operation: "select",
+		selectCols: "*",
+	}
+}
+
+// Rpc calls a database RPC function.
+func (d *DatabaseClient) Rpc(functionName string, params map[string]any) *RpcBuilder {
+	return &RpcBuilder{http: d.http, function: functionName, params: params}
+}
+
+// -----------------------------------------------------------------------
+// QueryBuilder
+// -----------------------------------------------------------------------
+
+// QueryBuilder provides a fluent interface for building database queries.
+type QueryBuilder struct {
+	http       *httpClient
+	table      string
+	operation  string // "select", "insert", "update", "delete", "upsert"
+	selectCols string
+	filters    []string
+	orderCol   string
+	orderDir   string
+	limitVal   *int
+	offsetVal  *int
+	singleRow  bool
+	maybeSingle bool
+	body       any
+}
+
+// Select specifies columns to return.
+func (q *QueryBuilder) Select(columns string) *QueryBuilder {
+	q.selectCols = columns
+	q.operation = "select"
+	return q
+}
+
+// Insert prepares an INSERT operation. Pass a slice of maps or structs.
+func (q *QueryBuilder) Insert(data any) *QueryBuilder {
+	q.operation = "insert"
+	q.body = data
+	return q
+}
+
+// Update prepares an UPDATE operation.
+func (q *QueryBuilder) Update(data map[string]any) *QueryBuilder {
+	q.operation = "update"
+	q.body = data
+	return q
+}
+
+// Delete prepares a DELETE operation.
+func (q *QueryBuilder) Delete() *QueryBuilder {
+	q.operation = "delete"
+	return q
+}
+
+// Upsert prepares an UPSERT operation.
+func (q *QueryBuilder) Upsert(data any) *QueryBuilder {
+	q.operation = "upsert"
+	q.body = data
+	return q
+}
+
+// -----------------------------------------------------------------------
+// Filters
+// -----------------------------------------------------------------------
+
+func (q *QueryBuilder) addFilter(col, op, value string) *QueryBuilder {
+	q.filters = append(q.filters, fmt.Sprintf("%s=%s.%s", col, op, value))
+	return q
+}
+
+// Eq filters rows where column equals value.
+func (q *QueryBuilder) Eq(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "eq", fmt.Sprintf("%v", value))
+}
+
+// Neq filters rows where column is not equal to value.
+func (q *QueryBuilder) Neq(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "neq", fmt.Sprintf("%v", value))
+}
+
+// Gt filters rows where column is greater than value.
+func (q *QueryBuilder) Gt(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "gt", fmt.Sprintf("%v", value))
+}
+
+// Gte filters rows where column is greater than or equal to value.
+func (q *QueryBuilder) Gte(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "gte", fmt.Sprintf("%v", value))
+}
+
+// Lt filters rows where column is less than value.
+func (q *QueryBuilder) Lt(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "lt", fmt.Sprintf("%v", value))
+}
+
+// Lte filters rows where column is less than or equal to value.
+func (q *QueryBuilder) Lte(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "lte", fmt.Sprintf("%v", value))
+}
+
+// Like filters using a LIKE pattern (case-sensitive).
+func (q *QueryBuilder) Like(column, pattern string) *QueryBuilder {
+	return q.addFilter(column, "like", pattern)
+}
+
+// ILike filters using an ILIKE pattern (case-insensitive).
+func (q *QueryBuilder) ILike(column, pattern string) *QueryBuilder {
+	return q.addFilter(column, "ilike", pattern)
+}
+
+// In filters rows where column value is in the provided list.
+func (q *QueryBuilder) In(column string, values []any) *QueryBuilder {
+	strs := make([]string, len(values))
+	for i, v := range values {
+		strs[i] = fmt.Sprintf("%v", v)
+	}
+	filter := fmt.Sprintf("%s=in.(%s)", column, strings.Join(strs, ","))
+	q.filters = append(q.filters, filter)
+	return q
+}
+
+// Is filters rows where column matches a special value: null, true, false.
+func (q *QueryBuilder) Is(column string, value any) *QueryBuilder {
+	return q.addFilter(column, "is", fmt.Sprintf("%v", value))
+}
+
+// -----------------------------------------------------------------------
+// Modifiers
+// -----------------------------------------------------------------------
+
+// Order sets the result ordering. dir should be "asc" or "desc".
+func (q *QueryBuilder) Order(column, dir string) *QueryBuilder {
+	q.orderCol = column
+	q.orderDir = dir
+	return q
+}
+
+// Limit restricts the number of rows returned.
+func (q *QueryBuilder) Limit(n int) *QueryBuilder {
+	q.limitVal = &n
+	return q
+}
+
+// Range paginates results: from and to are zero-based indices.
+func (q *QueryBuilder) Range(from, to int) *QueryBuilder {
+	count := to - from + 1
+	q.limitVal = &count
+	q.offsetVal = &from
+	return q
+}
+
+// Single asserts that exactly one row is returned; errors otherwise.
+func (q *QueryBuilder) Single() *QueryBuilder {
+	q.singleRow = true
+	return q
+}
+
+// MaybeSingle returns one row or nil; errors if more than one row is returned.
+func (q *QueryBuilder) MaybeSingle() *QueryBuilder {
+	q.maybeSingle = true
+	return q
+}
+
+// -----------------------------------------------------------------------
+// Execution
+// -----------------------------------------------------------------------
+
+// Execute runs the query and decodes the result into out.
+// For SELECT, out should be a pointer to a slice (e.g., *[]MyStruct).
+// For Single/MaybeSingle, out should be a pointer to a struct or map.
+func (q *QueryBuilder) Execute(out any) error {
+	params := q.buildParams()
+	path := "/api/database/records/" + q.table
+
+	switch q.operation {
+	case "select":
+		extraHeaders := map[string]string{}
+		if q.singleRow {
+			extraHeaders["Accept"] = "application/vnd.pgrst.object+json"
+		}
+		if q.maybeSingle {
+			// Fetch up to 2 rows; if >1, error
+			twoLimit := 2
+			params.Set("limit", fmt.Sprintf("%d", twoLimit))
+			var rows []json.RawMessage
+			if err := q.http.do("GET", path, nil, params, &rows, extraHeaders); err != nil {
+				return err
+			}
+			if len(rows) > 1 {
+				return &InsForgeError{Message: "MaybeSingle: multiple rows returned", StatusCode: 0}
+			}
+			if len(rows) == 0 {
+				return nil
+			}
+			return json.Unmarshal(rows[0], out)
+		}
+		return q.http.do("GET", path, nil, params, out, extraHeaders)
+
+	case "insert":
+		extraHeaders := map[string]string{
+			"Prefer": "return=representation",
+		}
+		return q.http.do("POST", path, q.body, params, out, extraHeaders)
+
+	case "upsert":
+		extraHeaders := map[string]string{
+			"Prefer": "return=representation,resolution=merge-duplicates",
+		}
+		return q.http.do("POST", path, q.body, params, out, extraHeaders)
+
+	case "update":
+		extraHeaders := map[string]string{
+			"Prefer": "return=representation",
+		}
+		return q.http.do("PATCH", path, q.body, params, out, extraHeaders)
+
+	case "delete":
+		extraHeaders := map[string]string{
+			"Prefer": "return=representation",
+		}
+		return q.http.do("DELETE", path, nil, params, out, extraHeaders)
+	}
+
+	return fmt.Errorf("insforge: unknown operation %q", q.operation)
+}
+
+// ExecuteRaw runs the query and returns raw JSON bytes.
+func (q *QueryBuilder) ExecuteRaw() (json.RawMessage, error) {
+	var raw json.RawMessage
+	if err := q.Execute(&raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (q *QueryBuilder) buildParams() url.Values {
+	params := url.Values{}
+	if q.operation == "select" {
+		if q.selectCols != "" && q.selectCols != "*" {
+			params.Set("select", q.selectCols)
+		}
+	}
+	for _, f := range q.filters {
+		// filters are already in "col=op.val" format; split at first "="
+		idx := strings.IndexByte(f, '=')
+		if idx < 0 {
+			continue
+		}
+		params.Add(f[:idx], f[idx+1:])
+	}
+	if q.orderCol != "" {
+		dir := q.orderDir
+		if dir == "" {
+			dir = "asc"
+		}
+		params.Set("order", q.orderCol+"."+dir)
+	}
+	if q.limitVal != nil {
+		params.Set("limit", fmt.Sprintf("%d", *q.limitVal))
+	}
+	if q.offsetVal != nil {
+		params.Set("offset", fmt.Sprintf("%d", *q.offsetVal))
+	}
+	return params
+}
+
+// -----------------------------------------------------------------------
+// RpcBuilder
+// -----------------------------------------------------------------------
+
+// RpcBuilder calls a Postgres RPC function.
+type RpcBuilder struct {
+	http     *httpClient
+	function string
+	params   map[string]any
+}
+
+// Execute calls the RPC function and decodes the result into out.
+func (r *RpcBuilder) Execute(out any) error {
+	return r.http.do("POST", "/api/database/rpc/"+r.function, r.params, nil, out, nil)
+}

--- a/sdks/go/insforge/functions.go
+++ b/sdks/go/insforge/functions.go
@@ -1,0 +1,113 @@
+package insforge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// FunctionsClient invokes InsForge serverless functions.
+type FunctionsClient struct {
+	http *httpClient
+}
+
+func newFunctionsClient(h *httpClient) *FunctionsClient {
+	return &FunctionsClient{http: h}
+}
+
+// InvokeOptions configures a function invocation.
+type InvokeOptions struct {
+	// Method is the HTTP method: GET, POST, PUT, PATCH, DELETE. Defaults to POST.
+	Method string
+	// Headers are extra HTTP headers to send with the request.
+	Headers map[string]string
+	// Body is the JSON-serializable request body (for POST/PUT/PATCH).
+	Body any
+}
+
+// InvokeResult holds the raw response from the function.
+type InvokeResult struct {
+	// Data contains the parsed JSON response (if JSON).
+	Data any
+	// RawBody contains the raw response bytes.
+	RawBody []byte
+	// StatusCode is the HTTP status code returned by the function.
+	StatusCode int
+}
+
+// Invoke calls the serverless function identified by slug.
+// Pass nil options to use defaults (POST with no body).
+func (f *FunctionsClient) Invoke(slug string, opts *InvokeOptions) (*InvokeResult, error) {
+	method := "POST"
+	var headers map[string]string
+	var body any
+
+	if opts != nil {
+		if opts.Method != "" {
+			method = opts.Method
+		}
+		headers = opts.Headers
+		body = opts.Body
+	}
+
+	// Functions live at /functions/{slug} (no /api/ prefix)
+	urlStr := f.http.buildURL("/functions/" + slug)
+
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("insforge: marshal function body: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, urlStr, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+f.http.bearerToken())
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := f.http.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("insforge: functions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("insforge: functions: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var apiErr InsForgeError
+		if jsonErr := json.Unmarshal(rawBody, &apiErr); jsonErr != nil {
+			apiErr.Message = string(rawBody)
+		}
+		apiErr.StatusCode = resp.StatusCode
+		return nil, &apiErr
+	}
+
+	result := &InvokeResult{
+		RawBody:    rawBody,
+		StatusCode: resp.StatusCode,
+	}
+
+	// Attempt JSON parse for convenience
+	if len(rawBody) > 0 {
+		var parsed any
+		if err := json.Unmarshal(rawBody, &parsed); err == nil {
+			result.Data = parsed
+		}
+	}
+
+	return result, nil
+}

--- a/sdks/go/insforge/http.go
+++ b/sdks/go/insforge/http.go
@@ -1,0 +1,299 @@
+package insforge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// InsForgeError is returned when the InsForge API responds with an error.
+type InsForgeError struct {
+	Message    string `json:"message"`
+	StatusCode int    `json:"statusCode"`
+	ErrorCode  string `json:"error"`
+	NextActions string `json:"nextActions"`
+}
+
+func (e *InsForgeError) Error() string {
+	if e.ErrorCode != "" {
+		return fmt.Sprintf("insforge: [%s] %s (HTTP %d)", e.ErrorCode, e.Message, e.StatusCode)
+	}
+	return fmt.Sprintf("insforge: %s (HTTP %d)", e.Message, e.StatusCode)
+}
+
+// sessionState holds the in-memory auth tokens. Thread-safe.
+type sessionState struct {
+	mu           sync.RWMutex
+	accessToken  string
+	refreshToken string
+	csrfToken    string
+	user         map[string]any
+}
+
+func (s *sessionState) setTokens(access, refresh, csrf string, user map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if access != "" {
+		s.accessToken = access
+	}
+	if refresh != "" {
+		s.refreshToken = refresh
+	}
+	if csrf != "" {
+		s.csrfToken = csrf
+	}
+	if user != nil {
+		s.user = user
+	}
+}
+
+func (s *sessionState) clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.accessToken = ""
+	s.refreshToken = ""
+	s.csrfToken = ""
+	s.user = nil
+}
+
+func (s *sessionState) getAccessToken() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.accessToken
+}
+
+func (s *sessionState) getRefreshToken() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.refreshToken
+}
+
+// httpClient is the low-level HTTP transport used by all SDK modules.
+type httpClient struct {
+	baseURL string
+	anonKey string
+	timeout time.Duration
+	state   *sessionState
+	client  *http.Client
+}
+
+func newHTTPClient(baseURL, anonKey, edgeFunctionToken string, timeoutSecs int) *httpClient {
+	state := &sessionState{}
+	if edgeFunctionToken != "" {
+		state.accessToken = edgeFunctionToken
+	}
+	return &httpClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		anonKey: anonKey,
+		timeout: time.Duration(timeoutSecs) * time.Second,
+		state:   state,
+		client:  &http.Client{Timeout: time.Duration(timeoutSecs) * time.Second},
+	}
+}
+
+func (h *httpClient) bearerToken() string {
+	if t := h.state.getAccessToken(); t != "" {
+		return t
+	}
+	return h.anonKey
+}
+
+func (h *httpClient) buildURL(p string) string {
+	base, _ := url.Parse(h.baseURL)
+	base.Path = base.Path + "/" + strings.TrimLeft(p, "/")
+	return base.String()
+}
+
+func (h *httpClient) newRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+h.bearerToken())
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func (h *httpClient) parseError(resp *http.Response) error {
+	var apiErr InsForgeError
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &apiErr); err != nil {
+		apiErr.Message = string(body)
+	}
+	apiErr.StatusCode = resp.StatusCode
+	return &apiErr
+}
+
+// do executes a request, checks for errors, and decodes the response into out.
+// Pass nil for out to discard the response body.
+func (h *httpClient) do(method, p string, reqBody any, queryParams url.Values, out any, extraHeaders map[string]string) error {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("insforge: marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	urlStr := h.buildURL(p)
+	if len(queryParams) > 0 {
+		urlStr += "?" + queryParams.Encode()
+	}
+
+	req, err := h.newRequest(method, urlStr, bodyReader)
+	if err != nil {
+		return err
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("insforge: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return h.parseError(resp)
+	}
+
+	if out == nil {
+		return nil
+	}
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("insforge: read response: %w", err)
+	}
+	if len(respBody) == 0 {
+		return nil
+	}
+	return json.Unmarshal(respBody, out)
+}
+
+// doRaw executes a request and returns the raw response body bytes.
+func (h *httpClient) doRaw(method, p string, reqBody any, queryParams url.Values, extraHeaders map[string]string) ([]byte, error) {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	urlStr := h.buildURL(p)
+	if len(queryParams) > 0 {
+		urlStr += "?" + queryParams.Encode()
+	}
+
+	req, err := h.newRequest(method, urlStr, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, h.parseError(resp)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// doStream executes a request and returns the response body as a streaming reader.
+// The caller is responsible for closing the reader.
+func (h *httpClient) doStream(method, p string, reqBody any) (io.ReadCloser, error) {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := h.newRequest(method, h.buildURL(p), bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a client without timeout for streaming
+	streamClient := &http.Client{}
+	resp, err := streamClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		return nil, h.parseError(resp)
+	}
+	return resp.Body, nil
+}
+
+// doPutExternal PUTs raw bytes to an external URL (e.g., presigned S3).
+func (h *httpClient) doPutExternal(externalURL string, data []byte, contentType string) error {
+	req, err := http.NewRequest(http.MethodPut, externalURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("insforge: external upload failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// doPostExternal POSTs multipart form data to an external URL (presigned S3 POST).
+func (h *httpClient) doPostExternal(externalURL string, fields map[string]string, fileKey, filename string, fileData []byte, contentType string) error {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		_ = w.WriteField(k, v)
+	}
+	fw, err := w.CreateFormFile(fileKey, filename)
+	if err != nil {
+		return err
+	}
+	if _, err = fw.Write(fileData); err != nil {
+		return err
+	}
+	w.Close()
+
+	req, err := http.NewRequest(http.MethodPost, externalURL, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("insforge: external upload failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/sdks/go/insforge/realtime.go
+++ b/sdks/go/insforge/realtime.go
@@ -1,0 +1,292 @@
+package insforge
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// ConnectionState represents the current state of the realtime connection.
+type ConnectionState string
+
+const (
+	ConnectionStateDisconnected ConnectionState = "disconnected"
+	ConnectionStateConnecting   ConnectionState = "connecting"
+	ConnectionStateConnected    ConnectionState = "connected"
+)
+
+// RealtimeMessage is a message received from a channel.
+type RealtimeMessage struct {
+	Channel string
+	Payload any
+}
+
+// EventHandler is a callback invoked when a message arrives on a channel.
+type EventHandler func(msg RealtimeMessage)
+
+// realtimeEnvelope is the wire format for realtime messages.
+type realtimeEnvelope struct {
+	Type    string `json:"type"`
+	Channel string `json:"channel,omitempty"`
+	Payload any    `json:"payload,omitempty"`
+}
+
+// RealtimeClient provides real-time pub/sub via WebSocket.
+type RealtimeClient struct {
+	http         *httpClient
+	mu           sync.RWMutex
+	conn         *websocket.Conn
+	state        ConnectionState
+	socketID     string
+	handlers     map[string][]EventHandler
+	onceHandlers map[string][]EventHandler
+	subscriptions map[string]bool
+	stopCh       chan struct{}
+}
+
+func newRealtimeClient(h *httpClient) *RealtimeClient {
+	return &RealtimeClient{
+		http:          h,
+		state:         ConnectionStateDisconnected,
+		handlers:      make(map[string][]EventHandler),
+		onceHandlers:  make(map[string][]EventHandler),
+		subscriptions: make(map[string]bool),
+	}
+}
+
+// Connect establishes the WebSocket connection to the InsForge realtime server.
+func (r *RealtimeClient) Connect() error {
+	r.mu.Lock()
+	r.state = ConnectionStateConnecting
+	r.mu.Unlock()
+
+	// Construct WebSocket URL from base URL
+	wsURL := r.http.baseURL
+	wsURL = strings.Replace(wsURL, "https://", "wss://", 1)
+	wsURL = strings.Replace(wsURL, "http://", "ws://", 1)
+	wsURL += "/realtime/websocket"
+
+	// Add auth token as query param
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		r.mu.Lock()
+		r.state = ConnectionStateDisconnected
+		r.mu.Unlock()
+		return fmt.Errorf("insforge: realtime: parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("token", r.http.bearerToken())
+	u.RawQuery = q.Encode()
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		Subprotocols:     []string{"insforge-realtime"},
+	}
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+r.http.bearerToken())
+
+	conn, _, err := dialer.Dial(u.String(), headers)
+	if err != nil {
+		r.mu.Lock()
+		r.state = ConnectionStateDisconnected
+		r.mu.Unlock()
+		return fmt.Errorf("insforge: realtime: dial: %w", err)
+	}
+
+	stopCh := make(chan struct{})
+	r.mu.Lock()
+	r.conn = conn
+	r.state = ConnectionStateConnected
+	r.stopCh = stopCh
+	r.mu.Unlock()
+
+	go r.readLoop(conn, stopCh)
+	return nil
+}
+
+// readLoop processes incoming WebSocket messages.
+func (r *RealtimeClient) readLoop(conn *websocket.Conn, stopCh chan struct{}) {
+	defer func() {
+		r.mu.Lock()
+		r.state = ConnectionStateDisconnected
+		r.conn = nil
+		r.socketID = ""
+		r.stopCh = nil
+		r.mu.Unlock()
+	}()
+
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+
+		var env realtimeEnvelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			continue
+		}
+
+		switch env.Type {
+		case "connected":
+			if sid, ok := env.Payload.(map[string]any); ok {
+				if id, ok := sid["socketId"].(string); ok {
+					r.mu.Lock()
+					r.socketID = id
+					r.mu.Unlock()
+				}
+			}
+		case "message":
+			if env.Channel != "" {
+				r.dispatch(env.Channel, RealtimeMessage{
+					Channel: env.Channel,
+					Payload: env.Payload,
+				})
+			}
+		}
+	}
+}
+
+// Disconnect closes the WebSocket connection.
+func (r *RealtimeClient) Disconnect() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopCh != nil {
+		close(r.stopCh)
+		r.stopCh = nil
+	}
+	if r.conn != nil {
+		_ = r.conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		r.conn.Close()
+		r.conn = nil
+	}
+	r.state = ConnectionStateDisconnected
+}
+
+// Subscribe subscribes to a channel and registers a handler.
+func (r *RealtimeClient) Subscribe(channel string, handler EventHandler) error {
+	r.mu.Lock()
+	r.handlers[channel] = append(r.handlers[channel], handler)
+	alreadySubscribed := r.subscriptions[channel]
+	r.subscriptions[channel] = true
+	conn := r.conn
+	r.mu.Unlock()
+
+	if !alreadySubscribed && conn != nil {
+		msg, _ := json.Marshal(realtimeEnvelope{Type: "subscribe", Channel: channel})
+		return conn.WriteMessage(websocket.TextMessage, msg)
+	}
+	return nil
+}
+
+// Unsubscribe removes all handlers for a channel.
+func (r *RealtimeClient) Unsubscribe(channel string) error {
+	r.mu.Lock()
+	delete(r.handlers, channel)
+	delete(r.onceHandlers, channel)
+	delete(r.subscriptions, channel)
+	conn := r.conn
+	r.mu.Unlock()
+
+	if conn != nil {
+		msg, _ := json.Marshal(realtimeEnvelope{Type: "unsubscribe", Channel: channel})
+		return conn.WriteMessage(websocket.TextMessage, msg)
+	}
+	return nil
+}
+
+// Publish sends a message to a channel.
+func (r *RealtimeClient) Publish(channel string, payload any) error {
+	r.mu.RLock()
+	conn := r.conn
+	r.mu.RUnlock()
+
+	if conn == nil {
+		return &InsForgeError{Message: "realtime: not connected"}
+	}
+	msg, err := json.Marshal(realtimeEnvelope{Type: "publish", Channel: channel, Payload: payload})
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, msg)
+}
+
+// On registers a persistent handler for a channel.
+func (r *RealtimeClient) On(channel string, handler EventHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers[channel] = append(r.handlers[channel], handler)
+}
+
+// Off removes all persistent handlers for a channel.
+func (r *RealtimeClient) Off(channel string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.handlers, channel)
+}
+
+// Once registers a one-time handler for a channel.
+func (r *RealtimeClient) Once(channel string, handler EventHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onceHandlers[channel] = append(r.onceHandlers[channel], handler)
+}
+
+// IsConnected returns true when the client is connected.
+func (r *RealtimeClient) IsConnected() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.state == ConnectionStateConnected
+}
+
+// ConnectionStateValue returns the current connection state.
+func (r *RealtimeClient) ConnectionStateValue() ConnectionState {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.state
+}
+
+// SocketID returns the server-assigned socket ID (available after Connect).
+func (r *RealtimeClient) SocketID() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.socketID
+}
+
+// GetSubscribedChannels returns the names of currently subscribed channels.
+func (r *RealtimeClient) GetSubscribedChannels() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	channels := make([]string, 0, len(r.subscriptions))
+	for ch := range r.subscriptions {
+		channels = append(channels, ch)
+	}
+	return channels
+}
+
+func (r *RealtimeClient) dispatch(channel string, msg RealtimeMessage) {
+	r.mu.Lock()
+	persistent := append([]EventHandler(nil), r.handlers[channel]...)
+	once := r.onceHandlers[channel]
+	delete(r.onceHandlers, channel)
+	r.mu.Unlock()
+
+	for _, h := range persistent {
+		go h(msg)
+	}
+	for _, h := range once {
+		go h(msg)
+	}
+}

--- a/sdks/go/insforge/sdk_test.go
+++ b/sdks/go/insforge/sdk_test.go
@@ -1,0 +1,387 @@
+package insforge_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/InsForge/InsForge/sdks/go/insforge"
+)
+
+// newTestServer creates an httptest server and returns a configured InsForgeClient.
+func newTestServer(t *testing.T, mux *http.ServeMux) *insforge.InsForgeClient {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return insforge.CreateClient(insforge.Config{
+		BaseURL: srv.URL,
+		AnonKey: "test-anon-key",
+	})
+}
+
+func jsonResponse(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// -----------------------------------------------------------------------
+// Auth tests
+// -----------------------------------------------------------------------
+
+func TestSignUp(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth/users", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		jsonResponse(w, 200, map[string]any{
+			"accessToken":  "access-123",
+			"refreshToken": "refresh-456",
+			"expiresIn":    3600,
+			"tokenType":    "Bearer",
+			"user": map[string]any{
+				"id":    "user-1",
+				"email": "test@example.com",
+			},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	session, err := client.Auth.SignUp("test@example.com", "password123", nil)
+	if err != nil {
+		t.Fatalf("SignUp error: %v", err)
+	}
+	if session.AccessToken != "access-123" {
+		t.Errorf("expected access token 'access-123', got %q", session.AccessToken)
+	}
+	if session.User.Email != "test@example.com" {
+		t.Errorf("expected email 'test@example.com', got %q", session.User.Email)
+	}
+}
+
+func TestSignInWithPassword(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth/sessions", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{
+			"accessToken":  "access-789",
+			"refreshToken": "refresh-101",
+			"expiresIn":    3600,
+			"user": map[string]any{
+				"id":    "user-2",
+				"email": "signin@example.com",
+			},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	session, err := client.Auth.SignInWithPassword("signin@example.com", "secret")
+	if err != nil {
+		t.Fatalf("SignInWithPassword error: %v", err)
+	}
+	if session.AccessToken != "access-789" {
+		t.Errorf("expected 'access-789', got %q", session.AccessToken)
+	}
+}
+
+func TestSignOut(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	client := newTestServer(t, mux)
+	if err := client.Auth.SignOut(); err != nil {
+		t.Fatalf("SignOut error: %v", err)
+	}
+}
+
+func TestAuthError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/auth/sessions", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 401, map[string]any{
+			"error":      "INVALID_CREDENTIALS",
+			"message":    "Invalid email or password",
+			"statusCode": 401,
+		})
+	})
+
+	client := newTestServer(t, mux)
+	_, err := client.Auth.SignInWithPassword("bad@example.com", "wrong")
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+	insErr, ok := err.(*insforge.InsForgeError)
+	if !ok {
+		t.Fatalf("expected *InsForgeError, got %T", err)
+	}
+	if insErr.StatusCode != 401 {
+		t.Errorf("expected status 401, got %d", insErr.StatusCode)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Database tests
+// -----------------------------------------------------------------------
+
+func TestDatabaseSelect(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/database/records/todos", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, []map[string]any{
+			{"id": 1, "title": "Buy milk"},
+			{"id": 2, "title": "Walk dog"},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	var rows []map[string]any
+	err := client.DB.From("todos").Select("*").Execute(&rows)
+	if err != nil {
+		t.Fatalf("Select error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rows))
+	}
+}
+
+func TestDatabaseInsert(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/database/records/todos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		jsonResponse(w, 201, []map[string]any{
+			{"id": 3, "title": "New todo"},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	var inserted []map[string]any
+	err := client.DB.From("todos").Insert([]map[string]any{{"title": "New todo"}}).Execute(&inserted)
+	if err != nil {
+		t.Fatalf("Insert error: %v", err)
+	}
+	if len(inserted) == 0 || inserted[0]["title"] != "New todo" {
+		t.Errorf("unexpected insert result: %v", inserted)
+	}
+}
+
+func TestDatabaseFilter(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/database/records/todos", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("id") != "eq.1" {
+			http.Error(w, "unexpected filter", http.StatusBadRequest)
+			return
+		}
+		jsonResponse(w, 200, []map[string]any{{"id": 1, "title": "Buy milk"}})
+	})
+
+	client := newTestServer(t, mux)
+	var rows []map[string]any
+	err := client.DB.From("todos").Select("*").Eq("id", 1).Execute(&rows)
+	if err != nil {
+		t.Fatalf("Filter error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 row, got %d", len(rows))
+	}
+}
+
+func TestDatabaseDelete(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/database/records/todos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(200)
+	})
+
+	client := newTestServer(t, mux)
+	err := client.DB.From("todos").Delete().Eq("id", 1).Execute(nil)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+}
+
+func TestRpc(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/database/rpc/my_func", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{"result": 42})
+	})
+
+	client := newTestServer(t, mux)
+	var result map[string]any
+	err := client.DB.Rpc("my_func", map[string]any{"x": 1}).Execute(&result)
+	if err != nil {
+		t.Fatalf("Rpc error: %v", err)
+	}
+	if result["result"] != float64(42) {
+		t.Errorf("expected result 42, got %v", result["result"])
+	}
+}
+
+// -----------------------------------------------------------------------
+// Storage tests
+// -----------------------------------------------------------------------
+
+func TestStorageUpload(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Strategy
+	mux.HandleFunc("/api/storage/buckets/avatars/upload-strategy", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{
+			"method":    "direct",
+			"uploadUrl": "http://" + r.Host + "/fake-upload",
+			"key":       "photo.png",
+		})
+	})
+
+	// Fake external upload endpoint
+	mux.HandleFunc("/fake-upload", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	// Confirm
+	mux.HandleFunc("/api/storage/buckets/avatars/objects/photo.png/confirm-upload", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{"url": "https://cdn.example.com/avatars/photo.png"})
+	})
+
+	client := newTestServer(t, mux)
+	publicURL, err := client.Storage.From("avatars").Upload("photo.png", []byte("fake-image-data"), "image/png")
+	if err != nil {
+		t.Fatalf("Upload error: %v", err)
+	}
+	if !strings.Contains(publicURL, "photo.png") {
+		t.Errorf("unexpected URL: %s", publicURL)
+	}
+}
+
+func TestStorageList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/storage/buckets/avatars/objects", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, []map[string]any{
+			{"key": "photo.png", "size": 1024},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	objects, err := client.Storage.From("avatars").List("")
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Errorf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestStorageRemove(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/storage/buckets/avatars/objects/photo.png", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(200)
+	})
+
+	client := newTestServer(t, mux)
+	if err := client.Storage.From("avatars").Remove("photo.png"); err != nil {
+		t.Fatalf("Remove error: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------
+// AI tests
+// -----------------------------------------------------------------------
+
+func TestAIChatCompletion(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ai/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{
+			"id":     "chatcmpl-1",
+			"object": "chat.completion",
+			"choices": []map[string]any{
+				{
+					"index":         0,
+					"finish_reason": "stop",
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": "Hello, world!",
+					},
+				},
+			},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	resp, err := client.AI.Chat.Create(insforge.ChatCompletionRequest{
+		Model: "gpt-4o",
+		Messages: []insforge.ChatMessage{
+			{Role: "user", Content: "Say hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat completion error: %v", err)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if resp.Choices[0].Message.Content != "Hello, world!" {
+		t.Errorf("unexpected content: %q", resp.Choices[0].Message.Content)
+	}
+}
+
+func TestAIImageGeneration(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ai/images/generate", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, 200, map[string]any{
+			"created": 1234567890,
+			"data": []map[string]any{
+				{"url": "https://example.com/generated.png"},
+			},
+		})
+	})
+
+	client := newTestServer(t, mux)
+	resp, err := client.AI.GenerateImage(insforge.ImageGenerationRequest{
+		Prompt: "A sunset over the ocean",
+		Size:   "1024x1024",
+	})
+	if err != nil {
+		t.Fatalf("GenerateImage error: %v", err)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatal("expected image data")
+	}
+}
+
+// -----------------------------------------------------------------------
+// Functions tests
+// -----------------------------------------------------------------------
+
+func TestFunctionInvoke(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/functions/send-email", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		jsonResponse(w, 200, map[string]any{"sent": true})
+	})
+
+	client := newTestServer(t, mux)
+	result, err := client.Functions.Invoke("send-email", &insforge.InvokeOptions{
+		Body: map[string]any{"to": "user@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	if result.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", result.StatusCode)
+	}
+}

--- a/sdks/go/insforge/storage.go
+++ b/sdks/go/insforge/storage.go
@@ -1,0 +1,143 @@
+package insforge
+
+import (
+	"io"
+	"net/url"
+	"path/filepath"
+)
+
+// StorageClient manages storage buckets.
+type StorageClient struct {
+	http *httpClient
+}
+
+func newStorageClient(h *httpClient) *StorageClient {
+	return &StorageClient{http: h}
+}
+
+// From returns a StorageBucket handle for the given bucket name.
+func (s *StorageClient) From(bucket string) *StorageBucket {
+	return &StorageBucket{http: s.http, bucket: bucket}
+}
+
+// StorageBucket provides file operations for a specific bucket.
+type StorageBucket struct {
+	http   *httpClient
+	bucket string
+}
+
+// uploadStrategyRequest is the body sent to request an upload strategy.
+type uploadStrategyRequest struct {
+	Key         string `json:"key"`
+	ContentType string `json:"contentType"`
+	Size        int    `json:"size"`
+}
+
+// uploadStrategyResponse describes how to upload the file.
+type uploadStrategyResponse struct {
+	Method    string            `json:"method"`   // "presigned" or "direct"
+	UploadURL string            `json:"uploadUrl"`
+	Fields    map[string]string `json:"fields,omitempty"`
+	Key       string            `json:"key"`
+}
+
+// confirmUploadResponse is the response from a confirmed upload.
+type confirmUploadResponse struct {
+	URL string `json:"url"`
+}
+
+// Upload uploads data to the bucket at the given key.
+// contentType should be e.g. "image/png".
+// Returns the public URL of the uploaded file.
+func (b *StorageBucket) Upload(key string, data []byte, contentType string) (string, error) {
+	strategyPath := "/api/storage/buckets/" + b.bucket + "/upload-strategy"
+	reqBody := uploadStrategyRequest{
+		Key:         key,
+		ContentType: contentType,
+		Size:        len(data),
+	}
+	var strategy uploadStrategyResponse
+	if err := b.http.do("POST", strategyPath, reqBody, nil, &strategy, nil); err != nil {
+		return "", err
+	}
+
+	switch strategy.Method {
+	case "presigned":
+		if err := b.http.doPostExternal(strategy.UploadURL, strategy.Fields, "file", filepath.Base(key), data, contentType); err != nil {
+			return "", err
+		}
+	default:
+		// "direct" or any other strategy
+		if err := b.http.doPutExternal(strategy.UploadURL, data, contentType); err != nil {
+			return "", err
+		}
+	}
+
+	// Confirm the upload
+	confirmPath := "/api/storage/buckets/" + b.bucket + "/objects/" + key + "/confirm-upload"
+	var confirmed confirmUploadResponse
+	if err := b.http.do("POST", confirmPath, map[string]string{"key": key}, nil, &confirmed, nil); err != nil {
+		return "", err
+	}
+	return confirmed.URL, nil
+}
+
+// downloadStrategyResponse describes how to download the file.
+type downloadStrategyResponse struct {
+	Method      string `json:"method"`
+	DownloadURL string `json:"downloadUrl"`
+}
+
+// Download retrieves the bytes of the file at the given key.
+func (b *StorageBucket) Download(key string) ([]byte, error) {
+	strategyPath := "/api/storage/buckets/" + b.bucket + "/objects/" + key + "/download-strategy"
+	var strategy downloadStrategyResponse
+	if err := b.http.do("POST", strategyPath, map[string]any{}, nil, &strategy, nil); err != nil {
+		return nil, err
+	}
+
+	switch strategy.Method {
+	case "presigned":
+		resp, err := b.http.client.Get(strategy.DownloadURL)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return nil, &InsForgeError{Message: "download failed", StatusCode: resp.StatusCode}
+		}
+		return io.ReadAll(resp.Body)
+	default:
+		// direct download via InsForge API
+		return b.http.doRaw("GET", "/api/storage/buckets/"+b.bucket+"/objects/"+key, nil, nil, nil)
+	}
+}
+
+// StorageObject represents a file listing entry.
+type StorageObject struct {
+	Key          string `json:"key"`
+	Size         int64  `json:"size"`
+	LastModified string `json:"lastModified"`
+	ContentType  string `json:"contentType"`
+	URL          string `json:"url"`
+}
+
+// List returns all objects in the bucket under the given prefix.
+func (b *StorageBucket) List(prefix string) ([]StorageObject, error) {
+	listPath := "/api/storage/buckets/" + b.bucket + "/objects"
+	params := url.Values{}
+	if prefix != "" {
+		params.Set("prefix", prefix)
+	}
+	var objects []StorageObject
+	if err := b.http.do("GET", listPath, nil, params, &objects, nil); err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
+// Remove deletes the file at the given key.
+func (b *StorageBucket) Remove(key string) error {
+	deletePath := "/api/storage/buckets/" + b.bucket + "/objects/" + key
+	return b.http.do("DELETE", deletePath, nil, nil, nil, nil)
+}


### PR DESCRIPTION
Part of #785 (Go SDK — Python SDK submitted separately in PR #1559)

This adds the Go SDK under `sdks/go/` with:
- **Auth** — signup, login, signout, session refresh
- **Database** — fluent QueryBuilder (From, Select, Insert, Update, Delete, Upsert, filters/modifiers)
- **Storage** — presigned URL upload, download, delete, list
- **AI** — chat completions with streaming (SSE + goroutine channel API)
- **Functions** — invoke, list
- **Realtime** — WebSocket subscriptions via `gorilla/websocket` (zero heavy dependencies)
- **HTTP** — client with retry, error handling, timeout

CI workflow at `.github/workflows/sdk-go.yml` runs tests + golangci-lint + go vet on Go 1.21–1.22.

This is a focused subset of the original PR #887 which was closed for trying to solve both Python and Go SDKs at once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the official Go SDK for InsForge with Auth, Database, Storage, AI, Functions, and Realtime APIs, plus tests and docs. Includes a CI workflow to run tests, `golangci-lint`, and `go vet` on Go 1.21–1.22.

- **New Features**
  - `insforge` client with modules: `Auth`, `DB`, `Storage`, `AI`, `Functions`, `Realtime`.
  - Auth: email/password signup/signin/signout, session refresh, profiles, reset, and OAuth flow.
  - Database: fluent QueryBuilder (select/insert/update/delete/upsert), filters/modifiers, RPC, and `Single`/`MaybeSingle`.
  - Storage: presigned/direct uploads with confirm, download, list, and delete.
  - AI: chat completions (streaming included), embeddings, and image generation.
  - Functions & Realtime: function invoke with method/headers/body; WebSocket pub/sub (subscribe/publish/once) via `github.com/gorilla/websocket`.

- **Dependencies**
  - Added `github.com/gorilla/websocket v1.4.2`.
  - New workflow `.github/workflows/sdk-go.yml` runs tests, `golangci-lint`, and `go vet` on Go 1.21–1.22.

<sup>Written for commit c4a5ded00a2935d6af9c7f6aebede3e29b2f622a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Go SDK for InsForge with auth, database, storage, AI, functions, and realtime support
> - Adds a new Go module at `sdks/go` with `InsForgeClient` as the top-level entry point, initialized via `CreateClient` with base URL and anon key.
> - Implements `AuthClient` covering sign-up, password and OAuth sign-in, session refresh, email verification, password reset, and user profile management.
> - Implements `DatabaseClient` with a fluent `QueryBuilder` supporting select/insert/update/delete/upsert, filter operators, ordering, pagination, and single-row semantics, plus an `RpcBuilder` for server-side function calls.
> - Implements `StorageClient` with presigned or direct upload/download, object listing, and deletion per bucket.
> - Implements `AIClient` for chat completions (streaming and non-streaming), embeddings, and image generation; `FunctionsClient` for edge function invocation; and `RealtimeClient` for WebSocket pub/sub with persistent and one-time channel handlers.
> - Adds a GitHub Actions workflow ([sdk-go.yml](.github/workflows/sdk-go.yml)) running tests with `-race`, `golangci-lint`, and `go vet` on changes to `sdks/go/**`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4a5ded.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Go SDK fully released with support for user authentication (sign up, sign in, OAuth, token management), database operations (CRUD, filtering, ordering, RPC calls), file storage (upload, download, list, remove), AI capabilities (chat completions, embeddings, image generation), serverless function invocation, and real-time pub/sub messaging.

* **Documentation**
  * Added comprehensive README with installation instructions, quick-start guide, and complete usage examples for all SDK features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->