### PR TITLE
feat: optional prompt compression for the Model Gateway (opt-in leanctx sidecar)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,18 @@ LOGS_DIR=
 # Used for AI-powered features and model gateway
 OPENROUTER_API_KEY=
 
+# Optional: leanctx prompt-compression sidecar for the Model Gateway.
+# When AI_COMPRESSION_URL is set, the gateway sends each request's prose to the
+# sidecar's POST /compress before calling OpenRouter, cutting prompt tokens (and
+# cost). Leave it empty to disable (default). The path is fail-open: any error or
+# timeout falls back to the original, uncompressed request.
+# Run the sidecar with: pip install 'leanctx[server,lingua]' && leanctx-serve
+AI_COMPRESSION_URL=
+# Per-request timeout (ms) for the sidecar call (default 2000).
+AI_COMPRESSION_TIMEOUT_MS=
+# Skip the sidecar unless a request's string content exceeds this many chars (default 6000).
+AI_COMPRESSION_MIN_CHARS=
+
 # -----------------------------------------------------------------------------
 # Stripe Payments Configuration (Optional)
 # -----------------------------------------------------------------------------

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -97,6 +97,12 @@ export interface AppConfig {
   };
   ai: {
     openrouterApiKey: string | undefined;
+    /** Optional leanctx compression sidecar base URL; unset → compression off. */
+    compressionUrl: string | undefined;
+    /** Per-request timeout (ms) for the compression sidecar call. */
+    compressionTimeoutMs: number;
+    /** Skip the sidecar unless the request's string content exceeds this many chars. */
+    compressionMinChars: number;
   };
 }
 
@@ -201,6 +207,10 @@ export function loadConfig(): AppConfig {
     },
     ai: {
       openrouterApiKey: process.env.OPENROUTER_API_KEY || undefined,
+      // Optional leanctx compression sidecar for the Model Gateway (default off).
+      compressionUrl: process.env.AI_COMPRESSION_URL || undefined,
+      compressionTimeoutMs: parseEnvInt(process.env.AI_COMPRESSION_TIMEOUT_MS, 2000),
+      compressionMinChars: parseEnvInt(process.env.AI_COMPRESSION_MIN_CHARS, 6000),
     },
   };
 }

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -10,6 +10,7 @@ import {
 import logger from '@/utils/logger.js';
 import { ChatCompletionOptions } from '@/types/ai.js';
 import { AppError } from '@/utils/errors.js';
+import { compressMessages } from '@/services/ai/prompt-compression.service.js';
 
 // OpenRouter plugin type for web search
 interface OpenRouterWebPlugin {
@@ -258,7 +259,9 @@ export class ChatCompletionService {
       // Build model ID with optional :thinking suffix
       const modelId = this.buildModelId(options.model, options.thinking);
 
-      const formattedMessages = this.formatMessages(messages);
+      // Optionally shrink prompt prose via the leanctx sidecar before the
+      // upstream call (no-op unless AI_COMPRESSION_URL is set; always fail-open).
+      const formattedMessages = await compressMessages(this.formatMessages(messages));
 
       // Build request with optional plugins (web search, file parser)
       const request: OpenRouterChatCompletionRequest = {
@@ -354,7 +357,9 @@ export class ChatCompletionService {
       // Build model ID with optional :thinking suffix
       const modelId = this.buildModelId(options.model, options.thinking);
 
-      const formattedMessages = this.formatMessages(messages);
+      // Optionally shrink prompt prose via the leanctx sidecar before the
+      // upstream call (no-op unless AI_COMPRESSION_URL is set; always fail-open).
+      const formattedMessages = await compressMessages(this.formatMessages(messages));
 
       // Build request with optional plugins (web search, file parser)
       const request: OpenRouterChatCompletionStreamingRequest = {

--- a/backend/src/services/ai/prompt-compression.service.ts
+++ b/backend/src/services/ai/prompt-compression.service.ts
@@ -1,0 +1,111 @@
+import OpenAI from 'openai';
+import { appConfig } from '@/infra/config/app.config.js';
+import logger from '@/utils/logger.js';
+
+/**
+ * Optional prompt compression for the Model Gateway (default OFF).
+ *
+ * When `AI_COMPRESSION_URL` points at a leanctx compression sidecar, the
+ * formatted chat messages are sent to its `POST /compress` endpoint before they
+ * go upstream to OpenRouter. The sidecar shrinks the natural-language ("prose")
+ * portions of system/user/assistant messages and forwards tool results and
+ * multimodal content verbatim, cutting prompt tokens — and therefore OpenRouter
+ * cost — with no change to the request schema, the route, or the public API.
+ *
+ * The path is strictly **fail-open**: when the feature is unset it is a no-op,
+ * and any error, timeout, non-OK status, or message-count mismatch falls back
+ * to the original messages. The gateway never depends on the sidecar for
+ * availability or correctness.
+ *
+ * Sidecar: https://pypi.org/project/leanctx/ (`leanctx-serve`).
+ */
+
+type ChatMessage = OpenAI.Chat.ChatCompletionMessageParam;
+
+interface CompressResponse {
+  messages?: unknown;
+}
+
+const COMPRESS_PATH = '/compress';
+
+/** True when a compression sidecar URL is configured. */
+export function isCompressionEnabled(): boolean {
+  return Boolean(appConfig.ai.compressionUrl);
+}
+
+/** Total length of the plain-string content the sidecar could actually shrink. */
+function compressibleChars(messages: ChatMessage[]): number {
+  let total = 0;
+  for (const message of messages) {
+    if (typeof message.content === 'string') {
+      total += message.content.length;
+    }
+  }
+  return total;
+}
+
+/**
+ * Compress messages via the leanctx sidecar, or return them unchanged.
+ *
+ * @param messages - Formatted OpenAI chat messages, as built by
+ *   `ChatCompletionService.formatMessages`.
+ * @returns The compressed messages (same count, same order) when the sidecar is
+ *   configured and responds successfully; otherwise the original messages.
+ */
+export async function compressMessages(messages: ChatMessage[]): Promise<ChatMessage[]> {
+  const baseUrl = appConfig.ai.compressionUrl;
+  if (!baseUrl) {
+    // Feature off → no-op, fully backward compatible.
+    return messages;
+  }
+
+  // Request-level gate: don't pay the sidecar round-trip on small prompts. The
+  // sidecar also enforces a per-message token floor, but short-circuiting tiny
+  // requests here keeps the added latency off the common path.
+  if (compressibleChars(messages) < appConfig.ai.compressionMinChars) {
+    return messages;
+  }
+
+  const url = `${baseUrl.replace(/\/+$/, '')}${COMPRESS_PATH}`;
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages }),
+      signal: AbortSignal.timeout(appConfig.ai.compressionTimeoutMs),
+    });
+
+    if (!response.ok) {
+      logger.warn('Prompt compression sidecar returned a non-OK status; using original messages', {
+        status: response.status,
+      });
+      return messages;
+    }
+
+    const data = (await response.json()) as CompressResponse;
+    const compressed = data.messages;
+
+    // One-in-one-out invariant: the sidecar preserves message count (it splices
+    // compressed prose back by index and forwards everything else verbatim). If
+    // that ever breaks, discard the result rather than risk dropping, adding, or
+    // reordering a message.
+    if (!Array.isArray(compressed) || compressed.length !== messages.length) {
+      logger.warn(
+        'Prompt compression returned an unexpected message count; using original messages',
+        {
+          expected: messages.length,
+          received: Array.isArray(compressed) ? compressed.length : null,
+        }
+      );
+      return messages;
+    }
+
+    return compressed as ChatMessage[];
+  } catch (error) {
+    // Fail open: compression must never break or stall a chat request.
+    logger.warn('Prompt compression failed; using original messages', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return messages;
+  }
+}

--- a/backend/tests/unit/prompt-compression.service.test.ts
+++ b/backend/tests/unit/prompt-compression.service.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type OpenAI from 'openai';
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.stubGlobal('fetch', mockFetch);
+
+import {
+  compressMessages,
+  isCompressionEnabled,
+} from '../../src/services/ai/prompt-compression.service';
+import { appConfig } from '../../src/infra/config/app.config';
+
+type ChatMessage = OpenAI.Chat.ChatCompletionMessageParam;
+
+// ~9600 chars, comfortably over the default 6000-char request gate.
+const bigText = 'lorem ipsum dolor sit amet '.repeat(360);
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: () => Promise.resolve(body) };
+}
+
+describe('prompt-compression connector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appConfig.ai.compressionUrl = undefined;
+    appConfig.ai.compressionTimeoutMs = 2000;
+    appConfig.ai.compressionMinChars = 6000;
+  });
+
+  it('is a no-op (no fetch) when no sidecar URL is configured', async () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: bigText }];
+
+    const out = await compressMessages(messages);
+
+    expect(isCompressionEnabled()).toBe(false);
+    expect(out).toBe(messages);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips the sidecar for requests below the size gate', async () => {
+    appConfig.ai.compressionUrl = 'http://sidecar:8459';
+    const messages: ChatMessage[] = [{ role: 'user', content: 'short prompt' }];
+
+    const out = await compressMessages(messages);
+
+    expect(out).toBe(messages);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns the sidecar-compressed messages on success and calls /compress', async () => {
+    appConfig.ai.compressionUrl = 'http://sidecar:8459/'; // trailing slash trimmed
+    const messages: ChatMessage[] = [
+      { role: 'system', content: bigText },
+      { role: 'user', content: bigText },
+    ];
+    const compressed: ChatMessage[] = [
+      { role: 'system', content: 'compressed system' },
+      { role: 'user', content: 'compressed user' },
+    ];
+    mockFetch.mockResolvedValueOnce(jsonResponse({ messages: compressed }));
+
+    const out = await compressMessages(messages);
+
+    expect(out).toEqual(compressed);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://sidecar:8459/compress');
+    expect(JSON.parse(init.body as string)).toEqual({ messages });
+  });
+
+  it('falls back to the original messages on a non-OK status', async () => {
+    appConfig.ai.compressionUrl = 'http://sidecar:8459';
+    const messages: ChatMessage[] = [{ role: 'user', content: bigText }];
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, false, 503));
+
+    const out = await compressMessages(messages);
+
+    expect(out).toBe(messages);
+  });
+
+  it('fails open when the sidecar throws or times out', async () => {
+    appConfig.ai.compressionUrl = 'http://sidecar:8459';
+    const messages: ChatMessage[] = [{ role: 'user', content: bigText }];
+    mockFetch.mockRejectedValueOnce(new Error('The operation was aborted due to timeout'));
+
+    const out = await compressMessages(messages);
+
+    expect(out).toBe(messages);
+  });
+
+  it('discards a response whose message count does not match the input', async () => {
+    appConfig.ai.compressionUrl = 'http://sidecar:8459';
+    const messages: ChatMessage[] = [
+      { role: 'user', content: bigText },
+      { role: 'assistant', content: bigText },
+    ];
+    mockFetch.mockResolvedValueOnce(jsonResponse({ messages: [{ role: 'user', content: 'only one' }] }));
+
+    const out = await compressMessages(messages);
+
+    expect(out).toBe(messages);
+  });
+});

--- a/deploy/compression/Dockerfile
+++ b/deploy/compression/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+#
+# leanctx prompt-compression sidecar for the InsForge Model Gateway (CPU image).
+#
+# Runs the leanctx HTTP service (leanctx-serve) with the ~1.2 GB LLMLingua-2
+# model baked in. When the backend's AI_COMPRESSION_URL points at this service,
+# the Model Gateway sends each request's prose to POST /compress before calling
+# OpenRouter, cutting prompt tokens (and cost). Source code, tool results, and
+# multimodal content are forwarded verbatim.
+#
+# It is opt-in: started only via the "compression" Compose profile, so default
+# deployments are unaffected. See ./README.md.
+#
+# leanctx's HTTP server (the [server] extra + the leanctx-serve console script)
+# is not yet part of the PyPI release, so we install from the pinned GitHub
+# commit below for a reproducible build.
+
+FROM python:3.12-slim
+
+ARG LINGUA_MODEL=microsoft/llmlingua-2-xlm-roberta-large-meetingbank
+# Pinned leanctx commit — has the [server] extra and leanctx-serve.
+ARG LEANCTX_REF=50e917fa2db91eaf25115f79a3324fec1451deed
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HOME=/models
+
+# git is required for the VCS install below.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU-only torch in its own layer (the default PyPI wheel bundles CUDA and is
+# ~2 GB larger; a separate layer also stays cached across edits).
+RUN pip install --index-url https://download.pytorch.org/whl/cpu torch
+
+# leanctx with [server] (FastAPI/uvicorn + leanctx-serve), [lingua] (LLMLingua-2),
+# and [tokens] (real tiktoken counts, not chars/4). Pinned for reproducibility.
+RUN pip install "leanctx[server,lingua,tokens] @ git+https://github.com/jia-gao/leanctx@${LEANCTX_REF}"
+
+# Bake the LLMLingua-2 weights into the image (offline, deterministic first boot).
+RUN python -c "from llmlingua import PromptCompressor; \
+PromptCompressor(model_name='${LINGUA_MODEL}', use_llmlingua2=True, device_map='cpu')"
+ENV HF_HUB_OFFLINE=1
+
+# --- Model Gateway compression defaults (override via compose / -e) ---
+#   threshold 1500  -> never compress short system/instruction turns
+#   dedup off       -> the gateway sends raw OpenAI messages; no upstream dedup
+ENV LEANCTX_SERVER_MODE=on \
+    LEANCTX_SERVER_THRESHOLD=1500 \
+    LEANCTX_SERVER_LINGUA_RATIO=0.5 \
+    LEANCTX_SERVER_LINGUA_DEVICE=cpu \
+    LEANCTX_SERVER_DEDUP=off
+
+EXPOSE 8459
+
+# Generous start-period: the startup warmup loads the model before serving.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=90s --retries=3 \
+  CMD python -c "import urllib.request,sys; \
+sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8459/health').getcode()==200 else 1)"
+
+# 0.0.0.0 so the container is reachable on the compose network; a single worker
+# keeps exactly one warm model in memory.
+CMD ["leanctx-serve", "--host", "0.0.0.0", "--port", "8459", "--workers", "1"]

--- a/deploy/compression/README.md
+++ b/deploy/compression/README.md
@@ -1,0 +1,52 @@
+# leanctx prompt-compression sidecar (optional)
+
+An opt-in [leanctx](https://pypi.org/project/leanctx/) sidecar that adds ML
+"prose" compression in front of the InsForge **Model Gateway**. When enabled,
+the gateway sends each chat request's natural-language content to this service's
+`POST /compress` before calling OpenRouter, cutting prompt tokens — and
+therefore OpenRouter cost. Source code, tool results, and multimodal content are
+forwarded verbatim.
+
+It is **off by default** and lives behind the `compression` Compose profile, so
+standard deployments are completely unaffected.
+
+## Enable it
+
+1. Start the sidecar (builds the image; first boot downloads the ~1.2 GB
+   LLMLingua-2 model and bakes it in, so give it a minute):
+
+   ```bash
+   docker compose --profile compression up -d --build compression
+   ```
+
+2. Point the backend at it — set in your `.env`, then restart `insforge`:
+
+   ```bash
+   AI_COMPRESSION_URL=http://compression:8459
+   ```
+
+   That is the only switch. Leaving `AI_COMPRESSION_URL` empty disables
+   compression entirely.
+
+## Behaviour & safety
+
+- **Fail-open:** if the sidecar is slow, erroring, or down, the gateway falls
+  back to the original (uncompressed) request — compression never breaks a call.
+- **Verbatim:** only `system`/`user`/`assistant` string prose is compressed;
+  tool results and multimodal (image) content pass through untouched.
+- **Thresholds:** short turns (< ~1500 tokens) and small requests are skipped,
+  so the round-trip is only paid where there is real prose to shrink.
+
+## Tuning (optional env on the `insforge` service)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `AI_COMPRESSION_URL` | _(empty / off)_ | Sidecar base URL, e.g. `http://compression:8459` |
+| `AI_COMPRESSION_TIMEOUT_MS` | `2000` | Per-request timeout for the sidecar call |
+| `AI_COMPRESSION_MIN_CHARS` | `6000` | Skip the sidecar below this much string content |
+
+## GPU
+
+The bundled image is CPU-only (portable; the model runs in seconds on first
+token under load). For lower latency, run it on a GPU / Apple-Silicon host and
+set `LEANCTX_SERVER_LINGUA_DEVICE=cuda` (or `mps`) on this service.

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -29,6 +29,11 @@ WORKER_TIMEOUT_MS=60000
 # Get your API key from https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
+# Optional: leanctx prompt-compression sidecar for the Model Gateway.
+# Start it with `docker compose --profile compression up -d --build compression`,
+# then set the URL below to enable. Empty = off. See deploy/compression/README.md.
+AI_COMPRESSION_URL=
+
 # Stripe Payments Configuration (Optional)
 # Get your secret keys from https://dashboard.stripe.com/apikeys
 STRIPE_LIVE_SECRET_KEY=

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -79,6 +79,11 @@ services:
       - POSTGREST_BASE_URL=http://postgrest:3000
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Optional prompt-compression sidecar (see the "compression" service and
+      # ../compression/README.md). Empty = off; enable: http://compression:8459
+      - AI_COMPRESSION_URL=${AI_COMPRESSION_URL:-}
+      - AI_COMPRESSION_TIMEOUT_MS=${AI_COMPRESSION_TIMEOUT_MS:-}
+      - AI_COMPRESSION_MIN_CHARS=${AI_COMPRESSION_MIN_CHARS:-}
       # Stripe Payments Configuration
       - STRIPE_TEST_SECRET_KEY=${STRIPE_TEST_SECRET_KEY:-}
       - STRIPE_LIVE_SECRET_KEY=${STRIPE_LIVE_SECRET_KEY:-}
@@ -147,6 +152,24 @@ services:
       retries: 5
       start_period: 15s
     restart: unless-stopped
+    networks:
+      - insforge-network
+
+  # Optional leanctx prompt-compression sidecar for the Model Gateway.
+  # Off by default — started only via the "compression" profile:
+  #   docker compose --profile compression up -d --build compression
+  # Then set AI_COMPRESSION_URL=http://compression:8459 in your .env.
+  # See ../compression/README.md.
+  compression:
+    build:
+      context: ../compression
+    image: insforge-compression
+    profiles: ["compression"]
+    ports:
+      - "${AI_COMPRESSION_PORT:-8459}:8459"
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     networks:
       - insforge-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,11 @@ services:
       - CLOUD_API_HOST=${CLOUD_API_HOST:-}
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Optional prompt-compression sidecar (see the "compression" service and
+      # deploy/compression/README.md). Empty = off; enable: http://compression:8459
+      - AI_COMPRESSION_URL=${AI_COMPRESSION_URL:-}
+      - AI_COMPRESSION_TIMEOUT_MS=${AI_COMPRESSION_TIMEOUT_MS:-}
+      - AI_COMPRESSION_MIN_CHARS=${AI_COMPRESSION_MIN_CHARS:-}
       # Stripe Payments Configuration
       - STRIPE_TEST_SECRET_KEY=${STRIPE_TEST_SECRET_KEY:-}
       - STRIPE_LIVE_SECRET_KEY=${STRIPE_LIVE_SECRET_KEY:-}
@@ -206,6 +211,24 @@ services:
         echo 'Starting Deno server on port 7133...' &&
         deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --unstable-worker-options --watch functions/server.ts
       "
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - insforge-network
+
+  # Optional leanctx prompt-compression sidecar for the Model Gateway.
+  # Off by default — started only via the "compression" profile:
+  #   docker compose --profile compression up -d --build compression
+  # Then set AI_COMPRESSION_URL=http://compression:8459 in your .env.
+  # See deploy/compression/README.md.
+  compression:
+    build:
+      context: ./deploy/compression
+    image: insforge-compression
+    profiles: ["compression"]
+    ports:
+      - "${AI_COMPRESSION_PORT:-8459}:8459"
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## What

Adds **optional, opt-in prompt compression** to the Model Gateway. When enabled, the gateway sends the natural-language ("prose") portions of each chat request to a small [leanctx](https://pypi.org/project/leanctx/) sidecar (LLMLingua-2) before forwarding to OpenRouter, cutting prompt tokens — and therefore OpenRouter cost — on token-heavy agent workloads. Source code, tool results, and multimodal content are forwarded verbatim.

**It is off by default and fully backward compatible.** With `AI_COMPRESSION_URL` unset, the new path is a no-op and nothing about the gateway changes.

## Why

Coding agents pull a lot of documentation, schemas, metadata, and logs into their prompts. That prose is highly compressible, and because the gateway bills per token through OpenRouter, shrinking it is a direct cost reduction with no API change.

## How it works

- **Connector** — `backend/src/services/ai/prompt-compression.service.ts`: a small `compressMessages()` helper wired into `ChatCompletionService.chat()` and `streamChat()`, right after `formatMessages()`. It POSTs the messages to the sidecar's `POST /compress` and splices the result back.
  - **Fail-open**: unset URL → no-op; any error, timeout, non-OK status, or message-count mismatch falls back to the original messages. The gateway never depends on the sidecar for availability.
  - **Gated**: small requests (below `AI_COMPRESSION_MIN_CHARS`) skip the round-trip entirely; the sidecar additionally leaves short turns (< ~1500 tokens) untouched.
  - **Verbatim**: only `system`/`user`/`assistant` string content is compressed; `tool` messages and multimodal content pass through unchanged.
- **Sidecar** — `deploy/compression/`: an optional Compose service behind the `compression` profile, so default deployments neither build nor run it.

## Configuration

| Env | Default | Meaning |
|-----|---------|---------|
| `AI_COMPRESSION_URL` | _(empty / off)_ | Sidecar base URL, e.g. `http://compression:8459` |
| `AI_COMPRESSION_TIMEOUT_MS` | `2000` | Per-request timeout for the sidecar call |
| `AI_COMPRESSION_MIN_CHARS` | `6000` | Skip the sidecar below this much string content |

Enable:

```bash
docker compose --profile compression up -d --build compression
# then set AI_COMPRESSION_URL=http://compression:8459 in .env and restart insforge
```

## Verification

- **Unit tests** (`prompt-compression.service.test.ts`, 6 cases): no-op when disabled, size-gate skip, success path, and the three fail-open paths (non-OK status, timeout/throw, message-count mismatch). `npm test` green.
- **Typecheck + lint**: `tsc --noEmit` and eslint/prettier clean.
- **Compose**: `docker compose config` valid; the `compression` service is absent by default and present only under `--profile compression`.
- **End-to-end build + smoke**: built the sidecar image and ran a real `/compress` round-trip — 4/4 messages preserved, the `tool` message byte-identical, and a representative prose payload compressed **~51% on tokens** (4879 → 2369) via the hybrid method.

## Notes

- The sidecar installs leanctx from a pinned commit because the `[server]` extra (the HTTP service) is not yet in the PyPI release. The CPU image bakes the LLMLingua-2 model for deterministic, offline first boot; a GPU / Apple-Silicon host lowers latency (`LEANCTX_SERVER_LINGUA_DEVICE=cuda|mps`).
- Happy to follow up with a benchmark (LongBench v2 for answer-quality parity plus a token-savings curve), or to adjust the defaults / naming to your preference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional prompt compression to the Model Gateway via a `leanctx` sidecar to cut prompt tokens and reduce OpenRouter cost. It’s off by default and fully fail-open.

- **New Features**
  - Added `compressMessages()` hook in chat and streaming paths to shrink only system/user/assistant prose; tool and multimodal content pass through.
  - Fail-open on unset URL, errors, timeouts, non-OK status, or message-count mismatch.
  - Request size gate via `AI_COMPRESSION_MIN_CHARS`; per-call timeout via `AI_COMPRESSION_TIMEOUT_MS`.
  - New `compression` Compose profile with sidecar Dockerfile and docs; default deployments unchanged.
  - Unit tests cover no-op, gate skip, success, and fail-open cases.

- **Migration**
  - Start sidecar: docker compose --profile compression up -d --build compression
  - Set `AI_COMPRESSION_URL=http://compression:8459` in your env and restart the service.
  - Optional tuning: `AI_COMPRESSION_TIMEOUT_MS` (default 2000), `AI_COMPRESSION_MIN_CHARS` (default 6000).

<sup>Written for commit 0c2d496425070a00ec727b1d938b86043a311ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in prompt compression sidecar to the Model Gateway
> - Introduces a new `compressMessages` step in [`ChatCompletionService`](https://github.com/InsForge/InsForge/pull/1569/files#diff-297e32e2fd38d624380a7511ee26fd7804caae265d3c8c9182ab03a51bfd16ec) that POSTs formatted messages to an external leanctx sidecar before forwarding to the upstream AI provider; applied to both streaming and non-streaming paths.
> - The compression service in [`prompt-compression.service.ts`](https://github.com/InsForge/InsForge/pull/1569/files#diff-303f288543952c59cb33303335a9487479353cadd874994b45853cfcaa32fa4e) is disabled by default and only activates when `AI_COMPRESSION_URL` is set and the total message content exceeds `AI_COMPRESSION_MIN_CHARS` (default 6000).
> - A Dockerfile and Compose service (under the `compression` profile) are added in [`deploy/compression/`](https://github.com/InsForge/InsForge/pull/1569/files#diff-fa02221ec02a7cebe11dea6669922569f4ca80a2749d91fed9faf533a8fa366e) to run the leanctx sidecar with LLMLingua-2 weights preloaded on port 8459.
> - Behavioral Change: when enabled, every chat request incurs an additional HTTP call to the sidecar with a configurable timeout (default 2000ms); errors and timeouts fail open, returning the original messages unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c2d496.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional prompt-compression feature for AI chat requests, reducing token consumption; configurable via environment variables and disabled by default.

* **Documentation**
  * Added configuration guide for the compression sidecar with deployment and tuning instructions.

* **Tests**
  * Added unit tests for compression service behavior.

* **Chores**
  * Added Docker deployment configuration for the compression sidecar service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->