### PR TITLE
fix(database): identify dashboard records by full composite primary key

### DIFF
--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -4,12 +4,14 @@ import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import {
   ERROR_CODES,
+  adminTableRecordPrimaryKeySchema,
   adminTableRecordUpdateQuerySchema,
   adminTableRecordUpdateRequestSchema,
   adminTableRecordLookupQuerySchema,
   adminTableRecordsCreateRequestSchema,
   adminTableRecordsDeleteQuerySchema,
   adminTableRecordsListQuerySchema,
+  type AdminTableRecordPrimaryKey,
   type AdminTableRecordsSortClause,
 } from '@insforge/shared-schemas';
 import { AdminRecordService } from '@/services/database/admin-record.service.js';
@@ -63,6 +65,41 @@ function parseSort(sort: string | undefined): AdminTableRecordsSortClause[] {
         direction: normalizedDirection as AdminTableRecordsSortClause['direction'],
       };
     });
+}
+
+function parseJsonQueryParam(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new AppError(
+      'Invalid pkKeys parameter.',
+      400,
+      ERROR_CODES.INVALID_INPUT,
+      'pkKeys must be a JSON-encoded primary key.'
+    );
+  }
+}
+
+// Parses the `pkKeys` query param for an update: a single JSON object mapping each
+// primary-key column to its value.
+function parsePrimaryKey(raw: string): AdminTableRecordPrimaryKey {
+  const validation = adminTableRecordPrimaryKeySchema.safeParse(parseJsonQueryParam(raw));
+  if (!validation.success) {
+    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+  }
+  return validation.data;
+}
+
+// Parses the `pkKeys` query param for a delete: a JSON array of primary-key objects.
+function parsePrimaryKeys(raw: string): AdminTableRecordPrimaryKey[] {
+  const validation = z
+    .array(adminTableRecordPrimaryKeySchema)
+    .min(1, 'At least one primary key is required.')
+    .safeParse(parseJsonQueryParam(raw));
+  if (!validation.success) {
+    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+  }
+  return validation.data;
 }
 
 function broadcastRecordChange(schemaName: string, tableName: string): void {
@@ -163,7 +200,7 @@ router.post(
 );
 
 router.patch(
-  '/tables/:tableName/records/:recordId',
+  '/tables/:tableName/records',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const schemaName = normalizeDatabaseSchemaName(req.query.schema);
@@ -175,6 +212,8 @@ router.patch(
           ERROR_CODES.INVALID_INPUT
         );
       }
+
+      const primaryKey = parsePrimaryKey(queryValidation.data.pkKeys);
 
       const bodyValidation = adminTableRecordUpdateRequestSchema.safeParse(req.body);
       if (!bodyValidation.success) {
@@ -188,8 +227,7 @@ router.patch(
       const updatedRecord = await recordsService.updateRecord(
         schemaName,
         req.params.tableName,
-        queryValidation.data.pkColumn,
-        req.params.recordId,
+        primaryKey,
         bodyValidation.data as DatabaseRecord
       );
 
@@ -211,25 +249,12 @@ router.delete(
         throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
       }
 
-      const pkValues = validation.data.pkValues
-        .split(',')
-        .map((value) => value.trim())
-        .filter(Boolean);
-
-      if (pkValues.length === 0) {
-        throw new AppError(
-          'pkValues must include at least one primary key value.',
-          400,
-          ERROR_CODES.INVALID_INPUT,
-          'Provide at least one non-empty primary key value.'
-        );
-      }
+      const primaryKeys = parsePrimaryKeys(validation.data.pkKeys);
 
       const deletedCount = await recordsService.deleteRecords(
         schemaName,
         req.params.tableName,
-        validation.data.pkColumn,
-        pkValues
+        primaryKeys
       );
 
       if (deletedCount > 0) {

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -157,7 +157,7 @@ export class AdminRecordService {
     }
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
       this.assertCompletePrimaryKey(
         metadata,
@@ -217,7 +217,7 @@ export class AdminRecordService {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
 
       if (primaryKeys.length === 0) {
         return 0;
@@ -300,7 +300,8 @@ export class AdminRecordService {
   private async getTableColumnMetadata(
     schemaName: string,
     tableName: string,
-    client?: PoolClient
+    client?: PoolClient,
+    includePrimaryKey = false
   ): Promise<TableColumnMetadata> {
     const queryable = client ?? this.dbManager.getPool();
     const result = await queryable.query<{
@@ -349,8 +350,11 @@ export class AdminRecordService {
       }
     }
 
-    const primaryKeyResult = await queryable.query<{ column_name: string }>(
-      `
+    // Only update/delete need the primary key, so skip this query on read/create paths.
+    let primaryKeyColumns: string[] = [];
+    if (includePrimaryKey) {
+      const primaryKeyResult = await queryable.query<{ column_name: string }>(
+        `
         SELECT kcu.column_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
@@ -362,14 +366,16 @@ export class AdminRecordService {
           AND tc.table_name = $2
         ORDER BY kcu.ordinal_position
       `,
-      [schemaName, tableName]
-    );
+        [schemaName, tableName]
+      );
+      primaryKeyColumns = primaryKeyResult.rows.map((row) => row.column_name);
+    }
 
     return {
       columnTypeMap,
       nullableColumns,
       searchableColumns,
-      primaryKeyColumns: primaryKeyResult.rows.map((row) => row.column_name),
+      primaryKeyColumns,
     };
   }
 

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -1,6 +1,6 @@
 import { AppError } from '@/utils/errors.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
-import { ERROR_CODES } from '@insforge/shared-schemas';
+import { ERROR_CODES, type AdminTableRecordPrimaryKey } from '@insforge/shared-schemas';
 import type { PoolClient } from 'pg';
 import type { DatabaseRecord } from '@/types/database.js';
 import { TEXT_LIKE_DATA_TYPES } from '@/utils/constants.js';
@@ -27,6 +27,9 @@ interface TableColumnMetadata {
   nullableColumns: Set<string>;
   searchableColumns: string[];
 }
+
+// A record's primary key as a map of column name -> value. Supports composite keys.
+type PrimaryKey = AdminTableRecordPrimaryKey;
 
 export class AdminRecordService {
   private static instance: AdminRecordService;
@@ -137,15 +140,24 @@ export class AdminRecordService {
   async updateRecord(
     schemaName: string,
     tableName: string,
-    pkColumn: string,
-    pkValue: string,
+    primaryKey: PrimaryKey,
     data: DatabaseRecord
   ): Promise<DatabaseRecord> {
     validateTableName(tableName);
 
+    const keyEntries = Object.entries(primaryKey);
+    if (keyEntries.length === 0) {
+      throw new AppError(
+        'Primary key is required to update a record.',
+        400,
+        ERROR_CODES.INVALID_INPUT,
+        'Provide at least one primary key column and value.'
+      );
+    }
+
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, pkColumn);
+      keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
 
       const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
       const entries = Object.entries(sanitizedRecord);
@@ -162,12 +174,19 @@ export class AdminRecordService {
       const assignments = entries.map(
         ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
       );
-      const values = entries.map(([, value]) => value);
-      values.push(pkValue);
+      const values: unknown[] = entries.map(([, value]) => value);
+
+      // WHERE matches the full primary-key tuple so composite keys target exactly one row.
+      const whereClauses = keyEntries.map(([columnName, value]) => {
+        values.push(value);
+        return `${quoteIdentifier(columnName)} = $${values.length}`;
+      });
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
       const result = await client.query<DatabaseRecord>(
-        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
+        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${whereClauses.join(
+          ' AND '
+        )} RETURNING *`,
         values
       );
 
@@ -188,24 +207,44 @@ export class AdminRecordService {
   async deleteRecords(
     schemaName: string,
     tableName: string,
-    pkColumn: string,
-    pkValues: string[]
+    primaryKeys: PrimaryKey[]
   ): Promise<number> {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, pkColumn);
 
-      if (pkValues.length === 0) {
+      if (primaryKeys.length === 0) {
         return 0;
       }
 
-      const placeholders = pkValues.map((_, index) => `$${index + 1}`);
+      const values: unknown[] = [];
+      // Each selected row is matched by its full primary-key tuple, OR'd together,
+      // so composite keys delete exactly the selected rows (not WHERE first_col IN (...)).
+      const rowClauses = primaryKeys.map((primaryKey) => {
+        const keyEntries = Object.entries(primaryKey);
+        if (keyEntries.length === 0) {
+          throw new AppError(
+            'Primary key is required to delete a record.',
+            400,
+            ERROR_CODES.INVALID_INPUT,
+            'Provide at least one primary key column and value for each record.'
+          );
+        }
+
+        const columnClauses = keyEntries.map(([columnName, value]) => {
+          this.assertColumnExists(metadata, columnName);
+          values.push(value);
+          return `${quoteIdentifier(columnName)} = $${values.length}`;
+        });
+
+        return `(${columnClauses.join(' AND ')})`;
+      });
+
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
       const result = await client.query(
-        `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
-        pkValues
+        `DELETE FROM ${qualifiedTableName} WHERE ${rowClauses.join(' OR ')}`,
+        values
       );
 
       return result.rowCount ?? 0;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -26,6 +26,7 @@ interface TableColumnMetadata {
   columnTypeMap: Record<string, string>;
   nullableColumns: Set<string>;
   searchableColumns: string[];
+  primaryKeyColumns: string[];
 }
 
 // A record's primary key as a map of column name -> value. Supports composite keys.
@@ -158,6 +159,10 @@ export class AdminRecordService {
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
+      this.assertCompletePrimaryKey(
+        metadata,
+        keyEntries.map(([columnName]) => columnName)
+      );
 
       const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
       const entries = Object.entries(sanitizedRecord);
@@ -232,8 +237,13 @@ export class AdminRecordService {
           );
         }
 
+        keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
+        this.assertCompletePrimaryKey(
+          metadata,
+          keyEntries.map(([columnName]) => columnName)
+        );
+
         const columnClauses = keyEntries.map(([columnName, value]) => {
-          this.assertColumnExists(metadata, columnName);
           values.push(value);
           return `${quoteIdentifier(columnName)} = $${values.length}`;
         });
@@ -339,11 +349,55 @@ export class AdminRecordService {
       }
     }
 
+    const primaryKeyResult = await queryable.query<{ column_name: string }>(
+      `
+        SELECT kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+          AND tc.table_name = kcu.table_name
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+          AND tc.table_schema = $1
+          AND tc.table_name = $2
+        ORDER BY kcu.ordinal_position
+      `,
+      [schemaName, tableName]
+    );
+
     return {
       columnTypeMap,
       nullableColumns,
       searchableColumns,
+      primaryKeyColumns: primaryKeyResult.rows.map((row) => row.column_name),
     };
+  }
+
+  /**
+   * Ensures the supplied key columns are exactly the table's primary key, so a
+   * partial composite key (e.g. only `tenant_id` of a `(tenant_id, item_id)` key)
+   * can't match and mutate more rows than intended. Tables with no detected
+   * primary key fall back to the caller-provided columns (validated for existence).
+   */
+  private assertCompletePrimaryKey(metadata: TableColumnMetadata, suppliedColumns: string[]): void {
+    const { primaryKeyColumns } = metadata;
+    if (primaryKeyColumns.length === 0) {
+      return;
+    }
+
+    const suppliedSet = new Set(suppliedColumns);
+    const matchesFullKey =
+      suppliedSet.size === primaryKeyColumns.length &&
+      primaryKeyColumns.every((column) => suppliedSet.has(column));
+
+    if (!matchesFullKey) {
+      throw new AppError(
+        'Primary key does not match the table primary key.',
+        400,
+        ERROR_CODES.INVALID_INPUT,
+        `Provide exactly these primary key columns: ${primaryKeyColumns.join(', ')}.`
+      );
+    }
   }
 
   private buildWhereClause(

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -26,7 +26,6 @@ interface TableColumnMetadata {
   columnTypeMap: Record<string, string>;
   nullableColumns: Set<string>;
   searchableColumns: string[];
-  primaryKeyColumns: string[];
 }
 
 // A record's primary key as a map of column name -> value. Supports composite keys.
@@ -157,10 +156,11 @@ export class AdminRecordService {
     }
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const primaryKeyColumns = await this.getPrimaryKeyColumns(schemaName, tableName, client);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
-      this.assertCompletePrimaryKey(
-        metadata,
+      this.assertKeyMatchesPrimaryKey(
+        primaryKeyColumns,
         keyEntries.map(([columnName]) => columnName)
       );
 
@@ -217,7 +217,8 @@ export class AdminRecordService {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const primaryKeyColumns = await this.getPrimaryKeyColumns(schemaName, tableName, client);
 
       if (primaryKeys.length === 0) {
         return 0;
@@ -238,8 +239,8 @@ export class AdminRecordService {
         }
 
         keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
-        this.assertCompletePrimaryKey(
-          metadata,
+        this.assertKeyMatchesPrimaryKey(
+          primaryKeyColumns,
           keyEntries.map(([columnName]) => columnName)
         );
 
@@ -300,8 +301,7 @@ export class AdminRecordService {
   private async getTableColumnMetadata(
     schemaName: string,
     tableName: string,
-    client?: PoolClient,
-    includePrimaryKey = false
+    client?: PoolClient
   ): Promise<TableColumnMetadata> {
     const queryable = client ?? this.dbManager.getPool();
     const result = await queryable.query<{
@@ -350,11 +350,25 @@ export class AdminRecordService {
       }
     }
 
-    // Only update/delete need the primary key, so skip this query on read/create paths.
-    let primaryKeyColumns: string[] = [];
-    if (includePrimaryKey) {
-      const primaryKeyResult = await queryable.query<{ column_name: string }>(
-        `
+    return {
+      columnTypeMap,
+      nullableColumns,
+      searchableColumns,
+    };
+  }
+
+  /**
+   * Fetches a table's primary-key columns (ordinal order). Returns an empty array
+   * only when the table genuinely has no primary key. Mutations call this directly,
+   * so an empty result can never be confused with "metadata wasn't loaded".
+   */
+  private async getPrimaryKeyColumns(
+    schemaName: string,
+    tableName: string,
+    client: PoolClient
+  ): Promise<string[]> {
+    const result = await client.query<{ column_name: string }>(
+      `
         SELECT kcu.column_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
@@ -366,27 +380,20 @@ export class AdminRecordService {
           AND tc.table_name = $2
         ORDER BY kcu.ordinal_position
       `,
-        [schemaName, tableName]
-      );
-      primaryKeyColumns = primaryKeyResult.rows.map((row) => row.column_name);
-    }
+      [schemaName, tableName]
+    );
 
-    return {
-      columnTypeMap,
-      nullableColumns,
-      searchableColumns,
-      primaryKeyColumns,
-    };
+    return result.rows.map((row) => row.column_name);
   }
 
   /**
    * Ensures the supplied key columns are exactly the table's primary key, so a
    * partial composite key (e.g. only `tenant_id` of a `(tenant_id, item_id)` key)
    * can't match and mutate more rows than intended. Tables with no detected
-   * primary key fall back to the caller-provided columns (validated for existence).
+   * primary key (empty `primaryKeyColumns`) fall back to the caller-provided
+   * columns (validated for existence elsewhere).
    */
-  private assertCompletePrimaryKey(metadata: TableColumnMetadata, suppliedColumns: string[]): void {
-    const { primaryKeyColumns } = metadata;
+  private assertKeyMatchesPrimaryKey(primaryKeyColumns: string[], suppliedColumns: string[]): void {
     if (primaryKeyColumns.length === 0) {
       return;
     }

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -136,10 +136,15 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
-      owner_id: '',
-      name: 'Renamed project',
-    });
+    const record = await service.updateRecord(
+      'public',
+      'projects',
+      { id: 'p1' },
+      {
+        owner_id: '',
+        name: 'Renamed project',
+      }
+    );
 
     expect(record).toEqual({ id: 'p1', owner_id: null, name: 'Renamed project' });
     const updateCall = clientQueryMock.mock.calls.find(
@@ -218,9 +223,14 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
-      priority: '',
-    });
+    const record = await service.updateRecord(
+      'public',
+      'projects',
+      { id: 'p1' },
+      {
+        priority: '',
+      }
+    );
 
     expect(record).toEqual({ id: 'p1', priority: null });
     const updateCall = clientQueryMock.mock.calls.find(
@@ -250,9 +260,14 @@ describe('AdminRecordService', () => {
     const service = AdminRecordService.getInstance();
 
     await expect(
-      service.updateRecord('public', 'projects', 'id', 'p1', {
-        priority: '',
-      })
+      service.updateRecord(
+        'public',
+        'projects',
+        { id: 'p1' },
+        {
+          priority: '',
+        }
+      )
     ).rejects.toBeInstanceOf(AppError);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
@@ -276,7 +291,10 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const deletedCount = await service.deleteRecords('public', 'projects', 'id', ['p1', 'p2']);
+    const deletedCount = await service.deleteRecords('public', 'projects', [
+      { id: 'p1' },
+      { id: 'p2' },
+    ]);
 
     expect(deletedCount).toBe(2);
 
@@ -290,6 +308,110 @@ describe('AdminRecordService', () => {
     expect(sqlCalls[0]).toBe('BEGIN');
     expect(deleteIndex).toBeGreaterThan(setRoleIndex);
     expect(commitIndex).toBeGreaterThan(deleteIndex);
+  });
+
+  it('updates a composite-key row using the full primary-key tuple', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE "public"."composite_pk_test"')) {
+        return {
+          rows: [{ tenant_id: 'tenant_a', item_id: 'item_2', label: 'second-updated' }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = AdminRecordService.getInstance();
+    const record = await service.updateRecord(
+      'public',
+      'composite_pk_test',
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+      { label: 'second-updated' }
+    );
+
+    expect(record).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'second-updated' });
+
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."composite_pk_test"')
+    );
+    // The WHERE clause must match both key columns, not just the (duplicated) first one.
+    expect(updateCall?.[0]).toContain(
+      'SET "label" = $1 WHERE "tenant_id" = $2 AND "item_id" = $3 RETURNING *'
+    );
+    expect(updateCall?.[1]).toEqual(['second-updated', 'tenant_a', 'item_2']);
+  });
+
+  it('deletes only the selected composite-key tuples', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
+        return { rowCount: 1, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+    // tenant_a is duplicated across rows; deleting must target the exact tuple only.
+    const deletedCount = await service.deleteRecords('public', 'composite_pk_test', [
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+    ]);
+
+    expect(deletedCount).toBe(1);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."composite_pk_test"')
+    );
+    expect(deleteCall?.[0]).toContain('WHERE ("tenant_id" = $1 AND "item_id" = $2)');
+    expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_2']);
+  });
+
+  it('matches each selected composite tuple independently when deleting many rows', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
+        return { rowCount: 2, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+    const deletedCount = await service.deleteRecords('public', 'composite_pk_test', [
+      { tenant_id: 'tenant_a', item_id: 'item_1' },
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+    ]);
+
+    expect(deletedCount).toBe(2);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."composite_pk_test"')
+    );
+    expect(deleteCall?.[0]).toContain(
+      'WHERE ("tenant_id" = $1 AND "item_id" = $2) OR ("tenant_id" = $3 AND "item_id" = $4)'
+    );
+    expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_1', 'tenant_a', 'item_2']);
   });
 
   it('discards the pooled client when admin transaction cleanup fails', async () => {
@@ -316,9 +438,14 @@ describe('AdminRecordService', () => {
     const service = AdminRecordService.getInstance();
 
     await expect(
-      service.updateRecord('public', 'projects', 'id', 'p1', {
-        name: 'Renamed project',
-      })
+      service.updateRecord(
+        'public',
+        'projects',
+        { id: 'p1' },
+        {
+          name: 'Renamed project',
+        }
+      )
     ).rejects.toBe(resetError);
 
     expect(clientQueryMock.mock.calls.map(([sql]) => sql as string)).toContain('ROLLBACK');

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -93,6 +93,7 @@ describe('AdminRecordService', () => {
           { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
         ],
       }) // metadata
+      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'u1', email: 'demo@example.com' }],
       }) // INSERT
@@ -126,6 +127,9 @@ describe('AdminRecordService', () => {
             { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return {
@@ -182,6 +186,7 @@ describe('AdminRecordService', () => {
           },
         ],
       }) // metadata
+      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'r1', name: '' }],
       }) // INSERT
@@ -213,6 +218,9 @@ describe('AdminRecordService', () => {
             },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return {
@@ -284,6 +292,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."projects"')) {
         return { rowCount: 2, rows: [] };
       }
@@ -297,6 +308,13 @@ describe('AdminRecordService', () => {
     ]);
 
     expect(deletedCount).toBe(2);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."projects"')
+    );
+    // Each selected single-column key is matched as its own AND-group, OR'd together.
+    expect(deleteCall?.[0]).toContain('WHERE ("id" = $1) OR ("id" = $2)');
+    expect(deleteCall?.[1]).toEqual(['p1', 'p2']);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
     const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
@@ -320,6 +338,9 @@ describe('AdminRecordService', () => {
             { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
       }
       if (sql.includes('UPDATE "public"."composite_pk_test"')) {
         return {
@@ -360,6 +381,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
         return { rowCount: 1, rows: [] };
       }
@@ -391,6 +415,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
         return { rowCount: 2, rows: [] };
       }
@@ -414,6 +441,47 @@ describe('AdminRecordService', () => {
     expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_1', 'tenant_a', 'item_2']);
   });
 
+  it('rejects a partial composite key instead of mutating unintended rows', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    // Supplying only the first PK column of a composite key must be rejected, not
+    // turned into a broad DELETE that removes every row sharing that value.
+    await expect(
+      service.deleteRecords('public', 'composite_pk_test', [{ tenant_id: 'tenant_a' }])
+    ).rejects.toBeInstanceOf(AppError);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls.some((sql) => sql.includes('DELETE FROM'))).toBe(false);
+    expect(sqlCalls).toContain('ROLLBACK');
+
+    // The same partial key must also be rejected on update.
+    await expect(
+      service.updateRecord('public', 'composite_pk_test', { tenant_id: 'tenant_a' }, { label: 'x' })
+    ).rejects.toBeInstanceOf(AppError);
+
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."composite_pk_test"')
+      )
+    ).toBe(false);
+  });
+
   it('discards the pooled client when admin transaction cleanup fails', async () => {
     const resetError = new Error('reset failed');
 
@@ -425,6 +493,9 @@ describe('AdminRecordService', () => {
             { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return { rows: [{ id: 'p1', name: 'Renamed project' }] };

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -484,6 +484,55 @@ describe('AdminRecordService', () => {
     ).toBe(false);
   });
 
+  it('falls back to the caller-provided key when the table has no primary key', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'name', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [] }; // table has no primary key
+      }
+      if (sql.includes('UPDATE "public"."pkless"')) {
+        return { rows: [{ id: 'p1', name: 'Renamed' }] };
+      }
+      if (sql.includes('DELETE FROM "public"."pkless"')) {
+        return { rowCount: 1, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    // With no detectable primary key, the supplied key columns are used as-is.
+    const updated = await service.updateRecord(
+      'public',
+      'pkless',
+      { id: 'p1' },
+      { name: 'Renamed' }
+    );
+    expect(updated).toEqual({ id: 'p1', name: 'Renamed' });
+
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."pkless"')
+    );
+    expect(updateCall?.[0]).toContain('WHERE "id" = $2 RETURNING *');
+    expect(updateCall?.[1]).toEqual(['Renamed', 'p1']);
+
+    const deletedCount = await service.deleteRecords('public', 'pkless', [{ id: 'p1' }]);
+    expect(deletedCount).toBe(1);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."pkless"')
+    );
+    expect(deleteCall?.[0]).toContain('WHERE ("id" = $1)');
+    expect(deleteCall?.[1]).toEqual(['p1']);
+  });
+
   it('discards the pooled client when admin transaction cleanup fails', async () => {
     const resetError = new Error('reset failed');
 

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -80,6 +80,10 @@ describe('AdminRecordService', () => {
     expect(resetRoleIndex).toBeGreaterThan(dataQueryIndex);
     expect(commitIndex).toBeGreaterThan(resetRoleIndex);
     expect(clientQueryMock.mock.calls[dataQueryIndex]?.[1]).toEqual(['%demo%', 10, 0]);
+    // Read paths must not pay for the primary-key metadata query.
+    expect(sqlCalls.some((sql) => sql.includes('information_schema.table_constraints'))).toBe(
+      false
+    );
   });
 
   it('delegates protected-schema writes to project_admin privileges', async () => {
@@ -93,7 +97,6 @@ describe('AdminRecordService', () => {
           { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
         ],
       }) // metadata
-      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'u1', email: 'demo@example.com' }],
       }) // INSERT
@@ -186,7 +189,6 @@ describe('AdminRecordService', () => {
           },
         ],
       }) // metadata
-      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'r1', name: '' }],
       }) // INSERT

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -4,8 +4,12 @@ import {
   DEFAULT_DATABASE_SCHEMA,
   buildDatabaseSchemaSearch,
   buildDynamicSchema,
+  decodeRecordKey,
+  encodeRecordKey,
   getDatabaseSchemaInfo,
   getInitialValues,
+  getPrimaryKeyColumns,
+  getRecordPrimaryKey,
   parseDatabaseTableReference,
 } from '#features/database/helpers';
 
@@ -63,6 +67,50 @@ describe('database helpers', () => {
     expect(schema.safeParse({ name: 'Ada', age: null }).success).toBe(true);
     expect(schema.safeParse({ name: '', age: 1 }).success).toBe(false);
     expect(schema.safeParse({ id: 'ignored', name: 'Ada', age: 1 }).success).toBe(true);
+  });
+
+  it('returns all primary-key columns in schema order, falling back to id', () => {
+    expect(
+      getPrimaryKeyColumns([
+        column({ columnName: 'tenant_id', isPrimaryKey: true }),
+        column({ columnName: 'item_id', isPrimaryKey: true }),
+        column({ columnName: 'label', isPrimaryKey: false }),
+      ])
+    ).toEqual(['tenant_id', 'item_id']);
+
+    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual(['id']);
+
+    // No primary key metadata -> fall back to the conventional `id` column.
+    expect(getPrimaryKeyColumns([column({ columnName: 'name' })])).toEqual(['id']);
+    expect(getPrimaryKeyColumns(undefined)).toEqual(['id']);
+  });
+
+  it('builds a record primary key tuple, coercing missing values to null', () => {
+    expect(
+      getRecordPrimaryKey({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'x' }, [
+        'tenant_id',
+        'item_id',
+      ])
+    ).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
+
+    expect(getRecordPrimaryKey({ id: 5 }, ['id'])).toEqual({ id: 5 });
+    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: null });
+  });
+
+  it('encodes the full key tuple and decodes it back, so duplicate first columns stay distinct', () => {
+    const pkColumns = ['tenant_id', 'item_id'];
+    const rowA = { tenant_id: 'tenant_a', item_id: 'item_1', label: 'first' };
+    const rowB = { tenant_id: 'tenant_a', item_id: 'item_2', label: 'second' };
+
+    const keyA = encodeRecordKey(rowA, pkColumns);
+    const keyB = encodeRecordKey(rowB, pkColumns);
+
+    // Same first PK column value, but the encoded keys must differ by the full tuple.
+    expect(keyA).not.toBe(keyB);
+    // Encoding is stable for identical tuples.
+    expect(encodeRecordKey({ ...rowA }, pkColumns)).toBe(keyA);
+
+    expect(decodeRecordKey(keyB)).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
   });
 
   it('uses backend schema metadata for protection state and keeps unknown schemas writable by default', () => {

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -78,7 +78,9 @@ describe('database helpers', () => {
       ])
     ).toEqual(['tenant_id', 'item_id']);
 
-    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual(['id']);
+    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual([
+      'id',
+    ]);
 
     // No primary key metadata -> fall back to the conventional `id` column.
     expect(getPrimaryKeyColumns([column({ columnName: 'name' })])).toEqual(['id']);

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -14,6 +14,7 @@ import {
 } from '#components/datagrid';
 import { ColumnSchema, ColumnType, TableSchema } from '@insforge/shared-schemas';
 import { ForeignKeyCell } from './ForeignKeyCell';
+import { encodeRecordKey, getPrimaryKeyColumns } from '#features/database/helpers';
 
 // Create a type adapter for database records
 // Database records are dynamic and must have string id for DataGrid compatibility
@@ -26,24 +27,24 @@ function DatabaseTextCellEditor({
   onRowChange,
   onClose,
   onCellEdit,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       const oldValue = row[column.key];
 
       if (onCellEdit && String(oldValue ?? '') !== String(newValue)) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [row, column.key, onCellEdit, onRowChange, onClose, primaryKeyColumn]
+    [row, column.key, onCellEdit, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -63,25 +64,25 @@ function DatabaseBooleanCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       const value: boolean | null = newValue === 'null' ? null : newValue === 'true';
 
       if (onCellEdit && row[column.key] !== value) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: value };
       onRowChange(updatedRow);
       onClose();
     },
-    [row, column.key, onRowChange, onClose, onCellEdit, primaryKeyColumn]
+    [row, column.key, onRowChange, onClose, onCellEdit, primaryKeyColumns]
   );
 
   return (
@@ -102,11 +103,11 @@ function DatabaseDateCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string | null) => {
@@ -114,14 +115,14 @@ function DatabaseDateCellEditor({
         onCellEdit &&
         new Date(row[column.key] as string).getTime() !== new Date(newValue ?? '').getTime()
       ) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue ?? '');
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue ?? '');
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [onCellEdit, row, column.key, onRowChange, onClose, primaryKeyColumn]
+    [onCellEdit, row, column.key, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -142,23 +143,23 @@ function DatabaseJsonCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       if (onCellEdit && row[column.key] !== newValue) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [column.key, onCellEdit, row, onRowChange, onClose, primaryKeyColumn]
+    [column.key, onCellEdit, row, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -183,7 +184,7 @@ export function convertSchemaToColumns(
     return [];
   }
 
-  const primaryKeyColumn = schema.columns.find((col) => col.isPrimaryKey)?.columnName || '';
+  const primaryKeyColumns = getPrimaryKeyColumns(schema.columns);
 
   // Create typed cell renderers
   const cellRenderers = createDefaultCellRenderer<DatabaseDataGridRow>();
@@ -238,7 +239,7 @@ export function convertSchemaToColumns(
           onJumpToTable={onJumpToTable}
         />
       );
-    } else if (col.columnName === primaryKeyColumn) {
+    } else if (col.isPrimaryKey) {
       column.renderCell = cellRenderers.id;
     } else if (col.type === ColumnType.BOOLEAN) {
       column.renderCell = cellRenderers.boolean;
@@ -247,7 +248,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.DATE) {
@@ -257,7 +258,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.DATETIME) {
@@ -267,7 +268,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.JSON) {
@@ -277,7 +278,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else {
@@ -286,7 +287,7 @@ export function convertSchemaToColumns(
         <DatabaseTextCellEditor
           {...props}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     }

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -6,6 +6,69 @@ export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
 
 export const SYSTEM_FIELDS = ['id', 'created_at', 'updated_at'];
 
+/**
+ * A record's primary key as a map of column name -> value.
+ * Supports composite (multi-column) primary keys.
+ */
+export type RecordPrimaryKey = Record<string, string | number | boolean | null>;
+
+/**
+ * Returns the primary-key column names for a table, in schema (ordinal) order.
+ * Falls back to `['id']` when the schema reports no primary key, preserving the
+ * previous single-column behavior for tables that don't expose key metadata.
+ */
+export function getPrimaryKeyColumns(columns?: ColumnSchema[]): string[] {
+  const primaryKeyColumns =
+    columns?.filter((column) => column.isPrimaryKey).map((column) => column.columnName) ?? [];
+  return primaryKeyColumns.length > 0 ? primaryKeyColumns : ['id'];
+}
+
+/**
+ * Builds the primary-key tuple for a row from the given primary-key columns.
+ * Missing values are coerced to null and non-scalar values to their string form,
+ * since primary keys are always scalar.
+ */
+export function getRecordPrimaryKey(
+  row: Record<string, unknown>,
+  primaryKeyColumns: string[]
+): RecordPrimaryKey {
+  const key: RecordPrimaryKey = {};
+  for (const columnName of primaryKeyColumns) {
+    const value = row[columnName];
+    if (value === undefined || value === null) {
+      key[columnName] = null;
+    } else if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      key[columnName] = value;
+    } else {
+      key[columnName] = String(value);
+    }
+  }
+  return key;
+}
+
+/**
+ * Encodes a row's full primary-key tuple into a stable string usable as a React
+ * grid row key. Two rows with the same key tuple encode identically (same identity).
+ */
+export function encodeRecordKey(
+  row: Record<string, unknown>,
+  primaryKeyColumns: string[]
+): string {
+  return JSON.stringify(getRecordPrimaryKey(row, primaryKeyColumns));
+}
+
+/**
+ * Decodes a grid row key produced by {@link encodeRecordKey} back into the
+ * primary-key tuple to send to the record update/delete APIs.
+ */
+export function decodeRecordKey(encodedKey: string): RecordPrimaryKey {
+  return JSON.parse(encodedKey) as RecordPrimaryKey;
+}
+
 // Helper function to build dynamic Zod schema based on column definitions
 export function buildDynamicSchema(columns: ColumnSchema[]) {
   const schemaFields: Record<string, z.ZodTypeAny> = {};

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -54,10 +54,7 @@ export function getRecordPrimaryKey(
  * Encodes a row's full primary-key tuple into a stable string usable as a React
  * grid row key. Two rows with the same key tuple encode identically (same identity).
  */
-export function encodeRecordKey(
-  row: Record<string, unknown>,
-  primaryKeyColumns: string[]
-): string {
+export function encodeRecordKey(row: Record<string, unknown>, primaryKeyColumns: string[]): string {
   return JSON.stringify(getRecordPrimaryKey(row, primaryKeyColumns));
 }
 

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,7 +1,10 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 import { databaseTableQueryKeys } from '#features/database/queryKeys';
-import { recordService } from '#features/database/services/record.service';
+import {
+  recordService,
+  type RecordPrimaryKey,
+} from '#features/database/services/record.service';
 import { useToast } from '#lib/hooks/useToast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -101,14 +104,12 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
   // Mutation to update a record
   const updateRecordMutation = useMutation({
     mutationFn: ({
-      pkColumn,
-      pkValue,
+      primaryKey,
       data,
     }: {
-      pkColumn: string;
-      pkValue: string;
+      primaryKey: RecordPrimaryKey;
       data: { [key: string]: ConvertedValue };
-    }) => recordService.updateRecord(tableName, pkColumn, pkValue, data, schemaName),
+    }) => recordService.updateRecord(tableName, primaryKey, data, schemaName),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordsQueryKeyPrefix });
       void queryClient.invalidateQueries({
@@ -124,14 +125,14 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
 
   // Mutation to delete a record
   const deleteRecordsMutation = useMutation({
-    mutationFn: (variables: { pkColumn: string; pkValues: string[] }) =>
-      recordService.deleteRecords(tableName, variables.pkColumn, variables.pkValues, schemaName),
+    mutationFn: (variables: { primaryKeys: RecordPrimaryKey[] }) =>
+      recordService.deleteRecords(tableName, variables.primaryKeys, schemaName),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: recordsQueryKeyPrefix });
       void queryClient.invalidateQueries({
         queryKey: databaseTableQueryKeys.tableSchema(schemaName, tableName),
       });
-      const count = variables.pkValues.length;
+      const count = variables.primaryKeys.length;
       if (count === 1) {
         showToast('Record deleted successfully', 'success');
       } else {
@@ -139,7 +140,7 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
       }
     },
     onError: (error: Error, variables) => {
-      const count = variables.pkValues.length;
+      const count = variables.primaryKeys.length;
       const recordText = count === 1 ? 'record' : 'records';
       const errorMessage =
         error instanceof Error ? error.message : `Failed to delete ${recordText}`;

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,10 +1,7 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 import { databaseTableQueryKeys } from '#features/database/queryKeys';
-import {
-  recordService,
-  type RecordPrimaryKey,
-} from '#features/database/services/record.service';
+import { recordService, type RecordPrimaryKey } from '#features/database/services/record.service';
 import { useToast } from '#lib/hooks/useToast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -227,10 +227,7 @@ export default function TablesPage() {
 
   // Full primary-key tuple (supports composite keys) used for row identity,
   // updates, and deletes.
-  const primaryKeyColumns = useMemo(
-    () => getPrimaryKeyColumns(schemaData?.columns),
-    [schemaData]
-  );
+  const primaryKeyColumns = useMemo(() => getPrimaryKeyColumns(schemaData?.columns), [schemaData]);
 
   const {
     mutate: importCSV,

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -39,7 +39,13 @@ import { useCSVExport } from '#features/database/hooks/useCSVExport';
 import { useTablePreferences } from '#features/database/hooks/useTablePreferences';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { usePageSize } from '#lib/hooks/usePageSize';
-import { DEFAULT_DATABASE_SCHEMA, getDatabaseSchemaInfo } from '#features/database/helpers';
+import {
+  DEFAULT_DATABASE_SCHEMA,
+  decodeRecordKey,
+  encodeRecordKey,
+  getDatabaseSchemaInfo,
+  getPrimaryKeyColumns,
+} from '#features/database/helpers';
 
 export default function TablesPage() {
   const location = useLocation();
@@ -219,9 +225,12 @@ export default function TablesPage() {
     !!editingTable
   );
 
-  const primaryKeyColumn = useMemo(() => {
-    return schemaData?.columns.find((col) => col.isPrimaryKey)?.columnName;
-  }, [schemaData]);
+  // Full primary-key tuple (supports composite keys) used for row identity,
+  // updates, and deletes.
+  const primaryKeyColumns = useMemo(
+    () => getPrimaryKeyColumns(schemaData?.columns),
+    [schemaData]
+  );
 
   const {
     mutate: importCSV,
@@ -415,8 +424,8 @@ export default function TablesPage() {
     setPreviewingTemplate(null);
   };
 
-  // Handle record update
-  const handleRecordUpdate = async (rowId: string, columnKey: string, newValue: string) => {
+  // Handle record update. `rowKey` is the encoded primary-key tuple from the grid.
+  const handleRecordUpdate = async (rowKey: string, columnKey: string, newValue: string) => {
     if (!selectedTable || selectedSchemaInfo.isProtected) {
       return;
     }
@@ -434,8 +443,7 @@ export default function TablesPage() {
         }
         const updates = { [columnKey]: conversionResult.value };
         await recordsHook.updateRecord({
-          pkColumn: primaryKeyColumn || 'id',
-          pkValue: rowId,
+          primaryKey: decodeRecordKey(rowKey),
           data: updates,
         });
       }
@@ -445,21 +453,21 @@ export default function TablesPage() {
     }
   };
 
-  // Handle bulk delete
-  const handleBulkDelete = async (ids: string[]) => {
-    if (!selectedTable || !ids.length || selectedSchemaInfo.isProtected) {
+  // Handle bulk delete. `rowKeys` are the encoded primary-key tuples from the grid.
+  const handleBulkDelete = async (rowKeys: string[]) => {
+    if (!selectedTable || !rowKeys.length || selectedSchemaInfo.isProtected) {
       return;
     }
 
     const shouldDelete = await confirm({
-      title: `Delete ${ids.length} ${ids.length === 1 ? 'Record' : 'Records'}`,
-      description: `Are you sure you want to delete ${ids.length} ${ids.length === 1 ? 'record' : 'records'}? This action cannot be undone.`,
+      title: `Delete ${rowKeys.length} ${rowKeys.length === 1 ? 'Record' : 'Records'}`,
+      description: `Are you sure you want to delete ${rowKeys.length} ${rowKeys.length === 1 ? 'record' : 'records'}? This action cannot be undone.`,
       confirmText: 'Delete',
       destructive: true,
     });
 
     if (shouldDelete) {
-      await recordsHook.deleteRecords({ pkColumn: primaryKeyColumn || 'id', pkValues: ids });
+      await recordsHook.deleteRecords({ primaryKeys: rowKeys.map(decodeRecordKey) });
       // Query invalidation is handled by the mutation, no manual refetch needed
       setSelectedRows(new Set());
     }
@@ -686,7 +694,7 @@ export default function TablesPage() {
                   loading={isLoadingTable && !tableData}
                   isSorting={isSorting}
                   isRefreshing={isRefreshing}
-                  rowKeyGetter={(row) => String(row[primaryKeyColumn || 'id'])}
+                  rowKeyGetter={(row) => encodeRecordKey(row, primaryKeyColumns)}
                   selectedRows={selectedRows}
                   onSelectedRowsChange={setSelectedRows}
                   sortColumns={sortColumns}

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -1,5 +1,5 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
-import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
+import { DEFAULT_DATABASE_SCHEMA, type RecordPrimaryKey } from '#features/database/helpers';
 import { apiClient } from '#lib/api/client';
 import { BulkUpsertResponse } from '@insforge/shared-schemas';
 import { convertToCSV, getExportFilename } from '#lib/utils/data-export';
@@ -8,6 +8,8 @@ interface AdminRecordListResponse {
   data: { [key: string]: ConvertedValue }[];
   pagination: { offset: number; limit: number; total: number };
 }
+
+export type { RecordPrimaryKey };
 
 export class RecordService {
   private buildAdminRecordsPath(
@@ -208,38 +210,32 @@ export class RecordService {
 
   updateRecord(
     table: string,
-    pkColumn: string,
-    pkValue: string,
+    primaryKey: RecordPrimaryKey,
     data: { [key: string]: ConvertedValue },
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    const params = new URLSearchParams({ pkColumn });
+    // pkKeys carries the full primary-key tuple so composite keys target one row.
+    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKey) });
 
-    return apiClient.request(
-      this.buildAdminRecordsPath(table, schemaName, `/${encodeURIComponent(pkValue)}`, params),
-      {
-        method: 'PATCH',
-        headers: apiClient.withAccessToken({
-          'Content-Type': 'application/json',
-        }),
-        body: JSON.stringify(data),
-      }
-    );
+    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
+      method: 'PATCH',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(data),
+    });
   }
 
   deleteRecords(
     table: string,
-    pkColumn: string,
-    pkValues: string[],
+    primaryKeys: RecordPrimaryKey[],
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    if (!pkValues.length) {
+    if (!primaryKeys.length) {
       return Promise.resolve();
     }
-    const params = new URLSearchParams({
-      pkColumn,
-      pkValues: pkValues.join(','),
-    });
+    // pkKeys is a JSON array of primary-key tuples so each selected row is matched exactly.
+    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKeys) });
 
     return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
       method: 'DELETE',

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -284,8 +284,27 @@ export const adminTableRecordsCreateRequestSchema = z
   .array(adminTableRecordSchema)
   .min(1, 'At least one record is required');
 
+// A primary-key value. Restricted to scalar types that survive a JSON round-trip
+// through the query string and that node-postgres can bind as a query parameter.
+export const adminTableRecordPkValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+// A single record's primary key as a map of pk column name -> value.
+// Supports composite primary keys (more than one column).
+export const adminTableRecordPrimaryKeySchema = z
+  .record(z.string().trim().min(1, 'Primary key column is required'), adminTableRecordPkValueSchema)
+  .refine((key) => Object.keys(key).length > 0, {
+    message: 'Primary key must include at least one column.',
+  });
+
+// `pkKeys` is a JSON-encoded object mapping each primary-key column to its value
+// for the record being updated, e.g. {"tenant_id":"t1","item_id":"i2"}.
 export const adminTableRecordUpdateQuerySchema = z.object({
-  pkColumn: z.string().trim().min(1, 'Primary key column is required'),
+  pkKeys: z.string().trim().min(1, 'Primary key is required'),
 });
 
 export const adminTableRecordUpdateRequestSchema = adminTableRecordSchema.refine(
@@ -295,9 +314,10 @@ export const adminTableRecordUpdateRequestSchema = adminTableRecordSchema.refine
   }
 );
 
+// `pkKeys` is a JSON-encoded array of primary-key objects, one per record to delete,
+// e.g. [{"tenant_id":"t1","item_id":"i2"},{"tenant_id":"t1","item_id":"i3"}].
 export const adminTableRecordsDeleteQuerySchema = z.object({
-  pkColumn: z.string().trim().min(1, 'Primary key column is required'),
-  pkValues: z.string().trim().min(1, 'At least one primary key value is required'),
+  pkKeys: z.string().trim().min(1, 'At least one primary key is required'),
 });
 
 export const adminTableRecordResponseSchema = adminTableRecordSchema;
@@ -368,6 +388,7 @@ export type AdminTableRecordsSortClause = z.infer<typeof adminTableRecordsSortCl
 export type AdminTableRecordsListQuery = z.infer<typeof adminTableRecordsListQuerySchema>;
 export type AdminTableRecordLookupQuery = z.infer<typeof adminTableRecordLookupQuerySchema>;
 export type AdminTableRecordsCreateRequest = z.infer<typeof adminTableRecordsCreateRequestSchema>;
+export type AdminTableRecordPrimaryKey = z.infer<typeof adminTableRecordPrimaryKeySchema>;
 export type AdminTableRecordUpdateQuery = z.infer<typeof adminTableRecordUpdateQuerySchema>;
 export type AdminTableRecordUpdateRequest = z.infer<typeof adminTableRecordUpdateRequestSchema>;
 export type AdminTableRecordsDeleteQuery = z.infer<typeof adminTableRecordsDeleteQuerySchema>;


### PR DESCRIPTION
Fixes #1570

## Summary

Database dashboard record edits/deletes mis-targeted rows on tables with composite primary keys. Row identity was collapsed to the **first** primary-key column end-to-end, so for tables like `(tenant_id, item_id)` where the first column repeats, editing or deleting one row could update/delete the wrong row or several rows.

This PR models record identity as the **full primary-key tuple** across the whole stack:

- **shared-schemas** (`database-api.schema.ts`): added `adminTableRecordPrimaryKeySchema` (a composite key map). Update/delete queries now take a JSON-encoded `pkKeys` (object for update, array for delete) instead of a single `pkColumn`/`pkValues`.
- **backend** (`admin-record.service.ts`, `admin.routes.ts`): `updateRecord` matches `WHERE col1 = $a AND col2 = $b ...`; `deleteRecords` matches each selected tuple as OR'd AND-groups (`WHERE (col1=$1 AND col2=$2) OR (...)`) instead of `WHERE first_col IN (...)`. The PATCH route drops the misleading `:recordId` path segment and carries the tuple in `pkKeys`.
- **dashboard** (`helpers.ts`, `TablesPage.tsx`, `DatabaseDataGrid.tsx`, `record.service.ts`, `useRecords.ts`): new `getPrimaryKeyColumns` / `encodeRecordKey` / `decodeRecordKey` helpers give the grid a stable composite row key. Cell edits and bulk deletes now send the full tuple, and PK cell styling applies to every PK column. Falls back to `['id']` when no PK metadata is present (preserves prior single-key behavior).

### Acceptance criteria
- ✅ Single-column primary keys continue to update/delete correctly (existing tests still pass; the generated SQL is unchanged for one-column keys).
- ✅ Composite primary keys use the full tuple for grid row keys, selection, updates, and deletes.
- ✅ Editing a row in a composite-PK table where the first PK value is duplicated updates exactly one row.
- ✅ Deleting selected rows deletes exactly the selected key tuples.

## How did you test this change?

- **Backend unit tests** (`backend/tests/unit/admin-record.service.test.ts`): updated existing single-key tests to the new signatures and added composite-PK regression tests — update targets the full tuple (`WHERE "tenant_id" = $2 AND "item_id" = $3`), single-tuple delete, and multi-tuple delete (`OR`'d AND-groups). All 11 pass.
- **Frontend unit tests** (`packages/dashboard/src/features/database/__tests__/helpers.test.ts`): added tests proving two rows that share a duplicated first PK column encode to **distinct** keys and round-trip through decode. All 8 pass.
- **Typecheck**: `@insforge/dashboard` passes cleanly; backend passes for the changed files (only pre-existing unrelated `razorpay` module-resolution error remains).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents wrong-row edits/deletes by identifying records with the full composite primary key and rejecting partial keys. Mutations use a dedicated PK lookup while read paths skip it. Fixes #1570.

- **Bug Fixes**
  - Use the full primary-key tuple across the dashboard and backend; grid row keys/editors encode the tuple; single-key tables behave the same.
  - Backend enforces exact table PK: updates match WHERE col1 AND col2; deletes match each selected tuple as OR’d AND-groups; partial or mismatched keys return 400. Tables with no detected PK fall back to caller-provided columns.
  - Mutations call a dedicated `information_schema` PK lookup so validation can’t be bypassed; list/lookup/create paths don’t run the lookup.

- **Migration**
  - PATCH /tables/:tableName/records now takes pkKeys (JSON object) in the query string and no longer uses :recordId in the path.
  - DELETE /tables/:tableName/records now takes pkKeys (JSON array of PK objects) instead of pkColumn/pkValues. Update direct API clients; the dashboard is already updated.

<sup>Written for commit 59c61d89f133249f68258cd09d3a2530423d5a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support composite primary keys for dashboard database record update and delete
> - Replaces single-column `pkColumn`/`pkValue` identifiers with a `pkKeys` JSON-encoded composite primary key object (or array for bulk delete) in both the API routes and client service calls.
> - `AdminRecordService.updateRecord` and `deleteRecords` now query `information_schema` to retrieve the full primary key definition and reject partial composite keys with a 400 error.
> - The dashboard data grid computes primary key columns via `getPrimaryKeyColumns`, encodes row identity as a full key tuple using `encodeRecordKey`, and passes decoded keys to update/delete mutations.
> - Shared schema in [database-api.schema.ts](https://github.com/InsForge/InsForge/pull/1584/files#diff-b36b10da732a6923ba4ff08476bd3df82a78720ab4015b38906da55567b904ff) adds `adminTableRecordPrimaryKeySchema` and replaces old query param schemas for update and delete endpoints.
> - Behavioral Change: PATCH endpoint path changes from `/tables/:tableName/records/:recordId` to `/tables/:tableName/records`; existing clients using `pkColumn`/`pkValues` or `recordId` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59c61d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record editing and deletion now fully support composite primary keys using encoded key tuples for row actions.
  * Dashboard row identifiers and editor updates are now driven by all primary-key columns (not just a single column).
* **Bug Fixes**
  * Update/delete targeting is stricter: operations require exact key-column matches and reject partial/invalid key inputs consistently.
  * Improved multi-record delete/update matching to ensure only intended rows are affected.
* **Tests**
  * Updated and expanded backend and dashboard tests for tuple encoding/decoding and composite-key SQL matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->