### PR TITLE
[codex] Add e2e testing skill

### DIFF
--- a/.agents/skills/insforge-dev/SKILL.md
+++ b/.agents/skills/insforge-dev/SKILL.md
@@ -14,6 +14,9 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+
+Use the cross-repo release workflow skill when preparing an OSS PR:
+
 - `e2e-testing`
 
 ## Core Rules

--- a/.agents/skills/insforge-dev/SKILL.md
+++ b/.agents/skills/insforge-dev/SKILL.md
@@ -14,6 +14,7 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+- `e2e-testing`
 
 ## Core Rules
 
@@ -64,5 +65,6 @@ Before opening a PR or pushing new commits to an existing PR branch, run **all**
    - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
 3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
 4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+5. Use `e2e-testing` to run the deterministic cross-repo E2E gate before opening, updating, or submitting the InsForge OSS PR.
 
 Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/.agents/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.agents/skills/insforge-dev/e2e-testing/SKILL.md
@@ -12,9 +12,9 @@ This is an additional release-quality gate. It does not replace local `typecheck
 ## Repositories
 
 - InsForge OSS repo: current workspace.
-- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+- E2E repo: remote GitHub repository `InsForge/agent-e2e`.
 
-If the sibling repo is not present, locate it with `find` or ask before cloning.
+Use the remote `InsForge/agent-e2e` repository for workflow dispatch and read-only workflow checks. Do not rely on a developer-specific local checkout path. Create or use a local checkout only when the deterministic fixture tests must be edited.
 
 ## Build The Test Tag
 
@@ -57,7 +57,9 @@ Do not start the cross-repo E2E workflow until the image build succeeds.
 
 ## Decide Whether `agent-e2e` Must Change
 
-Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `InsForge/agent-e2e`.
+
+For read-only checks, prefer remote GitHub access such as `gh api`, `gh repo view`, or remote file reads. Use a local checkout only when editing fixture files or when remote inspection is not enough to understand coverage.
 
 Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
 
@@ -86,10 +88,10 @@ gh run watch --repo InsForge/agent-e2e <run-id>
 
 ## If E2E Tests Need An Update
 
-Work in the sibling `agent-e2e` repo.
+Work in a local checkout of the remote `InsForge/agent-e2e` repo only for the fixture update.
 
-1. Make sure the repo is clean before switching branches.
-2. Start from `main` or an up-to-date branch based on `main`.
+1. Use an existing clean checkout or clone `https://github.com/InsForge/agent-e2e.git` into an isolated workspace.
+2. Fetch `origin` and start from `origin/main`.
 3. Create a branch named `codex/<short-topic>`.
 4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
 5. Run the smallest local validation that gives confidence:
@@ -117,7 +119,7 @@ If the deterministic fixture workflow passes:
 
 - Link the run in the InsForge PR body or final PR notes.
 - If an `agent-e2e` PR was required, link that PR too.
-- Proceed with opening or submitting the InsForge OSS PR.
+- Proceed with opening, updating, or submitting the InsForge OSS PR.
 
 If the deterministic fixture workflow fails:
 

--- a/.agents/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.agents/skills/insforge-dev/e2e-testing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: e2e-testing
+description: Use this skill when an InsForge maintainer has finished an OSS repo change and is ready to open, update, or submit the InsForge PR. Runs the release-quality deterministic E2E gate by building a package.json-derived InsForge test image tag, deciding whether sibling agent-e2e fixture coverage must change, dispatching the Deterministic Fixture E2E workflow, waiting for results, and triaging failures before PR submission.
+---
+
+# InsForge E2E Testing Gate
+
+Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening, updating, or submitting the InsForge OSS PR.
+
+This is an additional release-quality gate. It does not replace local `typecheck`, `lint`, `test`, or `build` validation from the parent `insforge-dev` skill.
+
+## Repositories
+
+- InsForge OSS repo: current workspace.
+- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+
+If the sibling repo is not present, locate it with `find` or ask before cloning.
+
+## Build The Test Tag
+
+1. Read the root InsForge `package.json` version.
+2. Increment only the patch number.
+3. Build a tag in this form:
+
+```text
+v<major>.<minor>.<patch+1>-<feature-or-issue-slug>
+```
+
+Example: root version `2.2.3` and feature `storage returning rls` becomes `v2.2.4-storage-returning-rls`.
+
+Use the `package.json` version as the only source of truth for the base version. Ignore higher existing test tags when calculating the base version.
+
+Slug rules:
+
+- Prefer the issue key, PR topic, or branch topic.
+- Lowercase all letters.
+- Replace runs of non-alphanumeric characters with one hyphen.
+- Trim leading and trailing hyphens.
+- Keep it short enough to scan in GitHub Actions and image tags.
+
+## Build The InsForge Image
+
+Dispatch the InsForge `Build and Push Docker Image` workflow with the test tag:
+
+```bash
+gh workflow run "Build and Push Docker Image" --repo InsForge/InsForge --ref <insforge-feature-branch> -f test_tag=<test-tag>
+```
+
+Then wait for the matching run to complete:
+
+```bash
+gh run list --repo InsForge/InsForge --workflow "Build and Push Docker Image" --limit 10
+gh run watch --repo InsForge/InsForge <run-id>
+```
+
+Do not start the cross-repo E2E workflow until the image build succeeds.
+
+## Decide Whether `agent-e2e` Must Change
+
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+
+Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
+
+- API contract or validation behavior.
+- Auth, permissions, RLS, storage, realtime, functions, schedules, AI, SDK, or CLI-visible behavior.
+- Any regression that local tests cover but the release gate should also protect across the deployed runtime.
+
+Do not update `agent-e2e` for internal refactors, docs-only changes, local test-only changes, or behavior already covered by the deterministic fixture with no assertion change needed.
+
+Ignore `Support Desk Agent E2E (Exploratory)`. It is not part of this gate.
+
+## If No E2E Test Update Is Needed
+
+Run the deterministic fixture workflow from `agent-e2e` main:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref main -f insforge_tag=<test-tag>
+```
+
+Find and watch the run:
+
+```bash
+gh run list --repo InsForge/agent-e2e --workflow "Deterministic Fixture E2E" --limit 10
+gh run watch --repo InsForge/agent-e2e <run-id>
+```
+
+## If E2E Tests Need An Update
+
+Work in the sibling `agent-e2e` repo.
+
+1. Make sure the repo is clean before switching branches.
+2. Start from `main` or an up-to-date branch based on `main`.
+3. Create a branch named `codex/<short-topic>`.
+4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
+5. Run the smallest local validation that gives confidence:
+
+```bash
+npm run typecheck
+npm run lint
+npm run fixture:e2e:dry
+```
+
+Run broader validation when the changed fixture area supports it.
+
+6. Open an `agent-e2e` PR for the fixture update.
+7. Dispatch the deterministic fixture workflow from the `agent-e2e` branch that contains the fixture update:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref <agent-e2e-branch> -f insforge_tag=<test-tag>
+```
+
+8. Watch the run before proceeding with the InsForge PR.
+
+## Interpret Results
+
+If the deterministic fixture workflow passes:
+
+- Link the run in the InsForge PR body or final PR notes.
+- If an `agent-e2e` PR was required, link that PR too.
+- Proceed with opening or submitting the InsForge OSS PR.
+
+If the deterministic fixture workflow fails:
+
+1. Inspect the failed job logs and uploaded artifact.
+2. Identify whether the failure is caused by the InsForge implementation, the new or existing deterministic fixture, a transient infrastructure problem, or an unrelated existing failure.
+3. Fix the correct branch:
+   - InsForge implementation bug: update the InsForge branch, rebuild the test image with the same tag or a new short retry tag, then rerun E2E.
+   - Fixture bug or missing assertion update: update the `agent-e2e` branch, rerun local validation, then rerun E2E from that branch.
+   - Transient infrastructure issue: rerun once after noting the evidence.
+4. Do not submit the InsForge PR until the deterministic result is clear or the user explicitly accepts the risk.
+
+## Report Back
+
+When finished, report:
+
+- Test tag used.
+- InsForge image workflow run result.
+- Whether `agent-e2e` changed.
+- Deterministic Fixture E2E run result.
+- Links to the InsForge PR, `agent-e2e` PR if any, and workflow runs.

--- a/.claude/skills/insforge-dev/SKILL.md
+++ b/.claude/skills/insforge-dev/SKILL.md
@@ -14,6 +14,9 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+
+Use the cross-repo release workflow skill when preparing an OSS PR:
+
 - `e2e-testing`
 
 ## Core Rules

--- a/.claude/skills/insforge-dev/SKILL.md
+++ b/.claude/skills/insforge-dev/SKILL.md
@@ -14,6 +14,7 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+- `e2e-testing`
 
 ## Core Rules
 
@@ -64,5 +65,6 @@ Before opening a PR or pushing new commits to an existing PR branch, run **all**
    - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
 3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
 4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+5. Use `e2e-testing` to run the deterministic cross-repo E2E gate before opening, updating, or submitting the InsForge OSS PR.
 
 Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/.claude/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.claude/skills/insforge-dev/e2e-testing/SKILL.md
@@ -12,9 +12,9 @@ This is an additional release-quality gate. It does not replace local `typecheck
 ## Repositories
 
 - InsForge OSS repo: current workspace.
-- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+- E2E repo: remote GitHub repository `InsForge/agent-e2e`.
 
-If the sibling repo is not present, locate it with `find` or ask before cloning.
+Use the remote `InsForge/agent-e2e` repository for workflow dispatch and read-only workflow checks. Do not rely on a developer-specific local checkout path. Create or use a local checkout only when the deterministic fixture tests must be edited.
 
 ## Build The Test Tag
 
@@ -57,7 +57,9 @@ Do not start the cross-repo E2E workflow until the image build succeeds.
 
 ## Decide Whether `agent-e2e` Must Change
 
-Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `InsForge/agent-e2e`.
+
+For read-only checks, prefer remote GitHub access such as `gh api`, `gh repo view`, or remote file reads. Use a local checkout only when editing fixture files or when remote inspection is not enough to understand coverage.
 
 Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
 
@@ -86,10 +88,10 @@ gh run watch --repo InsForge/agent-e2e <run-id>
 
 ## If E2E Tests Need An Update
 
-Work in the sibling `agent-e2e` repo.
+Work in a local checkout of the remote `InsForge/agent-e2e` repo only for the fixture update.
 
-1. Make sure the repo is clean before switching branches.
-2. Start from `main` or an up-to-date branch based on `main`.
+1. Use an existing clean checkout or clone `https://github.com/InsForge/agent-e2e.git` into an isolated workspace.
+2. Fetch `origin` and start from `origin/main`.
 3. Create a branch named `codex/<short-topic>`.
 4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
 5. Run the smallest local validation that gives confidence:
@@ -117,7 +119,7 @@ If the deterministic fixture workflow passes:
 
 - Link the run in the InsForge PR body or final PR notes.
 - If an `agent-e2e` PR was required, link that PR too.
-- Proceed with opening or submitting the InsForge OSS PR.
+- Proceed with opening, updating, or submitting the InsForge OSS PR.
 
 If the deterministic fixture workflow fails:
 

--- a/.claude/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.claude/skills/insforge-dev/e2e-testing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: e2e-testing
+description: Use this skill when an InsForge maintainer has finished an OSS repo change and is ready to open, update, or submit the InsForge PR. Runs the release-quality deterministic E2E gate by building a package.json-derived InsForge test image tag, deciding whether sibling agent-e2e fixture coverage must change, dispatching the Deterministic Fixture E2E workflow, waiting for results, and triaging failures before PR submission.
+---
+
+# InsForge E2E Testing Gate
+
+Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening, updating, or submitting the InsForge OSS PR.
+
+This is an additional release-quality gate. It does not replace local `typecheck`, `lint`, `test`, or `build` validation from the parent `insforge-dev` skill.
+
+## Repositories
+
+- InsForge OSS repo: current workspace.
+- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+
+If the sibling repo is not present, locate it with `find` or ask before cloning.
+
+## Build The Test Tag
+
+1. Read the root InsForge `package.json` version.
+2. Increment only the patch number.
+3. Build a tag in this form:
+
+```text
+v<major>.<minor>.<patch+1>-<feature-or-issue-slug>
+```
+
+Example: root version `2.2.3` and feature `storage returning rls` becomes `v2.2.4-storage-returning-rls`.
+
+Use the `package.json` version as the only source of truth for the base version. Ignore higher existing test tags when calculating the base version.
+
+Slug rules:
+
+- Prefer the issue key, PR topic, or branch topic.
+- Lowercase all letters.
+- Replace runs of non-alphanumeric characters with one hyphen.
+- Trim leading and trailing hyphens.
+- Keep it short enough to scan in GitHub Actions and image tags.
+
+## Build The InsForge Image
+
+Dispatch the InsForge `Build and Push Docker Image` workflow with the test tag:
+
+```bash
+gh workflow run "Build and Push Docker Image" --repo InsForge/InsForge --ref <insforge-feature-branch> -f test_tag=<test-tag>
+```
+
+Then wait for the matching run to complete:
+
+```bash
+gh run list --repo InsForge/InsForge --workflow "Build and Push Docker Image" --limit 10
+gh run watch --repo InsForge/InsForge <run-id>
+```
+
+Do not start the cross-repo E2E workflow until the image build succeeds.
+
+## Decide Whether `agent-e2e` Must Change
+
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+
+Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
+
+- API contract or validation behavior.
+- Auth, permissions, RLS, storage, realtime, functions, schedules, AI, SDK, or CLI-visible behavior.
+- Any regression that local tests cover but the release gate should also protect across the deployed runtime.
+
+Do not update `agent-e2e` for internal refactors, docs-only changes, local test-only changes, or behavior already covered by the deterministic fixture with no assertion change needed.
+
+Ignore `Support Desk Agent E2E (Exploratory)`. It is not part of this gate.
+
+## If No E2E Test Update Is Needed
+
+Run the deterministic fixture workflow from `agent-e2e` main:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref main -f insforge_tag=<test-tag>
+```
+
+Find and watch the run:
+
+```bash
+gh run list --repo InsForge/agent-e2e --workflow "Deterministic Fixture E2E" --limit 10
+gh run watch --repo InsForge/agent-e2e <run-id>
+```
+
+## If E2E Tests Need An Update
+
+Work in the sibling `agent-e2e` repo.
+
+1. Make sure the repo is clean before switching branches.
+2. Start from `main` or an up-to-date branch based on `main`.
+3. Create a branch named `codex/<short-topic>`.
+4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
+5. Run the smallest local validation that gives confidence:
+
+```bash
+npm run typecheck
+npm run lint
+npm run fixture:e2e:dry
+```
+
+Run broader validation when the changed fixture area supports it.
+
+6. Open an `agent-e2e` PR for the fixture update.
+7. Dispatch the deterministic fixture workflow from the `agent-e2e` branch that contains the fixture update:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref <agent-e2e-branch> -f insforge_tag=<test-tag>
+```
+
+8. Watch the run before proceeding with the InsForge PR.
+
+## Interpret Results
+
+If the deterministic fixture workflow passes:
+
+- Link the run in the InsForge PR body or final PR notes.
+- If an `agent-e2e` PR was required, link that PR too.
+- Proceed with opening or submitting the InsForge OSS PR.
+
+If the deterministic fixture workflow fails:
+
+1. Inspect the failed job logs and uploaded artifact.
+2. Identify whether the failure is caused by the InsForge implementation, the new or existing deterministic fixture, a transient infrastructure problem, or an unrelated existing failure.
+3. Fix the correct branch:
+   - InsForge implementation bug: update the InsForge branch, rebuild the test image with the same tag or a new short retry tag, then rerun E2E.
+   - Fixture bug or missing assertion update: update the `agent-e2e` branch, rerun local validation, then rerun E2E from that branch.
+   - Transient infrastructure issue: rerun once after noting the evidence.
+4. Do not submit the InsForge PR until the deterministic result is clear or the user explicitly accepts the risk.
+
+## Report Back
+
+When finished, report:
+
+- Test tag used.
+- InsForge image workflow run result.
+- Whether `agent-e2e` changed.
+- Deterministic Fixture E2E run result.
+- Links to the InsForge PR, `agent-e2e` PR if any, and workflow runs.

--- a/.codex/skills/insforge-dev/SKILL.md
+++ b/.codex/skills/insforge-dev/SKILL.md
@@ -14,6 +14,9 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+
+Use the cross-repo release workflow skill when preparing an OSS PR:
+
 - `e2e-testing`
 
 ## Core Rules

--- a/.codex/skills/insforge-dev/SKILL.md
+++ b/.codex/skills/insforge-dev/SKILL.md
@@ -14,6 +14,7 @@ Then use the narrowest package skill that matches the task:
 - `ui`
 - `shared-schemas`
 - `docs`
+- `e2e-testing`
 
 ## Core Rules
 
@@ -64,5 +65,6 @@ Before opening a PR or pushing new commits to an existing PR branch, run **all**
    - Auto-fixable prettier/eslint errors in your own diff must be fixed (`npx eslint --fix <file>` or `npm run format`).
 3. `npx turbo run test` (or the package-specific test command) — all tests must pass, including any new tests you added for the change.
 4. `npx turbo run build` if routing, config, schemas, or cross-package exports changed.
+5. Use `e2e-testing` to run the deterministic cross-repo E2E gate before opening, updating, or submitting the InsForge OSS PR.
 
 Never push with failing checks on files you touched, even if CI would catch them later. CI failures slow reviewers down and the lint fix almost always takes less than a minute locally.

--- a/.codex/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.codex/skills/insforge-dev/e2e-testing/SKILL.md
@@ -12,9 +12,9 @@ This is an additional release-quality gate. It does not replace local `typecheck
 ## Repositories
 
 - InsForge OSS repo: current workspace.
-- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+- E2E repo: remote GitHub repository `InsForge/agent-e2e`.
 
-If the sibling repo is not present, locate it with `find` or ask before cloning.
+Use the remote `InsForge/agent-e2e` repository for workflow dispatch and read-only workflow checks. Do not rely on a developer-specific local checkout path. Create or use a local checkout only when the deterministic fixture tests must be edited.
 
 ## Build The Test Tag
 
@@ -57,7 +57,9 @@ Do not start the cross-repo E2E workflow until the image build succeeds.
 
 ## Decide Whether `agent-e2e` Must Change
 
-Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `InsForge/agent-e2e`.
+
+For read-only checks, prefer remote GitHub access such as `gh api`, `gh repo view`, or remote file reads. Use a local checkout only when editing fixture files or when remote inspection is not enough to understand coverage.
 
 Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
 
@@ -86,10 +88,10 @@ gh run watch --repo InsForge/agent-e2e <run-id>
 
 ## If E2E Tests Need An Update
 
-Work in the sibling `agent-e2e` repo.
+Work in a local checkout of the remote `InsForge/agent-e2e` repo only for the fixture update.
 
-1. Make sure the repo is clean before switching branches.
-2. Start from `main` or an up-to-date branch based on `main`.
+1. Use an existing clean checkout or clone `https://github.com/InsForge/agent-e2e.git` into an isolated workspace.
+2. Fetch `origin` and start from `origin/main`.
 3. Create a branch named `codex/<short-topic>`.
 4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
 5. Run the smallest local validation that gives confidence:
@@ -117,7 +119,7 @@ If the deterministic fixture workflow passes:
 
 - Link the run in the InsForge PR body or final PR notes.
 - If an `agent-e2e` PR was required, link that PR too.
-- Proceed with opening or submitting the InsForge OSS PR.
+- Proceed with opening, updating, or submitting the InsForge OSS PR.
 
 If the deterministic fixture workflow fails:
 

--- a/.codex/skills/insforge-dev/e2e-testing/SKILL.md
+++ b/.codex/skills/insforge-dev/e2e-testing/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: e2e-testing
+description: Use this skill when an InsForge maintainer has finished an OSS repo change and is ready to open, update, or submit the InsForge PR. Runs the release-quality deterministic E2E gate by building a package.json-derived InsForge test image tag, deciding whether sibling agent-e2e fixture coverage must change, dispatching the Deterministic Fixture E2E workflow, waiting for results, and triaging failures before PR submission.
+---
+
+# InsForge E2E Testing Gate
+
+Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening, updating, or submitting the InsForge OSS PR.
+
+This is an additional release-quality gate. It does not replace local `typecheck`, `lint`, `test`, or `build` validation from the parent `insforge-dev` skill.
+
+## Repositories
+
+- InsForge OSS repo: current workspace.
+- E2E repo: sibling `agent-e2e`, usually at `/Users/lyu/Documents/GitHub/agent-e2e`.
+
+If the sibling repo is not present, locate it with `find` or ask before cloning.
+
+## Build The Test Tag
+
+1. Read the root InsForge `package.json` version.
+2. Increment only the patch number.
+3. Build a tag in this form:
+
+```text
+v<major>.<minor>.<patch+1>-<feature-or-issue-slug>
+```
+
+Example: root version `2.2.3` and feature `storage returning rls` becomes `v2.2.4-storage-returning-rls`.
+
+Use the `package.json` version as the only source of truth for the base version. Ignore higher existing test tags when calculating the base version.
+
+Slug rules:
+
+- Prefer the issue key, PR topic, or branch topic.
+- Lowercase all letters.
+- Replace runs of non-alphanumeric characters with one hyphen.
+- Trim leading and trailing hyphens.
+- Keep it short enough to scan in GitHub Actions and image tags.
+
+## Build The InsForge Image
+
+Dispatch the InsForge `Build and Push Docker Image` workflow with the test tag:
+
+```bash
+gh workflow run "Build and Push Docker Image" --repo InsForge/InsForge --ref <insforge-feature-branch> -f test_tag=<test-tag>
+```
+
+Then wait for the matching run to complete:
+
+```bash
+gh run list --repo InsForge/InsForge --workflow "Build and Push Docker Image" --limit 10
+gh run watch --repo InsForge/InsForge <run-id>
+```
+
+Do not start the cross-repo E2E workflow until the image build succeeds.
+
+## Decide Whether `agent-e2e` Must Change
+
+Inspect the InsForge diff and compare it with deterministic fixture coverage in `agent-e2e`.
+
+Update `agent-e2e` when the InsForge change adds, removes, or changes behavior that the deterministic fixture should assert, including:
+
+- API contract or validation behavior.
+- Auth, permissions, RLS, storage, realtime, functions, schedules, AI, SDK, or CLI-visible behavior.
+- Any regression that local tests cover but the release gate should also protect across the deployed runtime.
+
+Do not update `agent-e2e` for internal refactors, docs-only changes, local test-only changes, or behavior already covered by the deterministic fixture with no assertion change needed.
+
+Ignore `Support Desk Agent E2E (Exploratory)`. It is not part of this gate.
+
+## If No E2E Test Update Is Needed
+
+Run the deterministic fixture workflow from `agent-e2e` main:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref main -f insforge_tag=<test-tag>
+```
+
+Find and watch the run:
+
+```bash
+gh run list --repo InsForge/agent-e2e --workflow "Deterministic Fixture E2E" --limit 10
+gh run watch --repo InsForge/agent-e2e <run-id>
+```
+
+## If E2E Tests Need An Update
+
+Work in the sibling `agent-e2e` repo.
+
+1. Make sure the repo is clean before switching branches.
+2. Start from `main` or an up-to-date branch based on `main`.
+3. Create a branch named `codex/<short-topic>`.
+4. Update only the deterministic fixture validators, fixtures, app assertions, and docs needed for the InsForge behavior change.
+5. Run the smallest local validation that gives confidence:
+
+```bash
+npm run typecheck
+npm run lint
+npm run fixture:e2e:dry
+```
+
+Run broader validation when the changed fixture area supports it.
+
+6. Open an `agent-e2e` PR for the fixture update.
+7. Dispatch the deterministic fixture workflow from the `agent-e2e` branch that contains the fixture update:
+
+```bash
+gh workflow run "Deterministic Fixture E2E" --repo InsForge/agent-e2e --ref <agent-e2e-branch> -f insforge_tag=<test-tag>
+```
+
+8. Watch the run before proceeding with the InsForge PR.
+
+## Interpret Results
+
+If the deterministic fixture workflow passes:
+
+- Link the run in the InsForge PR body or final PR notes.
+- If an `agent-e2e` PR was required, link that PR too.
+- Proceed with opening or submitting the InsForge OSS PR.
+
+If the deterministic fixture workflow fails:
+
+1. Inspect the failed job logs and uploaded artifact.
+2. Identify whether the failure is caused by the InsForge implementation, the new or existing deterministic fixture, a transient infrastructure problem, or an unrelated existing failure.
+3. Fix the correct branch:
+   - InsForge implementation bug: update the InsForge branch, rebuild the test image with the same tag or a new short retry tag, then rerun E2E.
+   - Fixture bug or missing assertion update: update the `agent-e2e` branch, rerun local validation, then rerun E2E from that branch.
+   - Transient infrastructure issue: rerun once after noting the evidence.
+4. Do not submit the InsForge PR until the deterministic result is clear or the user explicitly accepts the risk.
+
+## Report Back
+
+When finished, report:
+
+- Test tag used.
+- InsForge image workflow run result.
+- Whether `agent-e2e` changed.
+- Deterministic Fixture E2E run result.
+- Links to the InsForge PR, `agent-e2e` PR if any, and workflow runs.

--- a/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
+++ b/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
@@ -1,0 +1,80 @@
+# E2E Testing Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `e2e-testing` child skill under `insforge-dev` so InsForge agents run the deterministic cross-repo E2E gate before submitting OSS PRs.
+
+**Architecture:** Implement the workflow as a new child `SKILL.md` mirrored across `.agents`, `.codex`, and `.claude`. Add a parent `insforge-dev` pointer in each surface so agents know to invoke the child skill during the pre-PR phase.
+
+**Tech Stack:** Markdown skill files, YAML frontmatter, GitHub CLI workflow commands, existing InsForge and `agent-e2e` GitHub Actions workflows.
+
+---
+
+### Task 1: Add The `e2e-testing` Child Skill
+
+**Files:**
+- Create: `.agents/skills/insforge-dev/e2e-testing/SKILL.md`
+- Create: `.codex/skills/insforge-dev/e2e-testing/SKILL.md`
+- Create: `.claude/skills/insforge-dev/e2e-testing/SKILL.md`
+
+- [ ] **Step 1: Create the skill content**
+
+Use the same content in all three files:
+
+```markdown
+---
+name: e2e-testing
+description: Use this skill when an InsForge maintainer has finished an OSS repo change and is ready to open, update, or submit the InsForge PR. Runs the release-quality deterministic E2E gate by building a package.json-derived InsForge test image tag, deciding whether sibling agent-e2e fixture coverage must change, dispatching the Deterministic Fixture E2E workflow, waiting for results, and triaging failures before PR submission.
+---
+
+# InsForge E2E Testing Gate
+
+Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening or submitting the InsForge OSS PR.
+```
+
+- [ ] **Step 2: Include exact workflow instructions**
+
+The body must cover package-version tag calculation, image build workflow dispatch, deterministic fixture dispatch, when to update `agent-e2e`, pass/fail triage, and the rule to ignore the support-desk workflow.
+
+### Task 2: Link The Child Skill From `insforge-dev`
+
+**Files:**
+- Modify: `.agents/skills/insforge-dev/SKILL.md`
+- Modify: `.codex/skills/insforge-dev/SKILL.md`
+- Modify: `.claude/skills/insforge-dev/SKILL.md`
+
+- [ ] **Step 1: Add `e2e-testing` to the child skill list**
+
+Add `e2e-testing` beside the existing child skills.
+
+- [ ] **Step 2: Add pre-PR invocation text**
+
+Add a short pre-PR rule: after local checks pass and before opening/submitting an OSS PR, use `e2e-testing` to run the deterministic cross-repo gate.
+
+### Task 3: Validate The Skill Markdown
+
+**Files:**
+- Inspect all changed skill files and the design/plan docs.
+
+- [ ] **Step 1: Check frontmatter and trigger text**
+
+Run:
+
+```bash
+sed -n '1,220p' .agents/skills/insforge-dev/e2e-testing/SKILL.md
+sed -n '1,140p' .agents/skills/insforge-dev/SKILL.md
+diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .codex/skills/insforge-dev/e2e-testing/SKILL.md
+diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .claude/skills/insforge-dev/e2e-testing/SKILL.md
+```
+
+Expected: the child skill has valid YAML frontmatter, the parent references `e2e-testing`, and mirrored child skills are identical.
+
+- [ ] **Step 2: Check git diff**
+
+Run:
+
+```bash
+git diff -- .agents/skills/insforge-dev .codex/skills/insforge-dev .claude/skills/insforge-dev docs/superpowers
+```
+
+Expected: only the new design/plan docs, the new child skill files, and the parent skill references changed.

--- a/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
+++ b/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Implement the workflow as a new child `SKILL.md` mirrored across `.agents`, `.codex`, and `.claude`. Add a parent `insforge-dev` pointer in each surface so agents know to invoke the child skill during the pre-PR phase.
 
-**Tech Stack:** Markdown skill files, YAML frontmatter, GitHub CLI workflow commands, existing InsForge and `agent-e2e` GitHub Actions workflows.
+**Tech Stack:** Markdown skill files, YAML front matter, GitHub CLI workflow commands, existing InsForge and `agent-e2e` GitHub Actions workflows.
 
 ---
 
@@ -56,7 +56,7 @@ Add a short pre-PR rule: after local checks pass and before opening/submitting a
 **Files:**
 - Inspect all changed skill files and the design/plan docs.
 
-- [ ] **Step 1: Check frontmatter and trigger text**
+- [ ] **Step 1: Check front matter and trigger text**
 
 Run:
 
@@ -67,7 +67,7 @@ diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .codex/skills/insforge-
 diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .claude/skills/insforge-dev/e2e-testing/SKILL.md
 ```
 
-Expected: the child skill has valid YAML frontmatter, the parent references `e2e-testing`, and mirrored child skills are identical.
+Expected: the child skill has valid YAML front matter, the parent references `e2e-testing`, and mirrored child skills are identical.
 
 - [ ] **Step 2: Check git diff**
 

--- a/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
+++ b/docs/superpowers/plans/2026-06-29-e2e-testing-skill.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add The `e2e-testing` Child Skill
+## Task 1: Add The `e2e-testing` Child Skill
 
 **Files:**
 - Create: `.agents/skills/insforge-dev/e2e-testing/SKILL.md`
@@ -29,14 +29,14 @@ description: Use this skill when an InsForge maintainer has finished an OSS repo
 
 # InsForge E2E Testing Gate
 
-Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening or submitting the InsForge OSS PR.
+Use this skill after local implementation and normal InsForge pre-PR checks pass, and before opening, updating, or submitting the InsForge OSS PR.
 ```
 
 - [ ] **Step 2: Include exact workflow instructions**
 
 The body must cover package-version tag calculation, image build workflow dispatch, deterministic fixture dispatch, when to update `agent-e2e`, pass/fail triage, and the rule to ignore the support-desk workflow.
 
-### Task 2: Link The Child Skill From `insforge-dev`
+## Task 2: Link The Child Skill From `insforge-dev`
 
 **Files:**
 - Modify: `.agents/skills/insforge-dev/SKILL.md`
@@ -49,9 +49,9 @@ Add `e2e-testing` beside the existing child skills.
 
 - [ ] **Step 2: Add pre-PR invocation text**
 
-Add a short pre-PR rule: after local checks pass and before opening/submitting an OSS PR, use `e2e-testing` to run the deterministic cross-repo gate.
+Add a short pre-PR rule: after local checks pass and before opening, updating, or submitting an OSS PR, use `e2e-testing` to run the deterministic cross-repo gate.
 
-### Task 3: Validate The Skill Markdown
+## Task 3: Validate The Skill Markdown
 
 **Files:**
 - Inspect all changed skill files and the design/plan docs.
@@ -63,8 +63,11 @@ Run:
 ```bash
 sed -n '1,220p' .agents/skills/insforge-dev/e2e-testing/SKILL.md
 sed -n '1,140p' .agents/skills/insforge-dev/SKILL.md
+sed -n '1,140p' .codex/skills/insforge-dev/SKILL.md
+sed -n '1,140p' .claude/skills/insforge-dev/SKILL.md
 diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .codex/skills/insforge-dev/e2e-testing/SKILL.md
 diff -u .agents/skills/insforge-dev/e2e-testing/SKILL.md .claude/skills/insforge-dev/e2e-testing/SKILL.md
+scripts/sync-skills.sh --check
 ```
 
 Expected: the child skill has valid YAML front matter, the parent references `e2e-testing`, and mirrored child skills are identical.

--- a/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
+++ b/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
@@ -42,4 +42,4 @@ The skill should not edit `agent-e2e` unless the InsForge change affects behavio
 
 ## Validation
 
-Validate the new skill by checking that each copied `SKILL.md` has valid frontmatter and that the parent `insforge-dev` skill references the child skill consistently across `.agents`, `.codex`, and `.claude`.
+Validate the new skill by checking that each copied `SKILL.md` has valid front matter and that the parent `insforge-dev` skill references the child skill consistently across `.agents`, `.codex`, and `.claude`.

--- a/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
+++ b/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
@@ -1,0 +1,45 @@
+# E2E Testing Skill Design
+
+## Goal
+
+Add an `e2e-testing` child skill under `insforge-dev` that agents use after finishing an InsForge OSS change and before opening or submitting the InsForge PR. The skill makes the deterministic cross-repo E2E gate explicit and repeatable.
+
+## Placement
+
+Create the skill under the existing InsForge repo skill surfaces:
+
+- `.agents/skills/insforge-dev/e2e-testing/SKILL.md`
+- `.codex/skills/insforge-dev/e2e-testing/SKILL.md`
+- `.claude/skills/insforge-dev/e2e-testing/SKILL.md`
+
+Update the parent `insforge-dev` skill in each surface so agents invoke `e2e-testing` during the pre-PR flow.
+
+## Workflow
+
+The skill should instruct agents to:
+
+1. Finish local implementation and the existing InsForge pre-PR checks first.
+2. Read the root InsForge `package.json` version and build a test tag by incrementing only the patch number:
+   - `2.2.3` becomes `v2.2.4-<feature-or-issue-slug>`.
+   - Ignore higher existing test tags when calculating the base version.
+3. Sanitize the feature or issue slug to lowercase alphanumeric words separated by hyphens.
+4. Dispatch InsForge's `Build and Push Docker Image` workflow with `test_tag=<tag>`.
+5. Wait for the image workflow to complete successfully before starting E2E.
+6. Inspect the InsForge change and decide whether deterministic fixture coverage in the sibling `agent-e2e` repo must change.
+7. If no fixture change is needed, dispatch `Deterministic Fixture E2E` from `agent-e2e` main with `insforge_tag=<tag>`.
+8. If fixture coverage must change, create or use an isolated `agent-e2e` branch from main, update validators/fixtures/docs, validate locally where practical, open an `agent-e2e` PR, then dispatch `Deterministic Fixture E2E` from that branch with `insforge_tag=<tag>`.
+9. Wait for the deterministic workflow result.
+10. If it passes, proceed with the InsForge OSS PR.
+11. If it fails, inspect logs and artifacts, decide whether the failure belongs to the InsForge implementation or the `agent-e2e` fixture update, fix the correct branch, and rerun the deterministic workflow.
+
+The skill must ignore the `Support Desk Agent E2E (Exploratory)` workflow. It is not part of this gate.
+
+## Boundaries
+
+The skill should not replace local InsForge unit, lint, typecheck, or build validation. It is an additional release-quality gate for OSS PR submission.
+
+The skill should not edit `agent-e2e` unless the InsForge change affects behavior that deterministic fixture coverage should assert.
+
+## Validation
+
+Validate the new skill by checking that each copied `SKILL.md` has valid frontmatter and that the parent `insforge-dev` skill references the child skill consistently across `.agents`, `.codex`, and `.claude`.

--- a/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
+++ b/docs/superpowers/specs/2026-06-29-e2e-testing-skill-design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add an `e2e-testing` child skill under `insforge-dev` that agents use after finishing an InsForge OSS change and before opening or submitting the InsForge PR. The skill makes the deterministic cross-repo E2E gate explicit and repeatable.
+Add an `e2e-testing` child skill under `insforge-dev` that agents use after finishing an InsForge OSS change and before opening, updating, or submitting the InsForge PR. The skill makes the deterministic cross-repo E2E gate explicit and repeatable.
 
 ## Placement
 
@@ -25,12 +25,12 @@ The skill should instruct agents to:
 3. Sanitize the feature or issue slug to lowercase alphanumeric words separated by hyphens.
 4. Dispatch InsForge's `Build and Push Docker Image` workflow with `test_tag=<tag>`.
 5. Wait for the image workflow to complete successfully before starting E2E.
-6. Inspect the InsForge change and decide whether deterministic fixture coverage in the sibling `agent-e2e` repo must change.
+6. Inspect the InsForge change and decide whether deterministic fixture coverage in the remote `InsForge/agent-e2e` repo must change.
 7. If no fixture change is needed, dispatch `Deterministic Fixture E2E` from `agent-e2e` main with `insforge_tag=<tag>`.
-8. If fixture coverage must change, create or use an isolated `agent-e2e` branch from main, update validators/fixtures/docs, validate locally where practical, open an `agent-e2e` PR, then dispatch `Deterministic Fixture E2E` from that branch with `insforge_tag=<tag>`.
+8. If fixture coverage must change, create or use a local checkout of the remote `InsForge/agent-e2e` repo, branch from `origin/main`, update validators/fixtures/docs, validate locally where practical, open an `agent-e2e` PR, then dispatch `Deterministic Fixture E2E` from that branch with `insforge_tag=<tag>`.
 9. Wait for the deterministic workflow result.
 10. If it passes, proceed with the InsForge OSS PR.
-11. If it fails, inspect logs and artifacts, decide whether the failure belongs to the InsForge implementation or the `agent-e2e` fixture update, fix the correct branch, and rerun the deterministic workflow.
+11. If it fails, inspect logs and artifacts, decide whether the failure belongs to the InsForge implementation, the `agent-e2e` fixture update, transient infrastructure, or an unrelated existing failure, then fix the correct branch or rerun with evidence.
 
 The skill must ignore the `Support Desk Agent E2E (Exploratory)` workflow. It is not part of this gate.
 
@@ -38,7 +38,7 @@ The skill must ignore the `Support Desk Agent E2E (Exploratory)` workflow. It is
 
 The skill should not replace local InsForge unit, lint, typecheck, or build validation. It is an additional release-quality gate for OSS PR submission.
 
-The skill should not edit `agent-e2e` unless the InsForge change affects behavior that deterministic fixture coverage should assert.
+The skill should not create or edit a local `agent-e2e` checkout unless the InsForge change affects behavior that deterministic fixture coverage should assert.
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- Add an insforge-dev/e2e-testing child skill that documents the package.json-derived test tag, image build workflow, Deterministic Fixture E2E dispatch, and failure triage path.
- Sync the new skill into .claude and .codex from the canonical .agents skill tree.
- Link the new gate from the parent insforge-dev pre-PR checklist and include the design/plan docs for the workflow.

## Validation
- scripts/sync-skills.sh --check
- npm run format:check
- npm run lint
- npm run typecheck
- npm test

## E2E Gate
- Not run for this PR because it only adds agent skill documentation and does not change InsForge runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `e2e-testing` child skill under `insforge-dev` to run a deterministic cross-repo E2E gate before opening, updating, or submitting InsForge PRs. Documents image tag derivation from `package.json`, exact workflow dispatch steps, and when to update `InsForge/agent-e2e`.

- **New Features**
  - Added `e2e-testing` skill mirrored in `.agents`, `.codex`, and `.claude`, with clear steps: build patch+1 test tag with slug rules, build image, run “Deterministic Fixture E2E,” triage, and report.
  - Updated parent `insforge-dev` skills to list cross-repo release workflow skills and require this gate before opening, updating, or submitting an InsForge OSS PR.
  - Clarified to use remote `InsForge/agent-e2e` for dispatch/read-only checks, use a local checkout only when fixtures change, and ignore the exploratory support-desk workflow; added plan/spec under `docs/superpowers/`.

- **Bug Fixes**
  - Fixed Mintlify spellcheck wording in the new skill docs.

<sup>Written for commit f423bf3c767caf9e96327164212bcf1cb7af4d57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add e2e-testing skill for the InsForge deterministic cross-repo E2E gate
> - Adds a new `e2e-testing` child skill document under `.agents/skills/insforge-dev/`, `.codex/skills/insforge-dev/`, and `.claude/skills/insforge-dev/`, covering test image tag derivation, image build workflow dispatch, fixture update decisions for `agent-e2e`, and deterministic E2E run monitoring.
> - Updates the parent `insforge-dev` SKILL.md on all three surfaces to reference the new child skill and adds a Pre-PR checklist item requiring the E2E gate to run before opening or updating an InsForge OSS PR.
> - Adds a design spec and implementation plan under `docs/superpowers/` documenting the skill's scope, workflow steps, and validation criteria.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1611 opened
>
> - Standardized terminology from 'frontmatter' to 'front matter' across documentation [20befab]
> - Updated `e2e-testing` skill to use remote `InsForge/agent-e2e` GitHub repository instead of local sibling repository paths [f423bf3]
> - Added directive to use cross-repo release workflow skill when preparing InsForge OSS pull requests [f423bf3]
> - Updated pull request workflow terminology to include opening, updating, or submitting [f423bf3]
> - Expanded e2e test failure triage guidance to include transient infrastructure and unrelated existing failures [f423bf3]
> - Added validation commands for mirrored skills inspection and sync verification [f423bf3]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3885a87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `e2e-testing` skill guide to the InsForge workflow with a deterministic cross-repo E2E gate.
  * Updated InsForge pre-PR checklist steps to require running `e2e-testing` before opening/updating/submitting an InsForge OSS PR.
* **Documentation**
  * Added implementation plan and design specs for the end-to-end deterministic testing flow, including how to compute the test image tag, dispatch/wait for workflows, and capture report-back details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->