### PR TITLE
Fix (#1603): Enabling RLS on storage.objects breaks PUBLIC-bucket uploads

### DIFF
--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -236,7 +236,7 @@ export class StorageService {
       return { etag: providerEtag, uploadedAt: result.rows[0].uploadedAt };
     };
     let uploadedObject: Awaited<ReturnType<typeof insertObject>>;
-    if (hasApiKey || ctx?.role === 'project_admin') {
+    if (hasApiKey || ctx?.role === 'project_admin' || (await this.isBucketPublic(bucket))) {
       uploadedObject = await runWithRootAccess(this.getPool(), insertObject);
     } else {
       if (!ctx) {
@@ -540,7 +540,7 @@ export class StorageService {
 
     const key = await this.generateNextAvailableKey(bucket, metadata.filename, this.getPool());
     const maxFileSizeBytes = await StorageConfigService.getInstance().getMaxFileSizeBytes();
-    if (hasApiKey || ctx?.role === 'project_admin') {
+    if (hasApiKey || ctx?.role === 'project_admin' || (await this.isBucketPublic(bucket))) {
       return this.provider.getUploadStrategy(bucket, key, metadata, maxFileSizeBytes);
     }
     if (!ctx) {
@@ -701,7 +701,7 @@ export class StorageService {
         [bucket, key, fileSize, metadata.contentType || null, finalEtag, userId]
       );
     let result: Awaited<ReturnType<typeof insertObjectRow>>;
-    if (hasApiKey || ctx?.role === 'project_admin') {
+    if (hasApiKey || ctx?.role === 'project_admin' || (await this.isBucketPublic(bucket))) {
       result = await runWithRootAccess(this.getPool(), insertObjectRow);
     } else {
       if (!ctx) {

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -276,6 +276,7 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       { rows: [{ name: 'photos' }], rowCount: 1 }, // root bucket existence check
       { rows: [], rowCount: 0 }, // root object dedup query
       { rows: [{ maxFileSizeMb: 50 }], rowCount: 1 }, // storage config
+      { rows: [{ public: false }], rowCount: 1 }, // public bucket check (private)
       { rows: [], rowCount: 0 }, // BEGIN
       { rows: [], rowCount: 0 }, // SET LOCAL ROLE authenticated
       { rows: [], rowCount: 0 }, // set_config(claims)
@@ -299,8 +300,8 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       params: ['photos'],
     });
     expect(calls[1].sql).toContain('SELECT key FROM storage.objects');
-    expect(calls[3].sql).toBe('BEGIN');
-    expect(calls[4].sql).toBe('SET LOCAL ROLE authenticated');
+    expect(calls[4].sql).toBe('BEGIN');
+    expect(calls[5].sql).toBe('SET LOCAL ROLE authenticated');
     expect(calls.map((c) => c.sql).slice(1)).not.toContain(
       'SELECT 1 FROM storage.buckets WHERE name = $1 LIMIT 1'
     );


### PR DESCRIPTION
## Summary
#fixes #1603


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1603. Restores uploads to public buckets when RLS is enabled on storage by bypassing RLS for write paths if the bucket is public.

- Bug Fixes
  - Treat public buckets like admin/API key sessions: run insert and upload strategy steps with root access when the bucket is public.
  - Update unit test to include the public-bucket check and adjust expected query order.

<sup>Written for commit 8ba5942d0549463895a440766f8ceeaab0b417a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix public-bucket uploads broken by RLS on `storage.objects`
> - Adds an `isBucketPublic` check in `StorageService` so that uploads to public buckets use `runWithRootAccess` instead of `withUserContext`, bypassing RLS for those buckets.
> - Applies the same check in `getUploadStrategy` so callers without admin or API-key credentials can obtain an upload strategy for public buckets without triggering the RLS insert probe.
> - Updates unit tests in [`storage-object-is-visible.test.ts`](https://github.com/InsForge/InsForge/pull/1606/files#diff-117e27eb6b9f85664bce92e076bdb8734da34914e8654154cdef88655e44521b) to assert the public-bucket check occurs before the RLS probe path.
> - Behavioral Change: non-admin, non-API-key callers can now upload to public buckets; previously this was blocked when RLS was enabled on `storage.objects`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ba5942.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Public buckets now handle uploads and upload confirmations more smoothly, without requiring the same user-context checks used for private buckets.
  * Upload strategy selection now correctly recognizes public buckets and follows the appropriate path.
  * Updated test coverage to reflect the revised bucket access flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->