### PR TITLE
fix(payments): safely add or rename notes column for Razorpay tables

### DIFF
--- a/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
+++ b/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
@@ -16,6 +16,7 @@ BEGIN
       WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
     ) THEN
       ALTER TABLE payments.razorpay_plans RENAME COLUMN metadata TO notes;
+      UPDATE payments.razorpay_plans SET notes = '{}'::JSONB WHERE notes IS NULL;
       ALTER TABLE payments.razorpay_plans
         ALTER COLUMN notes SET NOT NULL,
         ALTER COLUMN notes SET DEFAULT '{}'::JSONB;
@@ -37,6 +38,7 @@ BEGIN
       WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
     ) THEN
       ALTER TABLE payments.razorpay_subscriptions RENAME COLUMN metadata TO notes;
+      UPDATE payments.razorpay_subscriptions SET notes = '{}'::JSONB WHERE notes IS NULL;
       ALTER TABLE payments.razorpay_subscriptions
         ALTER COLUMN notes SET NOT NULL,
         ALTER COLUMN notes SET DEFAULT '{}'::JSONB;
@@ -58,6 +60,7 @@ BEGIN
       WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
     ) THEN
       ALTER TABLE payments.razorpay_orders RENAME COLUMN metadata TO notes;
+      UPDATE payments.razorpay_orders SET notes = '{}'::JSONB WHERE notes IS NULL;
       ALTER TABLE payments.razorpay_orders
         ALTER COLUMN notes SET NOT NULL,
         ALTER COLUMN notes SET DEFAULT '{}'::JSONB;

--- a/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
+++ b/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
@@ -1,0 +1,56 @@
+-- Up Migration
+--
+-- Ensure the notes column exists on all razorpay tables and safely migrate
+-- from the early alpha `metadata` column name to `notes` if necessary.
+-- This repairs environments where the tables were created before 049 ran.
+
+DO $$
+BEGIN
+  -- Fix payments.razorpay_plans
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'metadata'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_plans RENAME COLUMN metadata TO notes;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_plans ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  END IF;
+
+  -- Fix payments.razorpay_subscriptions
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'metadata'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_subscriptions RENAME COLUMN metadata TO notes;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_subscriptions ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  END IF;
+
+  -- Fix payments.razorpay_orders
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'metadata'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_orders RENAME COLUMN metadata TO notes;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
+  ) THEN
+    ALTER TABLE payments.razorpay_orders ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  END IF;
+END $$;

--- a/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
+++ b/backend/src/infra/database/migrations/052_fix-razorpay-notes-column.sql
@@ -7,50 +7,70 @@
 DO $$
 BEGIN
   -- Fix payments.razorpay_plans
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'metadata'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_plans RENAME COLUMN metadata TO notes;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_plans ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  IF to_regclass('payments.razorpay_plans') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'metadata'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_plans RENAME COLUMN metadata TO notes;
+      ALTER TABLE payments.razorpay_plans
+        ALTER COLUMN notes SET NOT NULL,
+        ALTER COLUMN notes SET DEFAULT '{}'::JSONB;
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_plans' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_plans ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+    END IF;
   END IF;
 
   -- Fix payments.razorpay_subscriptions
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'metadata'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_subscriptions RENAME COLUMN metadata TO notes;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_subscriptions ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  IF to_regclass('payments.razorpay_subscriptions') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'metadata'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_subscriptions RENAME COLUMN metadata TO notes;
+      ALTER TABLE payments.razorpay_subscriptions
+        ALTER COLUMN notes SET NOT NULL,
+        ALTER COLUMN notes SET DEFAULT '{}'::JSONB;
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_subscriptions' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_subscriptions ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+    END IF;
   END IF;
 
   -- Fix payments.razorpay_orders
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'metadata'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_orders RENAME COLUMN metadata TO notes;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
-  ) THEN
-    ALTER TABLE payments.razorpay_orders ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+  IF to_regclass('payments.razorpay_orders') IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'metadata'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_orders RENAME COLUMN metadata TO notes;
+      ALTER TABLE payments.razorpay_orders
+        ALTER COLUMN notes SET NOT NULL,
+        ALTER COLUMN notes SET DEFAULT '{}'::JSONB;
+    ELSIF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'payments' AND table_name = 'razorpay_orders' AND column_name = 'notes'
+    ) THEN
+      ALTER TABLE payments.razorpay_orders ADD COLUMN notes JSONB NOT NULL DEFAULT '{}'::JSONB;
+    END IF;
   END IF;
 END $$;
+
+-- Down Migration
+-- Column rename/addition is intentionally not reversed; rolling back would
+-- require knowing the prior column name per environment, which is not safely
+-- deterministic.

--- a/deploy/Dockerfile.deno
+++ b/deploy/Dockerfile.deno
@@ -1,7 +1,6 @@
 FROM denoland/deno:alpine-2.0.6
 
-# Create non-root user
-RUN addgroup -S deno && adduser -S deno -G deno
+# The denoland/deno image already creates the 'deno' user and runs as non-root.
 
 WORKDIR /app/functions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12322,6 +12322,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12343,6 +12344,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12364,6 +12366,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12385,6 +12388,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12406,6 +12410,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12427,6 +12432,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12448,6 +12454,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12469,6 +12476,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12490,6 +12498,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12511,6 +12520,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12532,6 +12542,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },


### PR DESCRIPTION
## Summary

Fixes #1564.

This PR resolves a critical bug on the production dashboard where the `Payments > Catalog` and `Payments > Subscriptions` tabs crash with the error: `column "notes" of relation "razorpay_plans" does not exist`.

**The Root Cause:**
The original `049` migration created the Razorpay tables using `CREATE TABLE IF NOT EXISTS`. Because the tables already existed in the live database from earlier alpha testing (when the column was still named `metadata`), the entire creation block was skipped. This meant the new `notes` column was never added to the existing tables in production.

**The Fix:**
I added a new migration script (`052_fix-razorpay-notes-column.sql`) that safely addresses this schema drift:
- It checks if the `metadata` column exists but `notes` doesn't, and renames it to `notes`.
- If neither exists, it safely adds the `notes` column natively.
- It applies these fixes to `razorpay_plans`, `razorpay_subscriptions`, and `razorpay_orders`.

## How did you test this change?

1. Replicated the exact database state locally by creating the `razorpay_plans` table with the old `metadata` column instead of `notes`.
2. Verified that the backend `Catalog` sync failed with the exact same error seen in production.
3. Ran `npm run migrate:up` to apply the new `052` migration.
4. Verified that the migration successfully executed and that Postgres successfully renamed the column.
5. Loaded the Dashboard UI locally and confirmed the `Catalog` and `Subscriptions` pages now render correctly without any sync errors.
<img width="1470" height="956" alt="Screenshot 2026-06-20 at 2 07 31 PM" src="https://github.com/user-attachments/assets/4dce0e61-f906-49e7-bb48-6af6214b0fdf" />

<img width="1470" height="956" alt="Screenshot 2026-06-20 at 2 08 11 PM" src="https://github.com/user-attachments/assets/f9b0cfb5-010c-4735-b62f-92bf4fc42c78" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production crashes on Payments > Catalog and Subscriptions by ensuring a `notes` JSONB column exists on all Razorpay tables and safely renaming legacy `metadata` when present. Adds a guarded migration to repair environments created before migration 049. Fixes #1564.

- **Bug Fixes**
  - Adds `052_fix-razorpay-notes-column.sql` with table guards; only runs if `payments.razorpay_plans`, `payments.razorpay_subscriptions`, or `payments.razorpay_orders` exist.
  - Renames `metadata` → `notes` when found; otherwise adds `notes JSONB NOT NULL DEFAULT '{}'::JSONB`.
  - Prevents dashboard errors caused by the earlier `CREATE TABLE IF NOT EXISTS` skip.

<sup>Written for commit dc4c54d261875172cba0ebbb1ff0a25dff2cb2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration to safely rename or add `notes` column on Razorpay tables
> - Adds [052_fix-razorpay-notes-column.sql](https://github.com/InsForge/InsForge/pull/1565/files#diff-582cff0c6248fd8ba600fcb870df8ff0a0c474d19be7fcd9b93b00331231550a) to ensure a `notes JSONB NOT NULL DEFAULT '{}'` column exists on `payments.razorpay_plans`, `payments.razorpay_subscriptions`, and `payments.razorpay_orders`.
> - If a `metadata` column exists and `notes` does not, the migration renames `metadata` to `notes`, backfills NULLs with `'{}'`, and applies the NOT NULL constraint and default.
> - If neither column exists, `notes` is added directly.
> - Also removes explicit `addgroup`/`adduser` commands from [Dockerfile.deno](https://github.com/InsForge/InsForge/pull/1565/files#diff-6c4e97eee15b7de3d2fe0fd94e64cbeebae9a76b99f21259121f2ff2016efa51), relying on the non-root `deno` user already provided by the base image.
> - Behavioral Change: the down migration does not reverse the rename or column addition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7396d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the payment database schema so Razorpay-related tables always include a `notes` JSONB column that is non-null (defaulting to `{}`), with automatic migration of legacy `metadata` usage.
* **Chores**
  * Simplified the Deno container setup by relying on the base image’s existing non-root user, while preserving the working directory and file ownership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->