### PR TITLE
feat(kv,vectors): add key-value store and pgvector vector store

### DIFF
--- a/backend/src/api/middlewares/store-actor.ts
+++ b/backend/src/api/middlewares/store-actor.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import type { AuthRequest, UserContext } from '@/api/middlewares/auth.js';
+
+// Shared by the kv and vectors stores. API keys and the admin dashboard
+// (project_admin JWT) manage the project-global store with full access via the
+// superuser pool (RLS bypassed); genuine end users operate as their own
+// authenticated/anon identity through RLS.
+export type StoreActor = { mode: 'admin' } | { mode: 'user'; ctx: UserContext };
+
+export function resolveStoreActor(req: AuthRequest): StoreActor {
+  if (req.hasApiKey || req.user?.role === 'project_admin') {
+    return { mode: 'admin' };
+  }
+  if (!req.user) {
+    throw new AppError('Authentication required', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+  }
+  return { mode: 'user', ctx: req.user };
+}
+
+export function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S> {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new AppError(
+      `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  return parsed.data;
+}
+
+// Validate a single path param against a shared schema so the HTTP surface
+// matches the exported contract instead of trusting raw req.params.
+export function parseParam(schema: z.ZodType<string>, value: string, label: string): string {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new AppError(
+      `Invalid ${label}: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  return parsed.data;
+}

--- a/backend/src/api/routes/kv/index.routes.ts
+++ b/backend/src/api/routes/kv/index.routes.ts
@@ -6,6 +6,8 @@ import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
 import {
   ERROR_CODES,
+  kvNamespaceSchema,
+  kvKeySchema,
   kvSetRequestSchema,
   kvIncrRequestSchema,
   kvCasRequestSchema,
@@ -46,6 +48,22 @@ function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S>
   return parsed.data;
 }
 
+// Validate path params against the shared KV bounds (length caps, no '/') so the
+// HTTP surface matches the exported contract instead of trusting raw req.params.
+function parseParam(schema: z.ZodType<string>, value: string, label: string): string {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new AppError(
+      `Invalid ${label}: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  return parsed.data;
+}
+const ns = (req: AuthRequest) => parseParam(kvNamespaceSchema, req.params.namespace, 'namespace');
+const key = (req: AuthRequest) => parseParam(kvKeySchema, req.params.key, 'key');
+
 // --- bulk ops (registered before the dynamic /entries routes) ---------------
 
 // POST /api/kv/mget
@@ -75,7 +93,7 @@ router.post('/mset', async (req: AuthRequest, res: Response, next: NextFunction)
 // GET /api/kv/entries/:namespace  (list keys)
 router.get('/entries/:namespace', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const keys = await kvService.list(resolveActor(req), req.params.namespace);
+    const keys = await kvService.list(resolveActor(req), ns(req));
     successResponse(res, { keys });
   } catch (error) {
     next(error);
@@ -87,7 +105,7 @@ router.get(
   '/entries/:namespace/:key/ttl',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const ttl = await kvService.ttl(resolveActor(req), req.params.namespace, req.params.key);
+      const ttl = await kvService.ttl(resolveActor(req), ns(req), key(req));
       successResponse(res, { ttl });
     } catch (error) {
       next(error);
@@ -100,13 +118,11 @@ router.get(
   '/entries/:namespace/:key',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const value = await kvService.get(resolveActor(req), req.params.namespace, req.params.key);
+      const namespace = ns(req);
+      const k = key(req);
+      const value = await kvService.get(resolveActor(req), namespace, k);
       if (value === null) {
-        throw new AppError(
-          `Key not found: ${req.params.namespace}/${req.params.key}`,
-          404,
-          ERROR_CODES.KV_NOT_FOUND
-        );
+        throw new AppError(`Key not found: ${namespace}/${k}`, 404, ERROR_CODES.KV_NOT_FOUND);
       }
       successResponse(res, { value });
     } catch (error) {
@@ -121,13 +137,10 @@ router.put(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const body = parseBody(kvSetRequestSchema, req.body);
-      const result = await kvService.set(
-        resolveActor(req),
-        req.params.namespace,
-        req.params.key,
-        body
-      );
-      successResponse(res, result, result.created ? 200 : 409);
+      // Always 200: a setnx conflict (created=false, entry=null) is a normal
+      // outcome the caller inspects via `created`, not an HTTP error.
+      const result = await kvService.set(resolveActor(req), ns(req), key(req), body);
+      successResponse(res, result);
     } catch (error) {
       next(error);
     }
@@ -139,7 +152,7 @@ router.delete(
   '/entries/:namespace/:key',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
-      const deleted = await kvService.del(resolveActor(req), req.params.namespace, req.params.key);
+      const deleted = await kvService.del(resolveActor(req), ns(req), key(req));
       successResponse(res, { deleted });
     } catch (error) {
       next(error);
@@ -153,12 +166,7 @@ router.post(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { by } = parseBody(kvIncrRequestSchema, req.body);
-      const value = await kvService.incrBy(
-        resolveActor(req),
-        req.params.namespace,
-        req.params.key,
-        by
-      );
+      const value = await kvService.incrBy(resolveActor(req), ns(req), key(req), by);
       successResponse(res, { value });
     } catch (error) {
       next(error);
@@ -171,13 +179,9 @@ router.post(
   '/entries/:namespace/:key/decr',
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
+      // `by` is validated positive; negate it here for the decrement.
       const { by } = parseBody(kvIncrRequestSchema, req.body);
-      const value = await kvService.incrBy(
-        resolveActor(req),
-        req.params.namespace,
-        req.params.key,
-        -by
-      );
+      const value = await kvService.incrBy(resolveActor(req), ns(req), key(req), -by);
       successResponse(res, { value });
     } catch (error) {
       next(error);
@@ -191,13 +195,7 @@ router.post(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { expected, next: nextValue } = parseBody(kvCasRequestSchema, req.body);
-      const entry = await kvService.cas(
-        resolveActor(req),
-        req.params.namespace,
-        req.params.key,
-        expected,
-        nextValue
-      );
+      const entry = await kvService.cas(resolveActor(req), ns(req), key(req), expected, nextValue);
       successResponse(res, { entry });
     } catch (error) {
       next(error);
@@ -211,18 +209,11 @@ router.post(
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { ttl } = parseBody(kvExpireRequestSchema, req.body);
-      const updated = await kvService.expire(
-        resolveActor(req),
-        req.params.namespace,
-        req.params.key,
-        ttl
-      );
+      const namespace = ns(req);
+      const k = key(req);
+      const updated = await kvService.expire(resolveActor(req), namespace, k, ttl);
       if (!updated) {
-        throw new AppError(
-          `Key not found: ${req.params.namespace}/${req.params.key}`,
-          404,
-          ERROR_CODES.KV_NOT_FOUND
-        );
+        throw new AppError(`Key not found: ${namespace}/${k}`, 404, ERROR_CODES.KV_NOT_FOUND);
       }
       successResponse(res, { updated });
     } catch (error) {

--- a/backend/src/api/routes/kv/index.routes.ts
+++ b/backend/src/api/routes/kv/index.routes.ts
@@ -1,7 +1,11 @@
 import { Router, Response, NextFunction } from 'express';
-import { z } from 'zod';
 import { AuthRequest, verifyUser } from '@/api/middlewares/auth.js';
-import { KvService, type KvActor } from '@/services/kv/kv.service.js';
+import {
+  resolveStoreActor as resolveActor,
+  parseBody,
+  parseParam,
+} from '@/api/middlewares/store-actor.js';
+import { KvService } from '@/services/kv/kv.service.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
 import {
@@ -23,44 +27,6 @@ const kvService = KvService.getInstance();
 // project-global store) and by app end users (own, RLS-scoped entries).
 router.use(verifyUser);
 
-// API-key callers and the admin dashboard (project_admin JWT) manage the
-// project-global store with full access via the superuser pool (RLS bypassed).
-// Only genuine end users operate as their authenticated/anon identity through RLS.
-function resolveActor(req: AuthRequest): KvActor {
-  if (req.hasApiKey || req.user?.role === 'project_admin') {
-    return { mode: 'admin' };
-  }
-  if (!req.user) {
-    throw new AppError('Authentication required', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
-  }
-  return { mode: 'user', ctx: req.user };
-}
-
-function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S> {
-  const parsed = schema.safeParse(body);
-  if (!parsed.success) {
-    throw new AppError(
-      `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
-      400,
-      ERROR_CODES.INVALID_INPUT
-    );
-  }
-  return parsed.data;
-}
-
-// Validate path params against the shared KV bounds (length caps, no '/') so the
-// HTTP surface matches the exported contract instead of trusting raw req.params.
-function parseParam(schema: z.ZodType<string>, value: string, label: string): string {
-  const parsed = schema.safeParse(value);
-  if (!parsed.success) {
-    throw new AppError(
-      `Invalid ${label}: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
-      400,
-      ERROR_CODES.INVALID_INPUT
-    );
-  }
-  return parsed.data;
-}
 const ns = (req: AuthRequest) => parseParam(kvNamespaceSchema, req.params.namespace, 'namespace');
 const key = (req: AuthRequest) => parseParam(kvKeySchema, req.params.key, 'key');
 

--- a/backend/src/api/routes/kv/index.routes.ts
+++ b/backend/src/api/routes/kv/index.routes.ts
@@ -1,0 +1,234 @@
+import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { AuthRequest, verifyUser } from '@/api/middlewares/auth.js';
+import { KvService, type KvActor } from '@/services/kv/kv.service.js';
+import { successResponse } from '@/utils/response.js';
+import { AppError } from '@/utils/errors.js';
+import {
+  ERROR_CODES,
+  kvSetRequestSchema,
+  kvIncrRequestSchema,
+  kvCasRequestSchema,
+  kvExpireRequestSchema,
+  kvMgetRequestSchema,
+  kvMsetRequestSchema,
+} from '@insforge/shared-schemas';
+
+const router = Router();
+const kvService = KvService.getInstance();
+
+// The KV store is reachable by the project API key (manages the shared
+// project-global store) and by app end users (own, RLS-scoped entries).
+router.use(verifyUser);
+
+// API-key callers and the admin dashboard (project_admin JWT) manage the
+// project-global store with full access via the superuser pool (RLS bypassed).
+// Only genuine end users operate as their authenticated/anon identity through RLS.
+function resolveActor(req: AuthRequest): KvActor {
+  if (req.hasApiKey || req.user?.role === 'project_admin') {
+    return { mode: 'admin' };
+  }
+  if (!req.user) {
+    throw new AppError('Authentication required', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+  }
+  return { mode: 'user', ctx: req.user };
+}
+
+function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S> {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new AppError(
+      `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  return parsed.data;
+}
+
+// --- bulk ops (registered before the dynamic /entries routes) ---------------
+
+// POST /api/kv/mget
+router.post('/mget', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { namespace, keys } = parseBody(kvMgetRequestSchema, req.body);
+    const values = await kvService.mget(resolveActor(req), namespace, keys);
+    successResponse(res, { values });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/kv/mset
+router.post('/mset', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { namespace, entries, ttl, visibility } = parseBody(kvMsetRequestSchema, req.body);
+    const count = await kvService.mset(resolveActor(req), namespace, entries, ttl, visibility);
+    successResponse(res, { count });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// --- single-key ops ---------------------------------------------------------
+
+// GET /api/kv/entries/:namespace  (list keys)
+router.get('/entries/:namespace', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const keys = await kvService.list(resolveActor(req), req.params.namespace);
+    successResponse(res, { keys });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/kv/entries/:namespace/:key/ttl
+router.get(
+  '/entries/:namespace/:key/ttl',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const ttl = await kvService.ttl(resolveActor(req), req.params.namespace, req.params.key);
+      successResponse(res, { ttl });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// GET /api/kv/entries/:namespace/:key
+router.get(
+  '/entries/:namespace/:key',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const value = await kvService.get(resolveActor(req), req.params.namespace, req.params.key);
+      if (value === null) {
+        throw new AppError(
+          `Key not found: ${req.params.namespace}/${req.params.key}`,
+          404,
+          ERROR_CODES.KV_NOT_FOUND
+        );
+      }
+      successResponse(res, { value });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// PUT /api/kv/entries/:namespace/:key
+router.put(
+  '/entries/:namespace/:key',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const body = parseBody(kvSetRequestSchema, req.body);
+      const result = await kvService.set(
+        resolveActor(req),
+        req.params.namespace,
+        req.params.key,
+        body
+      );
+      successResponse(res, result, result.created ? 200 : 409);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/kv/entries/:namespace/:key
+router.delete(
+  '/entries/:namespace/:key',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const deleted = await kvService.del(resolveActor(req), req.params.namespace, req.params.key);
+      successResponse(res, { deleted });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/kv/entries/:namespace/:key/incr
+router.post(
+  '/entries/:namespace/:key/incr',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { by } = parseBody(kvIncrRequestSchema, req.body);
+      const value = await kvService.incrBy(
+        resolveActor(req),
+        req.params.namespace,
+        req.params.key,
+        by
+      );
+      successResponse(res, { value });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/kv/entries/:namespace/:key/decr
+router.post(
+  '/entries/:namespace/:key/decr',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { by } = parseBody(kvIncrRequestSchema, req.body);
+      const value = await kvService.incrBy(
+        resolveActor(req),
+        req.params.namespace,
+        req.params.key,
+        -by
+      );
+      successResponse(res, { value });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/kv/entries/:namespace/:key/cas
+router.post(
+  '/entries/:namespace/:key/cas',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { expected, next: nextValue } = parseBody(kvCasRequestSchema, req.body);
+      const entry = await kvService.cas(
+        resolveActor(req),
+        req.params.namespace,
+        req.params.key,
+        expected,
+        nextValue
+      );
+      successResponse(res, { entry });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/kv/entries/:namespace/:key/expire
+router.post(
+  '/entries/:namespace/:key/expire',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { ttl } = parseBody(kvExpireRequestSchema, req.body);
+      const updated = await kvService.expire(
+        resolveActor(req),
+        req.params.namespace,
+        req.params.key,
+        ttl
+      );
+      if (!updated) {
+        throw new AppError(
+          `Key not found: ${req.params.namespace}/${req.params.key}`,
+          404,
+          ERROR_CODES.KV_NOT_FOUND
+        );
+      }
+      successResponse(res, { updated });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export { router as kvRouter };

--- a/backend/src/api/routes/vectors/index.routes.ts
+++ b/backend/src/api/routes/vectors/index.routes.ts
@@ -1,0 +1,136 @@
+import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { AuthRequest, verifyUser } from '@/api/middlewares/auth.js';
+import { VectorService, type VectorActor } from '@/services/vectors/vector.service.js';
+import { successResponse } from '@/utils/response.js';
+import { AppError } from '@/utils/errors.js';
+import {
+  ERROR_CODES,
+  createCollectionRequestSchema,
+  vectorUpsertRequestSchema,
+  vectorQueryRequestSchema,
+} from '@insforge/shared-schemas';
+
+const router = Router();
+const vectorService = VectorService.getInstance();
+
+// Reachable by the project API key (project-global store) and app end users
+// (own, RLS-scoped collections and items).
+router.use(verifyUser);
+
+// API-key callers and the admin dashboard (project_admin JWT) manage the
+// project-global store with full access via the superuser pool (RLS bypassed).
+// Only genuine end users operate as their authenticated/anon identity through RLS.
+function resolveActor(req: AuthRequest): VectorActor {
+  if (req.hasApiKey || req.user?.role === 'project_admin') {
+    return { mode: 'admin' };
+  }
+  if (!req.user) {
+    throw new AppError('Authentication required', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+  }
+  return { mode: 'user', ctx: req.user };
+}
+
+function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S> {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new AppError(
+      `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  return parsed.data;
+}
+
+// POST /api/vectors/collections
+router.post('/collections', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const input = parseBody(createCollectionRequestSchema, req.body);
+    const collection = await vectorService.createCollection(resolveActor(req), input);
+    successResponse(res, { collection }, 201);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/vectors/collections
+router.get('/collections', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const collections = await vectorService.listCollections(resolveActor(req));
+    successResponse(res, { collections });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/vectors/collections/:name
+router.delete('/collections/:name', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const deleted = await vectorService.deleteCollection(resolveActor(req), req.params.name);
+    if (!deleted) {
+      throw new AppError(
+        `Collection not found: ${req.params.name}`,
+        404,
+        ERROR_CODES.VECTOR_COLLECTION_NOT_FOUND
+      );
+    }
+    successResponse(res, { deleted });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/vectors/collections/:name/upsert
+router.post(
+  '/collections/:name/upsert',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { items } = parseBody(vectorUpsertRequestSchema, req.body);
+      const ids = await vectorService.upsert(resolveActor(req), req.params.name, items);
+      successResponse(res, { ids });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// POST /api/vectors/collections/:name/query
+router.post(
+  '/collections/:name/query',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const params = parseBody(vectorQueryRequestSchema, req.body);
+      const matches = await vectorService.query(resolveActor(req), req.params.name, params);
+      successResponse(res, { matches });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// DELETE /api/vectors/collections/:name/items/:itemId
+router.delete(
+  '/collections/:name/items/:itemId',
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const deleted = await vectorService.deleteItem(
+        resolveActor(req),
+        req.params.name,
+        req.params.itemId
+      );
+      if (!deleted) {
+        throw new AppError(
+          `Item not found: ${req.params.itemId}`,
+          404,
+          ERROR_CODES.VECTOR_ITEM_NOT_FOUND
+        );
+      }
+      successResponse(res, { deleted });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export { router as vectorRouter };

--- a/backend/src/api/routes/vectors/index.routes.ts
+++ b/backend/src/api/routes/vectors/index.routes.ts
@@ -1,7 +1,7 @@
 import { Router, Response, NextFunction } from 'express';
-import { z } from 'zod';
 import { AuthRequest, verifyUser } from '@/api/middlewares/auth.js';
-import { VectorService, type VectorActor } from '@/services/vectors/vector.service.js';
+import { resolveStoreActor as resolveActor, parseBody } from '@/api/middlewares/store-actor.js';
+import { VectorService } from '@/services/vectors/vector.service.js';
 import { successResponse } from '@/utils/response.js';
 import { AppError } from '@/utils/errors.js';
 import {
@@ -17,31 +17,6 @@ const vectorService = VectorService.getInstance();
 // Reachable by the project API key (project-global store) and app end users
 // (own, RLS-scoped collections and items).
 router.use(verifyUser);
-
-// API-key callers and the admin dashboard (project_admin JWT) manage the
-// project-global store with full access via the superuser pool (RLS bypassed).
-// Only genuine end users operate as their authenticated/anon identity through RLS.
-function resolveActor(req: AuthRequest): VectorActor {
-  if (req.hasApiKey || req.user?.role === 'project_admin') {
-    return { mode: 'admin' };
-  }
-  if (!req.user) {
-    throw new AppError('Authentication required', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
-  }
-  return { mode: 'user', ctx: req.user };
-}
-
-function parseBody<S extends z.ZodTypeAny>(schema: S, body: unknown): z.infer<S> {
-  const parsed = schema.safeParse(body);
-  if (!parsed.success) {
-    throw new AppError(
-      `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
-      400,
-      ERROR_CODES.INVALID_INPUT
-    );
-  }
-  return parsed.data;
-}
 
 // POST /api/vectors/collections
 router.post('/collections', async (req: AuthRequest, res: Response, next: NextFunction) => {

--- a/backend/src/infra/database/migrations/058_create-kv-schema.sql
+++ b/backend/src/infra/database/migrations/058_create-kv-schema.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- Migration 058: Key-Value store schema (Redis-like, Postgres-backed)
+-- Managed schema provisioned in every project, like memory.* / realtime.*.
+-- Stores arbitrary JSON addressed by (namespace, key), with TTL and
+-- owner-scoped Row Level Security for end-user access.
+-- ============================================================================
+
+CREATE SCHEMA IF NOT EXISTS kv;
+
+CREATE TABLE IF NOT EXISTS kv.entries (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  namespace   TEXT NOT NULL DEFAULT 'default',
+  key         TEXT NOT NULL,
+  value       JSONB NOT NULL,
+  -- NULL owner = project-global entry (managed via the project API key).
+  -- A set owner = an end-user-owned entry, gated by RLS on auth.uid().
+  owner_id    UUID,
+  visibility  TEXT NOT NULL DEFAULT 'private'
+              CHECK (visibility IN ('private', 'authed', 'public')),
+  expires_at  TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- (namespace, key) is unique per owner. NULLs are distinct in a plain UNIQUE,
+-- so collapse NULL owners onto a sentinel to keep project-global keys unique.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kv_entries_owner_ns_key
+  ON kv.entries (namespace, key, COALESCE(owner_id, '00000000-0000-0000-0000-000000000000'::uuid));
+
+CREATE INDEX IF NOT EXISTS idx_kv_entries_lookup ON kv.entries (namespace, key);
+-- Partial index supports the TTL sweep without bloating it with non-expiring rows.
+CREATE INDEX IF NOT EXISTS idx_kv_entries_expires_at
+  ON kv.entries (expires_at) WHERE expires_at IS NOT NULL;
+
+-- Keep updated_at fresh on UPDATE.
+DROP TRIGGER IF EXISTS trg_kv_entries_updated_at ON kv.entries;
+CREATE TRIGGER trg_kv_entries_updated_at
+BEFORE UPDATE ON kv.entries
+FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+-- End-user requests run as `authenticated`/`anon` (via withUserContext) and are
+-- gated here. The backend's API-key/admin path connects as the superuser pool
+-- role, which bypasses RLS and sees every row (project-global management).
+
+ALTER TABLE kv.entries ENABLE ROW LEVEL SECURITY;
+
+-- Read: own rows, anything public, and 'authed' rows for any signed-in user.
+DROP POLICY IF EXISTS kv_entries_select ON kv.entries;
+CREATE POLICY kv_entries_select ON kv.entries
+  FOR SELECT
+  USING (
+    owner_id = auth.uid()
+    OR visibility = 'public'
+    OR (visibility = 'authed' AND auth.uid() IS NOT NULL)
+  );
+
+-- Writes are always owner-only; owner_id must match the caller's identity.
+DROP POLICY IF EXISTS kv_entries_insert ON kv.entries;
+CREATE POLICY kv_entries_insert ON kv.entries
+  FOR INSERT
+  WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS kv_entries_update ON kv.entries;
+CREATE POLICY kv_entries_update ON kv.entries
+  FOR UPDATE
+  USING (owner_id = auth.uid())
+  WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS kv_entries_delete ON kv.entries;
+CREATE POLICY kv_entries_delete ON kv.entries
+  FOR DELETE
+  USING (owner_id = auth.uid());
+
+-- ============================================================================
+-- GRANTS
+-- ============================================================================
+GRANT USAGE ON SCHEMA kv TO authenticated, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON kv.entries TO authenticated;
+-- Anonymous callers can only read (RLS further limits them to public rows).
+GRANT SELECT ON kv.entries TO anon;

--- a/backend/src/infra/database/migrations/058_create-kv-schema.sql
+++ b/backend/src/infra/database/migrations/058_create-kv-schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE IF NOT EXISTS kv.entries (
 CREATE UNIQUE INDEX IF NOT EXISTS uq_kv_entries_owner_ns_key
   ON kv.entries (namespace, key, COALESCE(owner_id, '00000000-0000-0000-0000-000000000000'::uuid));
 
-CREATE INDEX IF NOT EXISTS idx_kv_entries_lookup ON kv.entries (namespace, key);
+-- (namespace, key) lookups are already served by the unique index above as a
+-- left-prefix B-tree scan, so no separate (namespace, key) index is needed.
 -- Partial index supports the TTL sweep without bloating it with non-expiring rows.
 CREATE INDEX IF NOT EXISTS idx_kv_entries_expires_at
   ON kv.entries (expires_at) WHERE expires_at IS NOT NULL;

--- a/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
+++ b/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
@@ -91,6 +91,8 @@ CREATE POLICY vector_items_delete ON vectors.items
 -- ============================================================================
 -- GRANTS
 -- ============================================================================
-GRANT USAGE ON SCHEMA vectors TO authenticated, anon;
+-- Only authenticated end users get table privileges; anon has no vector access,
+-- so it needs no schema USAGE.
+GRANT USAGE ON SCHEMA vectors TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON vectors.collections TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON vectors.items TO authenticated;

--- a/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
+++ b/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- Migration 059: Vector store schema (Pinecone-like, backed by pgvector)
+-- Managed schema provisioned in every project. Collections group fixed-dimension
+-- embeddings; items carry an embedding plus optional source text and metadata.
+-- Owner-scoped Row Level Security gates end-user access.
+-- ============================================================================
+
+-- Already created in migration 050; repeated for independence/idempotency.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE SCHEMA IF NOT EXISTS vectors;
+
+CREATE TABLE IF NOT EXISTS vectors.collections (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       TEXT NOT NULL,
+  dimension  INT NOT NULL DEFAULT 1536,
+  metric     TEXT NOT NULL DEFAULT 'cosine' CHECK (metric IN ('cosine', 'l2', 'ip')),
+  owner_id   UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Collection names are unique per owner (NULL owner = project-global).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_vector_collections_owner_name
+  ON vectors.collections (name, COALESCE(owner_id, '00000000-0000-0000-0000-000000000000'::uuid));
+
+CREATE TABLE IF NOT EXISTS vectors.items (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  collection_id UUID NOT NULL REFERENCES vectors.collections(id) ON DELETE CASCADE,
+  -- MVP fixes the column at 1536 to match the managed embedding model. A future
+  -- per-collection-table backend can vary this without changing the API.
+  embedding     VECTOR(1536) NOT NULL,
+  content       TEXT,
+  metadata      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  owner_id      UUID,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vector_items_collection ON vectors.items (collection_id);
+
+-- HNSW index for cosine similarity (the indexed/default metric; safe on empty
+-- tables). l2/ip queries compute correct distances but are not index-accelerated.
+CREATE INDEX IF NOT EXISTS idx_vector_items_embedding_cosine
+  ON vectors.items USING hnsw (embedding vector_cosine_ops);
+
+-- GIN index supports Pinecone-style metadata containment filters (metadata @> ...).
+CREATE INDEX IF NOT EXISTS idx_vector_items_metadata
+  ON vectors.items USING gin (metadata jsonb_path_ops);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+-- Same model as kv.*: end-user requests run as authenticated/anon via
+-- withUserContext and are gated here; the API-key/admin path uses the superuser
+-- pool role and bypasses RLS for project-global management.
+
+ALTER TABLE vectors.collections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vectors.items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS vector_collections_select ON vectors.collections;
+CREATE POLICY vector_collections_select ON vectors.collections
+  FOR SELECT USING (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_collections_insert ON vectors.collections;
+CREATE POLICY vector_collections_insert ON vectors.collections
+  FOR INSERT WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_collections_delete ON vectors.collections;
+CREATE POLICY vector_collections_delete ON vectors.collections
+  FOR DELETE USING (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_items_select ON vectors.items;
+CREATE POLICY vector_items_select ON vectors.items
+  FOR SELECT USING (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_items_insert ON vectors.items;
+CREATE POLICY vector_items_insert ON vectors.items
+  FOR INSERT WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_items_update ON vectors.items;
+CREATE POLICY vector_items_update ON vectors.items
+  FOR UPDATE USING (owner_id = auth.uid()) WITH CHECK (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS vector_items_delete ON vectors.items;
+CREATE POLICY vector_items_delete ON vectors.items
+  FOR DELETE USING (owner_id = auth.uid());
+
+-- ============================================================================
+-- GRANTS
+-- ============================================================================
+GRANT USAGE ON SCHEMA vectors TO authenticated, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON vectors.collections TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON vectors.items TO authenticated;

--- a/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
+++ b/backend/src/infra/database/migrations/059_create-vector-store-schema.sql
@@ -13,7 +13,11 @@ CREATE SCHEMA IF NOT EXISTS vectors;
 CREATE TABLE IF NOT EXISTS vectors.collections (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name       TEXT NOT NULL,
-  dimension  INT NOT NULL DEFAULT 1536,
+  -- vectors.items.embedding is fixed at VECTOR(1536) in this version, so the
+  -- collection dimension is constrained to match. A direct insert with any
+  -- other dimension would be unusable (upsert/query would fail); the CHECK
+  -- makes that contract enforceable at the DB level, not just in the service.
+  dimension  INT NOT NULL DEFAULT 1536 CHECK (dimension = 1536),
   metric     TEXT NOT NULL DEFAULT 'cosine' CHECK (metric IN ('cosine', 'l2', 'ip')),
   owner_id   UUID,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,8 @@ import secretsRouter from '@/api/routes/secrets/index.routes.js';
 import { usageRouter } from '@/api/routes/usage/index.routes.js';
 import { aiRouter } from '@/api/routes/ai/index.routes.js';
 import { memoryRouter } from '@/api/routes/memory/index.routes.js';
+import { kvRouter } from '@/api/routes/kv/index.routes.js';
+import { vectorRouter } from '@/api/routes/vectors/index.routes.js';
 import { realtimeRouter } from '@/api/routes/realtime/index.routes.js';
 import { emailRouter } from '@/api/routes/email/index.routes.js';
 import { deploymentsRouter } from '@/api/routes/deployments/index.routes.js';
@@ -198,6 +200,8 @@ export async function createApp() {
   apiRouter.use('/usage', usageRouter);
   apiRouter.use('/ai', aiRouter);
   apiRouter.use('/memory', memoryRouter);
+  apiRouter.use('/kv', kvRouter);
+  apiRouter.use('/vectors', vectorRouter);
   apiRouter.use('/realtime', realtimeRouter);
   apiRouter.use('/email', emailRouter);
   apiRouter.use('/deployments', deploymentsRouter);

--- a/backend/src/services/kv/kv.service.ts
+++ b/backend/src/services/kv/kv.service.ts
@@ -1,0 +1,420 @@
+import { Pool, PoolClient } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { withUserContext } from '@/services/database/user-context.service.js';
+import type { UserContext } from '@/api/middlewares/auth.js';
+import { AppError } from '@/utils/errors.js';
+import logger from '@/utils/logger.js';
+import { ERROR_CODES, type KvEntry, type KvVisibility } from '@insforge/shared-schemas';
+
+// Butterbase-style default: every new key expires in 30 days unless told otherwise.
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 30;
+// Hard cap on a single value's serialized size. Keeps KV honest as a cache/
+// config store rather than a blob store (use Storage for large payloads).
+const MAX_VALUE_BYTES = 256 * 1024;
+// project-global rows have NULL owner_id; collapse to this sentinel so a single
+// COALESCE predicate addresses the right row in both the admin and user paths.
+const OWNER_SENTINEL = '00000000-0000-0000-0000-000000000000';
+
+type Queryable = Pool | PoolClient;
+
+// API-key callers manage the shared project-global store (RLS-bypassing pool);
+// end users operate on their own rows through withUserContext + RLS.
+export type KvActor = { mode: 'admin' } | { mode: 'user'; ctx: UserContext };
+
+interface EntryRow {
+  value: unknown;
+  visibility: KvVisibility;
+  expires_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function toIso(value: Date | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+// For NOT NULL timestamp columns (created_at / updated_at).
+function toIsoRequired(value: Date): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+export class KvService {
+  private static instance: KvService;
+  private pool: Pool | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): KvService {
+    if (!KvService.instance) {
+      KvService.instance = new KvService();
+    }
+    return KvService.instance;
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  // Resolve the actor to (a queryable, the owner_id to read/write). Admin uses
+  // the superuser pool (RLS bypassed) and the project-global NULL owner. Users
+  // run inside withUserContext so RLS applies; only authenticated users own
+  // rows (anon/admin JWTs map to the NULL project-global owner).
+  private async run<T>(
+    actor: KvActor,
+    fn: (db: Queryable, ownerId: string | null) => Promise<T>
+  ): Promise<T> {
+    if (actor.mode === 'admin') {
+      return fn(this.getPool(), null);
+    }
+    const ctx = actor.ctx;
+    const ownerId = ctx.role === 'authenticated' ? ctx.id : null;
+    return withUserContext(this.getPool(), ctx, (client) => fn(client, ownerId));
+  }
+
+  private ownerParam(ownerId: string | null): string | null {
+    return ownerId;
+  }
+
+  private assertValueSize(value: unknown): string {
+    const serialized = JSON.stringify(value ?? null);
+    if (Buffer.byteLength(serialized, 'utf8') > MAX_VALUE_BYTES) {
+      throw new AppError(
+        `Value exceeds the ${MAX_VALUE_BYTES}-byte limit`,
+        413,
+        ERROR_CODES.KV_VALUE_TOO_LARGE
+      );
+    }
+    return serialized;
+  }
+
+  // undefined ttl -> default; null -> no expiry; number -> seconds from now.
+  private resolveTtl(ttl: number | null | undefined): number | null {
+    if (ttl === undefined) {
+      return DEFAULT_TTL_SECONDS;
+    }
+    return ttl;
+  }
+
+  async get(actor: KvActor, namespace: string, key: string): Promise<unknown | null> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `SELECT value FROM kv.entries
+          WHERE namespace = $1 AND key = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())`,
+        [namespace, key, OWNER_SENTINEL, this.ownerParam(ownerId)]
+      );
+      return result.rows.length ? (result.rows[0].value as unknown) : null;
+    });
+  }
+
+  async set(
+    actor: KvActor,
+    namespace: string,
+    key: string,
+    opts: {
+      // z.unknown() yields an optional property; undefined is normalized to null.
+      value?: unknown;
+      ttl?: number | null;
+      visibility?: KvVisibility;
+      ifNotExists?: boolean;
+    }
+  ): Promise<{ created: boolean; entry: KvEntry | null }> {
+    const serialized = this.assertValueSize(opts.value);
+    const ttlSeconds = this.resolveTtl(opts.ttl);
+    const visibility = opts.visibility ?? 'private';
+
+    return this.run(actor, async (db, ownerId) => {
+      // ON CONFLICT DO NOTHING for set-if-not-exists; otherwise overwrite.
+      const conflictClause = opts.ifNotExists
+        ? 'DO NOTHING'
+        : `DO UPDATE SET value = EXCLUDED.value,
+                         visibility = EXCLUDED.visibility,
+                         expires_at = EXCLUDED.expires_at`;
+      const result = await db.query(
+        `INSERT INTO kv.entries (namespace, key, value, owner_id, visibility, expires_at)
+         VALUES (
+           $1, $2, $3::jsonb, $4::uuid, $5,
+           CASE WHEN $6::int IS NULL THEN NULL ELSE NOW() + make_interval(secs => $6::int) END
+         )
+         ON CONFLICT (namespace, key, COALESCE(owner_id, $7::uuid)) ${conflictClause}
+         RETURNING value, visibility, expires_at, created_at, updated_at`,
+        [namespace, key, serialized, ownerId, visibility, ttlSeconds, OWNER_SENTINEL]
+      );
+
+      if (!result.rows.length) {
+        // ifNotExists hit an existing row — nothing written.
+        return { created: false, entry: null };
+      }
+      const row = result.rows[0] as EntryRow;
+      return {
+        created: true,
+        entry: {
+          namespace,
+          key,
+          value: row.value,
+          visibility: row.visibility,
+          expiresAt: toIso(row.expires_at),
+          createdAt: toIsoRequired(row.created_at),
+          updatedAt: toIsoRequired(row.updated_at),
+        },
+      };
+    });
+  }
+
+  async del(actor: KvActor, namespace: string, key: string): Promise<boolean> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `DELETE FROM kv.entries
+          WHERE namespace = $1 AND key = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)`,
+        [namespace, key, OWNER_SENTINEL, this.ownerParam(ownerId)]
+      );
+      return (result.rowCount ?? 0) > 0;
+    });
+  }
+
+  async exists(actor: KvActor, namespace: string, key: string): Promise<boolean> {
+    return (await this.get(actor, namespace, key)) !== null;
+  }
+
+  // Atomic increment. Initializes a missing key to `by`. Fails if the existing
+  // value is not a JSON number.
+  async incrBy(actor: KvActor, namespace: string, key: string, by: number): Promise<number> {
+    return this.run(actor, async (db, ownerId) => {
+      try {
+        const result = await db.query(
+          `INSERT INTO kv.entries (namespace, key, value, owner_id, visibility, expires_at)
+           VALUES (
+             $1, $2, to_jsonb($5::numeric), $4::uuid, 'private',
+             NOW() + make_interval(secs => $6::int)
+           )
+           ON CONFLICT (namespace, key, COALESCE(owner_id, $3::uuid))
+           DO UPDATE SET value = to_jsonb(
+             COALESCE((kv.entries.value #>> '{}')::numeric, 0) + $5::numeric
+           )
+           RETURNING value`,
+          [namespace, key, OWNER_SENTINEL, ownerId, by, DEFAULT_TTL_SECONDS]
+        );
+        return Number(result.rows[0].value);
+      } catch (error) {
+        // 22P02 invalid_text_representation: existing value wasn't numeric.
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          error.code === '22P02'
+        ) {
+          throw new AppError(
+            `Value at ${namespace}/${key} is not a number`,
+            400,
+            ERROR_CODES.KV_NOT_A_NUMBER
+          );
+        }
+        throw error;
+      }
+    });
+  }
+
+  // Compare-and-swap. Throws KV_CAS_MISMATCH (409) if the current value differs,
+  // KV_NOT_FOUND (404) if the key is absent/expired.
+  async cas(
+    actor: KvActor,
+    namespace: string,
+    key: string,
+    expected: unknown,
+    next: unknown
+  ): Promise<KvEntry> {
+    const serializedNext = this.assertValueSize(next);
+    const serializedExpected = JSON.stringify(expected ?? null);
+
+    return this.run(actor, async (db, ownerId) => {
+      const updated = await db.query(
+        `UPDATE kv.entries
+            SET value = $5::jsonb
+          WHERE namespace = $1 AND key = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND value = $6::jsonb
+            AND (expires_at IS NULL OR expires_at > NOW())
+        RETURNING value, visibility, expires_at, created_at, updated_at`,
+        [namespace, key, OWNER_SENTINEL, ownerId, serializedNext, serializedExpected]
+      );
+
+      if (updated.rows.length) {
+        const row = updated.rows[0] as EntryRow;
+        return {
+          namespace,
+          key,
+          value: row.value,
+          visibility: row.visibility,
+          expiresAt: toIso(row.expires_at),
+          createdAt: toIsoRequired(row.created_at),
+          updatedAt: toIsoRequired(row.updated_at),
+        };
+      }
+
+      // No row updated: distinguish absent key from a value mismatch.
+      const exists = await this.existsInTx(db, namespace, key, ownerId);
+      if (!exists) {
+        throw new AppError(`Key not found: ${namespace}/${key}`, 404, ERROR_CODES.KV_NOT_FOUND);
+      }
+      throw new AppError(
+        `Compare-and-swap failed: current value does not match expected`,
+        409,
+        ERROR_CODES.KV_CAS_MISMATCH
+      );
+    });
+  }
+
+  private async existsInTx(
+    db: Queryable,
+    namespace: string,
+    key: string,
+    ownerId: string | null
+  ): Promise<boolean> {
+    const result = await db.query(
+      `SELECT 1 FROM kv.entries
+        WHERE namespace = $1 AND key = $2
+          AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+          AND (expires_at IS NULL OR expires_at > NOW())`,
+      [namespace, key, OWNER_SENTINEL, ownerId]
+    );
+    return result.rows.length > 0;
+  }
+
+  // Set/clear the TTL without changing the value. Returns false if absent.
+  async expire(
+    actor: KvActor,
+    namespace: string,
+    key: string,
+    ttl: number | null
+  ): Promise<boolean> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `UPDATE kv.entries
+            SET expires_at = CASE WHEN $5::int IS NULL THEN NULL
+                                  ELSE NOW() + make_interval(secs => $5::int) END
+          WHERE namespace = $1 AND key = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())`,
+        [namespace, key, OWNER_SENTINEL, ownerId, ttl]
+      );
+      return (result.rowCount ?? 0) > 0;
+    });
+  }
+
+  // Remaining seconds until expiry; null if the key never expires. Throws 404
+  // if the key is absent/expired.
+  async ttl(actor: KvActor, namespace: string, key: string): Promise<number | null> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `SELECT EXTRACT(EPOCH FROM (expires_at - NOW())) AS ttl
+           FROM kv.entries
+          WHERE namespace = $1 AND key = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())`,
+        [namespace, key, OWNER_SENTINEL, ownerId]
+      );
+      if (!result.rows.length) {
+        throw new AppError(`Key not found: ${namespace}/${key}`, 404, ERROR_CODES.KV_NOT_FOUND);
+      }
+      const ttl = result.rows[0].ttl;
+      return ttl === null ? null : Math.floor(Number(ttl));
+    });
+  }
+
+  async mget(actor: KvActor, namespace: string, keys: string[]): Promise<Record<string, unknown>> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `SELECT key, value FROM kv.entries
+          WHERE namespace = $1 AND key = ANY($2::text[])
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())`,
+        [namespace, keys, OWNER_SENTINEL, ownerId]
+      );
+      const values: Record<string, unknown> = {};
+      for (const row of result.rows) {
+        values[row.key] = row.value;
+      }
+      return values;
+    });
+  }
+
+  async mset(
+    actor: KvActor,
+    namespace: string,
+    entries: Record<string, unknown>,
+    ttl?: number | null,
+    visibility?: KvVisibility
+  ): Promise<number> {
+    const ttlSeconds = this.resolveTtl(ttl);
+    const vis = visibility ?? 'private';
+    const pairs = Object.entries(entries);
+    for (const [, value] of pairs) {
+      this.assertValueSize(value);
+    }
+
+    return this.run(actor, async (db, ownerId) => {
+      let count = 0;
+      for (const [key, value] of pairs) {
+        await db.query(
+          `INSERT INTO kv.entries (namespace, key, value, owner_id, visibility, expires_at)
+           VALUES (
+             $1, $2, $3::jsonb, $4::uuid, $5,
+             CASE WHEN $6::int IS NULL THEN NULL ELSE NOW() + make_interval(secs => $6::int) END
+           )
+           ON CONFLICT (namespace, key, COALESCE(owner_id, $7::uuid))
+           DO UPDATE SET value = EXCLUDED.value,
+                         visibility = EXCLUDED.visibility,
+                         expires_at = EXCLUDED.expires_at`,
+          [namespace, key, JSON.stringify(value ?? null), ownerId, vis, ttlSeconds, OWNER_SENTINEL]
+        );
+        count++;
+      }
+      return count;
+    });
+  }
+
+  async list(
+    actor: KvActor,
+    namespace: string
+  ): Promise<
+    Array<{ key: string; visibility: KvVisibility; expiresAt: string | null; updatedAt: string }>
+  > {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `SELECT key, visibility, expires_at, updated_at FROM kv.entries
+          WHERE namespace = $1
+            AND COALESCE(owner_id, $2::uuid) = COALESCE($3::uuid, $2::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())
+          ORDER BY key ASC`,
+        [namespace, OWNER_SENTINEL, ownerId]
+      );
+      return result.rows.map((r) => ({
+        key: r.key,
+        visibility: r.visibility,
+        expiresAt: toIso(r.expires_at),
+        updatedAt: toIsoRequired(r.updated_at),
+      }));
+    });
+  }
+
+  // TTL sweep — deletes expired rows across the whole store. Runs as the admin
+  // pool (RLS bypassed) so a scheduled job can reclaim every owner's stale keys.
+  async cleanupExpired(): Promise<number> {
+    const result = await this.getPool().query(
+      `DELETE FROM kv.entries WHERE expires_at IS NOT NULL AND expires_at < NOW()`
+    );
+    const count = result.rowCount ?? 0;
+    if (count > 0) {
+      logger.info('KV expired entries swept', { count });
+    }
+    return count;
+  }
+}

--- a/backend/src/services/kv/kv.service.ts
+++ b/backend/src/services/kv/kv.service.ts
@@ -27,6 +27,8 @@ interface EntryRow {
   expires_at: Date | null;
   created_at: Date;
   updated_at: Date;
+  // (xmax = 0) — true only for a genuine INSERT, false when ON CONFLICT updated.
+  inserted?: boolean;
 }
 
 function toIso(value: Date | null): string | null {
@@ -144,17 +146,18 @@ export class KvService {
            CASE WHEN $6::int IS NULL THEN NULL ELSE NOW() + make_interval(secs => $6::int) END
          )
          ON CONFLICT (namespace, key, COALESCE(owner_id, $7::uuid)) ${conflictClause}
-         RETURNING value, visibility, expires_at, created_at, updated_at`,
+         RETURNING value, visibility, expires_at, created_at, updated_at, (xmax = 0) AS inserted`,
         [namespace, key, serialized, ownerId, visibility, ttlSeconds, OWNER_SENTINEL]
       );
 
       if (!result.rows.length) {
-        // ifNotExists hit an existing row — nothing written.
+        // ifNotExists (DO NOTHING) hit an existing row — nothing written.
         return { created: false, entry: null };
       }
       const row = result.rows[0] as EntryRow;
       return {
-        created: true,
+        // true only for a genuine insert; an upsert that updated reports false.
+        created: row.inserted === true,
         entry: {
           namespace,
           key,
@@ -173,9 +176,11 @@ export class KvService {
       const result = await db.query(
         `DELETE FROM kv.entries
           WHERE namespace = $1 AND key = $2
-            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)`,
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
+            AND (expires_at IS NULL OR expires_at > NOW())`,
         [namespace, key, OWNER_SENTINEL, this.ownerParam(ownerId)]
       );
+      // A logically-expired key reports deleted=false, matching get() returning null.
       return (result.rowCount ?? 0) > 0;
     });
   }
@@ -359,25 +364,29 @@ export class KvService {
     for (const [, value] of pairs) {
       this.assertValueSize(value);
     }
+    if (pairs.length === 0) {
+      return 0;
+    }
 
     return this.run(actor, async (db, ownerId) => {
-      let count = 0;
-      for (const [key, value] of pairs) {
-        await db.query(
-          `INSERT INTO kv.entries (namespace, key, value, owner_id, visibility, expires_at)
-           VALUES (
-             $1, $2, $3::jsonb, $4::uuid, $5,
-             CASE WHEN $6::int IS NULL THEN NULL ELSE NOW() + make_interval(secs => $6::int) END
-           )
-           ON CONFLICT (namespace, key, COALESCE(owner_id, $7::uuid))
-           DO UPDATE SET value = EXCLUDED.value,
-                         visibility = EXCLUDED.visibility,
-                         expires_at = EXCLUDED.expires_at`,
-          [namespace, key, JSON.stringify(value ?? null), ownerId, vis, ttlSeconds, OWNER_SENTINEL]
-        );
-        count++;
-      }
-      return count;
+      // One multi-row upsert so the whole batch is atomic: a failure on any key
+      // rolls back the rest instead of leaving a partial write.
+      const params: unknown[] = [ownerId, vis, ttlSeconds, OWNER_SENTINEL];
+      const rows = pairs.map(([key, value]) => {
+        const base = params.length;
+        params.push(namespace, key, JSON.stringify(value ?? null));
+        return `($${base + 1}, $${base + 2}, $${base + 3}::jsonb, $1::uuid, $2, CASE WHEN $3::int IS NULL THEN NULL ELSE NOW() + make_interval(secs => $3::int) END)`;
+      });
+      const result = await db.query(
+        `INSERT INTO kv.entries (namespace, key, value, owner_id, visibility, expires_at)
+         VALUES ${rows.join(', ')}
+         ON CONFLICT (namespace, key, COALESCE(owner_id, $4::uuid))
+         DO UPDATE SET value = EXCLUDED.value,
+                       visibility = EXCLUDED.visibility,
+                       expires_at = EXCLUDED.expires_at`,
+        params
+      );
+      return result.rowCount ?? pairs.length;
     });
   }
 

--- a/backend/src/services/kv/kv.service.ts
+++ b/backend/src/services/kv/kv.service.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolClient } from 'pg';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { withUserContext } from '@/services/database/user-context.service.js';
-import type { UserContext } from '@/api/middlewares/auth.js';
+import type { StoreActor } from '@/api/middlewares/store-actor.js';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import { ERROR_CODES, type KvEntry, type KvVisibility } from '@insforge/shared-schemas';
@@ -17,9 +17,9 @@ const OWNER_SENTINEL = '00000000-0000-0000-0000-000000000000';
 
 type Queryable = Pool | PoolClient;
 
-// API-key callers manage the shared project-global store (RLS-bypassing pool);
-// end users operate on their own rows through withUserContext + RLS.
-export type KvActor = { mode: 'admin' } | { mode: 'user'; ctx: UserContext };
+// API-key/admin callers manage the shared project-global store (RLS-bypassing
+// pool); end users operate on their own rows through withUserContext + RLS.
+export type KvActor = StoreActor;
 
 interface EntryRow {
   value: unknown;
@@ -79,10 +79,6 @@ export class KvService {
     return withUserContext(this.getPool(), ctx, (client) => fn(client, ownerId));
   }
 
-  private ownerParam(ownerId: string | null): string | null {
-    return ownerId;
-  }
-
   private assertValueSize(value: unknown): string {
     const serialized = JSON.stringify(value ?? null);
     if (Buffer.byteLength(serialized, 'utf8') > MAX_VALUE_BYTES) {
@@ -110,7 +106,7 @@ export class KvService {
           WHERE namespace = $1 AND key = $2
             AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
             AND (expires_at IS NULL OR expires_at > NOW())`,
-        [namespace, key, OWNER_SENTINEL, this.ownerParam(ownerId)]
+        [namespace, key, OWNER_SENTINEL, ownerId]
       );
       return result.rows.length ? (result.rows[0].value as unknown) : null;
     });
@@ -178,7 +174,7 @@ export class KvService {
           WHERE namespace = $1 AND key = $2
             AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)
             AND (expires_at IS NULL OR expires_at > NOW())`,
-        [namespace, key, OWNER_SENTINEL, this.ownerParam(ownerId)]
+        [namespace, key, OWNER_SENTINEL, ownerId]
       );
       // A logically-expired key reports deleted=false, matching get() returning null.
       return (result.rowCount ?? 0) > 0;
@@ -186,7 +182,9 @@ export class KvService {
   }
 
   async exists(actor: KvActor, namespace: string, key: string): Promise<boolean> {
-    return (await this.get(actor, namespace, key)) !== null;
+    // SELECT 1 instead of get(): avoids fetching a potentially large value JSONB
+    // just to test presence.
+    return this.run(actor, (db, ownerId) => this.existsInTx(db, namespace, key, ownerId));
   }
 
   // Atomic increment. Initializes a missing key to `by`. Fails if the existing

--- a/backend/src/services/vectors/vector.service.ts
+++ b/backend/src/services/vectors/vector.service.ts
@@ -1,8 +1,9 @@
 import { Pool, PoolClient } from 'pg';
+import { randomUUID } from 'crypto';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { EmbeddingService } from '@/services/ai/embedding.service.js';
 import { withUserContext } from '@/services/database/user-context.service.js';
-import type { UserContext } from '@/api/middlewares/auth.js';
+import type { StoreActor } from '@/api/middlewares/store-actor.js';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import {
@@ -21,7 +22,7 @@ const OWNER_SENTINEL = '00000000-0000-0000-0000-000000000000';
 
 type Queryable = Pool | PoolClient;
 
-export type VectorActor = { mode: 'admin' } | { mode: 'user'; ctx: UserContext };
+export type VectorActor = StoreActor;
 
 interface CollectionRow {
   id: string;
@@ -251,48 +252,40 @@ export class VectorService {
     collectionName: string,
     items: VectorUpsertItem[]
   ): Promise<string[]> {
+    // Resolve the collection under the actor's context (RLS) first, then embed
+    // outside any DB transaction so the provider HTTP call never holds a
+    // connection open.
+    const collection = await this.run(actor, (db, ownerId) =>
+      this.resolveCollection(db, collectionName, ownerId)
+    );
+    const embeddings = await this.resolveEmbeddings(items, collection.dimension);
+
+    // Pre-generate ids so the returned order matches the input and an
+    // explicit-id upsert is idempotent via ON CONFLICT (id) DO UPDATE.
+    const ids = items.map((item) => item.id ?? randomUUID());
+
     return this.run(actor, async (db, ownerId) => {
-      const collection = await this.resolveCollection(db, collectionName, ownerId);
-      const embeddings = await this.resolveEmbeddings(items, collection.dimension);
-
-      const ids: string[] = [];
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        const literal = toVectorLiteral(embeddings[i]);
-        const metadata = JSON.stringify(item.metadata ?? {});
-        const content = item.content ?? null;
-
-        if (item.id) {
-          // Caller-supplied id: update the existing owned row, else insert it.
-          const updated = await db.query(
-            `UPDATE vectors.items
-                SET embedding = $1::vector, content = $2, metadata = $3::jsonb
-              WHERE id = $4 AND collection_id = $5
-                AND COALESCE(owner_id, $6::uuid) = COALESCE($7::uuid, $6::uuid)
-            RETURNING id`,
-            [literal, content, metadata, item.id, collection.id, OWNER_SENTINEL, ownerId]
-          );
-          if (updated.rows.length) {
-            ids.push(updated.rows[0].id);
-            continue;
-          }
-          const inserted = await db.query(
-            `INSERT INTO vectors.items (id, collection_id, embedding, content, metadata, owner_id)
-             VALUES ($1, $2, $3::vector, $4, $5::jsonb, $6::uuid)
-             RETURNING id`,
-            [item.id, collection.id, literal, content, metadata, ownerId]
-          );
-          ids.push(inserted.rows[0].id);
-        } else {
-          const inserted = await db.query(
-            `INSERT INTO vectors.items (collection_id, embedding, content, metadata, owner_id)
-             VALUES ($1, $2::vector, $3, $4::jsonb, $5::uuid)
-             RETURNING id`,
-            [collection.id, literal, content, metadata, ownerId]
-          );
-          ids.push(inserted.rows[0].id);
-        }
-      }
+      // Single multi-row upsert so the whole batch commits or rolls back together.
+      const params: unknown[] = [collection.id, ownerId];
+      const rows = items.map((item, i) => {
+        const base = params.length;
+        params.push(
+          ids[i],
+          toVectorLiteral(embeddings[i]),
+          item.content ?? null,
+          JSON.stringify(item.metadata ?? {})
+        );
+        return `($${base + 1}, $1, $${base + 2}::vector, $${base + 3}, $${base + 4}::jsonb, $2::uuid)`;
+      });
+      await db.query(
+        `INSERT INTO vectors.items (id, collection_id, embedding, content, metadata, owner_id)
+         VALUES ${rows.join(', ')}
+         ON CONFLICT (id) DO UPDATE SET
+           embedding = EXCLUDED.embedding,
+           content = EXCLUDED.content,
+           metadata = EXCLUDED.metadata`,
+        params
+      );
       return ids;
     });
   }

--- a/backend/src/services/vectors/vector.service.ts
+++ b/backend/src/services/vectors/vector.service.ts
@@ -1,0 +1,394 @@
+import { Pool, PoolClient } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { EmbeddingService } from '@/services/ai/embedding.service.js';
+import { withUserContext } from '@/services/database/user-context.service.js';
+import type { UserContext } from '@/api/middlewares/auth.js';
+import { AppError } from '@/utils/errors.js';
+import logger from '@/utils/logger.js';
+import {
+  ERROR_CODES,
+  VECTOR_DEFAULT_DIMENSION,
+  type VectorCollection,
+  type VectorMatch,
+  type VectorMetric,
+  type VectorUpsertItem,
+} from '@insforge/shared-schemas';
+
+// Matches the column dimension in migration 059 and the managed embedding model.
+const EMBED_MODEL = 'openai/text-embedding-3-small';
+const EMBED_DIMENSIONS = VECTOR_DEFAULT_DIMENSION;
+const OWNER_SENTINEL = '00000000-0000-0000-0000-000000000000';
+
+type Queryable = Pool | PoolClient;
+
+export type VectorActor = { mode: 'admin' } | { mode: 'user'; ctx: UserContext };
+
+interface CollectionRow {
+  id: string;
+  name: string;
+  dimension: number;
+  metric: VectorMetric;
+  created_at: Date;
+}
+
+// pgvector accepts a bracketed float literal cast to ::vector.
+function toVectorLiteral(vec: number[]): string {
+  return `[${vec.join(',')}]`;
+}
+
+function toIso(value: Date): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+export class VectorService {
+  private static instance: VectorService;
+  private pool: Pool | null = null;
+  private embeddingService = EmbeddingService.getInstance();
+
+  private constructor() {}
+
+  public static getInstance(): VectorService {
+    if (!VectorService.instance) {
+      VectorService.instance = new VectorService();
+    }
+    return VectorService.instance;
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  private async run<T>(
+    actor: VectorActor,
+    fn: (db: Queryable, ownerId: string | null) => Promise<T>
+  ): Promise<T> {
+    if (actor.mode === 'admin') {
+      return fn(this.getPool(), null);
+    }
+    const ctx = actor.ctx;
+    const ownerId = ctx.role === 'authenticated' ? ctx.id : null;
+    return withUserContext(this.getPool(), ctx, (client) => fn(client, ownerId));
+  }
+
+  // ---- collections --------------------------------------------------------
+
+  async createCollection(
+    actor: VectorActor,
+    input: { name: string; dimension: number; metric: VectorMetric }
+  ): Promise<VectorCollection> {
+    // MVP backs every collection with a single VECTOR(1536) column, so the
+    // dimension is fixed. A future per-collection-table backend lifts this.
+    if (input.dimension !== EMBED_DIMENSIONS) {
+      throw new AppError(
+        `Only ${EMBED_DIMENSIONS}-dimension collections are supported in this version`,
+        400,
+        ERROR_CODES.VECTOR_DIMENSION_MISMATCH
+      );
+    }
+
+    return this.run(actor, async (db, ownerId) => {
+      try {
+        const result = await db.query(
+          `INSERT INTO vectors.collections (name, dimension, metric, owner_id)
+           VALUES ($1, $2, $3, $4::uuid)
+           RETURNING id, name, dimension, metric, created_at`,
+          [input.name, input.dimension, input.metric, ownerId]
+        );
+        const row = result.rows[0] as CollectionRow;
+        return {
+          id: row.id,
+          name: row.name,
+          dimension: row.dimension,
+          metric: row.metric,
+          createdAt: toIso(row.created_at),
+        };
+      } catch (error) {
+        // 23505 unique_violation: a collection with this name already exists.
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          error.code === '23505'
+        ) {
+          throw new AppError(
+            `Collection already exists: ${input.name}`,
+            409,
+            ERROR_CODES.VECTOR_COLLECTION_ALREADY_EXISTS
+          );
+        }
+        throw error;
+      }
+    });
+  }
+
+  async listCollections(actor: VectorActor): Promise<VectorCollection[]> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `SELECT id, name, dimension, metric, created_at FROM vectors.collections
+          WHERE COALESCE(owner_id, $1::uuid) = COALESCE($2::uuid, $1::uuid)
+          ORDER BY created_at DESC`,
+        [OWNER_SENTINEL, ownerId]
+      );
+      return result.rows.map((row: CollectionRow) => ({
+        id: row.id,
+        name: row.name,
+        dimension: row.dimension,
+        metric: row.metric,
+        createdAt: toIso(row.created_at),
+      }));
+    });
+  }
+
+  async deleteCollection(actor: VectorActor, name: string): Promise<boolean> {
+    return this.run(actor, async (db, ownerId) => {
+      const result = await db.query(
+        `DELETE FROM vectors.collections
+          WHERE name = $1
+            AND COALESCE(owner_id, $2::uuid) = COALESCE($3::uuid, $2::uuid)`,
+        [name, OWNER_SENTINEL, ownerId]
+      );
+      return (result.rowCount ?? 0) > 0;
+    });
+  }
+
+  private async resolveCollection(
+    db: Queryable,
+    name: string,
+    ownerId: string | null
+  ): Promise<CollectionRow> {
+    const result = await db.query(
+      `SELECT id, name, dimension, metric, created_at FROM vectors.collections
+        WHERE name = $1
+          AND COALESCE(owner_id, $2::uuid) = COALESCE($3::uuid, $2::uuid)`,
+      [name, OWNER_SENTINEL, ownerId]
+    );
+    if (!result.rows.length) {
+      throw new AppError(
+        `Collection not found: ${name}`,
+        404,
+        ERROR_CODES.VECTOR_COLLECTION_NOT_FOUND
+      );
+    }
+    return result.rows[0] as CollectionRow;
+  }
+
+  // ---- embeddings ---------------------------------------------------------
+
+  private async embed(texts: string[]): Promise<number[][]> {
+    const res = await this.embeddingService.createEmbeddings({
+      model: EMBED_MODEL,
+      input: texts,
+      dimensions: EMBED_DIMENSIONS,
+    });
+    return res.data.map((d) => {
+      if (!Array.isArray(d.embedding)) {
+        throw new AppError(
+          'Embedding provider returned no vector',
+          502,
+          ERROR_CODES.AI_UPSTREAM_UNAVAILABLE
+        );
+      }
+      return d.embedding;
+    });
+  }
+
+  // Resolve each item to a concrete embedding: bring-your-own vector (validated
+  // against the collection dimension) or auto-embedded from `content`. Content
+  // items are embedded in a single batched provider call.
+  private async resolveEmbeddings(
+    items: VectorUpsertItem[],
+    dimension: number
+  ): Promise<number[][]> {
+    const toEmbedIndexes: number[] = [];
+    const toEmbedTexts: string[] = [];
+    const out: (number[] | null)[] = items.map((item) => {
+      if (item.vector) {
+        if (item.vector.length !== dimension) {
+          throw new AppError(
+            `Vector has ${item.vector.length} dimensions, expected ${dimension}`,
+            400,
+            ERROR_CODES.VECTOR_DIMENSION_MISMATCH
+          );
+        }
+        return item.vector;
+      }
+      return null;
+    });
+
+    items.forEach((item, i) => {
+      if (out[i] === null && item.content) {
+        toEmbedIndexes.push(i);
+        toEmbedTexts.push(item.content);
+      }
+    });
+
+    if (toEmbedTexts.length) {
+      const embeddings = await this.embed(toEmbedTexts);
+      toEmbedIndexes.forEach((itemIndex, k) => {
+        out[itemIndex] = embeddings[k];
+      });
+    }
+
+    return out.map((vec, i) => {
+      if (!vec) {
+        throw new AppError(
+          `Item ${i} has neither a vector nor content`,
+          400,
+          ERROR_CODES.VECTOR_QUERY_INVALID
+        );
+      }
+      return vec;
+    });
+  }
+
+  // ---- items --------------------------------------------------------------
+
+  async upsert(
+    actor: VectorActor,
+    collectionName: string,
+    items: VectorUpsertItem[]
+  ): Promise<string[]> {
+    return this.run(actor, async (db, ownerId) => {
+      const collection = await this.resolveCollection(db, collectionName, ownerId);
+      const embeddings = await this.resolveEmbeddings(items, collection.dimension);
+
+      const ids: string[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        const literal = toVectorLiteral(embeddings[i]);
+        const metadata = JSON.stringify(item.metadata ?? {});
+        const content = item.content ?? null;
+
+        if (item.id) {
+          // Caller-supplied id: update the existing owned row, else insert it.
+          const updated = await db.query(
+            `UPDATE vectors.items
+                SET embedding = $1::vector, content = $2, metadata = $3::jsonb
+              WHERE id = $4 AND collection_id = $5
+                AND COALESCE(owner_id, $6::uuid) = COALESCE($7::uuid, $6::uuid)
+            RETURNING id`,
+            [literal, content, metadata, item.id, collection.id, OWNER_SENTINEL, ownerId]
+          );
+          if (updated.rows.length) {
+            ids.push(updated.rows[0].id);
+            continue;
+          }
+          const inserted = await db.query(
+            `INSERT INTO vectors.items (id, collection_id, embedding, content, metadata, owner_id)
+             VALUES ($1, $2, $3::vector, $4, $5::jsonb, $6::uuid)
+             RETURNING id`,
+            [item.id, collection.id, literal, content, metadata, ownerId]
+          );
+          ids.push(inserted.rows[0].id);
+        } else {
+          const inserted = await db.query(
+            `INSERT INTO vectors.items (collection_id, embedding, content, metadata, owner_id)
+             VALUES ($1, $2::vector, $3, $4::jsonb, $5::uuid)
+             RETURNING id`,
+            [collection.id, literal, content, metadata, ownerId]
+          );
+          ids.push(inserted.rows[0].id);
+        }
+      }
+      return ids;
+    });
+  }
+
+  async deleteItem(actor: VectorActor, collectionName: string, itemId: string): Promise<boolean> {
+    return this.run(actor, async (db, ownerId) => {
+      const collection = await this.resolveCollection(db, collectionName, ownerId);
+      const result = await db.query(
+        `DELETE FROM vectors.items
+          WHERE id = $1 AND collection_id = $2
+            AND COALESCE(owner_id, $3::uuid) = COALESCE($4::uuid, $3::uuid)`,
+        [itemId, collection.id, OWNER_SENTINEL, ownerId]
+      );
+      return (result.rowCount ?? 0) > 0;
+    });
+  }
+
+  // Distance operator + score expression per metric. Cosine is HNSW-indexed;
+  // l2/ip are correct but sequential-scan in the MVP.
+  private metricSql(metric: VectorMetric): { op: string; score: string } {
+    switch (metric) {
+      case 'l2':
+        return { op: '<->', score: '-(embedding <-> $1::vector)' };
+      case 'ip':
+        return { op: '<#>', score: '-(embedding <#> $1::vector)' };
+      case 'cosine':
+      default:
+        return { op: '<=>', score: '1 - (embedding <=> $1::vector)' };
+    }
+  }
+
+  async query(
+    actor: VectorActor,
+    collectionName: string,
+    params: {
+      vector?: number[];
+      text?: string;
+      topK: number;
+      filter?: Record<string, unknown>;
+      includeContent: boolean;
+    }
+  ): Promise<VectorMatch[]> {
+    return this.run(actor, async (db, ownerId) => {
+      const collection = await this.resolveCollection(db, collectionName, ownerId);
+
+      let vector = params.vector;
+      if (!vector && params.text) {
+        vector = (await this.embed([params.text]))[0];
+      }
+      if (!vector) {
+        throw new AppError(
+          'Provide either a vector or text to query',
+          400,
+          ERROR_CODES.VECTOR_QUERY_INVALID
+        );
+      }
+      if (vector.length !== collection.dimension) {
+        throw new AppError(
+          `Query vector has ${vector.length} dimensions, expected ${collection.dimension}`,
+          400,
+          ERROR_CODES.VECTOR_DIMENSION_MISMATCH
+        );
+      }
+
+      const { op, score } = this.metricSql(collection.metric);
+      const literal = toVectorLiteral(vector);
+      const args: unknown[] = [literal, collection.id];
+      let filterClause = '';
+      if (params.filter && Object.keys(params.filter).length > 0) {
+        args.push(JSON.stringify(params.filter));
+        filterClause = `AND metadata @> $${args.length}::jsonb`;
+      }
+      args.push(params.topK);
+      const limitParam = `$${args.length}`;
+
+      const result = await db.query(
+        `SELECT id, ${params.includeContent ? 'content' : 'NULL AS content'}, metadata,
+                ${score} AS score
+           FROM vectors.items
+          WHERE collection_id = $2 ${filterClause}
+          ORDER BY embedding ${op} $1::vector
+          LIMIT ${limitParam}`,
+        args
+      );
+
+      return result.rows.map((row) => ({
+        id: row.id,
+        score: Number(row.score),
+        content: row.content ?? null,
+        metadata: (row.metadata as Record<string, unknown>) ?? {},
+      }));
+    });
+  }
+
+  // Best-effort warning if the AI gateway isn't configured for auto-embed.
+  logEmbeddingDependency(): void {
+    logger.debug('VectorService auto-embed uses the Model Gateway', { model: EMBED_MODEL });
+  }
+}

--- a/backend/tests/unit/create-kv-schema-migration.test.ts
+++ b/backend/tests/unit/create-kv-schema-migration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '058_create-kv-schema.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('create kv schema migration', () => {
+  it('exists and is ordered after the prior migration', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+    const idx = migrations.indexOf(migrationFile);
+    const prev = migrations.indexOf('057_create-database-advisor.sql');
+    expect(prev).not.toBe(-1);
+    expect(idx).toBeGreaterThan(prev);
+  });
+
+  it('creates the kv schema and entries table idempotently', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/CREATE SCHEMA IF NOT EXISTS kv/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS kv\.entries/i);
+    expect(sql).toMatch(/value\s+JSONB NOT NULL/i);
+    expect(sql).toMatch(/expires_at\s+TIMESTAMPTZ/i);
+  });
+
+  it('constrains visibility to private/authed/public', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(
+      /visibility\s+TEXT NOT NULL[\s\S]*CHECK \(visibility IN \('private', 'authed', 'public'\)\)/i
+    );
+  });
+
+  it('makes (namespace, key) unique per owner via a COALESCE sentinel index', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS uq_kv_entries_owner_ns_key/i);
+    expect(sql).toMatch(/COALESCE\(owner_id, '00000000-0000-0000-0000-000000000000'::uuid\)/i);
+  });
+
+  it('enables RLS with owner-scoped policies dropped-before-created (idempotent)', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/ALTER TABLE kv\.entries ENABLE ROW LEVEL SECURITY/i);
+    for (const policy of [
+      'kv_entries_select',
+      'kv_entries_insert',
+      'kv_entries_update',
+      'kv_entries_delete',
+    ]) {
+      const dropIdx = sql.indexOf(`DROP POLICY IF EXISTS ${policy}`);
+      const createIdx = sql.indexOf(`CREATE POLICY ${policy}`);
+      expect(dropIdx, `${policy} drop`).toBeGreaterThan(-1);
+      expect(createIdx, `${policy} create`).toBeGreaterThan(dropIdx);
+    }
+    expect(sql).toMatch(/owner_id = auth\.uid\(\)/i);
+  });
+
+  it('grants writes to authenticated and read-only to anon', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/GRANT SELECT, INSERT, UPDATE, DELETE ON kv\.entries TO authenticated/i);
+    expect(sql).toMatch(/GRANT SELECT ON kv\.entries TO anon/i);
+  });
+
+  it('is idempotent on the updated_at trigger', () => {
+    const sql = readMigration();
+    const dropIdx = sql.indexOf('DROP TRIGGER IF EXISTS trg_kv_entries_updated_at');
+    const createIdx = sql.indexOf('CREATE TRIGGER trg_kv_entries_updated_at');
+    expect(dropIdx).toBeGreaterThan(-1);
+    expect(createIdx).toBeGreaterThan(dropIdx);
+  });
+});

--- a/backend/tests/unit/create-vector-store-schema-migration.test.ts
+++ b/backend/tests/unit/create-vector-store-schema-migration.test.ts
@@ -42,6 +42,11 @@ describe('create vector store schema migration', () => {
     expect(sql).toMatch(/REFERENCES vectors\.collections\(id\) ON DELETE CASCADE/i);
   });
 
+  it('enforces the fixed 1536 collection dimension with a CHECK constraint', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/dimension\s+INT NOT NULL DEFAULT 1536 CHECK \(dimension = 1536\)/i);
+  });
+
   it('creates the HNSW cosine index and the GIN metadata index', () => {
     const sql = readMigration();
     expect(sql).toMatch(/USING hnsw \(embedding vector_cosine_ops\)/i);

--- a/backend/tests/unit/create-vector-store-schema-migration.test.ts
+++ b/backend/tests/unit/create-vector-store-schema-migration.test.ts
@@ -60,8 +60,11 @@ describe('create vector store schema migration', () => {
     for (const policy of [
       'vector_collections_select',
       'vector_collections_insert',
+      'vector_collections_delete',
       'vector_items_select',
       'vector_items_insert',
+      'vector_items_update',
+      'vector_items_delete',
     ]) {
       const dropIdx = sql.indexOf(`DROP POLICY IF EXISTS ${policy}`);
       const createIdx = sql.indexOf(`CREATE POLICY ${policy}`);

--- a/backend/tests/unit/create-vector-store-schema-migration.test.ts
+++ b/backend/tests/unit/create-vector-store-schema-migration.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '059_create-vector-store-schema.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('create vector store schema migration', () => {
+  it('exists and is ordered after the kv migration', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+    const idx = migrations.indexOf(migrationFile);
+    const prev = migrations.indexOf('058_create-kv-schema.sql');
+    expect(prev).not.toBe(-1);
+    expect(idx).toBeGreaterThan(prev);
+  });
+
+  it('ensures pgvector and creates collections + items with a 1536-d vector', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/CREATE EXTENSION IF NOT EXISTS vector/i);
+    expect(sql).toMatch(/CREATE SCHEMA IF NOT EXISTS vectors/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS vectors\.collections/i);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS vectors\.items/i);
+    expect(sql).toMatch(/embedding\s+VECTOR\(1536\)/i);
+  });
+
+  it('constrains metric and cascades items on collection delete', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(
+      /metric\s+TEXT NOT NULL[\s\S]*CHECK \(metric IN \('cosine', 'l2', 'ip'\)\)/i
+    );
+    expect(sql).toMatch(/REFERENCES vectors\.collections\(id\) ON DELETE CASCADE/i);
+  });
+
+  it('creates the HNSW cosine index and the GIN metadata index', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/USING hnsw \(embedding vector_cosine_ops\)/i);
+    expect(sql).toMatch(/USING gin \(metadata jsonb_path_ops\)/i);
+  });
+
+  it('enables RLS with owner-scoped policies on both tables (idempotent)', () => {
+    const sql = readMigration();
+    expect(sql).toMatch(/ALTER TABLE vectors\.collections ENABLE ROW LEVEL SECURITY/i);
+    expect(sql).toMatch(/ALTER TABLE vectors\.items ENABLE ROW LEVEL SECURITY/i);
+    for (const policy of [
+      'vector_collections_select',
+      'vector_collections_insert',
+      'vector_items_select',
+      'vector_items_insert',
+    ]) {
+      const dropIdx = sql.indexOf(`DROP POLICY IF EXISTS ${policy}`);
+      const createIdx = sql.indexOf(`CREATE POLICY ${policy}`);
+      expect(dropIdx, `${policy} drop`).toBeGreaterThan(-1);
+      expect(createIdx, `${policy} create`).toBeGreaterThan(dropIdx);
+    }
+  });
+});

--- a/backend/tests/unit/kv.service.test.ts
+++ b/backend/tests/unit/kv.service.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the DB pool the service pulls from DatabaseManager.
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }));
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({ getPool: () => ({ query: mockQuery }) }),
+  },
+}));
+
+import { KvService } from '@/services/kv/kv.service';
+import { AppError } from '@/utils/errors';
+
+const ADMIN = { mode: 'admin' as const };
+
+describe('KvService (admin / project-global path)', () => {
+  const service = KvService.getInstance();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('get returns the stored JSON value, or null when missing/expired', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ value: { a: 1 } }], rowCount: 1 });
+    await expect(service.get(ADMIN, 'default', 'k')).resolves.toEqual({ a: 1 });
+
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await expect(service.get(ADMIN, 'default', 'missing')).resolves.toBeNull();
+  });
+
+  it('set defaults to a 30-day TTL and a NULL (project-global) owner', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          value: 'v',
+          visibility: 'private',
+          expires_at: new Date('2026-08-01T00:00:00Z'),
+          created_at: new Date('2026-06-28T00:00:00Z'),
+          updated_at: new Date('2026-06-28T00:00:00Z'),
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const result = await service.set(ADMIN, 'default', 'k', { value: 'v' });
+    expect(result.created).toBe(true);
+    const params = mockQuery.mock.calls[0][1] as unknown[];
+    // owner_id (param 4) is null; ttl seconds (param 6) is the 30-day default.
+    expect(params[3]).toBeNull();
+    expect(params[5]).toBe(60 * 60 * 24 * 30);
+  });
+
+  it('set with ttl=null persists a non-expiring entry', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          value: 'v',
+          visibility: 'private',
+          expires_at: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+      rowCount: 1,
+    });
+    await service.set(ADMIN, 'default', 'k', { value: 'v', ttl: null });
+    const params = mockQuery.mock.calls[0][1] as unknown[];
+    expect(params[5]).toBeNull();
+  });
+
+  it('set ifNotExists reports created=false when the row already exists', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await service.set(ADMIN, 'default', 'k', { value: 'v', ifNotExists: true });
+    expect(result).toEqual({ created: false, entry: null });
+  });
+
+  it('rejects values over the size cap before touching the database', async () => {
+    const huge = { blob: 'x'.repeat(300 * 1024) };
+    await expect(service.set(ADMIN, 'default', 'k', { value: huge })).rejects.toMatchObject({
+      code: 'KV_VALUE_TOO_LARGE',
+      statusCode: 413,
+    });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('incrBy returns the new numeric value', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ value: 5 }], rowCount: 1 });
+    await expect(service.incrBy(ADMIN, 'default', 'counter', 5)).resolves.toBe(5);
+  });
+
+  it('incrBy maps a non-numeric existing value (pg 22P02) to KV_NOT_A_NUMBER', async () => {
+    mockQuery.mockRejectedValueOnce({ code: '22P02' });
+    await expect(service.incrBy(ADMIN, 'default', 'k', 1)).rejects.toMatchObject({
+      code: 'KV_NOT_A_NUMBER',
+      statusCode: 400,
+    });
+  });
+
+  it('cas throws 409 on value mismatch and 404 when the key is absent', async () => {
+    // mismatch: UPDATE affects nothing, existence check finds the row
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    mockQuery.mockResolvedValueOnce({ rows: [{ '?column?': 1 }], rowCount: 1 });
+    await expect(service.cas(ADMIN, 'default', 'k', 'old', 'new')).rejects.toMatchObject({
+      code: 'KV_CAS_MISMATCH',
+      statusCode: 409,
+    });
+
+    // absent: UPDATE affects nothing, existence check finds nothing
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await expect(service.cas(ADMIN, 'default', 'k', 'old', 'new')).rejects.toMatchObject({
+      code: 'KV_NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it('ttl throws KV_NOT_FOUND when the key is absent', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await expect(service.ttl(ADMIN, 'default', 'k')).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('mget returns a key->value map, omitting missing keys', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { key: 'a', value: 1 },
+        { key: 'b', value: { nested: true } },
+      ],
+      rowCount: 2,
+    });
+    await expect(service.mget(ADMIN, 'default', ['a', 'b', 'c'])).resolves.toEqual({
+      a: 1,
+      b: { nested: true },
+    });
+  });
+});

--- a/backend/tests/unit/kv.service.test.ts
+++ b/backend/tests/unit/kv.service.test.ts
@@ -37,6 +37,7 @@ describe('KvService (admin / project-global path)', () => {
           expires_at: new Date('2026-08-01T00:00:00Z'),
           created_at: new Date('2026-06-28T00:00:00Z'),
           updated_at: new Date('2026-06-28T00:00:00Z'),
+          inserted: true,
         },
       ],
       rowCount: 1,
@@ -72,6 +73,41 @@ describe('KvService (admin / project-global path)', () => {
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const result = await service.set(ADMIN, 'default', 'k', { value: 'v', ifNotExists: true });
     expect(result).toEqual({ created: false, entry: null });
+  });
+
+  it('set reports created=false when ON CONFLICT updated an existing key (xmax)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          value: 'v',
+          visibility: 'private',
+          expires_at: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+          inserted: false, // xmax != 0 -> this was an update, not an insert
+        },
+      ],
+      rowCount: 1,
+    });
+    const result = await service.set(ADMIN, 'default', 'k', { value: 'v' });
+    expect(result.created).toBe(false);
+    expect(result.entry).not.toBeNull();
+    expect(mockQuery.mock.calls[0][0]).toContain('(xmax = 0) AS inserted');
+  });
+
+  it('del guards against logically-expired rows', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await expect(service.del(ADMIN, 'default', 'k')).resolves.toBe(false);
+    expect(mockQuery.mock.calls[0][0]).toContain('expires_at IS NULL OR expires_at > NOW()');
+  });
+
+  it('mset writes all pairs in a single atomic statement', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 2 });
+    await expect(service.mset(ADMIN, 'default', { a: 1, b: 2 })).resolves.toBe(2);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('ON CONFLICT');
+    expect((sql.match(/::jsonb/g) || []).length).toBe(2); // one value tuple per key
   });
 
   it('rejects values over the size cap before touching the database', async () => {

--- a/backend/tests/unit/vector.service.test.ts
+++ b/backend/tests/unit/vector.service.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockQuery, mockEmbed } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockEmbed: vi.fn(),
+}));
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({ getPool: () => ({ query: mockQuery }) }),
+  },
+}));
+
+vi.mock('@/services/ai/embedding.service.js', () => ({
+  EmbeddingService: {
+    getInstance: () => ({ createEmbeddings: mockEmbed }),
+  },
+}));
+
+import { VectorService } from '@/services/vectors/vector.service';
+
+const ADMIN = { mode: 'admin' as const };
+const DIM = 1536;
+const vec = (fill = 0.1) => Array.from({ length: DIM }, () => fill);
+
+function collectionRow(metric = 'cosine') {
+  return {
+    rows: [{ id: 'col-1', name: 'docs', dimension: DIM, metric, created_at: new Date() }],
+    rowCount: 1,
+  };
+}
+
+describe('VectorService', () => {
+  const service = VectorService.getInstance();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects collections whose dimension is not the supported 1536', async () => {
+    await expect(
+      service.createCollection(ADMIN, { name: 'x', dimension: 768, metric: 'cosine' })
+    ).rejects.toMatchObject({ code: 'VECTOR_DIMENSION_MISMATCH', statusCode: 400 });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('maps a unique-violation on create to VECTOR_COLLECTION_ALREADY_EXISTS', async () => {
+    mockQuery.mockRejectedValueOnce({ code: '23505' });
+    await expect(
+      service.createCollection(ADMIN, { name: 'docs', dimension: DIM, metric: 'cosine' })
+    ).rejects.toMatchObject({ code: 'VECTOR_COLLECTION_ALREADY_EXISTS', statusCode: 409 });
+  });
+
+  it('throws VECTOR_COLLECTION_NOT_FOUND when upserting into a missing collection', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // resolveCollection
+    await expect(service.upsert(ADMIN, 'nope', [{ vector: vec() }])).rejects.toMatchObject({
+      code: 'VECTOR_COLLECTION_NOT_FOUND',
+      statusCode: 404,
+    });
+  });
+
+  it('auto-embeds content items in a single batched provider call', async () => {
+    mockQuery.mockResolvedValueOnce(collectionRow()); // resolveCollection
+    mockEmbed.mockResolvedValueOnce({
+      data: [
+        { embedding: vec(0.1), index: 0 },
+        { embedding: vec(0.2), index: 1 },
+      ],
+    });
+    // one item brings its own vector, two need embedding
+    mockQuery.mockResolvedValue({ rows: [{ id: 'item-x' }], rowCount: 1 });
+
+    const ids = await service.upsert(ADMIN, 'docs', [
+      { vector: vec(0.9) },
+      { content: 'hello' },
+      { content: 'world' },
+    ]);
+
+    expect(ids).toHaveLength(3);
+    // exactly one embedding call, batched with both content strings
+    expect(mockEmbed).toHaveBeenCalledTimes(1);
+    expect(mockEmbed.mock.calls[0][0].input).toEqual(['hello', 'world']);
+  });
+
+  it('rejects a bring-your-own vector whose dimension is wrong', async () => {
+    mockQuery.mockResolvedValueOnce(collectionRow());
+    await expect(
+      service.upsert(ADMIN, 'docs', [{ vector: [0.1, 0.2, 0.3] }])
+    ).rejects.toMatchObject({ code: 'VECTOR_DIMENSION_MISMATCH', statusCode: 400 });
+  });
+
+  it('query uses the cosine operator and similarity score for a cosine collection', async () => {
+    mockQuery.mockResolvedValueOnce(collectionRow('cosine')); // resolveCollection
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'item-1', content: 'hi', metadata: { tag: 'a' }, score: 0.92 }],
+      rowCount: 1,
+    });
+
+    const matches = await service.query(ADMIN, 'docs', {
+      vector: vec(),
+      topK: 5,
+      includeContent: true,
+    });
+
+    expect(matches).toEqual([{ id: 'item-1', score: 0.92, content: 'hi', metadata: { tag: 'a' } }]);
+    const querySql = mockQuery.mock.calls[1][0] as string;
+    expect(querySql).toContain('embedding <=> $1::vector');
+    expect(querySql).toContain('1 - (embedding <=> $1::vector)');
+  });
+
+  it('query embeds text when no vector is supplied', async () => {
+    mockQuery.mockResolvedValueOnce(collectionRow('cosine'));
+    mockEmbed.mockResolvedValueOnce({ data: [{ embedding: vec(), index: 0 }] });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await service.query(ADMIN, 'docs', { text: 'find this', topK: 3, includeContent: true });
+    expect(mockEmbed).toHaveBeenCalledTimes(1);
+    expect(mockEmbed.mock.calls[0][0].input).toEqual(['find this']);
+  });
+
+  it('query applies a metadata containment filter when provided', async () => {
+    mockQuery.mockResolvedValueOnce(collectionRow('cosine'));
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await service.query(ADMIN, 'docs', {
+      vector: vec(),
+      topK: 5,
+      includeContent: false,
+      filter: { tenant: 'acme' },
+    });
+    const querySql = mockQuery.mock.calls[1][0] as string;
+    expect(querySql).toContain('metadata @>');
+  });
+});

--- a/docs/core-concepts/kv/overview.mdx
+++ b/docs/core-concepts/kv/overview.mdx
@@ -1,0 +1,153 @@
+---
+title: "Key-Value Store"
+sidebarTitle: "Overview"
+description: "A Redis-like key-value store with TTL, atomic counters, and compare-and-swap, backed by Postgres and row-level security."
+---
+
+Use the InsForge KV store for the data that doesn't belong in a table: cache entries, feature flags, rate-limit counters, session scratch, per-user preferences, and idempotency keys. Values are arbitrary JSON addressed by a `namespace` and a `key`, with optional time-to-live (TTL) expiry. It runs on the same Postgres instance as the rest of your project — no separate Redis to operate.
+
+<Note>
+  **When to reach for KV vs the Database.** Use KV for ephemeral or schemaless values keyed by a string, especially when you want TTL expiry or atomic counters. Use the [Database](/core-concepts/database/overview) when you need relations, queries across rows, or a typed REST surface.
+</Note>
+
+```mermaid
+graph TB
+    App[Client application] --> SDK[InsForge SDK / REST]
+    Agent[AI agent] --> APIKey[Project API key]
+
+    SDK --> KV[KV namespace]
+    APIKey --> KV
+
+    KV --> Entries[(kv.entries in Postgres)]
+    Auth[Auth token and RLS] --> KV
+    TTL[TTL sweep] --> Entries
+
+    style App fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style Agent fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style SDK fill:#1e40af,stroke:#3b82f6,color:#dbeafe
+    style APIKey fill:#1e40af,stroke:#3b82f6,color:#dbeafe
+    style KV fill:#166534,stroke:#22c55e,color:#dcfce7
+    style Entries fill:#0e7490,stroke:#06b6d4,color:#cffafe
+    style Auth fill:#4c1d95,stroke:#8b5cf6,color:#ede9fe
+    style TTL fill:#c2410c,stroke:#fb923c,color:#fed7aa
+```
+
+## Data model
+
+A KV entry is a JSON value addressed by `(namespace, key)`. Namespaces and keys are plain strings; `:` is the conventional separator inside a key (for example `user:123:prefs`). Both are single URL path segments — they must not contain `/`.
+
+Two access tiers share the same store:
+
+- **Project-global entries** — written with the project API key. These have no owner and are visible to anyone holding the API key (your agent, backend, or CLI). Use them for shared cache and config.
+- **End-user entries** — written with a user's auth token. These are owned by that user and isolated by Postgres row-level security; one user can never read or write another user's keys.
+
+### Visibility
+
+Every entry has a `visibility` that controls who else can read it (writes are always owner-only):
+
+| Visibility | Who can read |
+| --- | --- |
+| `private` (default) | Only the owner |
+| `authed` | Any signed-in user |
+| `public` | Anyone, including anonymous clients |
+
+## TTL and expiry
+
+Every new key defaults to a **30-day TTL**. Override it per write, or set it to never expire:
+
+- `ttl: <seconds>` — expire this many seconds from now
+- `ttl: null` — never expires
+- omit `ttl` — use the 30-day default
+
+Expired entries stop being readable immediately and are reclaimed by a background sweep. Use `expire` to change a TTL later and `ttl` to read the remaining seconds.
+
+## Features
+
+### Read and write
+
+```bash
+# Set a value (defaults to a 30-day TTL, private visibility)
+curl -X PUT "$INSFORGE_URL/api/kv/entries/default/greeting" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"value": {"text": "hello"}, "ttl": 3600}'
+
+# Get it back
+curl "$INSFORGE_URL/api/kv/entries/default/greeting" \
+  -H "Authorization: Bearer $API_KEY"
+# => { "value": { "text": "hello" } }
+
+# Delete it
+curl -X DELETE "$INSFORGE_URL/api/kv/entries/default/greeting" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+Pass `"ifNotExists": true` to a `PUT` to set a key only when it is absent (a `setnx`); the response reports `created: false` and a `409` status when the key already exists, leaving the existing value untouched.
+
+### Atomic counters
+
+`incr` and `decr` mutate a numeric value in a single statement, so concurrent callers never lose updates. A missing key initializes to `0` before applying the delta.
+
+```bash
+# Increment (initializes to 0, then adds `by`)
+curl -X POST "$INSFORGE_URL/api/kv/entries/default/page:views/incr" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"by": 1}'
+# => { "value": 1 }
+```
+
+Incrementing a value that isn't a JSON number returns `KV_NOT_A_NUMBER`.
+
+### Compare-and-swap
+
+`cas` writes `next` only if the current value still equals `expected` — the building block for optimistic concurrency and distributed locks. A mismatch returns `KV_CAS_MISMATCH` (`409`); a missing key returns `KV_NOT_FOUND` (`404`).
+
+```bash
+curl -X POST "$INSFORGE_URL/api/kv/entries/default/lock/cas" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"expected": "free", "next": "held"}'
+```
+
+### Bulk operations
+
+Read or write many keys in one round trip with `mget` and `mset`:
+
+```bash
+curl -X POST "$INSFORGE_URL/api/kv/mget" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"namespace": "default", "keys": ["a", "b", "c"]}'
+# => { "values": { "a": 1, "b": 2 } }   (missing keys are omitted)
+```
+
+### TTL management
+
+```bash
+# Change the TTL of an existing key
+curl -X POST "$INSFORGE_URL/api/kv/entries/default/session/expire" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"ttl": 900}'
+
+# Read the remaining seconds (null = never expires)
+curl "$INSFORGE_URL/api/kv/entries/default/session/ttl" \
+  -H "Authorization: Bearer $API_KEY"
+# => { "ttl": 899 }
+```
+
+### Row-level security
+
+End-user entries are enforced by Postgres RLS on `kv.entries`, keyed on `auth.uid()`. A signed-in user's token only ever sees their own keys plus any `public` entries and (when signed in) `authed` ones. The project API key connects with elevated privileges and manages the project-global store. You don't write any policies — the managed schema ships them.
+
+## Limits
+
+- Values are capped at **256 KB** serialized (`KV_VALUE_TOO_LARGE`). Store larger blobs in [Storage](/core-concepts/storage/overview).
+- `mget` reads up to 100 keys per call.
+
+## Next steps
+
+- Set up the [CLI](/quickstart) to link your project.
+- Use [Authentication](/core-concepts/authentication/overview) so end-user entries are owner-scoped.
+- Reach for the [Vector Store](/core-concepts/vector-store/overview) when you need semantic search instead of exact-key lookups.

--- a/docs/core-concepts/vector-store/overview.mdx
+++ b/docs/core-concepts/vector-store/overview.mdx
@@ -1,0 +1,112 @@
+---
+title: "Vector Store"
+sidebarTitle: "Overview"
+description: "A managed vector database for semantic search and RAG — collections, upsert, and similarity query, backed by pgvector."
+---
+
+Use the InsForge Vector Store to power semantic search, retrieval-augmented generation (RAG), recommendations, and deduplication. Group embeddings into **collections**, upsert items with a vector or raw text, then query by similarity with optional metadata filtering. It is backed by `pgvector` on the same Postgres instance as your data — a managed, Pinecone-style API without a separate vector database to run.
+
+<Note>
+  **Vector Store vs. raw pgvector.** The [Database](/core-concepts/database/pgvector) lets you add a `vector` column to your own tables and write SQL. The Vector Store is a higher-level managed API: collections, server-side embedding, and similarity queries over REST, with row-level security applied for you.
+</Note>
+
+```mermaid
+graph TB
+    App[Client / AI agent] --> SDK[InsForge SDK / REST]
+    SDK --> Collection[Vector collection]
+
+    Text[Raw text] --> Gateway[Model Gateway embeddings]
+    Gateway --> Collection
+    Vector[Bring-your-own vector] --> Collection
+
+    Collection --> Items[(vectors.items in Postgres)]
+    Items --> HNSW[HNSW index]
+    Query[Similarity query] --> HNSW
+
+    style App fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style SDK fill:#1e40af,stroke:#3b82f6,color:#dbeafe
+    style Collection fill:#166534,stroke:#22c55e,color:#dcfce7
+    style Gateway fill:#4c1d95,stroke:#8b5cf6,color:#ede9fe
+    style Items fill:#0e7490,stroke:#06b6d4,color:#cffafe
+    style HNSW fill:#c2410c,stroke:#fb923c,color:#fed7aa
+    style Query fill:#c2410c,stroke:#fb923c,color:#fed7aa
+```
+
+## Data model
+
+- **Collection** — a named group of vectors with a fixed `dimension` and a distance `metric`. Like KV and the rest of the platform, collections are either project-global (managed with the project API key) or owned by an end user and isolated by row-level security.
+- **Item** — an `embedding` plus optional source `content` (the text it was embedded from) and arbitrary JSON `metadata`. Provide your own `id` to make upserts idempotent.
+
+The current version fixes the embedding dimension at **1536**, matching the managed embedding model (`text-embedding-3-small`) served by the [Model Gateway](/core-concepts/ai/overview). The `cosine` metric is index-accelerated with HNSW; `l2` and `ip` are supported and return correct distances but are not index-accelerated yet.
+
+## Features
+
+### Create a collection
+
+```bash
+curl -X POST "$INSFORGE_URL/api/vectors/collections" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "docs", "dimension": 1536, "metric": "cosine"}'
+```
+
+### Upsert items
+
+Provide a `vector` directly, or send `content` and let InsForge embed it server-side via the Model Gateway. Content items in a single request are embedded in one batched call.
+
+```bash
+# Auto-embed from text
+curl -X POST "$INSFORGE_URL/api/vectors/collections/docs/upsert" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "items": [
+          { "content": "InsForge is an open-source backend platform.",
+            "metadata": { "source": "readme", "section": "intro" } },
+          { "content": "The KV store supports TTL and atomic counters.",
+            "metadata": { "source": "docs", "section": "kv" } }
+        ]
+      }'
+# => { "ids": ["..."] }
+```
+
+Pass an `id` on an item to overwrite an existing one; bring your own `vector` instead of `content` when you have already computed embeddings.
+
+### Query by similarity
+
+Query with a `vector` or with `text` (embedded for you). Add a `filter` to restrict matches by metadata (Pinecone-style JSON containment).
+
+```bash
+curl -X POST "$INSFORGE_URL/api/vectors/collections/docs/query" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "text": "how do I store a counter?",
+        "topK": 5,
+        "filter": { "source": "docs" }
+      }'
+# => { "matches": [ { "id": "...", "score": 0.83, "content": "...", "metadata": { ... } } ] }
+```
+
+`score` is the cosine similarity (higher is closer) for cosine collections. Set `includeContent: false` to return only ids, scores, and metadata.
+
+### Row-level security
+
+End-user collections and items are enforced by Postgres RLS keyed on `auth.uid()`, so each user's vectors are private to them. The project API key manages the project-global store. As with KV, the managed schema ships the policies — you don't write any.
+
+## A typical RAG flow
+
+1. **Index** your documents: chunk them, then `upsert` each chunk's `content` (InsForge embeds it).
+2. **Retrieve** at query time: `query` with the user's question `text` and a `topK` of 5–10.
+3. **Generate**: pass the retrieved `content` as context to a chat model through the [Model Gateway](/core-concepts/ai/overview).
+
+## Limits
+
+- Embedding dimension is fixed at 1536 in this version.
+- Up to 100 items per `upsert` and `topK` up to 100 per query.
+
+## Next steps
+
+- Set up the [CLI](/quickstart) to link your project.
+- Configure the [Model Gateway](/core-concepts/ai/overview) so server-side auto-embedding works.
+- Use the [Key-Value Store](/core-concepts/kv/overview) for exact-key cache and counters alongside semantic search.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,18 @@
                 ]
               },
               {
+                "group": "Key-Value Store",
+                "pages": [
+                  "core-concepts/kv/overview"
+                ]
+              },
+              {
+                "group": "Vector Store",
+                "pages": [
+                  "core-concepts/vector-store/overview"
+                ]
+              },
+              {
                 "group": "Edge Functions",
                 "pages": [
                   "core-concepts/functions/overview",

--- a/docs/products.mdx
+++ b/docs/products.mdx
@@ -3,7 +3,7 @@ title: "Products"
 description: "Every InsForge product in one place. Click any card to dive in."
 ---
 
-InsForge ships ten products, each exposed through the same REST surface, the
+InsForge ships twelve products, each exposed through the same REST surface, the
 same JWT auth, the same MCP server, and the same SDKs.
 
 <CardGroup cols={2}>
@@ -25,6 +25,16 @@ same JWT auth, the same MCP server, and the same SDKs.
   <Card title="Realtime" icon="tower-broadcast" href="/core-concepts/realtime/overview">
     Database changes, broadcast, and presence over one WebSocket connection.
     Subscriptions and client publish use RLS checks.
+  </Card>
+
+  <Card title="Key-Value Store" icon="key" href="/core-concepts/kv/overview">
+    Redis-like JSON KV with TTL, atomic counters, and compare-and-swap.
+    Owner-scoped by row-level security.
+  </Card>
+
+  <Card title="Vector Store" icon="magnifying-glass" href="/core-concepts/vector-store/overview">
+    Pinecone-style semantic search on pgvector. Collections, server-side
+    embedding, and metadata-filtered similarity queries.
   </Card>
 
   <Card title="Edge Functions" icon="bolt" href="/core-concepts/functions/overview">

--- a/packages/dashboard/src/features/kv/hooks/useKv.ts
+++ b/packages/dashboard/src/features/kv/hooks/useKv.ts
@@ -9,6 +9,8 @@ export function useKvKeys(namespace: string) {
   return useQuery({
     queryKey: [KV_KEYS_QUERY_KEY, namespace],
     queryFn: () => kvService.listKeys(namespace),
+    // Skip the request when there is no namespace (e.g. the input was cleared).
+    enabled: namespace.length > 0,
     staleTime: 30 * 1000,
     retry: false,
   });

--- a/packages/dashboard/src/features/kv/hooks/useKv.ts
+++ b/packages/dashboard/src/features/kv/hooks/useKv.ts
@@ -1,0 +1,48 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { kvService } from '#features/kv/services/kv.service';
+import { useToast } from '#lib/hooks/useToast';
+import type { KvSetRequest } from '@insforge/shared-schemas';
+
+export const KV_KEYS_QUERY_KEY = 'kv-keys';
+
+export function useKvKeys(namespace: string) {
+  return useQuery({
+    queryKey: [KV_KEYS_QUERY_KEY, namespace],
+    queryFn: () => kvService.listKeys(namespace),
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+}
+
+export function useSetKvEntry(namespace: string) {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: ({ key, input }: { key: string; input: KvSetRequest }) =>
+      kvService.setValue(namespace, key, input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [KV_KEYS_QUERY_KEY, namespace] });
+      showToast('Key saved', 'success');
+    },
+    onError: (error: Error) => {
+      showToast(error.message || 'Failed to save key', 'error');
+    },
+  });
+}
+
+export function useDeleteKvEntry(namespace: string) {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: (key: string) => kvService.deleteKey(namespace, key),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [KV_KEYS_QUERY_KEY, namespace] });
+      showToast('Key deleted', 'success');
+    },
+    onError: (error: Error) => {
+      showToast(error.message || 'Failed to delete key', 'error');
+    },
+  });
+}

--- a/packages/dashboard/src/features/kv/pages/KvPage.tsx
+++ b/packages/dashboard/src/features/kv/pages/KvPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Loader2, Plus, Trash2, Eye, XCircle, KeyRound } from 'lucide-react';
 import {
   Button,
@@ -53,13 +53,19 @@ export default function KvPage() {
   const [viewKey, setViewKey] = useState<string | null>(null);
   const [viewValue, setViewValue] = useState<unknown>(null);
   const [viewLoading, setViewLoading] = useState(false);
+  // Monotonic id so a slow getValue() can't overwrite a newer view request.
+  const viewRequestId = useRef(0);
 
-  const { data: keys = [], isLoading, error } = useKvKeys(namespace);
-  const setEntry = useSetKvEntry(namespace);
-  const deleteEntry = useDeleteKvEntry(namespace);
+  // Guard against an empty namespace (e.g. the input cleared) producing invalid
+  // list/save requests.
+  const activeNamespace = namespace.trim();
+
+  const { data: keys = [], isLoading, error } = useKvKeys(activeNamespace);
+  const setEntry = useSetKvEntry(activeNamespace);
+  const deleteEntry = useDeleteKvEntry(activeNamespace);
 
   const handleSave = async () => {
-    if (!newKey.trim()) {
+    if (!newKey.trim() || !activeNamespace) {
       return;
     }
     try {
@@ -75,15 +81,23 @@ export default function KvPage() {
   };
 
   const handleView = async (key: string) => {
+    const requestId = ++viewRequestId.current;
     setViewKey(key);
     setViewLoading(true);
+    setViewValue(null);
     try {
-      const value = await kvService.getValue(namespace, key);
-      setViewValue(value);
+      const value = await kvService.getValue(activeNamespace, key);
+      if (viewRequestId.current === requestId) {
+        setViewValue(value);
+      }
     } catch {
-      setViewValue('(failed to load value)');
+      if (viewRequestId.current === requestId) {
+        setViewValue('(failed to load value)');
+      }
     } finally {
-      setViewLoading(false);
+      if (viewRequestId.current === requestId) {
+        setViewLoading(false);
+      }
     }
   };
 
@@ -151,7 +165,7 @@ export default function KvPage() {
               <Button
                 variant="primary"
                 onClick={() => void handleSave()}
-                disabled={!newKey.trim() || setEntry.isPending}
+                disabled={!newKey.trim() || !activeNamespace || setEntry.isPending}
               >
                 {setEntry.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -203,10 +217,20 @@ export default function KvPage() {
                       {formatExpiry(entry.expiresAt)}
                     </div>
                     <div className="flex justify-end gap-1">
-                      <Button variant="ghost" size="sm" onClick={() => void handleView(entry.key)}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`View ${entry.key}`}
+                        onClick={() => void handleView(entry.key)}
+                      >
                         <Eye className="h-3.5 w-3.5" />
                       </Button>
-                      <Button variant="ghost" size="sm" onClick={() => setDeleteTarget(entry.key)}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`Delete ${entry.key}`}
+                        onClick={() => setDeleteTarget(entry.key)}
+                      >
                         <Trash2 className="h-3.5 w-3.5 text-destructive" />
                       </Button>
                     </div>

--- a/packages/dashboard/src/features/kv/pages/KvPage.tsx
+++ b/packages/dashboard/src/features/kv/pages/KvPage.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react';
+import { Loader2, Plus, Trash2, Eye, XCircle, KeyRound } from 'lucide-react';
+import {
+  Button,
+  Input,
+  Badge,
+  EmptyState,
+  Skeleton,
+  ConfirmDialog,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@insforge/ui';
+import { useKvKeys, useSetKvEntry, useDeleteKvEntry } from '#features/kv/hooks/useKv';
+import { kvService } from '#features/kv/services/kv.service';
+import type { KvVisibility } from '@insforge/shared-schemas';
+
+// Parse the value field as JSON, falling back to a plain string so the form
+// accepts both `{"a":1}` and `hello` without forcing the user to quote scalars.
+function parseValue(text: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return text;
+  }
+}
+
+function formatExpiry(expiresAt: string | null): string {
+  if (expiresAt === null) {
+    return 'Never';
+  }
+  return new Date(expiresAt).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function KvPage() {
+  const [namespace, setNamespace] = useState('default');
+  const [newKey, setNewKey] = useState('');
+  const [newValue, setNewValue] = useState('');
+  const [visibility, setVisibility] = useState<KvVisibility>('private');
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [viewKey, setViewKey] = useState<string | null>(null);
+  const [viewValue, setViewValue] = useState<unknown>(null);
+  const [viewLoading, setViewLoading] = useState(false);
+
+  const { data: keys = [], isLoading, error } = useKvKeys(namespace);
+  const setEntry = useSetKvEntry(namespace);
+  const deleteEntry = useDeleteKvEntry(namespace);
+
+  const handleSave = async () => {
+    if (!newKey.trim()) {
+      return;
+    }
+    try {
+      await setEntry.mutateAsync({
+        key: newKey.trim(),
+        input: { value: parseValue(newValue), visibility },
+      });
+      setNewKey('');
+      setNewValue('');
+    } catch {
+      // error toast handled in the hook
+    }
+  };
+
+  const handleView = async (key: string) => {
+    setViewKey(key);
+    setViewLoading(true);
+    try {
+      const value = await kvService.getValue(namespace, key);
+      setViewValue(value);
+    } catch {
+      setViewValue('(failed to load value)');
+    } finally {
+      setViewLoading(false);
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-[rgb(var(--semantic-0))]">
+      <div className="flex-1 min-h-0 overflow-y-auto px-10">
+        <div className="max-w-[1024px] w-full mx-auto flex flex-col gap-8 pt-10 pb-6">
+          {/* Header */}
+          <div className="flex flex-col gap-1">
+            <h1 className="text-2xl font-medium text-foreground leading-8">Key-Value Store</h1>
+            <p className="text-sm leading-5 text-muted-foreground">
+              Browse and manage the project-global key-value store. New keys default to a 30-day
+              TTL.
+            </p>
+          </div>
+
+          {/* Namespace selector */}
+          <div className="flex items-end gap-3">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm text-foreground">Namespace</label>
+              <Input
+                value={namespace}
+                onChange={(e) => setNamespace(e.target.value)}
+                placeholder="default"
+                className="w-[280px]"
+              />
+            </div>
+          </div>
+
+          {/* Create form */}
+          <div className="bg-card border border-[var(--alpha-8)] rounded-lg">
+            <div className="p-3 border-b border-[var(--alpha-8)]">
+              <p className="text-sm text-foreground">Add or overwrite a key</p>
+            </div>
+            <div className="flex flex-wrap items-end gap-4 p-6">
+              <div className="flex-1 min-w-[180px] flex flex-col gap-1.5">
+                <label className="text-sm text-foreground">Key</label>
+                <Input
+                  value={newKey}
+                  onChange={(e) => setNewKey(e.target.value)}
+                  placeholder="e.g. feature:new-checkout"
+                />
+              </div>
+              <div className="flex-1 min-w-[180px] flex flex-col gap-1.5">
+                <label className="text-sm text-foreground">Value (JSON or text)</label>
+                <Input
+                  value={newValue}
+                  onChange={(e) => setNewValue(e.target.value)}
+                  placeholder='{"enabled": true}'
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm text-foreground">Visibility</label>
+                <Select value={visibility} onValueChange={(v) => setVisibility(v as KvVisibility)}>
+                  <SelectTrigger className="w-[140px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    <SelectItem value="private">private</SelectItem>
+                    <SelectItem value="authed">authed</SelectItem>
+                    <SelectItem value="public">public</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                variant="primary"
+                onClick={() => void handleSave()}
+                disabled={!newKey.trim() || setEntry.isPending}
+              >
+                {setEntry.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Save
+              </Button>
+            </div>
+          </div>
+
+          {/* Keys list */}
+          {isLoading ? (
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : error ? (
+            <div className="flex items-center gap-2 text-destructive">
+              <XCircle className="w-5 h-5 shrink-0" />
+              <span className="text-sm">Failed to load keys. Please refresh the page.</span>
+            </div>
+          ) : keys.length === 0 ? (
+            <EmptyState
+              icon={KeyRound}
+              title="No keys in this namespace"
+              description="Add a key above, or write one from the SDK or an AI agent."
+            />
+          ) : (
+            <div className="flex max-h-full flex-col overflow-hidden rounded border border-[var(--alpha-8)] bg-card">
+              <div className="grid h-9 shrink-0 grid-cols-[minmax(160px,1fr)_120px_200px_120px] items-center border-b border-[var(--alpha-8)] px-3 text-xs text-muted-foreground">
+                <div>Key</div>
+                <div>Visibility</div>
+                <div>Expires</div>
+                <div className="text-right">Actions</div>
+              </div>
+              <div className="min-h-0 overflow-y-auto">
+                {keys.map((entry) => (
+                  <div
+                    key={entry.key}
+                    className="grid grid-cols-[minmax(160px,1fr)_120px_200px_120px] items-center border-b border-[var(--alpha-8)] px-3 py-2 last:border-b-0"
+                  >
+                    <div className="truncate font-mono text-sm text-foreground">{entry.key}</div>
+                    <div>
+                      <Badge variant="default">{entry.visibility}</Badge>
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {formatExpiry(entry.expiresAt)}
+                    </div>
+                    <div className="flex justify-end gap-1">
+                      <Button variant="ghost" size="sm" onClick={() => void handleView(entry.key)}>
+                        <Eye className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => setDeleteTarget(entry.key)}>
+                        <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Inline value viewer */}
+          {viewKey !== null && (
+            <div className="bg-card border border-[var(--alpha-8)] rounded-lg">
+              <div className="flex items-center justify-between p-3 border-b border-[var(--alpha-8)]">
+                <p className="font-mono text-sm text-foreground">{viewKey}</p>
+                <Button variant="ghost" size="sm" onClick={() => setViewKey(null)}>
+                  Close
+                </Button>
+              </div>
+              <div className="p-4">
+                {viewLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                ) : (
+                  <pre className="overflow-x-auto whitespace-pre-wrap break-all text-xs text-foreground">
+                    {JSON.stringify(viewValue, null, 2)}
+                  </pre>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+        title="Delete key?"
+        description={`This permanently deletes "${deleteTarget ?? ''}" from the "${namespace}" namespace.`}
+        confirmText="Delete"
+        destructive
+        isLoading={deleteEntry.isPending}
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteEntry.mutateAsync(deleteTarget);
+            if (viewKey === deleteTarget) {
+              setViewKey(null);
+            }
+            setDeleteTarget(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/kv/services/__tests__/kv.service.test.ts
+++ b/packages/dashboard/src/features/kv/services/__tests__/kv.service.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiClientMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+}));
+
+vi.mock('#lib/api/client', () => ({
+  apiClient: apiClientMock,
+}));
+
+import { KvService } from '#features/kv/services/kv.service';
+
+describe('KvService', () => {
+  let service: KvService;
+
+  beforeEach(() => {
+    apiClientMock.request.mockReset();
+    apiClientMock.withAccessToken.mockClear();
+    service = new KvService();
+  });
+
+  it('lists keys for a namespace and unwraps the response', async () => {
+    apiClientMock.request.mockResolvedValue({
+      keys: [{ key: 'a', visibility: 'private', expiresAt: null, updatedAt: '2026-06-28' }],
+    });
+
+    await expect(service.listKeys('default')).resolves.toEqual([
+      { key: 'a', visibility: 'private', expiresAt: null, updatedAt: '2026-06-28' },
+    ]);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/kv/entries/default', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  it('url-encodes the namespace and key when reading a value', async () => {
+    apiClientMock.request.mockResolvedValue({ value: { nested: true } });
+    await expect(service.getValue('ns:1', 'user:42')).resolves.toEqual({ nested: true });
+    expect(apiClientMock.request).toHaveBeenCalledWith('/kv/entries/ns%3A1/user%3A42', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  it('PUTs the set payload as JSON', async () => {
+    apiClientMock.request.mockResolvedValue({ created: true, entry: null });
+    await service.setValue('default', 'k', { value: { a: 1 }, visibility: 'public' });
+    expect(apiClientMock.request).toHaveBeenCalledWith('/kv/entries/default/k', {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ value: { a: 1 }, visibility: 'public' }),
+    });
+  });
+
+  it('deletes a key and returns the boolean flag', async () => {
+    apiClientMock.request.mockResolvedValue({ deleted: true });
+    await expect(service.deleteKey('default', 'k')).resolves.toBe(true);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/kv/entries/default/k', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+});

--- a/packages/dashboard/src/features/kv/services/kv.service.ts
+++ b/packages/dashboard/src/features/kv/services/kv.service.ts
@@ -1,0 +1,41 @@
+import { apiClient } from '#lib/api/client';
+import type { KvListResponse, KvSetResponse, KvSetRequest } from '@insforge/shared-schemas';
+
+function entryPath(namespace: string, key?: string): string {
+  const base = `/kv/entries/${encodeURIComponent(namespace)}`;
+  return key === undefined ? base : `${base}/${encodeURIComponent(key)}`;
+}
+
+export class KvService {
+  async listKeys(namespace: string): Promise<KvListResponse['keys']> {
+    const data = (await apiClient.request(entryPath(namespace), {
+      headers: apiClient.withAccessToken(),
+    })) as KvListResponse;
+    return data.keys;
+  }
+
+  async getValue(namespace: string, key: string): Promise<unknown> {
+    const data = (await apiClient.request(entryPath(namespace, key), {
+      headers: apiClient.withAccessToken(),
+    })) as { value: unknown };
+    return data.value;
+  }
+
+  async setValue(namespace: string, key: string, input: KvSetRequest): Promise<KvSetResponse> {
+    return (await apiClient.request(entryPath(namespace, key), {
+      method: 'PUT',
+      headers: apiClient.withAccessToken(),
+      body: JSON.stringify(input),
+    })) as KvSetResponse;
+  }
+
+  async deleteKey(namespace: string, key: string): Promise<boolean> {
+    const data = (await apiClient.request(entryPath(namespace, key), {
+      method: 'DELETE',
+      headers: apiClient.withAccessToken(),
+    })) as { deleted: boolean };
+    return data.deleted;
+  }
+}
+
+export const kvService = new KvService();

--- a/packages/dashboard/src/features/vectors/hooks/useVectors.ts
+++ b/packages/dashboard/src/features/vectors/hooks/useVectors.ts
@@ -1,0 +1,58 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { vectorStoreService } from '#features/vectors/services/vector.service';
+import { useToast } from '#lib/hooks/useToast';
+
+export const VECTOR_COLLECTIONS_QUERY_KEY = ['vector-collections'] as const;
+
+export function useCollections() {
+  return useQuery({
+    queryKey: VECTOR_COLLECTIONS_QUERY_KEY,
+    queryFn: () => vectorStoreService.listCollections(),
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+}
+
+export function useCreateCollection() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: (name: string) => vectorStoreService.createCollection(name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: VECTOR_COLLECTIONS_QUERY_KEY });
+      showToast('Collection created', 'success');
+    },
+    onError: (error: Error) => {
+      showToast(error.message || 'Failed to create collection', 'error');
+    },
+  });
+}
+
+export function useDeleteCollection() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: (name: string) => vectorStoreService.deleteCollection(name),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: VECTOR_COLLECTIONS_QUERY_KEY });
+      showToast('Collection deleted', 'success');
+    },
+    onError: (error: Error) => {
+      showToast(error.message || 'Failed to delete collection', 'error');
+    },
+  });
+}
+
+export function useQueryCollection() {
+  const { showToast } = useToast();
+
+  return useMutation({
+    mutationFn: ({ name, text, topK }: { name: string; text: string; topK: number }) =>
+      vectorStoreService.query(name, text, topK),
+    onError: (error: Error) => {
+      showToast(error.message || 'Query failed', 'error');
+    },
+  });
+}

--- a/packages/dashboard/src/features/vectors/pages/VectorPage.tsx
+++ b/packages/dashboard/src/features/vectors/pages/VectorPage.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+import { Loader2, Plus, Trash2, Search, XCircle, Boxes } from 'lucide-react';
+import {
+  Button,
+  Input,
+  Badge,
+  EmptyState,
+  Skeleton,
+  ConfirmDialog,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@insforge/ui';
+import {
+  useCollections,
+  useCreateCollection,
+  useDeleteCollection,
+  useQueryCollection,
+} from '#features/vectors/hooks/useVectors';
+import type { VectorMatch } from '@insforge/shared-schemas';
+
+export default function VectorPage() {
+  const [newName, setNewName] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [queryCollection, setQueryCollection] = useState<string>('');
+  const [queryText, setQueryText] = useState('');
+  const [matches, setMatches] = useState<VectorMatch[] | null>(null);
+
+  const { data: collections = [], isLoading, error } = useCollections();
+  const createCollection = useCreateCollection();
+  const deleteCollection = useDeleteCollection();
+  const runQuery = useQueryCollection();
+
+  const handleCreate = async () => {
+    if (!newName.trim()) {
+      return;
+    }
+    try {
+      await createCollection.mutateAsync(newName.trim());
+      setNewName('');
+    } catch {
+      // toast handled in the hook
+    }
+  };
+
+  const handleRunQuery = async () => {
+    if (!queryCollection || !queryText.trim()) {
+      return;
+    }
+    const result = await runQuery.mutateAsync({
+      name: queryCollection,
+      text: queryText.trim(),
+      topK: 10,
+    });
+    setMatches(result);
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-[rgb(var(--semantic-0))]">
+      <div className="flex-1 min-h-0 overflow-y-auto px-10">
+        <div className="max-w-[1024px] w-full mx-auto flex flex-col gap-8 pt-10 pb-6">
+          {/* Header */}
+          <div className="flex flex-col gap-1">
+            <h1 className="text-2xl font-medium text-foreground leading-8">Vector Store</h1>
+            <p className="text-sm leading-5 text-muted-foreground">
+              Manage embedding collections and run semantic similarity queries.
+            </p>
+          </div>
+
+          {/* Create collection */}
+          <div className="bg-card border border-[var(--alpha-8)] rounded-lg">
+            <div className="p-3 border-b border-[var(--alpha-8)]">
+              <p className="text-sm text-foreground">Create a collection</p>
+            </div>
+            <div className="flex items-end gap-4 p-6">
+              <div className="flex-1 flex flex-col gap-1.5">
+                <label className="text-sm text-foreground">Name</label>
+                <Input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="e.g. docs"
+                />
+              </div>
+              <Button
+                variant="primary"
+                onClick={() => void handleCreate()}
+                disabled={!newName.trim() || createCollection.isPending}
+              >
+                {createCollection.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="h-4 w-4" />
+                )}
+                Create
+              </Button>
+            </div>
+          </div>
+
+          {/* Collections list */}
+          {isLoading ? (
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : error ? (
+            <div className="flex items-center gap-2 text-destructive">
+              <XCircle className="w-5 h-5 shrink-0" />
+              <span className="text-sm">Failed to load collections. Please refresh the page.</span>
+            </div>
+          ) : collections.length === 0 ? (
+            <EmptyState
+              icon={Boxes}
+              title="No collections yet"
+              description="Create a collection above, then upsert items from the SDK or an AI agent."
+            />
+          ) : (
+            <div className="flex flex-col overflow-hidden rounded border border-[var(--alpha-8)] bg-card">
+              <div className="grid h-9 shrink-0 grid-cols-[minmax(160px,1fr)_120px_120px_100px] items-center border-b border-[var(--alpha-8)] px-3 text-xs text-muted-foreground">
+                <div>Name</div>
+                <div>Dimension</div>
+                <div>Metric</div>
+                <div className="text-right">Actions</div>
+              </div>
+              {collections.map((collection) => (
+                <div
+                  key={collection.id}
+                  className="grid grid-cols-[minmax(160px,1fr)_120px_120px_100px] items-center border-b border-[var(--alpha-8)] px-3 py-2 last:border-b-0"
+                >
+                  <div className="truncate font-mono text-sm text-foreground">
+                    {collection.name}
+                  </div>
+                  <div className="text-sm text-muted-foreground">{collection.dimension}</div>
+                  <div>
+                    <Badge variant="default">{collection.metric}</Badge>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteTarget(collection.name)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Query playground */}
+          {collections.length > 0 && (
+            <div className="bg-card border border-[var(--alpha-8)] rounded-lg">
+              <div className="p-3 border-b border-[var(--alpha-8)]">
+                <p className="text-sm text-foreground">Query playground</p>
+              </div>
+              <div className="flex flex-col gap-4 p-6">
+                <div className="flex flex-wrap items-end gap-4">
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-sm text-foreground">Collection</label>
+                    <Select value={queryCollection} onValueChange={setQueryCollection}>
+                      <SelectTrigger className="w-[200px]">
+                        <SelectValue placeholder="Select a collection" />
+                      </SelectTrigger>
+                      <SelectContent align="start">
+                        {collections.map((collection) => (
+                          <SelectItem key={collection.id} value={collection.name}>
+                            {collection.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex-1 min-w-[220px] flex flex-col gap-1.5">
+                    <label className="text-sm text-foreground">Query text</label>
+                    <Input
+                      value={queryText}
+                      onChange={(e) => setQueryText(e.target.value)}
+                      placeholder="Search by meaning…"
+                    />
+                  </div>
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleRunQuery()}
+                    disabled={!queryCollection || !queryText.trim() || runQuery.isPending}
+                  >
+                    {runQuery.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Search className="h-4 w-4" />
+                    )}
+                    Search
+                  </Button>
+                </div>
+
+                {matches !== null && (
+                  <div className="flex flex-col gap-2">
+                    {matches.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No matches.</p>
+                    ) : (
+                      matches.map((match) => (
+                        <div
+                          key={match.id}
+                          className="flex flex-col gap-1 rounded border border-[var(--alpha-8)] p-3"
+                        >
+                          <div className="flex items-center justify-between">
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {match.id}
+                            </span>
+                            <Badge variant="default">score {match.score.toFixed(4)}</Badge>
+                          </div>
+                          {match.content && (
+                            <p className="text-sm text-foreground">{match.content}</p>
+                          )}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+        title="Delete collection?"
+        description={`This permanently deletes "${deleteTarget ?? ''}" and all of its vectors.`}
+        confirmText="Delete"
+        destructive
+        isLoading={deleteCollection.isPending}
+        onConfirm={async () => {
+          if (deleteTarget) {
+            await deleteCollection.mutateAsync(deleteTarget);
+            if (queryCollection === deleteTarget) {
+              setQueryCollection('');
+              setMatches(null);
+            }
+            setDeleteTarget(null);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/vectors/services/__tests__/vector.service.test.ts
+++ b/packages/dashboard/src/features/vectors/services/__tests__/vector.service.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiClientMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+}));
+
+vi.mock('#lib/api/client', () => ({
+  apiClient: apiClientMock,
+}));
+
+import { VectorStoreService } from '#features/vectors/services/vector.service';
+
+describe('VectorStoreService', () => {
+  let service: VectorStoreService;
+
+  beforeEach(() => {
+    apiClientMock.request.mockReset();
+    apiClientMock.withAccessToken.mockClear();
+    service = new VectorStoreService();
+  });
+
+  it('lists collections and unwraps the response', async () => {
+    apiClientMock.request.mockResolvedValue({
+      collections: [
+        { id: '1', name: 'docs', dimension: 1536, metric: 'cosine', createdAt: '2026-06-28' },
+      ],
+    });
+    await expect(service.listCollections()).resolves.toHaveLength(1);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/vectors/collections', {
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  it('creates a collection with a POST and returns the collection', async () => {
+    const collection = {
+      id: '1',
+      name: 'docs',
+      dimension: 1536,
+      metric: 'cosine',
+      createdAt: '2026-06-28',
+    };
+    apiClientMock.request.mockResolvedValue({ collection });
+    await expect(service.createCollection('docs')).resolves.toEqual(collection);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/vectors/collections', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ name: 'docs' }),
+    });
+  });
+
+  it('queries a collection with text + topK and unwraps matches', async () => {
+    apiClientMock.request.mockResolvedValue({
+      matches: [{ id: 'i1', score: 0.9, content: 'hi', metadata: {} }],
+    });
+    await expect(service.query('docs', 'find this', 10)).resolves.toEqual([
+      { id: 'i1', score: 0.9, content: 'hi', metadata: {} },
+    ]);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/vectors/collections/docs/query', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ text: 'find this', topK: 10 }),
+    });
+  });
+
+  it('url-encodes the collection name on delete', async () => {
+    apiClientMock.request.mockResolvedValue({ deleted: true });
+    await expect(service.deleteCollection('my docs')).resolves.toBe(true);
+    expect(apiClientMock.request).toHaveBeenCalledWith('/vectors/collections/my%20docs', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+});

--- a/packages/dashboard/src/features/vectors/services/vector.service.ts
+++ b/packages/dashboard/src/features/vectors/services/vector.service.ts
@@ -1,0 +1,47 @@
+import { apiClient } from '#lib/api/client';
+import type {
+  ListCollectionsResponse,
+  VectorCollection,
+  VectorQueryResponse,
+  VectorMatch,
+} from '@insforge/shared-schemas';
+
+export class VectorStoreService {
+  async listCollections(): Promise<VectorCollection[]> {
+    const data = (await apiClient.request('/vectors/collections', {
+      headers: apiClient.withAccessToken(),
+    })) as ListCollectionsResponse;
+    return data.collections;
+  }
+
+  async createCollection(name: string): Promise<VectorCollection> {
+    const data = (await apiClient.request('/vectors/collections', {
+      method: 'POST',
+      headers: apiClient.withAccessToken(),
+      body: JSON.stringify({ name }),
+    })) as { collection: VectorCollection };
+    return data.collection;
+  }
+
+  async deleteCollection(name: string): Promise<boolean> {
+    const data = (await apiClient.request(`/vectors/collections/${encodeURIComponent(name)}`, {
+      method: 'DELETE',
+      headers: apiClient.withAccessToken(),
+    })) as { deleted: boolean };
+    return data.deleted;
+  }
+
+  async query(name: string, text: string, topK: number): Promise<VectorMatch[]> {
+    const data = (await apiClient.request(
+      `/vectors/collections/${encodeURIComponent(name)}/query`,
+      {
+        method: 'POST',
+        headers: apiClient.withAccessToken(),
+        body: JSON.stringify({ text, topK }),
+      }
+    )) as VectorQueryResponse;
+    return data.matches;
+  }
+}
+
+export const vectorStoreService = new VectorStoreService();

--- a/packages/dashboard/src/navigation/menuItems.ts
+++ b/packages/dashboard/src/navigation/menuItems.ts
@@ -16,6 +16,8 @@ import {
   Download,
   BookOpen,
   CreditCard,
+  KeyRound,
+  Boxes,
 } from 'lucide-react';
 
 export interface DashboardSecondaryMenuItem {
@@ -95,6 +97,18 @@ export const dashboardStaticMenuItems: DashboardPrimaryMenuItem[] = [
     label: 'Realtime',
     href: '/dashboard/realtime',
     icon: Radio,
+  },
+  {
+    id: 'kv',
+    label: 'Key-Value',
+    href: '/dashboard/kv',
+    icon: KeyRound,
+  },
+  {
+    id: 'vectors',
+    label: 'Vector Store',
+    href: '/dashboard/vectors',
+    icon: Boxes,
   },
   {
     id: 'ai',

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -13,6 +13,8 @@ import AuthMethodsPage from '#features/auth/pages/AuthMethodsPage';
 import EmailPage from '#features/auth/pages/EmailPage';
 import UsersPage from '#features/auth/pages/UsersPage';
 import ComputePage from '#features/compute/pages/ComputePage';
+import KvPage from '#features/kv/pages/KvPage';
+import VectorPage from '#features/vectors/pages/VectorPage';
 import DashboardLayout from '#features/dashboard/components/DashboardLayout';
 import DashboardPage from '#features/dashboard/pages/DashboardPage';
 import DTestDashboardPage from '#features/dashboard/pages/DTestDashboardPage';
@@ -146,6 +148,8 @@ function AuthenticatedRoutes() {
           <Route path="domains" element={<DeploymentDomainsPage />} />
         </Route>
         <Route path="/dashboard/compute" element={<ComputePage />} />
+        <Route path="/dashboard/kv" element={<KvPage />} />
+        <Route path="/dashboard/vectors" element={<VectorPage />} />
         {isCloudHosting && (
           <Route path="/dashboard/analytics" element={<AnalyticsLayout />}>
             <Route index element={<Navigate to="traffic" replace />} />

--- a/packages/shared-schemas/src/error-codes.schema.ts
+++ b/packages/shared-schemas/src/error-codes.schema.ts
@@ -116,6 +116,21 @@ const paymentErrorCodes = [
 
 const secretErrorCodes = ['SECRET_ALREADY_EXISTS', 'SECRET_NOT_FOUND'] as const;
 
+const kvErrorCodes = [
+  'KV_NOT_FOUND',
+  'KV_CAS_MISMATCH',
+  'KV_NOT_A_NUMBER',
+  'KV_VALUE_TOO_LARGE',
+] as const;
+
+const vectorErrorCodes = [
+  'VECTOR_COLLECTION_NOT_FOUND',
+  'VECTOR_COLLECTION_ALREADY_EXISTS',
+  'VECTOR_ITEM_NOT_FOUND',
+  'VECTOR_DIMENSION_MISMATCH',
+  'VECTOR_QUERY_INVALID',
+] as const;
+
 const generalErrorCodes = [
   'MISSING_FIELD',
   'ALREADY_EXISTS',
@@ -147,6 +162,8 @@ const errorCodeValues = [
   ...scheduleErrorCodes,
   ...paymentErrorCodes,
   ...secretErrorCodes,
+  ...kvErrorCodes,
+  ...vectorErrorCodes,
   ...generalErrorCodes,
 ] as const;
 

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -30,4 +30,6 @@ export * from './compute-services-api.schema.js';
 export * from './posthog.schema.js';
 export * from './posthog-api.schema.js';
 export * from './memory-api.schema.js';
+export * from './kv-api.schema.js';
+export * from './vector-api.schema.js';
 export * from './error-codes.schema.js';

--- a/packages/shared-schemas/src/kv-api.schema.ts
+++ b/packages/shared-schemas/src/kv-api.schema.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod';
+
+// ============================================================================
+// Key-Value store contracts (shared across backend, SDK, CLI, dashboard).
+// A KV entry is arbitrary JSON addressed by (namespace, key). Entries are
+// owner-scoped via RLS for end users; the project API key operates on the
+// shared project-global store (owner_id = NULL).
+// ============================================================================
+
+// Visibility maps onto RLS: 'private' = owner only, 'authed' = any signed-in
+// user can read, 'public' = anon can read. Writes are always owner-only.
+export const kvVisibilitySchema = z.enum(['private', 'authed', 'public']);
+export type KvVisibility = z.infer<typeof kvVisibilitySchema>;
+
+// Namespaces and keys are single URL path segments. ':' is allowed (the
+// conventional namespace separator inside a key); '/' is not.
+const namespaceSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[^/]+$/, 'Namespace must not contain "/"');
+const keySchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .regex(/^[^/]+$/, 'Key must not contain "/"');
+
+// Stored values are arbitrary JSON. z.unknown() keeps the contract honest:
+// the backend enforces the byte-size cap, not a shape.
+export const kvValueSchema = z.unknown();
+
+// TTL in seconds. null = never expires. Omitted = server default (30 days).
+const ttlSecondsSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(60 * 60 * 24 * 365 * 10);
+
+export const kvEntrySchema = z.object({
+  namespace: z.string(),
+  key: z.string(),
+  value: kvValueSchema,
+  visibility: kvVisibilitySchema,
+  expiresAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type KvEntry = z.infer<typeof kvEntrySchema>;
+
+// PUT /api/kv/entries/:namespace/:key
+export const kvSetRequestSchema = z.object({
+  value: kvValueSchema,
+  ttl: ttlSecondsSchema.nullable().optional(),
+  visibility: kvVisibilitySchema.optional(),
+  // set-if-not-exists; returns created=false on conflict instead of overwriting
+  ifNotExists: z.boolean().optional(),
+});
+export type KvSetRequest = z.infer<typeof kvSetRequestSchema>;
+
+export const kvSetResponseSchema = z.object({
+  created: z.boolean(),
+  entry: kvEntrySchema.nullable(),
+});
+export type KvSetResponse = z.infer<typeof kvSetResponseSchema>;
+
+// POST /api/kv/entries/:namespace/:key/incr  (and /decr)
+export const kvIncrRequestSchema = z.object({
+  by: z.number().default(1),
+  ttl: ttlSecondsSchema.nullable().optional(),
+});
+export type KvIncrRequest = z.infer<typeof kvIncrRequestSchema>;
+
+export const kvIncrResponseSchema = z.object({ value: z.number() });
+export type KvIncrResponse = z.infer<typeof kvIncrResponseSchema>;
+
+// POST /api/kv/entries/:namespace/:key/cas
+export const kvCasRequestSchema = z.object({
+  expected: kvValueSchema,
+  next: kvValueSchema,
+  ttl: ttlSecondsSchema.nullable().optional(),
+});
+export type KvCasRequest = z.infer<typeof kvCasRequestSchema>;
+
+// POST /api/kv/entries/:namespace/:key/expire
+export const kvExpireRequestSchema = z.object({
+  ttl: ttlSecondsSchema.nullable(),
+});
+export type KvExpireRequest = z.infer<typeof kvExpireRequestSchema>;
+
+export const kvTtlResponseSchema = z.object({ ttl: z.number().nullable() });
+export type KvTtlResponse = z.infer<typeof kvTtlResponseSchema>;
+
+// POST /api/kv/mget
+export const kvMgetRequestSchema = z.object({
+  namespace: namespaceSchema.default('default'),
+  keys: z.array(keySchema).min(1).max(100),
+});
+export type KvMgetRequest = z.infer<typeof kvMgetRequestSchema>;
+
+export const kvMgetResponseSchema = z.object({
+  // map of key -> value (missing/expired keys are omitted)
+  values: z.record(kvValueSchema),
+});
+export type KvMgetResponse = z.infer<typeof kvMgetResponseSchema>;
+
+// POST /api/kv/mset
+export const kvMsetRequestSchema = z.object({
+  namespace: namespaceSchema.default('default'),
+  entries: z.record(kvValueSchema),
+  ttl: ttlSecondsSchema.nullable().optional(),
+  visibility: kvVisibilitySchema.optional(),
+});
+export type KvMsetRequest = z.infer<typeof kvMsetRequestSchema>;
+
+export const kvMsetResponseSchema = z.object({ count: z.number() });
+export type KvMsetResponse = z.infer<typeof kvMsetResponseSchema>;
+
+// GET /api/kv/entries/:namespace  (list keys in a namespace)
+export const kvListResponseSchema = z.object({
+  keys: z.array(
+    z.object({
+      key: z.string(),
+      visibility: kvVisibilitySchema,
+      expiresAt: z.string().nullable(),
+      updatedAt: z.string(),
+    })
+  ),
+});
+export type KvListResponse = z.infer<typeof kvListResponseSchema>;

--- a/packages/shared-schemas/src/kv-api.schema.ts
+++ b/packages/shared-schemas/src/kv-api.schema.ts
@@ -13,13 +13,14 @@ export const kvVisibilitySchema = z.enum(['private', 'authed', 'public']);
 export type KvVisibility = z.infer<typeof kvVisibilitySchema>;
 
 // Namespaces and keys are single URL path segments. ':' is allowed (the
-// conventional namespace separator inside a key); '/' is not.
-const namespaceSchema = z
+// conventional namespace separator inside a key); '/' is not. Exported so the
+// route layer can validate path params against the same bounds.
+export const kvNamespaceSchema = z
   .string()
   .min(1)
   .max(256)
   .regex(/^[^/]+$/, 'Namespace must not contain "/"');
-const keySchema = z
+export const kvKeySchema = z
   .string()
   .min(1)
   .max(512)
@@ -64,9 +65,10 @@ export const kvSetResponseSchema = z.object({
 export type KvSetResponse = z.infer<typeof kvSetResponseSchema>;
 
 // POST /api/kv/entries/:namespace/:key/incr  (and /decr)
+// `by` is always positive; /decr negates it server-side. This prevents a
+// negative `by` on /decr from silently incrementing.
 export const kvIncrRequestSchema = z.object({
-  by: z.number().default(1),
-  ttl: ttlSecondsSchema.nullable().optional(),
+  by: z.number().positive().default(1),
 });
 export type KvIncrRequest = z.infer<typeof kvIncrRequestSchema>;
 
@@ -92,8 +94,8 @@ export type KvTtlResponse = z.infer<typeof kvTtlResponseSchema>;
 
 // POST /api/kv/mget
 export const kvMgetRequestSchema = z.object({
-  namespace: namespaceSchema.default('default'),
-  keys: z.array(keySchema).min(1).max(100),
+  namespace: kvNamespaceSchema.default('default'),
+  keys: z.array(kvKeySchema).min(1).max(100),
 });
 export type KvMgetRequest = z.infer<typeof kvMgetRequestSchema>;
 
@@ -105,7 +107,7 @@ export type KvMgetResponse = z.infer<typeof kvMgetResponseSchema>;
 
 // POST /api/kv/mset
 export const kvMsetRequestSchema = z.object({
-  namespace: namespaceSchema.default('default'),
+  namespace: kvNamespaceSchema.default('default'),
   entries: z.record(kvValueSchema),
   ttl: ttlSecondsSchema.nullable().optional(),
   visibility: kvVisibilitySchema.optional(),

--- a/packages/shared-schemas/src/vector-api.schema.ts
+++ b/packages/shared-schemas/src/vector-api.schema.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+// ============================================================================
+// Vector store contracts (Pinecone-like, backed by pgvector).
+// A collection groups items of a fixed embedding dimension; items carry an
+// embedding plus optional source text and JSON metadata. Items are owner-scoped
+// via RLS for end users; the project API key operates on the project-global
+// store (owner_id = NULL).
+// ============================================================================
+
+// MVP indexes cosine with HNSW. 'l2' / 'ip' are accepted and computed correctly
+// but are not index-accelerated yet (sequential scan) — see vector docs.
+export const vectorMetricSchema = z.enum(['cosine', 'l2', 'ip']);
+export type VectorMetric = z.infer<typeof vectorMetricSchema>;
+
+// Fixed in the MVP to match the managed embedding model (text-embedding-3-small).
+// Stored per-collection so a future per-collection-table backend can vary it.
+export const VECTOR_DEFAULT_DIMENSION = 1536;
+
+const collectionNameSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Collection name must be alphanumeric, "_" or "-"');
+
+export const vectorCollectionSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  dimension: z.number().int().positive(),
+  metric: vectorMetricSchema,
+  createdAt: z.string(),
+});
+export type VectorCollection = z.infer<typeof vectorCollectionSchema>;
+
+// POST /api/vectors/collections
+export const createCollectionRequestSchema = z.object({
+  name: collectionNameSchema,
+  dimension: z.number().int().positive().max(2000).default(VECTOR_DEFAULT_DIMENSION),
+  metric: vectorMetricSchema.default('cosine'),
+});
+export type CreateCollectionRequest = z.infer<typeof createCollectionRequestSchema>;
+
+export const listCollectionsResponseSchema = z.object({
+  collections: z.array(vectorCollectionSchema),
+});
+export type ListCollectionsResponse = z.infer<typeof listCollectionsResponseSchema>;
+
+// A single item to upsert. Provide either `vector` (bring-your-own embedding)
+// or `content` (auto-embedded server-side via the Model Gateway). `id` lets the
+// caller make upserts idempotent; omitted means insert with a generated id.
+export const vectorUpsertItemSchema = z
+  .object({
+    id: z.string().uuid().optional(),
+    vector: z.array(z.number()).min(1).optional(),
+    content: z.string().min(1).max(20_000).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .refine((v) => Boolean(v.vector) || Boolean(v.content), {
+    message: 'Provide either { vector } or { content }',
+  });
+export type VectorUpsertItem = z.infer<typeof vectorUpsertItemSchema>;
+
+// POST /api/vectors/collections/:name/upsert
+export const vectorUpsertRequestSchema = z.object({
+  items: z.array(vectorUpsertItemSchema).min(1).max(100),
+});
+export type VectorUpsertRequest = z.infer<typeof vectorUpsertRequestSchema>;
+
+export const vectorUpsertResponseSchema = z.object({
+  ids: z.array(z.string().uuid()),
+});
+export type VectorUpsertResponse = z.infer<typeof vectorUpsertResponseSchema>;
+
+// POST /api/vectors/collections/:name/query
+export const vectorQueryRequestSchema = z
+  .object({
+    vector: z.array(z.number()).min(1).optional(),
+    text: z.string().min(1).max(4_000).optional(),
+    topK: z.number().int().positive().max(100).default(10),
+    // Pinecone-style metadata filter, matched with the jsonb containment (@>) op.
+    filter: z.record(z.unknown()).optional(),
+    includeContent: z.boolean().default(true),
+  })
+  .refine((v) => Boolean(v.vector) || Boolean(v.text), {
+    message: 'Provide either { vector } or { text }',
+  });
+export type VectorQueryRequest = z.infer<typeof vectorQueryRequestSchema>;
+
+export const vectorMatchSchema = z.object({
+  id: z.string().uuid(),
+  score: z.number(),
+  content: z.string().nullable(),
+  metadata: z.record(z.unknown()),
+});
+export type VectorMatch = z.infer<typeof vectorMatchSchema>;
+
+export const vectorQueryResponseSchema = z.object({
+  matches: z.array(vectorMatchSchema),
+});
+export type VectorQueryResponse = z.infer<typeof vectorQueryResponseSchema>;


### PR DESCRIPTION
Closes #1609

## Summary

Adds two new Postgres-backed product domains, each following the existing `route → service → pool` architecture with shared-schemas contracts, owner-scoped RLS, idempotent migrations, unit tests, MCP/product docs, and dashboard feature pages.

### Key-Value Store (`/api/kv`)
Redis-like JSON store addressed by `(namespace, key)`:
- `get` / `set` / `del` / `exists`, `setnx`, atomic `incr`/`decr`, compare-and-swap, `expire`/`ttl`, `mget`/`mset`, list
- 30-day default TTL (configurable / `null` = never), 256 KB value cap
- Migration `058`: `kv.entries`, owner-unique index, TTL sweep index, RLS policies + grants

### Vector Store (`/api/vectors`)
Pinecone-style semantic search on `pgvector`:
- Collections + items, bring-your-own-vector **or** server-side auto-embed via the Model Gateway (`text-embedding-3-small`)
- Similarity query with `topK` and metadata `@>` filtering; HNSW cosine index
- Migration `059`: `vectors.collections` + `vectors.items` (`vector(1536)`), RLS policies + grants

### Auth model
End users are owner-scoped through RLS (`withUserContext`); API-key callers and the admin dashboard manage the project-global store via the superuser pool.

## Validation
- `turbo run typecheck lint build` — green across all workspaces
- Tests: backend (+`kv`/`vector` service + migration suites), dashboard (+service suites) — passing
- Verified end-to-end on a local Docker stack: migrations apply, routes live, similarity query ranks correctly

## Follow-ups (not in this PR)
- SDK helpers `client.kv.*` / `client.vectors.*` (docs currently use REST examples)
- OpenAPI specs `openapi/kv.yaml` + `openapi/vectors.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Postgres-backed key-value store and pgvector vector store with REST APIs and dashboard UI
> - Adds `KvService` backed by a new `kv.entries` table with JSONB values, RLS, TTL, visibility levels (`private`/`authed`/`public`), and operations including get/set/del/incr/cas/mget/mset exposed under `/api/kv`.
> - Adds `VectorService` backed by a new `vectors.collections`/`vectors.items` schema using pgvector with 1536-dim HNSW-indexed embeddings, cosine/l2/ip metrics, and metadata GIN filtering exposed under `/api/vectors`.
> - Adds dashboard pages at `/dashboard/kv` and `/dashboard/vectors` for managing entries and collections, running queries, and viewing results.
> - Adds shared Zod schemas in `packages/shared-schemas` for both APIs including error codes (`KV_NOT_FOUND`, `KV_CAS_MISMATCH`, `VECTOR_DIMENSION_MISMATCH`, etc.).
> - Database migrations [058_create-kv-schema.sql](https://github.com/InsForge/InsForge/pull/1608/files#diff-60d80c27a5f455df9b735a6ebc34f26a2bb9c4ef3952371fa5f3da2cf8e43fd5) and [059_create-vector-store-schema.sql](https://github.com/InsForge/InsForge/pull/1608/files#diff-26d9b2f79c45f19ab590ac1de355904288f98ff84d583fcb5f103fdf8ed79a1d) enable RLS so authenticated users access only their own rows; anonymous users can read public KV entries but have no vector store access.
> - Risk: vector embeddings are fixed at 1536 dimensions; collections with any other dimension are rejected with a 400 error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7174e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Key-Value Store and Vector Store capabilities, including backend REST APIs for namespaces/entries and vector collections (with TTL/visibility, bulk reads/writes, atomic counters, and compare-and-swap), plus new dashboard pages to manage KV keys and run vector queries.
  * Added corresponding client-side services/hooks for browsing, editing, and querying KV entries and vector collections.
* **Documentation**
  * Added core concept overviews for both stores and updated product/navigation pages.
* **Tests**
  * Added unit tests covering the new migrations, services, and client API wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->