### PR TITLE
Fix UI toast progress animation export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17438,7 +17438,7 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@hookform/resolvers": "^5.1.1",
         "@insforge/shared-schemas": "^1.1.51",
-        "@insforge/ui": "^0.1.5",
+        "@insforge/ui": "^0.1.6",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
@@ -17509,7 +17509,7 @@
     },
     "packages/ui": {
       "name": "@insforge/ui",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17438,7 +17438,7 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@hookform/resolvers": "^5.1.1",
         "@insforge/shared-schemas": "^1.1.51",
-        "@insforge/ui": "^0.1.6",
+        "@insforge/ui": "^0.1.7",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-popover": "^1.1.14",
@@ -17509,7 +17509,7 @@
     },
     "packages/ui": {
       "name": "@insforge/ui",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -54,7 +54,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@hookform/resolvers": "^5.1.1",
     "@insforge/shared-schemas": "^1.1.51",
-    "@insforge/ui": "^0.1.5",
+    "@insforge/ui": "^0.1.6",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -54,7 +54,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@hookform/resolvers": "^5.1.1",
     "@insforge/shared-schemas": "^1.1.51",
-    "@insforge/ui": "^0.1.6",
+    "@insforge/ui": "^0.1.7",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/ui",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": "InsForge",
   "description": "React UI component library, design tokens, and Tailwind preset for InsForge apps",
   "license": "Apache-2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "InsForge",
   "description": "React UI component library, design tokens, and Tailwind preset for InsForge apps",
   "license": "Apache-2.0",

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -164,3 +164,20 @@
 *::-webkit-scrollbar-thumb:hover {
   background-color: var(--alpha-16);
 }
+
+/* ============================================================
+   ANIMATIONS
+   ============================================================ */
+
+:root {
+  --animate-toast-progress: toast-progress linear forwards;
+}
+
+@keyframes toast-progress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -173,6 +173,10 @@
   --animate-toast-progress: toast-progress linear forwards;
 }
 
+.animate-toast-progress {
+  animation: var(--animate-toast-progress);
+}
+
 @keyframes toast-progress {
   from {
     transform: scaleX(0);

--- a/packages/ui/tailwind-preset.js
+++ b/packages/ui/tailwind-preset.js
@@ -18,15 +18,6 @@ const tailwindPreset = {
         card: 'rgb(var(--card))',
         toast: 'rgb(var(--toast))',
       },
-      keyframes: {
-        'toast-progress': {
-          from: { transform: 'scaleX(0)' },
-          to: { transform: 'scaleX(1)' },
-        },
-      },
-      animation: {
-        'toast-progress': 'toast-progress linear forwards',
-      },
     },
   },
 };


### PR DESCRIPTION
## Summary
- ship the toast progress animation token and keyframes from @insforge/ui styles.css
- bump @insforge/ui to 0.1.6 and update dashboard dependency metadata

## Verification
- cd packages/ui && npm run build
- cd packages/ui && npm run typecheck
- cd packages/ui && npm run lint
- cd packages/ui && npm test
- cd packages/dashboard && npm run typecheck
- cd packages/dashboard && npm run build
- npm run format:check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing toast progress animation in `@insforge/ui` by shipping the CSS variable, keyframes, and `.animate-toast-progress` class from `styles.css`, and removing the duplicate Tailwind preset. Toast progress bars now animate correctly in consuming apps, including the dashboard.

- **Bug Fixes**
  - Exported `--animate-toast-progress`, `@keyframes toast-progress`, and `.animate-toast-progress` in `packages/ui/src/styles.css`; removed duplicate animation/keyframes from `packages/ui/tailwind-preset.js`.

- **Dependencies**
  - Bumped `@insforge/ui` to `0.1.7` and updated the dashboard dependency.

<sup>Written for commit ede6c3a24df3c44ddfe7cd1ef0cad532b98688c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix toast progress animation in `@insforge/ui` styles
> Adds the missing `--animate-toast-progress` CSS variable and `@keyframes toast-progress` definition to [styles.css](https://github.com/InsForge/InsForge/pull/1622/files#diff-6a061dc487719fedcb0c123d09f0890af2f14789e8b8bdfa34ef1415a23804c4), which animates `scaleX` from 0 to 1. The `@insforge/ui` package is bumped to 0.1.6 and the dashboard dependency range is updated to match.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1622 opened
>
> - Removed `toast-progress` keyframes and animation from Tailwind preset configuration [fef980e]
> - Added `.animate-toast-progress` CSS utility class to the `@insforge/ui` package and bumped package version to 0.1.7 [ede6c3a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9ad292.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->