### PR TITLE
feat(security): Support JWKS-verifiable RS256 login tokens with HS256 fallback

### DIFF
--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -88,7 +88,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
         ? await proxyService.forwardAsAdmin(proxyRequest)
         : req.user?.role === 'anon'
           ? await proxyService.forwardAsAnon(proxyRequest)
-          : await proxyService.forward(proxyRequest);
+          : await proxyService.forwardAsUser(proxyRequest, req.user!);
 
     // Forward response headers
     const headers = PostgrestProxyService.filterHeaders(result.headers);

--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -86,9 +86,9 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     const result =
       req.user?.role === 'project_admin' || req.hasApiKey === true
         ? await proxyService.forwardAsAdmin(proxyRequest)
-        : req.user?.role === 'anon'
-          ? await proxyService.forwardAsAnon(proxyRequest)
-          : await proxyService.forwardAsUser(proxyRequest, req.user!);
+        : req.user
+          ? await proxyService.forwardAsUser(proxyRequest, req.user)
+          : await proxyService.forwardAsAnon(proxyRequest);
 
     // Forward response headers
     const headers = PostgrestProxyService.filterHeaders(result.headers);

--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -100,7 +100,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     const result =
       req.user?.role === 'project_admin' || req.hasApiKey === true
         ? await proxyService.forwardAsAdmin(proxyRequest)
-        : req.user
+        : req.user && req.user.role !== 'anon'
           ? await proxyService.forwardAsUser(proxyRequest, req.user)
           : await proxyService.forwardAsAnon(proxyRequest);
 

--- a/backend/src/api/routes/database/rpc.routes.ts
+++ b/backend/src/api/routes/database/rpc.routes.ts
@@ -51,7 +51,7 @@ const forwardRpcToPostgrest = async (req: AuthRequest, res: Response, next: Next
         ? await proxyService.forwardAsAdmin(proxyRequest)
         : req.user?.role === 'anon'
           ? await proxyService.forwardAsAnon(proxyRequest)
-          : await proxyService.forward(proxyRequest);
+          : await proxyService.forwardAsUser(proxyRequest, req.user!);
 
     const headers = PostgrestProxyService.filterHeaders(result.headers);
     Object.entries(headers).forEach(([key, value]) => res.setHeader(key, value));

--- a/backend/src/api/routes/database/rpc.routes.ts
+++ b/backend/src/api/routes/database/rpc.routes.ts
@@ -49,9 +49,9 @@ const forwardRpcToPostgrest = async (req: AuthRequest, res: Response, next: Next
     const result =
       req.user?.role === 'project_admin' || req.hasApiKey === true
         ? await proxyService.forwardAsAdmin(proxyRequest)
-        : req.user?.role === 'anon'
-          ? await proxyService.forwardAsAnon(proxyRequest)
-          : await proxyService.forwardAsUser(proxyRequest, req.user!);
+        : req.user
+          ? await proxyService.forwardAsUser(proxyRequest, req.user)
+          : await proxyService.forwardAsAnon(proxyRequest);
 
     const headers = PostgrestProxyService.filterHeaders(result.headers);
     Object.entries(headers).forEach(([key, value]) => res.setHeader(key, value));

--- a/backend/src/api/routes/database/rpc.routes.ts
+++ b/backend/src/api/routes/database/rpc.routes.ts
@@ -60,7 +60,7 @@ const forwardRpcToPostgrest = async (req: AuthRequest, res: Response, next: Next
     const result =
       req.user?.role === 'project_admin' || req.hasApiKey === true
         ? await proxyService.forwardAsAdmin(proxyRequest)
-        : req.user
+        : req.user && req.user.role !== 'anon'
           ? await proxyService.forwardAsUser(proxyRequest, req.user)
           : await proxyService.forwardAsAnon(proxyRequest);
 

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -45,6 +45,11 @@ const JWKS = createRemoteJWKSet(new URL(`${cloudApiHost}/.well-known/jwks.json`)
  */
 export class TokenManager {
   private static instance: TokenManager;
+  private privateKey: string | null = null;
+  private publicKey: string | null = null;
+  private kid: string | null = null;
+  private isLoaded = false;
+  private loadPromise: Promise<void> | null = null;
 
   private constructor() {
     if (!appConfig.app.jwtSecret) {
@@ -60,12 +65,101 @@ export class TokenManager {
   }
 
   /**
+   * Preload JWT asymmetric keys from the database.
+   */
+  async ensureKeysLoaded(): Promise<void> {
+    if (this.isLoaded) return;
+    if (this.loadPromise) return this.loadPromise;
+
+    this.loadPromise = (async () => {
+      try {
+        const { SecretService } = await import('../../services/secrets/secret.service.js');
+        const secretService = SecretService.getInstance();
+        const [priv, pub, kidVal] = await Promise.all([
+          secretService.getSecretByKey('JWT_PRIVATE_KEY'),
+          secretService.getSecretByKey('JWT_PUBLIC_KEY'),
+          secretService.getSecretByKey('JWT_KEY_ID'),
+        ]);
+
+        if (priv && pub && kidVal) {
+          this.privateKey = priv;
+          this.publicKey = pub;
+          this.kid = kidVal;
+          this.isLoaded = true;
+        } else {
+          // If keys do not exist yet (e.g. very early startup), initialize them
+          const keys = await secretService.initializeJwtKeyPair();
+          this.privateKey = keys.privateKey;
+          this.publicKey = keys.publicKey;
+          this.kid = keys.kid;
+          this.isLoaded = true;
+        }
+      } catch (error) {
+        // Do not throw on startup if db isn't fully ready; fallback to HS256
+        const log = await import('../../utils/logger.js');
+        log.default.error('Failed to load JWT asymmetric keys in TokenManager', { error });
+      }
+    })().finally(() => {
+      this.loadPromise = null;
+    });
+
+    return this.loadPromise;
+  }
+
+  /**
+   * Export the public key as a JWK Set (JWKS).
+   */
+  async getJwks(): Promise<{ keys: any[] }> {
+    await this.ensureKeysLoaded();
+    if (!this.publicKey || !this.kid) {
+      return { keys: [] };
+    }
+
+    try {
+      const pubKeyObject = crypto.createPublicKey(this.publicKey);
+      const jwk = pubKeyObject.export({ format: 'jwk' });
+      return {
+        keys: [
+          {
+            ...jwk,
+            alg: 'RS256',
+            use: 'sig',
+            kid: this.kid,
+          },
+        ],
+      };
+    } catch (error) {
+      const log = await import('../../utils/logger.js');
+      log.default.error('Failed to export public key as JWK', { error });
+      return { keys: [] };
+    }
+  }
+
+  /**
    * Generate JWT access token
    */
   generateAccessToken(payload: TokenPayloadSchema): string {
+    if (this.privateKey && this.kid) {
+      return jwt.sign(payload, this.privateKey, {
+        algorithm: 'RS256',
+        keyid: this.kid,
+        expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+      });
+    }
     return jwt.sign(payload, JWT_SECRET, {
       algorithm: 'HS256',
       expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    });
+  }
+
+  /**
+   * Generate PostgREST user token (HS256)
+   * Used for forwarding authenticated user requests to PostgREST
+   */
+  generatePostgrestUserToken(payload: TokenPayloadSchema): string {
+    return jwt.sign(payload, JWT_SECRET, {
+      algorithm: 'HS256',
+      expiresIn: '5m', // short-lived since it's only for this request forwarding
     });
   }
 
@@ -173,7 +267,32 @@ export class TokenManager {
    */
   verifyToken(token: string): TokenPayloadSchema {
     try {
-      const decoded = jwt.verify(token, JWT_SECRET) as TokenPayloadSchema;
+      const decodedToken = jwt.decode(token, { complete: true });
+      if (decodedToken && typeof decodedToken === 'object' && decodedToken.header) {
+        const header = decodedToken.header;
+        if (header.kid && header.alg === 'RS256' && this.publicKey && header.kid === this.kid) {
+          try {
+            const decoded = jwt.verify(token, this.publicKey, {
+              algorithms: ['RS256'],
+            }) as TokenPayloadSchema;
+            if (!decoded.sub) {
+              throw new AppError('Invalid token subject', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+            }
+            return {
+              sub: decoded.sub,
+              email: decoded.email,
+              role: decoded.role || 'authenticated',
+            };
+          } catch (err) {
+            throw err;
+          }
+        }
+      }
+
+      // Fallback to HS256
+      const decoded = jwt.verify(token, JWT_SECRET, {
+        algorithms: ['HS256'],
+      }) as TokenPayloadSchema;
       if (!decoded.sub) {
         throw new AppError('Invalid token subject', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
       }
@@ -182,7 +301,10 @@ export class TokenManager {
         email: decoded.email,
         role: decoded.role || 'authenticated',
       };
-    } catch {
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
       throw new AppError('Invalid token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }
   }

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -68,8 +68,12 @@ export class TokenManager {
    * Preload JWT asymmetric keys from the database.
    */
   async ensureKeysLoaded(): Promise<void> {
-    if (this.isLoaded) return;
-    if (this.loadPromise) return this.loadPromise;
+    if (this.isLoaded) {
+      return;
+    }
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
 
     this.loadPromise = (async () => {
       try {
@@ -109,7 +113,7 @@ export class TokenManager {
   /**
    * Export the public key as a JWK Set (JWKS).
    */
-  async getJwks(): Promise<{ keys: any[] }> {
+  async getJwks(): Promise<{ keys: Record<string, unknown>[] }> {
     await this.ensureKeysLoaded();
     if (!this.publicKey || !this.kid) {
       return { keys: [] };
@@ -271,21 +275,17 @@ export class TokenManager {
       if (decodedToken && typeof decodedToken === 'object' && decodedToken.header) {
         const header = decodedToken.header;
         if (header.kid && header.alg === 'RS256' && this.publicKey && header.kid === this.kid) {
-          try {
-            const decoded = jwt.verify(token, this.publicKey, {
-              algorithms: ['RS256'],
-            }) as TokenPayloadSchema;
-            if (!decoded.sub) {
-              throw new AppError('Invalid token subject', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
-            }
-            return {
-              sub: decoded.sub,
-              email: decoded.email,
-              role: decoded.role || 'authenticated',
-            };
-          } catch (err) {
-            throw err;
+          const decoded = jwt.verify(token, this.publicKey, {
+            algorithms: ['RS256'],
+          }) as TokenPayloadSchema;
+          if (!decoded.sub) {
+            throw new AppError('Invalid token subject', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
           }
+          return {
+            sub: decoded.sub,
+            email: decoded.email,
+            role: decoded.role || 'authenticated',
+          };
         }
       }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -42,6 +42,7 @@ import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
 import { appConfig } from '@/infra/config/app.config.js';
 import { TelemetryService } from '@/services/telemetry/telemetry.service.js';
+import { TokenManager } from '@/infra/security/token.manager.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -174,6 +175,19 @@ export async function createApp() {
 
   // Create API router and mount all API routes under /api
   const apiRouter = express.Router();
+
+  const jwksHandler = async (_req: Request, res: Response) => {
+    try {
+      const jwks = await TokenManager.getInstance().getJwks();
+      res.json(jwks);
+    } catch (error) {
+      logger.error('Failed to serve JWKS', { error });
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
+  };
+
+  app.get('/.well-known/jwks.json', jwksHandler);
+  apiRouter.get('/.well-known/jwks.json', jwksHandler);
 
   apiRouter.get('/health', (_req: Request, res: Response) => {
     const version = packageJson.version;

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -140,7 +140,7 @@ export class PostgrestProxyService {
     const userToken = this.tokenManager.generatePostgrestUserToken({
       sub: user.id,
       email: user.email,
-      role: user.role as any,
+      role: user.role as 'authenticated' | 'project_admin' | 'anon',
     });
 
     return this.forwardRequest({

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -129,6 +129,30 @@ export class PostgrestProxyService {
   }
 
   /**
+   * Gateway exchange for authenticated users: verify the user's token in the
+   * app layer, and swap it for a short-lived internal HS256 token containing the
+   * user's claims to forward to PostgREST.
+   */
+  async forwardAsUser(
+    request: ProxyRequest,
+    user: { id: string; email?: string; role: string }
+  ): Promise<ProxyResponse> {
+    const userToken = this.tokenManager.generatePostgrestUserToken({
+      sub: user.id,
+      email: user.email,
+      role: user.role as any,
+    });
+
+    return this.forwardRequest({
+      ...request,
+      headers: {
+        ...request.headers,
+        authorization: `Bearer ${userToken}`,
+      },
+    });
+  }
+
+  /**
    * Forward request to PostgREST with retry logic
    */
   private async forwardRequest(request: ProxyRequest): Promise<ProxyResponse> {

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -4,6 +4,8 @@ import https from 'https';
 import { TokenManager } from '@/infra/security/token.manager.js';
 import logger from '@/utils/logger.js';
 import { appConfig } from '@/infra/config/app.config.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
 
 const postgrestUrl = appConfig.database.postgrestBaseUrl;
 
@@ -137,10 +139,14 @@ export class PostgrestProxyService {
     request: ProxyRequest,
     user: { id: string; email?: string; role: string }
   ): Promise<ProxyResponse> {
+    if (user.role !== 'authenticated' && user.role !== 'project_admin' && user.role !== 'anon') {
+      throw new AppError('Invalid user role claim', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+
     const userToken = this.tokenManager.generatePostgrestUserToken({
       sub: user.id,
       email: user.email,
-      role: user.role as 'authenticated' | 'project_admin' | 'anon',
+      role: user.role,
     });
 
     return this.forwardRequest({

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -139,14 +139,14 @@ export class PostgrestProxyService {
     request: ProxyRequest,
     user: { id: string; email?: string; role: string }
   ): Promise<ProxyResponse> {
-    if (user.role !== 'authenticated' && user.role !== 'project_admin' && user.role !== 'anon') {
+    if (user.role !== 'authenticated' && user.role !== 'project_admin') {
       throw new AppError('Invalid user role claim', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
     }
 
     const userToken = this.tokenManager.generatePostgrestUserToken({
       sub: user.id,
       email: user.email,
-      role: user.role,
+      role: user.role as 'authenticated' | 'project_admin',
     });
 
     return this.forwardRequest({

--- a/backend/src/services/secrets/secret.service.ts
+++ b/backend/src/services/secrets/secret.service.ts
@@ -798,4 +798,94 @@ export class SecretService {
 
     return apiKey;
   }
+
+  /**
+   * Initialize JWT asymmetric keypair on startup.
+   */
+  async initializeJwtKeyPair(): Promise<{ privateKey: string; publicKey: string; kid: string }> {
+    const [existingPrivateKey, existingPublicKey, existingKid] = await Promise.all([
+      this.getSecretByKey('JWT_PRIVATE_KEY'),
+      this.getSecretByKey('JWT_PUBLIC_KEY'),
+      this.getSecretByKey('JWT_KEY_ID'),
+    ]);
+
+    if (existingPrivateKey && existingPublicKey && existingKid) {
+      logger.info('✅ JWT asymmetric keypair exists in database');
+      return {
+        privateKey: existingPrivateKey,
+        publicKey: existingPublicKey,
+        kid: existingKid,
+      };
+    }
+
+    // Generate new RSA-2048 keypair
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem',
+      },
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+      },
+    });
+
+    const kid = 'kid_' + crypto.randomBytes(16).toString('hex');
+
+    const client = await this.getPool().connect();
+    try {
+      await client.query('BEGIN');
+
+      // Check one more time inside transaction to prevent race conditions
+      const checkRes = await client.query(
+        "SELECT key FROM system.secrets WHERE key IN ('JWT_PRIVATE_KEY', 'JWT_PUBLIC_KEY', 'JWT_KEY_ID') FOR UPDATE"
+      );
+
+      if (checkRes.rows.length === 3) {
+        await client.query('ROLLBACK');
+        // Retrieve them again
+        const [pKey, pubKey, kId] = await Promise.all([
+          this.getSecretByKey('JWT_PRIVATE_KEY'),
+          this.getSecretByKey('JWT_PUBLIC_KEY'),
+          this.getSecretByKey('JWT_KEY_ID'),
+        ]);
+        return {
+          privateKey: pKey!,
+          publicKey: pubKey!,
+          kid: kId!,
+        };
+      }
+
+      // Delete any partial keys just in case
+      await client.query(
+        "DELETE FROM system.secrets WHERE key IN ('JWT_PRIVATE_KEY', 'JWT_PUBLIC_KEY', 'JWT_KEY_ID')"
+      );
+
+      // Create new ones
+      const privEncrypted = EncryptionManager.encrypt(privateKey);
+      const pubEncrypted = EncryptionManager.encrypt(publicKey);
+      const kidEncrypted = EncryptionManager.encrypt(kid);
+
+      await client.query(
+        `INSERT INTO system.secrets (key, value_ciphertext, is_reserved, is_active)
+         VALUES 
+           ('JWT_PRIVATE_KEY', $1, true, true),
+           ('JWT_PUBLIC_KEY', $2, true, true),
+           ('JWT_KEY_ID', $3, true, true)`,
+        [privEncrypted, pubEncrypted, kidEncrypted]
+      );
+
+      await client.query('COMMIT');
+      logger.info('✅ JWT asymmetric keypair generated and stored');
+      return { privateKey, publicKey, kid };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      logger.error('Failed to initialize JWT keypair', { error });
+      throw new Error('Failed to initialize JWT keypair');
+    } finally {
+      client.release();
+    }
+  }
 }
+

--- a/backend/src/services/secrets/secret.service.ts
+++ b/backend/src/services/secrets/secret.service.ts
@@ -845,15 +845,16 @@ export class SecretService {
       if (checkRes.rows.length === 3) {
         await client.query('ROLLBACK');
         // Retrieve them again
-        const [pKey, pubKey, kId] = await Promise.all([
-          this.getSecretByKey('JWT_PRIVATE_KEY'),
-          this.getSecretByKey('JWT_PUBLIC_KEY'),
-          this.getSecretByKey('JWT_KEY_ID'),
-        ]);
+        const pKey = await this.getSecretByKey('JWT_PRIVATE_KEY');
+        const pubKey = await this.getSecretByKey('JWT_PUBLIC_KEY');
+        const kId = await this.getSecretByKey('JWT_KEY_ID');
+        if (!pKey || !pubKey || !kId) {
+          throw new Error('Asymmetric keys were missing or corrupted in database');
+        }
         return {
-          privateKey: pKey!,
-          publicKey: pubKey!,
-          kid: kId!,
+          privateKey: pKey,
+          publicKey: pubKey,
+          kid: kId,
         };
       }
 
@@ -888,4 +889,3 @@ export class SecretService {
     }
   }
 }
-

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -6,6 +6,7 @@ import { StripeSyncService } from '@/services/payments/stripe/sync.service.js';
 import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import { OAuthProvidersSchema } from '@insforge/shared-schemas';
 import { AuthConfigService } from '@/services/auth/auth-config.service.js';
+import { TokenManager } from '@/infra/security/token.manager.js';
 
 /**
  * Seeds default auth configuration for cloud environments
@@ -253,6 +254,10 @@ export async function seedBackend(): Promise<void> {
         logger.info('✅ JWT_SECRET secret initialized');
       }
     }
+
+    // Initialize and load JWT asymmetric keypair
+    await secretService.initializeJwtKeyPair();
+    await TokenManager.getInstance().ensureKeysLoaded();
 
     logger.info(`API key generated: ${apiKey}`);
     logger.info(`Anon key generated: ${anonKey}`);

--- a/backend/tests/unit/records-auth.test.ts
+++ b/backend/tests/unit/records-auth.test.ts
@@ -27,6 +27,7 @@ const authMocks = vi.hoisted(() => {
 const proxyMocks = vi.hoisted(() => ({
   forward: vi.fn(),
   forwardAsAdmin: vi.fn(),
+  forwardAsUser: vi.fn(),
   filterHeaders: vi.fn((headers: Record<string, unknown>) => headers),
 }));
 
@@ -90,6 +91,7 @@ async function createApp() {
 
 function mockProxyResponses() {
   proxyMocks.forward.mockResolvedValue({ data: [{ via: 'user' }], status: 200, headers: {} });
+  proxyMocks.forwardAsUser.mockResolvedValue({ data: [{ via: 'user' }], status: 200, headers: {} });
   proxyMocks.forwardAsAdmin.mockResolvedValue({
     data: [{ via: 'project_admin' }],
     status: 200,
@@ -151,8 +153,9 @@ describe('Database Records Route Authentication', () => {
     await request(app).get('/api/database/records/widgets?select=id').expect(200);
 
     expect(authMocks.verifyUser).toHaveBeenCalledOnce();
-    expect(proxyMocks.forward).toHaveBeenCalledWith(
-      expect.objectContaining({ method: 'GET', path: '/widgets' })
+    expect(proxyMocks.forwardAsUser).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'GET', path: '/widgets' }),
+      expect.objectContaining({ id: 'user-id', role: 'authenticated' })
     );
     expect(proxyMocks.forwardAsAdmin).not.toHaveBeenCalled();
   });
@@ -211,8 +214,9 @@ describe('Database RPC Route Authentication', () => {
     await request(app).post('/api/database/rpc/do_work').send({ value: 1 }).expect(200);
 
     expect(authMocks.verifyUser).toHaveBeenCalledOnce();
-    expect(proxyMocks.forward).toHaveBeenCalledWith(
-      expect.objectContaining({ method: 'POST', path: '/rpc/do_work' })
+    expect(proxyMocks.forwardAsUser).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', path: '/rpc/do_work' }),
+      expect.objectContaining({ id: 'user-id', role: 'authenticated' })
     );
     expect(proxyMocks.forwardAsAdmin).not.toHaveBeenCalled();
   });

--- a/backend/tests/unit/secret-anon-key.test.ts
+++ b/backend/tests/unit/secret-anon-key.test.ts
@@ -53,6 +53,7 @@ describe('SecretService anon key', () => {
     mockClientQuery.mockReset();
     mockClientRelease.mockClear();
     mockConnect.mockClear();
+    vi.stubEnv('ACCESS_ANON_KEY', '');
   });
 
   afterEach(() => {

--- a/backend/tests/unit/seed-jwt-secret.test.ts
+++ b/backend/tests/unit/seed-jwt-secret.test.ts
@@ -4,6 +4,7 @@ const mockGetSecretByKey = vi.fn();
 const mockCreateSecret = vi.fn();
 const mockInitializeApiKey = vi.fn().mockResolvedValue('api-key');
 const mockInitializeAnonKey = vi.fn().mockResolvedValue('anon_test');
+const mockInitializeJwtKeyPair = vi.fn().mockResolvedValue({ privateKey: 'priv-key', publicKey: 'pub-key', kid: 'kid-id' });
 const mockIsCloudEnvironment = vi.fn();
 const mockGetApiBaseUrl = vi.fn().mockReturnValue('https://api.example.com');
 const mockClientQuery = vi.fn();
@@ -22,6 +23,7 @@ vi.mock('../../src/services/secrets/secret.service.js', () => ({
       createSecret: mockCreateSecret,
       initializeApiKey: mockInitializeApiKey,
       initializeAnonKey: mockInitializeAnonKey,
+      initializeJwtKeyPair: mockInitializeJwtKeyPair,
     }),
   },
 }));

--- a/backend/tests/unit/seed-jwt-secret.test.ts
+++ b/backend/tests/unit/seed-jwt-secret.test.ts
@@ -4,7 +4,9 @@ const mockGetSecretByKey = vi.fn();
 const mockCreateSecret = vi.fn();
 const mockInitializeApiKey = vi.fn().mockResolvedValue('api-key');
 const mockInitializeAnonKey = vi.fn().mockResolvedValue('anon_test');
-const mockInitializeJwtKeyPair = vi.fn().mockResolvedValue({ privateKey: 'priv-key', publicKey: 'pub-key', kid: 'kid-id' });
+const mockInitializeJwtKeyPair = vi
+  .fn()
+  .mockResolvedValue({ privateKey: 'priv-key', publicKey: 'pub-key', kid: 'kid-id' });
 const mockIsCloudEnvironment = vi.fn();
 const mockGetApiBaseUrl = vi.fn().mockReturnValue('https://api.example.com');
 const mockClientQuery = vi.fn();

--- a/backend/tests/unit/token-manager-jwks.test.ts
+++ b/backend/tests/unit/token-manager-jwks.test.ts
@@ -55,7 +55,7 @@ describe('TokenManager JWKS & RS256 Support', () => {
     expect(token).toBeDefined();
     
     // Decode the token header to inspect the kid and algorithm
-    const decoded = jwt.decode(token, { complete: true }) as any;
+    const decoded = jwt.decode(token, { complete: true }) as unknown as { header: { alg: string; kid: string } };
     expect(decoded).not.toBeNull();
     expect(decoded.header.alg).toBe('RS256');
     expect(decoded.header.kid).toBe(testKid);

--- a/backend/tests/unit/token-manager-jwks.test.ts
+++ b/backend/tests/unit/token-manager-jwks.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+
+// Generate mock RSA key pair for testing
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: 'spki',
+    format: 'pem',
+  },
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'pem',
+  },
+});
+const testKid = 'kid_test';
+
+const mockGetSecretByKey = vi.fn().mockImplementation((key: string) => {
+  if (key === 'JWT_PRIVATE_KEY') return privateKey;
+  if (key === 'JWT_PUBLIC_KEY') return publicKey;
+  if (key === 'JWT_KEY_ID') return testKid;
+  return null;
+});
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({
+      getSecretByKey: mockGetSecretByKey,
+      initializeJwtKeyPair: vi.fn().mockResolvedValue({
+        privateKey,
+        publicKey,
+        kid: testKid,
+      }),
+    }),
+  },
+}));
+
+import { TokenManager } from '../../src/infra/security/token.manager.js';
+
+describe('TokenManager JWKS & RS256 Support', () => {
+  let tokenManager: TokenManager;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tokenManager = TokenManager.getInstance();
+    // Ensure keys are loaded in token manager
+    await tokenManager.ensureKeysLoaded();
+  });
+
+  it('generates RS256 access tokens containing a kid header', async () => {
+    const payload = { sub: 'test-user-id', email: 'test@example.com', role: 'authenticated' as const };
+    const token = tokenManager.generateAccessToken(payload);
+    
+    expect(token).toBeDefined();
+    
+    // Decode the token header to inspect the kid and algorithm
+    const decoded = jwt.decode(token, { complete: true }) as any;
+    expect(decoded).not.toBeNull();
+    expect(decoded.header.alg).toBe('RS256');
+    expect(decoded.header.kid).toBe(testKid);
+  });
+
+  it('verifies the RS256 access token successfully', async () => {
+    const payload = { sub: 'test-user-id', email: 'test@example.com', role: 'authenticated' as const };
+    const token = tokenManager.generateAccessToken(payload);
+    
+    const verified = tokenManager.verifyToken(token);
+    expect(verified.sub).toBe(payload.sub);
+    expect(verified.email).toBe(payload.email);
+    expect(verified.role).toBe(payload.role);
+  });
+
+  it('falls back to verifying HS256 tokens signed with the shared secret', async () => {
+    const payload = { sub: 'legacy-user-id', email: 'legacy@example.com', role: 'authenticated' as const };
+    const legacyToken = jwt.sign(payload, process.env.JWT_SECRET || 'dev-secret-please-change-in-production', {
+      algorithm: 'HS256',
+      expiresIn: '15m',
+    });
+    
+    const verified = tokenManager.verifyToken(legacyToken);
+    expect(verified.sub).toBe(payload.sub);
+    expect(verified.email).toBe(payload.email);
+    expect(verified.role).toBe(payload.role);
+  });
+
+  it('exports the public key as a valid JWK Set (JWKS)', async () => {
+    const jwks = await tokenManager.getJwks();
+    expect(jwks).toBeDefined();
+    expect(jwks.keys).toBeDefined();
+    expect(jwks.keys.length).toBe(1);
+    
+    const key = jwks.keys[0];
+    expect(key.kty).toBe('RSA');
+    expect(key.alg).toBe('RS256');
+    expect(key.use).toBe('sig');
+    expect(key.kid).toBe(testKid);
+    expect(key.n).toBeDefined();
+    expect(key.e).toBeDefined();
+  });
+});

--- a/backend/tests/unit/token-manager-jwks.test.ts
+++ b/backend/tests/unit/token-manager-jwks.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-jwt-secret-please-change-in-production';
+});
+
 // Generate mock RSA key pair for testing
 const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
   modulusLength: 2048,
@@ -49,22 +53,32 @@ describe('TokenManager JWKS & RS256 Support', () => {
   });
 
   it('generates RS256 access tokens containing a kid header', async () => {
-    const payload = { sub: 'test-user-id', email: 'test@example.com', role: 'authenticated' as const };
+    const payload = {
+      sub: 'test-user-id',
+      email: 'test@example.com',
+      role: 'authenticated' as const,
+    };
     const token = tokenManager.generateAccessToken(payload);
-    
+
     expect(token).toBeDefined();
-    
+
     // Decode the token header to inspect the kid and algorithm
-    const decoded = jwt.decode(token, { complete: true }) as unknown as { header: { alg: string; kid: string } };
+    const decoded = jwt.decode(token, { complete: true }) as unknown as {
+      header: { alg: string; kid: string };
+    };
     expect(decoded).not.toBeNull();
     expect(decoded.header.alg).toBe('RS256');
     expect(decoded.header.kid).toBe(testKid);
   });
 
   it('verifies the RS256 access token successfully', async () => {
-    const payload = { sub: 'test-user-id', email: 'test@example.com', role: 'authenticated' as const };
+    const payload = {
+      sub: 'test-user-id',
+      email: 'test@example.com',
+      role: 'authenticated' as const,
+    };
     const token = tokenManager.generateAccessToken(payload);
-    
+
     const verified = tokenManager.verifyToken(token);
     expect(verified.sub).toBe(payload.sub);
     expect(verified.email).toBe(payload.email);
@@ -72,12 +86,20 @@ describe('TokenManager JWKS & RS256 Support', () => {
   });
 
   it('falls back to verifying HS256 tokens signed with the shared secret', async () => {
-    const payload = { sub: 'legacy-user-id', email: 'legacy@example.com', role: 'authenticated' as const };
-    const legacyToken = jwt.sign(payload, process.env.JWT_SECRET || 'dev-secret-please-change-in-production', {
-      algorithm: 'HS256',
-      expiresIn: '15m',
-    });
-    
+    const payload = {
+      sub: 'legacy-user-id',
+      email: 'legacy@example.com',
+      role: 'authenticated' as const,
+    };
+    const legacyToken = jwt.sign(
+      payload,
+      process.env.JWT_SECRET || 'dev-secret-please-change-in-production',
+      {
+        algorithm: 'HS256',
+        expiresIn: '15m',
+      }
+    );
+
     const verified = tokenManager.verifyToken(legacyToken);
     expect(verified.sub).toBe(payload.sub);
     expect(verified.email).toBe(payload.email);
@@ -89,7 +111,7 @@ describe('TokenManager JWKS & RS256 Support', () => {
     expect(jwks).toBeDefined();
     expect(jwks.keys).toBeDefined();
     expect(jwks.keys.length).toBe(1);
-    
+
     const key = jwks.keys[0];
     expect(key.kty).toBe('RSA');
     expect(key.alg).toBe('RS256');


### PR DESCRIPTION
closes - #1321 

### PR Summary

This pull request implements **Phase 1 (Dual Verification)** of the migration from symmetric `HS256` token signing to asymmetric `RS256` token signing verified via a published JWKS. It ensures that new logins issue asymmetric tokens while legacy tokens remain valid through their TTL.

#### Key Changes
1. **Asymmetric Key Generation & Storage**:
   - Added `initializeJwtKeyPair()` in `SecretService` to atomically generate and store RSA-2048 keypairs (`JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`, `JWT_KEY_ID`) in the `system.secrets` database table.
   - Loaded these keys into `TokenManager` memory during the backend seeding startup sequence.
2. **JWKS & Asymmetric Signing/Verification**:
   - Updated `TokenManager.generateAccessToken` to sign tokens using `RS256` (carrying the matching `kid` in the header) when keys are available.
   - Updated `TokenManager.verifyToken` to inspect the token's header. If a `kid` is present, it verifies the signature against the loaded public key. Otherwise, it gracefully falls back to legacy `HS256` and the shared `JWT_SECRET` verification.
   - Exposed JWKS endpoints at `/.well-known/jwks.json` and `/api/.well-known/jwks.json`.
3. **App-Layer Auth Proxying**:
   - Added `forwardAsUser` in `PostgrestProxyService` to swap verified client tokens (either RS256 or HS256) for a short-lived internal HS256 token signed with `JWT_SECRET` containing the user's claims before proxying database or RPC requests to PostgREST.
4. **Testing**:
   - Created a new unit test suite (`token-manager-jwks.test.ts`) validating key generation, RS256 signing, fallback HS256 validation, and JWKS JSON export.
   - Updated database mocks in `seed-jwt-secret.test.ts`.

---

### How to Verify this PR

#### Automated Tests
Run the backend unit tests:
```bash
cd backend
npx vitest run tests/unit/token-manager-jwks.test.ts tests/unit/token-manager-csrf.test.ts tests/unit/seed-jwt-secret.test.ts
```
<img width="963" height="440" alt="image" src="https://github.com/user-attachments/assets/eb137ad8-14f4-4872-822b-250511171bab" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JWKS-verifiable RS256 login tokens with automatic HS256 fallback. New tokens are RS256-signed and published via JWKS; legacy tokens still work, and anon routing and role checks are enforced.

- **New Features**
  - Generate and store RSA‑2048 keypairs in `system.secrets`; initialized in seed and preloaded on startup via `ensureKeysLoaded`.
  - `TokenManager`: RS256 signing with `kid`, dual verification with HS256 fallback, JWKS export (`getJwks`), and a 5‑minute `generatePostgrestUserToken`.
  - JWKS served at `/.well-known/jwks.json` and `/api/.well-known/jwks.json`.
  - Records/RPC routes now use `forwardAsUser` for authenticated users; admin goes through `forwardAsAdmin`, anon through `forwardAsAnon`.
  - Tests add `token-manager-jwks.test.ts` and update route/seed tests for RS256 verification, HS256 fallback, JWKS output, and user forwarding.

- **Bug Fixes**
  - Fixed anon routing regression: anon requests always use `forwardAsAnon`.
  - `forwardAsUser` now rejects `anon` and invalid role claims at runtime.

<sup>Written for commit a12a192fc80832d77b310a57771339d032ec2bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RS256/JWKS login token support with HS256 fallback for PostgREST forwarding
> - `TokenManager` now generates RS256 access tokens signed with a lazily-loaded RSA-2048 keypair (stored via `SecretService`), falling back to HS256 when no asymmetric keys are available; `verifyToken` accepts both.
> - A new `generatePostgrestUserToken` method mints short-lived HS256 tokens scoped to the authenticated user's claims for PostgREST forwarding.
> - `PostgrestProxyService` adds `forwardAsUser`, which injects the user-scoped HS256 token as a Bearer header; requests from authenticated (non-anon) users in [records.routes.ts](https://github.com/InsForge/InsForge/pull/1597/files#diff-c01e14d03a824af81835407cd114bbcb735d88c19d79419072c9ab855c80f8ff) and [rpc.routes.ts](https://github.com/InsForge/InsForge/pull/1597/files#diff-b850c8167243b70686638cf48e28faf3b424ef43ad82e20c6706c9abdeb87f6d) now route through this path instead of a generic forward.
> - The public key is exposed as JWKS at `/.well-known/jwks.json` and `/api/.well-known/jwks.json`.
> - On startup, [seed.ts](https://github.com/InsForge/InsForge/pull/1597/files#diff-63196e4b85e26873baaf8f4688c0de418f99bafec3af5143fdae6a9d44f6e9b7) initializes and preloads the RSA keypair into `TokenManager`.
> - Risk: authenticated database and RPC requests now receive a user-scoped token instead of the previous generic token, which may change PostgREST row-level security behavior for existing deployments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a12a192.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RS256 JWT signing with JWKS exposure at `/.well-known/jwks.json` (also available under `/api`).
  * Authenticated (non-admin) database/RPC proxy requests now forward using a user-scoped token.
* **Bug Fixes**
  * Updated proxy dispatch to avoid generic forwarding for authenticated non-admin requests.
  * Improved token verification to prefer RS256 when indicated, with HS256 fallback.
* **Tests**
  * Added unit coverage for RS256 token generation/verification and JWKS output.
  * Updated forwarding-auth tests and JWT secret initialization mocks for new keypair/JWKS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->