### PR TITLE
INS-420

### DIFF
--- a/backend/src/providers/logs/local.provider.ts
+++ b/backend/src/providers/logs/local.provider.ts
@@ -82,9 +82,11 @@ export class LocalFileProvider extends BaseLogProvider {
   private formatEventMessage(log: Record<string, unknown>): string | null {
     // Legacy Vector-transformed entries carry an appname field
     if (log.appname) {
-      // For error logs, include error and stack in eventMessage to match CloudWatch display
+      // For error logs, include error and stack in eventMessage to match CloudWatch display.
+      // Vector stored severity under metadata.level, not at the top level.
+      const level = (log.metadata as Record<string, unknown> | undefined)?.level ?? log.level;
       let eventMessage = String(log.event_message ?? '');
-      if (log.level === 'error' && log.error) {
+      if (level === 'error' && log.error) {
         eventMessage = `${eventMessage}\n\nError: ${log.error}`;
         if (log.stack) {
           eventMessage += `\n\nStack Trace:\n${log.stack}`;
@@ -98,8 +100,9 @@ export class LocalFileProvider extends BaseLogProvider {
       const metadata = (log.metadata ?? {}) as Record<string, unknown>;
 
       // HTTP request logs (see the request logger in server.ts) — format as an
-      // nginx-style line, matching what the Vector pipeline used to produce
-      if (metadata.duration !== undefined) {
+      // nginx-style line, matching what the Vector pipeline used to produce.
+      // Require method too so timing metadata on other logs doesn't match.
+      if (metadata.duration !== undefined && metadata.method !== undefined) {
         return [
           metadata.method,
           metadata.path,
@@ -115,9 +118,14 @@ export class LocalFileProvider extends BaseLogProvider {
 
       let eventMessage = `${log.level} - ${log.message}`;
       if (metadata.error) {
-        eventMessage += `\n\nError: ${metadata.error}`;
-        if (metadata.stack) {
-          eventMessage += `\n\nStack Trace:\n${metadata.stack}`;
+        // metadata.error is either a string or a flattened Error
+        // ({ message, stack } — see flattenErrors in utils/logger.ts)
+        const err = metadata.error as { message?: unknown; stack?: unknown } | string;
+        const errMessage = typeof err === 'object' && err.message !== undefined ? err.message : err;
+        const errStack = (typeof err === 'object' ? err.stack : undefined) ?? metadata.stack;
+        eventMessage += `\n\nError: ${errMessage}`;
+        if (errStack) {
+          eventMessage += `\n\nStack Trace:\n${errStack}`;
         }
       }
       return eventMessage;

--- a/backend/src/providers/logs/local.provider.ts
+++ b/backend/src/providers/logs/local.provider.ts
@@ -3,6 +3,7 @@ import { createInterface } from 'readline';
 import path from 'path';
 import { LogSchema, LogSourceSchema, LogStatsSchema } from '@insforge/shared-schemas';
 import { BaseLogProvider } from './base.provider.js';
+import { appConfig } from '@/infra/config/app.config.js';
 import logger from '@/utils/logger.js';
 
 export class LocalFileProvider extends BaseLogProvider {
@@ -15,7 +16,8 @@ export class LocalFileProvider extends BaseLogProvider {
   ]);
 
   async initialize(): Promise<void> {
-    this.logsDir = process.env.LOGS_DIR || path.resolve(process.cwd(), 'insforge-logs');
+    // Same directory the winston file transport writes to (utils/logger.ts).
+    this.logsDir = appConfig.server.logsDir;
     try {
       await fs.mkdir(this.logsDir, { recursive: true });
     } catch {
@@ -71,6 +73,59 @@ export class LocalFileProvider extends BaseLogProvider {
     };
   }
 
+  /**
+   * Build the display message for a parsed JSONL line, or null when the line
+   * is not a log entry we understand. Handles both line shapes found in these
+   * files: entries written by the winston file transport (utils/logger.ts) and
+   * legacy entries shipped by the Vector sidecar before it was removed.
+   */
+  private formatEventMessage(log: Record<string, unknown>): string | null {
+    // Legacy Vector-transformed entries carry an appname field
+    if (log.appname) {
+      // For error logs, include error and stack in eventMessage to match CloudWatch display
+      let eventMessage = String(log.event_message ?? '');
+      if (log.level === 'error' && log.error) {
+        eventMessage = `${eventMessage}\n\nError: ${log.error}`;
+        if (log.stack) {
+          eventMessage += `\n\nStack Trace:\n${log.stack}`;
+        }
+      }
+      return eventMessage;
+    }
+
+    // Winston file transport entries: { id, timestamp, message, level, metadata }
+    if (log.message !== undefined && log.level && log.timestamp) {
+      const metadata = (log.metadata ?? {}) as Record<string, unknown>;
+
+      // HTTP request logs (see the request logger in server.ts) — format as an
+      // nginx-style line, matching what the Vector pipeline used to produce
+      if (metadata.duration !== undefined) {
+        return [
+          metadata.method,
+          metadata.path,
+          metadata.status,
+          metadata.size,
+          metadata.duration,
+          '-',
+          metadata.ip,
+          '-',
+          metadata.userAgent,
+        ].join(' ');
+      }
+
+      let eventMessage = `${log.level} - ${log.message}`;
+      if (metadata.error) {
+        eventMessage += `\n\nError: ${metadata.error}`;
+        if (metadata.stack) {
+          eventMessage += `\n\nStack Trace:\n${metadata.stack}`;
+        }
+      }
+      return eventMessage;
+    }
+
+    return null;
+  }
+
   private async readLogsFromFile(
     filePath: string,
     limit: number,
@@ -98,24 +153,14 @@ export class LocalFileProvider extends BaseLogProvider {
 
       try {
         const log = JSON.parse(line);
-
-        // Only process Vector-transformed logs (have appname field)
-        if (!log.appname) {
+        const eventMessage = this.formatEventMessage(log);
+        if (eventMessage === null) {
           continue;
         }
 
         const logTime = new Date(log.timestamp).getTime();
 
         if (logTime < beforeMs) {
-          // For error logs, include error and stack in eventMessage to match CloudWatch display
-          let eventMessage = log.event_message || '';
-          if (log.level === 'error' && log.error) {
-            eventMessage = `${eventMessage}\n\nError: ${log.error}`;
-            if (log.stack) {
-              eventMessage += `\n\nStack Trace:\n${log.stack}`;
-            }
-          }
-
           logs.push({
             id: `${logTime}-${Math.random()}`,
             timestamp: log.timestamp,

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -8,6 +8,17 @@ const logsDir = appConfig.server.logsDir;
 
 const transports: winston.transport[] = [new winston.transports.Console()];
 
+// Error instances stringify to {} — flatten them so metadata like
+// `logger.error('...', { error })` survives the trip to disk. Stacks follow
+// the same production gate as winston.format.errors below.
+const flattenErrors = (_key: string, value: unknown) =>
+  value instanceof Error
+    ? {
+        message: value.message,
+        ...(process.env.NODE_ENV !== 'production' ? { stack: value.stack } : {}),
+      }
+    : value;
+
 // The JSONL file feeds the self-hosted dashboard logs (LocalFileProvider).
 // Cloud deployments ship stdout to CloudWatch via the awslogs driver and read
 // logs back through CloudWatchProvider, so writing the file there would only
@@ -25,18 +36,22 @@ if (!isCloudEnvironment()) {
         tailable: true,
         format: winston.format.printf((info) => {
           const { timestamp, level, message, ...metadata } = info;
-          return JSON.stringify({
-            id: `${Date.now()}-${Math.random()}`,
-            timestamp,
-            message,
-            level,
-            metadata,
-          });
+          return JSON.stringify(
+            {
+              id: `${Date.now()}-${Math.random()}`,
+              timestamp,
+              message,
+              level,
+              metadata,
+            },
+            flattenErrors
+          );
         }),
       })
     );
-  } catch {
-    // Logs directory is not writable — console logging still works.
+  } catch (error) {
+    // Console logging still works, but surface why the dashboard log file is missing
+    console.warn(`Could not initialize file logging at ${logsDir}:`, error);
   }
 }
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,8 +1,44 @@
 import winston from 'winston';
+import fs from 'fs';
 import path from 'path';
 import { appConfig } from '@/infra/config/app.config.js';
+import { isCloudEnvironment } from '@/utils/environment.js';
 
 const logsDir = appConfig.server.logsDir;
+
+const transports: winston.transport[] = [new winston.transports.Console()];
+
+// The JSONL file feeds the self-hosted dashboard logs (LocalFileProvider).
+// Cloud deployments ship stdout to CloudWatch via the awslogs driver and read
+// logs back through CloudWatchProvider, so writing the file there would only
+// grow the container filesystem with data nothing reads.
+if (!isCloudEnvironment()) {
+  try {
+    fs.mkdirSync(logsDir, { recursive: true });
+    transports.push(
+      new winston.transports.File({
+        filename: path.join(logsDir, 'insforge.logs.jsonl'),
+        // Rotate so the file cannot grow unbounded; LocalFileProvider only
+        // reads the base file, which `tailable` keeps as the newest one.
+        maxsize: 20 * 1024 * 1024,
+        maxFiles: 2,
+        tailable: true,
+        format: winston.format.printf((info) => {
+          const { timestamp, level, message, ...metadata } = info;
+          return JSON.stringify({
+            id: `${Date.now()}-${Math.random()}`,
+            timestamp,
+            message,
+            level,
+            metadata,
+          });
+        }),
+      })
+    );
+  } catch {
+    // Logs directory is not writable — console logging still works.
+  }
+}
 
 export const logger = winston.createLogger({
   level: appConfig.app.logLevel,
@@ -14,22 +50,7 @@ export const logger = winston.createLogger({
     winston.format.errors({ stack: process.env.NODE_ENV !== 'production' }),
     winston.format.json()
   ),
-  transports: [
-    new winston.transports.Console(),
-    new winston.transports.File({
-      filename: path.join(logsDir, 'insforge.logs.jsonl'),
-      format: winston.format.printf((info) => {
-        const { timestamp, level, message, ...metadata } = info;
-        return JSON.stringify({
-          id: `${Date.now()}-${Math.random()}`,
-          timestamp,
-          message,
-          level,
-          metadata,
-        });
-      }),
-    }),
-  ],
+  transports,
 });
 
 export default logger;

--- a/backend/tests/unit/local-log-provider.test.ts
+++ b/backend/tests/unit/local-log-provider.test.ts
@@ -54,12 +54,39 @@ const winstonRequestLog = {
   },
 };
 
-// Line shape shipped by the legacy Vector sidecar
+const winstonFlattenedErrorLog = {
+  id: '4-0.4',
+  timestamp: '2026-07-01T10:03:00.000Z',
+  message: 'Failed to record MCP usage',
+  level: 'error',
+  metadata: {
+    error: { message: 'kaboom', stack: 'Error: kaboom\n  at y.ts:2' },
+  },
+};
+
+const winstonTimingLog = {
+  id: '5-0.5',
+  timestamp: '2026-07-01T10:04:00.000Z',
+  message: 'Query finished',
+  level: 'info',
+  metadata: { duration: '50ms' },
+};
+
+// Line shapes shipped by the legacy Vector sidecar
 const vectorLog = {
   appname: 'insforge',
   timestamp: '2026-07-01T09:59:00.000Z',
   event_message: 'legacy vector line',
   metadata: { level: 'info' },
+};
+
+const vectorErrorLog = {
+  appname: 'insforge',
+  timestamp: '2026-07-01T09:58:00.000Z',
+  event_message: 'error - it broke',
+  metadata: { level: 'error' },
+  error: 'it broke',
+  stack: 'Error: it broke\n  at z.ts:3',
 };
 
 describe('LocalFileProvider', () => {
@@ -112,6 +139,26 @@ describe('LocalFileProvider', () => {
     expect(logs[0].eventMessage).toBe('GET /api/health 200 17 12ms - 127.0.0.1 - curl/8.0');
   });
 
+  it('renders flattened Error objects in metadata', async () => {
+    await writeLogFile([winstonFlattenedErrorLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toContain('error - Failed to record MCP usage');
+    expect(logs[0].eventMessage).toContain('Error: kaboom');
+    expect(logs[0].eventMessage).toContain('Stack Trace:\nError: kaboom');
+  });
+
+  it('does not mistake timing metadata for an HTTP request log', async () => {
+    await writeLogFile([winstonTimingLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toBe('info - Query finished');
+  });
+
   it('still parses legacy Vector lines', async () => {
     await writeLogFile([vectorLog]);
 
@@ -119,6 +166,16 @@ describe('LocalFileProvider', () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0].eventMessage).toBe('legacy vector line');
+  });
+
+  it('appends error details for legacy Vector error lines (metadata.level)', async () => {
+    await writeLogFile([vectorErrorLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toContain('Error: it broke');
+    expect(logs[0].eventMessage).toContain('Stack Trace:\nError: it broke');
   });
 
   it('skips unparseable and unknown-shape lines', async () => {

--- a/backend/tests/unit/local-log-provider.test.ts
+++ b/backend/tests/unit/local-log-provider.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import * as path from 'path';
+
+const logsDir = path.join(__dirname, 'test-insforge-logs');
+
+vi.mock('../../src/infra/config/app.config', () => ({
+  appConfig: {
+    server: { logsDir: path.join(__dirname, 'test-insforge-logs') },
+  },
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { LocalFileProvider } from '../../src/providers/logs/local.provider.ts';
+
+// Line shapes as written by the winston file transport (utils/logger.ts)
+const winstonAppLog = {
+  id: '1-0.1',
+  timestamp: '2026-07-01T10:00:00.000Z',
+  message: 'Server started',
+  level: 'info',
+  metadata: {},
+};
+
+const winstonErrorLog = {
+  id: '2-0.2',
+  timestamp: '2026-07-01T10:01:00.000Z',
+  message: 'Failed to sync functions',
+  level: 'error',
+  metadata: { error: 'boom', stack: 'Error: boom\n  at x.ts:1' },
+};
+
+const winstonRequestLog = {
+  id: '3-0.3',
+  timestamp: '2026-07-01T10:02:00.000Z',
+  message: 'HTTP Request',
+  level: 'info',
+  metadata: {
+    method: 'GET',
+    path: '/api/health',
+    status: 200,
+    size: 17,
+    duration: '12ms',
+    ip: '127.0.0.1',
+    userAgent: 'curl/8.0',
+  },
+};
+
+// Line shape shipped by the legacy Vector sidecar
+const vectorLog = {
+  appname: 'insforge',
+  timestamp: '2026-07-01T09:59:00.000Z',
+  event_message: 'legacy vector line',
+  metadata: { level: 'info' },
+};
+
+describe('LocalFileProvider', () => {
+  let provider: LocalFileProvider;
+
+  beforeEach(async () => {
+    await fs.mkdir(logsDir, { recursive: true });
+    provider = new LocalFileProvider();
+    await provider.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(logsDir, { recursive: true, force: true });
+  });
+
+  async function writeLogFile(lines: unknown[]) {
+    await fs.writeFile(
+      path.join(logsDir, 'insforge.logs.jsonl'),
+      lines.map((l) => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n') + '\n'
+    );
+  }
+
+  it('parses winston application log lines', async () => {
+    await writeLogFile([winstonAppLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toBe('info - Server started');
+    expect(logs[0].timestamp).toBe(winstonAppLog.timestamp);
+  });
+
+  it('appends error and stack for winston error lines', async () => {
+    await writeLogFile([winstonErrorLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toContain('error - Failed to sync functions');
+    expect(logs[0].eventMessage).toContain('Error: boom');
+    expect(logs[0].eventMessage).toContain('Stack Trace:');
+  });
+
+  it('formats winston HTTP request lines nginx-style', async () => {
+    await writeLogFile([winstonRequestLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toBe('GET /api/health 200 17 12ms - 127.0.0.1 - curl/8.0');
+  });
+
+  it('still parses legacy Vector lines', async () => {
+    await writeLogFile([vectorLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toBe('legacy vector line');
+  });
+
+  it('skips unparseable and unknown-shape lines', async () => {
+    await writeLogFile(['not json', { some: 'unrelated object' }, winstonAppLog]);
+
+    const { logs } = await provider.getLogsBySource('insforge.logs');
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].eventMessage).toBe('info - Server started');
+  });
+
+  it('respects the beforeTimestamp filter', async () => {
+    await writeLogFile([winstonAppLog, winstonErrorLog]);
+
+    const { logs } = await provider.getLogsBySource(
+      'insforge.logs',
+      100,
+      '2026-07-01T10:00:30.000Z'
+    );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].timestamp).toBe(winstonAppLog.timestamp);
+  });
+
+  it('returns empty for a missing log file', async () => {
+    const { logs, total } = await provider.getLogsBySource('postgres.logs');
+
+    expect(logs).toHaveLength(0);
+    expect(total).toBe(0);
+  });
+
+  it('searches across winston lines', async () => {
+    await writeLogFile([winstonAppLog, winstonErrorLog]);
+
+    const { logs, total } = await provider.searchLogs('boom');
+
+    expect(total).toBe(1);
+    expect(logs[0].source).toBe('insforge.logs');
+  });
+});

--- a/backend/tests/unit/logger-transports.test.ts
+++ b/backend/tests/unit/logger-transports.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import fs from 'fs/promises';
+import * as path from 'path';
+import winston from 'winston';
+
+const logsDir = path.join(__dirname, 'test-logger-logs');
+
+vi.mock('../../src/infra/config/app.config', () => ({
+  appConfig: {
+    app: { logLevel: 'info' },
+    server: { logsDir: path.join(__dirname, 'test-logger-logs') },
+  },
+}));
+
+const originalProfile = process.env.AWS_INSTANCE_PROFILE_NAME;
+
+async function importLogger() {
+  vi.resetModules();
+  const { logger } = await import('../../src/utils/logger.ts');
+  return logger;
+}
+
+describe('logger transports', () => {
+  beforeEach(() => {
+    delete process.env.AWS_INSTANCE_PROFILE_NAME;
+  });
+
+  afterEach(async () => {
+    await fs.rm(logsDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    if (originalProfile !== undefined) {
+      process.env.AWS_INSTANCE_PROFILE_NAME = originalProfile;
+    } else {
+      delete process.env.AWS_INSTANCE_PROFILE_NAME;
+    }
+  });
+
+  it('writes insforge.logs.jsonl when self-hosted', async () => {
+    const logger = await importLogger();
+
+    expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(true);
+
+    // The directory is created eagerly so the file transport can open its stream
+    await expect(fs.access(logsDir)).resolves.toBeUndefined();
+  });
+
+  it('round-trips a winston line through LocalFileProvider', async () => {
+    const logger = await importLogger();
+
+    logger.info('Round trip works');
+
+    const { LocalFileProvider } = await import('../../src/providers/logs/local.provider.ts');
+    const provider = new LocalFileProvider();
+    await provider.initialize();
+
+    // The file transport flushes asynchronously; poll briefly. initialize()
+    // itself logs through the same logger, so match the exact line.
+    let matches: { eventMessage: string }[] = [];
+    for (let i = 0; i < 20 && matches.length === 0; i++) {
+      const { logs } = await provider.getLogsBySource('insforge.logs');
+      matches = logs.filter((l) => l.eventMessage === 'info - Round trip works');
+      if (matches.length === 0) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+
+    expect(matches).toHaveLength(1);
+  });
+
+  it('does not add a file transport in cloud environments', async () => {
+    process.env.AWS_INSTANCE_PROFILE_NAME = 'insforge-instance-profile';
+
+    const logger = await importLogger();
+
+    expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
+    expect(logger.transports.some((t) => t instanceof winston.transports.Console)).toBe(true);
+    await expect(fs.access(logsDir)).rejects.toThrow();
+  });
+});

--- a/backend/tests/unit/logger-transports.test.ts
+++ b/backend/tests/unit/logger-transports.test.ts
@@ -40,33 +40,50 @@ describe('logger transports', () => {
   it('writes insforge.logs.jsonl when self-hosted', async () => {
     const logger = await importLogger();
 
-    expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(true);
+    const file = logger.transports.find(
+      (t): t is winston.transports.FileTransportInstance => t instanceof winston.transports.File
+    );
+    expect(file).toBeDefined();
+
+    // Rotation keeps the file bounded; tailable keeps the newest entries in
+    // the base file LocalFileProvider reads
+    expect(file?.maxsize).toBe(20 * 1024 * 1024);
+    expect(file?.maxFiles).toBe(2);
+    expect(file?.tailable).toBe(true);
 
     // The directory is created eagerly so the file transport can open its stream
     await expect(fs.access(logsDir)).resolves.toBeUndefined();
   });
 
-  it('round-trips a winston line through LocalFileProvider', async () => {
+  it('round-trips winston lines through LocalFileProvider', async () => {
     const logger = await importLogger();
 
     logger.info('Round trip works');
+    // Raw Error objects must survive serialization (the prevailing call-site
+    // pattern is `logger.error('...', { error })` with a real Error)
+    logger.error('Round trip failed', { error: new Error('kaboom') });
 
     const { LocalFileProvider } = await import('../../src/providers/logs/local.provider.ts');
     const provider = new LocalFileProvider();
     await provider.initialize();
 
     // The file transport flushes asynchronously; poll briefly. initialize()
-    // itself logs through the same logger, so match the exact line.
-    let matches: { eventMessage: string }[] = [];
-    for (let i = 0; i < 20 && matches.length === 0; i++) {
+    // itself logs through the same logger, so match the exact lines.
+    let plain: { eventMessage: string }[] = [];
+    let errored: { eventMessage: string }[] = [];
+    for (let i = 0; i < 20 && (plain.length === 0 || errored.length === 0); i++) {
       const { logs } = await provider.getLogsBySource('insforge.logs');
-      matches = logs.filter((l) => l.eventMessage === 'info - Round trip works');
-      if (matches.length === 0) {
+      plain = logs.filter((l) => l.eventMessage === 'info - Round trip works');
+      errored = logs.filter((l) => l.eventMessage.startsWith('error - Round trip failed'));
+      if (plain.length === 0 || errored.length === 0) {
         await new Promise((r) => setTimeout(r, 50));
       }
     }
 
-    expect(matches).toHaveLength(1);
+    expect(plain).toHaveLength(1);
+    expect(errored).toHaveLength(1);
+    expect(errored[0].eventMessage).toContain('Error: kaboom');
+    expect(errored[0].eventMessage).toContain('Stack Trace:');
   });
 
   it('does not add a file transport in cloud environments', async () => {

--- a/backend/tests/unit/storage-url-versioning.test.ts
+++ b/backend/tests/unit/storage-url-versioning.test.ts
@@ -4,8 +4,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // stable host. The service caches the value at call time, not import time.
 vi.mock('@/utils/environment.js', () => ({
   getApiBaseUrl: () => 'https://example.test',
-  // logger.ts (pulled in transitively) gates its file transport on this
-  isCloudEnvironment: () => false,
+  // logger.ts (pulled in transitively) gates its file transport on this;
+  // report cloud so the transport is skipped and no logs/ dir is created
+  isCloudEnvironment: () => true,
 }));
 
 // Stub DatabaseManager so StorageService construction doesn't touch a pool.

--- a/backend/tests/unit/storage-url-versioning.test.ts
+++ b/backend/tests/unit/storage-url-versioning.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 // stable host. The service caches the value at call time, not import time.
 vi.mock('@/utils/environment.js', () => ({
   getApiBaseUrl: () => 'https://example.test',
+  // logger.ts (pulled in transitively) gates its file transport on this
+  isCloudEnvironment: () => false,
 }));
 
 // Stub DatabaseManager so StorageService construction doesn't touch a pool.


### PR DESCRIPTION
## Summary

Fixes [INS-420](https://linear.app/insforge/issue/INS-420/triage-why-cloud-projects-are-saving-insforge-logs-too): cloud projects were writing `/insforge-logs/insforge.logs.jsonl` inside the container even though logs already ship to CloudWatch via the awslogs driver and are read back through CloudWatchProvider. The file was an unread, unrotated duplicate growing the container filesystem.

Root cause: the winston logger had an unconditional File transport, and the Dockerfile sets `LOGS_DIR=/insforge-logs` for every containerized deployment.

While triaging, this also surfaced that self-hosted dashboard logs have been dead since the Vector sidecar was removed in April — `LocalFileProvider` skipped every line lacking the Vector `appname` field, which winston never writes.

## Changes

- `backend/src/utils/logger.ts`: only add the File transport when not in a cloud environment; create the logs directory eagerly; rotate the file (20MB, 2 files, tailable) so self-hosted disks cannot grow unbounded either.
- `backend/src/providers/logs/local.provider.ts`: parse winston's native line shape — app logs as `level - message`, HTTP request logs as nginx-style lines (matching the old Vector output), error logs with `Error:` / `Stack Trace:` appended like the CloudWatch display. Legacy Vector lines still parse. The provider now reads from `appConfig.server.logsDir`, the same directory winston writes to (the two sides previously had different bare-metal defaults).

No insforge-standalone changes needed — cloud gating keys off `AWS_INSTANCE_PROFILE_NAME`, which provisioning already sets.

## Testing

- New `local-log-provider.test.ts`: winston and legacy Vector line parsing, request/error formatting, unknown-line skipping, timestamp filter, search.
- New `logger-transports.test.ts`: file transport present when self-hosted and absent in cloud, plus a real round-trip (winston write, LocalFileProvider read) so writer and reader formats cannot drift apart.
- Typecheck, eslint, prettier clean; remaining full-suite failures are pre-existing storage/S3 tests (missing `lru-cache` types), verified to fail identically on a clean tree.

Known limit: self-host regains backend logs; postgres/postgrest/function sources still have no writer without a log shipper (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cloud containers from writing local log files and restores self‑hosted dashboard logs. Fixes INS‑420 by removing duplicate on‑disk logs in cloud and aligning the reader/writer so logs show up again.

- **Bug Fixes**
  - Gate the `winston` file transport to non‑cloud; eagerly create the logs dir; rotate (20MB, 2 files, tailable); flatten `Error` metadata before JSONL; warn if file logging init fails.
  - `LocalFileProvider`: use `appConfig.server.logsDir`; parse both `winston` JSONL and legacy Vector; format HTTP lines only when `method` and `duration` exist; include error/stack; read legacy severity from `metadata.level`.
  - Cloud behavior: no local log file; logs stay in CloudWatch to avoid container disk growth. Self‑hosted instances get rotated on‑disk logs.
  - Tests: transport gating, rotation config, real `Error` round‑trip, legacy/winston parsing; storage URL versioning suite mocks `isCloudEnvironment` to report cloud and skip file logging.

<sup>Written for commit 36aa1032620c1c37590b12ca487ffbaf48b64177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add winston file transport logging and update `LocalFileProvider` to parse winston log entries
> - Adds a rotating JSONL file transport (`insforge.logs.jsonl`, max 20MB, 2 files) to the winston logger in non-cloud environments via [`logger.ts`](https://github.com/InsForge/InsForge/pull/1621/files#diff-a1b886b6dd6d43dd9e59b8abb92e3fc8f023eaff455660b387aec996fe09cbb9); cloud environments continue to log to console only.
> - Adds a `formatEventMessage` helper to [`LocalFileProvider`](https://github.com/InsForge/InsForge/pull/1621/files#diff-30a179baec282c28f60f8c996a63cba329f6e18f077de09f140a34d4ce0a723b) that parses both legacy Vector-shaped entries and new winston file transport entries, producing nginx-style lines for HTTP requests and appending error/stack for error-level logs.
> - Updates `LocalFileProvider.initialize()` to use `appConfig.server.logsDir` instead of `process.env.LOGS_DIR`.
> - Adds unit tests for both the logger transport selection and the updated `LocalFileProvider` parsing logic.
> - Behavioral Change: `readLogsFromFile` now includes winston-formatted lines in results; previously only Vector-shaped lines (with `appname`) were returned.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1621 opened
>
> - Extended mock for `@/utils/environment.js` module to return `false` for `isCloudEnvironment()` method alongside existing `getApiBaseUrl` mock [bf91ac0]
> - Implemented error flattening in the logging pipeline [55b0eb1]
> - Modified `LocalFileProvider.formatEventMessage` to derive severity from `metadata.level` for legacy Vector-shaped entries and tightened Winston HTTP request detection [55b0eb1]
> - Updated file transport configuration error handling and added rotation settings validation in tests [55b0eb1]
> - Added test coverage for error flattening and format detection improvements [55b0eb1]
> - Changed mock return value of `isCloudEnvironment` from `false` to `true` in `vi.mock('@/utils/environment.js')` block [36aa103]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc96bc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log viewing now supports both legacy and current log formats, so more application logs can be read successfully.
  * Logging now works more reliably across environments, including cloud deployments.

* **Bug Fixes**
  * Improved log parsing to skip only unsupported or invalid lines while keeping valid entries.
  * Fixed log storage path handling so local logs are saved from the configured app settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## E2E

Deterministic Fixture E2E passed against test image `v2.2.5-ins-420`: [run 28553763736](https://github.com/InsForge/agent-e2e/actions/runs/28553763736) (passed on all three revisions of this branch) ([image build](https://github.com/InsForge/InsForge/actions/runs/28551511433)). No `agent-e2e` fixture changes needed — no fixture asserts the logs API, and the cloud log-read path (CloudWatch) is unchanged.


