### PR TITLE
fix(dashboard): make Add Record dialog scroll with many columns

### DIFF
--- a/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
+++ b/packages/dashboard/src/features/database/components/RecordFormDialog.tsx
@@ -99,8 +99,11 @@ export function RecordFormDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent showCloseButton={false} className="w-[640px] max-w-[640px] p-0">
-        <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col">
-          <DialogHeader className="gap-0 px-4 py-3">
+        <form
+          onSubmit={(e) => void handleSubmit(e)}
+          className="flex max-h-[calc(100dvh-2rem)] flex-col"
+        >
+          <DialogHeader className="shrink-0 gap-0 px-4 py-3">
             <div className="flex w-full items-center gap-3">
               <div className="min-w-0 flex-1">
                 <DialogTitle className="text-base font-medium leading-7 text-foreground">
@@ -120,7 +123,7 @@ export function RecordFormDialog({
             </div>
           </DialogHeader>
 
-          <ScrollArea className="max-h-[500px]">
+          <ScrollArea className="min-h-0 flex-1">
             <div className="p-4">
               {displayFields.map((field, index) => (
                 <div key={field.columnName}>
@@ -141,7 +144,7 @@ export function RecordFormDialog({
             </div>
           </ScrollArea>
 
-          <DialogFooter className="gap-3 px-4 py-4">
+          <DialogFooter className="shrink-0 gap-3 px-4 py-4">
             {error && (
               <div className="mr-auto flex min-w-0 flex-1 items-center gap-1 text-sm leading-6 text-muted-foreground">
                 <AlertCircle className="size-4 shrink-0 text-destructive" />

--- a/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
@@ -33,6 +33,7 @@ describe('RecordFormDialog', () => {
         open
         onOpenChange={vi.fn()}
         tableName="wide_table"
+        schemaName="public"
         schema={makeSchema(30)}
       />
     );
@@ -55,6 +56,7 @@ describe('RecordFormDialog', () => {
         open
         onOpenChange={onOpenChange}
         tableName="wide_table"
+        schemaName="public"
         schema={makeSchema(40)}
         onSuccess={vi.fn()}
       />

--- a/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { ColumnSchema } from '@insforge/shared-schemas';
+
+const createRecord = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('#features/database/hooks/useRecords', () => ({
+  useRecords: () => ({ createRecord, isCreating: false }),
+}));
+
+import { RecordFormDialog } from '#features/database/components/RecordFormDialog';
+
+function makeSchema(columnCount: number): ColumnSchema[] {
+  const systemColumns: ColumnSchema[] = [
+    { columnName: 'id', type: 'uuid', isNullable: false, isUnique: true, isPrimaryKey: true },
+    { columnName: 'created_at', type: 'datetime', isNullable: false, isUnique: false },
+    { columnName: 'updated_at', type: 'datetime', isNullable: false, isUnique: false },
+  ];
+  const editableColumns: ColumnSchema[] = Array.from({ length: columnCount }, (_, index) => ({
+    columnName: `field_${index}`,
+    type: 'string',
+    isNullable: true,
+    isUnique: false,
+  }));
+  return [...systemColumns, ...editableColumns];
+}
+
+describe('RecordFormDialog', () => {
+  it('renders every editable column and filters system fields', () => {
+    render(
+      <RecordFormDialog
+        open
+        onOpenChange={vi.fn()}
+        tableName="wide_table"
+        schema={makeSchema(30)}
+      />
+    );
+
+    for (let index = 0; index < 30; index += 1) {
+      expect(screen.getByText(`field_${index}`)).toBeTruthy();
+    }
+    expect(screen.queryByText('id')).toBeNull();
+    expect(screen.queryByText('created_at')).toBeNull();
+    expect(screen.queryByText('updated_at')).toBeNull();
+  });
+
+  it('keeps footer actions reachable so a record can be submitted with many columns', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    createRecord.mockClear();
+
+    render(
+      <RecordFormDialog
+        open
+        onOpenChange={onOpenChange}
+        tableName="wide_table"
+        schema={makeSchema(40)}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Add Record' }));
+
+    await waitFor(() => {
+      expect(createRecord).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});


### PR DESCRIPTION
## What
Fixes #1595 — Add Record dialog overflowed the viewport with many columns; no usable scrollbar.

## Why
Centered `DialogContent` sizes to content (no max-height), and the field list's `ScrollArea` had only `max-h-[500px]`. The shared `ScrollArea` viewport is `h-full`, which needs a **definite** parent height to scroll — `max-h` alone is indefinite, so the body grew unbounded and clipped.

## Fix
Constrain the form to the viewport, make the field list the single scroll region (same pattern as `LinkRecordDialog`):
- form → `max-h-[calc(100dvh-2rem)] flex flex-col`
- header/footer → `shrink-0`
- field-list `ScrollArea` → `min-h-0 flex-1`

## Test
Added `RecordFormDialog.test.tsx` (component): many columns render, system fields filtered, footer Add Record stays reachable/submittable.
Run: `npm --workspace @insforge/dashboard run test:component -- RecordFormDialog`

> Note: layout/scroll isn't measurable in jsdom; the test guards the structural contract. `npx turbo run typecheck` has ~46 **pre-existing** errors on `main` (storage jest-dom matchers, socket.io types) unrelated to this change — none in touched 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Add Record dialog overflowing on wide tables by constraining form height and making only the field list scroll. Keeps the header and footer visible and actions clickable; addresses #1595.

- **Bug Fixes**
  - Form constrained to viewport: `max-h-[calc(100dvh-2rem)] flex flex-col`.
  - Header/footer set to not shrink: `shrink-0`.
  - Field list is the only scroll region: `ScrollArea` → `min-h-0 flex-1` (replaces `max-h-[500px]`).
  - Tests: added `RecordFormDialog.test.tsx` verifying many columns render, system fields are filtered, and "Add Record" stays submittable; updated to pass required `schemaName` prop in `@insforge/dashboard`.

<sup>Written for commit 25bceca77786ee65df65bead6efbd1137066fa62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Add Record dialog to scroll when many columns are present
> - Updates layout classes in [`RecordFormDialog.tsx`](https://github.com/InsForge/InsForge/pull/1600/files#diff-d3187dbcafd16ec1a63148f51efa47c0be0ebf57ed4bb6b64842c3d434ed04e5): the `<form>` gets `max-h-[calc(100dvh-2rem)]` and flex-column layout, header/footer get `shrink-0`, and the `<ScrollArea>` switches to `min-h-0 flex-1` so it fills remaining space and scrolls.
> - Adds a new test file [`RecordFormDialog.test.tsx`](https://github.com/InsForge/InsForge/pull/1600/files#diff-599e8e63a394b3012fd768c3763148ff10167c9371ec6a5f97f1362e25b0694e) covering field filtering (system fields excluded) and form submission with many columns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25bceca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the record form dialog layout so long forms remain usable: the dialog body now uses a full-height flex layout with a flex-based scroll area, keeping the footer and actions visible.
* **Tests**
  * Added React Testing Library + Vitest coverage to verify editable-field rendering (excluding system fields) and to confirm the “Add Record” flow calls record creation once and closes the dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->