### PR TITLE
[codex] fix realtime channel name helper

### DIFF
--- a/backend/src/infra/database/migrations/052_fix-realtime-channel-name-helper.sql
+++ b/backend/src/infra/database/migrations/052_fix-realtime-channel-name-helper.sql
@@ -1,0 +1,13 @@
+-- Normalize unset realtime channel runtime context.
+--
+-- PostgreSQL custom GUCs can read back as an empty string after a
+-- transaction-local value is cleared on a reused session. RLS policies should
+-- see one stable "no channel" value, so expose NULL rather than ''.
+CREATE OR REPLACE FUNCTION realtime.channel_name()
+RETURNS TEXT
+LANGUAGE sql STABLE
+AS $$
+  SELECT nullif(current_setting('realtime.channel_name', true), '')
+$$;
+
+GRANT EXECUTE ON FUNCTION realtime.channel_name() TO authenticated, anon, project_admin;

--- a/backend/src/infra/database/migrations/053_fix-realtime-channel-name-helper.sql
+++ b/backend/src/infra/database/migrations/053_fix-realtime-channel-name-helper.sql
@@ -3,11 +3,15 @@
 -- PostgreSQL custom GUCs can read back as an empty string after a
 -- transaction-local value is cleared on a reused session. RLS policies should
 -- see one stable "no channel" value, so expose NULL rather than ''.
+--
+-- CREATE OR REPLACE preserves the function's existing ACL, so the EXECUTE
+-- grants made in 017 (authenticated, anon) and 045 (project_admin) carry over
+-- without re-granting. We intentionally do not re-issue them: an unguarded
+-- GRANT ... TO project_admin would abort the migration wherever that role is
+-- absent -- the exact case 045-048 wrap in a pg_roles existence guard.
 CREATE OR REPLACE FUNCTION realtime.channel_name()
 RETURNS TEXT
 LANGUAGE sql STABLE
 AS $$
   SELECT nullif(current_setting('realtime.channel_name', true), '')
 $$;
-
-GRANT EXECUTE ON FUNCTION realtime.channel_name() TO authenticated, anon, project_admin;

--- a/backend/tests/unit/realtime-channel-name-helper-migration.test.ts
+++ b/backend/tests/unit/realtime-channel-name-helper-migration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '052_fix-realtime-channel-name-helper.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readSql(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('052_fix-realtime-channel-name-helper migration', () => {
+  it('migration file exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('replaces realtime.channel_name with a blank-to-NULL guard', () => {
+    const sql = readSql();
+
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION realtime\.channel_name\(\)/i);
+    expect(sql).toMatch(
+      /nullif\(\s*current_setting\(\s*'realtime\.channel_name'\s*,\s*true\s*\)\s*,\s*''\s*\)/i
+    );
+  });
+
+  it('keeps function execute grants for runtime roles', () => {
+    const sql = readSql();
+
+    expect(sql).toMatch(
+      /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+realtime\.channel_name\(\)\s+TO\s+authenticated,\s*anon,\s*project_admin/i
+    );
+  });
+
+  it('runs after database backups without editing historical migrations', () => {
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(
+      migrations.indexOf('051_create-database-backups.sql')
+    );
+
+    expect(readSql()).not.toMatch(/017_create-realtime-schema/i);
+  });
+});

--- a/backend/tests/unit/realtime-channel-name-helper-migration.test.ts
+++ b/backend/tests/unit/realtime-channel-name-helper-migration.test.ts
@@ -5,14 +5,14 @@ import { fileURLToPath } from 'url';
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
-const migrationFile = '052_fix-realtime-channel-name-helper.sql';
+const migrationFile = '053_fix-realtime-channel-name-helper.sql';
 const migrationPath = path.resolve(migrationDir, migrationFile);
 
 function readSql(): string {
   return fs.readFileSync(migrationPath, 'utf8');
 }
 
-describe('052_fix-realtime-channel-name-helper migration', () => {
+describe('053_fix-realtime-channel-name-helper migration', () => {
   it('migration file exists', () => {
     expect(fs.existsSync(migrationPath)).toBe(true);
   });
@@ -26,23 +26,25 @@ describe('052_fix-realtime-channel-name-helper migration', () => {
     );
   });
 
-  it('keeps function execute grants for runtime roles', () => {
+  it('relies on CREATE OR REPLACE to preserve grants rather than re-issuing them', () => {
     const sql = readSql();
 
-    expect(sql).toMatch(
-      /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+realtime\.channel_name\(\)\s+TO\s+authenticated,\s*anon,\s*project_admin/i
-    );
+    // CREATE OR REPLACE preserves the existing ACL, so the grants from 017/045
+    // carry over. Re-issuing an unguarded GRANT ... TO project_admin would abort
+    // the migration wherever that role is absent (045-048 guard it for a reason).
+    expect(sql).not.toMatch(/GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+realtime\.channel_name/i);
   });
 
-  it('runs after database backups without editing historical migrations', () => {
+  it('runs after existing migrations without editing historical migrations', () => {
     const migrations = fs
       .readdirSync(migrationDir)
       .filter((file) => file.endsWith('.sql'))
       .sort();
 
-    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(
-      migrations.indexOf('051_create-database-backups.sql')
-    );
+    const prerequisite = '052_add-s3-cors-tagging-versioning.sql';
+    expect(migrations).toContain(migrationFile);
+    expect(migrations).toContain(prerequisite);
+    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(migrations.indexOf(prerequisite));
 
     expect(readSql()).not.toMatch(/017_create-realtime-schema/i);
   });


### PR DESCRIPTION
## Summary
- Add a forward-only migration that normalizes `realtime.channel_name()` blank custom-GUC values to `NULL`.
- Preserve runtime EXECUTE grants for `authenticated`, `anon`, and `project_admin`.
- Add a migration unit test covering the helper definition, grants, and migration ordering.

## Why
PostgreSQL custom GUCs can read back as an empty string after a transaction-local value is cleared on a reused session. Policies should see one stable no-channel value, so the helper should expose `NULL` rather than `''`.

## Validation
- `npm run format:check`
- `npx turbo run lint`
- `npx turbo run typecheck`
- `npm test -- tests/unit/realtime-channel-name-helper-migration.test.ts tests/unit/migration-duplicate-numbers.test.ts`
- `npm test -- src/features/auth/components/__tests__/UserFormDialog.test.tsx` passed after the first full-suite run timed out on that unrelated dashboard test.

## Notes
- `npx turbo run test` was attempted twice. The first run timed out in `packages/dashboard/src/features/auth/components/__tests__/UserFormDialog.test.tsx`, which passed on direct rerun. The second run timed out in pre-existing backend test `backend/tests/unit/write-endpoint-limiter.test.ts`; that same test also times out when run directly. Neither failure touches the migration/test added here.
- No historical migration files were edited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the `realtime.channel_name()` helper to return NULL when unset, fixing policy checks that previously saw empty strings on reused sessions. Renumber the migration to 053 and rely on CREATE OR REPLACE to preserve existing EXECUTE grants without re-issuing them.

- **Bug Fixes**
  - Replace function body with `nullif(current_setting('realtime.channel_name', true), '')`.
  - Drop redundant GRANT statements; ACL is preserved automatically.
  - Add unit test for function SQL, grant preservation, and migration ordering after `052_add-s3-cors-tagging-versioning.sql`.

<sup>Written for commit fd331a3c8f7cbf5b5979f715502cf07762c0a18d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `realtime.channel_name` helper to return NULL when unset
> Updates the `realtime.channel_name()` SQL function via a new migration ([053_fix-realtime-channel-name-helper.sql](https://github.com/InsForge/InsForge/pull/1562/files#diff-d3c1486f2d098aac90aaad6454110199095686a5b5a00bb2d6368fe34f869a6b)) to return `NULL` instead of an empty string when the GUC is unset or empty, using `nullif(current_setting('realtime.channel_name', true), '')`. Uses `CREATE OR REPLACE` to preserve existing grants. Unit tests are added to validate migration content and ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd331a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime channel context handling to properly manage edge cases with undefined or empty channel states
  * Enhanced data validation in realtime operations for increased reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->