### PR TITLE
fix(storage): stop coupling RLS uploads to a SELECT policy (INSERT … RETURNING)

### DIFF
--- a/backend/src/services/secrets/secret.service.ts
+++ b/backend/src/services/secrets/secret.service.ts
@@ -432,8 +432,7 @@ export class SecretService {
       const result = await this.getPool().query(
         `DELETE FROM system.secrets
          WHERE expires_at IS NOT NULL
-         AND expires_at < NOW()
-         RETURNING id`
+         AND expires_at < NOW()`
       );
 
       const deletedCount = result.rowCount ?? 0;

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -214,26 +214,28 @@ export class StorageService {
     const finalKey = await this.generateNextAvailableKey(bucket, originalKey, this.getPool());
 
     const userId = ctx?.role === 'authenticated' ? ctx.id : null;
+    // Set uploaded_at app-side instead of reading back the DB default via
+    // RETURNING. Under RLS, INSERT ... RETURNING also applies the table's
+    // SELECT policies to the returned row, so an end-user upload fails unless
+    // the caller can also SELECT its own new row — wrongly coupling write
+    // success to read visibility. Supplying the value keeps this a pure INSERT
+    // gated only by the INSERT policy's WITH CHECK.
+    const uploadedAt = new Date();
     const insertObject = async (db: PoolClient) => {
       // INSERT before provider write so UNIQUE (bucket, key) catches any
       // race-window collision before any blob is touched. Provider write
       // stays inside the transaction — a provider failure throws, the tx
       // rolls back, and no orphan row remains.
-      const result = await db.query(
+      await db.query(
         `
-        INSERT INTO storage.objects (bucket, key, size, mime_type, uploaded_by, uploaded_via)
-        VALUES ($1, $2, $3, $4, $5, 'rest')
-        RETURNING uploaded_at as "uploadedAt"
+        INSERT INTO storage.objects (bucket, key, size, mime_type, uploaded_by, uploaded_via, uploaded_at)
+        VALUES ($1, $2, $3, $4, $5, 'rest', $6)
       `,
-        [bucket, finalKey, file.size, file.mimetype || null, userId]
+        [bucket, finalKey, file.size, file.mimetype || null, userId, uploadedAt]
       );
 
-      if (!result.rows[0]) {
-        throw new Error(`Failed to retrieve upload timestamp for ${bucket}/${finalKey}`);
-      }
-
       const { etag: providerEtag } = await this.provider.putObject(bucket, finalKey, file);
-      return { etag: providerEtag, uploadedAt: result.rows[0].uploadedAt };
+      return { etag: providerEtag, uploadedAt };
     };
     let uploadedObject: Awaited<ReturnType<typeof insertObject>>;
     if (hasApiKey || ctx?.role === 'project_admin') {
@@ -244,7 +246,7 @@ export class StorageService {
       }
       uploadedObject = await withUserContext(this.getPool(), ctx, insertObject);
     }
-    const { etag, uploadedAt } = uploadedObject;
+    const { etag } = uploadedObject;
 
     // Persist the etag as a best-effort step OUTSIDE the user-context
     // transaction. If we ran this inside the tx and the UPDATE failed, the
@@ -275,7 +277,7 @@ export class StorageService {
       key: finalKey,
       size: file.size,
       mimeType: file.mimetype,
-      uploadedAt,
+      uploadedAt: uploadedAt.toISOString(),
       url: this.buildObjectUrl(bucket, finalKey, etag || uploadedAt),
     };
   }
@@ -693,25 +695,25 @@ export class StorageService {
     // WITH CHECK on storage_objects_owner_insert verifies uploaded_by =
     // jwt.sub. Admin/API-key callers use the backend pool.
     const userId = ctx?.role === 'authenticated' ? ctx.id : null;
+    // Set uploaded_at app-side instead of reading it back via RETURNING. Under
+    // RLS, INSERT ... RETURNING also enforces the table's SELECT policies on
+    // the returned row, so confirm-upload would fail for any bucket that has
+    // an INSERT policy but no covering SELECT policy. A plain INSERT is gated
+    // solely by the INSERT policy's WITH CHECK, which is the intended check.
+    const uploadedAt = new Date();
     const insertObjectRow = (db: PoolClient) =>
       db.query(
-        `INSERT INTO storage.objects (bucket, key, size, mime_type, etag, uploaded_by, uploaded_via)
-         VALUES ($1, $2, $3, $4, $5, $6, 'rest')
-         RETURNING uploaded_at as "uploadedAt"`,
-        [bucket, key, fileSize, metadata.contentType || null, finalEtag, userId]
+        `INSERT INTO storage.objects (bucket, key, size, mime_type, etag, uploaded_by, uploaded_via, uploaded_at)
+         VALUES ($1, $2, $3, $4, $5, $6, 'rest', $7)`,
+        [bucket, key, fileSize, metadata.contentType || null, finalEtag, userId, uploadedAt]
       );
-    let result: Awaited<ReturnType<typeof insertObjectRow>>;
     if (hasApiKey || ctx?.role === 'project_admin') {
-      result = await runWithRootAccess(this.getPool(), insertObjectRow);
+      await runWithRootAccess(this.getPool(), insertObjectRow);
     } else {
       if (!ctx) {
         throw new AppError('Forbidden', 403, ERROR_CODES.STORAGE_PERMISSION_DENIED);
       }
-      result = await withUserContext(this.getPool(), ctx, insertObjectRow);
-    }
-
-    if (!result.rows[0]) {
-      throw new Error(`Failed to retrieve upload timestamp for ${bucket}/${key}`);
+      await withUserContext(this.getPool(), ctx, insertObjectRow);
     }
 
     return {
@@ -719,8 +721,8 @@ export class StorageService {
       key,
       size: fileSize,
       mimeType: metadata.contentType,
-      uploadedAt: result.rows[0].uploadedAt,
-      url: this.buildObjectUrl(bucket, key, finalEtag || result.rows[0].uploadedAt),
+      uploadedAt: uploadedAt.toISOString(),
+      url: this.buildObjectUrl(bucket, key, finalEtag || uploadedAt),
     };
   }
 

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -343,15 +343,15 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
   it('uploads objects for project_admin JWT callers through root access', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();
-    const uploadedAt = new Date('2026-01-01T00:00:00.000Z');
     const provider = {
       putObject: vi.fn(async () => ({ etag: 'etag-admin-upload' })),
     };
     (svc as unknown as { provider: typeof provider }).provider = provider;
 
+    // uploaded_at is supplied app-side, so the INSERT no longer uses RETURNING.
     queryResults = [
       { rows: [], rowCount: 0 }, // root object dedup query
-      { rows: [{ uploadedAt }], rowCount: 1 }, // root insert
+      { rows: [], rowCount: 1 }, // root insert (no RETURNING)
       { rows: [], rowCount: 1 }, // root etag update
     ];
 
@@ -367,8 +367,8 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       key: 'note.txt',
       size: 8,
       mimeType: 'text/plain',
-      uploadedAt,
     });
+    expect(typeof result.uploadedAt).toBe('string');
     expect(provider.putObject).toHaveBeenCalledOnce();
     expect(calls.map((c) => c.sql)).not.toContain('BEGIN');
     expect(calls.map((c) => c.sql)).not.toContain('SET LOCAL ROLE project_admin');
@@ -378,7 +378,6 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
   it('confirms presigned uploads for project_admin JWT callers through root access', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();
-    const uploadedAt = new Date('2026-01-01T00:00:00.000Z');
     const provider = {
       verifyObjectExists: vi.fn(async () => ({
         exists: true,
@@ -388,10 +387,11 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     };
     (svc as unknown as { provider: typeof provider }).provider = provider;
 
+    // uploaded_at is supplied app-side, so the INSERT no longer uses RETURNING.
     queryResults = [
       { rows: [{ maxFileSizeMb: 50 }], rowCount: 1 }, // storage config
       { rows: [], rowCount: 0 }, // already-confirmed check
-      { rows: [{ uploadedAt }], rowCount: 1 }, // root insert
+      { rows: [], rowCount: 1 }, // root insert (no RETURNING)
     ];
 
     const result = await svc.confirmUpload(
@@ -406,8 +406,8 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       key: 'note.txt',
       size: 8,
       mimeType: 'text/plain',
-      uploadedAt,
     });
+    expect(typeof result.uploadedAt).toBe('string');
     expect(calls.map((c) => c.sql)).not.toContain('BEGIN');
     expect(calls.map((c) => c.sql)).not.toContain('SET LOCAL ROLE project_admin');
     expect(calls.some((c) => c.sql.includes('INSERT INTO storage.objects'))).toBe(true);

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -368,11 +368,14 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       size: 8,
       mimeType: 'text/plain',
     });
-    expect(typeof result.uploadedAt).toBe('string');
+    // uploaded_at is an ISO string supplied app-side; assert it round-trips.
+    expect(new Date(result.uploadedAt).toISOString()).toBe(result.uploadedAt);
     expect(provider.putObject).toHaveBeenCalledOnce();
     expect(calls.map((c) => c.sql)).not.toContain('BEGIN');
     expect(calls.map((c) => c.sql)).not.toContain('SET LOCAL ROLE project_admin');
     expect(calls.some((c) => c.sql.includes('INSERT INTO storage.objects'))).toBe(true);
+    // The insert must not use RETURNING — that re-couples writes to SELECT RLS.
+    expect(calls.some((c) => /RETURNING/i.test(c.sql))).toBe(false);
   });
 
   it('confirms presigned uploads for project_admin JWT callers through root access', async () => {
@@ -407,10 +410,13 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       size: 8,
       mimeType: 'text/plain',
     });
-    expect(typeof result.uploadedAt).toBe('string');
+    // uploaded_at is an ISO string supplied app-side; assert it round-trips.
+    expect(new Date(result.uploadedAt).toISOString()).toBe(result.uploadedAt);
     expect(calls.map((c) => c.sql)).not.toContain('BEGIN');
     expect(calls.map((c) => c.sql)).not.toContain('SET LOCAL ROLE project_admin');
     expect(calls.some((c) => c.sql.includes('INSERT INTO storage.objects'))).toBe(true);
+    // The insert must not use RETURNING — that re-couples writes to SELECT RLS.
+    expect(calls.some((c) => /RETURNING/i.test(c.sql))).toBe(false);
   });
 
   it('deletes objects for project_admin JWT callers through root access', async () => {


### PR DESCRIPTION
## Problem

Uploading to a bucket fails under RLS — even with a permissive INSERT policy — with the misleading error:

```
new row violates row-level security policy for table "objects"
```

`putObject` and `confirmUpload` run `INSERT … RETURNING uploaded_at` inside the caller's RLS context. PostgreSQL applies **SELECT** policies to `RETURNING` output, so the upload only succeeds if the caller can also *read back* its just-inserted row. A bucket that has an INSERT policy but **no covering SELECT policy** fails every upload: the write authorization (INSERT `WITH CHECK`) passes, but the `RETURNING` read-back is denied.

This is exactly why enabling RLS on `storage.objects` broke public-bucket uploads. Reproduced on a live project: an authenticated user uploading to a public bucket got 403 even with `FOR INSERT … WITH CHECK (true)` and zero restrictive policies; adding a matching SELECT policy made it succeed — confirming the `RETURNING` read-back, not the INSERT, was the gate. It also explains the "upload-strategy probe passes but confirm-upload fails" report: the probe insert has no `RETURNING`, the confirm insert does.

## Fix

`uploaded_at` is a `DEFAULT NOW()` column whose value is only used for the response body and the cache-busting URL stamp. Supply it app-side and drop `RETURNING`:

- The INSERT is now gated **solely by the INSERT policy's `WITH CHECK`** — the intended authorization — so public and private buckets behave identically and an INSERT policy alone is sufficient to upload.
- The `getUploadStrategy` RLS probe (no `RETURNING`) and the real insert now exercise the same operation.
- No extra round-trip; the URL version stamp still uses the same `Date` (epoch-ms fallback), and the response field is the ISO string it already serialized to.

Also drops a useless `RETURNING id` in `SecretService.cleanupExpiredSecrets` (only `rowCount` is read).

## Scope / what's not here

These are the `RETURNING` statements that run under a user RLS context. The one remaining is `assertSubscriptionManagementAllowed` (`payments.razorpay_subscriptions`), which returns real data (the billing subject) and would need an admin read-back; it's latent today (no migration enables RLS on `payments.*`) so it's deliberately left out.

## Testing

- `npm run typecheck`, `npm run lint` clean.
- `tests/unit/storage-object-is-visible.test.ts` updated (the admin upload/confirm cases no longer assert a DB-returned timestamp) — 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RLS upload failures by removing `INSERT … RETURNING` from storage writes and setting `uploaded_at` app-side, so uploads only require the INSERT policy. Public and private buckets now behave the same, and presigned confirm matches the probe.

- **Bug Fixes**
  - `putObject` and `confirmUpload` set `uploaded_at` in app and drop `RETURNING`, decoupling writes from SELECT policies.
  - URL versioning now uses `etag` or the same in-app timestamp (ISO string).
  - Aligns the RLS probe and real insert to exercise the same operation.
  - Removes unused `RETURNING id` in `SecretService.cleanupExpiredSecrets`.
  - Tests assert `uploadedAt` ISO round-trip and that no executed SQL includes `RETURNING`.

<sup>Written for commit fb4fbb82ecb980e8cd808a0e4027a5bcdb57b8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `INSERT ... RETURNING` from storage uploads to decouple RLS INSERT from SELECT policy
> - RLS policies in Postgres apply SELECT-visibility rules when `INSERT ... RETURNING` is used, which caused uploads to fail for roles without a matching SELECT policy.
> - `StorageService.putObject` and `StorageService.confirmUpload` now generate `uploaded_at` app-side and pass it explicitly in the INSERT, removing all `RETURNING` clauses.
> - `SecretService.cleanupExpiredSecrets` also drops its `RETURNING id` clause, relying on `rowCount` instead.
> - Behavioral Change: `uploadedAt` in upload responses is now an app-generated ISO string rather than a DB-returned timestamp, so it may differ slightly from the value stored in the database.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1607 opened
>
> - Modified test assertions in `backend/tests/unit/storage-object-is-visible.test.ts` to validate ISO-8601 format compliance and verify INSERT statements do not use RETURNING clauses [fb4fbb8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9083ab9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload and upload-confirmation responses now return timestamps in a consistent ISO string format.
  * Returned upload metadata is more reliable, improving download-link versioning based on upload time.
  * Secret cleanup continues to remove expired entries and accurately reports how many were deleted.
* **Tests**
  * Updated unit tests to match the new database insert behavior for root-access upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->