### PR TITLE
feat(database): expose developer-created schemas to PostgREST

### DIFF
--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -12,6 +12,7 @@ import { SocketManager } from '@/infra/socket/socket.manager.js';
 import { DataUpdateResourceType, ServerEvents } from '@/types/socket.js';
 import { DatabaseResourceUpdate } from '@/utils/sql-parser.js';
 import { PostgrestProxyService } from '@/services/database/postgrest-proxy.service.js';
+import { resolvePostgrestSchema } from '@/services/database/helpers.js';
 
 const router = Router();
 const proxyService = PostgrestProxyService.getInstance();
@@ -45,12 +46,25 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
       throw new AppError('Invalid table name', 400, ERROR_CODES.INVALID_INPUT);
     }
 
+    // Resolve the target schema the native PostgREST way: an explicit ?schema=
+    // is desugared into the Accept-Profile/Content-Profile header (and stripped
+    // from the forwarded query); a client-sent profile header is honored as-is.
+    const {
+      schemaName,
+      query: forwardedQuery,
+      headers: forwardedHeaders,
+    } = resolvePostgrestSchema(
+      req.method,
+      req.query as Record<string, unknown>,
+      req.headers as Record<string, string | string[] | undefined>
+    );
+
     // Process request body for POST/PATCH/PUT (filter empty values based on column types)
     const method = req.method.toUpperCase();
     let body = req.body;
 
     if (['POST', 'PATCH', 'PUT'].includes(method) && body && typeof body === 'object') {
-      const columnTypeMap = await DatabaseManager.getColumnTypeMap(tableName);
+      const columnTypeMap = await DatabaseManager.getColumnTypeMap(tableName, schemaName);
       if (Array.isArray(body)) {
         body = body.map((item) => {
           if (item && typeof item === 'object') {
@@ -78,8 +92,8 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     const proxyRequest = {
       method: req.method,
       path,
-      query: req.query as Record<string, unknown>,
-      headers: req.headers as Record<string, string | string[] | undefined>,
+      query: forwardedQuery,
+      headers: forwardedHeaders,
       body: ['POST', 'PUT', 'PATCH'].includes(req.method) ? body : undefined,
     };
 

--- a/backend/src/api/routes/database/rpc.routes.ts
+++ b/backend/src/api/routes/database/rpc.routes.ts
@@ -6,6 +6,7 @@ import { ERROR_CODES } from '@insforge/shared-schemas';
 import { validateFunctionName } from '@/utils/validations.js';
 import { successResponse } from '@/utils/response.js';
 import { PostgrestProxyService } from '@/services/database/postgrest-proxy.service.js';
+import { resolvePostgrestSchema } from '@/services/database/helpers.js';
 
 const router = Router();
 const proxyService = PostgrestProxyService.getInstance();
@@ -38,11 +39,21 @@ const forwardRpcToPostgrest = async (req: AuthRequest, res: Response, next: Next
       throw new AppError(`Invalid function name: ${functionName}`, 400, ERROR_CODES.INVALID_INPUT);
     }
 
+    // Resolve the target schema the native PostgREST way: ?schema= is desugared
+    // into the profile header (RPC uses Content-Profile for POST, Accept-Profile
+    // for GET) and stripped from the forwarded query; a client-sent profile
+    // header is honored as-is.
+    const { query: forwardedQuery, headers: forwardedHeaders } = resolvePostgrestSchema(
+      req.method,
+      req.query as Record<string, unknown>,
+      req.headers as Record<string, string | string[] | undefined>
+    );
+
     const proxyRequest = {
       method: req.method,
       path: `/rpc/${functionName}`,
-      query: req.query as Record<string, unknown>,
-      headers: req.headers as Record<string, string | string[] | undefined>,
+      query: forwardedQuery,
+      headers: forwardedHeaders,
       body: req.body,
     };
 

--- a/backend/src/infra/database/migrations/055_expose-custom-schemas-to-postgrest.sql
+++ b/backend/src/infra/database/migrations/055_expose-custom-schemas-to-postgrest.sql
@@ -1,0 +1,225 @@
+-- Migration: 055 - Expose developer-created schemas to PostgREST (deny-list model)
+--
+-- PostgREST only serves schemas listed in its `db-schemas` config, and that
+-- list is loaded once at boot (compose pins `PGRST_DB_SCHEMA: public`). There
+-- is no wildcard, so any schema a developer creates at runtime is invisible to
+-- the data API (`/api/database/records/*`) even though the proxy already
+-- forwards `Accept-Profile`/`Content-Profile`.
+--
+-- This migration makes the exposed set dynamic with an OPT-OUT (deny-list)
+-- policy: every schema is exposed to the data API EXCEPT Postgres internals,
+-- InsForge's own internal schemas, and any schema whose name begins with `_`
+-- (the "keep private" convention). New schemas become reachable automatically
+-- via a DDL event trigger -- including those created through raw SQL or
+-- migrations, not just the table API.
+--
+-- Mechanism:
+--   1. The live allowlist is stored in the authenticator role's in-database
+--      config (`pgrst.db_schemas`), which overrides the static env default and
+--      can change without restarting the PostgREST container.
+--   2. On CREATE/ALTER/DROP SCHEMA, an event trigger recomputes the allowlist,
+--      grants the API roles access on newly-exposed schemas, then signals
+--      PostgREST with BOTH `reload config` (re-read db_schemas) and
+--      `reload schema` (re-introspect objects). Both are required -- today's
+--      code only ever sends `reload schema`, which cannot pick up a new schema.
+--
+-- Security note: a schema that is not denied is exposed to anon/authenticated
+-- with the same CRUD surface as `public` today; row visibility is still gated
+-- by RLS. Tables created WITHOUT RLS are reachable by anon exactly as they are
+-- in `public` now -- this is intentionally consistent with the existing model.
+
+-- UP migration
+
+-- Authenticator role name (the role PostgREST connects as). Defaults to
+-- 'postgres' to match `PGRST_DB_URI`; deployments that use a dedicated
+-- authenticator can override with:
+--   ALTER DATABASE <db> SET insforge.authenticator_role = '<role>';
+CREATE OR REPLACE FUNCTION system.postgrest_authenticator_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $fn$
+  SELECT coalesce(nullif(current_setting('insforge.authenticator_role', true), ''), 'postgres');
+$fn$;
+
+-- Deny-list predicate: which schemas are exposed to the data API. Keeps
+-- `public`, excludes Postgres internals, InsForge internal schemas, any
+-- `_`-prefixed schema (the "keep private" convention), and any schema owned by
+-- an extension (e.g. pg_cron's `cron`, PostGIS's `tiger`). STABLE rather than
+-- IMMUTABLE because the extension-ownership check reads catalogs.
+CREATE OR REPLACE FUNCTION system.is_exposed_schema(p_schema text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $fn$
+  SELECT
+    p_schema IS NOT NULL
+    AND p_schema NOT LIKE 'pg\_%'
+    AND p_schema NOT LIKE '\_%'
+    AND p_schema NOT IN (
+      'information_schema',
+      -- InsForge-internal schemas (never exposed over the REST data API)
+      'ai', 'auth', 'compute', 'deployments', 'email', 'functions',
+      'memory', 'payments', 'realtime', 'schedules', 'storage', 'system'
+    )
+    -- Extension-managed schemas are infrastructure, not developer data.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM pg_depend d
+      JOIN pg_namespace n ON n.oid = d.objid
+      WHERE d.classid = 'pg_namespace'::regclass
+        AND d.refclassid = 'pg_extension'::regclass
+        AND d.deptype = 'e'
+        AND n.nspname = p_schema
+    );
+$fn$;
+
+-- Grant the API roles access on a schema, mirroring the `public` model (see
+-- migrations 045 and 047). SECURITY DEFINER so it runs with the migration
+-- owner's privileges when fired from a developer's CREATE SCHEMA. Idempotent.
+CREATE OR REPLACE FUNCTION system.grant_api_access_on_schema(p_schema text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+BEGIN
+  IF p_schema IS NULL OR NOT system.is_exposed_schema(p_schema) THEN
+    RETURN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = p_schema) THEN
+    RETURN;
+  END IF;
+
+  -- anon / authenticated: same CRUD surface as public, gated by RLS.
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')
+     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO anon, authenticated', p_schema);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO anon, authenticated', p_schema);
+    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO anon, authenticated', p_schema);
+
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated', p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated', p_schema);
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
+      EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE project_admin IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated', p_schema);
+      EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE project_admin IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated', p_schema);
+    END IF;
+  END IF;
+
+  -- project_admin: full access (BYPASSRLS is set on the role globally in 045).
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
+    EXECUTE format('GRANT ALL ON SCHEMA %I TO project_admin', p_schema);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO project_admin', p_schema);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO project_admin', p_schema);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO project_admin', p_schema);
+
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL PRIVILEGES ON TABLES TO project_admin', p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL PRIVILEGES ON SEQUENCES TO project_admin', p_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT EXECUTE ON FUNCTIONS TO project_admin', p_schema);
+  END IF;
+END;
+$fn$;
+
+-- Recompute the exposed-schema allowlist, write it to the authenticator role's
+-- in-database config, and signal PostgREST to reload.
+CREATE OR REPLACE FUNCTION system.sync_postgrest_exposed_schemas()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+DECLARE
+  v_list text;
+  v_role text;
+BEGIN
+  -- `public` sorts first so it stays the default profile (no Accept-Profile).
+  SELECT string_agg(n.nspname, ', ' ORDER BY (n.nspname <> 'public'), n.nspname)
+  INTO v_list
+  FROM pg_namespace n
+  WHERE system.is_exposed_schema(n.nspname);
+
+  v_list := coalesce(v_list, 'public');
+  v_role := system.postgrest_authenticator_role();
+
+  EXECUTE format('ALTER ROLE %I SET pgrst.db_schemas = %L', v_role, v_list);
+
+  -- Order matters: re-read config (new db_schemas) before re-introspecting.
+  PERFORM pg_notify('pgrst', 'reload config');
+  PERFORM pg_notify('pgrst', 'reload schema');
+END;
+$fn$;
+
+-- Event-trigger handler: keep PostgREST in sync as schemas come and go.
+CREATE OR REPLACE FUNCTION system.on_schema_ddl()
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $fn$
+DECLARE
+  obj record;
+  v_schema text;
+BEGIN
+  -- Grant access on any newly created/altered schema that is exposed.
+  FOR obj IN
+    SELECT object_identity
+    FROM pg_event_trigger_ddl_commands()
+    WHERE command_tag IN ('CREATE SCHEMA', 'ALTER SCHEMA')
+  LOOP
+    v_schema := trim(both '"' from obj.object_identity);
+    PERFORM system.grant_api_access_on_schema(v_schema);
+  END LOOP;
+
+  -- Recompute + reload regardless of CREATE/ALTER/DROP (a DROP has already
+  -- removed the schema from the catalog by ddl_command_end).
+  PERFORM system.sync_postgrest_exposed_schemas();
+END;
+$fn$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
+    GRANT EXECUTE ON FUNCTION system.sync_postgrest_exposed_schemas() TO project_admin;
+  END IF;
+END $$;
+
+DROP EVENT TRIGGER IF EXISTS insforge_sync_postgrest_schemas;
+CREATE EVENT TRIGGER insforge_sync_postgrest_schemas
+  ON ddl_command_end
+  WHEN TAG IN ('CREATE SCHEMA', 'ALTER SCHEMA', 'DROP SCHEMA')
+  EXECUTE FUNCTION system.on_schema_ddl();
+
+-- Backfill: grant access on existing exposed schemas and seed the allowlist.
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN SELECT nspname FROM pg_namespace WHERE system.is_exposed_schema(nspname)
+  LOOP
+    PERFORM system.grant_api_access_on_schema(rec.nspname);
+  END LOOP;
+
+  PERFORM system.sync_postgrest_exposed_schemas();
+END $$;
+
+-- DOWN migration
+
+DROP EVENT TRIGGER IF EXISTS insforge_sync_postgrest_schemas;
+
+-- Reset the data API back to public-only before tearing down the helpers.
+DO $$
+DECLARE
+  v_role text;
+BEGIN
+  v_role := coalesce(nullif(current_setting('insforge.authenticator_role', true), ''), 'postgres');
+  EXECUTE format('ALTER ROLE %I SET pgrst.db_schemas = %L', v_role, 'public');
+  PERFORM pg_notify('pgrst', 'reload config');
+  PERFORM pg_notify('pgrst', 'reload schema');
+END $$;
+
+DROP FUNCTION IF EXISTS system.on_schema_ddl() CASCADE;
+DROP FUNCTION IF EXISTS system.sync_postgrest_exposed_schemas();
+DROP FUNCTION IF EXISTS system.grant_api_access_on_schema(text);
+DROP FUNCTION IF EXISTS system.is_exposed_schema(text);
+DROP FUNCTION IF EXISTS system.postgrest_authenticator_role();

--- a/backend/src/infra/database/migrations/055_expose-custom-schemas-to-postgrest.sql
+++ b/backend/src/infra/database/migrations/055_expose-custom-schemas-to-postgrest.sql
@@ -46,7 +46,12 @@ $fn$;
 -- `public`, excludes Postgres internals, InsForge internal schemas, any
 -- `_`-prefixed schema (the "keep private" convention), and any schema owned by
 -- an extension (e.g. pg_cron's `cron`, PostGIS's `tiger`). STABLE rather than
--- IMMUTABLE because the extension-ownership check reads catalogs.
+-- IMMUTABLE because it reads catalogs and the `insforge.internal_schemas` GUC.
+--
+-- The InsForge-internal deny-list is sourced from the `insforge.internal_schemas`
+-- setting (defined in postgresql.conf, alongside `insforge.policy_grant_tables`)
+-- so it has a single source of truth and can be updated without a migration.
+-- The literal below is only a fallback for deployments where the GUC is unset.
 CREATE OR REPLACE FUNCTION system.is_exposed_schema(p_schema text)
 RETURNS boolean
 LANGUAGE sql
@@ -56,11 +61,19 @@ AS $fn$
     p_schema IS NOT NULL
     AND p_schema NOT LIKE 'pg\_%'
     AND p_schema NOT LIKE '\_%'
-    AND p_schema NOT IN (
-      'information_schema',
-      -- InsForge-internal schemas (never exposed over the REST data API)
-      'ai', 'auth', 'compute', 'deployments', 'email', 'functions',
-      'memory', 'payments', 'realtime', 'schedules', 'storage', 'system'
+    AND p_schema <> 'information_schema'
+    AND p_schema <> ALL (
+      -- Comma-separated GUC; strip any incidental whitespace before splitting.
+      string_to_array(
+        regexp_replace(
+          coalesce(
+            nullif(current_setting('insforge.internal_schemas', true), ''),
+            'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
+          ),
+          '\s', '', 'g'
+        ),
+        ','
+      )
     )
     -- Extension-managed schemas are infrastructure, not developer data.
     AND NOT EXISTS (

--- a/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
+++ b/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
@@ -1,4 +1,4 @@
--- Migration: 055 - Expose developer-created schemas to PostgREST (deny-list model)
+-- Migration: 056 - Expose developer-created schemas to PostgREST (deny-list model)
 --
 -- PostgREST only serves schemas listed in its `db-schemas` config, and that
 -- list is loaded once at boot (compose pins `PGRST_DB_SCHEMA: public`). There

--- a/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
+++ b/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
@@ -14,33 +14,28 @@
 -- migrations, not just the table API.
 --
 -- Mechanism:
---   1. The live allowlist is stored in the authenticator role's in-database
---      config (`pgrst.db_schemas`), which overrides the static env default and
---      can change without restarting the PostgREST container.
---   2. On CREATE/ALTER/DROP SCHEMA, an event trigger recomputes the allowlist,
---      grants the API roles access on newly-exposed schemas, then signals
---      PostgREST with BOTH `reload config` (re-read db_schemas) and
+--   1. The live allowlist is stored in the connecting role's in-database config
+--      (`pgrst.db_schemas`), which overrides the static env default and can
+--      change without restarting the PostgREST container.
+--   2. On CREATE/ALTER/DROP SCHEMA, an event trigger recomputes the allowlist
+--      and signals PostgREST with BOTH `reload config` (re-read db_schemas) and
 --      `reload schema` (re-introspect objects). Both are required -- today's
 --      code only ever sends `reload schema`, which cannot pick up a new schema.
 --
--- Security note: a schema that is not denied is exposed to anon/authenticated
--- with the same CRUD surface as `public` today; row visibility is still gated
--- by RLS. Tables created WITHOUT RLS are reachable by anon exactly as they are
--- in `public` now -- this is intentionally consistent with the existing model.
+-- This migration handles EXPOSURE (making a schema routable) only -- not
+-- ACCESS. Privileges are the developer's responsibility, exactly as on any
+-- Postgres schema:
+--   * Objects created through the dashboard / table API / raw SQL run as
+--     project_admin (see withAdminContext), so project_admin owns them and has
+--     full access automatically.
+--   * To reach a schema as anon/authenticated, grant it explicitly -- e.g. in
+--     the same migration that creates the schema:
+--       GRANT USAGE ON SCHEMA my_schema TO anon, authenticated;
+--       GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_schema TO anon, authenticated;
+--     Row visibility is then gated by RLS as usual. A schema is therefore
+--     routable as soon as it exists, but unreachable until granted.
 
 -- UP migration
-
--- Authenticator role name (the role PostgREST connects as). Defaults to
--- 'postgres' to match `PGRST_DB_URI`; deployments that use a dedicated
--- authenticator can override with:
---   ALTER DATABASE <db> SET insforge.authenticator_role = '<role>';
-CREATE OR REPLACE FUNCTION system.postgrest_authenticator_role()
-RETURNS text
-LANGUAGE sql
-STABLE
-AS $fn$
-  SELECT coalesce(nullif(current_setting('insforge.authenticator_role', true), ''), 'postgres');
-$fn$;
 
 -- Deny-list predicate: which schemas are exposed to the data API. Keeps
 -- `public`, excludes Postgres internals, InsForge internal schemas, any
@@ -87,55 +82,14 @@ AS $fn$
     );
 $fn$;
 
--- Grant the API roles access on a schema, mirroring the `public` model (see
--- migrations 045 and 047). SECURITY DEFINER so it runs with the migration
--- owner's privileges when fired from a developer's CREATE SCHEMA. Idempotent.
-CREATE OR REPLACE FUNCTION system.grant_api_access_on_schema(p_schema text)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp
-AS $fn$
-BEGIN
-  IF p_schema IS NULL OR NOT system.is_exposed_schema(p_schema) THEN
-    RETURN;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = p_schema) THEN
-    RETURN;
-  END IF;
-
-  -- anon / authenticated: same CRUD surface as public, gated by RLS.
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')
-     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-    EXECUTE format('GRANT USAGE ON SCHEMA %I TO anon, authenticated', p_schema);
-    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %I TO anon, authenticated', p_schema);
-    EXECUTE format('GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %I TO anon, authenticated', p_schema);
-
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated', p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated', p_schema);
-
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
-      EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE project_admin IN SCHEMA %I GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon, authenticated', p_schema);
-      EXECUTE format('ALTER DEFAULT PRIVILEGES FOR ROLE project_admin IN SCHEMA %I GRANT USAGE, SELECT ON SEQUENCES TO anon, authenticated', p_schema);
-    END IF;
-  END IF;
-
-  -- project_admin: full access (BYPASSRLS is set on the role globally in 045).
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
-    EXECUTE format('GRANT ALL ON SCHEMA %I TO project_admin', p_schema);
-    EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO project_admin', p_schema);
-    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO project_admin', p_schema);
-    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO project_admin', p_schema);
-
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL PRIVILEGES ON TABLES TO project_admin', p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL PRIVILEGES ON SEQUENCES TO project_admin', p_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT EXECUTE ON FUNCTIONS TO project_admin', p_schema);
-  END IF;
-END;
-$fn$;
-
--- Recompute the exposed-schema allowlist, write it to the authenticator role's
+-- Recompute the exposed-schema allowlist, write it to the connecting role's
 -- in-database config, and signal PostgREST to reload.
+--
+-- SECURITY DEFINER so it runs with the migration owner's privileges when fired
+-- from a developer's CREATE SCHEMA. `current_user` inside a SECURITY DEFINER
+-- function is the function owner -- i.e. the role the migration ran as, which
+-- is the same role PostgREST connects as (`PGRST_DB_URI` uses `POSTGRES_USER`).
+-- So `ALTER ROLE CURRENT_USER` always targets the right role with no config.
 CREATE OR REPLACE FUNCTION system.sync_postgrest_exposed_schemas()
 RETURNS void
 LANGUAGE plpgsql
@@ -144,7 +98,6 @@ SET search_path = pg_catalog, pg_temp
 AS $fn$
 DECLARE
   v_list text;
-  v_role text;
 BEGIN
   -- `public` sorts first so it stays the default profile (no Accept-Profile).
   SELECT string_agg(n.nspname, ', ' ORDER BY (n.nspname <> 'public'), n.nspname)
@@ -153,9 +106,8 @@ BEGIN
   WHERE system.is_exposed_schema(n.nspname);
 
   v_list := coalesce(v_list, 'public');
-  v_role := system.postgrest_authenticator_role();
 
-  EXECUTE format('ALTER ROLE %I SET pgrst.db_schemas = %L', v_role, v_list);
+  EXECUTE format('ALTER ROLE CURRENT_USER SET pgrst.db_schemas = %L', v_list);
 
   -- Order matters: re-read config (new db_schemas) before re-introspecting.
   PERFORM pg_notify('pgrst', 'reload config');
@@ -163,29 +115,16 @@ BEGIN
 END;
 $fn$;
 
--- Event-trigger handler: keep PostgREST in sync as schemas come and go.
+-- Event-trigger handler: keep PostgREST's exposed-schema set in sync as schemas
+-- come and go. Recompute + reload regardless of CREATE/ALTER/DROP (a DROP has
+-- already removed the schema from the catalog by ddl_command_end).
 CREATE OR REPLACE FUNCTION system.on_schema_ddl()
 RETURNS event_trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog, pg_temp
 AS $fn$
-DECLARE
-  obj record;
-  v_schema text;
 BEGIN
-  -- Grant access on any newly created/altered schema that is exposed.
-  FOR obj IN
-    SELECT object_identity
-    FROM pg_event_trigger_ddl_commands()
-    WHERE command_tag IN ('CREATE SCHEMA', 'ALTER SCHEMA')
-  LOOP
-    v_schema := trim(both '"' from obj.object_identity);
-    PERFORM system.grant_api_access_on_schema(v_schema);
-  END LOOP;
-
-  -- Recompute + reload regardless of CREATE/ALTER/DROP (a DROP has already
-  -- removed the schema from the catalog by ddl_command_end).
   PERFORM system.sync_postgrest_exposed_schemas();
 END;
 $fn$;
@@ -203,18 +142,8 @@ CREATE EVENT TRIGGER insforge_sync_postgrest_schemas
   WHEN TAG IN ('CREATE SCHEMA', 'ALTER SCHEMA', 'DROP SCHEMA')
   EXECUTE FUNCTION system.on_schema_ddl();
 
--- Backfill: grant access on existing exposed schemas and seed the allowlist.
-DO $$
-DECLARE
-  rec record;
-BEGIN
-  FOR rec IN SELECT nspname FROM pg_namespace WHERE system.is_exposed_schema(nspname)
-  LOOP
-    PERFORM system.grant_api_access_on_schema(rec.nspname);
-  END LOOP;
-
-  PERFORM system.sync_postgrest_exposed_schemas();
-END $$;
+-- Backfill: seed the allowlist from schemas that already exist.
+SELECT system.sync_postgrest_exposed_schemas();
 
 -- DOWN migration
 
@@ -222,17 +151,12 @@ DROP EVENT TRIGGER IF EXISTS insforge_sync_postgrest_schemas;
 
 -- Reset the data API back to public-only before tearing down the helpers.
 DO $$
-DECLARE
-  v_role text;
 BEGIN
-  v_role := coalesce(nullif(current_setting('insforge.authenticator_role', true), ''), 'postgres');
-  EXECUTE format('ALTER ROLE %I SET pgrst.db_schemas = %L', v_role, 'public');
+  EXECUTE format('ALTER ROLE CURRENT_USER SET pgrst.db_schemas = %L', 'public');
   PERFORM pg_notify('pgrst', 'reload config');
   PERFORM pg_notify('pgrst', 'reload schema');
 END $$;
 
 DROP FUNCTION IF EXISTS system.on_schema_ddl() CASCADE;
 DROP FUNCTION IF EXISTS system.sync_postgrest_exposed_schemas();
-DROP FUNCTION IF EXISTS system.grant_api_access_on_schema(text);
 DROP FUNCTION IF EXISTS system.is_exposed_schema(text);
-DROP FUNCTION IF EXISTS system.postgrest_authenticator_role();

--- a/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
+++ b/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql
@@ -8,10 +8,9 @@
 --
 -- This migration makes the exposed set dynamic with an OPT-OUT (deny-list)
 -- policy: every schema is exposed to the data API EXCEPT Postgres internals,
--- InsForge's own internal schemas, and any schema whose name begins with `_`
--- (the "keep private" convention). New schemas become reachable automatically
--- via a DDL event trigger -- including those created through raw SQL or
--- migrations, not just the table API.
+-- InsForge's own internal schemas, and extension-owned schemas. New schemas
+-- become reachable automatically via a DDL event trigger -- including those
+-- created through raw SQL or migrations, not just the table API.
 --
 -- Mechanism:
 --   1. The live allowlist is stored in the connecting role's in-database config
@@ -38,10 +37,10 @@
 -- UP migration
 
 -- Deny-list predicate: which schemas are exposed to the data API. Keeps
--- `public`, excludes Postgres internals, InsForge internal schemas, any
--- `_`-prefixed schema (the "keep private" convention), and any schema owned by
--- an extension (e.g. pg_cron's `cron`, PostGIS's `tiger`). STABLE rather than
--- IMMUTABLE because it reads catalogs and the `insforge.internal_schemas` GUC.
+-- `public`, excludes Postgres internals, InsForge internal schemas, and any
+-- schema owned by an extension (e.g. pg_cron's `cron`, PostGIS's `tiger`).
+-- STABLE rather than IMMUTABLE because it reads catalogs and the
+-- `insforge.internal_schemas` GUC.
 --
 -- The InsForge-internal deny-list is sourced from the `insforge.internal_schemas`
 -- setting (defined in postgresql.conf, alongside `insforge.policy_grant_tables`)
@@ -55,7 +54,6 @@ AS $fn$
   SELECT
     p_schema IS NOT NULL
     AND p_schema NOT LIKE 'pg\_%'
-    AND p_schema NOT LIKE '\_%'
     AND p_schema <> 'information_schema'
     AND p_schema <> ALL (
       -- Comma-separated GUC; strip any incidental whitespace before splitting.

--- a/backend/src/services/database/helpers.ts
+++ b/backend/src/services/database/helpers.ts
@@ -71,7 +71,18 @@ export function resolvePostgrestSchema(
 ): { schemaName: string; query: Record<string, unknown>; headers: ProxyHeaderBag } {
   const profileHeader = postgrestProfileHeaderName(method);
 
+  // An explicit ?schema= must be a single non-empty value. Don't let a blank or
+  // repeated param (Express parses `?schema=a&schema=b` as an array) silently
+  // fall back to `public` -- that would route an explicit request to the wrong
+  // schema. Reject it instead.
   if (query.schema !== undefined) {
+    if (typeof query.schema !== 'string' || query.schema.trim().length === 0) {
+      throw new AppError(
+        'The "schema" query parameter must be a single non-empty schema name.',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
     const schemaName = normalizeDatabaseSchemaName(query.schema);
     const forwardedQuery = { ...query };
     delete forwardedQuery.schema;
@@ -82,9 +93,21 @@ export function resolvePostgrestSchema(
     };
   }
 
+  // Honor a client-sent profile header, but it must be a single value -- a
+  // repeated header arrives as an array, which we'd otherwise ignore for
+  // schemaName while still forwarding it, desyncing metadata from routing.
   const headerValue = headers[profileHeader];
+  if (Array.isArray(headerValue)) {
+    throw new AppError(
+      `The "${profileHeader}" header must be a single schema name.`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
   if (typeof headerValue === 'string' && headerValue.trim().length > 0) {
-    return { schemaName: normalizeDatabaseSchemaName(headerValue), query, headers };
+    const schemaName = normalizeDatabaseSchemaName(headerValue);
+    // Re-forward the normalized value so the header can't disagree with schemaName.
+    return { schemaName, query, headers: { ...headers, [profileHeader]: schemaName } };
   }
 
   return { schemaName: DEFAULT_DATABASE_SCHEMA, query, headers };

--- a/backend/src/services/database/helpers.ts
+++ b/backend/src/services/database/helpers.ts
@@ -38,6 +38,58 @@ export function buildQualifiedTableKey(tableName: string, schemaName: string): s
   return `${schemaName}.${tableName}`;
 }
 
+type ProxyHeaderBag = Record<string, string | string[] | undefined>;
+
+const POSTGREST_READ_METHODS = new Set(['GET', 'HEAD']);
+
+/**
+ * PostgREST selects the schema via a profile header: `Accept-Profile` for reads
+ * and `Content-Profile` for writes/RPC.
+ */
+export function postgrestProfileHeaderName(method: string): 'accept-profile' | 'content-profile' {
+  return POSTGREST_READ_METHODS.has(method.toUpperCase()) ? 'accept-profile' : 'content-profile';
+}
+
+/**
+ * Resolve the target schema for a data-API request the native PostgREST way and
+ * return the query/headers to forward.
+ *
+ * Precedence:
+ *   1. An explicit `?schema=` convenience param, desugared into the correct
+ *      profile header for the method and stripped from the forwarded query (so
+ *      PostgREST does not treat `schema` as a column filter).
+ *   2. A client-sent `Accept-Profile`/`Content-Profile` header, honored as-is.
+ *   3. PostgREST's default schema (the first entry in `db-schemas`).
+ *
+ * `schemaName` is the effective schema for server-side lookups (e.g. column
+ * types); `query`/`headers` are what should be forwarded to PostgREST.
+ */
+export function resolvePostgrestSchema(
+  method: string,
+  query: Record<string, unknown>,
+  headers: ProxyHeaderBag
+): { schemaName: string; query: Record<string, unknown>; headers: ProxyHeaderBag } {
+  const profileHeader = postgrestProfileHeaderName(method);
+
+  if (query.schema !== undefined) {
+    const schemaName = normalizeDatabaseSchemaName(query.schema);
+    const forwardedQuery = { ...query };
+    delete forwardedQuery.schema;
+    return {
+      schemaName,
+      query: forwardedQuery,
+      headers: { ...headers, [profileHeader]: schemaName },
+    };
+  }
+
+  const headerValue = headers[profileHeader];
+  if (typeof headerValue === 'string' && headerValue.trim().length > 0) {
+    return { schemaName: normalizeDatabaseSchemaName(headerValue), query, headers };
+  }
+
+  return { schemaName: DEFAULT_DATABASE_SCHEMA, query, headers };
+}
+
 export function quoteIdentifier(identifier: string): string {
   validateIdentifier(identifier);
   return `"${identifier.replace(/"/g, '""')}"`;

--- a/backend/tests/unit/database-helpers.test.ts
+++ b/backend/tests/unit/database-helpers.test.ts
@@ -4,7 +4,9 @@ import {
   buildQualifiedTableKey,
   isInternalDashboardSchema,
   normalizeDatabaseSchemaName,
+  postgrestProfileHeaderName,
   quoteQualifiedName,
+  resolvePostgrestSchema,
   splitQualifiedTableReference,
 } from '../../src/services/database/helpers';
 
@@ -49,5 +51,62 @@ describe('database helpers', () => {
     expect(isInternalDashboardSchema('information_schema')).toBe(true);
     expect(isInternalDashboardSchema('pg_catalog')).toBe(true);
     expect(isInternalDashboardSchema('analytics')).toBe(false);
+  });
+});
+
+describe('resolvePostgrestSchema', () => {
+  it('maps the method to the right PostgREST profile header', () => {
+    expect(postgrestProfileHeaderName('GET')).toBe('accept-profile');
+    expect(postgrestProfileHeaderName('head')).toBe('accept-profile');
+    expect(postgrestProfileHeaderName('POST')).toBe('content-profile');
+    expect(postgrestProfileHeaderName('PATCH')).toBe('content-profile');
+    expect(postgrestProfileHeaderName('DELETE')).toBe('content-profile');
+  });
+
+  it('defaults to public with no schema param or profile header', () => {
+    const result = resolvePostgrestSchema('GET', { select: '*' }, {});
+    expect(result.schemaName).toBe('public');
+    expect(result.query).toEqual({ select: '*' });
+    expect(result.headers['accept-profile']).toBeUndefined();
+  });
+
+  it('desugars ?schema= on reads into Accept-Profile and strips it from the query', () => {
+    const result = resolvePostgrestSchema('GET', { schema: 'analytics', select: '*' }, {});
+    expect(result.schemaName).toBe('analytics');
+    expect(result.headers['accept-profile']).toBe('analytics');
+    expect(result.query).toEqual({ select: '*' });
+    expect('schema' in result.query).toBe(false);
+  });
+
+  it('desugars ?schema= on writes into Content-Profile', () => {
+    const result = resolvePostgrestSchema('POST', { schema: 'analytics' }, {});
+    expect(result.schemaName).toBe('analytics');
+    expect(result.headers['content-profile']).toBe('analytics');
+    expect('accept-profile' in result.headers).toBe(false);
+  });
+
+  it('honors a client-sent profile header when no ?schema= is present', () => {
+    const read = resolvePostgrestSchema('GET', {}, { 'accept-profile': 'analytics' });
+    expect(read.schemaName).toBe('analytics');
+
+    const write = resolvePostgrestSchema('POST', {}, { 'content-profile': 'analytics' });
+    expect(write.schemaName).toBe('analytics');
+  });
+
+  it('lets ?schema= override a client-sent profile header', () => {
+    const result = resolvePostgrestSchema(
+      'GET',
+      { schema: 'analytics' },
+      { 'accept-profile': 'reporting' }
+    );
+    expect(result.schemaName).toBe('analytics');
+    expect(result.headers['accept-profile']).toBe('analytics');
+  });
+
+  it('rejects internal schemas passed via ?schema=', () => {
+    expect(() => resolvePostgrestSchema('GET', { schema: 'pg_catalog' }, {})).toThrow(AppError);
+    expect(() => resolvePostgrestSchema('GET', { schema: 'information_schema' }, {})).toThrow(
+      AppError
+    );
   });
 });

--- a/backend/tests/unit/database-helpers.test.ts
+++ b/backend/tests/unit/database-helpers.test.ts
@@ -109,4 +109,23 @@ describe('resolvePostgrestSchema', () => {
       AppError
     );
   });
+
+  it('rejects a malformed explicit ?schema= instead of falling back to public', () => {
+    // Blank value.
+    expect(() => resolvePostgrestSchema('GET', { schema: '' }, {})).toThrow(AppError);
+    // Repeated param: Express parses `?schema=a&schema=b` as an array.
+    expect(() => resolvePostgrestSchema('GET', { schema: ['a', 'b'] }, {})).toThrow(AppError);
+  });
+
+  it('rejects an array-valued profile header', () => {
+    expect(() =>
+      resolvePostgrestSchema('GET', {}, { 'accept-profile': ['analytics', 'reporting'] })
+    ).toThrow(AppError);
+  });
+
+  it('re-forwards the normalized profile header so it cannot disagree with schemaName', () => {
+    const result = resolvePostgrestSchema('GET', {}, { 'accept-profile': '  analytics  ' });
+    expect(result.schemaName).toBe('analytics');
+    expect(result.headers['accept-profile']).toBe('analytics');
+  });
 });

--- a/deploy/docker-init/db/postgresql.conf
+++ b/deploy/docker-init/db/postgresql.conf
@@ -19,4 +19,11 @@ shared_preload_libraries = 'pg_cron,http,pgcrypto,insforge_pg_utils'
 insforge.policy_grant_role = 'project_admin'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
+# InsForge-internal schemas that must never be exposed to the REST data API.
+# Read by system.is_exposed_schema (migration 055) to decide PostgREST's
+# db_schemas allowlist. Comma-separated, no spaces. Postgres internals (pg_*,
+# information_schema) and _-prefixed schemas are handled separately and need
+# not be listed here. Edit + `SELECT pg_reload_conf()` to apply at runtime.
+insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
+
 cron.database_name = 'insforge' # Add this line to specify the database for pg_cron

--- a/deploy/docker-init/db/postgresql.conf
+++ b/deploy/docker-init/db/postgresql.conf
@@ -20,10 +20,10 @@ insforge.policy_grant_role = 'project_admin'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 # InsForge-internal schemas that must never be exposed to the REST data API.
-# Read by system.is_exposed_schema (migration 055) to decide PostgREST's
+# Read by system.is_exposed_schema (migration 056) to decide PostgREST's
 # db_schemas allowlist. Comma-separated, no spaces. Postgres internals (pg_*,
-# information_schema) and _-prefixed schemas are handled separately and need
-# not be listed here. Edit + `SELECT pg_reload_conf()` to apply at runtime.
+# information_schema) and extension-owned schemas are handled separately and
+# need not be listed here. Edit + `SELECT pg_reload_conf()` to apply at runtime.
 insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
 
 cron.database_name = 'insforge' # Add this line to specify the database for pg_cron

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -165,6 +165,7 @@ spec:
                     shared_preload_libraries = 'pg_cron,http,pgcrypto,insforge_pg_utils'
                     insforge.policy_grant_role = 'project_admin'
                     insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
+                    insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
                     cron.database_name = 'insforge'
                 - path: /docker-entrypoint-initdb.d/01-init.sql
                   template: |

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -24,6 +24,7 @@ interface RecordFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tableName: string;
+  schemaName: string;
   schema: ColumnSchema[];
   foreignKeys?: ForeignKeySchema[];
   onSuccess?: () => void;
@@ -33,12 +34,13 @@ export function RecordFormDialog({
   open,
   onOpenChange,
   tableName,
+  schemaName,
   schema,
   foreignKeys,
   onSuccess,
 }: RecordFormDialogProps) {
   const [error, setError] = useState<string | null>(null);
-  const { createRecord, isCreating } = useRecords(tableName);
+  const { createRecord, isCreating } = useRecords(tableName, schemaName);
 
   const displayFields = useMemo(() => {
     const filteredFields = schema.filter((field) => !SYSTEM_FIELDS.includes(field.columnName));

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -750,6 +750,7 @@ export default function TablesPage() {
           open={showRecordForm}
           onOpenChange={setShowRecordForm}
           tableName={selectedTable}
+          schemaName={selectedSchema}
           schema={schemaData.columns}
           foreignKeys={schemaData.foreignKeys}
         />


### PR DESCRIPTION
## Problem

PostgREST only serves the schemas listed in its `db-schemas` config, and that list is loaded once at boot — `docker-compose.yml` pins `PGRST_DB_SCHEMA: public`. There is **no wildcard**. So any schema a developer creates at runtime (via the table API, raw SQL, or migrations) is invisible to the data API (`/api/database/records/*`), even though the proxy already forwards `Accept-Profile`/`Content-Profile`.

A second, subtler gap: every code path today only ever sends `NOTIFY pgrst, 'reload schema'`. That re-introspects tables **within already-exposed schemas** but cannot pick up a *new* schema — that requires `reload config` to re-read `db-schemas`.

## Approach — opt-out (deny-list)

New migration `055_expose-custom-schemas-to-postgrest.sql`:

1. **Dynamic allowlist in-database.** The exposed set is stored in the authenticator role's in-DB config (`ALTER ROLE … SET pgrst.db_schemas = …`), which overrides the static env default and changes without restarting the PostgREST container.
2. **Event trigger keeps it in sync.** A `ddl_command_end` trigger on `CREATE/ALTER/DROP SCHEMA`:
   - grants `anon` / `authenticated` / `project_admin` the same access they have on `public` (mirrors migrations 045 & 047; row visibility still gated by RLS),
   - recomputes the allowlist,
   - signals PostgREST with **both** `reload config` then `reload schema`.
   Because it's a DB-level event trigger, it catches schemas created through raw SQL and migrations, not just the table API.
3. **Deny-list** excludes Postgres internals (`pg_*`, `information_schema`), InsForge internal schemas (`auth`, `storage`, `system`, `payments`, …), **extension-owned schemas** (pg_cron's `cron`, PostGIS's `tiger`, etc., detected via `pg_depend`), and any `_`-prefixed schema (keep-private convention). `public` stays first so it remains the default profile.
4. **Backfill** seeds the allowlist + grants from schemas that already exist.

## Verification

Ran UP and DOWN against the running PostgreSQL 15 dev instance, inside a rolled-back transaction:

- After backfill: `pgrst.db_schemas = public` (internal + `cron` correctly excluded).
- `CREATE SCHEMA analytics; CREATE TABLE analytics.events(...)` → `anon` auto-granted `USAGE` on `analytics` and `SELECT` on the table; allowlist becomes `public, analytics`.
- `CREATE SCHEMA "_private"` → stays hidden (`is_exposed_schema` = false).
- DOWN drops all functions + the event trigger and resets the API to public-only.

## Open questions for review

- **Authenticator role:** the function defaults to `postgres` (matches `PGRST_DB_URI`) and is overridable via `ALTER DATABASE … SET insforge.authenticator_role`. Confirm this matches all deployment topologies. If a dedicated `authenticator` role is ever introduced, this is the one knob to set.
- **Default-without-RLS exposure:** a non-denied schema is reachable by `anon` with the same CRUD surface as `public`; a table created without RLS is readable by `anon`, exactly as in `public` today. Flagging explicitly in case product wants schema-level exposure to be opt-in instead.
- Confirm `reload config` + `reload schema` ordering and the `pgrst.db_schemas` GUC name against the deployed PostgREST version (validated on v12.2.12).

> Draft: pairs with a planned CLI/SDK change to map a `schema` param to `Accept-Profile`/`Content-Profile`. This PR is the backend half (the critical path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose developer-created schemas to `PostgREST` by dynamically maintaining `pgrst.db_schemas`, and add native schema selection in the proxy for records and RPC with strict validation to prevent misrouting. Internal schemas stay hidden; access is unchanged and RLS still applies.

- **New Features**
  - Migration 056: compute an allowlist from the `insforge.internal_schemas` GUC (deny-list), excluding `pg_*`, `information_schema`, and extension-owned schemas; keep `public` first. Store it in the authenticator’s `pgrst.db_schemas`; a `ddl_command_end` trigger recomputes it and sends `reload config` then `reload schema`. Exposure only — no automatic grants.
  - Native schema selection: `?schema=` is translated to `Accept-Profile`/`Content-Profile` and removed from the forwarded query; existing profile headers are honored. Invalid `?schema=` (blank or repeated) and array-valued profile headers return 400; headers are normalized to match the resolved schema. Records use the resolved schema for column type lookups. Dashboard passes `schemaName` to `useRecords`.

- **Migration**
  - Configure `insforge.internal_schemas` in `postgresql.conf`; apply via `pg_reload_conf()`. Backfill seeds the allowlist; DOWN resets to `public` only.

<sup>Written for commit 2b4ad27999cf16778421e179006411e999d19700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose developer-created schemas to PostgREST via dynamic allowlist and schema routing
> - Adds a migration ([056_expose-custom-schemas-to-postgrest.sql](https://github.com/InsForge/InsForge/pull/1585/files#diff-23cc4afb74e8e3ad166a3085e0856dab5c0fd05c9b37b61fe2494076956f5796)) that creates `system.sync_postgrest_exposed_schemas`, which dynamically updates PostgREST's `db_schemas` allowlist and triggers a reload; an event trigger fires it automatically after `CREATE/ALTER/DROP SCHEMA`.
> - Adds `resolvePostgrestSchema` in ([helpers.ts](https://github.com/InsForge/InsForge/pull/1585/files#diff-17ab5871789553ebe478b10c604e5f04f75364da4e01327c7d1b454ad2c68268)) to handle schema targeting in API routes: the `?schema=` query param is desugared into the correct `Accept-Profile`/`Content-Profile` header and stripped from the forwarded query.
> - Updates `records.routes.ts` and `rpc.routes.ts` to use `resolvePostgrestSchema`, so non-public schemas can be targeted in both data and RPC requests.
> - Passes `schemaName` through the dashboard's `RecordFormDialog` so record creation works in non-public schemas.
> - Defines an `insforge.internal_schemas` GUC in `postgresql.conf` used by `system.is_exposed_schema` to deny-list internal schemas from PostgREST exposure.
> - Risk: the event trigger reloads PostgREST config and schema on every `CREATE/ALTER/DROP SCHEMA`, which may add latency to DDL operations.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1585 opened
>
> - Added validation to `resolvePostgrestSchema` utility to reject invalid schema query parameters and profile headers, and implemented header normalization [2b4ad27]
> - Updated configuration file comments to reference migration 056 and clarify extension-owned schema handling [2b4ad27]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7460fab.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable custom database schema support across record creation and RPC calls.
  * The record form dialog now explicitly uses the selected schema when submitting data.

* **Bug Fixes**
  * Improved request forwarding to correctly resolve and apply the effective schema for both read and write operations.
  * Hardened schema handling by validating and normalizing schema inputs and preventing unsupported empty values from being forwarded.

* **Chores**
  * Updated PostgREST schema exposure to use a dynamic opt-out model and added automatic syncing on schema changes.

* **Tests**
  * Added unit coverage for schema/profile resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->