### PR TITLE
Label telemetry runtime environments

### DIFF
--- a/backend/src/services/telemetry/telemetry.service.ts
+++ b/backend/src/services/telemetry/telemetry.service.ts
@@ -9,6 +9,7 @@ import logger from '@/utils/logger.js';
 import packageJson from '../../../../package.json';
 
 export type TelemetryEventName = 'instance_started' | 'heartbeat';
+type TelemetryRuntimeEnvironment = 'production' | 'development' | 'test' | 'ci' | 'unknown';
 
 export interface TelemetryConfig {
   disabled: boolean;
@@ -35,6 +36,7 @@ interface PostHogTelemetryEvent {
     platform: NodeJS.Platform;
     arch: string;
     node_version: string;
+    runtime_environment: TelemetryRuntimeEnvironment;
     is_ci: boolean;
     storage_backend: 'local' | 's3' | 's3-compatible';
     features: {
@@ -64,21 +66,28 @@ function isCiEnvironment(): boolean {
   return CI_ENV_KEYS.some((key) => !!process.env[key]);
 }
 
-function isDevelopmentLikeRuntime(): boolean {
-  return (
+function detectRuntimeEnvironment(): TelemetryRuntimeEnvironment {
+  if (isCiEnvironment()) {
+    return 'ci';
+  }
+
+  if (
+    process.env.NODE_ENV === 'production' ||
     process.env.NODE_ENV === 'development' ||
-    process.env.NODE_ENV === 'test' ||
-    process.env.npm_lifecycle_event === 'dev'
-  );
+    process.env.NODE_ENV === 'test'
+  ) {
+    return process.env.NODE_ENV;
+  }
+
+  if (process.env.npm_lifecycle_event === 'dev') {
+    return 'development';
+  }
+
+  return 'unknown';
 }
 
 function isTelemetryRuntimeDisabled(): boolean {
-  return (
-    appConfig.telemetry.disabled ||
-    isCloudEnvironment() ||
-    isCiEnvironment() ||
-    isDevelopmentLikeRuntime()
-  );
+  return appConfig.telemetry.disabled || isCloudEnvironment();
 }
 
 function defaultTelemetryConfig(): TelemetryConfig {
@@ -234,6 +243,7 @@ export class TelemetryService {
         platform: os.platform(),
         arch: os.arch(),
         node_version: process.version,
+        runtime_environment: detectRuntimeEnvironment(),
         is_ci: isCiEnvironment(),
         storage_backend: detectStorageBackend(),
         features: {

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -9,6 +9,7 @@ import logger from '../../src/utils/logger';
 type FetchFunction = ConstructorParameters<typeof TelemetryService>[1];
 
 const tempRoots: string[] = [];
+const ciEnvKeys = ['CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'BUILDKITE', 'CIRCLECI', 'JENKINS_URL'];
 let savedEnv: NodeJS.ProcessEnv;
 
 beforeEach(() => {
@@ -112,22 +113,40 @@ describe('TelemetryService', () => {
     ]);
   });
 
-  it('does not send telemetry in CI by default', async () => {
+  it('marks CI telemetry with the CI runtime environment', async () => {
     process.env.CI = 'true';
+    const config = makeConfig();
     const fetchMock = makeFetchMock();
 
-    await new TelemetryService(undefined, fetchMock).sendEvent('instance_started');
+    await new TelemetryService(config, fetchMock).sendEvent('instance_started');
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    const body = getPostedBody(fetchMock);
+    expect(body.properties).toEqual(
+      expect.objectContaining({
+        runtime_environment: 'ci',
+        is_ci: true,
+      })
+    );
   });
 
-  it('does not send telemetry in local development by default', async () => {
+  it('marks local development telemetry with the development runtime environment', async () => {
+    for (const key of ciEnvKeys) {
+      delete process.env[key];
+    }
+    delete process.env.NODE_ENV;
     process.env.npm_lifecycle_event = 'dev';
+    const config = makeConfig();
     const fetchMock = makeFetchMock();
 
-    await new TelemetryService(undefined, fetchMock).sendEvent('instance_started');
+    await new TelemetryService(config, fetchMock).sendEvent('instance_started');
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    const body = getPostedBody(fetchMock);
+    expect(body.properties).toEqual(
+      expect.objectContaining({
+        runtime_environment: 'development',
+        is_ci: false,
+      })
+    );
   });
 
   it('starts once, schedules heartbeats, and stops the heartbeat timer', async () => {
@@ -198,6 +217,7 @@ describe('TelemetryService', () => {
         platform: process.platform,
         arch: process.arch,
         node_version: process.version,
+        runtime_environment: expect.stringMatching(/^(production|development|test|ci|unknown)$/),
         is_ci: expect.any(Boolean),
         storage_backend: expect.stringMatching(/^(local|s3|s3-compatible)$/),
         features: {

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -44,6 +44,15 @@ function makeFetchMock(status = 204): FetchFunction {
   return vi.fn(async () => new Response(null, { status })) as FetchFunction;
 }
 
+function clearRuntimeEnvironment(): void {
+  for (const key of ciEnvKeys) {
+    delete process.env[key];
+  }
+
+  delete process.env.NODE_ENV;
+  delete process.env.npm_lifecycle_event;
+}
+
 function getPostedBody(fetchMock: FetchFunction, callIndex = 0): Record<string, unknown> {
   const call = vi.mocked(fetchMock).mock.calls[callIndex];
   expect(call).toBeDefined();
@@ -130,10 +139,7 @@ describe('TelemetryService', () => {
   });
 
   it('marks local development telemetry with the development runtime environment', async () => {
-    for (const key of ciEnvKeys) {
-      delete process.env[key];
-    }
-    delete process.env.NODE_ENV;
+    clearRuntimeEnvironment();
     process.env.npm_lifecycle_event = 'dev';
     const config = makeConfig();
     const fetchMock = makeFetchMock();
@@ -148,6 +154,60 @@ describe('TelemetryService', () => {
       })
     );
   });
+
+  it.each([
+    {
+      name: 'CI takes precedence over NODE_ENV',
+      setup: () => {
+        clearRuntimeEnvironment();
+        process.env.CI = 'true';
+        process.env.NODE_ENV = 'test';
+      },
+      expectedRuntimeEnvironment: 'ci',
+      expectedIsCi: true,
+    },
+    {
+      name: 'production NODE_ENV',
+      setup: () => {
+        clearRuntimeEnvironment();
+        process.env.NODE_ENV = 'production';
+      },
+      expectedRuntimeEnvironment: 'production',
+      expectedIsCi: false,
+    },
+    {
+      name: 'test NODE_ENV',
+      setup: () => {
+        clearRuntimeEnvironment();
+        process.env.NODE_ENV = 'test';
+      },
+      expectedRuntimeEnvironment: 'test',
+      expectedIsCi: false,
+    },
+    {
+      name: 'unknown runtime',
+      setup: clearRuntimeEnvironment,
+      expectedRuntimeEnvironment: 'unknown',
+      expectedIsCi: false,
+    },
+  ])(
+    'marks telemetry with the $name runtime environment',
+    async ({ setup, expectedRuntimeEnvironment, expectedIsCi }) => {
+      setup();
+      const config = makeConfig();
+      const fetchMock = makeFetchMock();
+
+      await new TelemetryService(config, fetchMock).sendEvent('instance_started');
+
+      const body = getPostedBody(fetchMock);
+      expect(body.properties).toEqual(
+        expect.objectContaining({
+          runtime_environment: expectedRuntimeEnvironment,
+          is_ci: expectedIsCi,
+        })
+      );
+    }
+  );
 
   it('starts once, schedules heartbeats, and stops the heartbeat timer', async () => {
     vi.useFakeTimers();

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -176,6 +176,15 @@ describe('TelemetryService', () => {
       expectedIsCi: false,
     },
     {
+      name: 'development NODE_ENV',
+      setup: () => {
+        clearRuntimeEnvironment();
+        process.env.NODE_ENV = 'development';
+      },
+      expectedRuntimeEnvironment: 'development',
+      expectedIsCi: false,
+    },
+    {
       name: 'test NODE_ENV',
       setup: () => {
         clearRuntimeEnvironment();

--- a/docs/deployment/telemetry.mdx
+++ b/docs/deployment/telemetry.mdx
@@ -7,7 +7,7 @@ InsForge collects anonymous telemetry from self-hosted deployments to understand
 
 Telemetry is optional. You can disable it at any time.
 InsForge does not send this telemetry from InsForge Cloud.
-Self-hosted events include a coarse runtime label, such as production, development, test, CI, or unknown, so maintainers can separate local and automated runs from production deployments.
+Self-hosted events include a coarse runtime label, such as production, development, test, ci, or unknown, so maintainers can separate local and automated runs from production deployments.
 
 ## What InsForge sends
 

--- a/docs/deployment/telemetry.mdx
+++ b/docs/deployment/telemetry.mdx
@@ -7,7 +7,7 @@ InsForge collects anonymous telemetry from self-hosted deployments to understand
 
 Telemetry is optional. You can disable it at any time.
 InsForge does not send this telemetry from InsForge Cloud.
-Local development and CI runs are labeled in the event payload so maintainers can separate them from production deployments.
+Self-hosted events include a coarse runtime label, such as production, development, test, CI, or unknown, so maintainers can separate local and automated runs from production deployments.
 
 ## What InsForge sends
 

--- a/docs/deployment/telemetry.mdx
+++ b/docs/deployment/telemetry.mdx
@@ -6,7 +6,8 @@ description: "Understand and control InsForge self-host telemetry."
 InsForge collects anonymous telemetry from self-hosted deployments to understand active installs, version adoption, deployment methods, and which optional services are configured. This helps maintainers prioritize fixes, security notices, and deployment work for the open-source project.
 
 Telemetry is optional. You can disable it at any time.
-InsForge does not send this telemetry from InsForge Cloud, local development runs, or CI environments.
+InsForge does not send this telemetry from InsForge Cloud.
+Local development and CI runs are labeled in the event payload so maintainers can separate them from production deployments.
 
 ## What InsForge sends
 
@@ -21,7 +22,7 @@ Each event contains:
 - Event timestamp
 - Hosting mode, such as `self-hosted` or `cloud`
 - Coarse deployment method, such as Docker Compose, Railway, Zeabur, Sealos, Dokploy, Kubernetes, or unknown
-- Operating system, CPU architecture, Node.js version, and whether the process appears to be running in CI
+- Operating system, CPU architecture, Node.js version, runtime environment, and whether the process appears to be running in CI
 - Storage backend category: local filesystem, S3, or S3-compatible
 - Boolean flags for whether optional features are configured: site deployments, functions, compute, and OpenRouter
 


### PR DESCRIPTION
## Summary
- Keep telemetry enabled for self-hosted development and CI runs, while continuing to exclude InsForge Cloud.
- Add a coarse `runtime_environment` property (`production`, `development`, `test`, `ci`, or `unknown`) so telemetry can be segmented without sending raw env var values.
- Update telemetry docs to clarify that local development and CI events are labeled rather than suppressed.

## Validation
- `cd backend && npm test -- --run tests/unit/telemetry.service.test.ts tests/unit/app.config.test.ts`
- `npm run format:check`
- `npx turbo run typecheck`
- `npx turbo run lint`
- `cd backend && npm run build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Label telemetry events with runtime environment and send from CI and local development
> - Replaces the `isDevelopmentLikeRuntime` helper with `detectRuntimeEnvironment` in [telemetry.service.ts](https://github.com/InsForge/InsForge/pull/1592/files#diff-f9329a4b707337bd20a9665dd4b73673fe37f468ccad02ed830988ef5a15254a), which classifies the runtime as `'production'`, `'development'`, `'test'`, `'ci'`, or `'unknown'`.
> - Adds `runtime_environment` to every telemetry event payload so events can be filtered by environment in PostHog.
> - Removes CI and local development from the list of runtimes where telemetry is suppressed; telemetry is now only disabled when explicitly configured or running in InsForge Cloud.
> - Behavioral Change: telemetry events are now sent from CI pipelines and local development runs, labeled with the appropriate `runtime_environment` value.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1592 opened
>
> - Added `clearRuntimeEnvironment` utility function and updated `TelemetryService` tests to validate runtime environment labeling across multiple scenarios [52f95f8]
> - Updated telemetry documentation to describe runtime environment labeling [52f95f8]
> - Added test case for `development` runtime environment detection in `TelemetryService` and updated runtime environment label casing from uppercase to lowercase [39300cf]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b88692f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry events now include an explicit runtime environment label (production, development, test, ci, or unknown), along with an `is_ci` indicator.
* **Bug Fixes**
  * Telemetry is no longer disabled automatically for CI or development-like runs; it now follows the configured disablement setting and cloud-only behavior.
* **Documentation**
  * Updated telemetry documentation to clarify when telemetry is sent and which runtime details are included.
* **Tests**
  * Added/updated unit tests to verify correct runtime environment tagging across common and edge-case environment setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->