### PR TITLE
disable user signup bug fixed

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -4,7 +4,6 @@ import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES, type RoleSchema } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
-import logger from '@/utils/logger.js';
 
 export type UserContext = {
   /**
@@ -105,37 +104,6 @@ export async function verifyUser(req: AuthRequest, res: Response, next: NextFunc
   // Anything else (including no credentials) goes through JWT verification,
   // which produces the canonical 401 when the header is missing or invalid
   return verifyToken(req, res, next);
-}
-
-/**
- * Like verifyUser but doesn't require credentials.
- * - API key / anon key: verified same as verifyUser
- * - No credentials or invalid: proceeds without auth (adminCreatingUser = false)
- * - JWT: verified and proceeds (authenticated user)
- */
-export async function verifyOptionalUser(req: AuthRequest, res: Response, next: NextFunction) {
-  const apiKey = extractApiKey(req);
-  if (apiKey) {
-    return verifyApiKey(req, res, next);
-  }
-
-  const bearerToken = extractBearerToken(req.headers.authorization);
-  if (bearerToken) {
-    if (bearerToken.startsWith('anon_')) {
-      return verifyAnonKey(req, res, next);
-    }
-    try {
-      const payload = tokenManager.verifyToken(bearerToken);
-      setRequestUser(req, payload);
-    } catch (error) {
-      logger.debug('JWT verification failed in verifyOptionalUser, proceeding without auth', {
-        error,
-      });
-    }
-  }
-
-  // No credentials or auth failed → proceed as unauthenticated (anonymous registration)
-  next();
 }
 
 /**

--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -107,6 +107,27 @@ export async function verifyUser(req: AuthRequest, res: Response, next: NextFunc
 }
 
 /**
+ * Like verifyUser but doesn't require credentials.
+ * - API key / anon key: verified same as verifyUser
+ * - No credentials or invalid: proceeds without auth (adminCreatingUser = false)
+ * - JWT: verified and proceeds (authenticated user)
+ */
+export async function verifyOptionalUser(req: AuthRequest, res: Response, next: NextFunction) {
+  const apiKey = extractApiKey(req);
+  if (apiKey) {
+    return verifyApiKey(req, res, next);
+  }
+
+  const bearerToken = extractBearerToken(req.headers.authorization);
+  if (bearerToken && bearerToken.startsWith('anon_')) {
+    return verifyAnonKey(req, res, next);
+  }
+
+  // No credentials → proceed as unauthenticated (anonymous registration)
+  next();
+}
+
+/**
  * Verifies admin authentication (requires admin token)
  */
 export async function verifyAdmin(req: AuthRequest, res: Response, next: NextFunction) {

--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -4,6 +4,7 @@ import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES, type RoleSchema } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
+import logger from '@/utils/logger.js';
 
 export type UserContext = {
   /**
@@ -119,11 +120,21 @@ export async function verifyOptionalUser(req: AuthRequest, res: Response, next: 
   }
 
   const bearerToken = extractBearerToken(req.headers.authorization);
-  if (bearerToken && bearerToken.startsWith('anon_')) {
-    return verifyAnonKey(req, res, next);
+  if (bearerToken) {
+    if (bearerToken.startsWith('anon_')) {
+      return verifyAnonKey(req, res, next);
+    }
+    try {
+      const payload = tokenManager.verifyToken(bearerToken);
+      setRequestUser(req, payload);
+    } catch (error) {
+      logger.debug('JWT verification failed in verifyOptionalUser, proceeding without auth', {
+        error,
+      });
+    }
   }
 
-  // No credentials → proceed as unauthenticated (anonymous registration)
+  // No credentials or auth failed → proceed as unauthenticated (anonymous registration)
   next();
 }
 

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -13,6 +13,7 @@ import {
   verifyAdmin,
   verifyToken,
   extractBearerToken,
+  extractApiKey,
 } from '@/api/middlewares/auth.js';
 import adminRouter from './admin.routes.js';
 import oauthRouter from './oauth.routes.js';
@@ -343,17 +344,23 @@ router.post('/users', async (req: Request, res: Response, next: NextFunction) =>
     const clientType = parseClientType(req.query.client_type);
     let adminCreatingUser = false;
 
-    try {
-      const token = extractBearerToken(req.headers.authorization);
-      if (token) {
-        const payload = TokenManager.getInstance().verifyToken(token);
-        adminCreatingUser = payload?.role === 'project_admin';
+    const apiKey = extractApiKey(req);
+    if (apiKey) {
+      const secretService = SecretService.getInstance();
+      adminCreatingUser = await secretService.verifyApiKey(apiKey);
+    } else {
+      try {
+        const token = extractBearerToken(req.headers.authorization);
+        if (token) {
+          const payload = TokenManager.getInstance().verifyToken(token);
+          adminCreatingUser = payload?.role === 'project_admin';
+        }
+      } catch (error) {
+        // Not a valid token; treat as normal registration.
+        logger.debug('[Auth:CreateUser] Admin detection failed', {
+          error: error instanceof Error ? error.message : 'unknown',
+        });
       }
-    } catch (error) {
-      // Not a valid token; treat as normal registration.
-      logger.debug('[Auth:CreateUser] Admin detection failed', {
-        error: error instanceof Error ? error.message : 'unknown',
-      });
     }
 
     const validationResult = createUserRequestSchema.safeParse(req.body);

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -8,13 +8,7 @@ import { TokenManager } from '@/infra/security/token.manager.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
-import {
-  AuthRequest,
-  verifyAdmin,
-  verifyToken,
-  extractBearerToken,
-  extractApiKey,
-} from '@/api/middlewares/auth.js';
+import { AuthRequest, verifyAdmin, verifyToken, verifyUser } from '@/api/middlewares/auth.js';
 import adminRouter from './admin.routes.js';
 import oauthRouter from './oauth.routes.js';
 import customOAuthRouter from './custom-oauth.routes.js';
@@ -339,29 +333,12 @@ router.put('/config', verifyAdmin, async (req: AuthRequest, res: Response, next:
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
 // When called with a valid admin token (e.g. dashboard adding a user), we do NOT set session
 // cookie or return csrf/refresh tokens, so the admin's session is not overwritten.
-router.post('/users', async (req: Request, res: Response, next: NextFunction) => {
+router.post('/users', verifyUser, async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
     const clientType = parseClientType(req.query.client_type);
-    let adminCreatingUser = false;
-
-    const apiKey = extractApiKey(req);
-    if (apiKey) {
-      const secretService = SecretService.getInstance();
-      adminCreatingUser = await secretService.verifyApiKey(apiKey);
-    } else {
-      try {
-        const token = extractBearerToken(req.headers.authorization);
-        if (token) {
-          const payload = TokenManager.getInstance().verifyToken(token);
-          adminCreatingUser = payload?.role === 'project_admin';
-        }
-      } catch (error) {
-        // Not a valid token; treat as normal registration.
-        logger.debug('[Auth:CreateUser] Admin detection failed', {
-          error: error instanceof Error ? error.message : 'unknown',
-        });
-      }
-    }
+    // verifyUser has already authenticated the caller by credential shape.
+    // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
+    const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
 
     const validationResult = createUserRequestSchema.safeParse(req.body);
     if (!validationResult.success) {

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -8,12 +8,7 @@ import { TokenManager } from '@/infra/security/token.manager.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
-import {
-  AuthRequest,
-  verifyAdmin,
-  verifyOptionalUser,
-  verifyToken,
-} from '@/api/middlewares/auth.js';
+import { AuthRequest, verifyAdmin, verifyUser, verifyToken } from '@/api/middlewares/auth.js';
 import adminRouter from './admin.routes.js';
 import oauthRouter from './oauth.routes.js';
 import customOAuthRouter from './custom-oauth.routes.js';
@@ -338,85 +333,81 @@ router.put('/config', verifyAdmin, async (req: AuthRequest, res: Response, next:
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
 // When called with a valid admin token (e.g. dashboard adding a user), we do NOT set session
 // cookie or return csrf/refresh tokens, so the admin's session is not overwritten.
-router.post(
-  '/users',
-  verifyOptionalUser,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
-    try {
-      const clientType = parseClientType(req.query.client_type);
-      // verifyOptionalUser has already authenticated the caller by credential shape.
-      // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
-      const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
+router.post('/users', verifyUser, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const clientType = parseClientType(req.query.client_type);
+    // verifyUser has already authenticated the caller by credential shape.
+    // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
+    const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
 
-      const validationResult = createUserRequestSchema.safeParse(req.body);
-      if (!validationResult.success) {
+    const validationResult = createUserRequestSchema.safeParse(req.body);
+    if (!validationResult.success) {
+      throw new AppError(
+        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    if (!adminCreatingUser) {
+      const { disableSignup } = await authConfigService.getAuthConfig();
+      if (disableSignup) {
         throw new AppError(
-          validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-          400,
-          ERROR_CODES.INVALID_INPUT
+          'User signups are disabled for this project.',
+          403,
+          ERROR_CODES.AUTH_SIGNUP_DISABLED
         );
       }
-
-      if (!adminCreatingUser) {
-        const { disableSignup } = await authConfigService.getAuthConfig();
-        if (disableSignup) {
-          throw new AppError(
-            'User signups are disabled for this project.',
-            403,
-            ERROR_CODES.AUTH_SIGNUP_DISABLED
-          );
-        }
-      }
-
-      const {
-        email,
-        password,
-        name,
-        redirectTo,
-        autoConfirm: bodyAutoConfirm,
-      } = validationResult.data;
-      const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
-      const result: CreateUserResponse = await authService.register(
-        email,
-        password,
-        name,
-        redirectTo,
-        { isAdminCreation: adminCreatingUser, autoConfirm }
-      );
-
-      // Set refresh token based on client type (skip when admin is adding a user)
-      if (result.accessToken && result.user && !adminCreatingUser) {
-        const tokenManager = TokenManager.getInstance();
-        if (clientType === 'web') {
-          // Web clients: use httpOnly cookie + CSRF token
-          const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-            result.user.id,
-            'user'
-          );
-          setRefreshTokenCookie(res, refreshToken);
-          result.csrfToken = csrfToken;
-        } else {
-          const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
-          // Non-web clients (mobile, desktop, server): return refresh token in response body.
-          // Server clients cannot rely on browser cookies, so they follow the native-app flow.
-          result.refreshToken = refreshToken;
-        }
-      }
-
-      const socket = SocketManager.getInstance();
-      socket.broadcastToRoom(
-        'role:project_admin',
-        ServerEvents.DATA_UPDATE,
-        { resource: DataUpdateResourceType.USERS },
-        'system'
-      );
-
-      successResponse(res, result);
-    } catch (error) {
-      next(error);
     }
+
+    const {
+      email,
+      password,
+      name,
+      redirectTo,
+      autoConfirm: bodyAutoConfirm,
+    } = validationResult.data;
+    const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
+    const result: CreateUserResponse = await authService.register(
+      email,
+      password,
+      name,
+      redirectTo,
+      { isAdminCreation: adminCreatingUser, autoConfirm }
+    );
+
+    // Set refresh token based on client type (skip when admin is adding a user)
+    if (result.accessToken && result.user && !adminCreatingUser) {
+      const tokenManager = TokenManager.getInstance();
+      if (clientType === 'web') {
+        // Web clients: use httpOnly cookie + CSRF token
+        const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+          result.user.id,
+          'user'
+        );
+        setRefreshTokenCookie(res, refreshToken);
+        result.csrfToken = csrfToken;
+      } else {
+        const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
+        // Non-web clients (mobile, desktop, server): return refresh token in response body.
+        // Server clients cannot rely on browser cookies, so they follow the native-app flow.
+        result.refreshToken = refreshToken;
+      }
+    }
+
+    const socket = SocketManager.getInstance();
+    socket.broadcastToRoom(
+      'role:project_admin',
+      ServerEvents.DATA_UPDATE,
+      { resource: DataUpdateResourceType.USERS },
+      'system'
+    );
+
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 // POST /api/auth/sessions - Create a new session (login)
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -8,7 +8,12 @@ import { TokenManager } from '@/infra/security/token.manager.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
-import { AuthRequest, verifyAdmin, verifyToken, verifyUser } from '@/api/middlewares/auth.js';
+import {
+  AuthRequest,
+  verifyAdmin,
+  verifyOptionalUser,
+  verifyToken,
+} from '@/api/middlewares/auth.js';
 import adminRouter from './admin.routes.js';
 import oauthRouter from './oauth.routes.js';
 import customOAuthRouter from './custom-oauth.routes.js';
@@ -333,81 +338,85 @@ router.put('/config', verifyAdmin, async (req: AuthRequest, res: Response, next:
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
 // When called with a valid admin token (e.g. dashboard adding a user), we do NOT set session
 // cookie or return csrf/refresh tokens, so the admin's session is not overwritten.
-router.post('/users', verifyUser, async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const clientType = parseClientType(req.query.client_type);
-    // verifyUser has already authenticated the caller by credential shape.
-    // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
-    const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
+router.post(
+  '/users',
+  verifyOptionalUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const clientType = parseClientType(req.query.client_type);
+      // verifyUser has already authenticated the caller by credential shape.
+      // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
+      const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
 
-    const validationResult = createUserRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
-    }
-
-    if (!adminCreatingUser) {
-      const { disableSignup } = await authConfigService.getAuthConfig();
-      if (disableSignup) {
+      const validationResult = createUserRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
         throw new AppError(
-          'User signups are disabled for this project.',
-          403,
-          ERROR_CODES.AUTH_SIGNUP_DISABLED
+          validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
         );
       }
-    }
 
-    const {
-      email,
-      password,
-      name,
-      redirectTo,
-      autoConfirm: bodyAutoConfirm,
-    } = validationResult.data;
-    const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
-    const result: CreateUserResponse = await authService.register(
-      email,
-      password,
-      name,
-      redirectTo,
-      { isAdminCreation: adminCreatingUser, autoConfirm }
-    );
-
-    // Set refresh token based on client type (skip when admin is adding a user)
-    if (result.accessToken && result.user && !adminCreatingUser) {
-      const tokenManager = TokenManager.getInstance();
-      if (clientType === 'web') {
-        // Web clients: use httpOnly cookie + CSRF token
-        const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-          result.user.id,
-          'user'
-        );
-        setRefreshTokenCookie(res, refreshToken);
-        result.csrfToken = csrfToken;
-      } else {
-        const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
-        // Non-web clients (mobile, desktop, server): return refresh token in response body.
-        // Server clients cannot rely on browser cookies, so they follow the native-app flow.
-        result.refreshToken = refreshToken;
+      if (!adminCreatingUser) {
+        const { disableSignup } = await authConfigService.getAuthConfig();
+        if (disableSignup) {
+          throw new AppError(
+            'User signups are disabled for this project.',
+            403,
+            ERROR_CODES.AUTH_SIGNUP_DISABLED
+          );
+        }
       }
+
+      const {
+        email,
+        password,
+        name,
+        redirectTo,
+        autoConfirm: bodyAutoConfirm,
+      } = validationResult.data;
+      const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
+      const result: CreateUserResponse = await authService.register(
+        email,
+        password,
+        name,
+        redirectTo,
+        { isAdminCreation: adminCreatingUser, autoConfirm }
+      );
+
+      // Set refresh token based on client type (skip when admin is adding a user)
+      if (result.accessToken && result.user && !adminCreatingUser) {
+        const tokenManager = TokenManager.getInstance();
+        if (clientType === 'web') {
+          // Web clients: use httpOnly cookie + CSRF token
+          const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+            result.user.id,
+            'user'
+          );
+          setRefreshTokenCookie(res, refreshToken);
+          result.csrfToken = csrfToken;
+        } else {
+          const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
+          // Non-web clients (mobile, desktop, server): return refresh token in response body.
+          // Server clients cannot rely on browser cookies, so they follow the native-app flow.
+          result.refreshToken = refreshToken;
+        }
+      }
+
+      const socket = SocketManager.getInstance();
+      socket.broadcastToRoom(
+        'role:project_admin',
+        ServerEvents.DATA_UPDATE,
+        { resource: DataUpdateResourceType.USERS },
+        'system'
+      );
+
+      successResponse(res, result);
+    } catch (error) {
+      next(error);
     }
-
-    const socket = SocketManager.getInstance();
-    socket.broadcastToRoom(
-      'role:project_admin',
-      ServerEvents.DATA_UPDATE,
-      { resource: DataUpdateResourceType.USERS },
-      'system'
-    );
-
-    successResponse(res, result);
-  } catch (error) {
-    next(error);
   }
-});
+);
 
 // POST /api/auth/sessions - Create a new session (login)
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -344,7 +344,7 @@ router.post(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const clientType = parseClientType(req.query.client_type);
-      // verifyUser has already authenticated the caller by credential shape.
+      // verifyOptionalUser has already authenticated the caller by credential shape.
       // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
       const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
 

--- a/backend/tests/local/comprehensive-curl-tests.sh
+++ b/backend/tests/local/comprehensive-curl-tests.sh
@@ -3,11 +3,15 @@
 # Comprehensive curl tests for Traditional REST format
 # Tests all major endpoints to verify response formats
 
-BASE_URL="http://localhost:7130/api"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/../test-config.sh"
+
+BASE_URL="$TEST_API_BASE"
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+ANON_KEY=$(get_anon_key)
 
 echo "🧪 Comprehensive Traditional REST Format Tests"
 echo "============================================="
@@ -27,6 +31,7 @@ echo "Creating test user: $EMAIL"
 echo -e "\n${BLUE}2a. Register (Object Response)${NC}"
 REGISTER_RESPONSE=$(curl -s -X POST "$BASE_URL/auth/users" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{\"email\": \"$EMAIL\", \"password\": \"Test123!\", \"name\": \"Test User\"}")
 echo "$REGISTER_RESPONSE" | jq '.'
 TOKEN=$(echo "$REGISTER_RESPONSE" | jq -r '.accessToken')

--- a/backend/tests/local/test-auth-router.sh
+++ b/backend/tests/local/test-auth-router.sh
@@ -13,6 +13,7 @@ echo "🧪 Testing auth router..."
 # Use configuration from test-config.sh
 API_BASE="$TEST_API_BASE"
 AUTH_TOKEN=""
+ANON_KEY=$(get_anon_key)
 
 # Test function
 # $1: method, $2: endpoint, $3: data, $4: description, $5: extra header
@@ -63,6 +64,7 @@ register_test_user "$USER_EMAIL"
 echo "📝 Registering new user..."
 register_response=$(curl -s -X POST "$API_BASE/auth/users" \
     -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ANON_KEY" \
     -d '{"email":"'$USER_EMAIL'","password":"'$USER_PASS'","name":"'$USER_NAME'"}')
 
 if echo "$register_response" | grep -q '"accessToken"'; then
@@ -113,6 +115,7 @@ echo ""
 echo "📝 Registering with duplicate email..."
 duplicate_register_response=$(curl -s -X POST "$API_BASE/auth/users" \
     -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ANON_KEY" \
     -d '{"email":"'$USER_EMAIL'","password":"'$USER_PASS'","name":"'$USER_NAME' duplicate"}')
 
 if echo "$duplicate_register_response" | grep -q '"User already exists"'; then

--- a/backend/tests/local/test-id-field.sh
+++ b/backend/tests/local/test-id-field.sh
@@ -12,6 +12,7 @@ echo "=== Testing User Creation with ID Field ==="
 
 # Use configuration from test-config.sh
 API_URL="$TEST_API_BASE"
+ANON_KEY=$(get_anon_key)
 
 # Test users for cleanup tracking
 USER1_EMAIL="${TEST_USER_EMAIL_PREFIX}id_test1_$(date +%s)@example.com"
@@ -27,6 +28,7 @@ register_test_user "$USER3_EMAIL"
 print_info "1. Creating user without ID (auto-generate):"
 response1=$(curl -s -w "\n%{http_code}" -X POST "$API_URL/auth/users" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{
     \"email\": \"$USER1_EMAIL\",
     \"password\": \"password123\",
@@ -51,6 +53,7 @@ print_info "2. Creating user with custom ID:"
 CUSTOM_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 response2=$(curl -s -w "\n%{http_code}" -X POST "$API_URL/auth/users" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{
     \"id\": \"$CUSTOM_ID\",
     \"email\": \"$USER2_EMAIL\",
@@ -74,6 +77,7 @@ fi
 print_info "3. Creating user with duplicate ID (JWT auth ignores custom ID):"
 response3=$(curl -s -w "\n%{http_code}" -X POST "$API_URL/auth/users" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{
     \"id\": \"$CUSTOM_ID\",
     \"email\": \"$USER3_EMAIL\",

--- a/backend/tests/local/test-storage-rls.sh
+++ b/backend/tests/local/test-storage-rls.sh
@@ -32,6 +32,7 @@ PASS="testpass123"
 
 ALICE_EMAIL="alice-rls-$TS@example.com"
 BOB_EMAIL="bob-rls-$TS@example.com"
+ANON_KEY=$(get_anon_key)
 
 # === helpers ============================================================
 
@@ -128,8 +129,10 @@ curl -sS -X POST "$API/storage/buckets" \
 print_success "Bucket created: $BUCKET"
 
 curl -sS -X POST "$API/auth/users" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{\"email\":\"$ALICE_EMAIL\",\"password\":\"$PASS\",\"name\":\"Alice\"}" > /dev/null
 curl -sS -X POST "$API/auth/users" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ANON_KEY" \
   -d "{\"email\":\"$BOB_EMAIL\",\"password\":\"$PASS\",\"name\":\"Bob\"}" > /dev/null
 register_test_user "$ALICE_EMAIL"
 register_test_user "$BOB_EMAIL"

--- a/backend/tests/local/test-traditional-rest.sh
+++ b/backend/tests/local/test-traditional-rest.sh
@@ -19,6 +19,7 @@ API_BASE="$TEST_API_BASE"
 TEST_USER_EMAIL="testuser_rest_$(date +%s)@example.com"
 TEST_USER_PASSWORD="TestPass123!"
 AUTH_TOKEN=""
+ANON_KEY=$(get_anon_key)
 
 # Function to test response format
 test_response_format() {
@@ -85,6 +86,7 @@ ADMIN_TOKEN=$(get_admin_token)
 print_info "5. Creating test user for authenticated tests"
 auth_response=$(curl -s -X POST "$API_BASE/auth/users" \
     -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ANON_KEY" \
     -d "{
         \"email\": \"$TEST_USER_EMAIL\",
         \"password\": \"$TEST_USER_PASSWORD\",

--- a/backend/tests/test-config.sh
+++ b/backend/tests/test-config.sh
@@ -118,15 +118,31 @@ register_test_bucket() {
     TEST_BUCKETS_CREATED+=("$bucket_name")
 }
 
+# Function to get the public anon key from the metadata endpoint (requires admin auth)
+get_anon_key() {
+    local admin_token
+    admin_token=$(get_admin_token)
+    if [ -z "$admin_token" ]; then
+        echo ""
+        return 1
+    fi
+    local response
+    response=$(curl -s "$TEST_API_BASE/metadata/anon-key" \
+        -H "Authorization: Bearer $admin_token")
+    echo "$response" | grep -o '"anonKey":"[^"]*"' | cut -d'"' -f4
+}
+
 # Function to register a user with Better Auth
 register_user() {
     local email=$1
     local password=$2
     local name=${3:-"Test User"}
+    local anon_key="${4:-${ACCESS_ANON_KEY:-$(get_anon_key)}}"
     
-    # Use JWT registration
+    # Use JWT registration (requires anon key in Authorization header)
     curl -s -X POST "$TEST_API_BASE/auth/users" \
         -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $anon_key" \
         -d "{\"email\":\"$email\",\"password\":\"$password\",\"name\":\"$name\"}"
 }
 

--- a/backend/tests/unit/auth-create-user-route.test.ts
+++ b/backend/tests/unit/auth-create-user-route.test.ts
@@ -1,0 +1,202 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Router, Request, Response, NextFunction } from 'express';
+
+interface AppError {
+  statusCode: number;
+  code: string;
+  message: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  verifyUser: vi.fn(),
+  register: vi.fn(),
+  getAuthConfig: vi.fn(),
+  broadcastToRoom: vi.fn(),
+  generateRefreshToken: vi.fn(),
+  generateRefreshTokenWithCsrf: vi.fn(),
+}));
+
+vi.mock('@/api/middlewares/auth.js', () => ({
+  verifyUser: mocks.verifyUser,
+  verifyAdmin: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyToken: vi.fn((_req, _res, next: NextFunction) => next()),
+}));
+
+vi.mock('@/services/auth/auth.service.js', () => ({
+  AuthService: { getInstance: () => ({ register: mocks.register }) },
+}));
+
+vi.mock('@/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getAuthConfig: mocks.getAuthConfig,
+      validateRedirectUrl: vi.fn().mockResolvedValue(true),
+    }),
+  },
+}));
+
+vi.mock('@/infra/socket/socket.manager.js', () => ({
+  SocketManager: { getInstance: () => ({ broadcastToRoom: mocks.broadcastToRoom }) },
+}));
+
+vi.mock('@/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      verifyToken: vi.fn(),
+      generateAccessToken: vi.fn().mockReturnValue('test-access-token'),
+      generateRefreshToken: mocks.generateRefreshToken,
+      generateRefreshTokenWithCsrf: mocks.generateRefreshTokenWithCsrf,
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const NEW_USER = {
+  user: {
+    id: 'new-uuid',
+    email: 'new@test.com',
+    emailVerified: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    providers: ['email'],
+    profile: { name: 'Test' },
+    metadata: {},
+  },
+  accessToken: 'test-access-token',
+};
+
+function callRoute(
+  router: Router,
+  overrides: { headers?: Record<string, string>; body?: Record<string, unknown> }
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve) => {
+    let statusCode = 200;
+
+    const req: Partial<Request> = {
+      url: '/users',
+      method: 'POST',
+      headers: overrides.headers ?? {},
+      query: {},
+      body: overrides.body ?? {},
+    };
+
+    const res: Partial<Response> = {
+      status: vi.fn((c: number) => {
+        statusCode = c;
+        return res;
+      }),
+      json: vi.fn((d: unknown) => resolve({ statusCode, body: d })),
+      cookie: vi.fn(() => res),
+    };
+
+    router(
+      req as Request,
+      res as Response,
+      vi.fn((error?: unknown) => {
+        if (error && typeof error === 'object' && 'statusCode' in error) {
+          const appError = error as AppError;
+          resolve({
+            statusCode: appError.statusCode ?? 500,
+            body: {
+              error: appError.code,
+              message: appError.message,
+              statusCode: appError.statusCode ?? 500,
+            },
+          });
+        }
+      })
+    );
+  });
+}
+
+describe('POST /api/auth/users – disableSignup gate', () => {
+  let router: Router;
+
+  beforeAll(async () => {
+    router = (await import('../../src/api/routes/auth/index.routes.js')).default;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validBody = { email: 'test@test.com', password: 'Pass1234', name: 'Test' };
+
+  it('blocks anon/public signup when disableSignup=true', async () => {
+    mocks.verifyUser.mockImplementation((req, _res, next) => {
+      req.user = { id: 'anonymous', role: 'anon' };
+      next();
+    });
+    mocks.getAuthConfig.mockResolvedValue({ disableSignup: true });
+
+    const response = await callRoute(router, { body: validBody });
+
+    expect(response.statusCode).toBe(403);
+    expect((response.body as Record<string, unknown>).error).toBe('AUTH_SIGNUP_DISABLED');
+    expect(mocks.getAuthConfig).toHaveBeenCalledOnce();
+    expect(mocks.register).not.toHaveBeenCalled();
+  });
+
+  it('allows API-key admin user creation when disableSignup=true', async () => {
+    mocks.verifyUser.mockImplementation((req, _res, next) => {
+      req.hasApiKey = true;
+      next();
+    });
+    mocks.register.mockResolvedValue(NEW_USER);
+
+    const response = await callRoute(router, { body: validBody });
+
+    expect(response.statusCode).toBe(200);
+    expect((response.body as Record<string, unknown>).user).toMatchObject({
+      email: 'new@test.com',
+    });
+    expect(mocks.getAuthConfig).not.toHaveBeenCalled();
+    expect(mocks.register).toHaveBeenCalledOnce();
+    expect(mocks.register.mock.calls[0][4]).toMatchObject({ isAdminCreation: true });
+  });
+
+  it('allows admin JWT user creation when disableSignup=true', async () => {
+    mocks.verifyUser.mockImplementation((req, _res, next) => {
+      req.user = { id: 'admin-uuid', role: 'project_admin' };
+      next();
+    });
+    mocks.register.mockResolvedValue(NEW_USER);
+
+    const response = await callRoute(router, { body: validBody });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.getAuthConfig).not.toHaveBeenCalled();
+    expect(mocks.register.mock.calls[0][4]).toMatchObject({ isAdminCreation: true });
+  });
+
+  it('allows public signup when disableSignup=false', async () => {
+    mocks.verifyUser.mockImplementation((req, _res, next) => {
+      req.user = { id: 'anonymous', role: 'anon' };
+      next();
+    });
+    mocks.getAuthConfig.mockResolvedValue({ disableSignup: false });
+    mocks.register.mockResolvedValue(NEW_USER);
+    mocks.generateRefreshTokenWithCsrf.mockReturnValue({ refreshToken: 'rt', csrfToken: 'csrf' });
+
+    const response = await callRoute(router, { body: validBody });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.getAuthConfig).toHaveBeenCalledOnce();
+    expect(mocks.register).toHaveBeenCalledOnce();
+    expect(mocks.register.mock.calls[0][4]).toMatchObject({ isAdminCreation: false });
+  });
+
+  it('returns 400 for invalid request body', async () => {
+    mocks.verifyUser.mockImplementation((req, _res, next) => {
+      req.user = { id: 'anonymous', role: 'anon' };
+      next();
+    });
+
+    const response = await callRoute(router, { body: {} });
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/backend/tests/unit/auth-create-user-route.test.ts
+++ b/backend/tests/unit/auth-create-user-route.test.ts
@@ -190,6 +190,22 @@ describe('POST /api/auth/users – disableSignup gate', () => {
     expect(mocks.register.mock.calls[0][4]).toMatchObject({ isAdminCreation: false });
   });
 
+  it('returns 401 when no credentials are provided', async () => {
+    mocks.verifyUser.mockImplementation((_req, res) => {
+      res.status(401).json({
+        error: 'AUTH_INVALID_CREDENTIALS',
+        message: 'No token provided',
+        statusCode: 401,
+      });
+    });
+
+    const response = await callRoute(router, { body: validBody });
+
+    expect(response.statusCode).toBe(401);
+    expect((response.body as Record<string, unknown>).error).toBe('AUTH_INVALID_CREDENTIALS');
+    expect(mocks.register).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for invalid request body', async () => {
     mocks.verifyUser.mockImplementation((req, _res, next) => {
       req.user = { id: 'anonymous', role: 'anon' };

--- a/backend/tests/unit/auth-create-user-route.test.ts
+++ b/backend/tests/unit/auth-create-user-route.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/api/middlewares/auth.js', () => ({
   verifyUser: mocks.verifyUser,
+  verifyOptionalUser: mocks.verifyUser,
   verifyAdmin: vi.fn((_req, _res, next: NextFunction) => next()),
   verifyToken: vi.fn((_req, _res, next: NextFunction) => next()),
 }));


### PR DESCRIPTION
## Summary

#closes #1557

[screen-capture (3).webm](https://github.com/user-attachments/assets/24f4171a-39ba-4db2-ba7e-d10530b33d18)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where disabling user signup blocked admins or automation from creating users. `POST /api/auth/users` now uses `verifyUser` to accept API keys and admin JWTs, and requires an anon key for public signup; public requests are blocked when `disableSignup` is on.

- **Bug Fixes**
  - Switched to `verifyUser`; set `adminCreatingUser = req.hasApiKey || req.user?.role === 'project_admin'`; removed inline token parsing.
  - Public signup now requires an anon key; unauthenticated requests return 401 and are gated by `disableSignup` only for public calls.

- **Migration**
  - Clients doing public signup must send `Authorization: Bearer <anon-key>` when calling `POST /api/auth/users`.

<sup>Written for commit 3fef80e4fd3eabc7c7d0556729372bc3c918cfc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix disable-signup bug by requiring anon key credentials on `POST /api/auth/users`
> - The `POST /api/auth/users` route previously parsed auth headers manually, bypassing the disable-signup gate; it now uses `verifyUser` middleware and derives `adminCreatingUser` from `req.hasApiKey` or `req.user?.role === 'project_admin'`.
> - All local test scripts now authenticate user registration requests with an anon key obtained via a new `get_anon_key` helper in [test-config.sh](https://github.com/InsForge/InsForge/pull/1561/files#diff-34fe11ebd49ba70c6602dc0ae349c8e4ea163632b0d47f995c2efab9027111b9).
> - A new Vitest suite in [auth-create-user-route.test.ts](https://github.com/InsForge/InsForge/pull/1561/files#diff-137e995becc65d3915eee761e9aae21e807e8fd5e9aaae916ab7c5ae368c3f3e) covers the disable-signup gate, API-key bypass, admin-JWT bypass, and public signup flows.
> - Behavioral Change: anonymous registration requests without a valid anon key token now receive a 401 from `verifyUser` instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fef80e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `POST /api/auth/users` admin-user detection by using authentication results from middleware, ensuring correct behavior for admin vs public signups (including when signup is disabled).

* **New Features**
  * Added `verifyOptionalUser` middleware to authenticate requests only when credentials are present, without forcing authentication failures on unauthenticated requests.

* **Tests**
  * Added unit tests for `POST /api/auth/users` covering the `disableSignup` gate for public, API-key admin creation, project-admin creation, and invalid request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->