### PR TITLE
Backend part of the CSRF validation for browser sessions

### DIFF
--- a/backend/src/api/routes/auth/admin.routes.ts
+++ b/backend/src/api/routes/auth/admin.routes.ts
@@ -177,7 +177,12 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
       }
 
       if (payload.sessionType !== 'admin') {
-        throw new AppError('Invalid admin refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+        clearAdminRefreshTokenCookie(res);
+        successResponse(res, {
+          success: true,
+          message: 'Logged out successfully',
+        });
+        return;
       }
 
       const csrfHeader = req.headers['x-csrf-token'];

--- a/backend/src/api/routes/auth/admin.routes.ts
+++ b/backend/src/api/routes/auth/admin.routes.ts
@@ -164,16 +164,13 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
 
       try {
         payload = tokenManager.verifyRefreshToken(refreshToken);
-      } catch (error) {
-        if (error instanceof AppError && error.statusCode === 401) {
-          clearAdminRefreshTokenCookie(res);
-          successResponse(res, {
-            success: true,
-            message: 'Logged out successfully',
-          });
-          return;
-        }
-        throw error;
+      } catch {
+        clearAdminRefreshTokenCookie(res);
+        successResponse(res, {
+          success: true,
+          message: 'Logged out successfully',
+        });
+        return;
       }
 
       if (payload.sessionType !== 'admin') {

--- a/backend/src/api/routes/auth/admin.routes.ts
+++ b/backend/src/api/routes/auth/admin.routes.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { AuthService } from '@/services/auth/auth.service.js';
 import { AuthRequest, verifyToken } from '@/api/middlewares/auth.js';
-import { TokenManager } from '@/infra/security/token.manager.js';
+import { TokenManager, type RefreshTokenPayload } from '@/infra/security/token.manager.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
 import {
@@ -154,8 +154,40 @@ router.post('/refresh', (req: Request, res: Response, next: NextFunction) => {
 });
 
 // POST /api/auth/admin/logout - Logout dashboard session
-router.post('/logout', (_req: Request, res: Response, next: NextFunction) => {
+router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
   try {
+    const refreshToken = req.cookies?.[ADMIN_REFRESH_TOKEN_COOKIE_NAME];
+
+    if (refreshToken) {
+      const tokenManager = TokenManager.getInstance();
+      let payload: RefreshTokenPayload;
+
+      try {
+        payload = tokenManager.verifyRefreshToken(refreshToken);
+      } catch (error) {
+        if (error instanceof AppError && error.statusCode === 401) {
+          clearAdminRefreshTokenCookie(res);
+          successResponse(res, {
+            success: true,
+            message: 'Logged out successfully',
+          });
+          return;
+        }
+        throw error;
+      }
+
+      if (payload.sessionType !== 'admin') {
+        throw new AppError('Invalid admin refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+      }
+
+      const csrfHeader = req.headers['x-csrf-token'];
+      const csrfToken = typeof csrfHeader === 'string' ? csrfHeader : undefined;
+      if (!tokenManager.verifyCsrfToken(csrfToken, payload)) {
+        logger.warn('[Auth:AdminLogout] CSRF token validation failed');
+        throw new AppError('Invalid CSRF token', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+      }
+    }
+
     clearAdminRefreshTokenCookie(res);
 
     successResponse(res, {

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -621,16 +621,13 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
 
         try {
           payload = tokenManager.verifyRefreshToken(refreshToken);
-        } catch (error) {
-          if (error instanceof AppError && error.statusCode === 401) {
-            clearRefreshTokenCookie(res);
-            successResponse(res, {
-              success: true,
-              message: 'Logged out successfully',
-            });
-            return;
-          }
-          throw error;
+        } catch {
+          clearRefreshTokenCookie(res);
+          successResponse(res, {
+            success: true,
+            message: 'Logged out successfully',
+          });
+          return;
         }
 
         if (payload.sessionType !== 'user') {

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -4,7 +4,7 @@ import { AuthService } from '@/services/auth/auth.service.js';
 import { AuthConfigService } from '@/services/auth/auth-config.service.js';
 import { AuthOTPService, OTPPurpose } from '@/services/auth/auth-otp.service.js';
 import { AuditService } from '@/services/logs/audit.service.js';
-import { TokenManager } from '@/infra/security/token.manager.js';
+import { TokenManager, type RefreshTokenPayload } from '@/infra/security/token.manager.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
@@ -613,6 +613,38 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
     const clientType = parseClientType(req.query.client_type);
 
     if (clientType === 'web') {
+      const refreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE_NAME];
+
+      if (refreshToken) {
+        const tokenManager = TokenManager.getInstance();
+        let payload: RefreshTokenPayload;
+
+        try {
+          payload = tokenManager.verifyRefreshToken(refreshToken);
+        } catch (error) {
+          if (error instanceof AppError && error.statusCode === 401) {
+            clearRefreshTokenCookie(res);
+            successResponse(res, {
+              success: true,
+              message: 'Logged out successfully',
+            });
+            return;
+          }
+          throw error;
+        }
+
+        if (payload.sessionType !== 'user') {
+          throw new AppError('Invalid refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+        }
+
+        const csrfHeader = req.headers['x-csrf-token'];
+        const csrfToken = typeof csrfHeader === 'string' ? csrfHeader : undefined;
+        if (!tokenManager.verifyCsrfToken(csrfToken, payload)) {
+          logger.warn('[Auth:Logout] CSRF token validation failed');
+          throw new AppError('Invalid CSRF token', 403, ERROR_CODES.AUTH_UNAUTHORIZED);
+        }
+      }
+
       clearRefreshTokenCookie(res);
     }
     // For non-web clients: no server-side cleanup needed.

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -634,7 +634,12 @@ router.post('/logout', (req: Request, res: Response, next: NextFunction) => {
         }
 
         if (payload.sessionType !== 'user') {
-          throw new AppError('Invalid refresh session type', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+          clearRefreshTokenCookie(res);
+          successResponse(res, {
+            success: true,
+            message: 'Logged out successfully',
+          });
+          return;
         }
 
         const csrfHeader = req.headers['x-csrf-token'];

--- a/backend/tests/unit/auth-logout-csrf-route.test.ts
+++ b/backend/tests/unit/auth-logout-csrf-route.test.ts
@@ -178,7 +178,9 @@ describe('POST /api/auth/logout CSRF policy', () => {
   });
 
   it('keeps web logout idempotent when the refresh cookie is absent', async () => {
-    const response = await callLogout(router);
+    const response = await callLogout(router, {
+      query: { client_type: 'web' },
+    });
 
     expect(response.statusCode).toBe(200);
     expect(response.clearCookie).toHaveBeenCalledOnce();
@@ -191,6 +193,7 @@ describe('POST /api/auth/logout CSRF policy', () => {
     });
 
     const response = await callLogout(router, {
+      query: { client_type: 'web' },
       cookies: { insforge_refresh_token: 'stale-refresh-token' },
     });
 
@@ -203,6 +206,7 @@ describe('POST /api/auth/logout CSRF policy', () => {
     mocks.verifyCsrfToken.mockReturnValue(false);
 
     const response = await callLogout(router, {
+      query: { client_type: 'web' },
       cookies: { insforge_refresh_token: 'valid-refresh-token' },
     });
 
@@ -215,6 +219,7 @@ describe('POST /api/auth/logout CSRF policy', () => {
     mocks.verifyCsrfToken.mockReturnValue(false);
 
     const response = await callLogout(router, {
+      query: { client_type: 'web' },
       cookies: { insforge_refresh_token: 'valid-refresh-token' },
       headers: { 'x-csrf-token': ['csrf-a', 'csrf-b'] },
     });
@@ -224,24 +229,26 @@ describe('POST /api/auth/logout CSRF policy', () => {
     expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, userPayload);
   });
 
-  it('rejects non-user refresh sessions', async () => {
+  it('clears non-user refresh sessions from the user logout cookie slot', async () => {
     mocks.verifyRefreshToken.mockReturnValue({
       ...userPayload,
       sessionType: 'admin',
     });
 
     const response = await callLogout(router, {
+      query: { client_type: 'web' },
       cookies: { insforge_refresh_token: 'admin-refresh-token' },
       headers: { 'x-csrf-token': 'csrf-token' },
     });
 
-    expect(response.statusCode).toBe(401);
-    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
     expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
   });
 
   it('clears a valid web refresh cookie when CSRF is valid', async () => {
     const response = await callLogout(router, {
+      query: { client_type: 'web' },
       cookies: { insforge_refresh_token: 'valid-refresh-token' },
       headers: { 'x-csrf-token': 'csrf-token' },
     });
@@ -323,7 +330,7 @@ describe('POST /api/auth/admin/logout CSRF policy', () => {
     expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, adminPayload);
   });
 
-  it('rejects non-admin refresh sessions', async () => {
+  it('clears non-admin refresh sessions from the admin logout cookie slot', async () => {
     mocks.verifyRefreshToken.mockReturnValue(userPayload);
 
     const response = await callLogout(router, {
@@ -331,8 +338,8 @@ describe('POST /api/auth/admin/logout CSRF policy', () => {
       headers: { 'x-csrf-token': 'csrf-token' },
     });
 
-    expect(response.statusCode).toBe(401);
-    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
     expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
   });
 

--- a/backend/tests/unit/auth-logout-csrf-route.test.ts
+++ b/backend/tests/unit/auth-logout-csrf-route.test.ts
@@ -1,0 +1,349 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response, Router } from 'express';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { AppError } from '../../src/utils/errors';
+
+interface RefreshPayload {
+  sub: string;
+  type: 'refresh';
+  sessionType: 'user' | 'admin';
+  csrfNonce: string;
+}
+
+interface AppErrorLike {
+  statusCode: number;
+  code: string;
+  message: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  verifyRefreshToken: vi.fn(),
+  verifyCsrfToken: vi.fn(),
+}));
+
+vi.mock('@/api/middlewares/auth.js', () => ({
+  verifyUser: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyOptionalUser: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyAdmin: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyToken: vi.fn((_req, _res, next: NextFunction) => next()),
+}));
+
+vi.mock('@/services/auth/auth.service.js', () => ({
+  AuthService: {
+    getInstance: () => ({
+      register: vi.fn(),
+      login: vi.fn(),
+      getUserById: vi.fn(),
+      transformUserRecordToSchema: vi.fn(),
+      getUserSchemaById: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getAuthConfig: vi.fn(),
+      validateRedirectUrl: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/services/auth/auth-otp.service.js', () => ({
+  OTPPurpose: {
+    EMAIL_VERIFICATION: 'email_verification',
+    PASSWORD_RESET: 'password_reset',
+  },
+  AuthOTPService: {
+    getInstance: () => ({
+      createOTP: vi.fn(),
+      verifyOTP: vi.fn(),
+      verifyToken: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/services/logs/audit.service.js', () => ({
+  AuditService: { getInstance: () => ({ log: vi.fn() }) },
+}));
+
+vi.mock('@/services/secrets/secret.service.js', () => ({
+  SecretService: { getInstance: () => ({ getAnonKey: vi.fn() }) },
+}));
+
+vi.mock('@/services/email/smtp-config.service.js', () => ({
+  SmtpConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('@/services/email/email-template.service.js', () => ({
+  EmailTemplateService: { getInstance: () => ({}) },
+}));
+
+vi.mock('@/infra/socket/socket.manager.js', () => ({
+  SocketManager: { getInstance: () => ({ broadcastToRoom: vi.fn() }) },
+}));
+
+vi.mock('@/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      verifyRefreshToken: mocks.verifyRefreshToken,
+      verifyCsrfToken: mocks.verifyCsrfToken,
+      generateAccessToken: vi.fn(),
+      generateRefreshToken: vi.fn(),
+      generateRefreshTokenWithCsrf: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const userPayload: RefreshPayload = {
+  sub: 'user-1',
+  type: 'refresh',
+  sessionType: 'user',
+  csrfNonce: 'nonce',
+};
+
+const adminPayload: RefreshPayload = {
+  sub: 'admin',
+  type: 'refresh',
+  sessionType: 'admin',
+  csrfNonce: 'nonce',
+};
+
+function callLogout(
+  router: Router,
+  overrides: {
+    headers?: Request['headers'];
+    cookies?: Record<string, string>;
+    query?: Record<string, string>;
+  } = {}
+): Promise<{ statusCode: number; body: unknown; clearCookie: ReturnType<typeof vi.fn> }> {
+  return new Promise((resolve) => {
+    let statusCode = 200;
+
+    const req: Partial<Request> = {
+      url: '/logout',
+      method: 'POST',
+      headers: overrides.headers ?? {},
+      query: overrides.query ?? {},
+      cookies: overrides.cookies ?? {},
+      body: {},
+    };
+
+    const clearCookie = vi.fn(() => res);
+    const res: Partial<Response> = {
+      status: vi.fn((code: number) => {
+        statusCode = code;
+        return res;
+      }),
+      json: vi.fn((body: unknown) => resolve({ statusCode, body, clearCookie })),
+      clearCookie,
+    };
+
+    router(
+      req as Request,
+      res as Response,
+      vi.fn((error?: unknown) => {
+        if (error && typeof error === 'object' && 'statusCode' in error) {
+          const appError = error as AppErrorLike;
+          resolve({
+            statusCode: appError.statusCode,
+            body: {
+              error: appError.code,
+              message: appError.message,
+              statusCode: appError.statusCode,
+            },
+            clearCookie,
+          });
+        }
+      })
+    );
+  });
+}
+
+describe('POST /api/auth/logout CSRF policy', () => {
+  let router: Router;
+
+  beforeAll(async () => {
+    router = (await import('../../src/api/routes/auth/index.routes.js')).default;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verifyRefreshToken.mockReturnValue(userPayload);
+    mocks.verifyCsrfToken.mockReturnValue(true);
+  });
+
+  it('keeps web logout idempotent when the refresh cookie is absent', async () => {
+    const response = await callLogout(router);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale web refresh cookie without requiring CSRF', async () => {
+    mocks.verifyRefreshToken.mockImplementation(() => {
+      throw new AppError('Invalid or expired refresh token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+    });
+
+    const response = await callLogout(router, {
+      cookies: { insforge_refresh_token: 'stale-refresh-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid web refresh cookie when CSRF is missing', async () => {
+    mocks.verifyCsrfToken.mockReturnValue(false);
+
+    const response = await callLogout(router, {
+      cookies: { insforge_refresh_token: 'valid-refresh-token' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, userPayload);
+  });
+
+  it('rejects a valid web refresh cookie when CSRF header is multi-valued', async () => {
+    mocks.verifyCsrfToken.mockReturnValue(false);
+
+    const response = await callLogout(router, {
+      cookies: { insforge_refresh_token: 'valid-refresh-token' },
+      headers: { 'x-csrf-token': ['csrf-a', 'csrf-b'] },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, userPayload);
+  });
+
+  it('rejects non-user refresh sessions', async () => {
+    mocks.verifyRefreshToken.mockReturnValue({
+      ...userPayload,
+      sessionType: 'admin',
+    });
+
+    const response = await callLogout(router, {
+      cookies: { insforge_refresh_token: 'admin-refresh-token' },
+      headers: { 'x-csrf-token': 'csrf-token' },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it('clears a valid web refresh cookie when CSRF is valid', async () => {
+    const response = await callLogout(router, {
+      cookies: { insforge_refresh_token: 'valid-refresh-token' },
+      headers: { 'x-csrf-token': 'csrf-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith('csrf-token', userPayload);
+  });
+
+  it('leaves non-web logout unchanged', async () => {
+    const response = await callLogout(router, {
+      query: { client_type: 'mobile' },
+      cookies: { insforge_refresh_token: 'valid-refresh-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyRefreshToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/auth/admin/logout CSRF policy', () => {
+  let router: Router;
+
+  beforeAll(async () => {
+    router = (await import('../../src/api/routes/auth/admin.routes.js')).default;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.verifyRefreshToken.mockReturnValue(adminPayload);
+    mocks.verifyCsrfToken.mockReturnValue(true);
+  });
+
+  it('keeps admin logout idempotent when the refresh cookie is absent', async () => {
+    const response = await callLogout(router);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale admin refresh cookie without requiring CSRF', async () => {
+    mocks.verifyRefreshToken.mockImplementation(() => {
+      throw new AppError('Invalid or expired refresh token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+    });
+
+    const response = await callLogout(router, {
+      cookies: { insforge_admin_refresh_token: 'stale-admin-refresh-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid admin refresh cookie when CSRF is missing', async () => {
+    mocks.verifyCsrfToken.mockReturnValue(false);
+
+    const response = await callLogout(router, {
+      cookies: { insforge_admin_refresh_token: 'valid-admin-refresh-token' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, adminPayload);
+  });
+
+  it('rejects a valid admin refresh cookie when CSRF header is multi-valued', async () => {
+    mocks.verifyCsrfToken.mockReturnValue(false);
+
+    const response = await callLogout(router, {
+      cookies: { insforge_admin_refresh_token: 'valid-admin-refresh-token' },
+      headers: { 'x-csrf-token': ['csrf-a', 'csrf-b'] },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith(undefined, adminPayload);
+  });
+
+  it('rejects non-admin refresh sessions', async () => {
+    mocks.verifyRefreshToken.mockReturnValue(userPayload);
+
+    const response = await callLogout(router, {
+      cookies: { insforge_admin_refresh_token: 'user-refresh-token' },
+      headers: { 'x-csrf-token': 'csrf-token' },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.clearCookie).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it('clears a valid admin refresh cookie when CSRF is valid', async () => {
+    const response = await callLogout(router, {
+      cookies: { insforge_admin_refresh_token: 'valid-admin-refresh-token' },
+      headers: { 'x-csrf-token': 'csrf-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.clearCookie).toHaveBeenCalledOnce();
+    expect(mocks.verifyCsrfToken).toHaveBeenCalledWith('csrf-token', adminPayload);
+  });
+});

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -601,12 +601,32 @@ paths:
   /api/auth/logout:
     post:
       summary: Logout user
-      description: Logout and clear refresh token cookie
+      description: |
+        Logout the current client session.
+
+        Web clients use the httpOnly refresh token cookie. If a valid web refresh cookie is present,
+        the request must include the `X-CSRF-Token` header returned from login, registration, or refresh.
+        Missing, expired, invalid, or wrong-session-type refresh cookies are cleared idempotently and still
+        return success. Mobile, desktop, and server clients do not have server-side logout state and should
+        discard their stored refresh token after this request.
       tags:
         - Client
+      parameters:
+        - name: client_type
+          in: query
+          schema:
+            type: string
+            enum: [web, mobile, desktop, server]
+            default: web
+          description: Client type. Web clients clear the httpOnly refresh cookie; other clients should discard their local refresh token.
+        - name: X-CSRF-Token
+          in: header
+          schema:
+            type: string
+          description: CSRF token required for web clients when a valid refresh cookie is present
       responses:
         '200':
-          description: Logged out successfully
+          description: Logged out successfully. Also returned when the refresh cookie is missing, expired, invalid, or the wrong session type.
           content:
             application/json:
               schema:
@@ -616,6 +636,8 @@ paths:
                     type: boolean
                   message:
                     type: string
+        '403':
+          description: Invalid or missing CSRF token for a valid web refresh cookie
 
   /api/auth/sessions/current:
     get:
@@ -776,12 +798,24 @@ paths:
   /api/auth/admin/logout:
     post:
       summary: Logout admin dashboard session
-      description: Clears the dashboard-only `insforge_admin_refresh_token` cookie.
+      description: |
+        Clears the dashboard-only `insforge_admin_refresh_token` cookie.
+
+        If a valid admin refresh cookie is present, the request must include the `X-CSRF-Token`
+        header returned from admin login, admin session exchange, or admin refresh. Missing, expired,
+        invalid, or wrong-session-type admin refresh cookies are cleared idempotently and still return
+        success.
       tags:
         - Admin
+      parameters:
+        - name: X-CSRF-Token
+          in: header
+          schema:
+            type: string
+          description: CSRF token required when a valid admin refresh cookie is present
       responses:
         '200':
-          description: Logged out successfully
+          description: Logged out successfully. Also returned when the admin refresh cookie is missing, expired, invalid, or the wrong session type.
           content:
             application/json:
               schema:
@@ -791,6 +825,8 @@ paths:
                     type: boolean
                   message:
                     type: string
+        '403':
+          description: Invalid or missing CSRF token for a valid admin refresh cookie
 
   /api/auth/tokens/anon:
     post:


### PR DESCRIPTION
Closes #1329

Continuation of the PR #1605. As it is merged and the dashboard logout is confirmed to send the CSRF tokens over the logout endpoint, this PR is the backend CSRF validation for the tokens received.

## Summary

  - Require CSRF validation before clearing valid user refresh cookies on `POST /api/auth/logout`
  - Require CSRF validation before clearing valid admin refresh cookies on `POST /api/auth/admin/logout`
  - Keep logout idempotent for missing or stale refresh cookies
  - Add regression coverage for user and admin logout CSRF behavior

  ## Testing

  - `cd backend && npm test -- tests/unit/auth-logout-csrf-route.test.ts`
  - `cd backend && npm run typecheck`

CSRF validation is also included in `POST /api/auth/logout` (endpoint called from [InsForge/InsForge-sdk-js](https://github.com/InsForge/InsForge-sdk-js) which was already sending CSRF tokens but backend validation was not present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CSRF validation to user and admin logout for web sessions to block forged requests. Requires `X-CSRF-Token` only when a valid refresh cookie is present; stale, invalid, or wrong-session cookies are still cleared.

- **Bug Fixes**
  - Enforce CSRF on `POST /api/auth/logout` (with `client_type=web`) and `POST /api/auth/admin/logout` when the refresh cookie is valid and matches the session type.
  - Return 403 on missing/invalid CSRF; multi-valued `X-CSRF-Token` is invalid and cookies are not cleared.
  - Keep logout idempotent: clear missing/expired/mismatched refresh cookies without CSRF; non-web clients unchanged.
  - Add unit tests for both routes and edge cases; update `openapi/auth.yaml` with CSRF header and 403 responses.

- **Refactors**
  - Remove a redundant guard/rethrow in the logout flow to simplify error handling.

<sup>Written for commit 8d5eafb4e3b87320ab3c34b76e0038ae0d2d1d96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CSRF token validation to browser session logout endpoints
> - The `POST /api/auth/logout` (web client) and `POST /api/auth/admin/logout` endpoints now require a valid `X-CSRF-Token` header when a valid refresh cookie is present; missing or invalid CSRF returns 403.
> - When the refresh cookie is absent, expired, or belongs to the wrong session type, both endpoints still return 200 and clear the cookie — preserving idempotent logout behavior.
> - Non-web-client logout flows are unaffected.
> - Adds unit tests in [auth-logout-csrf-route.test.ts](https://github.com/InsForge/InsForge/pull/1613/files#diff-f4832db9301a6bb7654ab2ea48deff70ce9798ebcabee6c8b94c9b44fd60de8e) covering all scenarios, and updates [auth.yaml](https://github.com/InsForge/InsForge/pull/1613/files#diff-213defd0737c8c11fba7cfa9f5af7184fef3ec1133327d9cf3f7655244049a80) to document the new 403 responses and `X-CSRF-Token` header parameter.
> - Behavioral Change: web clients with a valid refresh cookie that omit or send a bad `X-CSRF-Token` will now receive 403 instead of a successful logout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d5eafb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened web and admin logout by verifying the relevant refresh token and requiring `X-CSRF-Token` when a valid cookie is present.
  * Logout is now idempotent for missing/expired/invalid or wrong-session refresh cookies (returns success and clears the cookie when appropriate).
  * If CSRF is missing/invalid/multi-valued, logout returns `403` and does not clear the cookie.
* **Tests**
  * Added unit tests covering CSRF and cookie-clearing behavior for both web (`/api/auth/logout`) and admin (`/api/auth/admin/logout`) logout routes.
* **Documentation**
  * Updated OpenAPI docs to reflect web vs non-web behavior and documented `403` CSRF failure cases for both endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->