### PR TITLE
Fix/composite fk link

### DIFF
--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -124,11 +124,15 @@ router.get(
         throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
       }
 
+      const { column, value } = validation.data;
+      const columns = Array.isArray(column) ? column : [column];
+      const values = Array.isArray(value) ? value : [value];
+
       const record = await recordsService.lookupRecord(
         schemaName,
         req.params.tableName,
-        validation.data.column,
-        validation.data.value
+        columns,
+        values
       );
 
       successResponse(res, record);

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -76,19 +76,32 @@ export class AdminRecordService {
   async lookupRecord(
     schemaName: string,
     tableName: string,
-    columnName: string,
-    value: string
+    columns: string[],
+    values: string[]
   ): Promise<DatabaseRecord | null> {
     validateTableName(tableName);
 
+    if (columns.length === 0 || columns.length !== values.length) {
+      throw new AppError(
+        'Columns and values must have the same non-zero length',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, columnName);
+      for (const col of columns) {
+        this.assertColumnExists(metadata, col);
+      }
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const whereClauses = columns.map(
+        (col, i) => `${quoteIdentifier(col)} = $${i + 1}`
+      );
       const result = await client.query<DatabaseRecord>(
-        `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
-        [value]
+        `SELECT * FROM ${qualifiedTableName} WHERE ${whereClauses.join(' AND ')} LIMIT 1`,
+        values
       );
 
       return result.rows[0] ?? null;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -96,9 +96,7 @@ export class AdminRecordService {
       }
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-      const whereClauses = columns.map(
-        (col, i) => `${quoteIdentifier(col)} = $${i + 1}`
-      );
+      const whereClauses = columns.map((col, i) => `${quoteIdentifier(col)} = $${i + 1}`);
       const result = await client.query<DatabaseRecord>(
         `SELECT * FROM ${qualifiedTableName} WHERE ${whereClauses.join(' AND ')} LIMIT 1`,
         values

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -187,36 +187,43 @@ export class DatabaseAdvanceService {
     // Export foreign key constraints
     const foreignKeysResult = await client.query(
       `
-      SELECT DISTINCT
-        'ALTER TABLE ' || quote_ident(tc.table_name) ||
-        ' ADD CONSTRAINT ' || quote_ident(tc.constraint_name) ||
-        ' FOREIGN KEY (' || quote_ident(kcu.column_name) || ')' ||
-        ' REFERENCES ' || quote_ident(ccu.table_name) ||
-        ' (' || quote_ident(ccu.column_name) || ')' ||
+      SELECT
+        'ALTER TABLE ' || quote_ident(ct.relname) ||
+        ' ADD CONSTRAINT ' || quote_ident(c.conname) ||
+        ' FOREIGN KEY (' || string_agg(quote_ident(a1.attname), ', ' ORDER BY u.pos) || ')' ||
+        ' REFERENCES ' || quote_ident(cf.relname) ||
+        ' (' || string_agg(quote_ident(a2.attname), ', ' ORDER BY u.pos) || ')' ||
         CASE
-          WHEN rc.delete_rule != 'NO ACTION' THEN ' ON DELETE ' || rc.delete_rule
+          WHEN c.confdeltype = 'c' THEN ' ON DELETE CASCADE'
+          WHEN c.confdeltype = 'n' THEN ' ON DELETE SET NULL'
+          WHEN c.confdeltype = 'r' THEN ' ON DELETE RESTRICT'
+          WHEN c.confdeltype = 'd' THEN ' ON DELETE SET DEFAULT'
           ELSE ''
         END ||
         CASE
-          WHEN rc.update_rule != 'NO ACTION' THEN ' ON UPDATE ' || rc.update_rule
+          WHEN c.confupdtype = 'c' THEN ' ON UPDATE CASCADE'
+          WHEN c.confupdtype = 'n' THEN ' ON UPDATE SET NULL'
+          WHEN c.confupdtype = 'r' THEN ' ON UPDATE RESTRICT'
+          WHEN c.confupdtype = 'd' THEN ' ON UPDATE SET DEFAULT'
           ELSE ''
         END || ';' as fk_statement,
-        tc.constraint_name
-      FROM information_schema.table_constraints AS tc
-      JOIN information_schema.key_column_usage AS kcu
-        ON tc.constraint_name = kcu.constraint_name
-        AND tc.table_schema = kcu.table_schema
-        AND kcu.table_name = tc.table_name
-      JOIN information_schema.constraint_column_usage AS ccu
-        ON ccu.constraint_name = tc.constraint_name
-        AND ccu.table_schema = tc.table_schema
-      LEFT JOIN information_schema.referential_constraints AS rc
-        ON tc.constraint_name = rc.constraint_name
-        AND tc.table_schema = rc.constraint_schema
-      WHERE tc.constraint_type = 'FOREIGN KEY'
-      AND tc.table_name = $1
-      AND tc.table_schema = 'public'
-      ORDER BY tc.constraint_name
+        c.conname as constraint_name
+      FROM pg_catalog.pg_constraint c
+      JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+      JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+      JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+      JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+      CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+        WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+      JOIN pg_catalog.pg_attribute a1
+        ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+      JOIN pg_catalog.pg_attribute a2
+        ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+      WHERE c.contype = 'f'
+        AND nt.nspname = 'public'
+        AND ct.relname = $1
+      GROUP BY c.conname, ct.relname, nf.nspname, cf.relname, c.confdeltype, c.confupdtype
+      ORDER BY c.conname
     `,
       [table]
     );
@@ -546,28 +553,37 @@ export class DatabaseAdvanceService {
           // Get foreign keys
           const foreignKeysResult = await client.query(
             `
-            SELECT DISTINCT
-              tc.constraint_name as "constraintName",
-              kcu.column_name as "columnName",
-              ccu.table_name as "foreignTableName",
-              ccu.column_name as "foreignColumnName",
-              rc.delete_rule as "deleteRule",
-              rc.update_rule as "updateRule"
-            FROM information_schema.table_constraints AS tc
-            JOIN information_schema.key_column_usage AS kcu
-              ON tc.constraint_name = kcu.constraint_name
-              AND tc.table_schema = kcu.table_schema
-              AND kcu.table_name = tc.table_name
-            JOIN information_schema.constraint_column_usage AS ccu
-              ON ccu.constraint_name = tc.constraint_name
-              AND ccu.table_schema = tc.table_schema
-            LEFT JOIN information_schema.referential_constraints AS rc
-              ON tc.constraint_name = rc.constraint_name
-              AND tc.table_schema = rc.constraint_schema
-            WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_name = $1
-            AND tc.table_schema = 'public'
-            ORDER BY "constraintName", "columnName"
+            SELECT
+              c.conname as "constraintName",
+              a1.attname as "columnName",
+              cf.relname as "foreignTableName",
+              a2.attname as "foreignColumnName",
+              u.pos as "ordinalPosition",
+              CASE c.confdeltype
+                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+                WHEN 'd' THEN 'SET DEFAULT'
+              END as "deleteRule",
+              CASE c.confupdtype
+                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+                WHEN 'd' THEN 'SET DEFAULT'
+              END as "updateRule"
+            FROM pg_catalog.pg_constraint c
+            JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+            JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+            JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+            JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+            CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+              WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+            JOIN pg_catalog.pg_attribute a1
+              ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+            JOIN pg_catalog.pg_attribute a2
+              ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+            WHERE c.contype = 'f'
+              AND nt.nspname = 'public'
+              AND ct.relname = $1
+            ORDER BY c.conname, u.pos
           `,
             [table]
           );

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -191,7 +191,7 @@ export class DatabaseAdvanceService {
         'ALTER TABLE ' || quote_ident(ct.relname) ||
         ' ADD CONSTRAINT ' || quote_ident(c.conname) ||
         ' FOREIGN KEY (' || string_agg(quote_ident(a1.attname), ', ' ORDER BY u.pos) || ')' ||
-        ' REFERENCES ' || quote_ident(cf.relname) ||
+        ' REFERENCES ' || CASE WHEN nf.nspname = 'public' THEN quote_ident(cf.relname) ELSE quote_ident(nf.nspname) || '.' || quote_ident(cf.relname) END ||
         ' (' || string_agg(quote_ident(a2.attname), ', ' ORDER BY u.pos) || ')' ||
         CASE
           WHEN c.confdeltype = 'c' THEN ' ON DELETE CASCADE'
@@ -556,7 +556,7 @@ export class DatabaseAdvanceService {
             SELECT
               c.conname as "constraintName",
               a1.attname as "columnName",
-              cf.relname as "foreignTableName",
+              CASE WHEN nf.nspname = 'public' THEN cf.relname ELSE nf.nspname || '.' || cf.relname END as "foreignTableName",
               a2.attname as "foreignColumnName",
               u.pos as "ordinalPosition",
               CASE c.confdeltype

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/utils/errors.js';
@@ -811,7 +812,12 @@ export class DatabaseTableService {
     const sourceCols = fk.referenceColumns.map((r) => r.sourceColumn);
     const refCols = fk.referenceColumns.map((r) => r.referenceColumn);
     const safeTableName = fk.referenceTable.replace(/\./g, '_');
-    const constraintName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
+    const baseName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
+    const MAX_IDENTIFIER_LENGTH = 63;
+    const constraintName =
+      baseName.length > MAX_IDENTIFIER_LENGTH
+        ? `${baseName.slice(0, MAX_IDENTIFIER_LENGTH - 9)}_${createHash('sha256').update(baseName).digest('hex').slice(0, 8)}`
+        : baseName;
     const onDelete = fk.onDelete || 'RESTRICT';
     const onUpdate = fk.onUpdate || 'RESTRICT';
 

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -524,10 +524,12 @@ export class DatabaseTableService {
           // Execute operations
 
           // Drop foreign key constraints
+          const droppedConstraints = new Set<string>();
           if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
             for (const col of dropForeignKeys) {
               const constraintName = foreignKeyMap.get(col)?.constraint_name;
-              if (constraintName) {
+              if (constraintName && !droppedConstraints.has(constraintName)) {
+                droppedConstraints.add(constraintName);
                 await client.query(
                   `
                   ALTER TABLE ${safeQualifiedTableName}

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -804,18 +804,24 @@ export class DatabaseTableService {
     if (!col.foreignKey) {
       return '';
     }
-    // Store foreign_key in a const to avoid repeated non-null assertions
     const fk = col.foreignKey;
-    // Use "auth_users" in constraint name for auth.users references
+    if (!fk.referenceColumns || fk.referenceColumns.length === 0) {
+      return '';
+    }
+    const sourceCols = fk.referenceColumns.map((r) => r.sourceColumn);
+    const refCols = fk.referenceColumns.map((r) => r.referenceColumn);
     const safeTableName = fk.referenceTable.replace(/\./g, '_');
-    const constraintName = `fk_${col.columnName}_${safeTableName}_${fk.referenceColumn}`;
+    const constraintName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
     const onDelete = fk.onDelete || 'RESTRICT';
     const onUpdate = fk.onUpdate || 'RESTRICT';
 
+    const sourcePart = sourceCols.map((c) => this.quoteIdentifier(c)).join(', ');
+    const refPart = refCols.map((c) => this.quoteIdentifier(c)).join(', ');
+
     if (include_source_column) {
-      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} FOREIGN KEY (${this.quoteIdentifier(col.columnName)}) REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${this.quoteIdentifier(fk.referenceColumn)}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
+      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} FOREIGN KEY (${sourcePart}) REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${refPart}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
     } else {
-      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${this.quoteIdentifier(fk.referenceColumn)}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
+      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${refPart}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
     }
   }
 
@@ -831,42 +837,81 @@ export class DatabaseTableService {
           ccu.table_schema AS foreign_schema,
           ccu.table_name AS foreign_table,
           ccu.column_name AS foreign_column,
+          kcu.ordinal_position,
           rc.delete_rule as on_delete,
           rc.update_rule as on_update
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu
           ON tc.constraint_name = kcu.constraint_name
           AND tc.table_schema = kcu.table_schema
-        JOIN information_schema.constraint_column_usage AS ccu
-          ON ccu.constraint_name = tc.constraint_name
+        JOIN information_schema.key_column_usage AS ccu
+          ON tc.unique_constraint_name = ccu.constraint_name
+          AND kcu.ordinal_position = ccu.ordinal_position
         JOIN information_schema.referential_constraints AS rc
           ON rc.constraint_name = tc.constraint_name
           AND rc.constraint_schema = tc.table_schema
         WHERE tc.constraint_type = 'FOREIGN KEY'
         AND tc.table_schema = $1
         AND tc.table_name = $2
+        ORDER BY tc.constraint_name, kcu.ordinal_position
       `,
       [schemaName, table]
     );
 
     const foreignKeys = result.rows;
 
-    // Create a map of column names to their foreign key info
-    const foreignKeyMap = new Map<string, ForeignKeyInfo>();
-    foreignKeys.forEach((fk: ForeignKeyRow) => {
-      // Prefix table name with schema if not public (e.g., "auth.users")
+    // Group rows by constraint_name, then map each source column to its FK info
+    const constraintGroups = new Map<string, {
+      constraintName: string;
+      referenceTable: string;
+      fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
+      onDelete: string;
+      onUpdate: string;
+    }>();
+
+    for (const fk of foreignKeys as ForeignKeyRow[]) {
       const referenceTable =
         fk.foreign_schema !== 'public'
           ? `${fk.foreign_schema}.${fk.foreign_table}`
           : fk.foreign_table;
-      foreignKeyMap.set(fk.from_column, {
-        constraint_name: fk.constraint_name,
-        referenceTable,
-        referenceColumn: fk.foreign_column,
-        onDelete: fk.on_delete as OnDeleteActionSchema,
-        onUpdate: fk.on_update as OnUpdateActionSchema,
-      });
-    });
+
+      let group = constraintGroups.get(fk.constraint_name);
+      if (!group) {
+        group = {
+          constraintName: fk.constraint_name,
+          referenceTable,
+          fromColumns: [],
+          onDelete: fk.on_delete,
+          onUpdate: fk.on_update,
+        };
+        constraintGroups.set(fk.constraint_name, group);
+      }
+      group.fromColumns.push({ name: fk.from_column, foreignColumn: fk.foreign_column, ordinal: fk.ordinal_position });
+    }
+
+    const foreignKeyMap = new Map<string, ForeignKeyInfo>();
+
+    for (const group of constraintGroups.values()) {
+      group.fromColumns.sort((a, b) => a.ordinal - b.ordinal);
+
+      const referenceColumns = group.fromColumns.map((c) => ({
+        sourceColumn: c.name,
+        referenceColumn: c.foreignColumn,
+      }));
+
+      const info: ForeignKeyInfo = {
+        constraint_name: group.constraintName,
+        referenceTable: group.referenceTable,
+        referenceColumns,
+        onDelete: group.onDelete as OnDeleteActionSchema,
+        onUpdate: group.onUpdate as OnUpdateActionSchema,
+      };
+
+      for (const c of group.fromColumns) {
+        foreignKeyMap.set(c.name, { ...info });
+      }
+    }
+
     return foreignKeyMap;
   }
 }

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -832,28 +832,37 @@ export class DatabaseTableService {
     const result = await this.getPool().query(
       `
         SELECT
-          tc.constraint_name,
-          kcu.column_name as from_column,
-          ccu.table_schema AS foreign_schema,
-          ccu.table_name AS foreign_table,
-          ccu.column_name AS foreign_column,
-          kcu.ordinal_position,
-          rc.delete_rule as on_delete,
-          rc.update_rule as on_update
-        FROM information_schema.table_constraints AS tc
-        JOIN information_schema.key_column_usage AS kcu
-          ON tc.constraint_name = kcu.constraint_name
-          AND tc.table_schema = kcu.table_schema
-        JOIN information_schema.key_column_usage AS ccu
-          ON tc.unique_constraint_name = ccu.constraint_name
-          AND kcu.ordinal_position = ccu.ordinal_position
-        JOIN information_schema.referential_constraints AS rc
-          ON rc.constraint_name = tc.constraint_name
-          AND rc.constraint_schema = tc.table_schema
-        WHERE tc.constraint_type = 'FOREIGN KEY'
-        AND tc.table_schema = $1
-        AND tc.table_name = $2
-        ORDER BY tc.constraint_name, kcu.ordinal_position
+          c.conname AS constraint_name,
+          a1.attname AS from_column,
+          nf.nspname AS foreign_schema,
+          cf.relname AS foreign_table,
+          a2.attname AS foreign_column,
+          u.pos AS ordinal_position,
+          CASE c.confdeltype
+            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+            WHEN 'd' THEN 'SET DEFAULT'
+          END AS on_delete,
+          CASE c.confupdtype
+            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+            WHEN 'd' THEN 'SET DEFAULT'
+          END AS on_update
+        FROM pg_catalog.pg_constraint c
+        JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+        JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+        JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+        JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+        CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+          WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+        JOIN pg_catalog.pg_attribute a1
+          ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+        JOIN pg_catalog.pg_attribute a2
+          ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+        WHERE c.contype = 'f'
+          AND nt.nspname = $1
+          AND ct.relname = $2
+        ORDER BY c.conname, u.pos
       `,
       [schemaName, table]
     );
@@ -861,13 +870,16 @@ export class DatabaseTableService {
     const foreignKeys = result.rows;
 
     // Group rows by constraint_name, then map each source column to its FK info
-    const constraintGroups = new Map<string, {
-      constraintName: string;
-      referenceTable: string;
-      fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
-      onDelete: string;
-      onUpdate: string;
-    }>();
+    const constraintGroups = new Map<
+      string,
+      {
+        constraintName: string;
+        referenceTable: string;
+        fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
+        onDelete: string;
+        onUpdate: string;
+      }
+    >();
 
     for (const fk of foreignKeys as ForeignKeyRow[]) {
       const referenceTable =
@@ -886,7 +898,11 @@ export class DatabaseTableService {
         };
         constraintGroups.set(fk.constraint_name, group);
       }
-      group.fromColumns.push({ name: fk.from_column, foreignColumn: fk.foreign_column, ordinal: fk.ordinal_position });
+      group.fromColumns.push({
+        name: fk.from_column,
+        foreignColumn: fk.foreign_column,
+        ordinal: fk.ordinal_position,
+      });
     }
 
     const foreignKeyMap = new Map<string, ForeignKeyInfo>();

--- a/backend/src/types/database.ts
+++ b/backend/src/types/database.ts
@@ -105,6 +105,7 @@ export interface ForeignKeyRow {
   foreign_schema: string;
   foreign_table: string;
   foreign_column: string;
+  ordinal_position: number;
   on_delete: string;
   on_update: string;
 }

--- a/backend/tests/local/test-fk-errors.sh
+++ b/backend/tests/local/test-fk-errors.sh
@@ -61,20 +61,20 @@ main_test() {
     
     # Test our error handling
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"fake_table\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"fake_table\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Non-existent table → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumn\":\"name\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"name\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Type mismatch → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"columnName\":\"cat_id\",\"foreignKey\":{\"referenceTable\":\"fake_cats\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"columnName\":\"cat_id\",\"foreignKey\":{\"referenceTable\":\"fake_cats\",\"referenceColumns\":[{\"sourceColumn\":\"cat_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "New column with non-existent table → 400" 400
     
     # Valid FK should work
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Valid FK constraint → 200" 200
     
     # Summary

--- a/backend/tests/unit/database-fkey-composite.test.ts
+++ b/backend/tests/unit/database-fkey-composite.test.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/utils/errors';
+
+// ---------------------------------------------------------------------------
+// Mocks – shared across both describe blocks
+// ---------------------------------------------------------------------------
+const { poolQueryMock, connectMock, clientQueryMock, releaseMock } = vi.hoisted(() => ({
+  poolQueryMock: vi.fn(),
+  connectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  releaseMock: vi.fn(),
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        query: poolQueryMock,
+        connect: connectMock,
+      })),
+    })),
+    clearColumnTypeCache: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+import { AdminRecordService } from '../../src/services/database/admin-record.service';
+import { DatabaseTableService } from '../../src/services/database/database-table.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeService() {
+  return DatabaseTableService.getInstance();
+}
+
+function makeAdminService() {
+  return AdminRecordService.getInstance();
+}
+
+// ---------------------------------------------------------------------------
+// Tests – getFkeyConstraints
+// ---------------------------------------------------------------------------
+describe('DatabaseTableService – getFkeyConstraints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('correctly pairs source and reference columns in a composite FK (positional join)', async () => {
+    const fkRows = [
+      {
+        constraint_name: 'fk_composite_test_ref_composite_tenant_id_item_id',
+        from_column: 'tenant_id',
+        foreign_schema: 'public',
+        foreign_table: 'ref_composite',
+        foreign_column: 'tenant_id',
+        ordinal_position: 1,
+        on_delete: 'NO ACTION',
+        on_update: 'CASCADE',
+      },
+      {
+        constraint_name: 'fk_composite_test_ref_composite_tenant_id_item_id',
+        from_column: 'item_id',
+        foreign_schema: 'public',
+        foreign_table: 'ref_composite',
+        foreign_column: 'item_id',
+        ordinal_position: 2,
+        on_delete: 'NO ACTION',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'composite_test');
+
+    expect(map.size).toBe(2);
+
+    // Each source column should map to the full composite FK info
+    for (const col of ['tenant_id', 'item_id']) {
+      const entry = map.get(col);
+      expect(entry).toBeDefined();
+      expect(entry!.constraint_name).toBe('fk_composite_test_ref_composite_tenant_id_item_id');
+      expect(entry!.referenceTable).toBe('ref_composite');
+      expect(entry!.referenceColumns).toHaveLength(2);
+      expect(entry!.referenceColumns[0]).toEqual({
+        sourceColumn: 'tenant_id',
+        referenceColumn: 'tenant_id',
+      });
+      expect(entry!.referenceColumns[1]).toEqual({
+        sourceColumn: 'item_id',
+        referenceColumn: 'item_id',
+      });
+    }
+  });
+
+  it('does not cross-join columns when reference column values are duplicated across tuples', async () => {
+    // Simulate two rows in the referenced table that share a common column value:
+    //   (tenant_a, item_1)
+    //   (tenant_a, item_2)
+    // The positional join must pair tenant_id→tenant_id and item_id→item_id,
+    // never tenant_id→item_id.
+    const fkRows = [
+      {
+        constraint_name: 'fk_child_parent_tenant_id_item_id',
+        from_column: 'tenant_id',
+        foreign_schema: 'public',
+        foreign_table: 'parent_composite',
+        foreign_column: 'tenant_id',
+        ordinal_position: 1,
+        on_delete: 'RESTRICT',
+        on_update: 'CASCADE',
+      },
+      {
+        constraint_name: 'fk_child_parent_tenant_id_item_id',
+        from_column: 'item_id',
+        foreign_schema: 'public',
+        foreign_table: 'parent_composite',
+        foreign_column: 'item_id',
+        ordinal_position: 2,
+        on_delete: 'RESTRICT',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'child');
+
+    const tenantEntry = map.get('tenant_id');
+    const itemEntry = map.get('item_id');
+
+    expect(tenantEntry).toBeDefined();
+    expect(itemEntry).toBeDefined();
+
+    // Both entries must carry the same full referenceColumns array
+    const expectedPairs = [
+      { sourceColumn: 'tenant_id', referenceColumn: 'tenant_id' },
+      { sourceColumn: 'item_id', referenceColumn: 'item_id' },
+    ];
+
+    expect(tenantEntry!.referenceColumns).toEqual(expectedPairs);
+    expect(itemEntry!.referenceColumns).toEqual(expectedPairs);
+  });
+
+  it('handles single-column FKs without breaking', async () => {
+    const fkRows = [
+      {
+        constraint_name: 'fk_orders_user_id',
+        from_column: 'user_id',
+        foreign_schema: 'public',
+        foreign_table: 'users',
+        foreign_column: 'id',
+        ordinal_position: 1,
+        on_delete: 'CASCADE',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'orders');
+
+    expect(map.size).toBe(1);
+    const entry = map.get('user_id');
+    expect(entry!.referenceColumns).toHaveLength(1);
+    expect(entry!.referenceColumns[0]).toEqual({
+      sourceColumn: 'user_id',
+      referenceColumn: 'id',
+    });
+    expect(entry!.referenceTable).toBe('users');
+    expect(entry!.onDelete).toBe('CASCADE');
+    expect(entry!.onUpdate).toBe('CASCADE');
+  });
+
+  it('returns empty map when table has no foreign keys', async () => {
+    poolQueryMock.mockResolvedValueOnce({ rows: [] });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'no_fk_table');
+
+    expect(map.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests – lookupRecord (multi-column)
+// ---------------------------------------------------------------------------
+describe('AdminRecordService – lookupRecord (composite FK)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: releaseMock,
+    });
+  });
+
+  it('builds multi-column WHERE clause and returns the correct record', async () => {
+    // Simulate metadata query + lookup query
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return {
+          rows: [
+            {
+              tenant_id: 'tenant_a',
+              item_id: 'item_2',
+              label: 'item A2',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'item_2']
+    );
+
+    // Verify the correct row was returned
+    expect(result).toEqual({
+      tenant_id: 'tenant_a',
+      item_id: 'item_2',
+      label: 'item A2',
+    });
+
+    // Verify the SQL uses multi-column WHERE
+    const dataQueryCall = clientQueryMock.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('SELECT * FROM')
+    );
+    expect(dataQueryCall).toBeDefined();
+    expect(dataQueryCall![0] as string).toMatch(
+      /WHERE\s+"tenant_id"\s*=\s*\$1\s+AND\s+"item_id"\s*=\s*\$2\s+LIMIT\s+1/i
+    );
+    expect(dataQueryCall![1]).toEqual(['tenant_a', 'item_2']);
+  });
+
+  it('returns null when no row matches the composite key', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'nonexistent']
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('throws when columns and values have mismatched lengths', async () => {
+    const service = makeAdminService();
+
+    await expect(
+      service.lookupRecord('public', 't', ['tenant_id', 'item_id'], ['tenant_a'])
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('correctly distinguishes between rows that share a column value', async () => {
+    // Two rows share the same tenant_id but have different item_ids.
+    // Lookup by (tenant_a, item_1) must return the first row, not the second.
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return {
+          rows: [
+            {
+              tenant_id: 'tenant_a',
+              item_id: 'item_1',
+              label: 'item A1',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'item_1']
+    );
+
+    expect(result).toEqual({
+      tenant_id: 'tenant_a',
+      item_id: 'item_1',
+      label: 'item A1',
+    });
+
+    // Confirm the exact params passed to the data query
+    const dataQueryCall = clientQueryMock.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('SELECT * FROM')
+    );
+    expect(dataQueryCall![1]).toEqual(['tenant_a', 'item_1']);
+  });
+});

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -297,14 +297,26 @@ paths:
                         type: object
                         required:
                           - referenceTable
-                          - referenceColumn
+                          - referenceColumns
                         properties:
                           referenceTable:
                             type: string
                             description: Table being referenced
-                          referenceColumn:
-                            type: string
-                            description: Column being referenced
+                          referenceColumns:
+                            type: array
+                            description: Column mappings (source → reference)
+                            items:
+                              type: object
+                              required:
+                                - sourceColumn
+                                - referenceColumn
+                              properties:
+                                sourceColumn:
+                                  type: string
+                                  description: Column in the current table
+                                referenceColumn:
+                                  type: string
+                                  description: Column in the referenced table
                           onDelete:
                             type: string
                             enum: [CASCADE, SET NULL, NO ACTION, RESTRICT]

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -233,8 +233,9 @@ export function convertSchemaToColumns(
           value={String(props.row[col.columnName] || '')}
           foreignKey={{
             table: col.foreignKey?.referenceTable || '',
-            column: col.foreignKey?.referenceColumn || '',
+            columns: col.foreignKey?.referenceColumns || [],
           }}
+          row={props.row}
           onJumpToTable={onJumpToTable}
         />
       );

--- a/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
@@ -9,6 +9,7 @@ import {
   PopoverTrigger,
   ConvertedValue,
   DataGrid,
+  type DatabaseRecord,
 } from '#components';
 import { useTables } from '#features/database/hooks/useTables';
 import { useRecords } from '#features/database/hooks/useRecords';
@@ -25,12 +26,13 @@ interface ForeignKeyCellProps {
   value: string;
   foreignKey: {
     table: string;
-    column: string;
+    columns: { sourceColumn: string; referenceColumn: string }[];
   };
+  row: DatabaseRecord;
   onJumpToTable?: (tableName: string, schemaName?: string) => void;
 }
 
-export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyCellProps) {
+export function ForeignKeyCell({ value, foreignKey, row, onJumpToTable }: ForeignKeyCellProps) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const isAuthUsers = foreignKey.table === AUTH_USERS_TABLE;
@@ -48,21 +50,33 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
     return formatValueForDisplay(val);
   };
 
-  // Fetch the referenced record when popover opens
-  const searchValue = value ? renderValue(value) : '';
+  // Guard: all FK column entries must have both sourceColumn and referenceColumn
+  const hasValidColumns = foreignKey.columns.every(
+    (c) => c.sourceColumn && c.referenceColumn
+  );
 
-  // For auth.users, fetch user by ID
+  // Collect all FK column values from the current row for multi-column lookup
+  const lookupColumns = hasValidColumns ? foreignKey.columns.map((c) => c.referenceColumn) : [];
+  const lookupValues = hasValidColumns
+    ? foreignKey.columns.map((c) => {
+        const raw = row[c.sourceColumn];
+        return raw !== null && raw !== undefined ? String(raw) : '';
+      })
+    : [];
+
+  // For auth.users, fetch user by ID (single-column lookup)
+  const searchValue = value ? renderValue(value) : '';
   const { data: authUserData, error: authUserError } = useQuery({
     queryKey: ['user', searchValue],
     queryFn: () => getUser(searchValue),
     enabled: isAuthUsers && open && !!value,
   });
 
-  // For regular tables, fetch by foreign key
+  // For regular tables, fetch by foreign key (supports composite)
   const { data: recordData, error: recordError } = recordsHook.useRecordByForeignKey(
-    foreignKey.column,
-    searchValue,
-    !isAuthUsers && open && !!value
+    lookupColumns,
+    lookupValues,
+    !isAuthUsers && open && hasValidColumns && lookupValues.every((v) => !!v)
   );
 
   // Use appropriate data source based on table type
@@ -143,7 +157,7 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
                   Referencing record from
                 </span>
                 <TypeBadge
-                  type={`${foreignKey.table}.${foreignKey.column}`}
+                  type={`${foreignKey.table}.${foreignKey.columns.map((c) => c.referenceColumn).join(',')}`}
                   className="dark:bg-neutral-800"
                 />
               </div>

--- a/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
@@ -51,9 +51,7 @@ export function ForeignKeyCell({ value, foreignKey, row, onJumpToTable }: Foreig
   };
 
   // Guard: all FK column entries must have both sourceColumn and referenceColumn
-  const hasValidColumns = foreignKey.columns.every(
-    (c) => c.sourceColumn && c.referenceColumn
-  );
+  const hasValidColumns = foreignKey.columns.every((c) => c.sourceColumn && c.referenceColumn);
 
   // Collect all FK column values from the current row for multi-column lookup
   const lookupColumns = hasValidColumns ? foreignKey.columns.map((c) => c.referenceColumn) : [];

--- a/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
@@ -43,7 +43,7 @@ export function ForeignKeyPopover({
   const [newForeignKey, setNewForeignKey] = useState<TableFormForeignKeySchema>({
     columnName: '',
     referenceTable: '',
-    referenceColumn: '',
+    referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
     onDelete: 'NO ACTION',
     onUpdate: 'NO ACTION',
   });
@@ -57,7 +57,9 @@ export function ForeignKeyPopover({
       setNewForeignKey({
         columnName: initialValue.columnName,
         referenceTable: initialValue.referenceTable,
-        referenceColumn: initialValue.referenceColumn,
+        referenceColumns: initialValue.referenceColumns?.length
+          ? initialValue.referenceColumns
+          : [{ sourceColumn: initialValue.columnName, referenceColumn: '' }],
         onDelete: initialValue.onDelete,
         onUpdate: initialValue.onUpdate,
       });
@@ -66,7 +68,7 @@ export function ForeignKeyPopover({
       setNewForeignKey({
         columnName: '',
         referenceTable: '',
-        referenceColumn: '',
+        referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
         onDelete: 'NO ACTION',
         onUpdate: 'NO ACTION',
       });
@@ -110,16 +112,32 @@ export function ForeignKeyPopover({
 
   // Calculate if the button should be enabled
   const isAddButtonEnabled = Boolean(
-    newForeignKey.columnName && newForeignKey.referenceTable && newForeignKey.referenceColumn
+    newForeignKey.columnName &&
+      newForeignKey.referenceTable &&
+      newForeignKey.referenceColumns[0]?.referenceColumn
   );
 
   const handleAddForeignKey = () => {
-    if (newForeignKey.columnName && newForeignKey.referenceTable && newForeignKey.referenceColumn) {
-      onAddForeignKey(newForeignKey);
+    if (
+      newForeignKey.columnName &&
+      newForeignKey.referenceTable &&
+      newForeignKey.referenceColumns[0]?.referenceColumn
+    ) {
+      // Ensure sourceColumn matches the selected columnName for dashboard-created FKs
+      const fk = {
+        ...newForeignKey,
+        referenceColumns: [
+          {
+            sourceColumn: newForeignKey.columnName,
+            referenceColumn: newForeignKey.referenceColumns[0].referenceColumn,
+          },
+        ],
+      };
+      onAddForeignKey(fk);
       setNewForeignKey({
         columnName: '',
         referenceTable: '',
-        referenceColumn: '',
+        referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
         onDelete: 'NO ACTION',
         onUpdate: 'NO ACTION',
       });
@@ -131,7 +149,7 @@ export function ForeignKeyPopover({
     setNewForeignKey({
       columnName: '',
       referenceTable: '',
-      referenceColumn: '',
+      referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
       onDelete: 'NO ACTION',
       onUpdate: 'NO ACTION',
     });
@@ -199,7 +217,7 @@ export function ForeignKeyPopover({
                   setNewForeignKey((prev) => ({
                     ...prev,
                     referenceTable: value,
-                    referenceColumn: '', // Reset column when table changes
+                    referenceColumns: [{ sourceColumn: prev.columnName || '', referenceColumn: '' }],
                   }));
                 }}
               >
@@ -231,19 +249,22 @@ export function ForeignKeyPopover({
                 </Label>
                 <Select
                   key={`column-select-${newForeignKey.referenceTable}`}
-                  value={newForeignKey.referenceColumn}
+                  value={newForeignKey.referenceColumns[0]?.referenceColumn || ''}
                   onValueChange={(value) =>
-                    setNewForeignKey((prev) => ({ ...prev, referenceColumn: value }))
+                    setNewForeignKey((prev) => ({
+                      ...prev,
+                      referenceColumns: [{ ...prev.referenceColumns[0], referenceColumn: value }],
+                    }))
                   }
                 >
                   <SelectTrigger className="w-70 h-10">
                     <span
                       className={cn(
                         'text-sm text-muted-foreground dark:text-neutral-400',
-                        newForeignKey.referenceColumn && 'text-black dark:text-white'
+                        newForeignKey.referenceColumns[0]?.referenceColumn && 'text-black dark:text-white'
                       )}
                     >
-                      {newForeignKey.referenceColumn || 'Select column'}
+                      {newForeignKey.referenceColumns[0]?.referenceColumn || 'Select column'}
                     </span>
                   </SelectTrigger>
                   <SelectContent className="max-w-[360px]">

--- a/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
@@ -113,8 +113,8 @@ export function ForeignKeyPopover({
   // Calculate if the button should be enabled
   const isAddButtonEnabled = Boolean(
     newForeignKey.columnName &&
-      newForeignKey.referenceTable &&
-      newForeignKey.referenceColumns[0]?.referenceColumn
+    newForeignKey.referenceTable &&
+    newForeignKey.referenceColumns[0]?.referenceColumn
   );
 
   const handleAddForeignKey = () => {
@@ -217,7 +217,9 @@ export function ForeignKeyPopover({
                   setNewForeignKey((prev) => ({
                     ...prev,
                     referenceTable: value,
-                    referenceColumns: [{ sourceColumn: prev.columnName || '', referenceColumn: '' }],
+                    referenceColumns: [
+                      { sourceColumn: prev.columnName || '', referenceColumn: '' },
+                    ],
                   }));
                 }}
               >
@@ -261,7 +263,8 @@ export function ForeignKeyPopover({
                     <span
                       className={cn(
                         'text-sm text-muted-foreground dark:text-neutral-400',
-                        newForeignKey.referenceColumns[0]?.referenceColumn && 'text-black dark:text-white'
+                        newForeignKey.referenceColumns[0]?.referenceColumn &&
+                          'text-black dark:text-white'
                       )}
                     >
                       {newForeignKey.referenceColumns[0]?.referenceColumn || 'Select column'}

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -259,6 +259,7 @@ export function LinkRecordDialog({
               data={records}
               columns={columns}
               loading={isLoading && !records.length}
+              rowKeyGetter={getRowKey}
               selectedRows={selectedRows}
               onSelectedRowsChange={(newSelectedRows) => {
                 const selectedId = Array.from(newSelectedRows)[0];

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -33,16 +33,19 @@ import { parseDatabaseTableReference } from '#features/database/helpers';
 
 const PAGE_SIZE = 50;
 
+// Non-printable delimiter that cannot appear in PG text values
+const ROW_KEY_DELIMITER = '\x00';
+
 interface LinkRecordDialogProps {
   referenceTable: string;
-  referenceColumn: string;
+  fkColumns: { sourceColumn: string; referenceColumn: string }[];
   onSelectRecord: (record: DatabaseRecord) => void;
   children: (openDialog: () => void) => ReactNode;
 }
 
 export function LinkRecordDialog({
   referenceTable,
-  referenceColumn,
+  fkColumns,
   onSelectRecord,
   children,
 }: LinkRecordDialogProps) {
@@ -91,6 +94,24 @@ export function LinkRecordDialog({
     !isAuthUsers && open
   );
 
+  // Determine PK columns for stable row key derivation
+  const pkColumns = useMemo(() => {
+    if (!schema?.columns) {
+      return [] as string[];
+    }
+    const explicitPks = schema.columns.filter((c: any) => c.isPrimaryKey).map((c: any) => c.columnName);
+    return explicitPks.length > 0 ? explicitPks : ['id'];
+  }, [schema]);
+
+  // Build a stable encoded key from a record's PK column values.
+  // Uses \x00 as delimiter since PG text cannot contain null bytes.
+  const getRowKey = useCallback(
+    (record: any): string => {
+      return pkColumns.map((col) => String(record[col] ?? '')).join(ROW_KEY_DELIMITER);
+    },
+    [pkColumns]
+  );
+
   // Combine data from either source
   const recordsData = useMemo(() => {
     if (isAuthUsers) {
@@ -127,37 +148,25 @@ export function LinkRecordDialog({
   const totalRecords = recordsData?.totalRecords || 0;
   const totalPages = Math.ceil(totalRecords / PAGE_SIZE);
 
-  // Create selected rows set for highlighting
+  // Create selected rows set using stable PK-derived keys
   const selectedRows = useMemo(() => {
     if (!selectedRecord) {
       return new Set<string>();
     }
-    return new Set([String(selectedRecord.id || '')]);
-  }, [selectedRecord]);
+    return new Set([getRowKey(selectedRecord)]);
+  }, [selectedRecord, getRowKey]);
 
-  // Handle cell click to select record - only for reference column
+  // Handle cell click to select record
   const handleCellClick = useCallback(
     (args: CellClickArgs<DataGridRowType>, event: CellMouseEvent) => {
-      // Only allow selection when clicking on the reference column
-      if (args.column.key !== referenceColumn) {
-        // Prevent the default selection behavior for non-reference columns
-        event?.preventDefault();
-        event?.stopPropagation();
-        return;
-      }
-
-      const record = records.find((r: DatabaseRecord) => String(r.id) === String(args.row.id));
-      if (record) {
-        setSelectedRecord(record);
-      }
+      setSelectedRecord(args.row as DatabaseRecord);
     },
-    [records, referenceColumn]
+    []
   );
 
   // Convert schema to columns for the DataGrid with visual distinction
   const columns = useMemo(() => {
     const cols = convertSchemaToColumns(schema);
-    // Add visual indication for the reference column (clickable column)
     return cols.map((col) => {
       const baseCol = {
         ...col,
@@ -168,52 +177,23 @@ export function LinkRecordDialog({
       };
 
       // Helper function to render cell value properly based on type
-      // Accepts DatabaseRecord value type and converts to display string
       const renderCellValue = (
         value: ConvertedValue | { [key: string]: string }[],
         type: ColumnType | undefined
       ): string => {
-        // For JSON type, if value is already an object/array, stringify it for formatValueForDisplay
         if (type === ColumnType.JSON && value !== null && typeof value === 'object') {
           return formatValueForDisplay(JSON.stringify(value), type);
         }
         return formatValueForDisplay(value as ConvertedValue, type);
       };
 
-      if (col.key === referenceColumn) {
-        return {
-          ...baseCol,
-          renderCell: (props: RenderCellProps<DataGridRowType>) => {
-            const displayValue = renderCellValue(props.row[col.key], col.type);
-            return (
-              <div className="w-full h-full flex items-center cursor-pointer">
-                <span className="truncate font-medium" title={displayValue}>
-                  {displayValue}
-                </span>
-              </div>
-            );
-          },
-          renderHeaderCell: (props: RenderHeaderCellProps<DataGridRowType>) => (
-            <SortableHeaderRenderer
-              column={col}
-              sortDirection={props.sortDirection}
-              columnType={col.type}
-              showTypeBadge={true}
-              mutedHeader={false}
-            />
-          ),
-        };
-      }
-
       return {
         ...baseCol,
-        cellClass: 'link-record-dialog-disabled-cell',
         renderCell: (props: RenderCellProps<DataGridRowType>) => {
           const displayValue = renderCellValue(props.row[col.key], col.type);
           return (
-            <div className="w-full h-full flex items-center cursor-not-allowed relative">
-              <div className="absolute inset-0 pointer-events-none opacity-0 hover:opacity-10 bg-gray-200 dark:bg-gray-600 transition-opacity z-5" />
-              <span className="truncate dark:text-zinc-300 opacity-70" title={displayValue}>
+            <div className="w-full h-full flex items-center cursor-pointer">
+              <span className="truncate font-medium" title={displayValue}>
                 {displayValue}
               </span>
             </div>
@@ -225,12 +205,12 @@ export function LinkRecordDialog({
             sortDirection={props.sortDirection}
             columnType={col.type}
             showTypeBadge={true}
-            mutedHeader={true}
+            mutedHeader={false}
           />
         ),
       };
     });
-  }, [schema, referenceColumn]);
+  }, [schema]);
 
   const handleConfirmSelection = () => {
     if (selectedRecord) {
@@ -258,7 +238,7 @@ export function LinkRecordDialog({
                 Select a record to reference from
               </span>
               <TypeBadge
-                type={`${referenceTable}.${referenceColumn}`}
+                type={`${referenceTable}.${fkColumns.map((c) => c.referenceColumn).join(',')}`}
                 className="dark:bg-neutral-700"
               />
             </div>
@@ -283,10 +263,9 @@ export function LinkRecordDialog({
               loading={isLoading && !records.length}
               selectedRows={selectedRows}
               onSelectedRowsChange={(newSelectedRows) => {
-                // Handle selection changes from cell clicks
                 const selectedId = Array.from(newSelectedRows)[0];
                 if (selectedId) {
-                  const record = records.find((r: DatabaseRecord) => String(r.id) === selectedId);
+                  const record = records.find((r: any) => getRowKey(r) === selectedId);
                   if (record) {
                     setSelectedRecord(record);
                   }

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -12,7 +12,6 @@ import {
   DataGrid,
   DataGridEmptyState,
   TypeBadge,
-  type CellMouseEvent,
   type CellClickArgs,
   type RenderCellProps,
   type RenderHeaderCellProps,
@@ -99,7 +98,9 @@ export function LinkRecordDialog({
     if (!schema?.columns) {
       return [] as string[];
     }
-    const explicitPks = schema.columns.filter((c: any) => c.isPrimaryKey).map((c: any) => c.columnName);
+    const explicitPks = schema.columns
+      .filter((c: any) => c.isPrimaryKey)
+      .map((c: any) => c.columnName);
     return explicitPks.length > 0 ? explicitPks : ['id'];
   }, [schema]);
 
@@ -157,12 +158,9 @@ export function LinkRecordDialog({
   }, [selectedRecord, getRowKey]);
 
   // Handle cell click to select record
-  const handleCellClick = useCallback(
-    (args: CellClickArgs<DataGridRowType>, event: CellMouseEvent) => {
-      setSelectedRecord(args.row as DatabaseRecord);
-    },
-    []
-  );
+  const handleCellClick = useCallback((args: CellClickArgs<DataGridRowType>) => {
+    setSelectedRecord(args.row as DatabaseRecord);
+  }, []);
 
   // Convert schema to columns for the DataGrid with visual distinction
   const columns = useMemo(() => {

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -123,7 +123,12 @@ export function RecordFormDialog({
                       <div className="h-px w-full bg-[var(--alpha-8)]" />
                     </div>
                   )}
-                  <RecordFormField field={field} form={form} tableName={tableName} />
+                  <RecordFormField
+                    field={field}
+                    columns={displayFields}
+                    form={form}
+                    tableName={tableName}
+                  />
                 </div>
               ))}
             </div>

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -472,7 +472,8 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
             <span className="truncate">Has a Foreign Key relation to</span>
             <FormMetaBadge>
-              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
+              {field.foreignKey.referenceTable}.
+              {field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
             </FormMetaBadge>
           </div>
         )}

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { Control, Controller, FieldError, UseFormReturn } from 'react-hook-form';
+import { Control, Controller, FieldError, UseFormReturn, UseFormSetValue } from 'react-hook-form';
 import { Calendar, Clock, Link2, X } from 'lucide-react';
 import { Button, Input, cn } from '@insforge/ui';
 import {
@@ -244,10 +244,11 @@ function FieldLabel({ field, tableName }: { field: ColumnSchema; tableName: stri
 interface FieldWithLinkProps {
   field: ColumnSchema;
   control: Control<DatabaseRecord>;
+  setValue: UseFormSetValue<DatabaseRecord>;
   children: ReactNode;
 }
 
-function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
+function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProps) {
   if (!field.foreignKey) {
     return <>{children}</>;
   }
@@ -272,7 +273,14 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
                 type="button"
                 variant="secondary"
                 size="icon"
-                onClick={() => formField.onChange('')}
+                onClick={() => {
+                  formField.onChange('');
+                  for (const refCol of foreignKey.referenceColumns) {
+                    if (refCol.sourceColumn !== field.columnName) {
+                      setValue(refCol.sourceColumn, '');
+                    }
+                  }
+                }}
                 className="h-8 w-8 shrink-0 rounded border border-[var(--alpha-8)] bg-card p-0"
                 title="Clear linked record"
               >
@@ -281,14 +289,17 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
             )}
             <LinkRecordDialog
               referenceTable={foreignKey.referenceTable}
-              referenceColumn={foreignKey.referenceColumn}
+              fkColumns={foreignKey.referenceColumns}
               onSelectRecord={(record: DatabaseRecord) => {
-                const referenceValue = record[foreignKey.referenceColumn];
-                const result = convertValueForColumn(field.type, String(referenceValue || ''));
-                if (result.success) {
-                  formField.onChange(result.value);
-                } else {
-                  formField.onChange(String(referenceValue || ''));
+                for (const refCol of foreignKey.referenceColumns) {
+                  const refValue = record[refCol.referenceColumn];
+                  const converted = convertValueForColumn(field.type, String(refValue || ''));
+                  const val = converted.success ? converted.value : String(refValue || '');
+                  if (refCol.sourceColumn === field.columnName) {
+                    formField.onChange(val);
+                  } else {
+                    setValue(refCol.sourceColumn, val);
+                  }
                 }
               }}
             >
@@ -319,6 +330,7 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
 export function RecordFormField({ field, form, tableName }: RecordFormFieldProps) {
   const {
     control,
+    setValue,
     formState: { errors },
   } = form;
 
@@ -452,7 +464,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
       <FieldLabel field={field} tableName={tableName} />
 
       <div className="min-w-0 space-y-1">
-        <FieldWithLink field={field} control={control}>
+        <FieldWithLink field={field} control={control} setValue={setValue}>
           {renderInput()}
         </FieldWithLink>
 
@@ -460,7 +472,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
             <span className="truncate">Has a Foreign Key relation to</span>
             <FormMetaBadge>
-              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumn}
+              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
             </FormMetaBadge>
           </div>
         )}

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { Control, Controller, FieldError, UseFormReturn, UseFormSetValue } from 'react-hook-form';
 import { Calendar, Clock, Link2, X } from 'lucide-react';
 import { Button, Input, cn } from '@insforge/ui';
@@ -222,6 +222,7 @@ function FormJsonEditor({ value, nullable, onChange }: FormJsonEditorProps) {
 
 interface RecordFormFieldProps {
   field: ColumnSchema;
+  columns: ColumnSchema[];
   form: UseFormReturn<DatabaseRecord>;
   tableName: string;
 }
@@ -243,12 +244,22 @@ function FieldLabel({ field, tableName }: { field: ColumnSchema; tableName: stri
 
 interface FieldWithLinkProps {
   field: ColumnSchema;
+  columns: ColumnSchema[];
   control: Control<DatabaseRecord>;
   setValue: UseFormSetValue<DatabaseRecord>;
   children: ReactNode;
 }
 
-function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProps) {
+function FieldWithLink({ field, columns, control, setValue, children }: FieldWithLinkProps) {
+  // Build type lookup for all columns (needed for sibling FK column coercion)
+  const columnTypeMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const col of columns) {
+      map[col.columnName] = col.type;
+    }
+    return map;
+  }, [columns]);
+
   if (!field.foreignKey) {
     return <>{children}</>;
   }
@@ -293,8 +304,10 @@ function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProp
               onSelectRecord={(record: DatabaseRecord) => {
                 for (const refCol of foreignKey.referenceColumns) {
                   const refValue = record[refCol.referenceColumn];
-                  const converted = convertValueForColumn(field.type, String(refValue || ''));
-                  const val = converted.success ? converted.value : String(refValue || '');
+                  const rawValue = String(refValue ?? '');
+                  const sourceType = columnTypeMap[refCol.sourceColumn] || field.type;
+                  const converted = convertValueForColumn(sourceType, rawValue);
+                  const val = converted.success ? converted.value : rawValue;
                   if (refCol.sourceColumn === field.columnName) {
                     formField.onChange(val);
                   } else {
@@ -327,7 +340,7 @@ function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProp
   );
 }
 
-export function RecordFormField({ field, form, tableName }: RecordFormFieldProps) {
+export function RecordFormField({ field, columns, form, tableName }: RecordFormFieldProps) {
   const {
     control,
     setValue,
@@ -464,7 +477,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
       <FieldLabel field={field} tableName={tableName} />
 
       <div className="min-w-0 space-y-1">
-        <FieldWithLink field={field} control={control} setValue={setValue}>
+        <FieldWithLink field={field} columns={columns} control={control} setValue={setValue}>
           {renderInput()}
         </FieldWithLink>
 

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -588,7 +588,8 @@ export function TableForm({
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
                           {fk.referenceTable}.
-                          {fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
+                          {fk.referenceColumns.find((c) => c.sourceColumn === fk.columnName)
+                            ?.referenceColumn ?? ''}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -458,7 +458,24 @@ export function TableForm({
   };
 
   const handleRemoveForeignKey = (columnName?: string) => {
-    setForeignKeys(foreignKeys.filter((fk) => fk.columnName !== columnName));
+    const removed = foreignKeys.find((fk) => fk.columnName === columnName);
+    if (!removed) {
+      return;
+    }
+
+    // Removing any one column must remove all sibling columns atomically.
+    const constraintKey = removed.referenceColumns
+      .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
+      .join('\x01');
+
+    setForeignKeys(
+      foreignKeys.filter((fk) => {
+        const key = fk.referenceColumns
+          .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
+          .join('\x01');
+        return key !== constraintKey;
+      })
+    );
     setForeignKeysDirty(true);
   };
 

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -132,7 +132,9 @@ export function TableForm({
             columnName: col.columnName,
             referenceTable:
               referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumn: col.foreignKey?.referenceColumn ?? '',
+            referenceColumns: col.foreignKey?.referenceColumns ?? [
+              { sourceColumn: col.columnName, referenceColumn: '' },
+            ],
             onDelete: col.foreignKey?.onDelete || 'NO ACTION',
             onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
           };
@@ -222,7 +224,7 @@ export function TableForm({
           ...(foreignKey && {
             foreignKey: {
               referenceTable: foreignKey.referenceTable,
-              referenceColumn: foreignKey.referenceColumn,
+              referenceColumns: foreignKey.referenceColumns,
               onDelete: foreignKey.onDelete,
               onUpdate: foreignKey.onUpdate,
             },
@@ -327,7 +329,9 @@ export function TableForm({
             columnName: col.columnName,
             referenceTable:
               referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumn: col.foreignKey?.referenceColumn ?? '',
+            referenceColumns: col.foreignKey?.referenceColumns ?? [
+              { sourceColumn: col.columnName, referenceColumn: '' },
+            ],
             onDelete: col.foreignKey?.onDelete || 'NO ACTION',
             onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
           };
@@ -342,7 +346,7 @@ export function TableForm({
             columnName: fk.columnName,
             foreignKey: {
               referenceTable: fk.referenceTable,
-              referenceColumn: fk.referenceColumn,
+              referenceColumns: fk.referenceColumns,
               onDelete: fk.onDelete,
               onUpdate: fk.onUpdate,
             },
@@ -566,7 +570,7 @@ export function TableForm({
                         <span className="truncate">{fk.columnName}</span>
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
-                          {fk.referenceTable}.{fk.referenceColumn}
+                          {fk.referenceTable}.{fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -570,7 +570,8 @@ export function TableForm({
                         <span className="truncate">{fk.columnName}</span>
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
-                          {fk.referenceTable}.{fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
+                          {fk.referenceTable}.
+                          {fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -53,13 +53,14 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
     });
   };
 
-  // Hook to fetch a single record by foreign key value
-  const useRecordByForeignKey = (columnName: string, value: string, enabled = true) => {
+  // Hook to fetch a single record by foreign key value(s).
+  // Supports composite foreign keys via parallel arrays of columns and values.
+  const useRecordByForeignKey = (columns: string[], values: string[], enabled = true) => {
     return useQuery({
-      queryKey: ['records', schemaName, tableName, 'foreignKey', columnName, value],
+      queryKey: ['records', schemaName, tableName, 'foreignKey', ...columns, ...values],
       queryFn: () =>
-        recordService.getRecordByForeignKeyValue(tableName, columnName, value, schemaName),
-      enabled: enabled && !!tableName && !!columnName && !!value,
+        recordService.getRecordByForeignKeyValue(tableName, columns, values, schemaName),
+      enabled: enabled && !!tableName && columns.length > 0 && columns.length === values.length,
       staleTime: 30 * 1000,
     });
   };

--- a/packages/dashboard/src/features/database/schema.ts
+++ b/packages/dashboard/src/features/database/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { columnSchema, foreignKeySchema, foreignKeyReferenceSchema } from '@insforge/shared-schemas';
+import { columnSchema, foreignKeySchema } from '@insforge/shared-schemas';
 
 // Foreign key form schema — single-column FK creation from the UI
 // Uses referenceColumns array (always 1 entry for dashboard-created FKs)

--- a/packages/dashboard/src/features/database/schema.ts
+++ b/packages/dashboard/src/features/database/schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
-import { columnSchema, foreignKeySchema } from '@insforge/shared-schemas';
+import { columnSchema, foreignKeySchema, foreignKeyReferenceSchema } from '@insforge/shared-schemas';
 
-// Foreign key schema
+// Foreign key form schema — single-column FK creation from the UI
+// Uses referenceColumns array (always 1 entry for dashboard-created FKs)
 export const tableFormForeignKeySchema = foreignKeySchema.extend({
   columnName: z.string(),
 });

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -83,23 +83,28 @@ export class RecordService {
   }
 
   /**
-   * Get a single record by foreign key value.
-   * Specifically designed for foreign key lookups.
+   * Get a single record by foreign key value(s).
+   * Supports composite foreign keys via multiple columns/values.
    *
    * @param tableName - Name of the table to search in
-   * @param columnName - Name of the column to filter by
-   * @param value - Value to match
+   * @param columns - Column name(s) to filter by
+   * @param values - Value(s) to match (parallel array to columns)
    * @returns Single record or null if not found
    */
   async getRecordByForeignKeyValue(
     tableName: string,
-    columnName: string,
-    value: string,
+    columns: string[],
+    values: string[],
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    const params = new URLSearchParams({
-      column: columnName,
-      value,
+    if (columns.length === 0 || columns.length !== values.length) {
+      throw new Error('Columns and values must have the same non-zero length');
+    }
+
+    const params = new URLSearchParams();
+    columns.forEach((col, i) => {
+      params.append('column', col);
+      params.append('value', values[i]);
     });
 
     return apiClient.request(this.buildAdminRecordsPath(tableName, schemaName, '/lookup', params), {

--- a/packages/dashboard/src/features/database/templates/ai-chatbot.ts
+++ b/packages/dashboard/src/features/database/templates/ai-chatbot.ts
@@ -19,7 +19,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -66,7 +66,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'conversations',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'conversation_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -113,7 +113,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'messages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'message_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -126,7 +126,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -166,7 +166,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/crm-system.ts
+++ b/packages/dashboard/src/features/database/templates/crm-system.ts
@@ -80,7 +80,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'companies',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
           },
@@ -148,7 +148,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'companies',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -161,7 +161,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'contacts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
           },
@@ -222,7 +222,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'contacts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -235,7 +235,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'deals',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'deal_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
+++ b/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
@@ -95,7 +95,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: true,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -170,7 +170,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'customers',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -224,7 +224,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'orders',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'order_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -237,7 +237,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'products',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
             onDelete: 'RESTRICT',
             onUpdate: 'CASCADE',
           },
@@ -277,7 +277,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'products',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -290,7 +290,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'customers',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/instagram-clone.ts
+++ b/packages/dashboard/src/features/database/templates/instagram-clone.ts
@@ -18,7 +18,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -58,7 +58,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -71,7 +71,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -104,7 +104,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -117,7 +117,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -143,7 +143,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'follower_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -156,7 +156,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'following_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/notion-clone.ts
+++ b/packages/dashboard/src/features/database/templates/notion-clone.ts
@@ -25,7 +25,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'owner_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -65,7 +65,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'workspaces',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'workspace_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -78,7 +78,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'parent_page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -91,7 +91,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -166,7 +166,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -179,7 +179,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -212,7 +212,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -225,7 +225,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/reddit-clone.ts
+++ b/packages/dashboard/src/features/database/templates/reddit-clone.ts
@@ -39,7 +39,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -79,7 +79,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'communities',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -92,7 +92,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -160,7 +160,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -173,7 +173,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -186,7 +186,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'comments',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'parent_comment_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -233,7 +233,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -246,7 +246,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -259,7 +259,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'comments',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'comment_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -292,7 +292,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'communities',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -305,7 +305,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -319,14 +319,17 @@ export function SchemaVisualizer({
               },
             });
           } else {
-            // Regular table-to-table edge — use first reference column for handle
-            const firstRefCol = column.foreignKey.referenceColumns[0]?.referenceColumn || '';
+            // Regular table-to-table edge — match target column to the current source column
+            const matchingRef = column.foreignKey.referenceColumns.find(
+              (r) => r.sourceColumn === column.columnName
+            );
+            const targetHandle = `${matchingRef?.referenceColumn || ''}-target`;
             edges.push({
               id: edgeId,
               source: table.tableName,
               target: column.foreignKey.referenceTable,
               sourceHandle: `${column.columnName}-source`,
-              targetHandle: `${firstRefCol}-target`,
+              targetHandle,
               type: 'smoothstep',
               animated: true,
               style: { stroke: edgeColor, strokeWidth: 2, zIndex: 1000 },

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -228,14 +228,14 @@ export function SchemaVisualizer({
       table.columns.forEach((column) => {
         if (column.foreignKey) {
           const targetTable = column.foreignKey.referenceTable;
-          const targetColumn = column.foreignKey.referenceColumn;
-
-          if (!referencedColumnsByTable[targetTable]) {
-            referencedColumnsByTable[targetTable] = [];
-          }
-          if (!referencedColumnsByTable[targetTable].includes(targetColumn)) {
-            referencedColumnsByTable[targetTable].push(targetColumn);
-          }
+          column.foreignKey.referenceColumns.forEach((ref) => {
+            if (!referencedColumnsByTable[targetTable]) {
+              referencedColumnsByTable[targetTable] = [];
+            }
+            if (!referencedColumnsByTable[targetTable].includes(ref.referenceColumn)) {
+              referencedColumnsByTable[targetTable].push(ref.referenceColumn);
+            }
+          });
         }
       });
     });
@@ -268,7 +268,7 @@ export function SchemaVisualizer({
         (column) =>
           column.foreignKey &&
           column.foreignKey.referenceTable === 'auth.users' &&
-          column.foreignKey.referenceColumn === 'id'
+          column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id')
       )
     );
 
@@ -298,7 +298,7 @@ export function SchemaVisualizer({
           // Check if this is a reference to users.id
           const isAuthReference =
             column.foreignKey.referenceTable === 'auth.users' &&
-            column.foreignKey.referenceColumn === 'id';
+            column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id');
 
           const edgeId = `${table.tableName}-${column.columnName}-${column.foreignKey.referenceTable}`;
 
@@ -319,13 +319,14 @@ export function SchemaVisualizer({
               },
             });
           } else {
-            // Regular table-to-table edge
+            // Regular table-to-table edge — use first reference column for handle
+            const firstRefCol = column.foreignKey.referenceColumns[0]?.referenceColumn || '';
             edges.push({
               id: edgeId,
               source: table.tableName,
               target: column.foreignKey.referenceTable,
               sourceHandle: `${column.columnName}-source`,
-              targetHandle: `${column.foreignKey.referenceColumn}-target`,
+              targetHandle: `${firstRefCol}-target`,
               type: 'smoothstep',
               animated: true,
               style: { stroke: edgeColor, strokeWidth: 2, zIndex: 1000 },

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -275,10 +275,22 @@ export const adminTableRecordsListQuerySchema = z
     }
   );
 
-export const adminTableRecordLookupQuerySchema = z.object({
-  column: z.string().trim().min(1, 'Column is required'),
-  value: z.string(),
-});
+export const adminTableRecordLookupQuerySchema = z
+  .object({
+    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+  })
+  .refine(
+    (data) => {
+      const cols = Array.isArray(data.column) ? data.column : [data.column];
+      const vals = Array.isArray(data.value) ? data.value : [data.value];
+      return cols.length === vals.length;
+    },
+    {
+      message: 'column and value must have the same number of entries',
+      path: ['value'],
+    }
+  );
 
 export const adminTableRecordsCreateRequestSchema = z
   .array(adminTableRecordSchema)

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -277,8 +277,8 @@ export const adminTableRecordsListQuerySchema = z
 
 export const adminTableRecordLookupQuerySchema = z
   .object({
-    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
-    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
+    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
   })
   .refine(
     (data) => {

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -278,7 +278,7 @@ export const adminTableRecordsListQuerySchema = z
 export const adminTableRecordLookupQuerySchema = z
   .object({
     column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
-    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
+    value: z.union([z.string(), z.array(z.string()).min(1)]),
   })
   .refine(
     (data) => {

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -31,9 +31,14 @@ export const columnTypeSchema = z.enum([
   ColumnType.JSON,
 ]);
 
+export const foreignKeyReferenceSchema = z.object({
+  sourceColumn: z.string().min(1, 'Source column cannot be empty'),
+  referenceColumn: z.string().min(1, 'Reference column cannot be empty'),
+});
+
 export const foreignKeySchema = z.object({
   referenceTable: z.string().min(1, 'Target table cannot be empty'),
-  referenceColumn: z.string().min(1, 'Target column cannot be empty'),
+  referenceColumns: z.array(foreignKeyReferenceSchema).min(1, 'At least one column mapping is required'),
   onDelete: onDeleteActionSchema,
   onUpdate: onUpdateActionSchema,
 });
@@ -65,6 +70,7 @@ export const tableSchema = z.object({
 
 export type TableSchema = z.infer<typeof tableSchema>;
 export type ColumnSchema = z.infer<typeof columnSchema>;
+export type ForeignKeyReferenceSchema = z.infer<typeof foreignKeyReferenceSchema>;
 export type ForeignKeySchema = z.infer<typeof foreignKeySchema>;
 export type OnUpdateActionSchema = z.infer<typeof onUpdateActionSchema>;
 export type OnDeleteActionSchema = z.infer<typeof onDeleteActionSchema>;

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -38,7 +38,9 @@ export const foreignKeyReferenceSchema = z.object({
 
 export const foreignKeySchema = z.object({
   referenceTable: z.string().min(1, 'Target table cannot be empty'),
-  referenceColumns: z.array(foreignKeyReferenceSchema).min(1, 'At least one column mapping is required'),
+  referenceColumns: z
+    .array(foreignKeyReferenceSchema)
+    .min(1, 'At least one column mapping is required'),
   onDelete: onDeleteActionSchema,
   onUpdate: onUpdateActionSchema,
 });


### PR DESCRIPTION
## Summary
#closes #1571


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full composite foreign key support across the API and dashboard, fixing record linking, multi-column lookups, and constraint handling. Closes #1571.

- **New Features**
  - Backend: composite FK introspection/export via `pg_catalog` with positional pairing; DDL emits multi‑column keys and truncates long names with a short hash; exports and introspection preserve non‑public schema prefixes; dropping FKs runs once per composite constraint.
  - API: `GET /admin/records/:table/lookup` accepts multiple `column`/`value` pairs; route coerces single inputs to arrays; validation enforces min(1) and equal lengths.
  - Shared schemas: `foreignKey.referenceColumn` → `referenceColumns: [{ sourceColumn, referenceColumn }]`.
  - Dashboard: FK cell builds composite lookups from the current row; link dialog uses PK‑derived row keys and allows selection from any cell; record form sets/clears all source columns and coerces types per column (fixes falsy handling); table form removes all sibling FK columns together and preserves schema‑qualified refs; visualizer matches edges by `sourceColumn` to the correct target handle.
  - Tests: unit tests for ordered composite FK pairing and multi‑column record lookup.

- **Migration**
  - Schema: switch to `foreignKey.referenceColumns` (array). Example: `{ referenceTable: 'users', referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }] }`.
  - Lookup API: send parallel arrays or repeated params. Example: `?column=tenant_id&value=tenant_a&column=item_id&value=item_2`. Arrays must be non‑empty and aligned.

<sup>Written for commit d2f2e1c901bfa408488f486427caa787f498d109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composite foreign key support across the database table editor, record forms, and API
> - Replaces the single `referenceColumn` field with a `referenceColumns` array (`{ sourceColumn, referenceColumn }[]`) in [foreignKeySchema](https://github.com/InsForge/InsForge/pull/1572/files#diff-8bd8cbcb35fb597c551a0a0d1d48761f43428744b9f5e9c4e0014c951b00751f), propagating the change through the table designer, record form, visualizer, and all database templates.
> - Updates `DatabaseTableService.getFkeyConstraints` and `generateFkeyConstraintStatement` to read composite FK metadata from `pg_catalog` and emit multi-column `FOREIGN KEY` SQL; constraint names exceeding 63 chars are truncated with a SHA-256 hash suffix.
> - Updates `AdminRecordService.lookupRecord`, the `GET /records/lookup` endpoint, `RecordService.getRecordByForeignKeyValue`, and `useRecordByForeignKey` to accept arrays of columns and values, building an AND-combined WHERE clause for composite key lookups.
> - `ForeignKeyCell` and `LinkRecordDialog` now derive lookup columns and values from the current row across all FK columns, only firing queries when all values are present.
> - `RecordFormField`'s `FieldWithLink` atomically writes all mapped source columns (with type coercion) when a linked record is selected or cleared.
> - Risk: `foreignKeySchema` is a breaking schema change — any caller passing `referenceColumn` as a string will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2f2e1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Foreign-key relationships now support composite keys with multi-column mappings across the dashboard (linking, editing, display, and record linking).
  * Updated dashboard templates and schema visualization to use the new composite foreign-key format.

* **Bug Fixes**
  * Backend foreign-key constraint generation, metadata extraction, and admin record lookup now correctly handle composite keys and multi-column queries.
  * Made foreign-key drops idempotent during schema updates.

* **Tests**
  * Added unit coverage for composite foreign-key mapping and multi-column record lookup.
  * Updated local FK error-handling test payloads to the new request format.

* **Documentation**
  * Updated the API schema/OpenAPI for composite foreign-key requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->