### PR TITLE
fix(database): composite primary & foreign key support for dashboard records

### DIFF
--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -4,12 +4,14 @@ import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import {
   ERROR_CODES,
+  adminTableRecordPrimaryKeySchema,
   adminTableRecordUpdateQuerySchema,
   adminTableRecordUpdateRequestSchema,
   adminTableRecordLookupQuerySchema,
   adminTableRecordsCreateRequestSchema,
   adminTableRecordsDeleteQuerySchema,
   adminTableRecordsListQuerySchema,
+  type AdminTableRecordPrimaryKey,
   type AdminTableRecordsSortClause,
 } from '@insforge/shared-schemas';
 import { AdminRecordService } from '@/services/database/admin-record.service.js';
@@ -63,6 +65,41 @@ function parseSort(sort: string | undefined): AdminTableRecordsSortClause[] {
         direction: normalizedDirection as AdminTableRecordsSortClause['direction'],
       };
     });
+}
+
+function parseJsonQueryParam(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new AppError(
+      'Invalid pkKeys parameter.',
+      400,
+      ERROR_CODES.INVALID_INPUT,
+      'pkKeys must be a JSON-encoded primary key.'
+    );
+  }
+}
+
+// Parses the `pkKeys` query param for an update: a single JSON object mapping each
+// primary-key column to its value.
+function parsePrimaryKey(raw: string): AdminTableRecordPrimaryKey {
+  const validation = adminTableRecordPrimaryKeySchema.safeParse(parseJsonQueryParam(raw));
+  if (!validation.success) {
+    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+  }
+  return validation.data;
+}
+
+// Parses the `pkKeys` query param for a delete: a JSON array of primary-key objects.
+function parsePrimaryKeys(raw: string): AdminTableRecordPrimaryKey[] {
+  const validation = z
+    .array(adminTableRecordPrimaryKeySchema)
+    .min(1, 'At least one primary key is required.')
+    .safeParse(parseJsonQueryParam(raw));
+  if (!validation.success) {
+    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
+  }
+  return validation.data;
 }
 
 function broadcastRecordChange(schemaName: string, tableName: string): void {
@@ -163,7 +200,7 @@ router.post(
 );
 
 router.patch(
-  '/tables/:tableName/records/:recordId',
+  '/tables/:tableName/records',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const schemaName = normalizeDatabaseSchemaName(req.query.schema);
@@ -175,6 +212,8 @@ router.patch(
           ERROR_CODES.INVALID_INPUT
         );
       }
+
+      const primaryKey = parsePrimaryKey(queryValidation.data.pkKeys);
 
       const bodyValidation = adminTableRecordUpdateRequestSchema.safeParse(req.body);
       if (!bodyValidation.success) {
@@ -188,8 +227,7 @@ router.patch(
       const updatedRecord = await recordsService.updateRecord(
         schemaName,
         req.params.tableName,
-        queryValidation.data.pkColumn,
-        req.params.recordId,
+        primaryKey,
         bodyValidation.data as DatabaseRecord
       );
 
@@ -211,25 +249,12 @@ router.delete(
         throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
       }
 
-      const pkValues = validation.data.pkValues
-        .split(',')
-        .map((value) => value.trim())
-        .filter(Boolean);
-
-      if (pkValues.length === 0) {
-        throw new AppError(
-          'pkValues must include at least one primary key value.',
-          400,
-          ERROR_CODES.INVALID_INPUT,
-          'Provide at least one non-empty primary key value.'
-        );
-      }
+      const primaryKeys = parsePrimaryKeys(validation.data.pkKeys);
 
       const deletedCount = await recordsService.deleteRecords(
         schemaName,
         req.params.tableName,
-        validation.data.pkColumn,
-        pkValues
+        primaryKeys
       );
 
       if (deletedCount > 0) {

--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -124,11 +124,15 @@ router.get(
         throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
       }
 
+      const { column, value } = validation.data;
+      const columns = Array.isArray(column) ? column : [column];
+      const values = Array.isArray(value) ? value : [value];
+
       const record = await recordsService.lookupRecord(
         schemaName,
         req.params.tableName,
-        validation.data.column,
-        validation.data.value
+        columns,
+        values
       );
 
       successResponse(res, record);

--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -4,14 +4,11 @@ import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import {
   ERROR_CODES,
-  adminTableRecordPrimaryKeySchema,
-  adminTableRecordUpdateQuerySchema,
   adminTableRecordUpdateRequestSchema,
   adminTableRecordLookupQuerySchema,
   adminTableRecordsCreateRequestSchema,
-  adminTableRecordsDeleteQuerySchema,
+  adminTableRecordsDeleteRequestSchema,
   adminTableRecordsListQuerySchema,
-  type AdminTableRecordPrimaryKey,
   type AdminTableRecordsSortClause,
 } from '@insforge/shared-schemas';
 import { AdminRecordService } from '@/services/database/admin-record.service.js';
@@ -65,41 +62,6 @@ function parseSort(sort: string | undefined): AdminTableRecordsSortClause[] {
         direction: normalizedDirection as AdminTableRecordsSortClause['direction'],
       };
     });
-}
-
-function parseJsonQueryParam(raw: string): unknown {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    throw new AppError(
-      'Invalid pkKeys parameter.',
-      400,
-      ERROR_CODES.INVALID_INPUT,
-      'pkKeys must be a JSON-encoded primary key.'
-    );
-  }
-}
-
-// Parses the `pkKeys` query param for an update: a single JSON object mapping each
-// primary-key column to its value.
-function parsePrimaryKey(raw: string): AdminTableRecordPrimaryKey {
-  const validation = adminTableRecordPrimaryKeySchema.safeParse(parseJsonQueryParam(raw));
-  if (!validation.success) {
-    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
-  }
-  return validation.data;
-}
-
-// Parses the `pkKeys` query param for a delete: a JSON array of primary-key objects.
-function parsePrimaryKeys(raw: string): AdminTableRecordPrimaryKey[] {
-  const validation = z
-    .array(adminTableRecordPrimaryKeySchema)
-    .min(1, 'At least one primary key is required.')
-    .safeParse(parseJsonQueryParam(raw));
-  if (!validation.success) {
-    throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
-  }
-  return validation.data;
 }
 
 function broadcastRecordChange(schemaName: string, tableName: string): void {
@@ -208,16 +170,6 @@ router.patch(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const schemaName = normalizeDatabaseSchemaName(req.query.schema);
-      const queryValidation = adminTableRecordUpdateQuerySchema.safeParse(req.query);
-      if (!queryValidation.success) {
-        throw new AppError(
-          getValidationMessage(queryValidation.error),
-          400,
-          ERROR_CODES.INVALID_INPUT
-        );
-      }
-
-      const primaryKey = parsePrimaryKey(queryValidation.data.pkKeys);
 
       const bodyValidation = adminTableRecordUpdateRequestSchema.safeParse(req.body);
       if (!bodyValidation.success) {
@@ -231,8 +183,8 @@ router.patch(
       const updatedRecord = await recordsService.updateRecord(
         schemaName,
         req.params.tableName,
-        primaryKey,
-        bodyValidation.data as DatabaseRecord
+        bodyValidation.data.pkKeys,
+        bodyValidation.data.data as DatabaseRecord
       );
 
       broadcastRecordChange(schemaName, req.params.tableName);
@@ -248,17 +200,15 @@ router.delete(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const schemaName = normalizeDatabaseSchemaName(req.query.schema);
-      const validation = adminTableRecordsDeleteQuerySchema.safeParse(req.query);
+      const validation = adminTableRecordsDeleteRequestSchema.safeParse(req.body);
       if (!validation.success) {
         throw new AppError(getValidationMessage(validation.error), 400, ERROR_CODES.INVALID_INPUT);
       }
 
-      const primaryKeys = parsePrimaryKeys(validation.data.pkKeys);
-
       const deletedCount = await recordsService.deleteRecords(
         schemaName,
         req.params.tableName,
-        primaryKeys
+        validation.data.pkKeys
       );
 
       if (deletedCount > 0) {

--- a/backend/src/api/routes/database/tables.routes.ts
+++ b/backend/src/api/routes/database/tables.routes.ts
@@ -44,8 +44,14 @@ router.post('/', verifyAdmin, async (req: AuthRequest, res: Response, next: Next
     }
 
     const schemaName = normalizeDatabaseSchemaName(req.query.schema);
-    const { tableName, columns, rlsEnabled } = validation.data;
-    const result = await tableService.createTable(schemaName, tableName, columns, rlsEnabled);
+    const { tableName, columns, foreignKeys, rlsEnabled } = validation.data;
+    const result = await tableService.createTable(
+      schemaName,
+      tableName,
+      columns,
+      foreignKeys,
+      rlsEnabled
+    );
 
     DatabaseManager.clearColumnTypeCache(tableName, schemaName);
 

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -76,19 +76,32 @@ export class AdminRecordService {
   async lookupRecord(
     schemaName: string,
     tableName: string,
-    columnName: string,
-    value: string
+    columns: string[],
+    values: string[]
   ): Promise<DatabaseRecord | null> {
     validateTableName(tableName);
 
+    if (columns.length === 0 || columns.length !== values.length) {
+      throw new AppError(
+        'Columns and values must have the same non-zero length',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, columnName);
+      for (const col of columns) {
+        this.assertColumnExists(metadata, col);
+      }
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
+      const whereClauses = columns.map(
+        (col, i) => `${quoteIdentifier(col)} = $${i + 1}`
+      );
       const result = await client.query<DatabaseRecord>(
-        `SELECT * FROM ${qualifiedTableName} WHERE ${quoteIdentifier(columnName)} = $1 LIMIT 1`,
-        [value]
+        `SELECT * FROM ${qualifiedTableName} WHERE ${whereClauses.join(' AND ')} LIMIT 1`,
+        values
       );
 
       return result.rows[0] ?? null;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -28,9 +28,6 @@ interface TableColumnMetadata {
   searchableColumns: string[];
 }
 
-// A record's primary key as a map of column name -> value. Supports composite keys.
-type PrimaryKey = AdminTableRecordPrimaryKey;
-
 export class AdminRecordService {
   private static instance: AdminRecordService;
   private dbManager = DatabaseManager.getInstance();
@@ -151,7 +148,7 @@ export class AdminRecordService {
   async updateRecord(
     schemaName: string,
     tableName: string,
-    primaryKey: PrimaryKey,
+    primaryKey: AdminTableRecordPrimaryKey,
     data: DatabaseRecord
   ): Promise<DatabaseRecord> {
     validateTableName(tableName);
@@ -223,7 +220,7 @@ export class AdminRecordService {
   async deleteRecords(
     schemaName: string,
     tableName: string,
-    primaryKeys: PrimaryKey[]
+    primaryKeys: AdminTableRecordPrimaryKey[]
   ): Promise<number> {
     validateTableName(tableName);
 

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -96,9 +96,7 @@ export class AdminRecordService {
       }
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
-      const whereClauses = columns.map(
-        (col, i) => `${quoteIdentifier(col)} = $${i + 1}`
-      );
+      const whereClauses = columns.map((col, i) => `${quoteIdentifier(col)} = $${i + 1}`);
       const result = await client.query<DatabaseRecord>(
         `SELECT * FROM ${qualifiedTableName} WHERE ${whereClauses.join(' AND ')} LIMIT 1`,
         values

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -157,7 +157,7 @@ export class AdminRecordService {
     }
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
       this.assertCompletePrimaryKey(
         metadata,
@@ -217,7 +217,7 @@ export class AdminRecordService {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
 
       if (primaryKeys.length === 0) {
         return 0;
@@ -300,7 +300,8 @@ export class AdminRecordService {
   private async getTableColumnMetadata(
     schemaName: string,
     tableName: string,
-    client?: PoolClient
+    client?: PoolClient,
+    includePrimaryKey = false
   ): Promise<TableColumnMetadata> {
     const queryable = client ?? this.dbManager.getPool();
     const result = await queryable.query<{
@@ -349,8 +350,11 @@ export class AdminRecordService {
       }
     }
 
-    const primaryKeyResult = await queryable.query<{ column_name: string }>(
-      `
+    // Only update/delete need the primary key, so skip this query on read/create paths.
+    let primaryKeyColumns: string[] = [];
+    if (includePrimaryKey) {
+      const primaryKeyResult = await queryable.query<{ column_name: string }>(
+        `
         SELECT kcu.column_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
@@ -362,14 +366,16 @@ export class AdminRecordService {
           AND tc.table_name = $2
         ORDER BY kcu.ordinal_position
       `,
-      [schemaName, tableName]
-    );
+        [schemaName, tableName]
+      );
+      primaryKeyColumns = primaryKeyResult.rows.map((row) => row.column_name);
+    }
 
     return {
       columnTypeMap,
       nullableColumns,
       searchableColumns,
-      primaryKeyColumns: primaryKeyResult.rows.map((row) => row.column_name),
+      primaryKeyColumns,
     };
   }
 

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -190,7 +190,12 @@ export class AdminRecordService {
       const values: unknown[] = entries.map(([, value]) => value);
 
       // WHERE matches the full primary-key tuple so composite keys target exactly one row.
+      // A null component (only possible on the keyless all-columns fallback) is matched
+      // with `IS NULL`, since `col = NULL` never matches.
       const whereClauses = keyEntries.map(([columnName, value]) => {
+        if (value === null) {
+          return `${quoteIdentifier(columnName)} IS NULL`;
+        }
         values.push(value);
         return `${quoteIdentifier(columnName)} = $${values.length}`;
       });
@@ -253,6 +258,9 @@ export class AdminRecordService {
         );
 
         const columnClauses = keyEntries.map(([columnName, value]) => {
+          if (value === null) {
+            return `${quoteIdentifier(columnName)} IS NULL`;
+          }
           values.push(value);
           return `${quoteIdentifier(columnName)} = $${values.length}`;
         });

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -1,6 +1,6 @@
 import { AppError } from '@/utils/errors.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
-import { ERROR_CODES } from '@insforge/shared-schemas';
+import { ERROR_CODES, type AdminTableRecordPrimaryKey } from '@insforge/shared-schemas';
 import type { PoolClient } from 'pg';
 import type { DatabaseRecord } from '@/types/database.js';
 import { TEXT_LIKE_DATA_TYPES } from '@/utils/constants.js';
@@ -27,6 +27,9 @@ interface TableColumnMetadata {
   nullableColumns: Set<string>;
   searchableColumns: string[];
 }
+
+// A record's primary key as a map of column name -> value. Supports composite keys.
+type PrimaryKey = AdminTableRecordPrimaryKey;
 
 export class AdminRecordService {
   private static instance: AdminRecordService;
@@ -137,15 +140,24 @@ export class AdminRecordService {
   async updateRecord(
     schemaName: string,
     tableName: string,
-    pkColumn: string,
-    pkValue: string,
+    primaryKey: PrimaryKey,
     data: DatabaseRecord
   ): Promise<DatabaseRecord> {
     validateTableName(tableName);
 
+    const keyEntries = Object.entries(primaryKey);
+    if (keyEntries.length === 0) {
+      throw new AppError(
+        'Primary key is required to update a record.',
+        400,
+        ERROR_CODES.INVALID_INPUT,
+        'Provide at least one primary key column and value.'
+      );
+    }
+
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, pkColumn);
+      keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
 
       const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
       const entries = Object.entries(sanitizedRecord);
@@ -162,12 +174,19 @@ export class AdminRecordService {
       const assignments = entries.map(
         ([columnName], index) => `${quoteIdentifier(columnName)} = $${index + 1}`
       );
-      const values = entries.map(([, value]) => value);
-      values.push(pkValue);
+      const values: unknown[] = entries.map(([, value]) => value);
+
+      // WHERE matches the full primary-key tuple so composite keys target exactly one row.
+      const whereClauses = keyEntries.map(([columnName, value]) => {
+        values.push(value);
+        return `${quoteIdentifier(columnName)} = $${values.length}`;
+      });
 
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
       const result = await client.query<DatabaseRecord>(
-        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${quoteIdentifier(pkColumn)} = $${values.length} RETURNING *`,
+        `UPDATE ${qualifiedTableName} SET ${assignments.join(', ')} WHERE ${whereClauses.join(
+          ' AND '
+        )} RETURNING *`,
         values
       );
 
@@ -188,24 +207,44 @@ export class AdminRecordService {
   async deleteRecords(
     schemaName: string,
     tableName: string,
-    pkColumn: string,
-    pkValues: string[]
+    primaryKeys: PrimaryKey[]
   ): Promise<number> {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
-      this.assertColumnExists(metadata, pkColumn);
 
-      if (pkValues.length === 0) {
+      if (primaryKeys.length === 0) {
         return 0;
       }
 
-      const placeholders = pkValues.map((_, index) => `$${index + 1}`);
+      const values: unknown[] = [];
+      // Each selected row is matched by its full primary-key tuple, OR'd together,
+      // so composite keys delete exactly the selected rows (not WHERE first_col IN (...)).
+      const rowClauses = primaryKeys.map((primaryKey) => {
+        const keyEntries = Object.entries(primaryKey);
+        if (keyEntries.length === 0) {
+          throw new AppError(
+            'Primary key is required to delete a record.',
+            400,
+            ERROR_CODES.INVALID_INPUT,
+            'Provide at least one primary key column and value for each record.'
+          );
+        }
+
+        const columnClauses = keyEntries.map(([columnName, value]) => {
+          this.assertColumnExists(metadata, columnName);
+          values.push(value);
+          return `${quoteIdentifier(columnName)} = $${values.length}`;
+        });
+
+        return `(${columnClauses.join(' AND ')})`;
+      });
+
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
       const result = await client.query(
-        `DELETE FROM ${qualifiedTableName} WHERE ${quoteIdentifier(pkColumn)} IN (${placeholders.join(', ')})`,
-        pkValues
+        `DELETE FROM ${qualifiedTableName} WHERE ${rowClauses.join(' OR ')}`,
+        values
       );
 
       return result.rowCount ?? 0;

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -26,6 +26,7 @@ interface TableColumnMetadata {
   columnTypeMap: Record<string, string>;
   nullableColumns: Set<string>;
   searchableColumns: string[];
+  primaryKeyColumns: string[];
 }
 
 // A record's primary key as a map of column name -> value. Supports composite keys.
@@ -158,6 +159,10 @@ export class AdminRecordService {
     return this.withAdminTransaction(async (client) => {
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
+      this.assertCompletePrimaryKey(
+        metadata,
+        keyEntries.map(([columnName]) => columnName)
+      );
 
       const sanitizedRecord = this.sanitizeUpdateRecord(data, metadata);
       const entries = Object.entries(sanitizedRecord);
@@ -232,8 +237,13 @@ export class AdminRecordService {
           );
         }
 
+        keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
+        this.assertCompletePrimaryKey(
+          metadata,
+          keyEntries.map(([columnName]) => columnName)
+        );
+
         const columnClauses = keyEntries.map(([columnName, value]) => {
-          this.assertColumnExists(metadata, columnName);
           values.push(value);
           return `${quoteIdentifier(columnName)} = $${values.length}`;
         });
@@ -339,11 +349,55 @@ export class AdminRecordService {
       }
     }
 
+    const primaryKeyResult = await queryable.query<{ column_name: string }>(
+      `
+        SELECT kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON tc.constraint_name = kcu.constraint_name
+          AND tc.table_schema = kcu.table_schema
+          AND tc.table_name = kcu.table_name
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+          AND tc.table_schema = $1
+          AND tc.table_name = $2
+        ORDER BY kcu.ordinal_position
+      `,
+      [schemaName, tableName]
+    );
+
     return {
       columnTypeMap,
       nullableColumns,
       searchableColumns,
+      primaryKeyColumns: primaryKeyResult.rows.map((row) => row.column_name),
     };
+  }
+
+  /**
+   * Ensures the supplied key columns are exactly the table's primary key, so a
+   * partial composite key (e.g. only `tenant_id` of a `(tenant_id, item_id)` key)
+   * can't match and mutate more rows than intended. Tables with no detected
+   * primary key fall back to the caller-provided columns (validated for existence).
+   */
+  private assertCompletePrimaryKey(metadata: TableColumnMetadata, suppliedColumns: string[]): void {
+    const { primaryKeyColumns } = metadata;
+    if (primaryKeyColumns.length === 0) {
+      return;
+    }
+
+    const suppliedSet = new Set(suppliedColumns);
+    const matchesFullKey =
+      suppliedSet.size === primaryKeyColumns.length &&
+      primaryKeyColumns.every((column) => suppliedSet.has(column));
+
+    if (!matchesFullKey) {
+      throw new AppError(
+        'Primary key does not match the table primary key.',
+        400,
+        ERROR_CODES.INVALID_INPUT,
+        `Provide exactly these primary key columns: ${primaryKeyColumns.join(', ')}.`
+      );
+    }
   }
 
   private buildWhereClause(

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -26,7 +26,6 @@ interface TableColumnMetadata {
   columnTypeMap: Record<string, string>;
   nullableColumns: Set<string>;
   searchableColumns: string[];
-  primaryKeyColumns: string[];
 }
 
 // A record's primary key as a map of column name -> value. Supports composite keys.
@@ -157,10 +156,11 @@ export class AdminRecordService {
     }
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const primaryKeyColumns = await this.getPrimaryKeyColumns(schemaName, tableName, client);
       keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
-      this.assertCompletePrimaryKey(
-        metadata,
+      this.assertKeyMatchesPrimaryKey(
+        primaryKeyColumns,
         keyEntries.map(([columnName]) => columnName)
       );
 
@@ -217,7 +217,8 @@ export class AdminRecordService {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
-      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client, true);
+      const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
+      const primaryKeyColumns = await this.getPrimaryKeyColumns(schemaName, tableName, client);
 
       if (primaryKeys.length === 0) {
         return 0;
@@ -238,8 +239,8 @@ export class AdminRecordService {
         }
 
         keyEntries.forEach(([columnName]) => this.assertColumnExists(metadata, columnName));
-        this.assertCompletePrimaryKey(
-          metadata,
+        this.assertKeyMatchesPrimaryKey(
+          primaryKeyColumns,
           keyEntries.map(([columnName]) => columnName)
         );
 
@@ -300,8 +301,7 @@ export class AdminRecordService {
   private async getTableColumnMetadata(
     schemaName: string,
     tableName: string,
-    client?: PoolClient,
-    includePrimaryKey = false
+    client?: PoolClient
   ): Promise<TableColumnMetadata> {
     const queryable = client ?? this.dbManager.getPool();
     const result = await queryable.query<{
@@ -350,11 +350,25 @@ export class AdminRecordService {
       }
     }
 
-    // Only update/delete need the primary key, so skip this query on read/create paths.
-    let primaryKeyColumns: string[] = [];
-    if (includePrimaryKey) {
-      const primaryKeyResult = await queryable.query<{ column_name: string }>(
-        `
+    return {
+      columnTypeMap,
+      nullableColumns,
+      searchableColumns,
+    };
+  }
+
+  /**
+   * Fetches a table's primary-key columns (ordinal order). Returns an empty array
+   * only when the table genuinely has no primary key. Mutations call this directly,
+   * so an empty result can never be confused with "metadata wasn't loaded".
+   */
+  private async getPrimaryKeyColumns(
+    schemaName: string,
+    tableName: string,
+    client: PoolClient
+  ): Promise<string[]> {
+    const result = await client.query<{ column_name: string }>(
+      `
         SELECT kcu.column_name
         FROM information_schema.table_constraints tc
         JOIN information_schema.key_column_usage kcu
@@ -366,27 +380,20 @@ export class AdminRecordService {
           AND tc.table_name = $2
         ORDER BY kcu.ordinal_position
       `,
-        [schemaName, tableName]
-      );
-      primaryKeyColumns = primaryKeyResult.rows.map((row) => row.column_name);
-    }
+      [schemaName, tableName]
+    );
 
-    return {
-      columnTypeMap,
-      nullableColumns,
-      searchableColumns,
-      primaryKeyColumns,
-    };
+    return result.rows.map((row) => row.column_name);
   }
 
   /**
    * Ensures the supplied key columns are exactly the table's primary key, so a
    * partial composite key (e.g. only `tenant_id` of a `(tenant_id, item_id)` key)
    * can't match and mutate more rows than intended. Tables with no detected
-   * primary key fall back to the caller-provided columns (validated for existence).
+   * primary key (empty `primaryKeyColumns`) fall back to the caller-provided
+   * columns (validated for existence elsewhere).
    */
-  private assertCompletePrimaryKey(metadata: TableColumnMetadata, suppliedColumns: string[]): void {
-    const { primaryKeyColumns } = metadata;
+  private assertKeyMatchesPrimaryKey(primaryKeyColumns: string[], suppliedColumns: string[]): void {
     if (primaryKeyColumns.length === 0) {
       return;
     }

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -187,36 +187,43 @@ export class DatabaseAdvanceService {
     // Export foreign key constraints
     const foreignKeysResult = await client.query(
       `
-      SELECT DISTINCT
-        'ALTER TABLE ' || quote_ident(tc.table_name) ||
-        ' ADD CONSTRAINT ' || quote_ident(tc.constraint_name) ||
-        ' FOREIGN KEY (' || quote_ident(kcu.column_name) || ')' ||
-        ' REFERENCES ' || quote_ident(ccu.table_name) ||
-        ' (' || quote_ident(ccu.column_name) || ')' ||
+      SELECT
+        'ALTER TABLE ' || quote_ident(ct.relname) ||
+        ' ADD CONSTRAINT ' || quote_ident(c.conname) ||
+        ' FOREIGN KEY (' || string_agg(quote_ident(a1.attname), ', ' ORDER BY u.pos) || ')' ||
+        ' REFERENCES ' || quote_ident(cf.relname) ||
+        ' (' || string_agg(quote_ident(a2.attname), ', ' ORDER BY u.pos) || ')' ||
         CASE
-          WHEN rc.delete_rule != 'NO ACTION' THEN ' ON DELETE ' || rc.delete_rule
+          WHEN c.confdeltype = 'c' THEN ' ON DELETE CASCADE'
+          WHEN c.confdeltype = 'n' THEN ' ON DELETE SET NULL'
+          WHEN c.confdeltype = 'r' THEN ' ON DELETE RESTRICT'
+          WHEN c.confdeltype = 'd' THEN ' ON DELETE SET DEFAULT'
           ELSE ''
         END ||
         CASE
-          WHEN rc.update_rule != 'NO ACTION' THEN ' ON UPDATE ' || rc.update_rule
+          WHEN c.confupdtype = 'c' THEN ' ON UPDATE CASCADE'
+          WHEN c.confupdtype = 'n' THEN ' ON UPDATE SET NULL'
+          WHEN c.confupdtype = 'r' THEN ' ON UPDATE RESTRICT'
+          WHEN c.confupdtype = 'd' THEN ' ON UPDATE SET DEFAULT'
           ELSE ''
         END || ';' as fk_statement,
-        tc.constraint_name
-      FROM information_schema.table_constraints AS tc
-      JOIN information_schema.key_column_usage AS kcu
-        ON tc.constraint_name = kcu.constraint_name
-        AND tc.table_schema = kcu.table_schema
-        AND kcu.table_name = tc.table_name
-      JOIN information_schema.constraint_column_usage AS ccu
-        ON ccu.constraint_name = tc.constraint_name
-        AND ccu.table_schema = tc.table_schema
-      LEFT JOIN information_schema.referential_constraints AS rc
-        ON tc.constraint_name = rc.constraint_name
-        AND tc.table_schema = rc.constraint_schema
-      WHERE tc.constraint_type = 'FOREIGN KEY'
-      AND tc.table_name = $1
-      AND tc.table_schema = 'public'
-      ORDER BY tc.constraint_name
+        c.conname as constraint_name
+      FROM pg_catalog.pg_constraint c
+      JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+      JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+      JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+      JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+      CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+        WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+      JOIN pg_catalog.pg_attribute a1
+        ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+      JOIN pg_catalog.pg_attribute a2
+        ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+      WHERE c.contype = 'f'
+        AND nt.nspname = 'public'
+        AND ct.relname = $1
+      GROUP BY c.conname, ct.relname, nf.nspname, cf.relname, c.confdeltype, c.confupdtype
+      ORDER BY c.conname
     `,
       [table]
     );
@@ -546,28 +553,37 @@ export class DatabaseAdvanceService {
           // Get foreign keys
           const foreignKeysResult = await client.query(
             `
-            SELECT DISTINCT
-              tc.constraint_name as "constraintName",
-              kcu.column_name as "columnName",
-              ccu.table_name as "foreignTableName",
-              ccu.column_name as "foreignColumnName",
-              rc.delete_rule as "deleteRule",
-              rc.update_rule as "updateRule"
-            FROM information_schema.table_constraints AS tc
-            JOIN information_schema.key_column_usage AS kcu
-              ON tc.constraint_name = kcu.constraint_name
-              AND tc.table_schema = kcu.table_schema
-              AND kcu.table_name = tc.table_name
-            JOIN information_schema.constraint_column_usage AS ccu
-              ON ccu.constraint_name = tc.constraint_name
-              AND ccu.table_schema = tc.table_schema
-            LEFT JOIN information_schema.referential_constraints AS rc
-              ON tc.constraint_name = rc.constraint_name
-              AND tc.table_schema = rc.constraint_schema
-            WHERE tc.constraint_type = 'FOREIGN KEY'
-            AND tc.table_name = $1
-            AND tc.table_schema = 'public'
-            ORDER BY "constraintName", "columnName"
+            SELECT
+              c.conname as "constraintName",
+              a1.attname as "columnName",
+              cf.relname as "foreignTableName",
+              a2.attname as "foreignColumnName",
+              u.pos as "ordinalPosition",
+              CASE c.confdeltype
+                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+                WHEN 'd' THEN 'SET DEFAULT'
+              END as "deleteRule",
+              CASE c.confupdtype
+                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+                WHEN 'd' THEN 'SET DEFAULT'
+              END as "updateRule"
+            FROM pg_catalog.pg_constraint c
+            JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+            JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+            JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+            JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+            CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+              WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+            JOIN pg_catalog.pg_attribute a1
+              ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+            JOIN pg_catalog.pg_attribute a2
+              ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+            WHERE c.contype = 'f'
+              AND nt.nspname = 'public'
+              AND ct.relname = $1
+            ORDER BY c.conname, u.pos
           `,
             [table]
           );

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -191,7 +191,7 @@ export class DatabaseAdvanceService {
         'ALTER TABLE ' || quote_ident(ct.relname) ||
         ' ADD CONSTRAINT ' || quote_ident(c.conname) ||
         ' FOREIGN KEY (' || string_agg(quote_ident(a1.attname), ', ' ORDER BY u.pos) || ')' ||
-        ' REFERENCES ' || quote_ident(cf.relname) ||
+        ' REFERENCES ' || CASE WHEN nf.nspname = 'public' THEN quote_ident(cf.relname) ELSE quote_ident(nf.nspname) || '.' || quote_ident(cf.relname) END ||
         ' (' || string_agg(quote_ident(a2.attname), ', ' ORDER BY u.pos) || ')' ||
         CASE
           WHEN c.confdeltype = 'c' THEN ' ON DELETE CASCADE'
@@ -556,7 +556,7 @@ export class DatabaseAdvanceService {
             SELECT
               c.conname as "constraintName",
               a1.attname as "columnName",
-              cf.relname as "foreignTableName",
+              CASE WHEN nf.nspname = 'public' THEN cf.relname ELSE nf.nspname || '.' || cf.relname END as "foreignTableName",
               a2.attname as "foreignColumnName",
               u.pos as "ordinalPosition",
               CASE c.confdeltype

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -7,6 +7,9 @@ import {
   type ExportDatabaseJsonData,
   type ImportDatabaseResponse,
   type BulkUpsertResponse,
+  type ForeignKeySchema,
+  type OnDeleteActionSchema,
+  type OnUpdateActionSchema,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { checkSqlExecutionGuards, parseSQLStatements } from '@/utils/sql-parser.js';
@@ -33,6 +36,50 @@ export class DatabaseAdvanceService {
    * Get table data using simple SELECT query
    * More reliable than streaming for moderate datasets
    */
+  // Groups the per-column FK rows from the JSON export query into table-level
+  // constraints (one entry per constraint, columns ordered by ordinal position),
+  // matching the table-level foreign-key model used everywhere else.
+  private groupExportedForeignKeyRows(
+    rows: {
+      constraintName: string;
+      columnName: string;
+      foreignTableName: string;
+      foreignColumnName: string;
+      ordinalPosition: number;
+      deleteRule: string;
+      updateRule: string;
+    }[]
+  ): ForeignKeySchema[] {
+    const byConstraint = new Map<string, ForeignKeySchema & { _ordinals: number[] }>();
+    for (const row of rows) {
+      let fk = byConstraint.get(row.constraintName);
+      if (!fk) {
+        fk = {
+          constraintName: row.constraintName,
+          referenceTable: row.foreignTableName,
+          referenceColumns: [],
+          onDelete: row.deleteRule as OnDeleteActionSchema,
+          onUpdate: row.updateRule as OnUpdateActionSchema,
+          _ordinals: [],
+        };
+        byConstraint.set(row.constraintName, fk);
+      }
+      fk.referenceColumns.push({
+        sourceColumn: row.columnName,
+        referenceColumn: row.foreignColumnName,
+      });
+      fk._ordinals.push(row.ordinalPosition);
+    }
+
+    return Array.from(byConstraint.values()).map(({ _ordinals, ...fk }) => {
+      fk.referenceColumns = _ordinals
+        .map((ordinal, i) => ({ ordinal, pair: fk.referenceColumns[i] }))
+        .sort((a, b) => a.ordinal - b.ordinal)
+        .map((entry) => entry.pair);
+      return fk;
+    });
+  }
+
   private async getTableData(
     client: PoolClient,
     table: string,
@@ -658,7 +705,7 @@ export class DatabaseAdvanceService {
           jsonData.tables[table] = {
             schema: schemaResult.rows,
             indexes: indexesResult.rows,
-            foreignKeys: foreignKeysResult.rows,
+            foreignKeys: this.groupExportedForeignKeyRows(foreignKeysResult.rows),
             rlsEnabled,
             policies: policiesResult.rows,
             triggers: triggersResult.rows,

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -605,7 +605,7 @@ export class DatabaseAdvanceService {
               a1.attname as "columnName",
               CASE WHEN nf.nspname = 'public' THEN cf.relname ELSE nf.nspname || '.' || cf.relname END as "foreignTableName",
               a2.attname as "foreignColumnName",
-              u.pos as "ordinalPosition",
+              u.pos::int as "ordinalPosition",
               CASE c.confdeltype
                 WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
                 WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -7,9 +7,6 @@ import {
   type ExportDatabaseJsonData,
   type ImportDatabaseResponse,
   type BulkUpsertResponse,
-  type ForeignKeySchema,
-  type OnDeleteActionSchema,
-  type OnUpdateActionSchema,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { checkSqlExecutionGuards, parseSQLStatements } from '@/utils/sql-parser.js';
@@ -18,6 +15,8 @@ import pgFormat from 'pg-format';
 import { parse } from 'csv-parse/sync';
 import { type PoolClient } from 'pg';
 import { withAdminContext } from './user-context.service.js';
+import type { ForeignKeyRow } from '@/types/database.js';
+import { FOREIGN_KEY_INTROSPECTION_QUERY, groupForeignKeyRows } from './helpers.js';
 
 export class DatabaseAdvanceService {
   private static instance: DatabaseAdvanceService;
@@ -36,50 +35,6 @@ export class DatabaseAdvanceService {
    * Get table data using simple SELECT query
    * More reliable than streaming for moderate datasets
    */
-  // Groups the per-column FK rows from the JSON export query into table-level
-  // constraints (one entry per constraint, columns ordered by ordinal position),
-  // matching the table-level foreign-key model used everywhere else.
-  private groupExportedForeignKeyRows(
-    rows: {
-      constraintName: string;
-      columnName: string;
-      foreignTableName: string;
-      foreignColumnName: string;
-      ordinalPosition: number;
-      deleteRule: string;
-      updateRule: string;
-    }[]
-  ): ForeignKeySchema[] {
-    const byConstraint = new Map<string, ForeignKeySchema & { _ordinals: number[] }>();
-    for (const row of rows) {
-      let fk = byConstraint.get(row.constraintName);
-      if (!fk) {
-        fk = {
-          constraintName: row.constraintName,
-          referenceTable: row.foreignTableName,
-          referenceColumns: [],
-          onDelete: row.deleteRule as OnDeleteActionSchema,
-          onUpdate: row.updateRule as OnUpdateActionSchema,
-          _ordinals: [],
-        };
-        byConstraint.set(row.constraintName, fk);
-      }
-      fk.referenceColumns.push({
-        sourceColumn: row.columnName,
-        referenceColumn: row.foreignColumnName,
-      });
-      fk._ordinals.push(row.ordinalPosition);
-    }
-
-    return Array.from(byConstraint.values()).map(({ _ordinals, ...fk }) => {
-      fk.referenceColumns = _ordinals
-        .map((ordinal, i) => ({ ordinal, pair: fk.referenceColumns[i] }))
-        .sort((a, b) => a.ordinal - b.ordinal)
-        .map((entry) => entry.pair);
-      return fk;
-    });
-  }
-
   private async getTableData(
     client: PoolClient,
     table: string,
@@ -597,43 +552,11 @@ export class DatabaseAdvanceService {
             [table]
           );
 
-          // Get foreign keys
-          const foreignKeysResult = await client.query(
-            `
-            SELECT
-              c.conname as "constraintName",
-              a1.attname as "columnName",
-              CASE WHEN nf.nspname = 'public' THEN cf.relname ELSE nf.nspname || '.' || cf.relname END as "foreignTableName",
-              a2.attname as "foreignColumnName",
-              u.pos::int as "ordinalPosition",
-              CASE c.confdeltype
-                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
-                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
-                WHEN 'd' THEN 'SET DEFAULT'
-              END as "deleteRule",
-              CASE c.confupdtype
-                WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
-                WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
-                WHEN 'd' THEN 'SET DEFAULT'
-              END as "updateRule"
-            FROM pg_catalog.pg_constraint c
-            JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
-            JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
-            JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
-            JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
-            CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
-              WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
-            JOIN pg_catalog.pg_attribute a1
-              ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
-            JOIN pg_catalog.pg_attribute a2
-              ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
-            WHERE c.contype = 'f'
-              AND nt.nspname = 'public'
-              AND ct.relname = $1
-            ORDER BY c.conname, u.pos
-          `,
-            [table]
-          );
+          // Get foreign keys (one entity per constraint, columns in ordinal order)
+          const foreignKeysResult = await client.query(FOREIGN_KEY_INTROSPECTION_QUERY, [
+            'public',
+            table,
+          ]);
 
           // Check if RLS is enabled on the table
           const rlsResult = await client.query(
@@ -705,7 +628,7 @@ export class DatabaseAdvanceService {
           jsonData.tables[table] = {
             schema: schemaResult.rows,
             indexes: indexesResult.rows,
-            foreignKeys: this.groupExportedForeignKeyRows(foreignKeysResult.rows),
+            foreignKeys: groupForeignKeyRows(foreignKeysResult.rows as ForeignKeyRow[]),
             rlsEnabled,
             policies: policiesResult.rows,
             triggers: triggersResult.rows,

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/utils/errors.js';
@@ -811,7 +812,12 @@ export class DatabaseTableService {
     const sourceCols = fk.referenceColumns.map((r) => r.sourceColumn);
     const refCols = fk.referenceColumns.map((r) => r.referenceColumn);
     const safeTableName = fk.referenceTable.replace(/\./g, '_');
-    const constraintName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
+    const baseName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
+    const MAX_IDENTIFIER_LENGTH = 63;
+    const constraintName =
+      baseName.length > MAX_IDENTIFIER_LENGTH
+        ? `${baseName.slice(0, MAX_IDENTIFIER_LENGTH - 9)}_${createHash('sha256').update(baseName).digest('hex').slice(0, 8)}`
+        : baseName;
     const onDelete = fk.onDelete || 'RESTRICT';
     const onUpdate = fk.onUpdate || 'RESTRICT';
 

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -859,7 +859,7 @@ export class DatabaseTableService {
           nf.nspname AS foreign_schema,
           cf.relname AS foreign_table,
           a2.attname AS foreign_column,
-          u.pos AS ordinal_position,
+          u.pos::int AS ordinal_position,
           CASE c.confdeltype
             WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
             WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -12,8 +12,6 @@ import {
   UpdateTableSchemaRequest,
   UpdateTableSchemaResponse,
   DeleteTableResponse,
-  OnDeleteActionSchema,
-  OnUpdateActionSchema,
   ForeignKeySchema,
 } from '@insforge/shared-schemas';
 import { validateIdentifier, validateSchemaName } from '@/utils/validations.js';
@@ -22,6 +20,8 @@ import {
   DEFAULT_DATABASE_SCHEMA,
   quoteQualifiedName,
   splitQualifiedTableReference,
+  FOREIGN_KEY_INTROSPECTION_QUERY,
+  groupForeignKeyRows,
 } from './helpers.js';
 import { withAdminContext } from './user-context.service.js';
 
@@ -851,95 +851,7 @@ export class DatabaseTableService {
   }
 
   private async getFkeyConstraints(schemaName: string, table: string): Promise<ForeignKeySchema[]> {
-    const result = await this.getPool().query(
-      `
-        SELECT
-          c.conname AS constraint_name,
-          a1.attname AS from_column,
-          nf.nspname AS foreign_schema,
-          cf.relname AS foreign_table,
-          a2.attname AS foreign_column,
-          u.pos::int AS ordinal_position,
-          CASE c.confdeltype
-            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
-            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
-            WHEN 'd' THEN 'SET DEFAULT'
-          END AS on_delete,
-          CASE c.confupdtype
-            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
-            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
-            WHEN 'd' THEN 'SET DEFAULT'
-          END AS on_update
-        FROM pg_catalog.pg_constraint c
-        JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
-        JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
-        JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
-        JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
-        CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
-          WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
-        JOIN pg_catalog.pg_attribute a1
-          ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
-        JOIN pg_catalog.pg_attribute a2
-          ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
-        WHERE c.contype = 'f'
-          AND nt.nspname = $1
-          AND ct.relname = $2
-        ORDER BY c.conname, u.pos
-      `,
-      [schemaName, table]
-    );
-
-    const foreignKeys = result.rows;
-
-    // Group rows by constraint_name into one entity per constraint. A composite key
-    // is a single entity carrying all its (source -> reference) pairs in ordinal order.
-    const constraintGroups = new Map<
-      string,
-      {
-        constraintName: string;
-        referenceTable: string;
-        fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
-        onDelete: string;
-        onUpdate: string;
-      }
-    >();
-
-    for (const fk of foreignKeys as ForeignKeyRow[]) {
-      const referenceTable =
-        fk.foreign_schema !== 'public'
-          ? `${fk.foreign_schema}.${fk.foreign_table}`
-          : fk.foreign_table;
-
-      let group = constraintGroups.get(fk.constraint_name);
-      if (!group) {
-        group = {
-          constraintName: fk.constraint_name,
-          referenceTable,
-          fromColumns: [],
-          onDelete: fk.on_delete,
-          onUpdate: fk.on_update,
-        };
-        constraintGroups.set(fk.constraint_name, group);
-      }
-      group.fromColumns.push({
-        name: fk.from_column,
-        foreignColumn: fk.foreign_column,
-        ordinal: fk.ordinal_position,
-      });
-    }
-
-    return Array.from(constraintGroups.values()).map((group) => {
-      group.fromColumns.sort((a, b) => a.ordinal - b.ordinal);
-      return {
-        constraintName: group.constraintName,
-        referenceTable: group.referenceTable,
-        referenceColumns: group.fromColumns.map((c) => ({
-          sourceColumn: c.name,
-          referenceColumn: c.foreignColumn,
-        })),
-        onDelete: group.onDelete as OnDeleteActionSchema,
-        onUpdate: group.onUpdate as OnUpdateActionSchema,
-      };
-    });
+    const result = await this.getPool().query(FOREIGN_KEY_INTROSPECTION_QUERY, [schemaName, table]);
+    return groupForeignKeyRows(result.rows as ForeignKeyRow[]);
   }
 }

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -524,10 +524,12 @@ export class DatabaseTableService {
           // Execute operations
 
           // Drop foreign key constraints
+          const droppedConstraints = new Set<string>();
           if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
             for (const col of dropForeignKeys) {
               const constraintName = foreignKeyMap.get(col)?.constraint_name;
-              if (constraintName) {
+              if (constraintName && !droppedConstraints.has(constraintName)) {
+                droppedConstraints.add(constraintName);
                 await client.query(
                   `
                   ALTER TABLE ${safeQualifiedTableName}

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -230,6 +230,21 @@ export class DatabaseTableService {
             })
             .join(', ');
 
+          // Reject foreign keys on system columns (consistent with updateTableSchema).
+          for (const fk of foreignKeys) {
+            const systemSourceColumn = fk.referenceColumns
+              .map((rc) => rc.sourceColumn)
+              .find((source) => Object.keys(reservedColumns).includes(source));
+            if (systemSourceColumn) {
+              throw new AppError(
+                'cannot add foreign key on system columns',
+                400,
+                ERROR_CODES.DATABASE_FORBIDDEN,
+                `You cannot add foreign key on the system column '${systemSourceColumn}'`
+              );
+            }
+          }
+
           // Prepare foreign key constraints — one statement per constraint entity.
           const foreignKeyConstraints = foreignKeys
             .map((fk) => this.generateFkeyConstraintStatement(fk, schemaName, true))
@@ -518,11 +533,18 @@ export class DatabaseTableService {
 
           // Execute operations
 
-          // Drop foreign key constraints by constraint name (only ones that exist on this table).
+          // Drop foreign key constraints by constraint name.
           if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
             for (const constraintName of dropForeignKeys) {
+              // Fail loudly on an unknown/stale name instead of reporting success while
+              // the constraint is still enforced (e.g. a typo'd or already-dropped name).
               if (!existingConstraintNames.has(constraintName)) {
-                continue;
+                throw new AppError(
+                  `Foreign key constraint '${constraintName}' does not exist on this table.`,
+                  404,
+                  ERROR_CODES.DATABASE_NOT_FOUND,
+                  'Refresh the table schema and retry; the constraint may have already been removed.'
+                );
               }
               await client.query(
                 `

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -804,18 +804,24 @@ export class DatabaseTableService {
     if (!col.foreignKey) {
       return '';
     }
-    // Store foreign_key in a const to avoid repeated non-null assertions
     const fk = col.foreignKey;
-    // Use "auth_users" in constraint name for auth.users references
+    if (!fk.referenceColumns || fk.referenceColumns.length === 0) {
+      return '';
+    }
+    const sourceCols = fk.referenceColumns.map((r) => r.sourceColumn);
+    const refCols = fk.referenceColumns.map((r) => r.referenceColumn);
     const safeTableName = fk.referenceTable.replace(/\./g, '_');
-    const constraintName = `fk_${col.columnName}_${safeTableName}_${fk.referenceColumn}`;
+    const constraintName = `fk_${sourceCols.join('_')}_${safeTableName}_${refCols.join('_')}`;
     const onDelete = fk.onDelete || 'RESTRICT';
     const onUpdate = fk.onUpdate || 'RESTRICT';
 
+    const sourcePart = sourceCols.map((c) => this.quoteIdentifier(c)).join(', ');
+    const refPart = refCols.map((c) => this.quoteIdentifier(c)).join(', ');
+
     if (include_source_column) {
-      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} FOREIGN KEY (${this.quoteIdentifier(col.columnName)}) REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${this.quoteIdentifier(fk.referenceColumn)}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
+      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} FOREIGN KEY (${sourcePart}) REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${refPart}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
     } else {
-      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${this.quoteIdentifier(fk.referenceColumn)}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
+      return `CONSTRAINT ${this.quoteIdentifier(constraintName)} REFERENCES ${this.quoteTableReference(fk.referenceTable, defaultSchemaName)}(${refPart}) ON DELETE ${onDelete} ON UPDATE ${onUpdate}`;
     }
   }
 
@@ -831,42 +837,81 @@ export class DatabaseTableService {
           ccu.table_schema AS foreign_schema,
           ccu.table_name AS foreign_table,
           ccu.column_name AS foreign_column,
+          kcu.ordinal_position,
           rc.delete_rule as on_delete,
           rc.update_rule as on_update
         FROM information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu
           ON tc.constraint_name = kcu.constraint_name
           AND tc.table_schema = kcu.table_schema
-        JOIN information_schema.constraint_column_usage AS ccu
-          ON ccu.constraint_name = tc.constraint_name
+        JOIN information_schema.key_column_usage AS ccu
+          ON tc.unique_constraint_name = ccu.constraint_name
+          AND kcu.ordinal_position = ccu.ordinal_position
         JOIN information_schema.referential_constraints AS rc
           ON rc.constraint_name = tc.constraint_name
           AND rc.constraint_schema = tc.table_schema
         WHERE tc.constraint_type = 'FOREIGN KEY'
         AND tc.table_schema = $1
         AND tc.table_name = $2
+        ORDER BY tc.constraint_name, kcu.ordinal_position
       `,
       [schemaName, table]
     );
 
     const foreignKeys = result.rows;
 
-    // Create a map of column names to their foreign key info
-    const foreignKeyMap = new Map<string, ForeignKeyInfo>();
-    foreignKeys.forEach((fk: ForeignKeyRow) => {
-      // Prefix table name with schema if not public (e.g., "auth.users")
+    // Group rows by constraint_name, then map each source column to its FK info
+    const constraintGroups = new Map<string, {
+      constraintName: string;
+      referenceTable: string;
+      fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
+      onDelete: string;
+      onUpdate: string;
+    }>();
+
+    for (const fk of foreignKeys as ForeignKeyRow[]) {
       const referenceTable =
         fk.foreign_schema !== 'public'
           ? `${fk.foreign_schema}.${fk.foreign_table}`
           : fk.foreign_table;
-      foreignKeyMap.set(fk.from_column, {
-        constraint_name: fk.constraint_name,
-        referenceTable,
-        referenceColumn: fk.foreign_column,
-        onDelete: fk.on_delete as OnDeleteActionSchema,
-        onUpdate: fk.on_update as OnUpdateActionSchema,
-      });
-    });
+
+      let group = constraintGroups.get(fk.constraint_name);
+      if (!group) {
+        group = {
+          constraintName: fk.constraint_name,
+          referenceTable,
+          fromColumns: [],
+          onDelete: fk.on_delete,
+          onUpdate: fk.on_update,
+        };
+        constraintGroups.set(fk.constraint_name, group);
+      }
+      group.fromColumns.push({ name: fk.from_column, foreignColumn: fk.foreign_column, ordinal: fk.ordinal_position });
+    }
+
+    const foreignKeyMap = new Map<string, ForeignKeyInfo>();
+
+    for (const group of constraintGroups.values()) {
+      group.fromColumns.sort((a, b) => a.ordinal - b.ordinal);
+
+      const referenceColumns = group.fromColumns.map((c) => ({
+        sourceColumn: c.name,
+        referenceColumn: c.foreignColumn,
+      }));
+
+      const info: ForeignKeyInfo = {
+        constraint_name: group.constraintName,
+        referenceTable: group.referenceTable,
+        referenceColumns,
+        onDelete: group.onDelete as OnDeleteActionSchema,
+        onUpdate: group.onUpdate as OnUpdateActionSchema,
+      };
+
+      for (const c of group.fromColumns) {
+        foreignKeyMap.set(c.name, { ...info });
+      }
+    }
+
     return foreignKeyMap;
   }
 }

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -2,13 +2,7 @@ import { createHash } from 'crypto';
 import { Pool } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { AppError } from '@/utils/errors.js';
-import {
-  COLUMN_TYPES,
-  ForeignKeyRow,
-  ColumnInfo,
-  PrimaryKeyInfo,
-  ForeignKeyInfo,
-} from '@/types/database.js';
+import { COLUMN_TYPES, ForeignKeyRow, ColumnInfo, PrimaryKeyInfo } from '@/types/database.js';
 import {
   ERROR_CODES,
   ColumnSchema,
@@ -147,6 +141,7 @@ export class DatabaseTableService {
     schemaName: string,
     table_name: string,
     columns: ColumnSchema[],
+    foreignKeys: ForeignKeySchema[] = [],
     use_RLS = true
   ): Promise<CreateTableResponse> {
     validateSchemaName(schemaName);
@@ -235,10 +230,9 @@ export class DatabaseTableService {
             })
             .join(', ');
 
-          // Prepare foreign key constraints
-          const foreignKeyConstraints = validatedColumns
-            .filter((col) => col.foreignKey)
-            .map((col) => this.generateFkeyConstraintStatement(col, schemaName, true))
+          // Prepare foreign key constraints — one statement per constraint entity.
+          const foreignKeyConstraints = foreignKeys
+            .map((fk) => this.generateFkeyConstraintStatement(fk, schemaName, true))
             .join(', ');
 
           // Create table with auto fields and foreign keys
@@ -373,8 +367,8 @@ export class DatabaseTableService {
         );
       }
 
-      // Get foreign key information
-      const foreignKeyMap = await this.getFkeyConstraints(schemaName, table);
+      // Get foreign key information (one entity per constraint)
+      const foreignKeys = await this.getFkeyConstraints(schemaName, table);
 
       // Get primary key information
       const primaryKeysResult = await client.query(
@@ -439,11 +433,9 @@ export class DatabaseTableService {
             isPrimaryKey: pkSet.has(col.column_name),
             isUnique: pkSet.has(col.column_name) || uniqueSet.has(col.column_name),
             defaultValue: this.parseDefaultValue(col.column_default),
-            ...(foreignKeyMap.has(col.column_name) && {
-              foreignKey: foreignKeyMap.get(col.column_name),
-            }),
           };
         }),
+        foreignKeys,
         recordCount: row_count,
       };
     } finally {
@@ -518,27 +510,28 @@ export class DatabaseTableService {
             );
           }
 
-          const foreignKeyMap = await this.getFkeyConstraints(schemaName, tableName);
+          const existingForeignKeys = await this.getFkeyConstraints(schemaName, tableName);
+          const existingConstraintNames = new Set(
+            existingForeignKeys.map((fk) => fk.constraintName).filter(Boolean)
+          );
           const completedOperations: string[] = [];
 
           // Execute operations
 
-          // Drop foreign key constraints
-          const droppedConstraints = new Set<string>();
+          // Drop foreign key constraints by constraint name (only ones that exist on this table).
           if (dropForeignKeys && Array.isArray(dropForeignKeys)) {
-            for (const col of dropForeignKeys) {
-              const constraintName = foreignKeyMap.get(col)?.constraint_name;
-              if (constraintName && !droppedConstraints.has(constraintName)) {
-                droppedConstraints.add(constraintName);
-                await client.query(
-                  `
+            for (const constraintName of dropForeignKeys) {
+              if (!existingConstraintNames.has(constraintName)) {
+                continue;
+              }
+              await client.query(
+                `
                   ALTER TABLE ${safeQualifiedTableName}
                   DROP CONSTRAINT ${this.quoteIdentifier(constraintName)}
                 `
-                );
+              );
 
-                completedOperations.push(`Dropped foreign key constraint on column: ${col}`);
-              }
+              completedOperations.push(`Dropped foreign key constraint: ${constraintName}`);
             }
           }
 
@@ -641,18 +634,21 @@ export class DatabaseTableService {
             }
           }
 
-          // Add foreign key constraints
+          // Add foreign key constraints — one ALTER per constraint entity.
           if (addForeignKeys && Array.isArray(addForeignKeys)) {
-            for (const col of addForeignKeys) {
-              if (Object.keys(reservedColumns).includes(col.columnName)) {
+            for (const fk of addForeignKeys) {
+              const systemSourceColumn = fk.referenceColumns
+                .map((rc) => rc.sourceColumn)
+                .find((source) => Object.keys(reservedColumns).includes(source));
+              if (systemSourceColumn) {
                 throw new AppError(
                   'cannot add foreign key on system columns',
                   404,
                   ERROR_CODES.DATABASE_FORBIDDEN,
-                  `You cannot add foreign key on the system column '${col.columnName}'`
+                  `You cannot add foreign key on the system column '${systemSourceColumn}'`
                 );
               }
-              const fkeyConstraint = this.generateFkeyConstraintStatement(col, schemaName, true);
+              const fkeyConstraint = this.generateFkeyConstraintStatement(fk, schemaName, true);
               await client.query(
                 `
                 ALTER TABLE ${safeQualifiedTableName}
@@ -660,7 +656,10 @@ export class DatabaseTableService {
               `
               );
 
-              completedOperations.push(`Added foreign key constraint on column: ${col.columnName}`);
+              const sourceColumns = fk.referenceColumns.map((rc) => rc.sourceColumn).join(', ');
+              completedOperations.push(
+                `Added foreign key constraint on column(s): ${sourceColumns}`
+              );
             }
           }
 
@@ -800,14 +799,10 @@ export class DatabaseTableService {
   }
 
   private generateFkeyConstraintStatement(
-    col: { columnName: string; foreignKey?: ForeignKeySchema },
+    fk: ForeignKeySchema,
     defaultSchemaName: string,
     include_source_column: boolean = true
   ) {
-    if (!col.foreignKey) {
-      return '';
-    }
-    const fk = col.foreignKey;
     if (!fk.referenceColumns || fk.referenceColumns.length === 0) {
       return '';
     }
@@ -833,10 +828,7 @@ export class DatabaseTableService {
     }
   }
 
-  private async getFkeyConstraints(
-    schemaName: string,
-    table: string
-  ): Promise<Map<string, ForeignKeyInfo>> {
+  private async getFkeyConstraints(schemaName: string, table: string): Promise<ForeignKeySchema[]> {
     const result = await this.getPool().query(
       `
         SELECT
@@ -877,7 +869,8 @@ export class DatabaseTableService {
 
     const foreignKeys = result.rows;
 
-    // Group rows by constraint_name, then map each source column to its FK info
+    // Group rows by constraint_name into one entity per constraint. A composite key
+    // is a single entity carrying all its (source -> reference) pairs in ordinal order.
     const constraintGroups = new Map<
       string,
       {
@@ -913,29 +906,18 @@ export class DatabaseTableService {
       });
     }
 
-    const foreignKeyMap = new Map<string, ForeignKeyInfo>();
-
-    for (const group of constraintGroups.values()) {
+    return Array.from(constraintGroups.values()).map((group) => {
       group.fromColumns.sort((a, b) => a.ordinal - b.ordinal);
-
-      const referenceColumns = group.fromColumns.map((c) => ({
-        sourceColumn: c.name,
-        referenceColumn: c.foreignColumn,
-      }));
-
-      const info: ForeignKeyInfo = {
-        constraint_name: group.constraintName,
+      return {
+        constraintName: group.constraintName,
         referenceTable: group.referenceTable,
-        referenceColumns,
+        referenceColumns: group.fromColumns.map((c) => ({
+          sourceColumn: c.name,
+          referenceColumn: c.foreignColumn,
+        })),
         onDelete: group.onDelete as OnDeleteActionSchema,
         onUpdate: group.onUpdate as OnUpdateActionSchema,
       };
-
-      for (const c of group.fromColumns) {
-        foreignKeyMap.set(c.name, { ...info });
-      }
-    }
-
-    return foreignKeyMap;
+    });
   }
 }

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -832,28 +832,37 @@ export class DatabaseTableService {
     const result = await this.getPool().query(
       `
         SELECT
-          tc.constraint_name,
-          kcu.column_name as from_column,
-          ccu.table_schema AS foreign_schema,
-          ccu.table_name AS foreign_table,
-          ccu.column_name AS foreign_column,
-          kcu.ordinal_position,
-          rc.delete_rule as on_delete,
-          rc.update_rule as on_update
-        FROM information_schema.table_constraints AS tc
-        JOIN information_schema.key_column_usage AS kcu
-          ON tc.constraint_name = kcu.constraint_name
-          AND tc.table_schema = kcu.table_schema
-        JOIN information_schema.key_column_usage AS ccu
-          ON tc.unique_constraint_name = ccu.constraint_name
-          AND kcu.ordinal_position = ccu.ordinal_position
-        JOIN information_schema.referential_constraints AS rc
-          ON rc.constraint_name = tc.constraint_name
-          AND rc.constraint_schema = tc.table_schema
-        WHERE tc.constraint_type = 'FOREIGN KEY'
-        AND tc.table_schema = $1
-        AND tc.table_name = $2
-        ORDER BY tc.constraint_name, kcu.ordinal_position
+          c.conname AS constraint_name,
+          a1.attname AS from_column,
+          nf.nspname AS foreign_schema,
+          cf.relname AS foreign_table,
+          a2.attname AS foreign_column,
+          u.pos AS ordinal_position,
+          CASE c.confdeltype
+            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+            WHEN 'd' THEN 'SET DEFAULT'
+          END AS on_delete,
+          CASE c.confupdtype
+            WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+            WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+            WHEN 'd' THEN 'SET DEFAULT'
+          END AS on_update
+        FROM pg_catalog.pg_constraint c
+        JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+        JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+        JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+        JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+        CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+          WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+        JOIN pg_catalog.pg_attribute a1
+          ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+        JOIN pg_catalog.pg_attribute a2
+          ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+        WHERE c.contype = 'f'
+          AND nt.nspname = $1
+          AND ct.relname = $2
+        ORDER BY c.conname, u.pos
       `,
       [schemaName, table]
     );
@@ -861,13 +870,16 @@ export class DatabaseTableService {
     const foreignKeys = result.rows;
 
     // Group rows by constraint_name, then map each source column to its FK info
-    const constraintGroups = new Map<string, {
-      constraintName: string;
-      referenceTable: string;
-      fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
-      onDelete: string;
-      onUpdate: string;
-    }>();
+    const constraintGroups = new Map<
+      string,
+      {
+        constraintName: string;
+        referenceTable: string;
+        fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
+        onDelete: string;
+        onUpdate: string;
+      }
+    >();
 
     for (const fk of foreignKeys as ForeignKeyRow[]) {
       const referenceTable =
@@ -886,7 +898,11 @@ export class DatabaseTableService {
         };
         constraintGroups.set(fk.constraint_name, group);
       }
-      group.fromColumns.push({ name: fk.from_column, foreignColumn: fk.foreign_column, ordinal: fk.ordinal_position });
+      group.fromColumns.push({
+        name: fk.from_column,
+        foreignColumn: fk.foreign_column,
+        ordinal: fk.ordinal_position,
+      });
     }
 
     const foreignKeyMap = new Map<string, ForeignKeyInfo>();

--- a/backend/src/services/database/helpers.ts
+++ b/backend/src/services/database/helpers.ts
@@ -1,5 +1,11 @@
 import { AppError } from '@/utils/errors.js';
-import { ERROR_CODES } from '@insforge/shared-schemas';
+import {
+  ERROR_CODES,
+  type ForeignKeySchema,
+  type OnDeleteActionSchema,
+  type OnUpdateActionSchema,
+} from '@insforge/shared-schemas';
+import type { ForeignKeyRow } from '@/types/database.js';
 import { validateIdentifier, validateSchemaName, validateTableName } from '@/utils/validations.js';
 
 export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
@@ -74,4 +80,107 @@ export function splitQualifiedTableReference(
     schemaName,
     tableName,
   };
+}
+
+/**
+ * Parameterized pg_catalog query returning one row per foreign-key column pair,
+ * ordered by (constraint name, column ordinal position). A composite key produces
+ * one row per column; group the rows with {@link groupForeignKeyRows}.
+ *
+ * Params: $1 = schema name, $2 = table name.
+ *
+ * Single source of truth for FK introspection — used by both the table-schema
+ * service and the JSON export so the two can never drift (column ordering,
+ * referential-action mapping, schema qualification).
+ */
+export const FOREIGN_KEY_INTROSPECTION_QUERY = `
+  SELECT
+    c.conname AS constraint_name,
+    a1.attname AS from_column,
+    nf.nspname AS foreign_schema,
+    cf.relname AS foreign_table,
+    a2.attname AS foreign_column,
+    u.pos::int AS ordinal_position,
+    CASE c.confdeltype
+      WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+      WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+      WHEN 'd' THEN 'SET DEFAULT'
+    END AS on_delete,
+    CASE c.confupdtype
+      WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT'
+      WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL'
+      WHEN 'd' THEN 'SET DEFAULT'
+    END AS on_update
+  FROM pg_catalog.pg_constraint c
+  JOIN pg_catalog.pg_class ct ON c.conrelid = ct.oid
+  JOIN pg_catalog.pg_namespace nt ON ct.relnamespace = nt.oid
+  JOIN pg_catalog.pg_class cf ON c.confrelid = cf.oid
+  JOIN pg_catalog.pg_namespace nf ON cf.relnamespace = nf.oid
+  CROSS JOIN LATERAL unnest(c.conkey, c.confkey)
+    WITH ORDINALITY AS u(src_attnum, ref_attnum, pos)
+  JOIN pg_catalog.pg_attribute a1
+    ON a1.attnum = u.src_attnum AND a1.attrelid = c.conrelid
+  JOIN pg_catalog.pg_attribute a2
+    ON a2.attnum = u.ref_attnum AND a2.attrelid = c.confrelid
+  WHERE c.contype = 'f'
+    AND nt.nspname = $1
+    AND ct.relname = $2
+  ORDER BY c.conname, u.pos
+`;
+
+/**
+ * Groups the per-column rows from {@link FOREIGN_KEY_INTROSPECTION_QUERY} into one
+ * entity per constraint. A composite key becomes a single entity carrying all its
+ * (source -> reference) pairs in ordinal order. References to non-public schemas
+ * are qualified as `schema.table`.
+ */
+export function groupForeignKeyRows(rows: ForeignKeyRow[]): ForeignKeySchema[] {
+  const constraintGroups = new Map<
+    string,
+    {
+      constraintName: string;
+      referenceTable: string;
+      fromColumns: { name: string; foreignColumn: string; ordinal: number }[];
+      onDelete: string;
+      onUpdate: string;
+    }
+  >();
+
+  for (const fk of rows) {
+    const referenceTable =
+      fk.foreign_schema !== 'public'
+        ? `${fk.foreign_schema}.${fk.foreign_table}`
+        : fk.foreign_table;
+
+    let group = constraintGroups.get(fk.constraint_name);
+    if (!group) {
+      group = {
+        constraintName: fk.constraint_name,
+        referenceTable,
+        fromColumns: [],
+        onDelete: fk.on_delete,
+        onUpdate: fk.on_update,
+      };
+      constraintGroups.set(fk.constraint_name, group);
+    }
+    group.fromColumns.push({
+      name: fk.from_column,
+      foreignColumn: fk.foreign_column,
+      ordinal: fk.ordinal_position,
+    });
+  }
+
+  return Array.from(constraintGroups.values()).map((group) => {
+    group.fromColumns.sort((a, b) => a.ordinal - b.ordinal);
+    return {
+      constraintName: group.constraintName,
+      referenceTable: group.referenceTable,
+      referenceColumns: group.fromColumns.map((c) => ({
+        sourceColumn: c.name,
+        referenceColumn: c.foreignColumn,
+      })),
+      onDelete: group.onDelete as OnDeleteActionSchema,
+      onUpdate: group.onUpdate as OnUpdateActionSchema,
+    };
+  });
 }

--- a/backend/src/types/database.ts
+++ b/backend/src/types/database.ts
@@ -1,5 +1,5 @@
 // Type definitions for database schema management
-import { ColumnType, ColumnSchema, ForeignKeySchema } from '@insforge/shared-schemas';
+import { ColumnType, ColumnSchema } from '@insforge/shared-schemas';
 
 // Database metadata format returned by getDatabaseMetadata
 export interface DatabaseMetadata {
@@ -92,11 +92,6 @@ export interface ForeignKeyDefinition {
   on_delete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
   on_update?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
 }
-
-// Type definition for foreign key information
-export type ForeignKeyInfo = ForeignKeySchema & {
-  constraint_name: string;
-};
 
 // Type definition for foreign key row from database
 export interface ForeignKeyRow {

--- a/backend/src/types/database.ts
+++ b/backend/src/types/database.ts
@@ -105,6 +105,7 @@ export interface ForeignKeyRow {
   foreign_schema: string;
   foreign_table: string;
   foreign_column: string;
+  ordinal_position: number;
   on_delete: string;
   on_update: string;
 }

--- a/backend/tests/local/test-fk-errors.sh
+++ b/backend/tests/local/test-fk-errors.sh
@@ -61,20 +61,20 @@ main_test() {
     
     # Test our error handling
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"fake_table\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"referenceTable\":\"fake_table\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}]}" \
         "Non-existent table → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"name\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"name\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}]}" \
         "Type mismatch → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"columnName\":\"cat_id\",\"foreignKey\":{\"referenceTable\":\"fake_cats\",\"referenceColumns\":[{\"sourceColumn\":\"cat_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"referenceTable\":\"fake_cats\",\"referenceColumns\":[{\"sourceColumn\":\"cat_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}]}" \
         "New column with non-existent table → 400" 400
     
     # Valid FK should work
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}]}" \
         "Valid FK constraint → 200" 200
     
     # Summary

--- a/backend/tests/local/test-fk-errors.sh
+++ b/backend/tests/local/test-fk-errors.sh
@@ -61,20 +61,20 @@ main_test() {
     
     # Test our error handling
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"fake_table\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"fake_table\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Non-existent table → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumn\":\"name\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"name\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Type mismatch → 400" 400
     
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"columnName\":\"cat_id\",\"foreignKey\":{\"referenceTable\":\"fake_cats\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addColumns\":[{\"columnName\":\"cat_id\",\"type\":\"uuid\",\"isNullable\":true,\"isUnique\":false}],\"addForeignKeys\":[{\"columnName\":\"cat_id\",\"foreignKey\":{\"referenceTable\":\"fake_cats\",\"referenceColumns\":[{\"sourceColumn\":\"cat_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "New column with non-existent table → 400" 400
     
     # Valid FK should work
     test_fk "PATCH" "/database/tables/$POSTS_TABLE/schema" \
-        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumn\":\"id\",\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
+        "{\"addForeignKeys\":[{\"columnName\":\"author_id\",\"foreignKey\":{\"referenceTable\":\"$USERS_TABLE\",\"referenceColumns\":[{\"sourceColumn\":\"author_id\",\"referenceColumn\":\"id\"}],\"onDelete\":\"CASCADE\",\"onUpdate\":\"CASCADE\"}}]}" \
         "Valid FK constraint → 200" 200
     
     # Summary

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -136,10 +136,15 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
-      owner_id: '',
-      name: 'Renamed project',
-    });
+    const record = await service.updateRecord(
+      'public',
+      'projects',
+      { id: 'p1' },
+      {
+        owner_id: '',
+        name: 'Renamed project',
+      }
+    );
 
     expect(record).toEqual({ id: 'p1', owner_id: null, name: 'Renamed project' });
     const updateCall = clientQueryMock.mock.calls.find(
@@ -218,9 +223,14 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const record = await service.updateRecord('public', 'projects', 'id', 'p1', {
-      priority: '',
-    });
+    const record = await service.updateRecord(
+      'public',
+      'projects',
+      { id: 'p1' },
+      {
+        priority: '',
+      }
+    );
 
     expect(record).toEqual({ id: 'p1', priority: null });
     const updateCall = clientQueryMock.mock.calls.find(
@@ -250,9 +260,14 @@ describe('AdminRecordService', () => {
     const service = AdminRecordService.getInstance();
 
     await expect(
-      service.updateRecord('public', 'projects', 'id', 'p1', {
-        priority: '',
-      })
+      service.updateRecord(
+        'public',
+        'projects',
+        { id: 'p1' },
+        {
+          priority: '',
+        }
+      )
     ).rejects.toBeInstanceOf(AppError);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
@@ -276,7 +291,10 @@ describe('AdminRecordService', () => {
     });
 
     const service = AdminRecordService.getInstance();
-    const deletedCount = await service.deleteRecords('public', 'projects', 'id', ['p1', 'p2']);
+    const deletedCount = await service.deleteRecords('public', 'projects', [
+      { id: 'p1' },
+      { id: 'p2' },
+    ]);
 
     expect(deletedCount).toBe(2);
 
@@ -290,6 +308,110 @@ describe('AdminRecordService', () => {
     expect(sqlCalls[0]).toBe('BEGIN');
     expect(deleteIndex).toBeGreaterThan(setRoleIndex);
     expect(commitIndex).toBeGreaterThan(deleteIndex);
+  });
+
+  it('updates a composite-key row using the full primary-key tuple', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE "public"."composite_pk_test"')) {
+        return {
+          rows: [{ tenant_id: 'tenant_a', item_id: 'item_2', label: 'second-updated' }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = AdminRecordService.getInstance();
+    const record = await service.updateRecord(
+      'public',
+      'composite_pk_test',
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+      { label: 'second-updated' }
+    );
+
+    expect(record).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'second-updated' });
+
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."composite_pk_test"')
+    );
+    // The WHERE clause must match both key columns, not just the (duplicated) first one.
+    expect(updateCall?.[0]).toContain(
+      'SET "label" = $1 WHERE "tenant_id" = $2 AND "item_id" = $3 RETURNING *'
+    );
+    expect(updateCall?.[1]).toEqual(['second-updated', 'tenant_a', 'item_2']);
+  });
+
+  it('deletes only the selected composite-key tuples', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
+        return { rowCount: 1, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+    // tenant_a is duplicated across rows; deleting must target the exact tuple only.
+    const deletedCount = await service.deleteRecords('public', 'composite_pk_test', [
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+    ]);
+
+    expect(deletedCount).toBe(1);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."composite_pk_test"')
+    );
+    expect(deleteCall?.[0]).toContain('WHERE ("tenant_id" = $1 AND "item_id" = $2)');
+    expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_2']);
+  });
+
+  it('matches each selected composite tuple independently when deleting many rows', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
+        return { rowCount: 2, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+    const deletedCount = await service.deleteRecords('public', 'composite_pk_test', [
+      { tenant_id: 'tenant_a', item_id: 'item_1' },
+      { tenant_id: 'tenant_a', item_id: 'item_2' },
+    ]);
+
+    expect(deletedCount).toBe(2);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."composite_pk_test"')
+    );
+    expect(deleteCall?.[0]).toContain(
+      'WHERE ("tenant_id" = $1 AND "item_id" = $2) OR ("tenant_id" = $3 AND "item_id" = $4)'
+    );
+    expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_1', 'tenant_a', 'item_2']);
   });
 
   it('discards the pooled client when admin transaction cleanup fails', async () => {
@@ -316,9 +438,14 @@ describe('AdminRecordService', () => {
     const service = AdminRecordService.getInstance();
 
     await expect(
-      service.updateRecord('public', 'projects', 'id', 'p1', {
-        name: 'Renamed project',
-      })
+      service.updateRecord(
+        'public',
+        'projects',
+        { id: 'p1' },
+        {
+          name: 'Renamed project',
+        }
+      )
     ).rejects.toBe(resetError);
 
     expect(clientQueryMock.mock.calls.map(([sql]) => sql as string)).toContain('ROLLBACK');

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -93,6 +93,7 @@ describe('AdminRecordService', () => {
           { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
         ],
       }) // metadata
+      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'u1', email: 'demo@example.com' }],
       }) // INSERT
@@ -126,6 +127,9 @@ describe('AdminRecordService', () => {
             { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return {
@@ -182,6 +186,7 @@ describe('AdminRecordService', () => {
           },
         ],
       }) // metadata
+      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'r1', name: '' }],
       }) // INSERT
@@ -213,6 +218,9 @@ describe('AdminRecordService', () => {
             },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return {
@@ -284,6 +292,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."projects"')) {
         return { rowCount: 2, rows: [] };
       }
@@ -297,6 +308,13 @@ describe('AdminRecordService', () => {
     ]);
 
     expect(deletedCount).toBe(2);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."projects"')
+    );
+    // Each selected single-column key is matched as its own AND-group, OR'd together.
+    expect(deleteCall?.[0]).toContain('WHERE ("id" = $1) OR ("id" = $2)');
+    expect(deleteCall?.[1]).toEqual(['p1', 'p2']);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
     const setRoleIndex = sqlCalls.indexOf('SET LOCAL ROLE project_admin');
@@ -320,6 +338,9 @@ describe('AdminRecordService', () => {
             { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
       }
       if (sql.includes('UPDATE "public"."composite_pk_test"')) {
         return {
@@ -360,6 +381,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
         return { rowCount: 1, rows: [] };
       }
@@ -391,6 +415,9 @@ describe('AdminRecordService', () => {
           ],
         };
       }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
       if (sql.includes('DELETE FROM "public"."composite_pk_test"')) {
         return { rowCount: 2, rows: [] };
       }
@@ -414,6 +441,47 @@ describe('AdminRecordService', () => {
     expect(deleteCall?.[1]).toEqual(['tenant_a', 'item_1', 'tenant_a', 'item_2']);
   });
 
+  it('rejects a partial composite key instead of mutating unintended rows', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'tenant_id' }, { column_name: 'item_id' }] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    // Supplying only the first PK column of a composite key must be rejected, not
+    // turned into a broad DELETE that removes every row sharing that value.
+    await expect(
+      service.deleteRecords('public', 'composite_pk_test', [{ tenant_id: 'tenant_a' }])
+    ).rejects.toBeInstanceOf(AppError);
+
+    const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
+    expect(sqlCalls.some((sql) => sql.includes('DELETE FROM'))).toBe(false);
+    expect(sqlCalls).toContain('ROLLBACK');
+
+    // The same partial key must also be rejected on update.
+    await expect(
+      service.updateRecord('public', 'composite_pk_test', { tenant_id: 'tenant_a' }, { label: 'x' })
+    ).rejects.toBeInstanceOf(AppError);
+
+    expect(
+      clientQueryMock.mock.calls.some(
+        ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."composite_pk_test"')
+      )
+    ).toBe(false);
+  });
+
   it('discards the pooled client when admin transaction cleanup fails', async () => {
     const resetError = new Error('reset failed');
 
@@ -425,6 +493,9 @@ describe('AdminRecordService', () => {
             { column_name: 'name', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
           ],
         };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [{ column_name: 'id' }] };
       }
       if (sql.includes('UPDATE "public"."projects"')) {
         return { rows: [{ id: 'p1', name: 'Renamed project' }] };

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -484,6 +484,55 @@ describe('AdminRecordService', () => {
     ).toBe(false);
   });
 
+  it('falls back to the caller-provided key when the table has no primary key', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'id', data_type: 'uuid', is_nullable: 'NO', udt_name: 'uuid' },
+            { column_name: 'name', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [] }; // table has no primary key
+      }
+      if (sql.includes('UPDATE "public"."pkless"')) {
+        return { rows: [{ id: 'p1', name: 'Renamed' }] };
+      }
+      if (sql.includes('DELETE FROM "public"."pkless"')) {
+        return { rowCount: 1, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    // With no detectable primary key, the supplied key columns are used as-is.
+    const updated = await service.updateRecord(
+      'public',
+      'pkless',
+      { id: 'p1' },
+      { name: 'Renamed' }
+    );
+    expect(updated).toEqual({ id: 'p1', name: 'Renamed' });
+
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."pkless"')
+    );
+    expect(updateCall?.[0]).toContain('WHERE "id" = $2 RETURNING *');
+    expect(updateCall?.[1]).toEqual(['Renamed', 'p1']);
+
+    const deletedCount = await service.deleteRecords('public', 'pkless', [{ id: 'p1' }]);
+    expect(deletedCount).toBe(1);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."pkless"')
+    );
+    expect(deleteCall?.[0]).toContain('WHERE ("id" = $1)');
+    expect(deleteCall?.[1]).toEqual(['p1']);
+  });
+
   it('discards the pooled client when admin transaction cleanup fails', async () => {
     const resetError = new Error('reset failed');
 

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -80,6 +80,10 @@ describe('AdminRecordService', () => {
     expect(resetRoleIndex).toBeGreaterThan(dataQueryIndex);
     expect(commitIndex).toBeGreaterThan(resetRoleIndex);
     expect(clientQueryMock.mock.calls[dataQueryIndex]?.[1]).toEqual(['%demo%', 10, 0]);
+    // Read paths must not pay for the primary-key metadata query.
+    expect(sqlCalls.some((sql) => sql.includes('information_schema.table_constraints'))).toBe(
+      false
+    );
   });
 
   it('delegates protected-schema writes to project_admin privileges', async () => {
@@ -93,7 +97,6 @@ describe('AdminRecordService', () => {
           { column_name: 'email', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
         ],
       }) // metadata
-      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'u1', email: 'demo@example.com' }],
       }) // INSERT
@@ -186,7 +189,6 @@ describe('AdminRecordService', () => {
           },
         ],
       }) // metadata
-      .mockResolvedValueOnce({ rows: [{ column_name: 'id' }] }) // primary key columns
       .mockResolvedValueOnce({
         rows: [{ id: 'r1', name: '' }],
       }) // INSERT

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -533,6 +533,59 @@ describe('AdminRecordService', () => {
     expect(deleteCall?.[1]).toEqual(['p1']);
   });
 
+  it('matches a null key column with IS NULL on a keyless table', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'name', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+            { column_name: 'email', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('information_schema.table_constraints')) {
+        return { rows: [] }; // table has no primary key
+      }
+      if (sql.includes('UPDATE "public"."pkless"')) {
+        return { rows: [{ name: 'alice', email: 'fixed@x.com' }] };
+      }
+      if (sql.includes('DELETE FROM "public"."pkless"')) {
+        return { rowCount: 1, rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const service = AdminRecordService.getInstance();
+
+    // A genuinely-null column in the all-columns fallback key must match the row
+    // with `IS NULL`, not `= ''` (which would silently match nothing).
+    const updated = await service.updateRecord(
+      'public',
+      'pkless',
+      { name: 'alice', email: null },
+      { email: 'fixed@x.com' }
+    );
+    expect(updated).toEqual({ name: 'alice', email: 'fixed@x.com' });
+
+    const updateCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE "public"."pkless"')
+    );
+    // The null component becomes `IS NULL` and binds no parameter for it.
+    expect(updateCall?.[0]).toContain('WHERE "name" = $2 AND "email" IS NULL RETURNING *');
+    expect(updateCall?.[1]).toEqual(['fixed@x.com', 'alice']);
+
+    const deletedCount = await service.deleteRecords('public', 'pkless', [
+      { name: 'alice', email: null },
+    ]);
+    expect(deletedCount).toBe(1);
+
+    const deleteCall = clientQueryMock.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('DELETE FROM "public"."pkless"')
+    );
+    expect(deleteCall?.[0]).toContain('WHERE ("name" = $1 AND "email" IS NULL)');
+    expect(deleteCall?.[1]).toEqual(['alice']);
+  });
+
   it('discards the pooled client when admin transaction cleanup fails', async () => {
     const resetError = new Error('reset failed');
 

--- a/backend/tests/unit/database-fkey-composite.test.ts
+++ b/backend/tests/unit/database-fkey-composite.test.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/utils/errors';
+
+// ---------------------------------------------------------------------------
+// Mocks – shared across both describe blocks
+// ---------------------------------------------------------------------------
+const { poolQueryMock, connectMock, clientQueryMock, releaseMock } = vi.hoisted(() => ({
+  poolQueryMock: vi.fn(),
+  connectMock: vi.fn(),
+  clientQueryMock: vi.fn(),
+  releaseMock: vi.fn(),
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        query: poolQueryMock,
+        connect: connectMock,
+      })),
+    })),
+    clearColumnTypeCache: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+import { AdminRecordService } from '../../src/services/database/admin-record.service';
+import { DatabaseTableService } from '../../src/services/database/database-table.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeService() {
+  return DatabaseTableService.getInstance();
+}
+
+function makeAdminService() {
+  return AdminRecordService.getInstance();
+}
+
+// ---------------------------------------------------------------------------
+// Tests – getFkeyConstraints
+// ---------------------------------------------------------------------------
+describe('DatabaseTableService – getFkeyConstraints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('correctly pairs source and reference columns in a composite FK (positional join)', async () => {
+    const fkRows = [
+      {
+        constraint_name: 'fk_composite_test_ref_composite_tenant_id_item_id',
+        from_column: 'tenant_id',
+        foreign_schema: 'public',
+        foreign_table: 'ref_composite',
+        foreign_column: 'tenant_id',
+        ordinal_position: 1,
+        on_delete: 'NO ACTION',
+        on_update: 'CASCADE',
+      },
+      {
+        constraint_name: 'fk_composite_test_ref_composite_tenant_id_item_id',
+        from_column: 'item_id',
+        foreign_schema: 'public',
+        foreign_table: 'ref_composite',
+        foreign_column: 'item_id',
+        ordinal_position: 2,
+        on_delete: 'NO ACTION',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'composite_test');
+
+    expect(map.size).toBe(2);
+
+    // Each source column should map to the full composite FK info
+    for (const col of ['tenant_id', 'item_id']) {
+      const entry = map.get(col);
+      expect(entry).toBeDefined();
+      expect(entry!.constraint_name).toBe('fk_composite_test_ref_composite_tenant_id_item_id');
+      expect(entry!.referenceTable).toBe('ref_composite');
+      expect(entry!.referenceColumns).toHaveLength(2);
+      expect(entry!.referenceColumns[0]).toEqual({
+        sourceColumn: 'tenant_id',
+        referenceColumn: 'tenant_id',
+      });
+      expect(entry!.referenceColumns[1]).toEqual({
+        sourceColumn: 'item_id',
+        referenceColumn: 'item_id',
+      });
+    }
+  });
+
+  it('does not cross-join columns when reference column values are duplicated across tuples', async () => {
+    // Simulate two rows in the referenced table that share a common column value:
+    //   (tenant_a, item_1)
+    //   (tenant_a, item_2)
+    // The positional join must pair tenant_id→tenant_id and item_id→item_id,
+    // never tenant_id→item_id.
+    const fkRows = [
+      {
+        constraint_name: 'fk_child_parent_tenant_id_item_id',
+        from_column: 'tenant_id',
+        foreign_schema: 'public',
+        foreign_table: 'parent_composite',
+        foreign_column: 'tenant_id',
+        ordinal_position: 1,
+        on_delete: 'RESTRICT',
+        on_update: 'CASCADE',
+      },
+      {
+        constraint_name: 'fk_child_parent_tenant_id_item_id',
+        from_column: 'item_id',
+        foreign_schema: 'public',
+        foreign_table: 'parent_composite',
+        foreign_column: 'item_id',
+        ordinal_position: 2,
+        on_delete: 'RESTRICT',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'child');
+
+    const tenantEntry = map.get('tenant_id');
+    const itemEntry = map.get('item_id');
+
+    expect(tenantEntry).toBeDefined();
+    expect(itemEntry).toBeDefined();
+
+    // Both entries must carry the same full referenceColumns array
+    const expectedPairs = [
+      { sourceColumn: 'tenant_id', referenceColumn: 'tenant_id' },
+      { sourceColumn: 'item_id', referenceColumn: 'item_id' },
+    ];
+
+    expect(tenantEntry!.referenceColumns).toEqual(expectedPairs);
+    expect(itemEntry!.referenceColumns).toEqual(expectedPairs);
+  });
+
+  it('handles single-column FKs without breaking', async () => {
+    const fkRows = [
+      {
+        constraint_name: 'fk_orders_user_id',
+        from_column: 'user_id',
+        foreign_schema: 'public',
+        foreign_table: 'users',
+        foreign_column: 'id',
+        ordinal_position: 1,
+        on_delete: 'CASCADE',
+        on_update: 'CASCADE',
+      },
+    ];
+
+    poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'orders');
+
+    expect(map.size).toBe(1);
+    const entry = map.get('user_id');
+    expect(entry!.referenceColumns).toHaveLength(1);
+    expect(entry!.referenceColumns[0]).toEqual({
+      sourceColumn: 'user_id',
+      referenceColumn: 'id',
+    });
+    expect(entry!.referenceTable).toBe('users');
+    expect(entry!.onDelete).toBe('CASCADE');
+    expect(entry!.onUpdate).toBe('CASCADE');
+  });
+
+  it('returns empty map when table has no foreign keys', async () => {
+    poolQueryMock.mockResolvedValueOnce({ rows: [] });
+
+    const service = makeService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const map = await (service as any).getFkeyConstraints('public', 'no_fk_table');
+
+    expect(map.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests – lookupRecord (multi-column)
+// ---------------------------------------------------------------------------
+describe('AdminRecordService – lookupRecord (composite FK)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: releaseMock,
+    });
+  });
+
+  it('builds multi-column WHERE clause and returns the correct record', async () => {
+    // Simulate metadata query + lookup query
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return {
+          rows: [
+            {
+              tenant_id: 'tenant_a',
+              item_id: 'item_2',
+              label: 'item A2',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'item_2']
+    );
+
+    // Verify the correct row was returned
+    expect(result).toEqual({
+      tenant_id: 'tenant_a',
+      item_id: 'item_2',
+      label: 'item A2',
+    });
+
+    // Verify the SQL uses multi-column WHERE
+    const dataQueryCall = clientQueryMock.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('SELECT * FROM')
+    );
+    expect(dataQueryCall).toBeDefined();
+    expect(dataQueryCall![0] as string).toMatch(
+      /WHERE\s+"tenant_id"\s*=\s*\$1\s+AND\s+"item_id"\s*=\s*\$2\s+LIMIT\s+1/i
+    );
+    expect(dataQueryCall![1]).toEqual(['tenant_a', 'item_2']);
+  });
+
+  it('returns null when no row matches the composite key', async () => {
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'nonexistent']
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('throws when columns and values have mismatched lengths', async () => {
+    const service = makeAdminService();
+
+    await expect(
+      service.lookupRecord('public', 't', ['tenant_id', 'item_id'], ['tenant_a'])
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('correctly distinguishes between rows that share a column value', async () => {
+    // Two rows share the same tenant_id but have different item_ids.
+    // Lookup by (tenant_a, item_1) must return the first row, not the second.
+    clientQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM information_schema.columns')) {
+        return {
+          rows: [
+            { column_name: 'tenant_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'item_id', data_type: 'text', is_nullable: 'NO', udt_name: 'text' },
+            { column_name: 'label', data_type: 'text', is_nullable: 'YES', udt_name: 'text' },
+          ],
+        };
+      }
+      if (sql.includes('SELECT * FROM')) {
+        return {
+          rows: [
+            {
+              tenant_id: 'tenant_a',
+              item_id: 'item_1',
+              label: 'item A1',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const service = makeAdminService();
+    const result = await service.lookupRecord(
+      'public',
+      'parent_composite',
+      ['tenant_id', 'item_id'],
+      ['tenant_a', 'item_1']
+    );
+
+    expect(result).toEqual({
+      tenant_id: 'tenant_a',
+      item_id: 'item_1',
+      label: 'item A1',
+    });
+
+    // Confirm the exact params passed to the data query
+    const dataQueryCall = clientQueryMock.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('SELECT * FROM')
+    );
+    expect(dataQueryCall![1]).toEqual(['tenant_a', 'item_1']);
+  });
+});

--- a/backend/tests/unit/database-fkey-composite.test.ts
+++ b/backend/tests/unit/database-fkey-composite.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ForeignKeySchema } from '@insforge/shared-schemas';
 import { AppError } from '../../src/utils/errors';
 
 // ---------------------------------------------------------------------------
@@ -34,6 +35,19 @@ import { DatabaseTableService } from '../../src/services/database/database-table
 // ---------------------------------------------------------------------------
 function makeService() {
   return DatabaseTableService.getInstance();
+}
+
+// Typed accessor for the private getFkeyConstraints method under test (no `any`).
+type FkeyConstraintsAccessor = {
+  getFkeyConstraints(schemaName: string, table: string): Promise<ForeignKeySchema[]>;
+};
+
+function getFkeyConstraints(
+  service: DatabaseTableService,
+  schemaName: string,
+  table: string
+): Promise<ForeignKeySchema[]> {
+  return (service as unknown as FkeyConstraintsAccessor).getFkeyConstraints(schemaName, table);
 }
 
 function makeAdminService() {
@@ -75,27 +89,17 @@ describe('DatabaseTableService – getFkeyConstraints', () => {
     poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
 
     const service = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const map = await (service as any).getFkeyConstraints('public', 'composite_test');
+    const fks = await getFkeyConstraints(service, 'public', 'composite_test');
 
-    expect(map.size).toBe(2);
-
-    // Each source column should map to the full composite FK info
-    for (const col of ['tenant_id', 'item_id']) {
-      const entry = map.get(col);
-      expect(entry).toBeDefined();
-      expect(entry!.constraint_name).toBe('fk_composite_test_ref_composite_tenant_id_item_id');
-      expect(entry!.referenceTable).toBe('ref_composite');
-      expect(entry!.referenceColumns).toHaveLength(2);
-      expect(entry!.referenceColumns[0]).toEqual({
-        sourceColumn: 'tenant_id',
-        referenceColumn: 'tenant_id',
-      });
-      expect(entry!.referenceColumns[1]).toEqual({
-        sourceColumn: 'item_id',
-        referenceColumn: 'item_id',
-      });
-    }
+    // One entity per constraint, carrying all column pairs in ordinal order.
+    expect(fks).toHaveLength(1);
+    const entry = fks[0];
+    expect(entry.constraintName).toBe('fk_composite_test_ref_composite_tenant_id_item_id');
+    expect(entry.referenceTable).toBe('ref_composite');
+    expect(entry.referenceColumns).toEqual([
+      { sourceColumn: 'tenant_id', referenceColumn: 'tenant_id' },
+      { sourceColumn: 'item_id', referenceColumn: 'item_id' },
+    ]);
   });
 
   it('does not cross-join columns when reference column values are duplicated across tuples', async () => {
@@ -130,23 +134,14 @@ describe('DatabaseTableService – getFkeyConstraints', () => {
     poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
 
     const service = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const map = await (service as any).getFkeyConstraints('public', 'child');
+    const fks = await getFkeyConstraints(service, 'public', 'child');
 
-    const tenantEntry = map.get('tenant_id');
-    const itemEntry = map.get('item_id');
-
-    expect(tenantEntry).toBeDefined();
-    expect(itemEntry).toBeDefined();
-
-    // Both entries must carry the same full referenceColumns array
-    const expectedPairs = [
+    // The positional join must pair tenant_id→tenant_id and item_id→item_id.
+    expect(fks).toHaveLength(1);
+    expect(fks[0].referenceColumns).toEqual([
       { sourceColumn: 'tenant_id', referenceColumn: 'tenant_id' },
       { sourceColumn: 'item_id', referenceColumn: 'item_id' },
-    ];
-
-    expect(tenantEntry!.referenceColumns).toEqual(expectedPairs);
-    expect(itemEntry!.referenceColumns).toEqual(expectedPairs);
+    ]);
   });
 
   it('handles single-column FKs without breaking', async () => {
@@ -166,29 +161,23 @@ describe('DatabaseTableService – getFkeyConstraints', () => {
     poolQueryMock.mockResolvedValueOnce({ rows: fkRows });
 
     const service = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const map = await (service as any).getFkeyConstraints('public', 'orders');
+    const fks = await getFkeyConstraints(service, 'public', 'orders');
 
-    expect(map.size).toBe(1);
-    const entry = map.get('user_id');
-    expect(entry!.referenceColumns).toHaveLength(1);
-    expect(entry!.referenceColumns[0]).toEqual({
-      sourceColumn: 'user_id',
-      referenceColumn: 'id',
-    });
-    expect(entry!.referenceTable).toBe('users');
-    expect(entry!.onDelete).toBe('CASCADE');
-    expect(entry!.onUpdate).toBe('CASCADE');
+    expect(fks).toHaveLength(1);
+    const entry = fks[0];
+    expect(entry.referenceColumns).toEqual([{ sourceColumn: 'user_id', referenceColumn: 'id' }]);
+    expect(entry.referenceTable).toBe('users');
+    expect(entry.onDelete).toBe('CASCADE');
+    expect(entry.onUpdate).toBe('CASCADE');
   });
 
-  it('returns empty map when table has no foreign keys', async () => {
+  it('returns an empty list when table has no foreign keys', async () => {
     poolQueryMock.mockResolvedValueOnce({ rows: [] });
 
     const service = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const map = await (service as any).getFkeyConstraints('public', 'no_fk_table');
+    const fks = await getFkeyConstraints(service, 'public', 'no_fk_table');
 
-    expect(map.size).toBe(0);
+    expect(fks).toEqual([]);
   });
 });
 

--- a/backend/tests/unit/database-schema-routes.test.ts
+++ b/backend/tests/unit/database-schema-routes.test.ts
@@ -40,7 +40,9 @@ describe('database schema route wiring', () => {
     expect(tableRoutesSource).toContain(
       'const { tableName, columns, foreignKeys, rlsEnabled } = validation.data'
     );
-    expect(tableRoutesSource).toContain('tableService.createTable(');
+    expect(tableRoutesSource).toMatch(
+      /tableService\.createTable\(\s*schemaName,\s*tableName,\s*columns,\s*foreignKeys,\s*rlsEnabled\s*\)/s
+    );
     expect(tableRoutesSource).toContain('tableService.getTableSchema(schemaName, tableName)');
     expect(tableRoutesSource).toContain(
       'tableService.updateTableSchema(schemaName, tableName, operations)'

--- a/backend/tests/unit/database-schema-routes.test.ts
+++ b/backend/tests/unit/database-schema-routes.test.ts
@@ -38,8 +38,9 @@ describe('database schema route wiring', () => {
   it('passes schema names through table management handlers', () => {
     expect(tableRoutesSource).toContain('tableService.listTables(schemaName)');
     expect(tableRoutesSource).toContain(
-      'tableService.createTable(schemaName, tableName, columns, rlsEnabled)'
+      'const { tableName, columns, foreignKeys, rlsEnabled } = validation.data'
     );
+    expect(tableRoutesSource).toContain('tableService.createTable(');
     expect(tableRoutesSource).toContain('tableService.getTableSchema(schemaName, tableName)');
     expect(tableRoutesSource).toContain(
       'tableService.updateTableSchema(schemaName, tableName, operations)'

--- a/backend/tests/unit/database-table-project-admin.test.ts
+++ b/backend/tests/unit/database-table-project-admin.test.ts
@@ -85,6 +85,7 @@ describe('DatabaseTableService project_admin DDL context', () => {
       'public',
       'posts',
       [{ columnName: 'title', type: ColumnType.STRING, isNullable: false }],
+      [],
       true
     );
 
@@ -145,6 +146,7 @@ describe('DatabaseTableService project_admin DDL context', () => {
       'auth',
       'users_copy',
       [{ columnName: 'email', type: ColumnType.STRING, isNullable: false }],
+      [],
       true
     );
 

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -531,15 +531,19 @@ components:
       required:
         - referenceTable
         - referenceColumns
+        - onDelete
+        - onUpdate
       properties:
         constraintName:
           type: string
           description: Constraint name. Returned when reading the schema; derived by the backend on create.
         referenceTable:
           type: string
+          minLength: 1
           description: Table being referenced
         referenceColumns:
           type: array
+          minItems: 1
           description: Ordered (source → reference) column pairs
           items:
             type: object
@@ -558,7 +562,7 @@ components:
           enum: [CASCADE, SET NULL, SET DEFAULT, NO ACTION, RESTRICT]
         onUpdate:
           type: string
-          enum: [CASCADE, NO ACTION, RESTRICT]
+          enum: [CASCADE, SET NULL, SET DEFAULT, NO ACTION, RESTRICT]
     Migration:
       type: object
       required:

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -297,14 +297,26 @@ paths:
                         type: object
                         required:
                           - referenceTable
-                          - referenceColumn
+                          - referenceColumns
                         properties:
                           referenceTable:
                             type: string
                             description: Table being referenced
-                          referenceColumn:
-                            type: string
-                            description: Column being referenced
+                          referenceColumns:
+                            type: array
+                            description: Column mappings (source → reference)
+                            items:
+                              type: object
+                              required:
+                                - sourceColumn
+                                - referenceColumn
+                              properties:
+                                sourceColumn:
+                                  type: string
+                                  description: Column in the current table
+                                referenceColumn:
+                                  type: string
+                                  description: Column in the referenced table
                           onDelete:
                             type: string
                             enum: [CASCADE, SET NULL, NO ACTION, RESTRICT]

--- a/openapi/tables.yaml
+++ b/openapi/tables.yaml
@@ -65,17 +65,11 @@ paths:
                         type: boolean
                       defaultValue:
                         type: string
-                      foreignKey:
-                        type: object
-                        properties:
-                          table:
-                            type: string
-                          column:
-                            type: string
-                          onDelete:
-                            type: string
-                            enum: [CASCADE, SET NULL, NO ACTION, RESTRICT]
-                            default: NO ACTION
+                foreignKeys:
+                  type: array
+                  description: Table-level foreign key constraints
+                  items:
+                    $ref: '#/components/schemas/ForeignKeyConstraint'
                 rlsEnabled:
                   type: boolean
                   default: false
@@ -160,16 +154,11 @@ paths:
                           nullable: true
                         isPrimaryKey:
                           type: boolean
-                        foreignKey:
-                          type: object
-                          nullable: true
-                          properties:
-                            table:
-                              type: string
-                            column:
-                              type: string
-                            on_delete:
-                              type: string
+                  foreignKeys:
+                    type: array
+                    description: Table-level foreign key constraints (one entry per constraint)
+                    items:
+                      $ref: '#/components/schemas/ForeignKeyConstraint'
               example:
                 tableName: "posts"
                 columns:
@@ -179,24 +168,26 @@ paths:
                     unique: true
                     default: "gen_random_uuid()"
                     isPrimaryKey: true
-                    foreignKey: null
                   - name: "title"
                     type: "string"
                     nullable: false
                     unique: false
                     default: null
                     isPrimaryKey: false
-                    foreignKey: null
                   - name: "userId"
                     type: "uuid"
                     nullable: false
                     unique: false
                     default: null
                     isPrimaryKey: false
-                    foreignKey:
-                      table: "auth.users"
-                      column: "id"
-                      on_delete: "CASCADE"
+                foreignKeys:
+                  - constraintName: "fk_userId_auth_users_id"
+                    referenceTable: "auth.users"
+                    referenceColumns:
+                      - sourceColumn: "userId"
+                        referenceColumn: "id"
+                    onDelete: "CASCADE"
+                    onUpdate: "CASCADE"
         '404':
           description: Table not found
           content:
@@ -283,56 +274,15 @@ paths:
                         description: New default value for the column (optional)
                 addForeignKeys:
                   type: array
-                  description: Add foreign key constraints to existing columns
+                  description: Add foreign key constraints (one entry per constraint; composite keys list multiple column mappings)
                   items:
-                    type: object
-                    required:
-                      - columnName
-                      - foreignKey
-                    properties:
-                      columnName:
-                        type: string
-                        description: Name of the column to add foreign key to
-                      foreignKey:
-                        type: object
-                        required:
-                          - referenceTable
-                          - referenceColumns
-                        properties:
-                          referenceTable:
-                            type: string
-                            description: Table being referenced
-                          referenceColumns:
-                            type: array
-                            description: Column mappings (source → reference)
-                            items:
-                              type: object
-                              required:
-                                - sourceColumn
-                                - referenceColumn
-                              properties:
-                                sourceColumn:
-                                  type: string
-                                  description: Column in the current table
-                                referenceColumn:
-                                  type: string
-                                  description: Column in the referenced table
-                          onDelete:
-                            type: string
-                            enum: [CASCADE, SET NULL, NO ACTION, RESTRICT]
-                            default: RESTRICT
-                            description: Action on delete
-                          onUpdate:
-                            type: string
-                            enum: [CASCADE, SET NULL, NO ACTION, RESTRICT]
-                            default: RESTRICT
-                            description: Action on update
+                    $ref: '#/components/schemas/ForeignKeyConstraint'
                 dropForeignKeys:
                   type: array
-                  description: Remove foreign key constraints from columns
+                  description: Constraint names of foreign keys to drop
                   items:
                     type: string
-                    description: Name of the column with foreign key to drop
+                    description: Name of the foreign key constraint to drop
                 renameTable:
                   type: object
                   description: Rename the table
@@ -575,6 +525,40 @@ components:
       name: X-API-Key
   
   schemas:
+    ForeignKeyConstraint:
+      type: object
+      description: A table-level foreign key constraint. One entry per constraint; composite keys list multiple column mappings.
+      required:
+        - referenceTable
+        - referenceColumns
+      properties:
+        constraintName:
+          type: string
+          description: Constraint name. Returned when reading the schema; derived by the backend on create.
+        referenceTable:
+          type: string
+          description: Table being referenced
+        referenceColumns:
+          type: array
+          description: Ordered (source → reference) column pairs
+          items:
+            type: object
+            required:
+              - sourceColumn
+              - referenceColumn
+            properties:
+              sourceColumn:
+                type: string
+                description: Column in the current table
+              referenceColumn:
+                type: string
+                description: Column in the referenced table
+        onDelete:
+          type: string
+          enum: [CASCADE, SET NULL, SET DEFAULT, NO ACTION, RESTRICT]
+        onUpdate:
+          type: string
+          enum: [CASCADE, NO ACTION, RESTRICT]
     Migration:
       type: object
       required:

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -82,8 +82,18 @@ describe('database helpers', () => {
       'id',
     ]);
 
-    // No primary key metadata -> fall back to the conventional `id` column.
-    expect(getPrimaryKeyColumns([column({ columnName: 'name' })])).toEqual(['id']);
+    // No primary key metadata but an `id` column exists -> use `id`.
+    expect(
+      getPrimaryKeyColumns([column({ columnName: 'id' }), column({ columnName: 'name' })])
+    ).toEqual(['id']);
+
+    // No primary key and no `id` column -> use every column so distinct rows keep
+    // distinct identities (instead of all collapsing to a single `{"id":null}` key).
+    expect(
+      getPrimaryKeyColumns([column({ columnName: 'name' }), column({ columnName: 'email' })])
+    ).toEqual(['name', 'email']);
+
+    // No metadata at all -> fall back to the conventional `id` column.
     expect(getPrimaryKeyColumns(undefined)).toEqual(['id']);
   });
 

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -4,8 +4,12 @@ import {
   DEFAULT_DATABASE_SCHEMA,
   buildDatabaseSchemaSearch,
   buildDynamicSchema,
+  decodeRecordKey,
+  encodeRecordKey,
   getDatabaseSchemaInfo,
   getInitialValues,
+  getPrimaryKeyColumns,
+  getRecordPrimaryKey,
   parseDatabaseTableReference,
 } from '#features/database/helpers';
 
@@ -63,6 +67,50 @@ describe('database helpers', () => {
     expect(schema.safeParse({ name: 'Ada', age: null }).success).toBe(true);
     expect(schema.safeParse({ name: '', age: 1 }).success).toBe(false);
     expect(schema.safeParse({ id: 'ignored', name: 'Ada', age: 1 }).success).toBe(true);
+  });
+
+  it('returns all primary-key columns in schema order, falling back to id', () => {
+    expect(
+      getPrimaryKeyColumns([
+        column({ columnName: 'tenant_id', isPrimaryKey: true }),
+        column({ columnName: 'item_id', isPrimaryKey: true }),
+        column({ columnName: 'label', isPrimaryKey: false }),
+      ])
+    ).toEqual(['tenant_id', 'item_id']);
+
+    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual(['id']);
+
+    // No primary key metadata -> fall back to the conventional `id` column.
+    expect(getPrimaryKeyColumns([column({ columnName: 'name' })])).toEqual(['id']);
+    expect(getPrimaryKeyColumns(undefined)).toEqual(['id']);
+  });
+
+  it('builds a record primary key tuple, coercing missing values to null', () => {
+    expect(
+      getRecordPrimaryKey({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'x' }, [
+        'tenant_id',
+        'item_id',
+      ])
+    ).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
+
+    expect(getRecordPrimaryKey({ id: 5 }, ['id'])).toEqual({ id: 5 });
+    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: null });
+  });
+
+  it('encodes the full key tuple and decodes it back, so duplicate first columns stay distinct', () => {
+    const pkColumns = ['tenant_id', 'item_id'];
+    const rowA = { tenant_id: 'tenant_a', item_id: 'item_1', label: 'first' };
+    const rowB = { tenant_id: 'tenant_a', item_id: 'item_2', label: 'second' };
+
+    const keyA = encodeRecordKey(rowA, pkColumns);
+    const keyB = encodeRecordKey(rowB, pkColumns);
+
+    // Same first PK column value, but the encoded keys must differ by the full tuple.
+    expect(keyA).not.toBe(keyB);
+    // Encoding is stable for identical tuples.
+    expect(encodeRecordKey({ ...rowA }, pkColumns)).toBe(keyA);
+
+    expect(decodeRecordKey(keyB)).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
   });
 
   it('uses backend schema metadata for protection state and keeps unknown schemas writable by default', () => {

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -97,7 +97,7 @@ describe('database helpers', () => {
     expect(getPrimaryKeyColumns(undefined)).toEqual(['id']);
   });
 
-  it('builds a record primary key tuple, coercing missing values to null', () => {
+  it('builds a record primary key tuple, coercing missing values to empty string', () => {
     expect(
       getRecordPrimaryKey({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'x' }, [
         'tenant_id',
@@ -106,7 +106,8 @@ describe('database helpers', () => {
     ).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
 
     expect(getRecordPrimaryKey({ id: 5 }, ['id'])).toEqual({ id: 5 });
-    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: null });
+    // PK columns are NOT NULL; a missing value is coerced to '' (non-null scalar).
+    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: '' });
   });
 
   it('encodes the full key tuple and decodes it back, so duplicate first columns stay distinct', () => {

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -97,7 +97,7 @@ describe('database helpers', () => {
     expect(getPrimaryKeyColumns(undefined)).toEqual(['id']);
   });
 
-  it('builds a record primary key tuple, coercing missing values to empty string', () => {
+  it('builds a record primary key tuple, preserving null for missing values', () => {
     expect(
       getRecordPrimaryKey({ tenant_id: 'tenant_a', item_id: 'item_2', label: 'x' }, [
         'tenant_id',
@@ -106,8 +106,13 @@ describe('database helpers', () => {
     ).toEqual({ tenant_id: 'tenant_a', item_id: 'item_2' });
 
     expect(getRecordPrimaryKey({ id: 5 }, ['id'])).toEqual({ id: 5 });
-    // PK columns are NOT NULL; a missing value is coerced to '' (non-null scalar).
-    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: '' });
+    // Missing/null values stay null (the record API matches them with `col IS NULL`),
+    // so a keyless table's null column still identifies its row instead of `col = ''`.
+    expect(getRecordPrimaryKey({}, ['id'])).toEqual({ id: null });
+    expect(getRecordPrimaryKey({ name: 'a', email: null }, ['name', 'email'])).toEqual({
+      name: 'a',
+      email: null,
+    });
   });
 
   it('encodes the full key tuple and decodes it back, so duplicate first columns stay distinct', () => {

--- a/packages/dashboard/src/features/database/__tests__/helpers.test.ts
+++ b/packages/dashboard/src/features/database/__tests__/helpers.test.ts
@@ -78,7 +78,9 @@ describe('database helpers', () => {
       ])
     ).toEqual(['tenant_id', 'item_id']);
 
-    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual(['id']);
+    expect(getPrimaryKeyColumns([column({ columnName: 'id', isPrimaryKey: true })])).toEqual([
+      'id',
+    ]);
 
     // No primary key metadata -> fall back to the conventional `id` column.
     expect(getPrimaryKeyColumns([column({ columnName: 'name' })])).toEqual(['id']);

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -237,7 +237,11 @@ export function convertSchemaToColumns(
       // Foreign key column - show reference popover, disable editing
       column.renderCell = (props: RenderCellProps<DatabaseDataGridRow>) => (
         <ForeignKeyCell
-          value={String(props.row[col.columnName] || '')}
+          value={
+            props.row[col.columnName] === null || props.row[col.columnName] === undefined
+              ? ''
+              : String(props.row[col.columnName])
+          }
           foreignKey={{
             table: foreignKey.referenceTable,
             columns: foreignKey.referenceColumns,

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -14,6 +14,7 @@ import {
 } from '#components/datagrid';
 import { ColumnSchema, ColumnType, TableSchema } from '@insforge/shared-schemas';
 import { ForeignKeyCell } from './ForeignKeyCell';
+import { encodeRecordKey, getPrimaryKeyColumns } from '#features/database/helpers';
 
 // Create a type adapter for database records
 // Database records are dynamic and must have string id for DataGrid compatibility
@@ -26,24 +27,24 @@ function DatabaseTextCellEditor({
   onRowChange,
   onClose,
   onCellEdit,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       const oldValue = row[column.key];
 
       if (onCellEdit && String(oldValue ?? '') !== String(newValue)) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [row, column.key, onCellEdit, onRowChange, onClose, primaryKeyColumn]
+    [row, column.key, onCellEdit, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -63,25 +64,25 @@ function DatabaseBooleanCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       const value: boolean | null = newValue === 'null' ? null : newValue === 'true';
 
       if (onCellEdit && row[column.key] !== value) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: value };
       onRowChange(updatedRow);
       onClose();
     },
-    [row, column.key, onRowChange, onClose, onCellEdit, primaryKeyColumn]
+    [row, column.key, onRowChange, onClose, onCellEdit, primaryKeyColumns]
   );
 
   return (
@@ -102,11 +103,11 @@ function DatabaseDateCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string | null) => {
@@ -114,14 +115,14 @@ function DatabaseDateCellEditor({
         onCellEdit &&
         new Date(row[column.key] as string).getTime() !== new Date(newValue ?? '').getTime()
       ) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue ?? '');
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue ?? '');
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [onCellEdit, row, column.key, onRowChange, onClose, primaryKeyColumn]
+    [onCellEdit, row, column.key, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -142,23 +143,23 @@ function DatabaseJsonCellEditor({
   onClose,
   onCellEdit,
   columnSchema,
-  primaryKeyColumn,
+  primaryKeyColumns,
 }: RenderEditCellProps<DatabaseDataGridRow> & {
   onCellEdit?: (rowId: string, columnKey: string, newValue: string) => Promise<void>;
   columnSchema: ColumnSchema;
-  primaryKeyColumn: string;
+  primaryKeyColumns: string[];
 }) {
   const handleValueChange = React.useCallback(
     (newValue: string) => {
       if (onCellEdit && row[column.key] !== newValue) {
-        void onCellEdit(String(row[primaryKeyColumn] || ''), column.key, newValue);
+        void onCellEdit(encodeRecordKey(row, primaryKeyColumns), column.key, newValue);
       }
 
       const updatedRow = { ...row, [column.key]: newValue };
       onRowChange(updatedRow);
       onClose();
     },
-    [column.key, onCellEdit, row, onRowChange, onClose, primaryKeyColumn]
+    [column.key, onCellEdit, row, onRowChange, onClose, primaryKeyColumns]
   );
 
   return (
@@ -183,7 +184,7 @@ export function convertSchemaToColumns(
     return [];
   }
 
-  const primaryKeyColumn = schema.columns.find((col) => col.isPrimaryKey)?.columnName || '';
+  const primaryKeyColumns = getPrimaryKeyColumns(schema.columns);
 
   // Create typed cell renderers
   const cellRenderers = createDefaultCellRenderer<DatabaseDataGridRow>();
@@ -238,7 +239,7 @@ export function convertSchemaToColumns(
           onJumpToTable={onJumpToTable}
         />
       );
-    } else if (col.columnName === primaryKeyColumn) {
+    } else if (col.isPrimaryKey) {
       column.renderCell = cellRenderers.id;
     } else if (col.type === ColumnType.BOOLEAN) {
       column.renderCell = cellRenderers.boolean;
@@ -247,7 +248,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.DATE) {
@@ -257,7 +258,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.DATETIME) {
@@ -267,7 +268,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else if (col.type === ColumnType.JSON) {
@@ -277,7 +278,7 @@ export function convertSchemaToColumns(
           {...props}
           columnSchema={col}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     } else {
@@ -286,7 +287,7 @@ export function convertSchemaToColumns(
         <DatabaseTextCellEditor
           {...props}
           onCellEdit={onCellEdit}
-          primaryKeyColumn={primaryKeyColumn}
+          primaryKeyColumns={primaryKeyColumns}
         />
       );
     }

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -14,7 +14,11 @@ import {
 } from '#components/datagrid';
 import { ColumnSchema, ColumnType, TableSchema } from '@insforge/shared-schemas';
 import { ForeignKeyCell } from './ForeignKeyCell';
-import { encodeRecordKey, getPrimaryKeyColumns } from '#features/database/helpers';
+import {
+  encodeRecordKey,
+  getForeignKeyByColumn,
+  getPrimaryKeyColumns,
+} from '#features/database/helpers';
 
 // Create a type adapter for database records
 // Database records are dynamic and must have string id for DataGrid compatibility
@@ -185,11 +189,13 @@ export function convertSchemaToColumns(
   }
 
   const primaryKeyColumns = getPrimaryKeyColumns(schema.columns);
+  const foreignKeyByColumn = getForeignKeyByColumn(schema.foreignKeys);
 
   // Create typed cell renderers
   const cellRenderers = createDefaultCellRenderer<DatabaseDataGridRow>();
 
   return schema.columns.map((col: ColumnSchema) => {
+    const foreignKey = foreignKeyByColumn.get(col.columnName);
     const savedColumnWidth = columnWidths?.[col.columnName];
     const width =
       typeof savedColumnWidth === 'number' &&
@@ -227,14 +233,14 @@ export function convertSchemaToColumns(
     };
 
     // Set custom renderers - check for foreign key first (highest priority)
-    if (col.foreignKey) {
+    if (foreignKey) {
       // Foreign key column - show reference popover, disable editing
       column.renderCell = (props: RenderCellProps<DatabaseDataGridRow>) => (
         <ForeignKeyCell
           value={String(props.row[col.columnName] || '')}
           foreignKey={{
-            table: col.foreignKey?.referenceTable || '',
-            columns: col.foreignKey?.referenceColumns || [],
+            table: foreignKey.referenceTable,
+            columns: foreignKey.referenceColumns,
           }}
           row={props.row}
           onJumpToTable={onJumpToTable}

--- a/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
+++ b/packages/dashboard/src/features/database/components/DatabaseDataGrid.tsx
@@ -233,8 +233,9 @@ export function convertSchemaToColumns(
           value={String(props.row[col.columnName] || '')}
           foreignKey={{
             table: col.foreignKey?.referenceTable || '',
-            column: col.foreignKey?.referenceColumn || '',
+            columns: col.foreignKey?.referenceColumns || [],
           }}
+          row={props.row}
           onJumpToTable={onJumpToTable}
         />
       );

--- a/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
@@ -9,6 +9,7 @@ import {
   PopoverTrigger,
   ConvertedValue,
   DataGrid,
+  type DatabaseRecord,
 } from '#components';
 import { useTables } from '#features/database/hooks/useTables';
 import { useRecords } from '#features/database/hooks/useRecords';
@@ -25,12 +26,13 @@ interface ForeignKeyCellProps {
   value: string;
   foreignKey: {
     table: string;
-    column: string;
+    columns: { sourceColumn: string; referenceColumn: string }[];
   };
+  row: DatabaseRecord;
   onJumpToTable?: (tableName: string, schemaName?: string) => void;
 }
 
-export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyCellProps) {
+export function ForeignKeyCell({ value, foreignKey, row, onJumpToTable }: ForeignKeyCellProps) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const isAuthUsers = foreignKey.table === AUTH_USERS_TABLE;
@@ -48,21 +50,33 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
     return formatValueForDisplay(val);
   };
 
-  // Fetch the referenced record when popover opens
-  const searchValue = value ? renderValue(value) : '';
+  // Guard: all FK column entries must have both sourceColumn and referenceColumn
+  const hasValidColumns = foreignKey.columns.every(
+    (c) => c.sourceColumn && c.referenceColumn
+  );
 
-  // For auth.users, fetch user by ID
+  // Collect all FK column values from the current row for multi-column lookup
+  const lookupColumns = hasValidColumns ? foreignKey.columns.map((c) => c.referenceColumn) : [];
+  const lookupValues = hasValidColumns
+    ? foreignKey.columns.map((c) => {
+        const raw = row[c.sourceColumn];
+        return raw !== null && raw !== undefined ? String(raw) : '';
+      })
+    : [];
+
+  // For auth.users, fetch user by ID (single-column lookup)
+  const searchValue = value ? renderValue(value) : '';
   const { data: authUserData, error: authUserError } = useQuery({
     queryKey: ['user', searchValue],
     queryFn: () => getUser(searchValue),
     enabled: isAuthUsers && open && !!value,
   });
 
-  // For regular tables, fetch by foreign key
+  // For regular tables, fetch by foreign key (supports composite)
   const { data: recordData, error: recordError } = recordsHook.useRecordByForeignKey(
-    foreignKey.column,
-    searchValue,
-    !isAuthUsers && open && !!value
+    lookupColumns,
+    lookupValues,
+    !isAuthUsers && open && hasValidColumns && lookupValues.every((v) => !!v)
   );
 
   // Use appropriate data source based on table type
@@ -143,7 +157,7 @@ export function ForeignKeyCell({ value, foreignKey, onJumpToTable }: ForeignKeyC
                   Referencing record from
                 </span>
                 <TypeBadge
-                  type={`${foreignKey.table}.${foreignKey.column}`}
+                  type={`${foreignKey.table}.${foreignKey.columns.map((c) => c.referenceColumn).join(',')}`}
                   className="dark:bg-neutral-800"
                 />
               </div>

--- a/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyCell.tsx
@@ -51,9 +51,7 @@ export function ForeignKeyCell({ value, foreignKey, row, onJumpToTable }: Foreig
   };
 
   // Guard: all FK column entries must have both sourceColumn and referenceColumn
-  const hasValidColumns = foreignKey.columns.every(
-    (c) => c.sourceColumn && c.referenceColumn
-  );
+  const hasValidColumns = foreignKey.columns.every((c) => c.sourceColumn && c.referenceColumn);
 
   // Collect all FK column values from the current row for multi-column lookup
   const lookupColumns = hasValidColumns ? foreignKey.columns.map((c) => c.referenceColumn) : [];

--- a/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
@@ -43,7 +43,7 @@ export function ForeignKeyPopover({
   const [newForeignKey, setNewForeignKey] = useState<TableFormForeignKeySchema>({
     columnName: '',
     referenceTable: '',
-    referenceColumn: '',
+    referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
     onDelete: 'NO ACTION',
     onUpdate: 'NO ACTION',
   });
@@ -57,7 +57,9 @@ export function ForeignKeyPopover({
       setNewForeignKey({
         columnName: initialValue.columnName,
         referenceTable: initialValue.referenceTable,
-        referenceColumn: initialValue.referenceColumn,
+        referenceColumns: initialValue.referenceColumns?.length
+          ? initialValue.referenceColumns
+          : [{ sourceColumn: initialValue.columnName, referenceColumn: '' }],
         onDelete: initialValue.onDelete,
         onUpdate: initialValue.onUpdate,
       });
@@ -66,7 +68,7 @@ export function ForeignKeyPopover({
       setNewForeignKey({
         columnName: '',
         referenceTable: '',
-        referenceColumn: '',
+        referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
         onDelete: 'NO ACTION',
         onUpdate: 'NO ACTION',
       });
@@ -110,16 +112,32 @@ export function ForeignKeyPopover({
 
   // Calculate if the button should be enabled
   const isAddButtonEnabled = Boolean(
-    newForeignKey.columnName && newForeignKey.referenceTable && newForeignKey.referenceColumn
+    newForeignKey.columnName &&
+      newForeignKey.referenceTable &&
+      newForeignKey.referenceColumns[0]?.referenceColumn
   );
 
   const handleAddForeignKey = () => {
-    if (newForeignKey.columnName && newForeignKey.referenceTable && newForeignKey.referenceColumn) {
-      onAddForeignKey(newForeignKey);
+    if (
+      newForeignKey.columnName &&
+      newForeignKey.referenceTable &&
+      newForeignKey.referenceColumns[0]?.referenceColumn
+    ) {
+      // Ensure sourceColumn matches the selected columnName for dashboard-created FKs
+      const fk = {
+        ...newForeignKey,
+        referenceColumns: [
+          {
+            sourceColumn: newForeignKey.columnName,
+            referenceColumn: newForeignKey.referenceColumns[0].referenceColumn,
+          },
+        ],
+      };
+      onAddForeignKey(fk);
       setNewForeignKey({
         columnName: '',
         referenceTable: '',
-        referenceColumn: '',
+        referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
         onDelete: 'NO ACTION',
         onUpdate: 'NO ACTION',
       });
@@ -131,7 +149,7 @@ export function ForeignKeyPopover({
     setNewForeignKey({
       columnName: '',
       referenceTable: '',
-      referenceColumn: '',
+      referenceColumns: [{ sourceColumn: '', referenceColumn: '' }],
       onDelete: 'NO ACTION',
       onUpdate: 'NO ACTION',
     });
@@ -199,7 +217,7 @@ export function ForeignKeyPopover({
                   setNewForeignKey((prev) => ({
                     ...prev,
                     referenceTable: value,
-                    referenceColumn: '', // Reset column when table changes
+                    referenceColumns: [{ sourceColumn: prev.columnName || '', referenceColumn: '' }],
                   }));
                 }}
               >
@@ -231,19 +249,22 @@ export function ForeignKeyPopover({
                 </Label>
                 <Select
                   key={`column-select-${newForeignKey.referenceTable}`}
-                  value={newForeignKey.referenceColumn}
+                  value={newForeignKey.referenceColumns[0]?.referenceColumn || ''}
                   onValueChange={(value) =>
-                    setNewForeignKey((prev) => ({ ...prev, referenceColumn: value }))
+                    setNewForeignKey((prev) => ({
+                      ...prev,
+                      referenceColumns: [{ ...prev.referenceColumns[0], referenceColumn: value }],
+                    }))
                   }
                 >
                   <SelectTrigger className="w-70 h-10">
                     <span
                       className={cn(
                         'text-sm text-muted-foreground dark:text-neutral-400',
-                        newForeignKey.referenceColumn && 'text-black dark:text-white'
+                        newForeignKey.referenceColumns[0]?.referenceColumn && 'text-black dark:text-white'
                       )}
                     >
-                      {newForeignKey.referenceColumn || 'Select column'}
+                      {newForeignKey.referenceColumns[0]?.referenceColumn || 'Select column'}
                     </span>
                   </SelectTrigger>
                   <SelectContent className="max-w-[360px]">

--- a/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
+++ b/packages/dashboard/src/features/database/components/ForeignKeyPopover.tsx
@@ -113,8 +113,8 @@ export function ForeignKeyPopover({
   // Calculate if the button should be enabled
   const isAddButtonEnabled = Boolean(
     newForeignKey.columnName &&
-      newForeignKey.referenceTable &&
-      newForeignKey.referenceColumns[0]?.referenceColumn
+    newForeignKey.referenceTable &&
+    newForeignKey.referenceColumns[0]?.referenceColumn
   );
 
   const handleAddForeignKey = () => {
@@ -217,7 +217,9 @@ export function ForeignKeyPopover({
                   setNewForeignKey((prev) => ({
                     ...prev,
                     referenceTable: value,
-                    referenceColumns: [{ sourceColumn: prev.columnName || '', referenceColumn: '' }],
+                    referenceColumns: [
+                      { sourceColumn: prev.columnName || '', referenceColumn: '' },
+                    ],
                   }));
                 }}
               >
@@ -261,7 +263,8 @@ export function ForeignKeyPopover({
                     <span
                       className={cn(
                         'text-sm text-muted-foreground dark:text-neutral-400',
-                        newForeignKey.referenceColumns[0]?.referenceColumn && 'text-black dark:text-white'
+                        newForeignKey.referenceColumns[0]?.referenceColumn &&
+                          'text-black dark:text-white'
                       )}
                     >
                       {newForeignKey.referenceColumns[0]?.referenceColumn || 'Select column'}

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -259,6 +259,7 @@ export function LinkRecordDialog({
               data={records}
               columns={columns}
               loading={isLoading && !records.length}
+              rowKeyGetter={getRowKey}
               selectedRows={selectedRows}
               onSelectedRowsChange={(newSelectedRows) => {
                 const selectedId = Array.from(newSelectedRows)[0];

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -33,16 +33,19 @@ import { parseDatabaseTableReference } from '#features/database/helpers';
 
 const PAGE_SIZE = 50;
 
+// Non-printable delimiter that cannot appear in PG text values
+const ROW_KEY_DELIMITER = '\x00';
+
 interface LinkRecordDialogProps {
   referenceTable: string;
-  referenceColumn: string;
+  fkColumns: { sourceColumn: string; referenceColumn: string }[];
   onSelectRecord: (record: DatabaseRecord) => void;
   children: (openDialog: () => void) => ReactNode;
 }
 
 export function LinkRecordDialog({
   referenceTable,
-  referenceColumn,
+  fkColumns,
   onSelectRecord,
   children,
 }: LinkRecordDialogProps) {
@@ -91,6 +94,24 @@ export function LinkRecordDialog({
     !isAuthUsers && open
   );
 
+  // Determine PK columns for stable row key derivation
+  const pkColumns = useMemo(() => {
+    if (!schema?.columns) {
+      return [] as string[];
+    }
+    const explicitPks = schema.columns.filter((c: any) => c.isPrimaryKey).map((c: any) => c.columnName);
+    return explicitPks.length > 0 ? explicitPks : ['id'];
+  }, [schema]);
+
+  // Build a stable encoded key from a record's PK column values.
+  // Uses \x00 as delimiter since PG text cannot contain null bytes.
+  const getRowKey = useCallback(
+    (record: any): string => {
+      return pkColumns.map((col) => String(record[col] ?? '')).join(ROW_KEY_DELIMITER);
+    },
+    [pkColumns]
+  );
+
   // Combine data from either source
   const recordsData = useMemo(() => {
     if (isAuthUsers) {
@@ -127,37 +148,25 @@ export function LinkRecordDialog({
   const totalRecords = recordsData?.totalRecords || 0;
   const totalPages = Math.ceil(totalRecords / PAGE_SIZE);
 
-  // Create selected rows set for highlighting
+  // Create selected rows set using stable PK-derived keys
   const selectedRows = useMemo(() => {
     if (!selectedRecord) {
       return new Set<string>();
     }
-    return new Set([String(selectedRecord.id || '')]);
-  }, [selectedRecord]);
+    return new Set([getRowKey(selectedRecord)]);
+  }, [selectedRecord, getRowKey]);
 
-  // Handle cell click to select record - only for reference column
+  // Handle cell click to select record
   const handleCellClick = useCallback(
     (args: CellClickArgs<DataGridRowType>, event: CellMouseEvent) => {
-      // Only allow selection when clicking on the reference column
-      if (args.column.key !== referenceColumn) {
-        // Prevent the default selection behavior for non-reference columns
-        event?.preventDefault();
-        event?.stopPropagation();
-        return;
-      }
-
-      const record = records.find((r: DatabaseRecord) => String(r.id) === String(args.row.id));
-      if (record) {
-        setSelectedRecord(record);
-      }
+      setSelectedRecord(args.row as DatabaseRecord);
     },
-    [records, referenceColumn]
+    []
   );
 
   // Convert schema to columns for the DataGrid with visual distinction
   const columns = useMemo(() => {
     const cols = convertSchemaToColumns(schema);
-    // Add visual indication for the reference column (clickable column)
     return cols.map((col) => {
       const baseCol = {
         ...col,
@@ -168,52 +177,23 @@ export function LinkRecordDialog({
       };
 
       // Helper function to render cell value properly based on type
-      // Accepts DatabaseRecord value type and converts to display string
       const renderCellValue = (
         value: ConvertedValue | { [key: string]: string }[],
         type: ColumnType | undefined
       ): string => {
-        // For JSON type, if value is already an object/array, stringify it for formatValueForDisplay
         if (type === ColumnType.JSON && value !== null && typeof value === 'object') {
           return formatValueForDisplay(JSON.stringify(value), type);
         }
         return formatValueForDisplay(value as ConvertedValue, type);
       };
 
-      if (col.key === referenceColumn) {
-        return {
-          ...baseCol,
-          renderCell: (props: RenderCellProps<DataGridRowType>) => {
-            const displayValue = renderCellValue(props.row[col.key], col.type);
-            return (
-              <div className="w-full h-full flex items-center cursor-pointer">
-                <span className="truncate font-medium" title={displayValue}>
-                  {displayValue}
-                </span>
-              </div>
-            );
-          },
-          renderHeaderCell: (props: RenderHeaderCellProps<DataGridRowType>) => (
-            <SortableHeaderRenderer
-              column={col}
-              sortDirection={props.sortDirection}
-              columnType={col.type}
-              showTypeBadge={true}
-              mutedHeader={false}
-            />
-          ),
-        };
-      }
-
       return {
         ...baseCol,
-        cellClass: 'link-record-dialog-disabled-cell',
         renderCell: (props: RenderCellProps<DataGridRowType>) => {
           const displayValue = renderCellValue(props.row[col.key], col.type);
           return (
-            <div className="w-full h-full flex items-center cursor-not-allowed relative">
-              <div className="absolute inset-0 pointer-events-none opacity-0 hover:opacity-10 bg-gray-200 dark:bg-gray-600 transition-opacity z-5" />
-              <span className="truncate dark:text-zinc-300 opacity-70" title={displayValue}>
+            <div className="w-full h-full flex items-center cursor-pointer">
+              <span className="truncate font-medium" title={displayValue}>
                 {displayValue}
               </span>
             </div>
@@ -225,12 +205,12 @@ export function LinkRecordDialog({
             sortDirection={props.sortDirection}
             columnType={col.type}
             showTypeBadge={true}
-            mutedHeader={true}
+            mutedHeader={false}
           />
         ),
       };
     });
-  }, [schema, referenceColumn]);
+  }, [schema]);
 
   const handleConfirmSelection = () => {
     if (selectedRecord) {
@@ -258,7 +238,7 @@ export function LinkRecordDialog({
                 Select a record to reference from
               </span>
               <TypeBadge
-                type={`${referenceTable}.${referenceColumn}`}
+                type={`${referenceTable}.${fkColumns.map((c) => c.referenceColumn).join(',')}`}
                 className="dark:bg-neutral-700"
               />
             </div>
@@ -283,10 +263,9 @@ export function LinkRecordDialog({
               loading={isLoading && !records.length}
               selectedRows={selectedRows}
               onSelectedRowsChange={(newSelectedRows) => {
-                // Handle selection changes from cell clicks
                 const selectedId = Array.from(newSelectedRows)[0];
                 if (selectedId) {
-                  const record = records.find((r: DatabaseRecord) => String(r.id) === selectedId);
+                  const record = records.find((r: any) => getRowKey(r) === selectedId);
                   if (record) {
                     setSelectedRecord(record);
                   }

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -28,7 +28,7 @@ import { convertSchemaToColumns } from './DatabaseDataGrid';
 import { formatValueForDisplay } from '#lib/utils/utils';
 import { ColumnType } from '@insforge/shared-schemas';
 import { AUTH_USERS_TABLE, authUsersSchema } from '#features/database/constants';
-import { parseDatabaseTableReference } from '#features/database/helpers';
+import { getPrimaryKeyColumns, parseDatabaseTableReference } from '#features/database/helpers';
 
 const PAGE_SIZE = 50;
 
@@ -93,21 +93,17 @@ export function LinkRecordDialog({
     !isAuthUsers && open
   );
 
-  // Determine PK columns for stable row key derivation
-  const pkColumns = useMemo(() => {
-    if (!schema?.columns) {
-      return [] as string[];
-    }
-    const explicitPks = schema.columns
-      .filter((c: any) => c.isPrimaryKey)
-      .map((c: any) => c.columnName);
-    return explicitPks.length > 0 ? explicitPks : ['id'];
-  }, [schema]);
+  // Determine PK columns for stable row key derivation. auth.users is keyed by id;
+  // DB tables reuse the shared PK helper (full composite key, falling back to id).
+  const pkColumns = useMemo(
+    () => (isAuthUsers ? ['id'] : getPrimaryKeyColumns(fetchedSchema?.columns)),
+    [isAuthUsers, fetchedSchema]
+  );
 
   // Build a stable encoded key from a record's PK column values.
   // Uses \x00 as delimiter since PG text cannot contain null bytes.
   const getRowKey = useCallback(
-    (record: any): string => {
+    (record: DatabaseRecord): string => {
       return pkColumns.map((col) => String(record[col] ?? '')).join(ROW_KEY_DELIMITER);
     },
     [pkColumns]
@@ -264,7 +260,7 @@ export function LinkRecordDialog({
               onSelectedRowsChange={(newSelectedRows) => {
                 const selectedId = Array.from(newSelectedRows)[0];
                 if (selectedId) {
-                  const record = records.find((r: any) => getRowKey(r) === selectedId);
+                  const record = records.find((r) => getRowKey(r) === selectedId);
                   if (record) {
                     setSelectedRecord(record);
                   }

--- a/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
+++ b/packages/dashboard/src/features/database/components/LinkRecordDialog.tsx
@@ -12,7 +12,6 @@ import {
   DataGrid,
   DataGridEmptyState,
   TypeBadge,
-  type CellMouseEvent,
   type CellClickArgs,
   type RenderCellProps,
   type RenderHeaderCellProps,
@@ -99,7 +98,9 @@ export function LinkRecordDialog({
     if (!schema?.columns) {
       return [] as string[];
     }
-    const explicitPks = schema.columns.filter((c: any) => c.isPrimaryKey).map((c: any) => c.columnName);
+    const explicitPks = schema.columns
+      .filter((c: any) => c.isPrimaryKey)
+      .map((c: any) => c.columnName);
     return explicitPks.length > 0 ? explicitPks : ['id'];
   }, [schema]);
 
@@ -157,12 +158,9 @@ export function LinkRecordDialog({
   }, [selectedRecord, getRowKey]);
 
   // Handle cell click to select record
-  const handleCellClick = useCallback(
-    (args: CellClickArgs<DataGridRowType>, event: CellMouseEvent) => {
-      setSelectedRecord(args.row as DatabaseRecord);
-    },
-    []
-  );
+  const handleCellClick = useCallback((args: CellClickArgs<DataGridRowType>) => {
+    setSelectedRecord(args.row as DatabaseRecord);
+  }, []);
 
   // Convert schema to columns for the DataGrid with visual distinction
   const columns = useMemo(() => {

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -17,14 +17,15 @@ import { ScrollArea } from '#components';
 import { useRecords } from '#features/database/hooks/useRecords';
 import { buildDynamicSchema, getInitialValues } from '#features/database';
 import { RecordFormField } from './RecordFormField';
-import { ColumnSchema } from '@insforge/shared-schemas';
-import { SYSTEM_FIELDS } from '#features/database/helpers';
+import { ColumnSchema, type ForeignKeySchema } from '@insforge/shared-schemas';
+import { getForeignKeyByColumn, SYSTEM_FIELDS } from '#features/database/helpers';
 
 interface RecordFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tableName: string;
   schema: ColumnSchema[];
+  foreignKeys?: ForeignKeySchema[];
   onSuccess?: () => void;
 }
 
@@ -33,6 +34,7 @@ export function RecordFormDialog({
   onOpenChange,
   tableName,
   schema,
+  foreignKeys,
   onSuccess,
 }: RecordFormDialogProps) {
   const [error, setError] = useState<string | null>(null);
@@ -42,6 +44,8 @@ export function RecordFormDialog({
     const filteredFields = schema.filter((field) => !SYSTEM_FIELDS.includes(field.columnName));
     return filteredFields;
   }, [schema]);
+
+  const foreignKeyByColumn = useMemo(() => getForeignKeyByColumn(foreignKeys), [foreignKeys]);
 
   const dynamicSchema = useMemo(() => {
     const schema = buildDynamicSchema(displayFields);
@@ -128,6 +132,7 @@ export function RecordFormDialog({
                     columns={displayFields}
                     form={form}
                     tableName={tableName}
+                    foreignKey={foreignKeyByColumn.get(field.columnName)}
                   />
                 </div>
               ))}

--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -123,7 +123,12 @@ export function RecordFormDialog({
                       <div className="h-px w-full bg-[var(--alpha-8)]" />
                     </div>
                   )}
-                  <RecordFormField field={field} form={form} tableName={tableName} />
+                  <RecordFormField
+                    field={field}
+                    columns={displayFields}
+                    form={form}
+                    tableName={tableName}
+                  />
                 </div>
               ))}
             </div>

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -293,10 +293,12 @@ function FieldWithLink({
                 variant="secondary"
                 size="icon"
                 onClick={() => {
-                  formField.onChange('');
+                  // Clear every key component to null (not ''), so nullable non-string
+                  // columns (integer/boolean/uuid) clear to NULL instead of failing validation.
+                  formField.onChange(null);
                   for (const refCol of foreignKey.referenceColumns) {
                     if (refCol.sourceColumn !== field.columnName) {
-                      setValue(refCol.sourceColumn, '');
+                      setValue(refCol.sourceColumn, null);
                     }
                   }
                 }}
@@ -312,10 +314,17 @@ function FieldWithLink({
               onSelectRecord={(record: DatabaseRecord) => {
                 for (const refCol of foreignKey.referenceColumns) {
                   const refValue = record[refCol.referenceColumn];
-                  const rawValue = String(refValue ?? '');
-                  const sourceType = columnTypeMap[refCol.sourceColumn] || field.type;
-                  const converted = convertValueForColumn(sourceType, rawValue);
-                  const val = converted.success ? converted.value : rawValue;
+                  // Preserve a null referenced value as null (don't coerce to ''),
+                  // so a nullable key component stores NULL instead of failing validation.
+                  let val: ConvertedValue | null;
+                  if (refValue === null || refValue === undefined) {
+                    val = null;
+                  } else {
+                    const rawValue = String(refValue);
+                    const sourceType = columnTypeMap[refCol.sourceColumn] || field.type;
+                    const converted = convertValueForColumn(sourceType, rawValue);
+                    val = converted.success ? converted.value : rawValue;
+                  }
                   if (refCol.sourceColumn === field.columnName) {
                     formField.onChange(val);
                   } else {

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -472,7 +472,8 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
             <span className="truncate">Has a Foreign Key relation to</span>
             <FormMetaBadge>
-              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
+              {field.foreignKey.referenceTable}.
+              {field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
             </FormMetaBadge>
           </div>
         )}

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { Control, Controller, FieldError, UseFormReturn } from 'react-hook-form';
+import { Control, Controller, FieldError, UseFormReturn, UseFormSetValue } from 'react-hook-form';
 import { Calendar, Clock, Link2, X } from 'lucide-react';
 import { Button, Input, cn } from '@insforge/ui';
 import {
@@ -244,10 +244,11 @@ function FieldLabel({ field, tableName }: { field: ColumnSchema; tableName: stri
 interface FieldWithLinkProps {
   field: ColumnSchema;
   control: Control<DatabaseRecord>;
+  setValue: UseFormSetValue<DatabaseRecord>;
   children: ReactNode;
 }
 
-function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
+function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProps) {
   if (!field.foreignKey) {
     return <>{children}</>;
   }
@@ -272,7 +273,14 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
                 type="button"
                 variant="secondary"
                 size="icon"
-                onClick={() => formField.onChange('')}
+                onClick={() => {
+                  formField.onChange('');
+                  for (const refCol of foreignKey.referenceColumns) {
+                    if (refCol.sourceColumn !== field.columnName) {
+                      setValue(refCol.sourceColumn, '');
+                    }
+                  }
+                }}
                 className="h-8 w-8 shrink-0 rounded border border-[var(--alpha-8)] bg-card p-0"
                 title="Clear linked record"
               >
@@ -281,14 +289,17 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
             )}
             <LinkRecordDialog
               referenceTable={foreignKey.referenceTable}
-              referenceColumn={foreignKey.referenceColumn}
+              fkColumns={foreignKey.referenceColumns}
               onSelectRecord={(record: DatabaseRecord) => {
-                const referenceValue = record[foreignKey.referenceColumn];
-                const result = convertValueForColumn(field.type, String(referenceValue || ''));
-                if (result.success) {
-                  formField.onChange(result.value);
-                } else {
-                  formField.onChange(String(referenceValue || ''));
+                for (const refCol of foreignKey.referenceColumns) {
+                  const refValue = record[refCol.referenceColumn];
+                  const converted = convertValueForColumn(field.type, String(refValue || ''));
+                  const val = converted.success ? converted.value : String(refValue || '');
+                  if (refCol.sourceColumn === field.columnName) {
+                    formField.onChange(val);
+                  } else {
+                    setValue(refCol.sourceColumn, val);
+                  }
                 }
               }}
             >
@@ -319,6 +330,7 @@ function FieldWithLink({ field, control, children }: FieldWithLinkProps) {
 export function RecordFormField({ field, form, tableName }: RecordFormFieldProps) {
   const {
     control,
+    setValue,
     formState: { errors },
   } = form;
 
@@ -452,7 +464,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
       <FieldLabel field={field} tableName={tableName} />
 
       <div className="min-w-0 space-y-1">
-        <FieldWithLink field={field} control={control}>
+        <FieldWithLink field={field} control={control} setValue={setValue}>
           {renderInput()}
         </FieldWithLink>
 
@@ -460,7 +472,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
             <span className="truncate">Has a Foreign Key relation to</span>
             <FormMetaBadge>
-              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumn}
+              {field.foreignKey.referenceTable}.{field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
             </FormMetaBadge>
           </div>
         )}

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { Control, Controller, FieldError, UseFormReturn, UseFormSetValue } from 'react-hook-form';
 import { Calendar, Clock, Link2, X } from 'lucide-react';
 import { Button, Input, cn } from '@insforge/ui';
@@ -222,6 +222,7 @@ function FormJsonEditor({ value, nullable, onChange }: FormJsonEditorProps) {
 
 interface RecordFormFieldProps {
   field: ColumnSchema;
+  columns: ColumnSchema[];
   form: UseFormReturn<DatabaseRecord>;
   tableName: string;
 }
@@ -243,12 +244,22 @@ function FieldLabel({ field, tableName }: { field: ColumnSchema; tableName: stri
 
 interface FieldWithLinkProps {
   field: ColumnSchema;
+  columns: ColumnSchema[];
   control: Control<DatabaseRecord>;
   setValue: UseFormSetValue<DatabaseRecord>;
   children: ReactNode;
 }
 
-function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProps) {
+function FieldWithLink({ field, columns, control, setValue, children }: FieldWithLinkProps) {
+  // Build type lookup for all columns (needed for sibling FK column coercion)
+  const columnTypeMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const col of columns) {
+      map[col.columnName] = col.type;
+    }
+    return map;
+  }, [columns]);
+
   if (!field.foreignKey) {
     return <>{children}</>;
   }
@@ -293,8 +304,10 @@ function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProp
               onSelectRecord={(record: DatabaseRecord) => {
                 for (const refCol of foreignKey.referenceColumns) {
                   const refValue = record[refCol.referenceColumn];
-                  const converted = convertValueForColumn(field.type, String(refValue || ''));
-                  const val = converted.success ? converted.value : String(refValue || '');
+                  const rawValue = String(refValue ?? '');
+                  const sourceType = columnTypeMap[refCol.sourceColumn] || field.type;
+                  const converted = convertValueForColumn(sourceType, rawValue);
+                  const val = converted.success ? converted.value : rawValue;
                   if (refCol.sourceColumn === field.columnName) {
                     formField.onChange(val);
                   } else {
@@ -327,7 +340,7 @@ function FieldWithLink({ field, control, setValue, children }: FieldWithLinkProp
   );
 }
 
-export function RecordFormField({ field, form, tableName }: RecordFormFieldProps) {
+export function RecordFormField({ field, columns, form, tableName }: RecordFormFieldProps) {
   const {
     control,
     setValue,
@@ -464,7 +477,7 @@ export function RecordFormField({ field, form, tableName }: RecordFormFieldProps
       <FieldLabel field={field} tableName={tableName} />
 
       <div className="min-w-0 space-y-1">
-        <FieldWithLink field={field} control={control} setValue={setValue}>
+        <FieldWithLink field={field} columns={columns} control={control} setValue={setValue}>
           {renderInput()}
         </FieldWithLink>
 

--- a/packages/dashboard/src/features/database/components/RecordFormField.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormField.tsx
@@ -9,7 +9,7 @@ import {
   type DatabaseRecord,
   type ConvertedValue,
 } from '#components';
-import { ColumnSchema, ColumnType } from '@insforge/shared-schemas';
+import { ColumnSchema, ColumnType, type ForeignKeySchema } from '@insforge/shared-schemas';
 import { convertValueForColumn, formatValueForDisplay } from '#lib/utils/utils';
 import { LinkRecordDialog } from './LinkRecordDialog';
 import { isValid, parseISO } from 'date-fns';
@@ -225,6 +225,8 @@ interface RecordFormFieldProps {
   columns: ColumnSchema[];
   form: UseFormReturn<DatabaseRecord>;
   tableName: string;
+  // Foreign key whose source column is this field, if any (table-level FK).
+  foreignKey?: ForeignKeySchema;
 }
 
 function FieldLabel({ field, tableName }: { field: ColumnSchema; tableName: string }) {
@@ -247,10 +249,18 @@ interface FieldWithLinkProps {
   columns: ColumnSchema[];
   control: Control<DatabaseRecord>;
   setValue: UseFormSetValue<DatabaseRecord>;
+  foreignKey?: ForeignKeySchema;
   children: ReactNode;
 }
 
-function FieldWithLink({ field, columns, control, setValue, children }: FieldWithLinkProps) {
+function FieldWithLink({
+  field,
+  columns,
+  control,
+  setValue,
+  foreignKey,
+  children,
+}: FieldWithLinkProps) {
   // Build type lookup for all columns (needed for sibling FK column coercion)
   const columnTypeMap = useMemo(() => {
     const map: Record<string, string> = {};
@@ -260,11 +270,9 @@ function FieldWithLink({ field, columns, control, setValue, children }: FieldWit
     return map;
   }, [columns]);
 
-  if (!field.foreignKey) {
+  if (!foreignKey) {
     return <>{children}</>;
   }
-
-  const foreignKey = field.foreignKey;
 
   return (
     <Controller
@@ -340,7 +348,13 @@ function FieldWithLink({ field, columns, control, setValue, children }: FieldWit
   );
 }
 
-export function RecordFormField({ field, columns, form, tableName }: RecordFormFieldProps) {
+export function RecordFormField({
+  field,
+  columns,
+  form,
+  tableName,
+  foreignKey,
+}: RecordFormFieldProps) {
   const {
     control,
     setValue,
@@ -477,16 +491,22 @@ export function RecordFormField({ field, columns, form, tableName }: RecordFormF
       <FieldLabel field={field} tableName={tableName} />
 
       <div className="min-w-0 space-y-1">
-        <FieldWithLink field={field} columns={columns} control={control} setValue={setValue}>
+        <FieldWithLink
+          field={field}
+          columns={columns}
+          control={control}
+          setValue={setValue}
+          foreignKey={foreignKey}
+        >
           {renderInput()}
         </FieldWithLink>
 
-        {field.foreignKey && (
+        {foreignKey && (
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
             <span className="truncate">Has a Foreign Key relation to</span>
             <FormMetaBadge>
-              {field.foreignKey.referenceTable}.
-              {field.foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
+              {foreignKey.referenceTable}.
+              {foreignKey.referenceColumns.map((c) => c.referenceColumn).join(',')}
             </FormMetaBadge>
           </div>
         )}

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -120,25 +120,22 @@ export function TableForm({
         })),
       });
 
-      // Set foreign keys from editTable
-      const existingForeignKeys = editTable.columns
-        .filter((col) => !SYSTEM_FIELDS.includes(col.columnName) && col.foreignKey)
-        .map((col) => {
-          const referenceTableValue = col.foreignKey?.referenceTable ?? '';
-          const { schemaName: referenceSchemaName, tableName: referenceTableName } =
-            parseDatabaseTableReference(referenceTableValue, schemaName);
+      // Set foreign keys from editTable (one entry per table-level constraint)
+      const existingForeignKeys = (editTable.foreignKeys ?? []).map((fk) => {
+        const { schemaName: referenceSchemaName, tableName: referenceTableName } =
+          parseDatabaseTableReference(fk.referenceTable, schemaName);
 
-          return {
-            columnName: col.columnName,
-            referenceTable:
-              referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumns: col.foreignKey?.referenceColumns ?? [
-              { sourceColumn: col.columnName, referenceColumn: '' },
-            ],
-            onDelete: col.foreignKey?.onDelete || 'NO ACTION',
-            onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
-          };
-        });
+        return {
+          constraintName: fk.constraintName,
+          // Primary source column, used only to associate the FK with a column row in the UI.
+          columnName: fk.referenceColumns[0]?.sourceColumn ?? '',
+          referenceTable:
+            referenceSchemaName === schemaName ? referenceTableName : fk.referenceTable,
+          referenceColumns: fk.referenceColumns,
+          onDelete: fk.onDelete || 'NO ACTION',
+          onUpdate: fk.onUpdate || 'NO ACTION',
+        };
+      });
       setForeignKeys(existingForeignKeys);
     } else {
       form.reset({
@@ -210,29 +207,23 @@ export function TableForm({
 
   const createTableMutation = useMutation({
     mutationFn: (data: TableFormSchema) => {
-      const columns = data.columns.map((col) => {
-        // Find foreign key for this field if it exists
-        const foreignKey = foreignKeys.find((fk) => fk.columnName === col.columnName);
+      const columns = data.columns.map((col) => ({
+        columnName: col.columnName,
+        type: col.type,
+        isNullable: col.isNullable,
+        isUnique: col.isUnique,
+        defaultValue: col.defaultValue,
+      }));
 
-        return {
-          columnName: col.columnName,
-          type: col.type,
-          isNullable: col.isNullable,
-          isUnique: col.isUnique,
-          defaultValue: col.defaultValue,
-          // Embed foreign key information directly in the column
-          ...(foreignKey && {
-            foreignKey: {
-              referenceTable: foreignKey.referenceTable,
-              referenceColumns: foreignKey.referenceColumns,
-              onDelete: foreignKey.onDelete,
-              onUpdate: foreignKey.onUpdate,
-            },
-          }),
-        };
-      });
+      // Foreign keys are table-level: one entity per constraint.
+      const tableForeignKeys = foreignKeys.map((fk) => ({
+        referenceTable: fk.referenceTable,
+        referenceColumns: fk.referenceColumns,
+        onDelete: fk.onDelete,
+        onUpdate: fk.onUpdate,
+      }));
 
-      return tableService.createTable(schemaName, data.tableName, columns);
+      return tableService.createTable(schemaName, data.tableName, columns, tableForeignKeys);
     },
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ['database-metadata'] });
@@ -316,50 +307,28 @@ export function TableForm({
         }
       });
 
-      // Handle foreign keys
-      // Get existing foreign keys from editTable
-      const existingForeignKeys = existingUserColumns
-        .filter((col) => col.foreignKey)
-        .map((col) => {
-          const referenceTableValue = col.foreignKey?.referenceTable ?? '';
-          const { schemaName: referenceSchemaName, tableName: referenceTableName } =
-            parseDatabaseTableReference(referenceTableValue, schemaName);
+      // Handle foreign keys, identified by constraint name (table-level entities).
+      const existingForeignKeys = editTable.foreignKeys ?? [];
+      const formConstraintNames = new Set(
+        foreignKeys.map((fk) => fk.constraintName).filter(Boolean)
+      );
 
-          return {
-            columnName: col.columnName,
-            referenceTable:
-              referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumns: col.foreignKey?.referenceColumns ?? [
-              { sourceColumn: col.columnName, referenceColumn: '' },
-            ],
-            onDelete: col.foreignKey?.onDelete || 'NO ACTION',
-            onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
-          };
-        });
-
-      // Compare with new foreign keys
+      // Newly added FKs have no constraint name yet → add them.
       foreignKeys.forEach((fk) => {
-        const existingFK = existingForeignKeys.find((efk) => efk.columnName === fk.columnName);
-
-        if (!existingFK) {
+        if (!fk.constraintName) {
           addForeignKeys.push({
-            columnName: fk.columnName,
-            foreignKey: {
-              referenceTable: fk.referenceTable,
-              referenceColumns: fk.referenceColumns,
-              onDelete: fk.onDelete,
-              onUpdate: fk.onUpdate,
-            },
+            referenceTable: fk.referenceTable,
+            referenceColumns: fk.referenceColumns,
+            onDelete: fk.onDelete,
+            onUpdate: fk.onUpdate,
           });
         }
       });
 
-      // Check for dropped foreign keys
+      // Existing constraints no longer present in the form → drop them by name.
       existingForeignKeys.forEach((efk) => {
-        const stillExists = foreignKeys.find((fk) => fk.columnName === efk.columnName);
-        if (!stillExists) {
-          // This foreign key was removed
-          dropForeignKeys.push(efk.columnName);
+        if (efk.constraintName && !formConstraintNames.has(efk.constraintName)) {
+          dropForeignKeys.push(efk.constraintName);
         }
       });
 
@@ -458,24 +427,12 @@ export function TableForm({
   };
 
   const handleRemoveForeignKey = (columnName?: string) => {
-    const removed = foreignKeys.find((fk) => fk.columnName === columnName);
-    if (!removed) {
+    // Each entry is one constraint, so removing by its (primary) source column
+    // drops the whole constraint — including composite keys.
+    if (!foreignKeys.some((fk) => fk.columnName === columnName)) {
       return;
     }
-
-    // Removing any one column must remove all sibling columns atomically.
-    const constraintKey = removed.referenceColumns
-      .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
-      .join('\x01');
-
-    setForeignKeys(
-      foreignKeys.filter((fk) => {
-        const key = fk.referenceColumns
-          .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
-          .join('\x01');
-        return key !== constraintKey;
-      })
-    );
+    setForeignKeys(foreignKeys.filter((fk) => fk.columnName !== columnName));
     setForeignKeysDirty(true);
   };
 
@@ -584,12 +541,13 @@ export function TableForm({
                     >
                       <div className="flex items-center gap-2 overflow-hidden px-2.5 text-[13px] leading-[18px]">
                         <Link className="size-5 shrink-0 text-muted-foreground" />
-                        <span className="truncate">{fk.columnName}</span>
+                        <span className="truncate">
+                          {fk.referenceColumns.map((c) => c.sourceColumn).join(', ')}
+                        </span>
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
                           {fk.referenceTable}.
-                          {fk.referenceColumns.find((c) => c.sourceColumn === fk.columnName)
-                            ?.referenceColumn ?? ''}
+                          {fk.referenceColumns.map((c) => c.referenceColumn).join(', ')}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -588,7 +588,8 @@ export function TableForm({
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
                           {fk.referenceTable}.
-                          {fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
+                          {fk.referenceColumns.find((c) => c.sourceColumn === fk.columnName)
+                            ?.referenceColumn ?? ''}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -458,7 +458,24 @@ export function TableForm({
   };
 
   const handleRemoveForeignKey = (columnName?: string) => {
-    setForeignKeys(foreignKeys.filter((fk) => fk.columnName !== columnName));
+    const removed = foreignKeys.find((fk) => fk.columnName === columnName);
+    if (!removed) {
+      return;
+    }
+
+    // Removing any one column must remove all sibling columns atomically.
+    const constraintKey = removed.referenceColumns
+      .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
+      .join('\x01');
+
+    setForeignKeys(
+      foreignKeys.filter((fk) => {
+        const key = fk.referenceColumns
+          .map((rc) => `${rc.sourceColumn}\x00${rc.referenceColumn}`)
+          .join('\x01');
+        return key !== constraintKey;
+      })
+    );
     setForeignKeysDirty(true);
   };
 

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -132,7 +132,9 @@ export function TableForm({
             columnName: col.columnName,
             referenceTable:
               referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumn: col.foreignKey?.referenceColumn ?? '',
+            referenceColumns: col.foreignKey?.referenceColumns ?? [
+              { sourceColumn: col.columnName, referenceColumn: '' },
+            ],
             onDelete: col.foreignKey?.onDelete || 'NO ACTION',
             onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
           };
@@ -222,7 +224,7 @@ export function TableForm({
           ...(foreignKey && {
             foreignKey: {
               referenceTable: foreignKey.referenceTable,
-              referenceColumn: foreignKey.referenceColumn,
+              referenceColumns: foreignKey.referenceColumns,
               onDelete: foreignKey.onDelete,
               onUpdate: foreignKey.onUpdate,
             },
@@ -327,7 +329,9 @@ export function TableForm({
             columnName: col.columnName,
             referenceTable:
               referenceSchemaName === schemaName ? referenceTableName : referenceTableValue,
-            referenceColumn: col.foreignKey?.referenceColumn ?? '',
+            referenceColumns: col.foreignKey?.referenceColumns ?? [
+              { sourceColumn: col.columnName, referenceColumn: '' },
+            ],
             onDelete: col.foreignKey?.onDelete || 'NO ACTION',
             onUpdate: col.foreignKey?.onUpdate || 'NO ACTION',
           };
@@ -342,7 +346,7 @@ export function TableForm({
             columnName: fk.columnName,
             foreignKey: {
               referenceTable: fk.referenceTable,
-              referenceColumn: fk.referenceColumn,
+              referenceColumns: fk.referenceColumns,
               onDelete: fk.onDelete,
               onUpdate: fk.onUpdate,
             },
@@ -566,7 +570,7 @@ export function TableForm({
                         <span className="truncate">{fk.columnName}</span>
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
-                          {fk.referenceTable}.{fk.referenceColumn}
+                          {fk.referenceTable}.{fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -570,7 +570,8 @@ export function TableForm({
                         <span className="truncate">{fk.columnName}</span>
                         <MoveRight className="size-5 shrink-0 text-muted-foreground" />
                         <span className="truncate">
-                          {fk.referenceTable}.{fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
+                          {fk.referenceTable}.
+                          {fk.referenceColumns.map((c) => c.referenceColumn).join(',')}
                         </span>
                       </div>
                       <div className="truncate px-2.5 text-[13px] leading-[18px]">

--- a/packages/dashboard/src/features/database/components/TableForm.tsx
+++ b/packages/dashboard/src/features/database/components/TableForm.tsx
@@ -127,6 +127,8 @@ export function TableForm({
 
         return {
           constraintName: fk.constraintName,
+          // Stable identity: an existing constraint is uniquely identified by its name.
+          uid: fk.constraintName ?? crypto.randomUUID(),
           // Primary source column, used only to associate the FK with a column row in the UI.
           columnName: fk.referenceColumns[0]?.sourceColumn ?? '',
           referenceTable:
@@ -210,6 +212,7 @@ export function TableForm({
       const columns = data.columns.map((col) => ({
         columnName: col.columnName,
         type: col.type,
+        isPrimaryKey: col.isPrimaryKey,
         isNullable: col.isNullable,
         isUnique: col.isUnique,
         defaultValue: col.defaultValue,
@@ -406,33 +409,28 @@ export function TableForm({
 
   const handleAddForeignKey = (fk: TableFormForeignKeySchema) => {
     if (editingForeignKey) {
-      // Update existing foreign key
+      // Update existing foreign key (matched by stable uid, not source column).
       setForeignKeys(
         foreignKeys.map((existingFk) =>
-          existingFk.columnName === editingForeignKey ? { ...fk } : existingFk
+          existingFk.uid === editingForeignKey ? { ...fk, uid: existingFk.uid } : existingFk
         )
       );
       setEditingForeignKey(undefined);
       setForeignKeysDirty(true);
     } else {
-      // Add new foreign key
-      setForeignKeys([
-        ...foreignKeys,
-        {
-          ...fk,
-        },
-      ]);
+      // Add new foreign key with a fresh client-side identity.
+      setForeignKeys([...foreignKeys, { ...fk, uid: crypto.randomUUID() }]);
     }
     setForeignKeysDirty(true);
   };
 
-  const handleRemoveForeignKey = (columnName?: string) => {
-    // Each entry is one constraint, so removing by its (primary) source column
-    // drops the whole constraint — including composite keys.
-    if (!foreignKeys.some((fk) => fk.columnName === columnName)) {
+  const handleRemoveForeignKey = (uid?: string) => {
+    // Identify by stable uid so constraints sharing a first source column
+    // (e.g. multi-tenant `tenant_id`) are removed individually, not together.
+    if (!foreignKeys.some((fk) => fk.uid === uid)) {
       return;
     }
-    setForeignKeys(foreignKeys.filter((fk) => fk.columnName !== columnName));
+    setForeignKeys(foreignKeys.filter((fk) => fk.uid !== uid));
     setForeignKeysDirty(true);
   };
 
@@ -534,7 +532,7 @@ export function TableForm({
 
                   {foreignKeys.map((fk, index) => (
                     <div
-                      key={fk.columnName}
+                      key={fk.uid ?? fk.columnName}
                       className={`group grid h-12 grid-cols-[minmax(260px,1fr)_190px_190px_52px] items-center px-1.5 hover:bg-[var(--alpha-4)] ${
                         index === foreignKeys.length - 1 ? '' : 'border-b border-[var(--alpha-8)]'
                       }`}
@@ -559,7 +557,7 @@ export function TableForm({
                       <div className="flex items-center justify-end px-2.5">
                         <button
                           type="button"
-                          onClick={() => handleRemoveForeignKey(fk.columnName)}
+                          onClick={() => handleRemoveForeignKey(fk.uid)}
                           className="flex size-8 items-center justify-center rounded text-muted-foreground opacity-0 transition-[opacity,colors] group-hover:opacity-100 hover:bg-[var(--alpha-8)] hover:text-foreground focus-visible:opacity-100"
                           aria-label="Remove"
                         >
@@ -599,7 +597,7 @@ export function TableForm({
               onAddForeignKey={handleAddForeignKey}
               initialValue={
                 editingForeignKey
-                  ? foreignKeys.find((fk) => fk.columnName === editingForeignKey)
+                  ? foreignKeys.find((fk) => fk.uid === editingForeignKey)
                   : undefined
               }
             />

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -1,5 +1,6 @@
 import { jsonSchema } from '#lib/utils/schemaValidations';
 import {
+  type AdminTableRecordPrimaryKey,
   ColumnSchema,
   ColumnType,
   type DatabaseSchemaInfo,
@@ -33,10 +34,11 @@ export function getForeignKeyByColumn(
 }
 
 /**
- * A record's primary key as a map of column name -> value.
- * Supports composite (multi-column) primary keys.
+ * A record's primary key as a map of column name -> value. Supports composite keys.
+ * Aliased to the backend contract so the dashboard and API can't drift; PK columns
+ * are NOT NULL, so values are non-null scalars.
  */
-export type RecordPrimaryKey = Record<string, string | number | boolean | null>;
+export type RecordPrimaryKey = AdminTableRecordPrimaryKey;
 
 /**
  * Returns the primary-key column names for a table, in schema (ordinal) order.
@@ -73,7 +75,9 @@ export function getRecordPrimaryKey(
   for (const columnName of primaryKeyColumns) {
     const value = row[columnName];
     if (value === undefined || value === null) {
-      key[columnName] = null;
+      // PK columns are NOT NULL; this branch is defensive for pathological rows
+      // (e.g. the no-PK fallback). Use '' to stay a non-null scalar and a stable key.
+      key[columnName] = '';
     } else if (
       typeof value === 'string' ||
       typeof value === 'number' ||
@@ -105,10 +109,7 @@ function isRecordPrimaryKey(value: unknown): value is RecordPrimaryKey {
   }
   return Object.values(value).every(
     (item) =>
-      item === null ||
-      typeof item === 'string' ||
-      typeof item === 'number' ||
-      typeof item === 'boolean'
+      typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean'
   );
 }
 

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -46,7 +46,18 @@ export type RecordPrimaryKey = Record<string, string | number | boolean | null>;
 export function getPrimaryKeyColumns(columns?: ColumnSchema[]): string[] {
   const primaryKeyColumns =
     columns?.filter((column) => column.isPrimaryKey).map((column) => column.columnName) ?? [];
-  return primaryKeyColumns.length > 0 ? primaryKeyColumns : ['id'];
+  if (primaryKeyColumns.length > 0) {
+    return primaryKeyColumns;
+  }
+
+  const allColumns = columns?.map((column) => column.columnName) ?? [];
+  if (allColumns.includes('id')) {
+    return ['id'];
+  }
+  // No declared primary key and no `id` column: fall back to every column so distinct
+  // rows keep distinct grid identities instead of all collapsing to a single
+  // `{"id":null}` key (which would merge selection/edit/delete across rows).
+  return allColumns.length > 0 ? allColumns : ['id'];
 }
 
 /**
@@ -88,12 +99,32 @@ export function encodeRecordKey(row: Record<string, unknown>, primaryKeyColumns:
  * Decodes a grid row key produced by {@link encodeRecordKey} back into the
  * primary-key tuple to send to the record update/delete APIs.
  */
+function isRecordPrimaryKey(value: unknown): value is RecordPrimaryKey {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    (item) =>
+      item === null ||
+      typeof item === 'string' ||
+      typeof item === 'number' ||
+      typeof item === 'boolean'
+  );
+}
+
 export function decodeRecordKey(encodedKey: string): RecordPrimaryKey {
+  let parsed: unknown;
   try {
-    return JSON.parse(encodedKey) as RecordPrimaryKey;
+    parsed = JSON.parse(encodedKey);
   } catch {
     throw new Error(`Invalid record key: ${encodedKey}`);
   }
+  // Reject anything that isn't a plain scalar-valued object before it reaches the
+  // update/delete APIs as pkKeys (JSON.parse also accepts null, arrays, scalars).
+  if (!isRecordPrimaryKey(parsed)) {
+    throw new Error(`Invalid record key: ${encodedKey}`);
+  }
+  return parsed;
 }
 
 // Helper function to build dynamic Zod schema based on column definitions

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -6,6 +6,69 @@ export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
 
 export const SYSTEM_FIELDS = ['id', 'created_at', 'updated_at'];
 
+/**
+ * A record's primary key as a map of column name -> value.
+ * Supports composite (multi-column) primary keys.
+ */
+export type RecordPrimaryKey = Record<string, string | number | boolean | null>;
+
+/**
+ * Returns the primary-key column names for a table, in schema (ordinal) order.
+ * Falls back to `['id']` when the schema reports no primary key, preserving the
+ * previous single-column behavior for tables that don't expose key metadata.
+ */
+export function getPrimaryKeyColumns(columns?: ColumnSchema[]): string[] {
+  const primaryKeyColumns =
+    columns?.filter((column) => column.isPrimaryKey).map((column) => column.columnName) ?? [];
+  return primaryKeyColumns.length > 0 ? primaryKeyColumns : ['id'];
+}
+
+/**
+ * Builds the primary-key tuple for a row from the given primary-key columns.
+ * Missing values are coerced to null and non-scalar values to their string form,
+ * since primary keys are always scalar.
+ */
+export function getRecordPrimaryKey(
+  row: Record<string, unknown>,
+  primaryKeyColumns: string[]
+): RecordPrimaryKey {
+  const key: RecordPrimaryKey = {};
+  for (const columnName of primaryKeyColumns) {
+    const value = row[columnName];
+    if (value === undefined || value === null) {
+      key[columnName] = null;
+    } else if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      key[columnName] = value;
+    } else {
+      key[columnName] = String(value);
+    }
+  }
+  return key;
+}
+
+/**
+ * Encodes a row's full primary-key tuple into a stable string usable as a React
+ * grid row key. Two rows with the same key tuple encode identically (same identity).
+ */
+export function encodeRecordKey(
+  row: Record<string, unknown>,
+  primaryKeyColumns: string[]
+): string {
+  return JSON.stringify(getRecordPrimaryKey(row, primaryKeyColumns));
+}
+
+/**
+ * Decodes a grid row key produced by {@link encodeRecordKey} back into the
+ * primary-key tuple to send to the record update/delete APIs.
+ */
+export function decodeRecordKey(encodedKey: string): RecordPrimaryKey {
+  return JSON.parse(encodedKey) as RecordPrimaryKey;
+}
+
 // Helper function to build dynamic Zod schema based on column definitions
 export function buildDynamicSchema(columns: ColumnSchema[]) {
   const schemaFields: Record<string, z.ZodTypeAny> = {};

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -1,10 +1,36 @@
 import { jsonSchema } from '#lib/utils/schemaValidations';
-import { ColumnSchema, ColumnType, type DatabaseSchemaInfo } from '@insforge/shared-schemas';
+import {
+  ColumnSchema,
+  ColumnType,
+  type DatabaseSchemaInfo,
+  type ForeignKeySchema,
+} from '@insforge/shared-schemas';
 import { z } from 'zod';
 
 export const DEFAULT_DATABASE_SCHEMA = 'public' as const;
 
 export const SYSTEM_FIELDS = ['id', 'created_at', 'updated_at'];
+
+/**
+ * Derives a source-column -> foreign-key lookup from a table's table-level
+ * foreign keys. Each participating source column maps to its (shared) constraint,
+ * so a composite key resolves the same entity from any of its columns. This is a
+ * computed view for per-column rendering; the table's `foreignKeys` list stays the
+ * single source of truth.
+ */
+export function getForeignKeyByColumn(
+  foreignKeys?: ForeignKeySchema[]
+): Map<string, ForeignKeySchema> {
+  const byColumn = new Map<string, ForeignKeySchema>();
+  for (const fk of foreignKeys ?? []) {
+    for (const ref of fk.referenceColumns) {
+      if (!byColumn.has(ref.sourceColumn)) {
+        byColumn.set(ref.sourceColumn, fk);
+      }
+    }
+  }
+  return byColumn;
+}
 
 /**
  * A record's primary key as a map of column name -> value.

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -54,10 +54,7 @@ export function getRecordPrimaryKey(
  * Encodes a row's full primary-key tuple into a stable string usable as a React
  * grid row key. Two rows with the same key tuple encode identically (same identity).
  */
-export function encodeRecordKey(
-  row: Record<string, unknown>,
-  primaryKeyColumns: string[]
-): string {
+export function encodeRecordKey(row: Record<string, unknown>, primaryKeyColumns: string[]): string {
   return JSON.stringify(getRecordPrimaryKey(row, primaryKeyColumns));
 }
 

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -108,8 +108,7 @@ function isRecordPrimaryKey(value: unknown): value is RecordPrimaryKey {
     return false;
   }
   return Object.values(value).every(
-    (item) =>
-      typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean'
+    (item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean'
   );
 }
 

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -63,7 +63,11 @@ export function encodeRecordKey(row: Record<string, unknown>, primaryKeyColumns:
  * primary-key tuple to send to the record update/delete APIs.
  */
 export function decodeRecordKey(encodedKey: string): RecordPrimaryKey {
-  return JSON.parse(encodedKey) as RecordPrimaryKey;
+  try {
+    return JSON.parse(encodedKey) as RecordPrimaryKey;
+  } catch {
+    throw new Error(`Invalid record key: ${encodedKey}`);
+  }
 }
 
 // Helper function to build dynamic Zod schema based on column definitions

--- a/packages/dashboard/src/features/database/helpers.ts
+++ b/packages/dashboard/src/features/database/helpers.ts
@@ -64,8 +64,8 @@ export function getPrimaryKeyColumns(columns?: ColumnSchema[]): string[] {
 
 /**
  * Builds the primary-key tuple for a row from the given primary-key columns.
- * Missing values are coerced to null and non-scalar values to their string form,
- * since primary keys are always scalar.
+ * Missing/null values are preserved as null and non-scalar values coerced to
+ * their string form, since primary keys are always scalar.
  */
 export function getRecordPrimaryKey(
   row: Record<string, unknown>,
@@ -75,9 +75,11 @@ export function getRecordPrimaryKey(
   for (const columnName of primaryKeyColumns) {
     const value = row[columnName];
     if (value === undefined || value === null) {
-      // PK columns are NOT NULL; this branch is defensive for pathological rows
-      // (e.g. the no-PK fallback). Use '' to stay a non-null scalar and a stable key.
-      key[columnName] = '';
+      // PK columns are NOT NULL, so this only triggers on the no-PK fallback
+      // (key = all columns). Keep null — the record API matches it with
+      // `col IS NULL`, so a genuinely-null column still identifies its row.
+      // Coercing to '' would build `col = ''` and silently match nothing.
+      key[columnName] = null;
     } else if (
       typeof value === 'string' ||
       typeof value === 'number' ||
@@ -108,7 +110,11 @@ function isRecordPrimaryKey(value: unknown): value is RecordPrimaryKey {
     return false;
   }
   return Object.values(value).every(
-    (item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean'
+    (item) =>
+      item === null ||
+      typeof item === 'string' ||
+      typeof item === 'number' ||
+      typeof item === 'boolean'
   );
 }
 

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,7 +1,10 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 import { databaseTableQueryKeys } from '#features/database/queryKeys';
-import { recordService } from '#features/database/services/record.service';
+import {
+  recordService,
+  type RecordPrimaryKey,
+} from '#features/database/services/record.service';
 import { useToast } from '#lib/hooks/useToast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -101,14 +104,12 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
   // Mutation to update a record
   const updateRecordMutation = useMutation({
     mutationFn: ({
-      pkColumn,
-      pkValue,
+      primaryKey,
       data,
     }: {
-      pkColumn: string;
-      pkValue: string;
+      primaryKey: RecordPrimaryKey;
       data: { [key: string]: ConvertedValue };
-    }) => recordService.updateRecord(tableName, pkColumn, pkValue, data, schemaName),
+    }) => recordService.updateRecord(tableName, primaryKey, data, schemaName),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordsQueryKeyPrefix });
       void queryClient.invalidateQueries({
@@ -124,14 +125,14 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
 
   // Mutation to delete a record
   const deleteRecordsMutation = useMutation({
-    mutationFn: (variables: { pkColumn: string; pkValues: string[] }) =>
-      recordService.deleteRecords(tableName, variables.pkColumn, variables.pkValues, schemaName),
+    mutationFn: (variables: { primaryKeys: RecordPrimaryKey[] }) =>
+      recordService.deleteRecords(tableName, variables.primaryKeys, schemaName),
     onSuccess: (_data, variables) => {
       void queryClient.invalidateQueries({ queryKey: recordsQueryKeyPrefix });
       void queryClient.invalidateQueries({
         queryKey: databaseTableQueryKeys.tableSchema(schemaName, tableName),
       });
-      const count = variables.pkValues.length;
+      const count = variables.primaryKeys.length;
       if (count === 1) {
         showToast('Record deleted successfully', 'success');
       } else {
@@ -139,7 +140,7 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
       }
     },
     onError: (error: Error, variables) => {
-      const count = variables.pkValues.length;
+      const count = variables.primaryKeys.length;
       const recordText = count === 1 ? 'record' : 'records';
       const errorMessage =
         error instanceof Error ? error.message : `Failed to delete ${recordText}`;

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,7 +1,7 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
-import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
+import { DEFAULT_DATABASE_SCHEMA, type RecordPrimaryKey } from '#features/database/helpers';
 import { databaseTableQueryKeys } from '#features/database/queryKeys';
-import { recordService, type RecordPrimaryKey } from '#features/database/services/record.service';
+import { recordService } from '#features/database/services/record.service';
 import { useToast } from '#lib/hooks/useToast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -53,13 +53,14 @@ export function useRecords(tableName: string, schemaName: string = DEFAULT_DATAB
     });
   };
 
-  // Hook to fetch a single record by foreign key value
-  const useRecordByForeignKey = (columnName: string, value: string, enabled = true) => {
+  // Hook to fetch a single record by foreign key value(s).
+  // Supports composite foreign keys via parallel arrays of columns and values.
+  const useRecordByForeignKey = (columns: string[], values: string[], enabled = true) => {
     return useQuery({
-      queryKey: ['records', schemaName, tableName, 'foreignKey', columnName, value],
+      queryKey: ['records', schemaName, tableName, 'foreignKey', ...columns, ...values],
       queryFn: () =>
-        recordService.getRecordByForeignKeyValue(tableName, columnName, value, schemaName),
-      enabled: enabled && !!tableName && !!columnName && !!value,
+        recordService.getRecordByForeignKeyValue(tableName, columns, values, schemaName),
+      enabled: enabled && !!tableName && columns.length > 0 && columns.length === values.length,
       staleTime: 30 * 1000,
     });
   };

--- a/packages/dashboard/src/features/database/hooks/useRecords.ts
+++ b/packages/dashboard/src/features/database/hooks/useRecords.ts
@@ -1,10 +1,7 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
 import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
 import { databaseTableQueryKeys } from '#features/database/queryKeys';
-import {
-  recordService,
-  type RecordPrimaryKey,
-} from '#features/database/services/record.service';
+import { recordService, type RecordPrimaryKey } from '#features/database/services/record.service';
 import { useToast } from '#lib/hooks/useToast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -751,6 +751,7 @@ export default function TablesPage() {
           onOpenChange={setShowRecordForm}
           tableName={selectedTable}
           schema={schemaData.columns}
+          foreignKeys={schemaData.foreignKeys}
         />
       )}
 

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -227,10 +227,7 @@ export default function TablesPage() {
 
   // Full primary-key tuple (supports composite keys) used for row identity,
   // updates, and deletes.
-  const primaryKeyColumns = useMemo(
-    () => getPrimaryKeyColumns(schemaData?.columns),
-    [schemaData]
-  );
+  const primaryKeyColumns = useMemo(() => getPrimaryKeyColumns(schemaData?.columns), [schemaData]);
 
   const {
     mutate: importCSV,

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -39,7 +39,13 @@ import { useCSVExport } from '#features/database/hooks/useCSVExport';
 import { useTablePreferences } from '#features/database/hooks/useTablePreferences';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { usePageSize } from '#lib/hooks/usePageSize';
-import { DEFAULT_DATABASE_SCHEMA, getDatabaseSchemaInfo } from '#features/database/helpers';
+import {
+  DEFAULT_DATABASE_SCHEMA,
+  decodeRecordKey,
+  encodeRecordKey,
+  getDatabaseSchemaInfo,
+  getPrimaryKeyColumns,
+} from '#features/database/helpers';
 
 export default function TablesPage() {
   const location = useLocation();
@@ -219,9 +225,12 @@ export default function TablesPage() {
     !!editingTable
   );
 
-  const primaryKeyColumn = useMemo(() => {
-    return schemaData?.columns.find((col) => col.isPrimaryKey)?.columnName;
-  }, [schemaData]);
+  // Full primary-key tuple (supports composite keys) used for row identity,
+  // updates, and deletes.
+  const primaryKeyColumns = useMemo(
+    () => getPrimaryKeyColumns(schemaData?.columns),
+    [schemaData]
+  );
 
   const {
     mutate: importCSV,
@@ -415,8 +424,8 @@ export default function TablesPage() {
     setPreviewingTemplate(null);
   };
 
-  // Handle record update
-  const handleRecordUpdate = async (rowId: string, columnKey: string, newValue: string) => {
+  // Handle record update. `rowKey` is the encoded primary-key tuple from the grid.
+  const handleRecordUpdate = async (rowKey: string, columnKey: string, newValue: string) => {
     if (!selectedTable || selectedSchemaInfo.isProtected) {
       return;
     }
@@ -434,8 +443,7 @@ export default function TablesPage() {
         }
         const updates = { [columnKey]: conversionResult.value };
         await recordsHook.updateRecord({
-          pkColumn: primaryKeyColumn || 'id',
-          pkValue: rowId,
+          primaryKey: decodeRecordKey(rowKey),
           data: updates,
         });
       }
@@ -445,21 +453,21 @@ export default function TablesPage() {
     }
   };
 
-  // Handle bulk delete
-  const handleBulkDelete = async (ids: string[]) => {
-    if (!selectedTable || !ids.length || selectedSchemaInfo.isProtected) {
+  // Handle bulk delete. `rowKeys` are the encoded primary-key tuples from the grid.
+  const handleBulkDelete = async (rowKeys: string[]) => {
+    if (!selectedTable || !rowKeys.length || selectedSchemaInfo.isProtected) {
       return;
     }
 
     const shouldDelete = await confirm({
-      title: `Delete ${ids.length} ${ids.length === 1 ? 'Record' : 'Records'}`,
-      description: `Are you sure you want to delete ${ids.length} ${ids.length === 1 ? 'record' : 'records'}? This action cannot be undone.`,
+      title: `Delete ${rowKeys.length} ${rowKeys.length === 1 ? 'Record' : 'Records'}`,
+      description: `Are you sure you want to delete ${rowKeys.length} ${rowKeys.length === 1 ? 'record' : 'records'}? This action cannot be undone.`,
       confirmText: 'Delete',
       destructive: true,
     });
 
     if (shouldDelete) {
-      await recordsHook.deleteRecords({ pkColumn: primaryKeyColumn || 'id', pkValues: ids });
+      await recordsHook.deleteRecords({ primaryKeys: rowKeys.map(decodeRecordKey) });
       // Query invalidation is handled by the mutation, no manual refetch needed
       setSelectedRows(new Set());
     }
@@ -686,7 +694,7 @@ export default function TablesPage() {
                   loading={isLoadingTable && !tableData}
                   isSorting={isSorting}
                   isRefreshing={isRefreshing}
-                  rowKeyGetter={(row) => String(row[primaryKeyColumn || 'id'])}
+                  rowKeyGetter={(row) => encodeRecordKey(row, primaryKeyColumns)}
                   selectedRows={selectedRows}
                   onSelectedRowsChange={setSelectedRows}
                   sortColumns={sortColumns}

--- a/packages/dashboard/src/features/database/schema.ts
+++ b/packages/dashboard/src/features/database/schema.ts
@@ -5,6 +5,10 @@ import { columnSchema, foreignKeySchema } from '@insforge/shared-schemas';
 // Uses referenceColumns array (always 1 entry for dashboard-created FKs)
 export const tableFormForeignKeySchema = foreignKeySchema.extend({
   columnName: z.string(),
+  // Stable client-side identity for a form FK row. Existing constraints reuse their
+  // constraintName; newly added ones get a generated id. Used so constraints that
+  // share a first source column (e.g. multi-tenant `tenant_id`) stay distinct.
+  uid: z.string().optional(),
 });
 
 export const tableFormColumnSchema = columnSchema.extend({

--- a/packages/dashboard/src/features/database/schema.ts
+++ b/packages/dashboard/src/features/database/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { columnSchema, foreignKeySchema, foreignKeyReferenceSchema } from '@insforge/shared-schemas';
+import { columnSchema, foreignKeySchema } from '@insforge/shared-schemas';
 
 // Foreign key form schema — single-column FK creation from the UI
 // Uses referenceColumns array (always 1 entry for dashboard-created FKs)

--- a/packages/dashboard/src/features/database/schema.ts
+++ b/packages/dashboard/src/features/database/schema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
-import { columnSchema, foreignKeySchema } from '@insforge/shared-schemas';
+import { columnSchema, foreignKeySchema, foreignKeyReferenceSchema } from '@insforge/shared-schemas';
 
-// Foreign key schema
+// Foreign key form schema — single-column FK creation from the UI
+// Uses referenceColumns array (always 1 entry for dashboard-created FKs)
 export const tableFormForeignKeySchema = foreignKeySchema.extend({
   columnName: z.string(),
 });

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -83,23 +83,28 @@ export class RecordService {
   }
 
   /**
-   * Get a single record by foreign key value.
-   * Specifically designed for foreign key lookups.
+   * Get a single record by foreign key value(s).
+   * Supports composite foreign keys via multiple columns/values.
    *
    * @param tableName - Name of the table to search in
-   * @param columnName - Name of the column to filter by
-   * @param value - Value to match
+   * @param columns - Column name(s) to filter by
+   * @param values - Value(s) to match (parallel array to columns)
    * @returns Single record or null if not found
    */
   async getRecordByForeignKeyValue(
     tableName: string,
-    columnName: string,
-    value: string,
+    columns: string[],
+    values: string[],
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    const params = new URLSearchParams({
-      column: columnName,
-      value,
+    if (columns.length === 0 || columns.length !== values.length) {
+      throw new Error('Columns and values must have the same non-zero length');
+    }
+
+    const params = new URLSearchParams();
+    columns.forEach((col, i) => {
+      params.append('column', col);
+      params.append('value', values[i]);
     });
 
     return apiClient.request(this.buildAdminRecordsPath(tableName, schemaName, '/lookup', params), {

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -1,5 +1,5 @@
 import { ConvertedValue } from '#components/datagrid/datagridTypes';
-import { DEFAULT_DATABASE_SCHEMA } from '#features/database/helpers';
+import { DEFAULT_DATABASE_SCHEMA, type RecordPrimaryKey } from '#features/database/helpers';
 import { apiClient } from '#lib/api/client';
 import { BulkUpsertResponse } from '@insforge/shared-schemas';
 import { convertToCSV, getExportFilename } from '#lib/utils/data-export';
@@ -8,6 +8,8 @@ interface AdminRecordListResponse {
   data: { [key: string]: ConvertedValue }[];
   pagination: { offset: number; limit: number; total: number };
 }
+
+export type { RecordPrimaryKey };
 
 export class RecordService {
   private buildAdminRecordsPath(
@@ -208,38 +210,32 @@ export class RecordService {
 
   updateRecord(
     table: string,
-    pkColumn: string,
-    pkValue: string,
+    primaryKey: RecordPrimaryKey,
     data: { [key: string]: ConvertedValue },
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    const params = new URLSearchParams({ pkColumn });
+    // pkKeys carries the full primary-key tuple so composite keys target one row.
+    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKey) });
 
-    return apiClient.request(
-      this.buildAdminRecordsPath(table, schemaName, `/${encodeURIComponent(pkValue)}`, params),
-      {
-        method: 'PATCH',
-        headers: apiClient.withAccessToken({
-          'Content-Type': 'application/json',
-        }),
-        body: JSON.stringify(data),
-      }
-    );
+    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
+      method: 'PATCH',
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify(data),
+    });
   }
 
   deleteRecords(
     table: string,
-    pkColumn: string,
-    pkValues: string[],
+    primaryKeys: RecordPrimaryKey[],
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    if (!pkValues.length) {
+    if (!primaryKeys.length) {
       return Promise.resolve();
     }
-    const params = new URLSearchParams({
-      pkColumn,
-      pkValues: pkValues.join(','),
-    });
+    // pkKeys is a JSON array of primary-key tuples so each selected row is matched exactly.
+    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKeys) });
 
     return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
       method: 'DELETE',

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -9,8 +9,6 @@ interface AdminRecordListResponse {
   pagination: { offset: number; limit: number; total: number };
 }
 
-export type { RecordPrimaryKey };
-
 export class RecordService {
   private buildAdminRecordsPath(
     tableName: string,
@@ -219,15 +217,14 @@ export class RecordService {
     data: { [key: string]: ConvertedValue },
     schemaName: string = DEFAULT_DATABASE_SCHEMA
   ) {
-    // pkKeys carries the full primary-key tuple so composite keys target one row.
-    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKey) });
-
-    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
+    // pkKeys (the full primary-key tuple) and data travel in the body so composite
+    // keys are validated structurally instead of being crammed into the query string.
+    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, ''), {
       method: 'PATCH',
       headers: apiClient.withAccessToken({
         'Content-Type': 'application/json',
       }),
-      body: JSON.stringify(data),
+      body: JSON.stringify({ pkKeys: primaryKey, data }),
     });
   }
 
@@ -239,12 +236,14 @@ export class RecordService {
     if (!primaryKeys.length) {
       return Promise.resolve();
     }
-    // pkKeys is a JSON array of primary-key tuples so each selected row is matched exactly.
-    const params = new URLSearchParams({ pkKeys: JSON.stringify(primaryKeys) });
-
-    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, '', params), {
+    // pkKeys (one tuple per record) travels in the body so each selected row is
+    // matched exactly without a length-limited query string.
+    return apiClient.request(this.buildAdminRecordsPath(table, schemaName, ''), {
       method: 'DELETE',
-      headers: apiClient.withAccessToken(),
+      headers: apiClient.withAccessToken({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({ pkKeys: primaryKeys }),
     });
   }
 

--- a/packages/dashboard/src/features/database/services/table.service.ts
+++ b/packages/dashboard/src/features/database/services/table.service.ts
@@ -3,6 +3,7 @@ import { buildDatabaseSchemaSearch, DEFAULT_DATABASE_SCHEMA } from '#features/da
 import {
   ColumnSchema,
   CreateTableRequest,
+  type ForeignKeySchema,
   GetTableSchemaResponse,
   UpdateTableSchemaRequest,
   UpdateTableSchemaResponse,
@@ -33,8 +34,13 @@ export class TableService {
     );
   }
 
-  createTable(schemaName: string, tableName: string, columns: ColumnSchema[]) {
-    const body: CreateTableRequest = { tableName, columns, rlsEnabled: true };
+  createTable(
+    schemaName: string,
+    tableName: string,
+    columns: ColumnSchema[],
+    foreignKeys: ForeignKeySchema[] = []
+  ) {
+    const body: CreateTableRequest = { tableName, columns, foreignKeys, rlsEnabled: true };
 
     return apiClient.request(`/database/tables${buildDatabaseSchemaSearch(schemaName)}`, {
       method: 'POST',

--- a/packages/dashboard/src/features/database/templates/ai-chatbot.ts
+++ b/packages/dashboard/src/features/database/templates/ai-chatbot.ts
@@ -17,12 +17,6 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'title',
@@ -53,6 +47,14 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'messages',
@@ -64,12 +66,6 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'conversations',
-            referenceColumns: [{ sourceColumn: 'conversation_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'role',
@@ -100,6 +96,14 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'conversations',
+          referenceColumns: [{ sourceColumn: 'conversation_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'feedback',
@@ -111,12 +115,6 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'messages',
-            referenceColumns: [{ sourceColumn: 'message_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -124,12 +122,6 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'rating',
@@ -153,6 +145,20 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'messages',
+          referenceColumns: [{ sourceColumn: 'message_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'prompts',
@@ -164,12 +170,6 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'title',
@@ -219,6 +219,14 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/ai-chatbot.ts
+++ b/packages/dashboard/src/features/database/templates/ai-chatbot.ts
@@ -19,7 +19,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -66,7 +66,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'conversations',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'conversation_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -113,7 +113,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'messages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'message_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -126,7 +126,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -166,7 +166,7 @@ export const aiChatbotTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/crm-system.ts
+++ b/packages/dashboard/src/features/database/templates/crm-system.ts
@@ -80,7 +80,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'companies',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
           },
@@ -148,7 +148,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'companies',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -161,7 +161,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'contacts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
           },
@@ -222,7 +222,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'contacts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -235,7 +235,7 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'deals',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'deal_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/crm-system.ts
+++ b/packages/dashboard/src/features/database/templates/crm-system.ts
@@ -78,12 +78,6 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'companies',
-            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
-            onDelete: 'SET NULL',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'first_name',
@@ -135,6 +129,14 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'companies',
+          referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'deals',
@@ -146,12 +148,6 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'companies',
-            referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'contact_id',
@@ -159,12 +155,6 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'contacts',
-            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
-            onDelete: 'SET NULL',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'title',
@@ -209,6 +199,20 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'companies',
+          referenceColumns: [{ sourceColumn: 'company_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'contacts',
+          referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'activities',
@@ -220,12 +224,6 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'contacts',
-            referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'deal_id',
@@ -233,12 +231,6 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'deals',
-            referenceColumns: [{ sourceColumn: 'deal_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'type',
@@ -281,6 +273,20 @@ export const crmSystemTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'contacts',
+          referenceColumns: [{ sourceColumn: 'contact_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'deals',
+          referenceColumns: [{ sourceColumn: 'deal_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
+++ b/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
@@ -95,7 +95,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: true,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -170,7 +170,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'customers',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -224,7 +224,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'orders',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'order_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -237,7 +237,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'products',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
             onDelete: 'RESTRICT',
             onUpdate: 'CASCADE',
           },
@@ -277,7 +277,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'products',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -290,7 +290,7 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'customers',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
+++ b/packages/dashboard/src/features/database/templates/ecommerce-platform.ts
@@ -93,12 +93,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: true,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'first_name',
@@ -157,6 +151,14 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'orders',
@@ -168,12 +170,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'customers',
-            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'status',
@@ -211,6 +207,14 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'customers',
+          referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'order_items',
@@ -222,12 +226,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'orders',
-            referenceColumns: [{ sourceColumn: 'order_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'product_id',
@@ -235,12 +233,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'products',
-            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
-            onDelete: 'RESTRICT',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'quantity',
@@ -264,6 +256,20 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'orders',
+          referenceColumns: [{ sourceColumn: 'order_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'products',
+          referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
+          onDelete: 'RESTRICT',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'reviews',
@@ -275,12 +281,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'products',
-            referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'customer_id',
@@ -288,12 +288,6 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'customers',
-            referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'rating',
@@ -315,6 +309,20 @@ export const ecommercePlatformTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'products',
+          referenceColumns: [{ sourceColumn: 'product_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'customers',
+          referenceColumns: [{ sourceColumn: 'customer_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/instagram-clone.ts
+++ b/packages/dashboard/src/features/database/templates/instagram-clone.ts
@@ -18,7 +18,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -58,7 +58,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -71,7 +71,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -104,7 +104,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -117,7 +117,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -143,7 +143,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'follower_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -156,7 +156,7 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'following_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/instagram-clone.ts
+++ b/packages/dashboard/src/features/database/templates/instagram-clone.ts
@@ -16,12 +16,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'image_url',
@@ -45,6 +39,14 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'comments',
@@ -56,12 +58,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'posts',
-            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -69,12 +65,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'content',
@@ -91,6 +81,20 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'posts',
+          referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'likes',
@@ -102,12 +106,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'post_id',
@@ -115,12 +113,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'posts',
-            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'created_at',
@@ -128,6 +120,20 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'posts',
+          referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },
@@ -141,12 +147,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'follower_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'following_id',
@@ -154,12 +154,6 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'following_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'created_at',
@@ -167,6 +161,20 @@ export const instagramCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'follower_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'following_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/notion-clone.ts
+++ b/packages/dashboard/src/features/database/templates/notion-clone.ts
@@ -23,12 +23,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'owner_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'icon',
@@ -52,6 +46,14 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'owner_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'pages',
@@ -63,12 +65,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'workspaces',
-            referenceColumns: [{ sourceColumn: 'workspace_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'parent_page_id',
@@ -76,12 +72,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'pages',
-            referenceColumns: [{ sourceColumn: 'parent_page_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'creator_id',
@@ -89,12 +79,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'title',
@@ -153,6 +137,26 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'workspaces',
+          referenceColumns: [{ sourceColumn: 'workspace_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'pages',
+          referenceColumns: [{ sourceColumn: 'parent_page_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'page_shares',
@@ -164,12 +168,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'pages',
-            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -177,12 +175,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'permission',
@@ -199,6 +191,20 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'pages',
+          referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'attachments',
@@ -210,12 +216,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'pages',
-            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -223,12 +223,6 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'file_name',
@@ -264,6 +258,20 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'pages',
+          referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/notion-clone.ts
+++ b/packages/dashboard/src/features/database/templates/notion-clone.ts
@@ -25,7 +25,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'owner_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -65,7 +65,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'workspaces',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'workspace_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -78,7 +78,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'parent_page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -91,7 +91,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -166,7 +166,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -179,7 +179,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -212,7 +212,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'pages',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'page_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -225,7 +225,7 @@ export const notionCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/database/templates/reddit-clone.ts
+++ b/packages/dashboard/src/features/database/templates/reddit-clone.ts
@@ -37,12 +37,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'is_active',
@@ -66,6 +60,14 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'posts',
@@ -77,12 +79,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'communities',
-            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -90,12 +86,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'title',
@@ -147,6 +137,20 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'communities',
+          referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'comments',
@@ -158,12 +162,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'posts',
-            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -171,12 +169,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'parent_comment_id',
@@ -184,12 +176,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'comments',
-            referenceColumns: [{ sourceColumn: 'parent_comment_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'content',
@@ -220,6 +206,26 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'posts',
+          referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'comments',
+          referenceColumns: [{ sourceColumn: 'parent_comment_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'votes',
@@ -231,12 +237,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'post_id',
@@ -244,12 +244,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'posts',
-            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'comment_id',
@@ -257,12 +251,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'comments',
-            referenceColumns: [{ sourceColumn: 'comment_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'vote_type',
@@ -279,6 +267,26 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
         },
       ],
+      foreignKeys: [
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'posts',
+          referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'comments',
+          referenceColumns: [{ sourceColumn: 'comment_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+      ],
     },
     {
       tableName: 'community_members',
@@ -290,12 +298,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'communities',
-            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'user_id',
@@ -303,12 +305,6 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: false,
           isUnique: false,
-          foreignKey: {
-            referenceTable: 'auth.users',
-            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
-            onDelete: 'CASCADE',
-            onUpdate: 'CASCADE',
-          },
         },
         {
           columnName: 'role',
@@ -323,6 +319,20 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isPrimaryKey: false,
           isNullable: true,
           isUnique: false,
+        },
+      ],
+      foreignKeys: [
+        {
+          referenceTable: 'communities',
+          referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        },
+        {
+          referenceTable: 'auth.users',
+          referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
         },
       ],
     },

--- a/packages/dashboard/src/features/database/templates/reddit-clone.ts
+++ b/packages/dashboard/src/features/database/templates/reddit-clone.ts
@@ -39,7 +39,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'creator_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -79,7 +79,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'communities',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -92,7 +92,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -160,7 +160,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -173,7 +173,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -186,7 +186,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'comments',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'parent_comment_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -233,7 +233,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -246,7 +246,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'posts',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'post_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -259,7 +259,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'comments',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'comment_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -292,7 +292,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'communities',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'community_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },
@@ -305,7 +305,7 @@ export const redditCloneTemplate: DatabaseTemplate = {
           isUnique: false,
           foreignKey: {
             referenceTable: 'auth.users',
-            referenceColumn: 'id',
+            referenceColumns: [{ sourceColumn: 'user_id', referenceColumn: 'id' }],
             onDelete: 'CASCADE',
             onUpdate: 'CASCADE',
           },

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -319,14 +319,17 @@ export function SchemaVisualizer({
               },
             });
           } else {
-            // Regular table-to-table edge — use first reference column for handle
-            const firstRefCol = column.foreignKey.referenceColumns[0]?.referenceColumn || '';
+            // Regular table-to-table edge — match target column to the current source column
+            const matchingRef = column.foreignKey.referenceColumns.find(
+              (r) => r.sourceColumn === column.columnName
+            );
+            const targetHandle = `${matchingRef?.referenceColumn || ''}-target`;
             edges.push({
               id: edgeId,
               source: table.tableName,
               target: column.foreignKey.referenceTable,
               sourceHandle: `${column.columnName}-source`,
-              targetHandle: `${firstRefCol}-target`,
+              targetHandle,
               type: 'smoothstep',
               animated: true,
               style: { stroke: edgeColor, strokeWidth: 2, zIndex: 1000 },

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -225,18 +225,16 @@ export function SchemaVisualizer({
     const referencedColumnsByTable: Record<string, string[]> = {};
 
     tables.forEach((table) => {
-      table.columns.forEach((column) => {
-        if (column.foreignKey) {
-          const targetTable = column.foreignKey.referenceTable;
-          column.foreignKey.referenceColumns.forEach((ref) => {
-            if (!referencedColumnsByTable[targetTable]) {
-              referencedColumnsByTable[targetTable] = [];
-            }
-            if (!referencedColumnsByTable[targetTable].includes(ref.referenceColumn)) {
-              referencedColumnsByTable[targetTable].push(ref.referenceColumn);
-            }
-          });
-        }
+      (table.foreignKeys ?? []).forEach((fk) => {
+        const targetTable = fk.referenceTable;
+        fk.referenceColumns.forEach((ref) => {
+          if (!referencedColumnsByTable[targetTable]) {
+            referencedColumnsByTable[targetTable] = [];
+          }
+          if (!referencedColumnsByTable[targetTable].includes(ref.referenceColumn)) {
+            referencedColumnsByTable[targetTable].push(ref.referenceColumn);
+          }
+        });
       });
     });
 
@@ -264,11 +262,10 @@ export function SchemaVisualizer({
 
     // Check if any tables reference users.id
     const isUsersReferenced = tables.some((table) =>
-      table.columns.some(
-        (column) =>
-          column.foreignKey &&
-          column.foreignKey.referenceTable === 'auth.users' &&
-          column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id')
+      (table.foreignKeys ?? []).some(
+        (fk) =>
+          fk.referenceTable === 'auth.users' &&
+          fk.referenceColumns.some((r) => r.referenceColumn === 'id')
       )
     );
 
@@ -293,14 +290,15 @@ export function SchemaVisualizer({
     const edgeColor = resolvedTheme === 'dark' ? 'white' : '#18181b'; // zinc-950 for light mode
 
     tables.forEach((table) => {
-      table.columns.forEach((column) => {
-        if (column.foreignKey) {
-          // Check if this is a reference to users.id
-          const isAuthReference =
-            column.foreignKey.referenceTable === 'auth.users' &&
-            column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id');
+      (table.foreignKeys ?? []).forEach((fk) => {
+        // Check if this is a reference to users.id
+        const isAuthReference =
+          fk.referenceTable === 'auth.users' &&
+          fk.referenceColumns.some((r) => r.referenceColumn === 'id');
 
-          const edgeId = `${table.tableName}-${column.columnName}-${column.foreignKey.referenceTable}`;
+        // One edge per (source -> reference) column pair so composite keys render fully.
+        fk.referenceColumns.forEach((ref) => {
+          const edgeId = `${table.tableName}-${ref.sourceColumn}-${fk.referenceTable}`;
 
           if (isAuthReference) {
             // Connect to the authentication node
@@ -308,7 +306,7 @@ export function SchemaVisualizer({
               id: edgeId,
               source: table.tableName,
               target: 'authentication',
-              sourceHandle: `${column.columnName}-source`,
+              sourceHandle: `${ref.sourceColumn}-source`,
               targetHandle: 'id-target',
               type: 'smoothstep',
               animated: true,
@@ -319,17 +317,13 @@ export function SchemaVisualizer({
               },
             });
           } else {
-            // Regular table-to-table edge — match target column to the current source column
-            const matchingRef = column.foreignKey.referenceColumns.find(
-              (r) => r.sourceColumn === column.columnName
-            );
-            const targetHandle = `${matchingRef?.referenceColumn || ''}-target`;
+            // Regular table-to-table edge — connect this source column to its target column.
             edges.push({
               id: edgeId,
               source: table.tableName,
-              target: column.foreignKey.referenceTable,
-              sourceHandle: `${column.columnName}-source`,
-              targetHandle,
+              target: fk.referenceTable,
+              sourceHandle: `${ref.sourceColumn}-source`,
+              targetHandle: `${ref.referenceColumn}-target`,
               type: 'smoothstep',
               animated: true,
               style: { stroke: edgeColor, strokeWidth: 2, zIndex: 1000 },
@@ -339,7 +333,7 @@ export function SchemaVisualizer({
               },
             });
           }
-        }
+        });
       });
     });
 

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -298,7 +298,15 @@ export function SchemaVisualizer({
 
         // One edge per (source -> reference) column pair so composite keys render fully.
         fk.referenceColumns.forEach((ref) => {
-          const edgeId = `${table.tableName}-${ref.sourceColumn}-${fk.referenceTable}`;
+          // Include the constraint and both columns so multiple constraints from the
+          // same source column to the same table get distinct (non-colliding) edge IDs.
+          const edgeId = [
+            table.tableName,
+            fk.constraintName ?? 'foreign-key',
+            ref.sourceColumn,
+            fk.referenceTable,
+            ref.referenceColumn,
+          ].join('-');
 
           if (isAuthReference) {
             // Connect to the authentication node

--- a/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
+++ b/packages/dashboard/src/features/visualizer/components/SchemaVisualizer.tsx
@@ -228,14 +228,14 @@ export function SchemaVisualizer({
       table.columns.forEach((column) => {
         if (column.foreignKey) {
           const targetTable = column.foreignKey.referenceTable;
-          const targetColumn = column.foreignKey.referenceColumn;
-
-          if (!referencedColumnsByTable[targetTable]) {
-            referencedColumnsByTable[targetTable] = [];
-          }
-          if (!referencedColumnsByTable[targetTable].includes(targetColumn)) {
-            referencedColumnsByTable[targetTable].push(targetColumn);
-          }
+          column.foreignKey.referenceColumns.forEach((ref) => {
+            if (!referencedColumnsByTable[targetTable]) {
+              referencedColumnsByTable[targetTable] = [];
+            }
+            if (!referencedColumnsByTable[targetTable].includes(ref.referenceColumn)) {
+              referencedColumnsByTable[targetTable].push(ref.referenceColumn);
+            }
+          });
         }
       });
     });
@@ -268,7 +268,7 @@ export function SchemaVisualizer({
         (column) =>
           column.foreignKey &&
           column.foreignKey.referenceTable === 'auth.users' &&
-          column.foreignKey.referenceColumn === 'id'
+          column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id')
       )
     );
 
@@ -298,7 +298,7 @@ export function SchemaVisualizer({
           // Check if this is a reference to users.id
           const isAuthReference =
             column.foreignKey.referenceTable === 'auth.users' &&
-            column.foreignKey.referenceColumn === 'id';
+            column.foreignKey.referenceColumns.some((r) => r.referenceColumn === 'id');
 
           const edgeId = `${table.tableName}-${column.columnName}-${column.foreignKey.referenceTable}`;
 
@@ -319,13 +319,14 @@ export function SchemaVisualizer({
               },
             });
           } else {
-            // Regular table-to-table edge
+            // Regular table-to-table edge — use first reference column for handle
+            const firstRefCol = column.foreignKey.referenceColumns[0]?.referenceColumn || '';
             edges.push({
               id: edgeId,
               source: table.tableName,
               target: column.foreignKey.referenceTable,
               sourceHandle: `${column.columnName}-source`,
-              targetHandle: `${column.foreignKey.referenceColumn}-target`,
+              targetHandle: `${firstRefCol}-target`,
               type: 'smoothstep',
               animated: true,
               style: { stroke: edgeColor, strokeWidth: 2, zIndex: 1000 },

--- a/packages/dashboard/src/features/visualizer/components/TableNode.tsx
+++ b/packages/dashboard/src/features/visualizer/components/TableNode.tsx
@@ -3,6 +3,7 @@ import { Database, Circle, Key, ExternalLink } from 'lucide-react';
 import { Handle, Position } from '@xyflow/react';
 import { useNavigate } from 'react-router-dom';
 import { TableSchema } from '@insforge/shared-schemas';
+import { getForeignKeyByColumn } from '#features/database/helpers';
 
 interface TableNodeProps {
   data: {
@@ -15,6 +16,8 @@ interface TableNodeProps {
 export function TableNode({ data }: TableNodeProps) {
   const navigate = useNavigate();
   const { table, referencedColumns = [], showRecordCount = true } = data;
+  // Source columns that participate in a foreign key (table-level constraints).
+  const foreignKeyColumns = getForeignKeyByColumn(table.foreignKeys);
 
   const getColumnIcon = (isReferenced: boolean = false) => {
     // If column is referenced by another table (has incoming connections)
@@ -81,7 +84,7 @@ export function TableNode({ data }: TableNodeProps) {
             className="flex items-center justify-between p-3 border-b border-[var(--alpha-8)] last:border-b-0 relative"
           >
             {/* Source handle for foreign key columns - invisible and non-interactive */}
-            {column.foreignKey && (
+            {foreignKeyColumns.has(column.columnName) && (
               <Handle
                 type="source"
                 position={Position.Right}
@@ -130,7 +133,7 @@ export function TableNode({ data }: TableNodeProps) {
                 </span>
               </div>
               {/* Show white dot with outer circle for foreign key columns, gray circle for others */}
-              {column.foreignKey ? (
+              {foreignKeyColumns.has(column.columnName) ? (
                 <div className="w-5 h-5 flex items-center justify-center relative">
                   <Circle
                     className="w-5 h-5 text-zinc-950 dark:text-white fill-none stroke-current"

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -293,23 +293,28 @@ export const adminTableRecordPrimaryKeySchema = z
     message: 'Primary key must include at least one column.',
   });
 
-// `pkKeys` is a JSON-encoded object mapping each primary-key column to its value
-// for the record being updated, e.g. {"tenant_id":"t1","item_id":"i2"}.
-export const adminTableRecordUpdateQuerySchema = z.object({
-  pkKeys: z.string().trim().min(1, 'Primary key is required'),
-});
-
-export const adminTableRecordUpdateRequestSchema = adminTableRecordSchema.refine(
+// The columns to set on update (at least one).
+export const adminTableRecordUpdateDataSchema = adminTableRecordSchema.refine(
   (record) => Object.keys(record).length > 0,
   {
     message: 'At least one field is required.',
   }
 );
 
-// `pkKeys` is a JSON-encoded array of primary-key objects, one per record to delete,
-// e.g. [{"tenant_id":"t1","item_id":"i2"},{"tenant_id":"t1","item_id":"i3"}].
-export const adminTableRecordsDeleteQuerySchema = z.object({
-  pkKeys: z.string().trim().min(1, 'At least one primary key is required'),
+// Update request body: the primary-key tuple identifying the row plus the columns
+// to set. Carried in the body (not the query string) so composite keys are
+// validated structurally, e.g. { "pkKeys": {"tenant_id":"t1","item_id":"i2"}, "data": {...} }.
+export const adminTableRecordUpdateRequestSchema = z.object({
+  pkKeys: adminTableRecordPrimaryKeySchema,
+  data: adminTableRecordUpdateDataSchema,
+});
+
+// Delete request body: one primary-key tuple per record to delete,
+// e.g. { "pkKeys": [{"tenant_id":"t1","item_id":"i2"},{"tenant_id":"t1","item_id":"i3"}] }.
+export const adminTableRecordsDeleteRequestSchema = z.object({
+  pkKeys: z
+    .array(adminTableRecordPrimaryKeySchema)
+    .min(1, 'At least one primary key is required'),
 });
 
 export const adminTableRecordResponseSchema = adminTableRecordSchema;
@@ -381,9 +386,8 @@ export type AdminTableRecordsListQuery = z.infer<typeof adminTableRecordsListQue
 export type AdminTableRecordLookupQuery = z.infer<typeof adminTableRecordLookupQuerySchema>;
 export type AdminTableRecordsCreateRequest = z.infer<typeof adminTableRecordsCreateRequestSchema>;
 export type AdminTableRecordPrimaryKey = z.infer<typeof adminTableRecordPrimaryKeySchema>;
-export type AdminTableRecordUpdateQuery = z.infer<typeof adminTableRecordUpdateQuerySchema>;
 export type AdminTableRecordUpdateRequest = z.infer<typeof adminTableRecordUpdateRequestSchema>;
-export type AdminTableRecordsDeleteQuery = z.infer<typeof adminTableRecordsDeleteQuerySchema>;
+export type AdminTableRecordsDeleteRequest = z.infer<typeof adminTableRecordsDeleteRequestSchema>;
 export type AdminTableRecordResponse = z.infer<typeof adminTableRecordResponseSchema>;
 export type AdminTableRecordLookupResponse = z.infer<typeof adminTableRecordLookupResponseSchema>;
 export type AdminTableRecordsCreateResponse = z.infer<typeof adminTableRecordsCreateResponseSchema>;

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -280,10 +280,17 @@ export const adminTableRecordsCreateRequestSchema = z
   .min(1, 'At least one record is required');
 
 // A primary-key value. Restricted to scalar types that survive a JSON round-trip
-// through the query string and that node-postgres can bind as a query parameter.
-// `null` is excluded: PK columns are NOT NULL, and `WHERE col = NULL` never matches,
-// so a null key would silently affect zero rows instead of failing loudly.
-export const adminTableRecordPkValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+// and that node-postgres can bind as a query parameter, plus `null`.
+// `null` is matched with `col IS NULL` (not `col = NULL`) by the record service,
+// so it correctly identifies rows in keyless tables whose fallback identity (all
+// columns) includes a genuinely-null column. On a real (NOT NULL) primary key a
+// null value simply matches no row, surfacing as a clear "record not found".
+export const adminTableRecordPkValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
 
 // A single record's primary key as a map of pk column name -> value.
 // Supports composite primary keys (more than one column).

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -275,10 +275,22 @@ export const adminTableRecordsListQuerySchema = z
     }
   );
 
-export const adminTableRecordLookupQuerySchema = z.object({
-  column: z.string().trim().min(1, 'Column is required'),
-  value: z.string(),
-});
+export const adminTableRecordLookupQuerySchema = z
+  .object({
+    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+  })
+  .refine(
+    (data) => {
+      const cols = Array.isArray(data.column) ? data.column : [data.column];
+      const vals = Array.isArray(data.value) ? data.value : [data.value];
+      return cols.length === vals.length;
+    },
+    {
+      message: 'column and value must have the same number of entries',
+      path: ['value'],
+    }
+  );
 
 export const adminTableRecordsCreateRequestSchema = z
   .array(adminTableRecordSchema)

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -132,16 +132,9 @@ export const exportJsonDataSchema = z.object({
           isPrimary: z.boolean().nullable(),
         })
       ),
-      foreignKeys: z.array(
-        z.object({
-          constraintName: z.string(),
-          columnName: z.string(),
-          foreignTableName: z.string(),
-          foreignColumnName: z.string(),
-          deleteRule: z.string().nullable(),
-          updateRule: z.string().nullable(),
-        })
-      ),
+      // Table-level foreign keys: one entry per constraint (composite keys list
+      // multiple column mappings), consistent with the rest of the schema model.
+      foreignKeys: z.array(foreignKeySchema),
       rlsEnabled: z.boolean().optional(),
       policies: z.array(
         z.object({

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -16,6 +16,7 @@ export const createTableRequestSchema = tableSchema
   .pick({
     tableName: true,
     columns: true,
+    foreignKeys: true,
   })
   .extend({
     rlsEnabled: z.boolean().default(true),
@@ -36,13 +37,7 @@ export const createTableResponseSchema = tableSchema
 export const getTableSchemaResponseSchema = tableSchema;
 
 export const updateTableSchemaRequestSchema = z.object({
-  addColumns: z
-    .array(
-      columnSchema.omit({
-        foreignKey: true,
-      })
-    )
-    .optional(),
+  addColumns: z.array(columnSchema).optional(),
   dropColumns: z.array(z.string()).optional(),
   updateColumns: z
     .array(
@@ -57,14 +52,9 @@ export const updateTableSchemaRequestSchema = z.object({
       })
     )
     .optional(),
-  addForeignKeys: z
-    .array(
-      z.object({
-        columnName: z.string().min(1, 'Column name is required for adding foreign key'),
-        foreignKey: foreignKeySchema,
-      })
-    )
-    .optional(),
+  // Each entry is a full foreign-key constraint (composite keys are one entry).
+  addForeignKeys: z.array(foreignKeySchema).optional(),
+  // Constraint names to drop.
   dropForeignKeys: z.array(z.string()).optional(),
   renameTable: z
     .object({

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -277,8 +277,8 @@ export const adminTableRecordsListQuerySchema = z
 
 export const adminTableRecordLookupQuerySchema = z
   .object({
-    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
-    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1))]),
+    column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
+    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
   })
   .refine(
     (data) => {

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -298,12 +298,9 @@ export const adminTableRecordsCreateRequestSchema = z
 
 // A primary-key value. Restricted to scalar types that survive a JSON round-trip
 // through the query string and that node-postgres can bind as a query parameter.
-export const adminTableRecordPkValueSchema = z.union([
-  z.string(),
-  z.number(),
-  z.boolean(),
-  z.null(),
-]);
+// `null` is excluded: PK columns are NOT NULL, and `WHERE col = NULL` never matches,
+// so a null key would silently affect zero rows instead of failing loudly.
+export const adminTableRecordPkValueSchema = z.union([z.string(), z.number(), z.boolean()]);
 
 // A single record's primary key as a map of pk column name -> value.
 // Supports composite primary keys (more than one column).

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -284,8 +284,27 @@ export const adminTableRecordsCreateRequestSchema = z
   .array(adminTableRecordSchema)
   .min(1, 'At least one record is required');
 
+// A primary-key value. Restricted to scalar types that survive a JSON round-trip
+// through the query string and that node-postgres can bind as a query parameter.
+export const adminTableRecordPkValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+// A single record's primary key as a map of pk column name -> value.
+// Supports composite primary keys (more than one column).
+export const adminTableRecordPrimaryKeySchema = z
+  .record(z.string().trim().min(1, 'Primary key column is required'), adminTableRecordPkValueSchema)
+  .refine((key) => Object.keys(key).length > 0, {
+    message: 'Primary key must include at least one column.',
+  });
+
+// `pkKeys` is a JSON-encoded object mapping each primary-key column to its value
+// for the record being updated, e.g. {"tenant_id":"t1","item_id":"i2"}.
 export const adminTableRecordUpdateQuerySchema = z.object({
-  pkColumn: z.string().trim().min(1, 'Primary key column is required'),
+  pkKeys: z.string().trim().min(1, 'Primary key is required'),
 });
 
 export const adminTableRecordUpdateRequestSchema = adminTableRecordSchema.refine(
@@ -295,9 +314,10 @@ export const adminTableRecordUpdateRequestSchema = adminTableRecordSchema.refine
   }
 );
 
+// `pkKeys` is a JSON-encoded array of primary-key objects, one per record to delete,
+// e.g. [{"tenant_id":"t1","item_id":"i2"},{"tenant_id":"t1","item_id":"i3"}].
 export const adminTableRecordsDeleteQuerySchema = z.object({
-  pkColumn: z.string().trim().min(1, 'Primary key column is required'),
-  pkValues: z.string().trim().min(1, 'At least one primary key value is required'),
+  pkKeys: z.string().trim().min(1, 'At least one primary key is required'),
 });
 
 export const adminTableRecordResponseSchema = adminTableRecordSchema;
@@ -368,6 +388,7 @@ export type AdminTableRecordsSortClause = z.infer<typeof adminTableRecordsSortCl
 export type AdminTableRecordsListQuery = z.infer<typeof adminTableRecordsListQuerySchema>;
 export type AdminTableRecordLookupQuery = z.infer<typeof adminTableRecordLookupQuerySchema>;
 export type AdminTableRecordsCreateRequest = z.infer<typeof adminTableRecordsCreateRequestSchema>;
+export type AdminTableRecordPrimaryKey = z.infer<typeof adminTableRecordPrimaryKeySchema>;
 export type AdminTableRecordUpdateQuery = z.infer<typeof adminTableRecordUpdateQuerySchema>;
 export type AdminTableRecordUpdateRequest = z.infer<typeof adminTableRecordUpdateRequestSchema>;
 export type AdminTableRecordsDeleteQuery = z.infer<typeof adminTableRecordsDeleteQuerySchema>;

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -312,9 +312,7 @@ export const adminTableRecordUpdateRequestSchema = z.object({
 // Delete request body: one primary-key tuple per record to delete,
 // e.g. { "pkKeys": [{"tenant_id":"t1","item_id":"i2"},{"tenant_id":"t1","item_id":"i3"}] }.
 export const adminTableRecordsDeleteRequestSchema = z.object({
-  pkKeys: z
-    .array(adminTableRecordPrimaryKeySchema)
-    .min(1, 'At least one primary key is required'),
+  pkKeys: z.array(adminTableRecordPrimaryKeySchema).min(1, 'At least one primary key is required'),
 });
 
 export const adminTableRecordResponseSchema = adminTableRecordSchema;

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -278,7 +278,7 @@ export const adminTableRecordsListQuerySchema = z
 export const adminTableRecordLookupQuerySchema = z
   .object({
     column: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
-    value: z.union([z.string().trim().min(1), z.array(z.string().trim().min(1)).min(1)]),
+    value: z.union([z.string(), z.array(z.string()).min(1)]),
   })
   .refine(
     (data) => {

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -11,7 +11,15 @@ export enum ColumnType {
   JSON = 'json',
 }
 
-export const onUpdateActionSchema = z.enum(['CASCADE', 'RESTRICT', 'NO ACTION']);
+// Postgres supports the same referential actions for ON UPDATE as ON DELETE;
+// introspection can return SET NULL / SET DEFAULT, so the schema must accept them.
+export const onUpdateActionSchema = z.enum([
+  'CASCADE',
+  'SET NULL',
+  'SET DEFAULT',
+  'RESTRICT',
+  'NO ACTION',
+]);
 export const onDeleteActionSchema = z.enum([
   'CASCADE',
   'SET NULL',

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -31,9 +31,14 @@ export const columnTypeSchema = z.enum([
   ColumnType.JSON,
 ]);
 
+export const foreignKeyReferenceSchema = z.object({
+  sourceColumn: z.string().min(1, 'Source column cannot be empty'),
+  referenceColumn: z.string().min(1, 'Reference column cannot be empty'),
+});
+
 export const foreignKeySchema = z.object({
   referenceTable: z.string().min(1, 'Target table cannot be empty'),
-  referenceColumn: z.string().min(1, 'Target column cannot be empty'),
+  referenceColumns: z.array(foreignKeyReferenceSchema).min(1, 'At least one column mapping is required'),
   onDelete: onDeleteActionSchema,
   onUpdate: onUpdateActionSchema,
 });
@@ -65,6 +70,7 @@ export const tableSchema = z.object({
 
 export type TableSchema = z.infer<typeof tableSchema>;
 export type ColumnSchema = z.infer<typeof columnSchema>;
+export type ForeignKeyReferenceSchema = z.infer<typeof foreignKeyReferenceSchema>;
 export type ForeignKeySchema = z.infer<typeof foreignKeySchema>;
 export type OnUpdateActionSchema = z.infer<typeof onUpdateActionSchema>;
 export type OnDeleteActionSchema = z.infer<typeof onDeleteActionSchema>;

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -38,7 +38,9 @@ export const foreignKeyReferenceSchema = z.object({
 
 export const foreignKeySchema = z.object({
   referenceTable: z.string().min(1, 'Target table cannot be empty'),
-  referenceColumns: z.array(foreignKeyReferenceSchema).min(1, 'At least one column mapping is required'),
+  referenceColumns: z
+    .array(foreignKeyReferenceSchema)
+    .min(1, 'At least one column mapping is required'),
   onDelete: onDeleteActionSchema,
   onUpdate: onUpdateActionSchema,
 });

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -36,7 +36,12 @@ export const foreignKeyReferenceSchema = z.object({
   referenceColumn: z.string().min(1, 'Reference column cannot be empty'),
 });
 
+// A foreign key is a table-level constraint: one entity per constraint, with an
+// ordered list of (source -> reference) column pairs. Composite keys are a single
+// entity with multiple pairs, never duplicated across columns.
 export const foreignKeySchema = z.object({
+  // Constraint identity. Populated when reading schema; derived by the backend on create.
+  constraintName: z.string().optional(),
   referenceTable: z.string().min(1, 'Target table cannot be empty'),
   referenceColumns: z
     .array(foreignKeyReferenceSchema)
@@ -55,7 +60,6 @@ export const columnSchema = z.object({
   isPrimaryKey: z.boolean().optional(),
   isNullable: z.boolean(),
   isUnique: z.boolean(),
-  foreignKey: foreignKeySchema.optional(),
 });
 
 export const tableSchema = z.object({
@@ -65,6 +69,8 @@ export const tableSchema = z.object({
     .min(1, 'Table name cannot be empty')
     .max(64, 'Table name must be less than 64 characters'),
   columns: z.array(columnSchema).min(1, 'At least one column is required'),
+  // Foreign keys are table-level, one entry per constraint.
+  foreignKeys: z.array(foreignKeySchema).optional(),
   recordCount: z.number().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),


### PR DESCRIPTION
## Summary

Graduates the composite-key work to `main`. This branch integrates two merged PRs plus follow-up review fixes:

- **Composite foreign keys** (1572) — backend metadata, multi-column record lookup, dashboard FK components/visualizer/templates updated for the `referenceColumns` array format.
- **Composite primary keys** (1584) — dashboard record edit/delete now identify rows by the full primary-key tuple instead of collapsing identity to the first PK column. Grid row keys, selection, updates, and deletes all carry the complete tuple; the backend matches `WHERE col1 = $a AND col2 = $b ...` for updates and OR'd AND-groups for deletes, and rejects partial/mismatched keys with a 400.

## Review follow-ups applied in this PR

Both unresolved P2 findings from 1584's review:

- **`decodeRecordKey` guards `JSON.parse`** — a stale or malformed grid row key now throws a clear `Invalid record key` error instead of an uncaught `SyntaxError` that silently crashes the update/delete handler.
- **`adminTableRecordPkValueSchema` no longer allows `null`** — PK columns are `NOT NULL` and `WHERE col = NULL` never matches, so a null key would silently affect zero rows. It's now rejected at the schema boundary so the request fails loudly.

## Migration note

The admin PATCH/DELETE record endpoints take `pkKeys` (JSON-encoded tuple / array of tuples) instead of `pkColumn`/`pkValues`/`:recordId`. This is the admin-only API; the dashboard is updated in lockstep. Direct API consumers of the admin endpoints must update.

## Testing

- Typecheck: shared-schemas, dashboard, backend (only the pre-existing unrelated `lru-cache` declaration error remains).
- Unit tests: backend `admin-record.service` (13) and composite-FK suite, dashboard `helpers` (8) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full composite primary and foreign key support across backend and dashboard. Records are identified and mutated by the full primary‑key tuple; APIs, UI, and OpenAPI are updated with strict validation and clearer edge‑case handling.

- **New Features**
  - `@insforge/shared-schemas`: add table‑level `foreignKeys[]` with ordered `referenceColumns[]` and optional `constraintName`; accept `SET NULL`/`SET DEFAULT` for `onUpdate`; enforce non‑empty lookup arrays with `.min(1)`; `createTableRequest` includes `foreignKeys[]`.
  - Backend: `createTable` accepts `foreignKeys[]` and rejects FKs on system columns; introspection/export use a unified query and return one FK per constraint with ordered column pairs; constraint names are hashed/truncated for Postgres’s 63‑byte limit; `lookupRecord` supports multi‑column queries via parallel `columns[]`/`values[]`; updates/deletes enforce exact full‑PK matches; dropping unknown FK constraints returns 404; read paths skip PK‑metadata queries.
  - Dashboard: grid row identity, edits, and deletes use encoded PK tuples; FK UI resolves composite references, preserves falsy values, and writes `null` for cleared composite parts; `TableForm` manages table‑level FKs with stable IDs and preserves `isPrimaryKey`; `SchemaVisualizer` links by `referenceColumns` and keeps multiple edges distinct; helpers add encode/decode PK, validate decoded `pkKeys`, and fall back to all columns for row identity when no PK/`id` is present. Templates and tests updated. OpenAPI reflects the new shapes.

- **Migration**
  - Admin record PATCH/DELETE require `pkKeys` (JSON tuple or array of tuples). `:recordId` and `pkColumn`/`pkValues` are removed.
  - Column‑level `foreignKey` is removed. Use table‑level `foreignKeys[]` with `referenceColumns: [{ sourceColumn, referenceColumn }]`. `createTable` now includes `foreignKeys[]`. `updateTableSchema` uses `addForeignKeys[]` (entities) and `dropForeignKeys[]` (by `constraintName`). Update any API consumers, seeds, and templates.

<sup>Written for commit 87ff753ff35ebe528a75cdef5e394daeac51cd1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add composite primary and foreign key support to database table management
> - Refactors foreign keys from per-column properties to table-level constraints throughout the stack, with a new `foreignKeySchema` carrying a `referenceColumns` array of `{sourceColumn, referenceColumn}` mappings.
> - Updates `AdminRecordService` methods (`updateRecord`, `deleteRecords`, `lookupRecord`) to accept composite primary key objects instead of single `pkColumn`/`pkValue` pairs, with full validation against actual table PKs.
> - Updates `DatabaseTableService` (`getFkeyConstraints`, `generateFkeyConstraintStatement`) to discover and emit multi-column FK constraints via `pg_catalog`, with length-safe constraint names using a SHA-256 hash suffix.
> - Updates all dashboard UI components (`TablesPage`, `RecordFormField`, `LinkRecordDialog`, `ForeignKeyCell`, `ForeignKeyPopover`, `TableForm`) to use encoded composite PK tuples for row identity and composite FK metadata for linking records.
> - Migrates all database template files (`ai-chatbot`, `crm-system`, `ecommerce-platform`, etc.) and `SchemaVisualizer` to use table-level `foreignKeys` arrays.
> - Risk: API shape changes are breaking — `PATCH`/`DELETE` record routes now use `pkKeys` (JSON-encoded PK objects) instead of `pkColumn`/`pkValues`/`:recordId`; callers must update accordingly.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1587 opened
>
> - Converted foreign key representation from per-column rows to table-level composite constraints with ordered column mappings [86f6d29]
> - Fixed foreign key field handling to preserve NULL values instead of coercing to empty strings for non-string columns [86f6d29]
> - Implemented composite primary key support for record identity and validation [86f6d29]
> - Implemented stable UID-based tracking for foreign key constraints in table editor to support multiple constraints on the same source column [86f6d29]
> - Added backend validation to prevent foreign keys on system columns and enforce constraint existence when dropping [86f6d29]
> - Included primary key flags in table creation API payload [86f6d29]
> - Moved primary key identification from query parameters to request body for table record update and delete operations [c24ce0b]
> - Fixed ordinal position data type in foreign key metadata queries [c24ce0b]
> - Modified primary key handling in frontend helpers to use empty strings instead of null values [c24ce0b]
> - Updated type references and imports for primary key handling [c24ce0b]
> - Reformatted code in primary key handling logic [c684138]
> - Added null value support for composite primary and foreign key components across the database admin API [87ff753]
> - Consolidated foreign key introspection queries into shared constants and helper functions [87ff753]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd624ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added composite primary key support across table records, editing, bulk actions, and record linking.
  * Added table-level foreign key support (including composite FK mappings) for schema creation, updates, and visualizations.
* **Bug Fixes**
  * Improved admin record lookup/update/delete to target exact composite-key rows.
  * Foreign key modeling now preserves correct source/reference column ordering and referential actions.
* **Documentation / API Changes**
  * Updated tables API and shared contracts: foreign keys are now table constraints, and record update/delete now use structured primary-key payloads (`pkKeys`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->