### PR TITLE
INS-417: Minor UX tweaks for backend advisor and telemetry

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { type ReactNode, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge } from '@insforge/ui';
 import { Braces, Database, Download, HardDrive, User } from 'lucide-react';
@@ -67,6 +67,22 @@ export function DTestConnectedDashboard() {
     advisorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
+  // The advisor section only mounts in cloud-hosting mode, so only make these
+  // badges clickable when there is somewhere for them to scroll to.
+  const renderAdvisorBadge = (content: ReactNode, label: string) =>
+    isCloudHostingMode ? (
+      <button
+        type="button"
+        onClick={scrollToAdvisor}
+        className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
+        aria-label={label}
+      >
+        {content}
+      </button>
+    ) : (
+      <div className={STATUS_BADGE_CLASS}>{content}</div>
+    );
+
   const projectName = isCloudProject
     ? projectInfo.name || 'My InsForge Project'
     : 'My InsForge Project';
@@ -109,19 +125,17 @@ export function DTestConnectedDashboard() {
             )}
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <button
-              type="button"
-              onClick={scrollToAdvisor}
-              className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
-              aria-label="View backend advisor"
-            >
-              <span className="flex h-5 w-5 items-center justify-center">
-                <span
-                  className={`h-2 w-2 rounded-full ${isHealthy ? 'bg-emerald-400' : 'bg-amber-400'}`}
-                />
-              </span>
-              <span className="px-1">{projectHealth}</span>
-            </button>
+            {renderAdvisorBadge(
+              <>
+                <span className="flex h-5 w-5 items-center justify-center">
+                  <span
+                    className={`h-2 w-2 rounded-full ${isHealthy ? 'bg-emerald-400' : 'bg-amber-400'}`}
+                  />
+                </span>
+                <span className="px-1">{projectHealth}</span>
+              </>,
+              'View backend advisor'
+            )}
             {lastBackupAge && (
               <button
                 type="button"
@@ -133,19 +147,16 @@ export function DTestConnectedDashboard() {
                 <span className="px-1">Last Backup {lastBackupAge}</span>
               </button>
             )}
-            {criticalCount > 0 && (
-              <button
-                type="button"
-                onClick={scrollToAdvisor}
-                className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
-                aria-label="View critical issues in backend advisor"
-              >
-                <CriticalIcon className="h-5 w-5 text-destructive" />
-                <span className="px-1">
-                  {criticalCount} Critical {criticalCount === 1 ? 'Issue' : 'Issues'}
-                </span>
-              </button>
-            )}
+            {criticalCount > 0 &&
+              renderAdvisorBadge(
+                <>
+                  <CriticalIcon className="h-5 w-5 text-destructive" />
+                  <span className="px-1">
+                    {criticalCount} Critical {criticalCount === 1 ? 'Issue' : 'Issues'}
+                  </span>
+                </>,
+                'View critical issues in backend advisor'
+              )}
           </div>
         </div>
 

--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectedDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Badge } from '@insforge/ui';
 import { Braces, Database, Download, HardDrive, User } from 'lucide-react';
@@ -61,6 +61,11 @@ export function DTestConnectedDashboard() {
   const isBranch = project?.isBranch === true;
   const lastBackupQuery = useLastBackup();
   const advisorLatest = useAdvisorLatest();
+  const advisorRef = useRef<HTMLDivElement>(null);
+
+  const scrollToAdvisor = () => {
+    advisorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
 
   const projectName = isCloudProject
     ? projectInfo.name || 'My InsForge Project'
@@ -104,27 +109,42 @@ export function DTestConnectedDashboard() {
             )}
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <div className={STATUS_BADGE_CLASS}>
+            <button
+              type="button"
+              onClick={scrollToAdvisor}
+              className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
+              aria-label="View backend advisor"
+            >
               <span className="flex h-5 w-5 items-center justify-center">
                 <span
                   className={`h-2 w-2 rounded-full ${isHealthy ? 'bg-emerald-400' : 'bg-amber-400'}`}
                 />
               </span>
               <span className="px-1">{projectHealth}</span>
-            </div>
+            </button>
             {lastBackupAge && (
-              <div className={STATUS_BADGE_CLASS}>
+              <button
+                type="button"
+                onClick={() => void navigate('/dashboard/database/backups')}
+                className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
+                aria-label="View backup & restore"
+              >
                 <CloudDoneIcon className="h-5 w-5 text-primary" />
                 <span className="px-1">Last Backup {lastBackupAge}</span>
-              </div>
+              </button>
             )}
             {criticalCount > 0 && (
-              <div className={STATUS_BADGE_CLASS}>
+              <button
+                type="button"
+                onClick={scrollToAdvisor}
+                className={`${STATUS_BADGE_CLASS} transition-colors hover:bg-[var(--alpha-8)]`}
+                aria-label="View critical issues in backend advisor"
+              >
                 <CriticalIcon className="h-5 w-5 text-destructive" />
                 <span className="px-1">
                   {criticalCount} Critical {criticalCount === 1 ? 'Issue' : 'Issues'}
                 </span>
-              </div>
+              </button>
             )}
           </div>
         </div>
@@ -181,7 +201,9 @@ export function DTestConnectedDashboard() {
         {isCloudHostingMode && (
           <>
             <ObservabilitySection />
-            <BackendAdvisorSection />
+            <div ref={advisorRef} className="scroll-mt-10">
+              <BackendAdvisorSection />
+            </div>
           </>
         )}
       </div>

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -1,4 +1,6 @@
 import { type MouseEventHandler, type ReactNode, useId, useMemo, useRef, useState } from 'react';
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
 import type { DashboardMetricDataPoint } from '#types';
 import { aggregateMetricSeries } from '#features/dashboard/utils/aggregateMetricSeries';
 
@@ -15,6 +17,8 @@ export interface MetricChartCardProps {
   fixedDomain?: [number, number];
   /** Formatter for axis labels (threshold + zero). Defaults to `${v}%`. */
   formatAxisLabel?: (value: number) => string;
+  /** Short explanation of the metric, surfaced via an info tooltip next to the title. */
+  description?: string;
 }
 
 const SPARKLINE_WIDTH = 434;
@@ -107,6 +111,7 @@ export function MetricChartCard({
   threshold,
   fixedDomain,
   formatAxisLabel,
+  description,
 }: MetricChartCardProps) {
   const effectiveDomain =
     fixedDomain ?? (threshold !== undefined ? FIXED_PERCENT_DOMAIN : undefined);
@@ -164,6 +169,10 @@ export function MetricChartCard({
     threshold !== undefined ? 100 - ((threshold - domainMin) / domainRange) * 100 : 0;
   const renderAxisLabel = (value: number) =>
     formatAxisLabel ? formatAxisLabel(value) : `${value}%`;
+  const thresholdNote =
+    threshold !== undefined
+      ? `Green while healthy; the line turns red above ${renderAxisLabel(threshold)}.`
+      : null;
   const gradientTransitionHalfWidth = 8;
   const gradientTransitionStart = Math.max(
     0,
@@ -180,6 +189,25 @@ export function MetricChartCard({
         <div className="flex items-center gap-1.5 text-[13px] leading-[22px] text-muted-foreground">
           <span className="flex h-5 w-5 shrink-0 items-center justify-center">{icon}</span>
           <span className="truncate">{title}</span>
+          {description && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label={`About ${title}`}
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[240px] text-left font-normal normal-case">
+                  <p>{description}</p>
+                  {thresholdNote && <p className="mt-1 opacity-80">{thresholdNote}</p>}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
         <p className="text-[20px] font-medium leading-7 text-foreground">
           {isLoading ? '—' : renderValue(aggregates.latest)}

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactNode, useId, useMemo, useRef, useState } from 'react';
 import { Info } from 'lucide-react';
-import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
 import type { DashboardMetricDataPoint } from '#types';
 import { aggregateMetricSeries } from '#features/dashboard/utils/aggregateMetricSeries';
 
@@ -193,15 +193,13 @@ export function MetricChartCard({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
+                  <button
                     type="button"
-                    variant="ghost"
-                    size="icon-sm"
+                    className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
                     aria-label={`About ${title}`}
-                    className="h-4 w-4 shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
                   >
                     <Info className="h-3.5 w-3.5" />
-                  </Button>
+                  </button>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-[240px] text-left font-normal normal-case">
                   <p>{description}</p>

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactNode, useId, useMemo, useRef, useState } from 'react';
 import { Info } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
 import type { DashboardMetricDataPoint } from '#types';
 import { aggregateMetricSeries } from '#features/dashboard/utils/aggregateMetricSeries';
 
@@ -193,13 +193,15 @@ export function MetricChartCard({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <button
+                  <Button
                     type="button"
-                    className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                    variant="ghost"
+                    size="icon-sm"
                     aria-label={`About ${title}`}
+                    className="h-4 w-4 shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
                   >
                     <Info className="h-3.5 w-3.5" />
-                  </button>
+                  </Button>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-[240px] text-left font-normal normal-case">
                   <p>{description}</p>

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -19,6 +19,7 @@ interface MetricConfig {
   icon: React.ReactNode;
   format: (value: number) => string;
   threshold?: number;
+  description: string;
 }
 
 const PERCENT = (value: number) => `${value.toFixed(1)}%`;
@@ -53,6 +54,8 @@ const METRICS: MetricConfig[] = [
     icon: <Cpu className="h-5 w-5" />,
     format: PERCENT,
     threshold: 60,
+    description:
+      "How hard your instance's processor is working. Sustained high usage slows down API requests and background jobs.",
   },
   {
     metric: 'memory_usage',
@@ -60,18 +63,24 @@ const METRICS: MetricConfig[] = [
     icon: <MemoryStick className="h-5 w-5" />,
     format: PERCENT,
     threshold: 85,
+    description:
+      "How much of your instance's RAM is in use. When memory runs low, processes can be killed or start swapping, which hurts performance.",
   },
   {
     metric: 'network_in',
     title: 'Network In',
     icon: <ArrowDownToLine className="h-5 w-5" />,
     format: BYTES_PER_SEC,
+    description:
+      'Rate of data flowing into your instance, such as file uploads and incoming API requests.',
   },
   {
     metric: 'network_out',
     title: 'Network Out',
     icon: <ArrowUpFromLine className="h-5 w-5" />,
     format: BYTES_PER_SEC,
+    description:
+      'Rate of data leaving your instance, such as query results and file downloads served to clients.',
   },
 ];
 
@@ -149,6 +158,7 @@ export function ObservabilitySection() {
                   formatValue={config.format}
                   isLoading={isLoading}
                   threshold={config.threshold}
+                  description={config.description}
                 />
               );
             });
@@ -167,6 +177,7 @@ export function ObservabilitySection() {
                 threshold={diskCardProps.threshold}
                 fixedDomain={diskCardProps.fixedDomain}
                 formatAxisLabel={BYTES_SIZE}
+                description="How much of your instance's storage the database, files, and logs are using. A full disk stops writes and can take the backend offline."
               />
             );
             return cards;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements INS-417 UX tweaks: make dashboard status badges clickable and add metric info tooltips to improve navigation and clarity. Health/critical badges scroll to Backend Advisor in cloud-hosting mode; the backup badge opens Backups.

- **New Features**
  - Status badges are interactive with hover states and aria labels. Health/critical badges smooth-scroll to Backend Advisor only in cloud-hosting mode; otherwise they stay static. Backup badge navigates to `/dashboard/database/backups`.
  - Metric cards show an info tooltip using `@insforge/ui` `Tooltip` with a plain button trigger, including short descriptions and threshold notes. Added descriptions for CPU, Memory, Network In/Out, and Disk usage.

<sup>Written for commit 0ce23b38f8860e759ff3677ea68af54bade7b4c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add clickable dashboard badges and info tooltips to observability metric cards
> - In cloud-hosting mode, the project health and critical issues badges in `DTestConnectedDashboard` are now buttons that smoothly scroll to the `BackendAdvisorSection`; in non-cloud mode they remain non-interactive.
> - The last-backup badge is now a button that navigates to `/dashboard/database/backups` on click.
> - Observability metric cards in `ObservabilitySection` now accept a `description` prop and render an info tooltip next to the card title for CPU, Memory, Network In/Out, and Disk Usage metrics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ce23b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard status badges are now clickable where applicable, including smooth scrolling to the backend advisor section and navigation to backup details.
  * Observability metric cards can show an info icon with a tooltip when descriptive text is available (CPU, memory, network, and disk).
  * Tooltip guidance can include threshold context to clarify healthy vs critical conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->