### PR TITLE
fix(deps): dedupe lru-cache to a single root v11 so backend resolves the named export

### DIFF
--- a/backend/tests/unit/lru-cache-resolution.test.ts
+++ b/backend/tests/unit/lru-cache-resolution.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Regression guard for the lru-cache dedup fix.
+ *
+ * backend/src/services/storage/s3-access-key.service.ts does
+ * `import { LRUCache } from 'lru-cache'`, which only works on v11 (v11's CJS
+ * build exposes `LRUCache` as a named export). @babel/helper-compilation-targets
+ * pulls lru-cache@5, whose `module.exports` IS the class and has no named
+ * export. If npm hoists babel's v5 to the workspace root, the backend import
+ * resolves to `undefined` in any partially-installed checkout -> "LRUCache is
+ * not a constructor" (and tsc loses the bundled types). The root `lru-cache`
+ * devDependency in the workspace package.json pins v11 to the root hoist slot;
+ * these tests fail loudly if that guarantee ever regresses (e.g. the root
+ * devDependency is pruned as "unused" or npm's hoisting flips on an upgrade).
+ */
+describe('lru-cache resolution', () => {
+  test('exposes the named LRUCache export as a constructor', async () => {
+    const { LRUCache } = await import('lru-cache');
+    expect(typeof LRUCache).toBe('function');
+    expect(() => new LRUCache<string, string>({ max: 1 })).not.toThrow();
+  });
+
+  test('hoists lru-cache v11 (not babel’s v5) to the workspace root', () => {
+    const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+    const rootLruCachePkg = resolve(workspaceRoot, 'node_modules/lru-cache/package.json');
+
+    expect(existsSync(rootLruCachePkg)).toBe(true);
+
+    const { version } = JSON.parse(readFileSync(rootLruCachePkg, 'utf8')) as { version: string };
+    expect(version.split('.')[0]).toBe('11');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "globals": "^13.24.0",
+        "lru-cache": "^11.3.5",
         "prettier": "^3.6.2",
         "rimraf": "^5.0.5",
         "turbo": "^2.9.16",
@@ -193,15 +194,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "backend/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "frontend": {
@@ -1365,6 +1357,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -3138,16 +3140,6 @@
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "lru-cache": "^11.2.7"
-      }
-    },
-    "node_modules/@pgpmjs/server-utils/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@pgpmjs/types": {
@@ -12108,16 +12100,6 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -12689,13 +12671,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide-react": {
@@ -13455,15 +13436,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -13526,16 +13498,6 @@
         "lru-cache": "^11.2.7",
         "pg": "^8.21.0",
         "pg-env": "^1.16.0"
-      }
-    },
-    "node_modules/pg-cache/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/pg-cloudflare": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "globals": "^13.24.0",
+    "lru-cache": "^11.3.5",
     "prettier": "^3.6.2",
     "rimraf": "^5.0.5",
     "turbo": "^2.9.16",


### PR DESCRIPTION
## Problem

Storage/S3 backend tests recurrently fail in fresh/half-installed git worktrees with `TypeError: LRUCache is not a constructor` (~13 tests across `s3-access-key.service.test.ts`, `storage-routes.test.ts`, `s3-gateway-multipart.integration.test.ts`), plus a typecheck error `Could not find a declaration file for module 'lru-cache'` in `s3-access-key.service.ts`. A clean `npm ci` hides it, so standard CI never hits it.

Two consumers need mutually incompatible `lru-cache` APIs from the same specifier:

| Consumer | Code | Needs |
|---|---|---|
| `backend/src/services/storage/s3-access-key.service.ts:3` | `import { LRUCache }` | **v11 only** — v11's CJS build exports `LRUCache` as a *named* export, no default |
| `@babel/helper-compilation-targets/lib/index.js:143` | `new require("lru-cache")(...)` | **v5 only** — v5's `module.exports` *is* the class |

npm was hoisting babel's **v5 to the root** `node_modules/lru-cache` and nesting backend's v11 under `backend/node_modules`. When a worktree comes up without a backend-local `lru-cache`, backend's import walks up to the root v5 → `LRUCache` is `undefined` → not a constructor; and `tsc` sees v5 (no bundled types) → missing declaration file.

## Fix

Add `lru-cache@^11.3.5` as a direct **root** `devDependency`.

A direct dependency deterministically claims the root `node_modules` slot, so **v11 lands at the root** and babel's transitive **v5 is forced to nest** under `@babel/helper-compilation-targets/node_modules/lru-cache` (still works — babel gets its v5, `import { LRUCache }` gets v11).

### Why not `overrides`
- Overrides change version *selection*, not hoist *position* — npm re-hoists babel's v5 to root regardless.
- A blanket `overrides` forcing v11 everywhere also drags `path-scurry`'s v10 out of its declared `^10` range, an unvetted bump. The direct-dep approach leaves path-scurry untouched.

### Why this ends the recurrence
Backend now **dedupes to the root v11** (no nested copy), so the previously-broken walk-up-to-root state resolves to a compatible version *by construction* — the failure mode is structurally eliminated, not papered over by a fresh install. The lockfile change is a **net dedup**: five duplicate v11 copies (backend, jsdom, pg-cache, @pgpmjs/server-utils, top-level path-scurry) collapse into one root **v11.5.1**; rimraf's path-scurry@1 keeps its **v10.4.3**.

## Validation

Run in the exact failing state (`backend/node_modules/lru-cache` absent → resolves up to root):

- **13 storage/s3 tests pass** (previously-failing files); 1 skipped is the pre-existing `RUN_S3_GATEWAY_INTEGRATION=1` gate
- `turbo run typecheck` ✓ (declaration-file error gone)
- `turbo run lint` ✓
- `turbo run build` ✓ (babel/vite still build on nested v5)
- `turbo run test` ✓ — **1663 passed / 17 skipped**

Isolated dependency-hygiene fix — no storage-permissions/migration work bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped `lru-cache` to a single root v11 so the backend’s `import { LRUCache }` resolves correctly. Added a unit test to ensure the root hoist stays at v11 and the named export constructs.

- **Dependencies**
  - Added `lru-cache@^11.3.5` to root devDependencies to pin v11 at the root; `@babel/helper-compilation-targets` keeps its nested v5.

<sup>Written for commit 3d42418990ab09491245abec29cb68e33981034c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `lru-cache` to a single root v11 instance to fix named export resolution
> Adds `lru-cache@^11.3.5` as an explicit root dependency in [package.json](https://github.com/InsForge/InsForge/pull/1619/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) so the package manager deduplicates all transitive copies to a single v11 instance. This fixes a runtime error where the backend could not resolve the named export from `lru-cache` due to multiple conflicting versions being installed.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1619 opened
>
> - Added tests to verify `lru-cache` v11 resolution and API [3d42418]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4099b2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability around cache module loading so the correct constructor is available at runtime.
* **Tests**
  * Added a regression test to protect against future package resolution issues.
* **Chores**
  * Updated the app’s shared development dependency for cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->