### PR TITLE
Switch metric info hint to click-triggered popover

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -1,6 +1,6 @@
 import { type MouseEventHandler, type ReactNode, useId, useMemo, useRef, useState } from 'react';
 import { Info } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@insforge/ui';
+import { Popover, PopoverContent, PopoverTrigger } from '#components';
 import type { DashboardMetricDataPoint } from '#types';
 import { aggregateMetricSeries } from '#features/dashboard/utils/aggregateMetricSeries';
 
@@ -190,23 +190,24 @@ export function MetricChartCard({
           <span className="flex h-5 w-5 shrink-0 items-center justify-center">{icon}</span>
           <span className="truncate">{title}</span>
           {description && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label={`About ${title}`}
-                  >
-                    <Info className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-[240px] text-left font-normal normal-case">
-                  <p>{description}</p>
-                  {thresholdNote && <p className="mt-1 opacity-80">{thresholdNote}</p>}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                  aria-label={`About ${title}`}
+                >
+                  <Info className="h-3.5 w-3.5" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                className="w-auto max-w-[260px] p-3 text-left text-[13px] font-normal normal-case leading-5"
+              >
+                <p>{description}</p>
+                {thresholdNote && <p className="mt-1 text-muted-foreground">{thresholdNote}</p>}
+              </PopoverContent>
+            </Popover>
           )}
         </div>
         <p className="text-[20px] font-medium leading-7 text-foreground">

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -202,10 +202,10 @@ export function MetricChartCard({
               </PopoverTrigger>
               <PopoverContent
                 align="start"
-                className="w-auto max-w-[260px] p-3 text-left text-[13px] font-normal normal-case leading-5"
+                className="w-auto max-w-[260px] rounded border-[var(--border)] bg-[rgb(var(--foreground))] p-2 text-left text-xs font-normal normal-case leading-4 text-[rgb(var(--inverse))] shadow-[0_4px_4px_rgba(0,0,0,0.08)]"
               >
                 <p>{description}</p>
-                {thresholdNote && <p className="mt-1 text-muted-foreground">{thresholdNote}</p>}
+                {thresholdNote && <p className="mt-1">{thresholdNote}</p>}
               </PopoverContent>
             </Popover>
           )}


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does -->

## How did you test this change?

<!-- Describe how you tested this PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the metric info hint from a hover tooltip to a click-triggered popover in `MetricChartCard` to improve accessibility and touch support. Replaces `@insforge/ui` tooltip with `#components` popover, aligns content start, sets 260px max width, and matches the shared tooltip style (padding, small text/leading, border, inverse text, subtle shadow); keeps the description and optional threshold note.

<sup>Written for commit 0a0a1344d65c4ab578b588d9f80b77b34e3ef9fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch metric info hint in `MetricChartCard` from tooltip to click-triggered popover
> Replaces the hover tooltip on the info button in [MetricChartCard.tsx](https://github.com/InsForge/InsForge/pull/1620/files#diff-6c59402e5bdc7fe1aae45ecea455773b19caa4d2fe4a692e6a0ed7ccd27dedd6) with a click-triggered `Popover`. The popover is start-aligned and uses updated styling (max width 260px, new background/border/shadow classes). The `opacity-80` class is removed from the threshold note paragraph.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a0a134.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the metric chart info display to use a more reliable popover interaction instead of a tooltip.
  * Refreshed the metric description and threshold note layout, spacing, and typography for clearer readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->