### PR TITLE
fix: remove obsolete version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - insforge-network
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
@@ -20,7 +18,7 @@ services:
     networks:
       - insforge-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes: #1617 

## Description
Removes the obsolete `version: '3.8'` attribute from the root `docker-compose.yml` file. Docker Compose V2 ignores this field and prints a warning, causing unnecessary noise during local development.

## Changes
- Removed `version: '3.8'` line from docker-compose.yml
- No functional changes to services
- Aligns with deploy/docker-compose/docker-compose.yml which already omits this attribute

## Testing
- [x] Ran `docker compose config` - no warnings
- [x] Verified services start correctly
- [x] No other changes made
- [x] Passed lint checks
- [x] Passed prettier checks

Closes #1617

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove obsolete `version` attribute from `docker-compose.yml`
> The top-level `version: '3.8'` field in [docker-compose.yml](https://github.com/InsForge/InsForge/pull/1623/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) is deprecated in recent versions of Docker Compose and no longer has any effect. Removing it eliminates the deprecation warning without changing service behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 739483e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the Compose configuration by removing an outdated top-level setting. No service behavior or environment setup changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->