### PR TITLE
Grant anon runtime role access to storage.objects

### DIFF
--- a/backend/src/infra/database/migrations/058_grant-anon-storage-access.sql
+++ b/backend/src/infra/database/migrations/058_grant-anon-storage-access.sql
@@ -1,0 +1,53 @@
+-- Migration: 058 - Grant the anonymous runtime role access to storage.objects
+--
+-- Storage access control lives in RLS on storage.objects (migration 036), and
+-- the runtime enforces it by running each end-user request under the matching
+-- database role (`SET LOCAL ROLE anon | authenticated` in withUserContext).
+--
+-- The `authenticated` role has held USAGE on the storage schema plus DML on
+-- storage.objects since migration 036, so projects can already write RLS
+-- policies that let authenticated end-users reach storage. The `anon` role
+-- never kept the same treatment: migration 044 briefly granted it, migration
+-- 047 revoked it, and since then any anon request that reaches storage.objects
+-- fails with `permission denied for schema storage` BEFORE RLS is evaluated.
+-- Postgres checks table/schema privileges first and RLS only narrows what a
+-- privileged role may see -- it never grants access -- so an anon policy
+-- (`CREATE POLICY ... TO anon`) is dead code today: anon cannot reach the table
+-- for the policy to run.
+--
+-- This migration makes anon symmetric with authenticated so RLS is the single
+-- control surface for both roles. It grants schema/table privileges ONLY; it
+-- creates no policy and does not change RLS enablement. Row access stays exactly
+-- as the project's RLS posture dictates:
+--   * RLS enabled, no anon policy -> anon denied. Projects opt in by writing a
+--     policy suited to the bucket (public-read, path-scoped, etc.).
+--   * RLS disabled -> anon has the same open access `authenticated` already has.
+--     This matches the intentional "usable by default" posture from migration
+--     047 and the Supabase model, where disabling RLS opens a table to the
+--     anon key. Locking it down is done by enabling RLS and writing policies.
+--
+-- Buckets stay API-managed: anon receives no privileges on storage.buckets,
+-- exactly like authenticated. Public-bucket downloads continue to be served
+-- through the backend API via runWithRootAccess and do not depend on these
+-- grants. auth.jwt() EXECUTE was already granted to anon in migration 036, so
+-- anon RLS policies can read JWT claims once this schema USAGE lands.
+--
+-- Safety / idempotency:
+--   * Guarded on the anon role and storage schema existing, so the migration is
+--     a no-op (never errors) on databases where they are absent.
+--   * GRANT is inherently idempotent, so re-running (migrate:redo) is safe.
+--   * Forward-only: there is no down migration -- these grants are the intended
+--     steady state and reverting them would restore the anon dead-policy gap.
+--     This matches the repository convention (most migrations have no down).
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')
+     AND to_regnamespace('storage') IS NOT NULL THEN
+    GRANT USAGE ON SCHEMA storage TO anon;
+
+    IF to_regclass('storage.objects') IS NOT NULL THEN
+      GRANT SELECT, INSERT, UPDATE, DELETE ON storage.objects TO anon;
+    END IF;
+  END IF;
+END $$;

--- a/backend/tests/unit/grant-anon-storage-access-migration.test.ts
+++ b/backend/tests/unit/grant-anon-storage-access-migration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '058_grant-anon-storage-access.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+// Executable SQL only, with `--` comments stripped. Assertions about what the
+// migration does (and does not do) must not trip over the explanatory header.
+function readMigrationSql(): string {
+  return readMigration()
+    .split('\n')
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+}
+
+describe('grant anon storage access migration', () => {
+  it('migration file exists and runs after the anon storage revoke', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    // Must land after 047, which revoked anon's storage access; otherwise the
+    // revoke would win and anon would still be locked out.
+    expect(migrations.indexOf(migrationFile)).toBeGreaterThan(
+      migrations.indexOf('047_harden-internal-runtime-defaults.sql')
+    );
+  });
+
+  it('grants schema USAGE and object DML to anon', () => {
+    const sql = readMigrationSql();
+
+    expect(sql).toMatch(/GRANT\s+USAGE\s+ON\s+SCHEMA\s+storage\s+TO\s+anon/i);
+    expect(sql).toMatch(
+      /GRANT\s+SELECT,\s*INSERT,\s*UPDATE,\s*DELETE\s+ON\s+storage\.objects\s+TO\s+anon/i
+    );
+  });
+
+  it('is guarded on the anon role and storage schema existing', () => {
+    const sql = readMigrationSql();
+
+    expect(sql).toMatch(/EXISTS\s+\(\s*SELECT\s+1\s+FROM\s+pg_roles\s+WHERE\s+rolname\s+=\s+'anon'/i);
+    expect(sql).toMatch(/to_regnamespace\('storage'\)\s+IS\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/to_regclass\('storage\.objects'\)\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('does not touch RLS enablement or create any policy', () => {
+    const sql = readMigrationSql();
+
+    expect(sql).not.toMatch(/ROW\s+LEVEL\s+SECURITY/i);
+    expect(sql).not.toMatch(/CREATE\s+POLICY/i);
+    expect(sql).not.toMatch(/DROP\s+POLICY/i);
+  });
+
+  it('does not grant anon any privileges on buckets and does not revoke anything', () => {
+    const sql = readMigrationSql();
+
+    expect(sql).not.toMatch(/storage\.buckets/i);
+    expect(sql).not.toMatch(/REVOKE/i);
+  });
+});


### PR DESCRIPTION
## Summary

Grants the `anon` database role `USAGE` on the `storage` schema and DML on `storage.objects`, making it symmetric with `authenticated` so RLS is the single control surface for both roles.

## Background

The runtime enforces storage access by running each end-user request under the matching database role (`SET LOCAL ROLE anon | authenticated` in `withUserContext`), and access control lives in RLS on `storage.objects` (migration 036).

`authenticated` has held schema `USAGE` + object DML since [036](backend/src/infra/database/migrations/036_storage-third-party-auth-support.sql). `anon` did not: [044](backend/src/infra/database/migrations/044_prefer-request-jwt-claims.sql) granted it, [047](backend/src/infra/database/migrations/047_harden-internal-runtime-defaults.sql) revoked it. Since then, any anon request that reaches `storage.objects` fails with `permission denied for schema storage` **before** RLS is evaluated — Postgres checks table/schema privileges first, and RLS only narrows access, never grants it. So an anon storage policy (`CREATE POLICY ... TO anon`) is dead code today: anon can't reach the table for the policy to run.

Confirmed the runtime path: an `anon_...` key → `verifyUser` → `verifyAnonKey` sets `role: 'anon'`; `listObjects`/`getObject` then call `withUserContext` → `SET LOCAL ROLE anon` → query fails at the grant layer.

## Change

Migration `058` grants `anon`:
- `GRANT USAGE ON SCHEMA storage`
- `GRANT SELECT, INSERT, UPDATE, DELETE ON storage.objects`

It creates **no policy** and does **not** change RLS enablement. Row access stays governed by each project's RLS posture:
- RLS enabled, no anon policy → anon denied. Projects opt in by writing a policy suited to the bucket (public-read, path-scoped, etc.).
- RLS disabled → anon has the same open access `authenticated` already has. This matches the intentional "usable by default" posture from 047 and the Supabase model (disabling RLS opens a table to the anon key).

Buckets stay API-managed (no anon grant on `storage.buckets`). Public-bucket downloads are unaffected — they're served via `runWithRootAccess` and never depended on these grants. `auth.jwt()` `EXECUTE` was already granted to anon in 036, so anon policies can read JWT claims once schema `USAGE` lands.

The migration is guarded on the role/schema existing, idempotent (`GRANT`), and forward-only, matching repo convention.

## Test

Adds `grant-anon-storage-access-migration.test.ts` (follows the per-migration content-test convention): asserts the grants, the guards, ordering after 047, and that the migration touches neither RLS/policies nor `storage.buckets`. All 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the `anon` runtime role to reach `storage.objects` so RLS controls access for both `anon` and `authenticated`. This removes schema-level blocks that caused permission errors and makes anon storage policies effective.

- **Bug Fixes**
  - Grant `USAGE` on `storage` and `SELECT, INSERT, UPDATE, DELETE` on `storage.objects` to `anon`.
  - No RLS/policy changes; RLS remains the gate. With RLS enabled and no anon policy, `anon` is denied. With RLS disabled, `anon` matches `authenticated`.
  - No privileges on `storage.buckets`; public downloads remain served via root access.
  - Safe, idempotent migration with guards; adds unit tests for grants, guards, and non-interference with RLS and buckets.

<sup>Written for commit ea209b1b3e10f3e360545e614a51a34d9016abca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant the `anon` runtime role USAGE and DML access to `storage.objects`
> Adds a database migration ([058_grant-anon-storage-access.sql](https://github.com/InsForge/InsForge/pull/1618/files#diff-cbf5c10ab90a40c72260ac240309f5e032f844f54c540f4fa886bcb8d916395a)) that grants the `anon` Postgres role USAGE on the `storage` schema and SELECT, INSERT, UPDATE, DELETE on `storage.objects`. The grants are wrapped in a conditional `DO` block that checks for the existence of the `anon` role, `storage` schema, and `storage.objects` table before executing, so the migration is a no-op when prerequisites are absent. Row-level access remains governed by existing RLS policies — no RLS or policy changes are included. Unit tests verify grant content, ordering relative to the prior revoke migration, guard conditions, and that `storage.buckets` and REVOKE statements are not touched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea209b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous users now have the same access to storage objects as authenticated users, improving consistency in storage access behavior.
  * The change is safely applied only when the required database roles and storage schema are available.
* **Tests**
  * Added coverage to verify the storage access update is applied in the correct order and only includes the intended permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->