### PR TITLE
fix(backend): do not start server on import of server.ts

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -382,7 +382,8 @@ async function cleanup() {
 // (e.g. by tests that build the app via createApp()). Importing this module
 // previously bound the port and started realtime/seed logic as a side effect.
 // Fixes #1299.
-const isMainModule = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isMainModule =
+  !!process.argv[1] && import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href;
 
 if (isMainModule) {
   void initializeServer();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import fs from 'fs';
 import authRouter from '@/api/routes/auth/index.routes.js';
 import databaseRouter from '@/api/routes/database/index.routes.js';
@@ -336,8 +336,6 @@ async function initializeServer() {
   }
 }
 
-void initializeServer();
-
 async function cleanup() {
   logger.info('Shutting down gracefully...');
 
@@ -379,5 +377,15 @@ async function cleanup() {
   process.exit(0);
 }
 
-process.on('SIGINT', () => void cleanup());
-process.on('SIGTERM', () => void cleanup());
+// Only start the HTTP server and register process-level handlers when this
+// file is run directly (e.g. `node dist/server.js`), NOT when it is imported
+// (e.g. by tests that build the app via createApp()). Importing this module
+// previously bound the port and started realtime/seed logic as a side effect.
+// Fixes #1299.
+const isMainModule = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
+  void initializeServer();
+  process.on('SIGINT', () => void cleanup());
+  process.on('SIGTERM', () => void cleanup());
+}


### PR DESCRIPTION
## What
Importing `backend/src/server.ts` had a side effect: it called `void initializeServer()` at the top level (and registered SIGINT/SIGTERM handlers), so any import bound the port, started realtime/socket/seed logic, and kept the process alive. This made the backend entrypoint hard to test, reuse, and reason about.

## Fix
Guard server startup and the process-level handlers behind an ESM main-module check (`import.meta.url === pathToFileURL(process.argv[1]).href`) so they only run when the file is executed directly (`node dist/server.js`), not when imported. The exported `createApp()` is now safely importable for tests and tooling. App construction and process startup are now separated, as requested in the issue.

## Testing
- `npm run typecheck` - passes
- `npm run lint` - passes
- `npm test -- tests/unit/records-auth.test.ts` - 6/6 pass

Note: `tests/unit/records-auth.test.ts` currently defines its own local `createApp()` because the real one could not be imported without booting the server. This change unblocks importing the real `createApp()` in tests.

Closes #1299

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop starting the backend server when `backend/src/server.ts` is imported. Startup and signal handlers run only when the file is executed directly. Fixes #1299.

- **Bug Fixes**
  - Added an ESM main-module guard using `import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href` to run `initializeServer()` and register SIGINT/SIGTERM only when executed directly.
  - Canonicalized `process.argv[1]` with `fs.realpathSync` so the check works with symlinked entrypoints (e.g., npm/pnpm bin links).

<sup>Written for commit 80f395a445bd477ecbc8853cc2780ca279d0fbba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `server.ts` to not start the HTTP server on import
> Previously, importing [server.ts](https://github.com/InsForge/InsForge/pull/1588/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa) would immediately invoke `initializeServer()` and register `SIGINT`/`SIGTERM` handlers as a side effect. Now, server startup and signal handler registration only occur when the module is run as the main entrypoint, detected by comparing `import.meta.url` to the file URL of `process.argv[1]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80f395a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the server from starting automatically when the module is imported, avoiding unintended side effects during testing and other imports.
  * Ensured startup and shutdown signal handling run only when the server is launched directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->