### PR TITLE
fix: add body size cap to S3 CompleteMultipartUpload and centralize upload limits

### DIFF
--- a/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
@@ -46,8 +46,6 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
           requestId: req.s3Auth.requestId,
         }
       );
-      req.unpipe?.();
-      req.destroy?.();
       return;
     }
     chunks.push(b);

--- a/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
@@ -37,10 +37,15 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     const b = c as Buffer;
     received += b.length;
     if (received > MAX_COMPLETE_MPU_BODY_BYTES) {
-      sendS3Error(res, 'EntityTooLarge', 'CompleteMultipartUpload body exceeds maximum allowed size', {
-        resource: req.path,
-        requestId: req.s3Auth.requestId,
-      });
+      sendS3Error(
+        res,
+        'EntityTooLarge',
+        'CompleteMultipartUpload body exceeds maximum allowed size',
+        {
+          resource: req.path,
+          requestId: req.s3Auth.requestId,
+        }
+      );
       req.unpipe?.();
       req.destroy?.();
       return;

--- a/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
+++ b/backend/src/api/routes/s3-gateway/commands/complete-multipart-upload.ts
@@ -5,6 +5,8 @@ import { parseXml, toXml } from '../xml.js';
 import { sendS3Error } from '../errors.js';
 import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 
+const MAX_COMPLETE_MPU_BODY_BYTES = 1024 * 1024;
+
 const partSchema = z.object({
   PartNumber: z.coerce.number().int().positive().max(10_000),
   ETag: z.string().min(1),
@@ -30,8 +32,20 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   }
 
   const chunks: Buffer[] = [];
+  let received = 0;
   for await (const c of req) {
-    chunks.push(c as Buffer);
+    const b = c as Buffer;
+    received += b.length;
+    if (received > MAX_COMPLETE_MPU_BODY_BYTES) {
+      sendS3Error(res, 'EntityTooLarge', 'CompleteMultipartUpload body exceeds maximum allowed size', {
+        resource: req.path,
+        requestId: req.s3Auth.requestId,
+      });
+      req.unpipe?.();
+      req.destroy?.();
+      return;
+    }
+    chunks.push(b);
   }
 
   let parsed: unknown;

--- a/backend/src/api/routes/s3-gateway/commands/put-object.ts
+++ b/backend/src/api/routes/s3-gateway/commands/put-object.ts
@@ -8,17 +8,7 @@ import {
   AwsChunkedPayloadParser,
   ChunkSignatureV4Parser,
 } from '@/services/storage/s3-signature.js';
-
-const AWS_MAX_PUT_OBJECT_GB = 5;
-
-function capBytes(): number {
-  const override = Number(process.env.S3_PROTOCOL_MAX_OBJECT_SIZE_GB);
-  const effective =
-    Number.isFinite(override) && override > 0 && override < AWS_MAX_PUT_OBJECT_GB
-      ? override
-      : AWS_MAX_PUT_OBJECT_GB;
-  return effective * 1024 * 1024 * 1024;
-}
+import { appConfig } from '@/infra/config/app.config.js';
 
 /**
  * Transform that counts bytes and errors if it exceeds the cap. Used on the
@@ -124,7 +114,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
       ? plainLen
       : null;
 
-  const cap = capBytes();
+  const cap = appConfig.storage.maxS3UploadSize;
   if (contentLength !== null && contentLength > cap) {
     sendS3Error(res, 'EntityTooLarge', `Object too large: ${contentLength} > ${cap}`, {
       resource: req.path,

--- a/backend/src/api/routes/s3-gateway/commands/upload-part.ts
+++ b/backend/src/api/routes/s3-gateway/commands/upload-part.ts
@@ -10,6 +10,7 @@ import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
 import { appConfig } from '@/infra/config/app.config.js';
 
 const MAX_PART_NUMBER = 10_000;
+const AWS_S3_PER_PART_HARD_CAP = 5 * 1024 * 1024 * 1024;
 
 class ByteLimitStream extends Transform {
   private received = 0;
@@ -72,6 +73,7 @@ function parseDecodedLength(raw: unknown): number | null {
 export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
   const bucket = getS3Bucket(req);
   const key = getS3Key(req);
+  const partLimit = Math.min(appConfig.storage.maxS3UploadSize, AWS_S3_PER_PART_HARD_CAP);
 
   const partNumberRaw = req.query.partNumber;
   const uploadIdRaw = req.query.uploadId;
@@ -117,7 +119,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     });
     return;
   }
-  if (contentLength > appConfig.storage.maxS3UploadSize) {
+  if (contentLength > partLimit) {
     sendS3Error(res, 'EntityTooLarge', `Part too large: ${contentLength}`, {
       resource: req.path,
       requestId: req.s3Auth.requestId,
@@ -134,13 +136,13 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
       scope: req.s3Auth.scope,
       acceptTrailer: isSignedStreamTrailer,
     });
-    const limiter = new ByteLimitStream(appConfig.storage.maxS3UploadSize);
+    const limiter = new ByteLimitStream(partLimit);
     const coalesce = new MinChunkSizeStream(MIN_UPSTREAM_CHUNK_BYTES);
     req.pipe(parser).pipe(limiter).pipe(coalesce);
     body = coalesce;
   } else if (isUnsignedStreamTrailer) {
     const parser = new AwsChunkedPayloadParser();
-    const limiter = new ByteLimitStream(appConfig.storage.maxS3UploadSize);
+    const limiter = new ByteLimitStream(partLimit);
     const coalesce = new MinChunkSizeStream(MIN_UPSTREAM_CHUNK_BYTES);
     req.pipe(parser).pipe(limiter).pipe(coalesce);
     body = coalesce;

--- a/backend/src/api/routes/s3-gateway/commands/upload-part.ts
+++ b/backend/src/api/routes/s3-gateway/commands/upload-part.ts
@@ -7,8 +7,8 @@ import {
 } from '@/services/storage/s3-signature.js';
 import { sendS3Error, S3ProtocolError } from '../errors.js';
 import { S3GatewayRequest, getS3Bucket, getS3Key } from '../request.js';
+import { appConfig } from '@/infra/config/app.config.js';
 
-const MAX_PART_BYTES = 5 * 1024 * 1024 * 1024;
 const MAX_PART_NUMBER = 10_000;
 
 class ByteLimitStream extends Transform {
@@ -117,7 +117,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     });
     return;
   }
-  if (contentLength > MAX_PART_BYTES) {
+  if (contentLength > appConfig.storage.maxS3UploadSize) {
     sendS3Error(res, 'EntityTooLarge', `Part too large: ${contentLength}`, {
       resource: req.path,
       requestId: req.s3Auth.requestId,
@@ -134,13 +134,13 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
       scope: req.s3Auth.scope,
       acceptTrailer: isSignedStreamTrailer,
     });
-    const limiter = new ByteLimitStream(MAX_PART_BYTES);
+    const limiter = new ByteLimitStream(appConfig.storage.maxS3UploadSize);
     const coalesce = new MinChunkSizeStream(MIN_UPSTREAM_CHUNK_BYTES);
     req.pipe(parser).pipe(limiter).pipe(coalesce);
     body = coalesce;
   } else if (isUnsignedStreamTrailer) {
     const parser = new AwsChunkedPayloadParser();
-    const limiter = new ByteLimitStream(MAX_PART_BYTES);
+    const limiter = new ByteLimitStream(appConfig.storage.maxS3UploadSize);
     const coalesce = new MinChunkSizeStream(MIN_UPSTREAM_CHUNK_BYTES);
     req.pipe(parser).pipe(limiter).pipe(coalesce);
     body = coalesce;

--- a/backend/src/api/routes/s3-gateway/index.routes.ts
+++ b/backend/src/api/routes/s3-gateway/index.routes.ts
@@ -86,9 +86,18 @@ s3GatewayRouter.use((req, res, next) => {
 });
 
 // 3) Early Content-Length check for body-consuming operations.
+// For aws-chunked streaming uploads the wire Content-Length includes
+// chunk framing overhead; use x-amz-decoded-content-length instead.
 s3GatewayRouter.use((req: Request, res: Response, next) => {
+  const rawDecoded = req.headers['x-amz-decoded-content-length'];
+  const isStreaming =
+    typeof rawDecoded === 'string' && /^\d+$/.test(rawDecoded);
   const rawCl = req.headers['content-length'];
-  const contentLength = typeof rawCl === 'string' && /^\d+$/.test(rawCl) ? Number(rawCl) : null;
+  const contentLength = isStreaming
+    ? Number(rawDecoded)
+    : typeof rawCl === 'string' && /^\d+$/.test(rawCl)
+      ? Number(rawCl)
+      : null;
   if (contentLength === null || contentLength <= appConfig.storage.maxS3UploadSize) {
     next();
     return;

--- a/backend/src/api/routes/s3-gateway/index.routes.ts
+++ b/backend/src/api/routes/s3-gateway/index.routes.ts
@@ -88,8 +88,7 @@ s3GatewayRouter.use((req, res, next) => {
 // 3) Early Content-Length check for body-consuming operations.
 s3GatewayRouter.use((req: Request, res: Response, next) => {
   const rawCl = req.headers['content-length'];
-  const contentLength =
-    typeof rawCl === 'string' && /^\d+$/.test(rawCl) ? Number(rawCl) : null;
+  const contentLength = typeof rawCl === 'string' && /^\d+$/.test(rawCl) ? Number(rawCl) : null;
   if (contentLength === null || contentLength <= appConfig.storage.maxS3UploadSize) {
     next();
     return;
@@ -99,13 +98,17 @@ s3GatewayRouter.use((req: Request, res: Response, next) => {
   const q = new Set(Object.keys(req.query));
   const hasKey = p.replace(/^\/+/, '').includes('/');
   const isLargeBodyOp =
-    (m === 'PUT' && hasKey && !q.has('tagging') && !req.headers['x-amz-copy-source']) ||
-    (m === 'POST' && hasKey && q.has('uploadId'));
+    m === 'PUT' && hasKey && !q.has('tagging') && !req.headers['x-amz-copy-source'];
   if (isLargeBodyOp) {
-    sendS3Error(res, 'EntityTooLarge', `Object exceeds max upload size (${appConfig.storage.maxS3UploadSize} bytes)`, {
-      resource: req.path,
-      requestId: (req as S3AuthenticatedRequest).s3Auth?.requestId,
-    });
+    sendS3Error(
+      res,
+      'EntityTooLarge',
+      `Object exceeds max upload size (${appConfig.storage.maxS3UploadSize} bytes)`,
+      {
+        resource: req.path,
+        requestId: (req as S3AuthenticatedRequest).s3Auth?.requestId,
+      }
+    );
     return;
   }
   next();

--- a/backend/src/api/routes/s3-gateway/index.routes.ts
+++ b/backend/src/api/routes/s3-gateway/index.routes.ts
@@ -4,6 +4,7 @@ import { dispatchOp, parseBucketAndKey, S3Op } from './dispatch.js';
 import { S3GatewayRequest } from './request.js';
 import { sendS3Error, S3ProtocolError } from './errors.js';
 import { StorageService } from '@/services/storage/storage.service.js';
+import { appConfig } from '@/infra/config/app.config.js';
 import logger from '@/utils/logger.js';
 import * as listBuckets from './commands/list-buckets.js';
 import * as headBucket from './commands/head-bucket.js';
@@ -84,7 +85,33 @@ s3GatewayRouter.use((req, res, next) => {
   s3Sigv4Middleware(req, res, next).catch(next);
 });
 
-// 3) Dispatch to the operation handler.
+// 3) Early Content-Length check for body-consuming operations.
+s3GatewayRouter.use((req: Request, res: Response, next) => {
+  const rawCl = req.headers['content-length'];
+  const contentLength =
+    typeof rawCl === 'string' && /^\d+$/.test(rawCl) ? Number(rawCl) : null;
+  if (contentLength === null || contentLength <= appConfig.storage.maxS3UploadSize) {
+    next();
+    return;
+  }
+  const m = req.method.toUpperCase();
+  const p = req.path;
+  const q = new Set(Object.keys(req.query));
+  const hasKey = p.replace(/^\/+/, '').includes('/');
+  const isLargeBodyOp =
+    (m === 'PUT' && hasKey && !q.has('tagging') && !req.headers['x-amz-copy-source']) ||
+    (m === 'POST' && hasKey && q.has('uploadId'));
+  if (isLargeBodyOp) {
+    sendS3Error(res, 'EntityTooLarge', `Object exceeds max upload size (${appConfig.storage.maxS3UploadSize} bytes)`, {
+      resource: req.path,
+      requestId: (req as S3AuthenticatedRequest).s3Auth?.requestId,
+    });
+    return;
+  }
+  next();
+});
+
+// 4) Dispatch to the operation handler.
 s3GatewayRouter.use(async (req: Request, res: Response) => {
   const query: Record<string, string | string[] | undefined> = {};
   for (const [k, v] of Object.entries(req.query)) {

--- a/backend/src/api/routes/s3-gateway/index.routes.ts
+++ b/backend/src/api/routes/s3-gateway/index.routes.ts
@@ -90,8 +90,7 @@ s3GatewayRouter.use((req, res, next) => {
 // chunk framing overhead; use x-amz-decoded-content-length instead.
 s3GatewayRouter.use((req: Request, res: Response, next) => {
   const rawDecoded = req.headers['x-amz-decoded-content-length'];
-  const isStreaming =
-    typeof rawDecoded === 'string' && /^\d+$/.test(rawDecoded);
+  const isStreaming = typeof rawDecoded === 'string' && /^\d+$/.test(rawDecoded);
   const rawCl = req.headers['content-length'];
   const contentLength = isStreaming
     ? Number(rawDecoded)

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -111,13 +111,16 @@ function parseEnvInt(val: string | undefined, fallback: number): number {
   return parsed;
 }
 
+const AWS_MAX_SINGLE_PUT_BYTES = 5 * 1024 * 1024 * 1024;
+
 function parseEnvBytes(val: string | undefined, fallback: number): number {
   if (!val) return fallback;
-  const parsed = parseInt(val, 10);
-  if (isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed)) {
+  if (!/^\d+$/.test(val)) return fallback;
+  const parsed = Number(val);
+  if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed <= 0) {
     return fallback;
   }
-  return parsed;
+  return Math.min(parsed, AWS_MAX_SINGLE_PUT_BYTES);
 }
 
 export function loadConfig(): AppConfig {

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -84,6 +84,7 @@ export interface AppConfig {
     s3ForcePathStyle: boolean;
     awsConfigBucket: string;
     awsConfigRegion: string;
+    maxS3UploadSize: number;
   };
   functions: {
     denoRuntimeUrl: string;
@@ -102,6 +103,15 @@ export interface AppConfig {
 }
 
 function parseEnvInt(val: string | undefined, fallback: number): number {
+  if (!val) return fallback;
+  const parsed = parseInt(val, 10);
+  if (isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed)) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseEnvBytes(val: string | undefined, fallback: number): number {
   if (!val) return fallback;
   const parsed = parseInt(val, 10);
   if (isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed)) {
@@ -188,6 +198,7 @@ export function loadConfig(): AppConfig {
       s3ForcePathStyle: process.env.S3_FORCE_PATH_STYLE !== 'false',
       awsConfigBucket: process.env.AWS_CONFIG_BUCKET || 'insforge-config',
       awsConfigRegion: process.env.AWS_CONFIG_REGION || 'us-east-2',
+      maxS3UploadSize: parseEnvBytes(process.env.S3_MAX_OBJECT_SIZE_BYTES, 5 * 1024 * 1024 * 1024),
     },
     functions: {
       denoRuntimeUrl: process.env.DENO_RUNTIME_URL || 'http://localhost:7133',


### PR DESCRIPTION
## Summary

CompleteMultipartUpload had no body size cap — was reading the entire request into memory. PutObject/UploadPart already had streaming limits but they were split between a random env var (`S3_PROTOCOL_MAX_OBJECT_SIZE_GB`) and a hardcoded 5 GiB constant.

Moved everything to `appConfig.storage.maxS3UploadSize` (env var `S3_MAX_OBJECT_SIZE_BYTES`, default 5 GiB). Also added a Content-Length middleware so oversized PutObject/UploadPart requests get rejected before the handler starts streaming. CompleteMultipartUpload now caps at 1 MiB (10k parts × ~80 bytes each is plenty).

Files touched:
- `app.config.ts` — added the config key
- `s3-gateway/index.routes.ts` — new middleware
- `commands/put-object.ts`, `upload-part.ts` — swapped to appConfig
- `commands/complete-multipart-upload.ts` — added body cap

Fixes #1579

## How did you test this change?

`tsc --noEmit` is clean (no new errors). Existing S3 gateway unit tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict body size cap to S3 `CompleteMultipartUpload` and centralizes S3 upload limits in config. Enforces limits early (including aws-chunked streams) to reduce memory and keep behavior consistent.

- **Bug Fixes**
  - Capped `CompleteMultipartUpload` XML body to 1 MiB; rejects with `EntityTooLarge`.
  - Centralized limits in `appConfig.storage.maxS3UploadSize` (env `S3_MAX_OBJECT_SIZE_BYTES`) and applied to `PutObject`/`UploadPart`; per-part limit is `min(config, 5 GiB)` and single PUT values above 5 GiB are clamped.
  - Added early size check middleware for large PUTs; uses `x-amz-decoded-content-length` for aws-chunked uploads and rejects oversize bodies before streaming.

- **Migration**
  - Use `S3_MAX_OBJECT_SIZE_BYTES` (bytes). The old `S3_PROTOCOL_MAX_OBJECT_SIZE_GB` is no longer read. Values above 5 GiB are clamped; default remains 5 GiB.

<sup>Written for commit 0673d7e44c845657017b9e630591ed048fe3a21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add body size cap to S3 `CompleteMultipartUpload` and centralize upload limits via config
> - Adds a 1 MiB body size cap to `CompleteMultipartUpload` in [complete-multipart-upload.ts](https://github.com/InsForge/InsForge/pull/1580/files#diff-3dd2068228c83883b1e51970c20dc502ab3a88533b423dcea64a91bbe62a578e); requests exceeding it return `EntityTooLarge`.
> - Introduces `storage.maxS3UploadSize` in [app.config.ts](https://github.com/InsForge/InsForge/pull/1580/files#diff-24b06be8fbc5ad753cf4ae7c1e6d9c70c7740c17331319f8eb0fc50b559527fb), parsed from `S3_MAX_OBJECT_SIZE_BYTES` and capped at 5 GiB, replacing scattered local constants.
> - `PutObject` and `UploadPart` handlers now derive their size limits from `appConfig.storage.maxS3UploadSize` instead of local GB-based helpers.
> - Adds an early-rejection middleware in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1580/files#diff-25a2a8dbaa7249208eb4c1b72056163b08d94086a341b2a36060b8c2525d6c47) that rejects oversized PUT object requests before they reach handlers, using the effective content length (or `x-amz-decoded-content-length` for streaming uploads).
> - Behavioral Change: operators can now tune the maximum upload size via `S3_MAX_OBJECT_SIZE_BYTES`; the default remains 5 GiB but previously hardcoded limits may differ from prior behavior if the env var is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0673d7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum upload size for S3 gateway `PUT` requests, enforced early using request size headers (with support for aws-chunked uploads).
* **Bug Fixes**
  * Multipart uploads and completed multipart requests now reject oversized bodies with S3-style `EntityTooLarge` errors, avoiding unnecessary buffering.
  * Upload-part and object upload limits now consistently use the configured maximum, with AWS hard caps applied for parts.
* **Chores**
  * Introduced `maxS3UploadSize` config derived from `S3_MAX_OBJECT_SIZE_BYTES` with safe parsing and a 5 GiB fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->