### PR TITLE
Send CSRF token on dashboard logout

### DIFF
--- a/packages/dashboard/src/features/login/services/login.service.test.ts
+++ b/packages/dashboard/src/features/login/services/login.service.test.ts
@@ -3,17 +3,17 @@ import { apiClient } from '#lib/api/client';
 import { setDashboardBackendUrl } from '#lib/config/runtime';
 import { loginService } from './login.service';
 
+beforeEach(() => {
+  vi.stubGlobal('document', { cookie: '' });
+});
+
+afterEach(() => {
+  apiClient.clearTokens();
+  setDashboardBackendUrl('');
+  vi.unstubAllGlobals();
+});
+
 describe('LoginService refreshAccessToken', () => {
-  beforeEach(() => {
-    vi.stubGlobal('document', { cookie: '' });
-  });
-
-  afterEach(() => {
-    apiClient.clearTokens();
-    setDashboardBackendUrl('');
-    vi.unstubAllGlobals();
-  });
-
   it('uses the configured dashboard API base URL for admin refresh', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -37,15 +37,17 @@ describe('LoginService refreshAccessToken', () => {
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
-        headers: {
+        headers: expect.objectContaining({
           'Content-Type': 'application/json',
           'X-CSRF-Token': 'csrf-token',
-        },
+        }),
         signal: expect.any(AbortSignal),
       })
     );
   });
+});
 
+describe('LoginService logout', () => {
   it('sends the stored CSRF token on admin logout', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -54,6 +56,7 @@ describe('LoginService refreshAccessToken', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
     setDashboardBackendUrl('https://dashboard.example.com/');
+    apiClient.setAccessToken('access-token');
     apiClient.setCsrfToken('csrf-token');
 
     await loginService.logout();
@@ -63,9 +66,36 @@ describe('LoginService refreshAccessToken', () => {
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
-        headers: {
+        headers: expect.objectContaining({
+          Authorization: 'Bearer access-token',
           'X-CSRF-Token': 'csrf-token',
-        },
+        }),
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it('omits the CSRF token header on admin logout when no CSRF token is stored', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ success: true })),
+      headers: new Headers(),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setDashboardBackendUrl('https://dashboard.example.com/');
+    apiClient.setAccessToken('access-token');
+    apiClient.clearCsrfToken();
+
+    await loginService.logout();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://dashboard.example.com/api/auth/admin/logout',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.not.objectContaining({
+          'X-CSRF-Token': expect.any(String),
+        }),
         signal: expect.any(AbortSignal),
       })
     );

--- a/packages/dashboard/src/features/login/services/login.service.test.ts
+++ b/packages/dashboard/src/features/login/services/login.service.test.ts
@@ -45,4 +45,29 @@ describe('LoginService refreshAccessToken', () => {
       })
     );
   });
+
+  it('sends the stored CSRF token on admin logout', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ success: true })),
+      headers: new Headers(),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setDashboardBackendUrl('https://dashboard.example.com/');
+    apiClient.setCsrfToken('csrf-token');
+
+    await loginService.logout();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://dashboard.example.com/api/auth/admin/logout',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'X-CSRF-Token': 'csrf-token',
+        },
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
 });

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -59,13 +59,10 @@ export class LoginService {
   async logout(): Promise<void> {
     try {
       const csrfToken = apiClient.getCsrfToken();
+      const headers = csrfToken ? { 'X-CSRF-Token': csrfToken } : undefined;
       await apiClient.request('/auth/admin/logout', {
         method: 'POST',
-        ...(csrfToken && {
-          headers: {
-            'X-CSRF-Token': csrfToken,
-          },
-        }),
+        ...(headers && { headers }),
         skipRefresh: true,
       });
     } catch {

--- a/packages/dashboard/src/features/login/services/login.service.ts
+++ b/packages/dashboard/src/features/login/services/login.service.ts
@@ -58,8 +58,14 @@ export class LoginService {
 
   async logout(): Promise<void> {
     try {
+      const csrfToken = apiClient.getCsrfToken();
       await apiClient.request('/auth/admin/logout', {
         method: 'POST',
+        ...(csrfToken && {
+          headers: {
+            'X-CSRF-Token': csrfToken,
+          },
+        }),
         skipRefresh: true,
       });
     } catch {


### PR DESCRIPTION
Related to #1329 but does not close it.

## Summary

  - Include the stored X-CSRF-Token header when the dashboard sends POST /api/auth/admin/logout

  - Keep logout backward-compatible with current servers that ignore the extra header

  - Add unit coverage for the logout request contract

  ## Why

  This prepares browser-based logout flows for backend CSRF enforcement. Sending the header first is safe because existing backends ignore it, and future backends can require it without breaking updated dashboard clients.

  ## Tests

  - cd packages/dashboard && npm run test:unit -- src/
    features/login/services/login.service.test.ts

  - cd packages/dashboard && npm run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the stored CSRF token with dashboard admin logout (POST /api/auth/admin/logout) to prepare for backend CSRF enforcement while staying backward-compatible. Related to #1329.

- New Features
  - Logout now includes `X-CSRF-Token` when available; omitted when absent to support existing servers.
  - Expanded tests to verify Authorization passthrough, CSRF header present/absent, POST + include credentials, and abort signal handling.

<sup>Written for commit 02ea71ba6a945fa49dea7539f032ee28249898ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send CSRF token in dashboard logout request
> The `LoginService.logout` method now retrieves the stored CSRF token from `apiClient` and includes it as an `X-CSRF-Token` header in the `POST /auth/admin/logout` request. The header is omitted when no CSRF token is stored. Tests in [login.service.test.ts](https://github.com/InsForge/InsForge/pull/1605/files#diff-5bf720e98bdf5f5fd69507ee92c4c770b7481547da767d3137ce639d190ef916) cover both cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02ea71b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout security by conditionally attaching the current CSRF token to the logout request when available.
  * Logout still follows the authenticated flow, uses the same request options, and clears local authentication tokens after the request.

* **Tests**
  * Expanded logout test coverage to validate the correct logout endpoint, HTTP method, credentials mode, CSRF header inclusion/omission behavior, and abort signal usage.
  * Strengthened test isolation by resetting shared browser state and backend URL between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->