### PR TITLE
Implement batch delete functionality for storage objects

### DIFF
--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -621,11 +621,7 @@ router.delete(
 
       successResponse(res, result);
     } catch (error) {
-      if (error instanceof Error && error.message.includes('Invalid')) {
-        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
-      } else {
-        next(error);
-      }
+      next(error);
     }
   }
 );

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -599,6 +599,7 @@ router.delete(
 // DELETE /api/storage/buckets/:bucketName/objects - Delete multiple objects from bucket (requires auth)
 router.delete(
   '/buckets/:bucketName/objects',
+  s3AccessKeyManagementRateLimiter,
   verifyUser,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -599,7 +599,6 @@ router.delete(
 // DELETE /api/storage/buckets/:bucketName/objects - Delete multiple objects from bucket (requires auth)
 router.delete(
   '/buckets/:bucketName/objects',
-  s3AccessKeyManagementRateLimiter,
   verifyUser,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {

--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -8,6 +8,7 @@ import { dynamicUploadSingle, handleUploadError } from '@/api/middlewares/upload
 import {
   ERROR_CODES,
   createBucketRequestSchema,
+  deleteObjectsRequestSchema,
   updateBucketRequestSchema,
   updateStorageConfigRequestSchema,
   createS3AccessKeyRequestSchema,
@@ -591,6 +592,40 @@ router.delete(
       );
     } catch (error) {
       next(error);
+    }
+  }
+);
+
+// DELETE /api/storage/buckets/:bucketName/objects - Delete multiple objects from bucket (requires auth)
+router.delete(
+  '/buckets/:bucketName/objects',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { bucketName } = req.params;
+      const validation = deleteObjectsRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError(
+          validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.STORAGE_INVALID_PARAMETER
+        );
+      }
+
+      const result = await StorageService.getInstance().deleteObjects(
+        req.user,
+        bucketName,
+        validation.data.keys,
+        !!req.hasApiKey
+      );
+
+      successResponse(res, result);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Invalid')) {
+        next(new AppError(error.message, 400, ERROR_CODES.STORAGE_INVALID_PARAMETER));
+      } else {
+        next(error);
+      }
     }
   }
 );

--- a/backend/src/providers/storage/base.provider.ts
+++ b/backend/src/providers/storage/base.provider.ts
@@ -12,6 +12,11 @@ export interface GetObjectResult extends ObjectMetadata {
   body: Readable;
 }
 
+export interface DeleteObjectsResult {
+  deleted: string[];
+  failed: Array<{ key: string; message: string }>;
+}
+
 /**
  * Storage provider interface
  * Defines the contract that all storage providers must implement
@@ -27,10 +32,7 @@ export interface StorageProvider {
   putObject(bucket: string, key: string, file: Express.Multer.File): Promise<{ etag: string }>;
   getObject(bucket: string, key: string): Promise<Buffer | null>;
   deleteObject(bucket: string, key: string): Promise<void>;
-  deleteObjects(
-    bucket: string,
-    keys: string[]
-  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }>;
+  deleteObjects(bucket: string, keys: string[]): Promise<DeleteObjectsResult>;
   createBucket(bucket: string): Promise<void>;
   deleteBucket(bucket: string): Promise<void>;
 

--- a/backend/src/providers/storage/base.provider.ts
+++ b/backend/src/providers/storage/base.provider.ts
@@ -27,6 +27,10 @@ export interface StorageProvider {
   putObject(bucket: string, key: string, file: Express.Multer.File): Promise<{ etag: string }>;
   getObject(bucket: string, key: string): Promise<Buffer | null>;
   deleteObject(bucket: string, key: string): Promise<void>;
+  deleteObjects(
+    bucket: string,
+    keys: string[]
+  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }>;
   createBucket(bucket: string): Promise<void>;
   deleteBucket(bucket: string): Promise<void>;
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -1,17 +1,22 @@
 import crypto from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
-import { StorageProvider, ObjectMetadata, GetObjectResult } from './base.provider.js';
+import {
+  StorageProvider,
+  ObjectMetadata,
+  GetObjectResult,
+  DeleteObjectsResult,
+} from './base.provider.js';
 import { getApiBaseUrl } from '@/utils/environment.js';
 import { AppError } from '@/utils/errors.js';
 import {
   ERROR_CODES,
   DownloadStrategyResponse,
+  DELETE_OBJECT_FAILURE_MESSAGE,
   UploadStrategyResponse,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 
-const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 const DELETE_OBJECTS_CONCURRENCY = 25;
 
 /**
@@ -85,10 +90,7 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
-  async deleteObjects(
-    bucket: string,
-    keys: string[]
-  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }> {
+  async deleteObjects(bucket: string, keys: string[]): Promise<DeleteObjectsResult> {
     const deleted: string[] = [];
     const failed: Array<{ key: string; message: string }> = [];
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -12,6 +12,7 @@ import {
 import logger from '@/utils/logger.js';
 
 const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
+const DELETE_OBJECTS_CONCURRENCY = 25;
 
 /**
  * Local filesystem storage implementation
@@ -88,33 +89,36 @@ export class LocalStorageProvider implements StorageProvider {
     bucket: string,
     keys: string[]
   ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }> {
-    const results = await Promise.allSettled(
-      keys.map(async (key) => {
-        await this.deleteObject(bucket, key);
-        return key;
-      })
-    );
-
     const deleted: string[] = [];
     const failed: Array<{ key: string; message: string }> = [];
 
-    results.forEach((result, index) => {
-      const key = keys[index];
-      if (result.status === 'fulfilled') {
-        deleted.push(key);
-      } else {
-        const reason = result.reason;
-        logger.warn('Local storage object delete failed', {
-          bucket,
-          key,
-          error: reason instanceof Error ? reason.message : String(reason),
-        });
-        failed.push({
-          key,
-          message: DELETE_OBJECT_FAILURE_MESSAGE,
-        });
-      }
-    });
+    for (let index = 0; index < keys.length; index += DELETE_OBJECTS_CONCURRENCY) {
+      const batchKeys = keys.slice(index, index + DELETE_OBJECTS_CONCURRENCY);
+      const results = await Promise.allSettled(
+        batchKeys.map(async (key) => {
+          await this.deleteObject(bucket, key);
+          return key;
+        })
+      );
+
+      results.forEach((result, resultIndex) => {
+        const key = batchKeys[resultIndex];
+        if (result.status === 'fulfilled') {
+          deleted.push(key);
+        } else {
+          const reason = result.reason;
+          logger.warn('Local storage object delete failed', {
+            bucket,
+            key,
+            error: reason instanceof Error ? reason.message : String(reason),
+          });
+          failed.push({
+            key,
+            message: DELETE_OBJECT_FAILURE_MESSAGE,
+          });
+        }
+      });
+    }
 
     return { deleted, failed };
   }

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -81,6 +81,36 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
+  async deleteObjects(
+    bucket: string,
+    keys: string[]
+  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }> {
+    const results = await Promise.allSettled(
+      keys.map(async (key) => {
+        await this.deleteObject(bucket, key);
+        return key;
+      })
+    );
+
+    const deleted: string[] = [];
+    const failed: Array<{ key: string; message: string }> = [];
+
+    results.forEach((result, index) => {
+      const key = keys[index];
+      if (result.status === 'fulfilled') {
+        deleted.push(key);
+      } else {
+        const reason = result.reason;
+        failed.push({
+          key,
+          message: reason instanceof Error ? reason.message : String(reason),
+        });
+      }
+    });
+
+    return { deleted, failed };
+  }
+
   async createBucket(bucket: string): Promise<void> {
     const bucketPath = this.getValidatedPath(bucket);
     await fs.mkdir(bucketPath, { recursive: true });

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -9,6 +9,9 @@ import {
   DownloadStrategyResponse,
   UploadStrategyResponse,
 } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 
 /**
  * Local filesystem storage implementation
@@ -101,9 +104,14 @@ export class LocalStorageProvider implements StorageProvider {
         deleted.push(key);
       } else {
         const reason = result.reason;
+        logger.warn('Local storage object delete failed', {
+          bucket,
+          key,
+          error: reason instanceof Error ? reason.message : String(reason),
+        });
         failed.push({
           key,
-          message: reason instanceof Error ? reason.message : String(reason),
+          message: DELETE_OBJECT_FAILURE_MESSAGE,
         });
       }
     });

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -221,6 +221,38 @@ export class S3StorageProvider implements StorageProvider {
     await this.s3Client.send(command);
   }
 
+  async deleteObjects(
+    bucket: string,
+    keys: string[]
+  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }> {
+    if (!this.s3Client) {
+      throw new Error('S3 client not initialized');
+    }
+    if (keys.length === 0) {
+      return { deleted: [], failed: [] };
+    }
+
+    const s3KeyToOriginalKey = new Map(keys.map((key) => [this.getS3Key(bucket, key), key]));
+    const command = new DeleteObjectsCommand({
+      Bucket: this.s3Bucket,
+      Delete: {
+        Objects: keys.map((key) => ({ Key: this.getS3Key(bucket, key) })),
+      },
+    });
+    const response = await this.s3Client.send(command);
+    const failed = (response.Errors ?? []).map((error) => {
+      const originalKey = error.Key ? (s3KeyToOriginalKey.get(error.Key) ?? error.Key) : '';
+      return {
+        key: originalKey,
+        message: error.Message ?? error.Code ?? 'Failed to delete object',
+      };
+    });
+    const failedKeys = new Set(failed.map((error) => error.key));
+    const deleted = keys.filter((key) => !failedKeys.has(key));
+
+    return { deleted, failed };
+  }
+
   async createBucket(_bucket: string): Promise<void> {
     // In S3 with multi-tenant, we don't create actual buckets
     // We just use folders under the app key

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -264,18 +264,12 @@ export class S3StorageProvider implements StorageProvider {
         });
       }
 
-      if (errorsWithKeys.length !== responseErrors.length) {
+      const hasUnkeyedErrors = errorsWithKeys.length !== responseErrors.length;
+      if (hasUnkeyedErrors) {
         logger.warn('S3 batch object delete returned an error without a key', {
           bucket,
           batchSize: batchKeys.length,
         });
-        failed.push(
-          ...batchKeys.map((key) => ({
-            key,
-            message: DELETE_OBJECT_FAILURE_MESSAGE,
-          }))
-        );
-        continue;
       }
 
       const batchFailed = errorsWithKeys.map((error) => {
@@ -287,7 +281,26 @@ export class S3StorageProvider implements StorageProvider {
       });
 
       const failedKeys = new Set(batchFailed.map((error) => error.key));
-      deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));
+      const responseDeleted = (response.Deleted ?? [])
+        .map((deletedObject) =>
+          deletedObject.Key ? (s3KeyToOriginalKey.get(deletedObject.Key) ?? deletedObject.Key) : ''
+        )
+        .filter((key) => key.length > 0);
+
+      if (responseDeleted.length > 0) {
+        deleted.push(...responseDeleted.filter((key) => !failedKeys.has(key)));
+      } else if (!hasUnkeyedErrors) {
+        deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));
+      } else {
+        failed.push(
+          ...batchKeys
+            .filter((key) => !failedKeys.has(key))
+            .map((key) => ({
+              key,
+              message: DELETE_OBJECT_FAILURE_MESSAGE,
+            }))
+        );
+      }
       failed.push(...batchFailed);
     }
 

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -17,8 +17,17 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import { getSignedUrl as getCloudFrontSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { Readable } from 'stream';
-import { UploadStrategyResponse, DownloadStrategyResponse } from '@insforge/shared-schemas';
-import { StorageProvider, ObjectMetadata, GetObjectResult } from './base.provider.js';
+import {
+  UploadStrategyResponse,
+  DownloadStrategyResponse,
+  DELETE_OBJECT_FAILURE_MESSAGE,
+} from '@insforge/shared-schemas';
+import {
+  StorageProvider,
+  ObjectMetadata,
+  GetObjectResult,
+  DeleteObjectsResult,
+} from './base.provider.js';
 import logger from '@/utils/logger.js';
 import { appConfig } from '@/infra/config/app.config.js';
 
@@ -43,7 +52,6 @@ function isS3NotFound(err: unknown): boolean {
 
 const ONE_HOUR_IN_SECONDS = 3600;
 const SEVEN_DAYS_IN_SECONDS = 604800;
-const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 const MAX_DELETE_OBJECTS_PER_REQUEST = 1000;
 
 /**
@@ -223,10 +231,7 @@ export class S3StorageProvider implements StorageProvider {
     await this.s3Client.send(command);
   }
 
-  async deleteObjects(
-    bucket: string,
-    keys: string[]
-  ): Promise<{ deleted: string[]; failed: Array<{ key: string; message: string }> }> {
+  async deleteObjects(bucket: string, keys: string[]): Promise<DeleteObjectsResult> {
     if (!this.s3Client) {
       throw new Error('S3 client not initialized');
     }
@@ -244,6 +249,7 @@ export class S3StorageProvider implements StorageProvider {
         Bucket: this.s3Bucket,
         Delete: {
           Objects: batchKeys.map((key) => ({ Key: this.getS3Key(bucket, key) })),
+          Quiet: true,
         },
       });
       const response = await this.s3Client.send(command);
@@ -281,26 +287,7 @@ export class S3StorageProvider implements StorageProvider {
       });
 
       const failedKeys = new Set(batchFailed.map((error) => error.key));
-      const responseDeleted = (response.Deleted ?? [])
-        .map((deletedObject) =>
-          deletedObject.Key ? (s3KeyToOriginalKey.get(deletedObject.Key) ?? deletedObject.Key) : ''
-        )
-        .filter((key) => key.length > 0);
-
-      if (responseDeleted.length > 0) {
-        deleted.push(...responseDeleted.filter((key) => !failedKeys.has(key)));
-      } else if (!hasUnkeyedErrors) {
-        deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));
-      } else {
-        failed.push(
-          ...batchKeys
-            .filter((key) => !failedKeys.has(key))
-            .map((key) => ({
-              key,
-              message: DELETE_OBJECT_FAILURE_MESSAGE,
-            }))
-        );
-      }
+      deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));
       failed.push(...batchFailed);
     }
 
@@ -335,6 +322,7 @@ export class S3StorageProvider implements StorageProvider {
             Objects: listResponse.Contents.filter((obj) => obj.Key !== undefined).map((obj) => ({
               Key: obj.Key as string,
             })),
+            Quiet: true,
           },
         });
         await this.s3Client.send(deleteCommand);

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -247,24 +247,44 @@ export class S3StorageProvider implements StorageProvider {
         },
       });
       const response = await this.s3Client.send(command);
-      const batchFailed = (response.Errors ?? []).map((error) => {
-        const originalKey = error.Key ? (s3KeyToOriginalKey.get(error.Key) ?? error.Key) : '';
-        return {
-          key: originalKey,
-          message: DELETE_OBJECT_FAILURE_MESSAGE,
-        };
-      });
+      const responseErrors = response.Errors ?? [];
+      const errorsWithKeys = responseErrors.filter(
+        (error): error is (typeof responseErrors)[number] & { Key: string } =>
+          typeof error.Key === 'string' && error.Key.length > 0
+      );
 
-      if (response.Errors?.length) {
+      if (responseErrors.length > 0) {
         logger.warn('S3 batch object delete returned errors', {
           bucket,
-          errors: response.Errors.map((error) => ({
+          errors: responseErrors.map((error) => ({
             key: error.Key,
             code: error.Code,
             message: error.Message,
           })),
         });
       }
+
+      if (errorsWithKeys.length !== responseErrors.length) {
+        logger.warn('S3 batch object delete returned an error without a key', {
+          bucket,
+          batchSize: batchKeys.length,
+        });
+        failed.push(
+          ...batchKeys.map((key) => ({
+            key,
+            message: DELETE_OBJECT_FAILURE_MESSAGE,
+          }))
+        );
+        continue;
+      }
+
+      const batchFailed = errorsWithKeys.map((error) => {
+        const originalKey = s3KeyToOriginalKey.get(error.Key) ?? error.Key;
+        return {
+          key: originalKey,
+          message: DELETE_OBJECT_FAILURE_MESSAGE,
+        };
+      });
 
       const failedKeys = new Set(batchFailed.map((error) => error.key));
       deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));

--- a/backend/src/providers/storage/s3.provider.ts
+++ b/backend/src/providers/storage/s3.provider.ts
@@ -43,6 +43,8 @@ function isS3NotFound(err: unknown): boolean {
 
 const ONE_HOUR_IN_SECONDS = 3600;
 const SEVEN_DAYS_IN_SECONDS = 604800;
+const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
+const MAX_DELETE_OBJECTS_PER_REQUEST = 1000;
 
 /**
  * S3 storage implementation
@@ -232,23 +234,42 @@ export class S3StorageProvider implements StorageProvider {
       return { deleted: [], failed: [] };
     }
 
-    const s3KeyToOriginalKey = new Map(keys.map((key) => [this.getS3Key(bucket, key), key]));
-    const command = new DeleteObjectsCommand({
-      Bucket: this.s3Bucket,
-      Delete: {
-        Objects: keys.map((key) => ({ Key: this.getS3Key(bucket, key) })),
-      },
-    });
-    const response = await this.s3Client.send(command);
-    const failed = (response.Errors ?? []).map((error) => {
-      const originalKey = error.Key ? (s3KeyToOriginalKey.get(error.Key) ?? error.Key) : '';
-      return {
-        key: originalKey,
-        message: error.Message ?? error.Code ?? 'Failed to delete object',
-      };
-    });
-    const failedKeys = new Set(failed.map((error) => error.key));
-    const deleted = keys.filter((key) => !failedKeys.has(key));
+    const deleted: string[] = [];
+    const failed: Array<{ key: string; message: string }> = [];
+
+    for (let index = 0; index < keys.length; index += MAX_DELETE_OBJECTS_PER_REQUEST) {
+      const batchKeys = keys.slice(index, index + MAX_DELETE_OBJECTS_PER_REQUEST);
+      const s3KeyToOriginalKey = new Map(batchKeys.map((key) => [this.getS3Key(bucket, key), key]));
+      const command = new DeleteObjectsCommand({
+        Bucket: this.s3Bucket,
+        Delete: {
+          Objects: batchKeys.map((key) => ({ Key: this.getS3Key(bucket, key) })),
+        },
+      });
+      const response = await this.s3Client.send(command);
+      const batchFailed = (response.Errors ?? []).map((error) => {
+        const originalKey = error.Key ? (s3KeyToOriginalKey.get(error.Key) ?? error.Key) : '';
+        return {
+          key: originalKey,
+          message: DELETE_OBJECT_FAILURE_MESSAGE,
+        };
+      });
+
+      if (response.Errors?.length) {
+        logger.warn('S3 batch object delete returned errors', {
+          bucket,
+          errors: response.Errors.map((error) => ({
+            key: error.Key,
+            code: error.Code,
+            message: error.Message,
+          })),
+        });
+      }
+
+      const failedKeys = new Set(batchFailed.map((error) => error.key));
+      deleted.push(...batchKeys.filter((key) => !failedKeys.has(key)));
+      failed.push(...batchFailed);
+    }
 
     return { deleted, failed };
   }

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -7,6 +7,7 @@ import { withUserContext } from '@/services/database/user-context.service.js';
 import { StorageRecord } from '@/types/storage.js';
 import {
   ERROR_CODES,
+  DeleteObjectsResponse,
   StorageBucketSchema,
   StorageFileSchema,
   StorageMetadataSchema,
@@ -372,6 +373,57 @@ export class StorageService {
 
     await this.provider.deleteObject(bucket, key);
     return true;
+  }
+
+  async deleteObjects(
+    ctx: UserContext | undefined,
+    bucket: string,
+    keys: string[],
+    hasApiKey: boolean = false
+  ): Promise<DeleteObjectsResponse> {
+    this.validateBucketName(bucket);
+    const uniqueKeys = [...new Set(keys)];
+    uniqueKeys.forEach((key) => this.validateKey(key));
+
+    const deleteObjectRows = async (db: PoolClient): Promise<string[]> => {
+      const result = await db.query<{ key: string }>(
+        'DELETE FROM storage.objects WHERE bucket = $1 AND key = ANY($2::text[]) RETURNING key',
+        [bucket, uniqueKeys]
+      );
+      return result.rows.map((row) => row.key);
+    };
+
+    let dbDeletedKeys: string[];
+    if (hasApiKey || ctx?.role === 'project_admin') {
+      dbDeletedKeys = await runWithRootAccess(this.getPool(), deleteObjectRows);
+    } else {
+      if (!ctx) {
+        throw new AppError('Forbidden', 403, ERROR_CODES.STORAGE_PERMISSION_DENIED);
+      }
+      dbDeletedKeys = await withUserContext(this.getPool(), ctx, deleteObjectRows);
+    }
+
+    const dbDeletedKeySet = new Set(dbDeletedKeys);
+    const notFound = uniqueKeys.filter((key) => !dbDeletedKeySet.has(key));
+    if (dbDeletedKeys.length === 0) {
+      return { deleted: [], notFound, failed: [] };
+    }
+
+    try {
+      const providerResult = await this.provider.deleteObjects(bucket, dbDeletedKeys);
+      return {
+        deleted: providerResult.deleted,
+        notFound,
+        failed: providerResult.failed,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        deleted: [],
+        notFound,
+        failed: dbDeletedKeys.map((key) => ({ key, message })),
+      };
+    }
   }
 
   async listObjects(

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -408,7 +408,9 @@ export class StorageService {
       }
       const failedKeys = new Set(failed.map((failure) => failure.key));
       return {
-        deleted: dbDeletedKeys.filter((key) => providerDeletedKeys.has(key) && !failedKeys.has(key)),
+        deleted: dbDeletedKeys.filter(
+          (key) => providerDeletedKeys.has(key) && !failedKeys.has(key)
+        ),
         notFound,
         failed,
       };

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -8,6 +8,7 @@ import { StorageRecord } from '@/types/storage.js';
 import {
   ERROR_CODES,
   DELETE_OBJECT_FAILURE_MESSAGE,
+  DeleteObjectResult,
   DeleteObjectsResponse,
   StorageBucketSchema,
   StorageFileSchema,
@@ -337,7 +338,7 @@ export class StorageService {
     hasApiKey: boolean = false
   ): Promise<boolean> {
     const result = await this.deleteObjects(ctx, bucket, [key], hasApiKey);
-    return !result.notFound.includes(key);
+    return result.results.some((entry) => entry.key === key && entry.status !== 'notFound');
   }
 
   async deleteObjects(
@@ -369,9 +370,10 @@ export class StorageService {
     }
 
     const dbDeletedKeySet = new Set(dbDeletedKeys);
-    const notFound = uniqueKeys.filter((key) => !dbDeletedKeySet.has(key));
     if (dbDeletedKeys.length === 0) {
-      return { deleted: [], notFound, failed: [] };
+      return {
+        results: uniqueKeys.map((key) => ({ key, status: 'notFound' })),
+      };
     }
 
     try {
@@ -379,12 +381,32 @@ export class StorageService {
       const providerDeletedKeys = new Set(
         providerResult.deleted.filter((key) => dbDeletedKeySet.has(key))
       );
-      const failed = providerResult.failed.filter((failure) => dbDeletedKeySet.has(failure.key));
-      const providerFailedKeys = new Set(failed.map((failure) => failure.key));
-      const unreconciledFailures = dbDeletedKeys
-        .filter((key) => !providerDeletedKeys.has(key) && !providerFailedKeys.has(key))
-        .map((key) => ({ key, message: DELETE_OBJECT_FAILURE_MESSAGE }));
-      failed.push(...unreconciledFailures);
+      const failedByKey = new Map(
+        providerResult.failed
+          .filter((failure) => dbDeletedKeySet.has(failure.key))
+          .map((failure) => [failure.key, failure.message])
+      );
+
+      const results: DeleteObjectResult[] = uniqueKeys.map((key) => {
+        if (!dbDeletedKeySet.has(key)) {
+          return { key, status: 'notFound' };
+        }
+        const failureMessage = failedByKey.get(key);
+        if (failureMessage) {
+          return { key, status: 'failed', message: failureMessage };
+        }
+        if (providerDeletedKeys.has(key)) {
+          return { key, status: 'deleted' };
+        }
+        return { key, status: 'failed', message: DELETE_OBJECT_FAILURE_MESSAGE };
+      });
+
+      const failed = results
+        .filter((result) => result.status === 'failed')
+        .map((result) => ({
+          key: result.key,
+          message: result.message ?? DELETE_OBJECT_FAILURE_MESSAGE,
+        }));
 
       if (failed.length > 0) {
         logger.warn('Storage provider batch delete partially failed after DB rows were deleted', {
@@ -392,14 +414,7 @@ export class StorageService {
           failed,
         });
       }
-      const failedKeys = new Set(failed.map((failure) => failure.key));
-      return {
-        deleted: dbDeletedKeys.filter(
-          (key) => providerDeletedKeys.has(key) && !failedKeys.has(key)
-        ),
-        notFound,
-        failed,
-      };
+      return { results };
     } catch (error) {
       logger.error('Storage provider batch delete failed', {
         bucket,
@@ -407,9 +422,11 @@ export class StorageService {
         error: error instanceof Error ? error.message : String(error),
       });
       return {
-        deleted: [],
-        notFound,
-        failed: dbDeletedKeys.map((key) => ({ key, message: DELETE_OBJECT_FAILURE_MESSAGE })),
+        results: uniqueKeys.map((key) =>
+          dbDeletedKeySet.has(key)
+            ? { key, status: 'failed', message: DELETE_OBJECT_FAILURE_MESSAGE }
+            : { key, status: 'notFound' }
+        ),
       };
     }
   }

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -27,6 +27,7 @@ const PUBLIC_BUCKET_EXPIRY = 0; // Public buckets don't expire
 const PRIVATE_BUCKET_EXPIRY = 3600; // Private buckets expire in 1 hour
 const MIN_SIGNED_URL_EXPIRY = 1; // 1 second
 const MAX_SIGNED_URL_EXPIRY = 604800; // 7 days — S3 SigV4 presign ceiling
+const DELETE_OBJECTS_FAILURE_MESSAGE = 'Failed to delete objects';
 
 type StorageObjectResult = {
   file: Buffer;
@@ -417,12 +418,12 @@ export class StorageService {
         failed: providerResult.failed,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        deleted: [],
-        notFound,
-        failed: dbDeletedKeys.map((key) => ({ key, message })),
-      };
+      logger.error('Storage provider batch delete failed', {
+        bucket,
+        keys: dbDeletedKeys,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new AppError(DELETE_OBJECTS_FAILURE_MESSAGE, 500, ERROR_CODES.INTERNAL_ERROR);
     }
   }
 

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -7,6 +7,7 @@ import { withUserContext } from '@/services/database/user-context.service.js';
 import { StorageRecord } from '@/types/storage.js';
 import {
   ERROR_CODES,
+  DELETE_OBJECT_FAILURE_MESSAGE,
   DeleteObjectsResponse,
   StorageBucketSchema,
   StorageFileSchema,
@@ -27,7 +28,6 @@ const PUBLIC_BUCKET_EXPIRY = 0; // Public buckets don't expire
 const PRIVATE_BUCKET_EXPIRY = 3600; // Private buckets expire in 1 hour
 const MIN_SIGNED_URL_EXPIRY = 1; // 1 second
 const MAX_SIGNED_URL_EXPIRY = 604800; // 7 days — S3 SigV4 presign ceiling
-const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 
 type StorageObjectResult = {
   file: Buffer;
@@ -350,38 +350,8 @@ export class StorageService {
     key: string,
     hasApiKey: boolean = false
   ): Promise<boolean> {
-    this.validateBucketName(bucket);
-    this.validateKey(key);
-
-    // DB DELETE first (RLS DELETE policy gates authorization) so a permissive
-    // SELECT + restrictive DELETE policy combo can't be exploited to destroy
-    // other users' blobs. If rowCount=0 the caller had no DELETE permission
-    // (or the row was already gone) — return false without touching storage.
-    // Provider delete then runs outside the tx; failure here leaves an orphan
-    // blob that an external GC sweep can reclaim, but never an orphan row.
-    const deleteObjectRow = async (db: PoolClient) => {
-      const result = await db.query('DELETE FROM storage.objects WHERE bucket = $1 AND key = $2', [
-        bucket,
-        key,
-      ]);
-      return (result.rowCount ?? 0) > 0;
-    };
-    let deleted: boolean;
-    if (hasApiKey || ctx?.role === 'project_admin') {
-      deleted = await runWithRootAccess(this.getPool(), deleteObjectRow);
-    } else {
-      if (!ctx) {
-        throw new AppError('Forbidden', 403, ERROR_CODES.STORAGE_PERMISSION_DENIED);
-      }
-      deleted = await withUserContext(this.getPool(), ctx, deleteObjectRow);
-    }
-
-    if (!deleted) {
-      return false;
-    }
-
-    await this.provider.deleteObject(bucket, key);
-    return true;
+    const result = await this.deleteObjects(ctx, bucket, [key], hasApiKey);
+    return !result.notFound.includes(key);
   }
 
   async deleteObjects(
@@ -420,17 +390,27 @@ export class StorageService {
 
     try {
       const providerResult = await this.provider.deleteObjects(bucket, dbDeletedKeys);
-      if (providerResult.failed.length > 0) {
+      const providerDeletedKeys = new Set(
+        providerResult.deleted.filter((key) => dbDeletedKeySet.has(key))
+      );
+      const failed = providerResult.failed.filter((failure) => dbDeletedKeySet.has(failure.key));
+      const providerFailedKeys = new Set(failed.map((failure) => failure.key));
+      const unreconciledFailures = dbDeletedKeys
+        .filter((key) => !providerDeletedKeys.has(key) && !providerFailedKeys.has(key))
+        .map((key) => ({ key, message: DELETE_OBJECT_FAILURE_MESSAGE }));
+      failed.push(...unreconciledFailures);
+
+      if (failed.length > 0) {
         logger.warn('Storage provider batch delete partially failed after DB rows were deleted', {
           bucket,
-          failed: providerResult.failed,
+          failed,
         });
       }
-      const failedKeys = new Set(providerResult.failed.map((failure) => failure.key));
+      const failedKeys = new Set(failed.map((failure) => failure.key));
       return {
-        deleted: providerResult.deleted.filter((key) => !failedKeys.has(key)),
+        deleted: dbDeletedKeys.filter((key) => providerDeletedKeys.has(key) && !failedKeys.has(key)),
         notFound,
-        failed: providerResult.failed,
+        failed,
       };
     } catch (error) {
       logger.error('Storage provider batch delete failed', {

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -27,6 +27,7 @@ const PUBLIC_BUCKET_EXPIRY = 0; // Public buckets don't expire
 const PRIVATE_BUCKET_EXPIRY = 3600; // Private buckets expire in 1 hour
 const MIN_SIGNED_URL_EXPIRY = 1; // 1 second
 const MAX_SIGNED_URL_EXPIRY = 604800; // 7 days — S3 SigV4 presign ceiling
+const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 
 type StorageObjectResult = {
   file: Buffer;
@@ -425,10 +426,11 @@ export class StorageService {
           failed: providerResult.failed,
         });
       }
+      const failedKeys = new Set(providerResult.failed.map((failure) => failure.key));
       return {
-        deleted: dbDeletedKeys,
+        deleted: providerResult.deleted.filter((key) => !failedKeys.has(key)),
         notFound,
-        failed: [],
+        failed: providerResult.failed,
       };
     } catch (error) {
       logger.error('Storage provider batch delete failed', {
@@ -437,9 +439,9 @@ export class StorageService {
         error: error instanceof Error ? error.message : String(error),
       });
       return {
-        deleted: dbDeletedKeys,
+        deleted: [],
         notFound,
-        failed: [],
+        failed: dbDeletedKeys.map((key) => ({ key, message: DELETE_OBJECT_FAILURE_MESSAGE })),
       };
     }
   }

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -27,7 +27,6 @@ const PUBLIC_BUCKET_EXPIRY = 0; // Public buckets don't expire
 const PRIVATE_BUCKET_EXPIRY = 3600; // Private buckets expire in 1 hour
 const MIN_SIGNED_URL_EXPIRY = 1; // 1 second
 const MAX_SIGNED_URL_EXPIRY = 604800; // 7 days — S3 SigV4 presign ceiling
-const DELETE_OBJECTS_FAILURE_MESSAGE = 'Failed to delete objects';
 
 type StorageObjectResult = {
   file: Buffer;
@@ -85,14 +84,22 @@ export class StorageService {
   private validateBucketName(bucket: string): void {
     // Simple validation: alphanumeric, hyphens, underscores
     if (!/^[a-zA-Z0-9_-]+$/.test(bucket)) {
-      throw new Error('Invalid bucket name. Use only letters, numbers, hyphens, and underscores.');
+      throw new AppError(
+        'Invalid bucket name. Use only letters, numbers, hyphens, and underscores.',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
   }
 
   private validateKey(key: string): void {
     // Prevent directory traversal
     if (key.includes('..') || key.startsWith('/')) {
-      throw new Error('Invalid key. Cannot use ".." or start with "/"');
+      throw new AppError(
+        'Invalid key. Cannot use ".." or start with "/"',
+        400,
+        ERROR_CODES.STORAGE_INVALID_PARAMETER
+      );
     }
   }
 
@@ -412,10 +419,16 @@ export class StorageService {
 
     try {
       const providerResult = await this.provider.deleteObjects(bucket, dbDeletedKeys);
+      if (providerResult.failed.length > 0) {
+        logger.warn('Storage provider batch delete partially failed after DB rows were deleted', {
+          bucket,
+          failed: providerResult.failed,
+        });
+      }
       return {
-        deleted: providerResult.deleted,
+        deleted: dbDeletedKeys,
         notFound,
-        failed: providerResult.failed,
+        failed: [],
       };
     } catch (error) {
       logger.error('Storage provider batch delete failed', {
@@ -423,7 +436,11 @@ export class StorageService {
         keys: dbDeletedKeys,
         error: error instanceof Error ? error.message : String(error),
       });
-      throw new AppError(DELETE_OBJECTS_FAILURE_MESSAGE, 500, ERROR_CODES.INTERNAL_ERROR);
+      return {
+        deleted: dbDeletedKeys,
+        notFound,
+        failed: [],
+      };
     }
   }
 

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs/promises', async () => {
   return {
     ...actual,
     rm: vi.fn(actual.rm),
+    unlink: vi.fn(actual.unlink),
   };
 });
 
@@ -122,6 +123,54 @@ describe('LocalStorageProvider - putObject etag', () => {
     const a = await provider.putObject('etagBucket', 'k', makeFile(Buffer.from('v1')));
     const b = await provider.putObject('etagBucket', 'k', makeFile(Buffer.from('v2')));
     expect(a.etag).not.toBe(b.etag);
+  });
+});
+
+describe('LocalStorageProvider - deleteObjects', () => {
+  const baseDir = path.join(__dirname, 'test-storage-delete-objects');
+  let provider: LocalStorageProvider;
+
+  beforeEach(async () => {
+    provider = new LocalStorageProvider(baseDir);
+    await provider.initialize();
+    await provider.createBucket('batchBucket');
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('deletes multiple files and ignores missing files', async () => {
+    await fs.mkdir(path.join(baseDir, 'batchBucket', 'folder'), { recursive: true });
+    await fs.writeFile(path.join(baseDir, 'batchBucket', 'a.txt'), 'a');
+    await fs.writeFile(path.join(baseDir, 'batchBucket', 'folder', 'b.txt'), 'b');
+
+    const result = await provider.deleteObjects('batchBucket', [
+      'a.txt',
+      'folder/b.txt',
+      'missing.txt',
+    ]);
+
+    expect(result).toEqual({
+      deleted: ['a.txt', 'folder/b.txt', 'missing.txt'],
+      failed: [],
+    });
+    await expect(fs.access(path.join(baseDir, 'batchBucket', 'a.txt'))).rejects.toThrow();
+    await expect(fs.access(path.join(baseDir, 'batchBucket', 'folder', 'b.txt'))).rejects.toThrow();
+  });
+
+  it('reports unexpected unlink failures per key', async () => {
+    vi.spyOn(fs, 'unlink').mockRejectedValueOnce(
+      Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    );
+
+    const result = await provider.deleteObjects('batchBucket', ['blocked.txt']);
+
+    expect(result).toEqual({
+      deleted: [],
+      failed: [{ key: 'blocked.txt', message: 'permission denied' }],
+    });
   });
 });
 

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -169,7 +169,7 @@ describe('LocalStorageProvider - deleteObjects', () => {
 
     expect(result).toEqual({
       deleted: [],
-      failed: [{ key: 'blocked.txt', message: 'permission denied' }],
+      failed: [{ key: 'blocked.txt', message: 'Failed to delete object' }],
     });
   });
 });

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -172,6 +172,23 @@ describe('LocalStorageProvider - deleteObjects', () => {
       failed: [{ key: 'blocked.txt', message: 'Failed to delete object' }],
     });
   });
+
+  it('limits concurrent unlink calls when deleting many files', async () => {
+    let active = 0;
+    let maxActive = 0;
+    vi.spyOn(fs, 'unlink').mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active -= 1;
+    });
+    const keys = Array.from({ length: 30 }, (_, index) => `file-${index}.txt`);
+
+    const result = await provider.deleteObjects('batchBucket', keys);
+
+    expect(result).toEqual({ deleted: keys, failed: [] });
+    expect(maxActive).toBeLessThanOrEqual(25);
+  });
 });
 
 describe('LocalStorageProvider - getDownloadStrategy versioning', () => {

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -442,6 +442,77 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
   });
 
+  it('batch deletes objects for project_admin JWT callers through root access', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const svc = StorageService.getInstance();
+    const provider = {
+      deleteObjects: vi.fn(async () => ({
+        deleted: ['a.txt'],
+        failed: [{ key: 'b.txt', message: 'provider denied' }],
+      })),
+    };
+    (svc as unknown as { provider: typeof provider }).provider = provider;
+
+    queryResults = [{ rows: [{ key: 'a.txt' }, { key: 'b.txt' }], rowCount: 2 }];
+
+    const result = await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', [
+      'a.txt',
+      'b.txt',
+      'missing.txt',
+      'a.txt',
+    ]);
+
+    expect(result).toEqual({
+      deleted: ['a.txt'],
+      notFound: ['missing.txt'],
+      failed: [{ key: 'b.txt', message: 'provider denied' }],
+    });
+    expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['a.txt', 'b.txt']);
+    expect(calls.map((c) => c.sql)).toEqual([
+      'DELETE FROM storage.objects WHERE bucket = $1 AND key = ANY($2::text[]) RETURNING key',
+    ]);
+    expect(calls[0].params).toEqual(['photos', ['a.txt', 'b.txt', 'missing.txt']]);
+  });
+
+  it('batch deletes objects through withUserContext for authenticated callers', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const svc = StorageService.getInstance();
+    const provider = {
+      deleteObjects: vi.fn(async () => ({ deleted: ['mine.txt'], failed: [] })),
+    };
+    (svc as unknown as { provider: typeof provider }).provider = provider;
+
+    queryResults = [
+      { rows: [], rowCount: 0 }, // BEGIN
+      { rows: [], rowCount: 0 }, // SET LOCAL ROLE authenticated
+      { rows: [], rowCount: 0 }, // set_config(claims)
+      { rows: [{ key: 'mine.txt' }], rowCount: 1 }, // RLS-authorized delete
+      { rows: [], rowCount: 0 }, // COMMIT
+      { rows: [], rowCount: 0 }, // RESET ROLE
+    ];
+
+    const result = await svc.deleteObjects(
+      { id: 'alice-sub', email: 'alice@example.com', role: 'authenticated' },
+      'photos',
+      ['mine.txt', 'not-mine.txt']
+    );
+
+    expect(result).toEqual({
+      deleted: ['mine.txt'],
+      notFound: ['not-mine.txt'],
+      failed: [],
+    });
+    expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['mine.txt']);
+    expect(calls.map((c) => c.sql)).toEqual([
+      'BEGIN',
+      'SET LOCAL ROLE authenticated',
+      'SELECT set_config($1, $2, true)',
+      'DELETE FROM storage.objects WHERE bucket = $1 AND key = ANY($2::text[]) RETURNING key',
+      'COMMIT',
+      'RESET ROLE',
+    ]);
+  });
+
   it('returns true for public bucket objects without requiring user context', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -508,9 +508,11 @@ describe('StorageService.getObjectMetadataVisible — RLS-gated visibility check
     ]);
 
     expect(result).toEqual({
-      deleted: ['a.txt'],
-      notFound: ['missing.txt'],
-      failed: [{ key: 'b.txt', message: 'provider denied' }],
+      results: [
+        { key: 'a.txt', status: 'deleted' },
+        { key: 'b.txt', status: 'failed', message: 'provider denied' },
+        { key: 'missing.txt', status: 'notFound' },
+      ],
     });
     expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['a.txt', 'b.txt']);
     expect(calls.map((c) => c.sql)).toEqual([
@@ -543,9 +545,10 @@ describe('StorageService.getObjectMetadataVisible — RLS-gated visibility check
     );
 
     expect(result).toEqual({
-      deleted: ['mine.txt'],
-      notFound: ['not-mine.txt'],
-      failed: [],
+      results: [
+        { key: 'mine.txt', status: 'deleted' },
+        { key: 'not-mine.txt', status: 'notFound' },
+      ],
     });
     expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['mine.txt']);
     expect(calls.map((c) => c.sql)).toEqual([
@@ -577,9 +580,10 @@ describe('StorageService.getObjectMetadataVisible — RLS-gated visibility check
     ]);
 
     expect(result).toEqual({
-      deleted: ['a.txt'],
-      notFound: [],
-      failed: [{ key: 'b.txt', message: 'Failed to delete object' }],
+      results: [
+        { key: 'a.txt', status: 'deleted' },
+        { key: 'b.txt', status: 'failed', message: 'Failed to delete object' },
+      ],
     });
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       'Storage provider batch delete partially failed after DB rows were deleted',
@@ -607,9 +611,7 @@ describe('StorageService.getObjectMetadataVisible — RLS-gated visibility check
     ]);
 
     expect(result).toEqual({
-      deleted: [],
-      notFound: [],
-      failed: [{ key: 'a.txt', message: 'Failed to delete object' }],
+      results: [{ key: 'a.txt', status: 'failed', message: 'Failed to delete object' }],
     });
     expect(loggerMocks.error).toHaveBeenCalledWith('Storage provider batch delete failed', {
       bucket: 'photos',

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Pool, PoolClient } from 'pg';
 
+const loggerMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: loggerMocks,
+}));
+
 // Mock the database manager so StorageService can be instantiated without
 // touching a real pool. The service caches the pool internally; we hand it
 // our mock via a controlled getInstance/getPool flow.
@@ -36,6 +46,9 @@ function makeMockPool(): Pool {
 describe('StorageService.objectIsVisible — RLS-gated visibility check', () => {
   beforeEach(async () => {
     mockPool = makeMockPool();
+    loggerMocks.info.mockClear();
+    loggerMocks.error.mockClear();
+    loggerMocks.warn.mockClear();
     vi.resetModules();
   });
 
@@ -463,9 +476,9 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
 
     expect(result).toEqual({
-      deleted: ['a.txt'],
+      deleted: ['a.txt', 'b.txt'],
       notFound: ['missing.txt'],
-      failed: [{ key: 'b.txt', message: 'provider denied' }],
+      failed: [],
     });
     expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['a.txt', 'b.txt']);
     expect(calls.map((c) => c.sql)).toEqual([
@@ -513,9 +526,8 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
   });
 
-  it('throws a sanitized error when the provider batch delete fails unexpectedly', async () => {
+  it('reports DB-deleted objects as deleted when the provider batch delete fails unexpectedly', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
-    const { AppError } = await import('@/utils/errors.js');
     const svc = StorageService.getInstance();
     const provider = {
       deleteObjects: vi.fn(async () => {
@@ -526,16 +538,40 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
 
     queryResults = [{ rows: [{ key: 'a.txt' }], rowCount: 1 }];
 
+    const result = await svc.deleteObjects(
+      { id: 'local:admin', role: 'project_admin' },
+      'photos',
+      ['a.txt']
+    );
+
+    expect(result).toEqual({
+      deleted: ['a.txt'],
+      notFound: [],
+      failed: [],
+    });
+    expect(loggerMocks.error).toHaveBeenCalledWith('Storage provider batch delete failed', {
+      bucket: 'photos',
+      keys: ['a.txt'],
+      error: '/var/private/storage/photos/a.txt permission denied',
+    });
+  });
+
+  it('rejects invalid batch delete keys as storage validation errors before querying', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const { AppError } = await import('@/utils/errors.js');
+    const svc = StorageService.getInstance();
+
     try {
-      await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', ['a.txt']);
+      await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', ['../bad']);
       throw new Error('Expected deleteObjects to throw');
     } catch (error) {
       expect(error).toBeInstanceOf(AppError);
       expect(error).toMatchObject({
-        message: 'Failed to delete objects',
-        statusCode: 500,
+        message: 'Invalid key. Cannot use ".." or start with "/"',
+        statusCode: 400,
       });
     }
+    expect(calls).toEqual([]);
   });
 
   it('returns true for public bucket objects without requiring user context', async () => {

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -538,11 +538,9 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
 
     queryResults = [{ rows: [{ key: 'a.txt' }], rowCount: 1 }];
 
-    const result = await svc.deleteObjects(
-      { id: 'local:admin', role: 'project_admin' },
-      'photos',
-      ['a.txt']
-    );
+    const result = await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', [
+      'a.txt',
+    ]);
 
     expect(result).toEqual({
       deleted: ['a.txt'],

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -476,9 +476,9 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
 
     expect(result).toEqual({
-      deleted: ['a.txt', 'b.txt'],
+      deleted: ['a.txt'],
       notFound: ['missing.txt'],
-      failed: [],
+      failed: [{ key: 'b.txt', message: 'provider denied' }],
     });
     expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['a.txt', 'b.txt']);
     expect(calls.map((c) => c.sql)).toEqual([
@@ -526,7 +526,7 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
   });
 
-  it('reports DB-deleted objects as deleted when the provider batch delete fails unexpectedly', async () => {
+  it('reports DB-deleted objects as failed when the provider batch delete fails unexpectedly', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();
     const provider = {
@@ -543,9 +543,9 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
 
     expect(result).toEqual({
-      deleted: ['a.txt'],
+      deleted: [],
       notFound: [],
-      failed: [],
+      failed: [{ key: 'a.txt', message: 'Failed to delete object' }],
     });
     expect(loggerMocks.error).toHaveBeenCalledWith('Storage provider batch delete failed', {
       bucket: 'photos',

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -513,6 +513,31 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     ]);
   });
 
+  it('throws a sanitized error when the provider batch delete fails unexpectedly', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const { AppError } = await import('@/utils/errors.js');
+    const svc = StorageService.getInstance();
+    const provider = {
+      deleteObjects: vi.fn(async () => {
+        throw new Error('/var/private/storage/photos/a.txt permission denied');
+      }),
+    };
+    (svc as unknown as { provider: typeof provider }).provider = provider;
+
+    queryResults = [{ rows: [{ key: 'a.txt' }], rowCount: 1 }];
+
+    try {
+      await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', ['a.txt']);
+      throw new Error('Expected deleteObjects to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect(error).toMatchObject({
+        message: 'Failed to delete objects',
+        statusCode: 500,
+      });
+    }
+  });
+
   it('returns true for public bucket objects without requiring user context', async () => {
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -436,11 +436,11 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     const { StorageService } = await import('@/services/storage/storage.service.js');
     const svc = StorageService.getInstance();
     const provider = {
-      deleteObject: vi.fn(async () => {}),
+      deleteObjects: vi.fn(async () => ({ deleted: ['note.txt'], failed: [] })),
     };
     (svc as unknown as { provider: typeof provider }).provider = provider;
 
-    queryResults = [{ rows: [], rowCount: 1 }];
+    queryResults = [{ rows: [{ key: 'note.txt' }], rowCount: 1 }];
 
     const deleted = await svc.deleteObject(
       { id: 'local:admin', role: 'project_admin' },
@@ -449,10 +449,40 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
     );
 
     expect(deleted).toBe(true);
-    expect(provider.deleteObject).toHaveBeenCalledWith('photos', 'note.txt');
+    expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['note.txt']);
     expect(calls.map((c) => c.sql)).toEqual([
-      'DELETE FROM storage.objects WHERE bucket = $1 AND key = $2',
+      'DELETE FROM storage.objects WHERE bucket = $1 AND key = ANY($2::text[]) RETURNING key',
     ]);
+  });
+
+  it('returns true for single deletes after the DB row is deleted even when provider cleanup fails', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const svc = StorageService.getInstance();
+    const provider = {
+      deleteObjects: vi.fn(async () => ({
+        deleted: [],
+        failed: [{ key: 'note.txt', message: 'provider denied' }],
+      })),
+    };
+    (svc as unknown as { provider: typeof provider }).provider = provider;
+
+    queryResults = [{ rows: [{ key: 'note.txt' }], rowCount: 1 }];
+
+    const deleted = await svc.deleteObject(
+      { id: 'local:admin', role: 'project_admin' },
+      'photos',
+      'note.txt'
+    );
+
+    expect(deleted).toBe(true);
+    expect(provider.deleteObjects).toHaveBeenCalledWith('photos', ['note.txt']);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      'Storage provider batch delete partially failed after DB rows were deleted',
+      {
+        bucket: 'photos',
+        failed: [{ key: 'note.txt', message: 'provider denied' }],
+      }
+    );
   });
 
   it('batch deletes objects for project_admin JWT callers through root access', async () => {
@@ -524,6 +554,38 @@ describe('StorageService.objectIsVisible — RLS-gated visibility check', () => 
       'COMMIT',
       'RESET ROLE',
     ]);
+  });
+
+  it('reports DB-deleted objects as failed when provider result omits them', async () => {
+    const { StorageService } = await import('@/services/storage/storage.service.js');
+    const svc = StorageService.getInstance();
+    const provider = {
+      deleteObjects: vi.fn(async () => ({
+        deleted: ['a.txt'],
+        failed: [],
+      })),
+    };
+    (svc as unknown as { provider: typeof provider }).provider = provider;
+
+    queryResults = [{ rows: [{ key: 'a.txt' }, { key: 'b.txt' }], rowCount: 2 }];
+
+    const result = await svc.deleteObjects({ id: 'local:admin', role: 'project_admin' }, 'photos', [
+      'a.txt',
+      'b.txt',
+    ]);
+
+    expect(result).toEqual({
+      deleted: ['a.txt'],
+      notFound: [],
+      failed: [{ key: 'b.txt', message: 'Failed to delete object' }],
+    });
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      'Storage provider batch delete partially failed after DB rows were deleted',
+      {
+        bucket: 'photos',
+        failed: [{ key: 'b.txt', message: 'Failed to delete object' }],
+      }
+    );
   });
 
   it('reports DB-deleted objects as failed when the provider batch delete fails unexpectedly', async () => {

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -9,6 +9,7 @@ const storageMocks = vi.hoisted(() => ({
   getObjectMetadataRow: vi.fn(),
   getObject: vi.fn(),
   objectIsVisible: vi.fn(),
+  deleteObjects: vi.fn(),
 }));
 
 const authMocks = vi.hoisted(() => ({
@@ -112,9 +113,10 @@ describe('Storage routes', () => {
   test('batch delete route validates body and delegates to storage service', async () => {
     vi.resetModules();
     storageMocks.deleteObjects.mockResolvedValue({
-      deleted: ['a.txt'],
-      notFound: ['missing.txt'],
-      failed: [],
+      results: [
+        { key: 'a.txt', status: 'deleted' },
+        { key: 'missing.txt', status: 'notFound' },
+      ],
     });
 
     const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
@@ -140,9 +142,10 @@ describe('Storage routes', () => {
 
     expect(response.statusCode, response.body).toBe(200);
     expect(JSON.parse(response.body)).toEqual({
-      deleted: ['a.txt'],
-      notFound: ['missing.txt'],
-      failed: [],
+      results: [
+        { key: 'a.txt', status: 'deleted' },
+        { key: 'missing.txt', status: 'notFound' },
+      ],
     });
     expect(storageMocks.deleteObjects).toHaveBeenCalledWith(
       undefined,

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -6,6 +6,7 @@ const storageMocks = vi.hoisted(() => ({
   isBucketPublic: vi.fn(),
   objectIsVisible: vi.fn(),
   getDownloadStrategy: vi.fn(),
+  deleteObjects: vi.fn(),
 }));
 
 const authMocks = vi.hoisted(() => ({
@@ -14,26 +15,43 @@ const authMocks = vi.hoisted(() => ({
 }));
 
 const requestMethod = (
-  method: 'GET' | 'POST',
+  method: 'DELETE' | 'GET' | 'POST',
   port: number,
-  path: string
+  path: string,
+  body?: string
 ): Promise<{ statusCode: number; body: string }> =>
   new Promise((resolve, reject) => {
-    const request = http.request({ hostname: '127.0.0.1', port, path, method }, (response) => {
-      let body = '';
-      response.setEncoding('utf8');
-      response.on('data', (chunk) => {
-        body += chunk;
-      });
-      response.on('end', () => resolve({ statusCode: response.statusCode ?? 0, body }));
-    });
+    const headers = body
+      ? {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        }
+      : undefined;
+    const request = http.request(
+      { hostname: '127.0.0.1', port, path, method, headers },
+      (response) => {
+        let responseBody = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        response.on('end', () =>
+          resolve({ statusCode: response.statusCode ?? 0, body: responseBody })
+        );
+      }
+    );
 
     request.on('error', reject);
+    if (body) {
+      request.write(body);
+    }
     request.end();
   });
 
 const post = (port: number, path: string) => requestMethod('POST', port, path);
 const get = (port: number, path: string) => requestMethod('GET', port, path);
+const deleteJson = (port: number, path: string, body: string) =>
+  requestMethod('DELETE', port, path, body);
 
 const routeErrorHandler: ErrorRequestHandler = (error, _req, res, next) => {
   void next;
@@ -87,6 +105,77 @@ describe('Storage routes', () => {
     server?.close();
     server = undefined;
     vi.clearAllMocks();
+  });
+
+  test('batch delete route validates body and delegates to storage service', async () => {
+    vi.resetModules();
+    storageMocks.deleteObjects.mockResolvedValue({
+      deleted: ['a.txt'],
+      notFound: ['missing.txt'],
+      failed: [],
+    });
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await deleteJson(
+      address.port,
+      '/api/storage/buckets/photos/objects',
+      JSON.stringify({ keys: ['a.txt', 'missing.txt'] })
+    );
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      deleted: ['a.txt'],
+      notFound: ['missing.txt'],
+      failed: [],
+    });
+    expect(storageMocks.deleteObjects).toHaveBeenCalledWith(
+      undefined,
+      'photos',
+      ['a.txt', 'missing.txt'],
+      false
+    );
+  });
+
+  test('batch delete route returns 400 for an empty key list', async () => {
+    vi.resetModules();
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await deleteJson(
+      address.port,
+      '/api/storage/buckets/photos/objects',
+      JSON.stringify({ keys: [] })
+    );
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(storageMocks.deleteObjects).not.toHaveBeenCalled();
   });
 
   test('download strategy route captures nested object keys', async () => {

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from 'vitest';
 import { S3StorageProvider } from '../../src/providers/storage/s3.provider.ts';
-import { CopyObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  CopyObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import crypto from 'crypto';
 
@@ -141,6 +146,36 @@ describe('S3StorageProvider — branch fallback', () => {
       const p = makeProvider('parentkey');
       await expect(p.headObject('photos', 'a.txt')).rejects.toThrow();
       expect(sendMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteObjects', () => {
+    it('sends one DeleteObjectsCommand and maps S3 errors back to original keys', async () => {
+      sendMock.mockResolvedValueOnce({
+        Errors: [
+          {
+            Key: 'branchkey/photos/b.txt',
+            Code: 'AccessDenied',
+            Message: 'denied',
+          },
+        ],
+      });
+      const p = makeProvider('parentkey');
+
+      const result = await p.deleteObjects('photos', ['a.txt', 'b.txt']);
+
+      expect(result).toEqual({
+        deleted: ['a.txt'],
+        failed: [{ key: 'b.txt', message: 'denied' }],
+      });
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const command = sendMock.mock.calls[0][0] as DeleteObjectsCommand;
+      expect(command.input).toMatchObject({
+        Bucket: 'bucket',
+        Delete: {
+          Objects: [{ Key: 'branchkey/photos/a.txt' }, { Key: 'branchkey/photos/b.txt' }],
+        },
+      });
     });
   });
 

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -174,6 +174,7 @@ describe('S3StorageProvider — branch fallback', () => {
         Bucket: 'bucket',
         Delete: {
           Objects: [{ Key: 'branchkey/photos/a.txt' }, { Key: 'branchkey/photos/b.txt' }],
+          Quiet: true,
         },
       });
     });
@@ -190,14 +191,15 @@ describe('S3StorageProvider — branch fallback', () => {
       const firstCommand = sendMock.mock.calls[0][0] as DeleteObjectsCommand;
       const secondCommand = sendMock.mock.calls[1][0] as DeleteObjectsCommand;
       expect(firstCommand.input.Delete?.Objects).toHaveLength(1000);
+      expect(firstCommand.input.Delete?.Quiet).toBe(true);
       expect(secondCommand.input.Delete?.Objects).toEqual([
         { Key: 'branchkey/photos/file-1000.txt' },
       ]);
+      expect(secondCommand.input.Delete?.Quiet).toBe(true);
     });
 
-    it('preserves confirmed deleted keys when S3 returns an error without a key', async () => {
+    it('reports keys absent from keyed S3 errors as deleted when S3 returns an error without a key', async () => {
       sendMock.mockResolvedValueOnce({
-        Deleted: [{ Key: 'branchkey/photos/a.txt' }],
         Errors: [
           {
             Code: 'InternalError',
@@ -210,7 +212,7 @@ describe('S3StorageProvider — branch fallback', () => {
       const result = await p.deleteObjects('photos', ['a.txt', 'b.txt']);
 
       expect(result).toEqual({
-        deleted: ['a.txt'],
+        deleted: ['a.txt', 'b.txt'],
         failed: [],
       });
     });

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -166,7 +166,7 @@ describe('S3StorageProvider — branch fallback', () => {
 
       expect(result).toEqual({
         deleted: ['a.txt'],
-        failed: [{ key: 'b.txt', message: 'denied' }],
+        failed: [{ key: 'b.txt', message: 'Failed to delete object' }],
       });
       expect(sendMock).toHaveBeenCalledTimes(1);
       const command = sendMock.mock.calls[0][0] as DeleteObjectsCommand;
@@ -176,6 +176,23 @@ describe('S3StorageProvider — branch fallback', () => {
           Objects: [{ Key: 'branchkey/photos/a.txt' }, { Key: 'branchkey/photos/b.txt' }],
         },
       });
+    });
+
+    it('chunks deletes into S3-compatible batches of 1000 objects', async () => {
+      sendMock.mockResolvedValue({});
+      const p = makeProvider('parentkey');
+      const keys = Array.from({ length: 1001 }, (_, index) => `file-${index}.txt`);
+
+      const result = await p.deleteObjects('photos', keys);
+
+      expect(result).toEqual({ deleted: keys, failed: [] });
+      expect(sendMock).toHaveBeenCalledTimes(2);
+      const firstCommand = sendMock.mock.calls[0][0] as DeleteObjectsCommand;
+      const secondCommand = sendMock.mock.calls[1][0] as DeleteObjectsCommand;
+      expect(firstCommand.input.Delete?.Objects).toHaveLength(1000);
+      expect(secondCommand.input.Delete?.Objects).toEqual([
+        { Key: 'branchkey/photos/file-1000.txt' },
+      ]);
     });
   });
 

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -195,8 +195,9 @@ describe('S3StorageProvider — branch fallback', () => {
       ]);
     });
 
-    it('marks the whole batch failed when S3 returns an error without a key', async () => {
+    it('preserves confirmed deleted keys when S3 returns an error without a key', async () => {
       sendMock.mockResolvedValueOnce({
+        Deleted: [{ Key: 'branchkey/photos/a.txt' }],
         Errors: [
           {
             Code: 'InternalError',
@@ -209,11 +210,8 @@ describe('S3StorageProvider — branch fallback', () => {
       const result = await p.deleteObjects('photos', ['a.txt', 'b.txt']);
 
       expect(result).toEqual({
-        deleted: [],
-        failed: [
-          { key: 'a.txt', message: 'Failed to delete object' },
-          { key: 'b.txt', message: 'Failed to delete object' },
-        ],
+        deleted: ['a.txt'],
+        failed: [],
       });
     });
   });

--- a/backend/tests/unit/storage-s3-fallback.test.ts
+++ b/backend/tests/unit/storage-s3-fallback.test.ts
@@ -194,6 +194,28 @@ describe('S3StorageProvider — branch fallback', () => {
         { Key: 'branchkey/photos/file-1000.txt' },
       ]);
     });
+
+    it('marks the whole batch failed when S3 returns an error without a key', async () => {
+      sendMock.mockResolvedValueOnce({
+        Errors: [
+          {
+            Code: 'InternalError',
+            Message: 'missing key',
+          },
+        ],
+      });
+      const p = makeProvider('parentkey');
+
+      const result = await p.deleteObjects('photos', ['a.txt', 'b.txt']);
+
+      expect(result).toEqual({
+        deleted: [],
+        failed: [
+          { key: 'a.txt', message: 'Failed to delete object' },
+          { key: 'b.txt', message: 'Failed to delete object' },
+        ],
+      });
+    });
   });
 
   describe('getObjectStream', () => {

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -392,6 +392,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - deleted
+                  - notFound
+                  - failed
                 properties:
                   deleted:
                     type: array
@@ -405,6 +409,9 @@ paths:
                     type: array
                     items:
                       type: object
+                      required:
+                        - key
+                        - message
                       properties:
                         key:
                           type: string

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -353,6 +353,7 @@ paths:
 
     delete:
       summary: Delete Multiple Objects
+      description: Deletes up to 1000 objects from a bucket for the authenticated caller. Object row deletion is authorized through storage RLS, and the response reports per-key outcomes for rows deleted from the database, keys not visible or missing, and provider-level failures.
       tags:
         - Client
       security:

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -394,37 +394,35 @@ paths:
               schema:
                 type: object
                 required:
-                  - deleted
-                  - notFound
-                  - failed
+                  - results
                 properties:
-                  deleted:
-                    type: array
-                    items:
-                      type: string
-                  notFound:
-                    type: array
-                    items:
-                      type: string
-                  failed:
+                  results:
                     type: array
                     items:
                       type: object
                       required:
                         - key
-                        - message
+                        - status
                       properties:
                         key:
                           type: string
+                        status:
+                          type: string
+                          enum:
+                            - deleted
+                            - notFound
+                            - failed
                         message:
                           type: string
+                          description: Present when status is failed.
               example:
-                deleted:
-                  - users/user123.jpg
-                notFound:
-                  - users/missing.png
-                failed:
+                results:
+                  - key: users/user123.jpg
+                    status: deleted
+                  - key: users/missing.png
+                    status: notFound
                   - key: users/locked.png
+                    status: failed
                     message: Failed to delete object
         '400':
           description: Invalid bucket name or object keys

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -351,6 +351,86 @@ paths:
                 statusCode: 404
                 nextActions: "Create the bucket first"
 
+    delete:
+      summary: Delete Multiple Objects
+      tags:
+        - Client
+      security:
+        - apiKey: []
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9_-]+$'
+          example: avatars
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - keys
+              properties:
+                keys:
+                  type: array
+                  minItems: 1
+                  maxItems: 1000
+                  items:
+                    type: string
+                    minLength: 1
+            example:
+              keys:
+                - users/user123.jpg
+                - users/user456.png
+      responses:
+        '200':
+          description: Batch delete result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: array
+                    items:
+                      type: string
+                  notFound:
+                    type: array
+                    items:
+                      type: string
+                  failed:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        message:
+                          type: string
+              example:
+                deleted:
+                  - users/user123.jpg
+                notFound:
+                  - users/missing.png
+                failed:
+                  - key: users/locked.png
+                    message: Failed to delete object
+        '400':
+          description: Invalid bucket name or object keys
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Permission denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/storage/buckets/{bucketName}/upload-strategy:
     post:
       summary: Get Upload Strategy (Direct or Presigned URL)

--- a/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
+++ b/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiClientMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+}));
+
+vi.mock('#lib/api/client', () => ({
+  apiClient: apiClientMock,
+}));
+
+import { storageService } from '#features/storage/services/storage.service';
+
+describe('storageService', () => {
+  beforeEach(() => {
+    apiClientMock.request.mockReset();
+    apiClientMock.withAccessToken.mockClear();
+  });
+
+  it('deletes objects with one batch DELETE request', async () => {
+    apiClientMock.request.mockResolvedValue({
+      deleted: ['a.txt'],
+      notFound: ['missing.txt'],
+      failed: [{ key: 'blocked.txt', message: 'Access denied' }],
+    });
+
+    const result = await storageService.deleteObjects('photos', [
+      'a.txt',
+      'missing.txt',
+      'blocked.txt',
+    ]);
+
+    expect(apiClientMock.request).toHaveBeenCalledWith('/storage/buckets/photos/objects', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ keys: ['a.txt', 'missing.txt', 'blocked.txt'] }),
+    });
+    expect(result.success).toEqual(['a.txt']);
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0]).toMatchObject({
+      key: 'missing.txt',
+      error: new Error('Object not found'),
+    });
+    expect(result.failures[1]).toMatchObject({
+      key: 'blocked.txt',
+      error: new Error('Access denied'),
+    });
+  });
+
+  it('does not call the API for an empty delete list', async () => {
+    await expect(storageService.deleteObjects('photos', [])).resolves.toEqual({
+      success: [],
+      failures: [],
+    });
+
+    expect(apiClientMock.request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
+++ b/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
@@ -55,4 +55,46 @@ describe('storageService', () => {
 
     expect(apiClientMock.request).not.toHaveBeenCalled();
   });
+
+  it('chunks deletes into batches of 1000 objects', async () => {
+    apiClientMock.request
+      .mockResolvedValueOnce({
+        deleted: Array.from({ length: 1000 }, (_, index) => `file-${index}.txt`),
+        notFound: [],
+        failed: [],
+      })
+      .mockResolvedValueOnce({
+        deleted: ['file-1000.txt'],
+        notFound: [],
+        failed: [],
+      });
+    const keys = Array.from({ length: 1001 }, (_, index) => `file-${index}.txt`);
+
+    const result = await storageService.deleteObjects('photos', keys);
+
+    expect(result).toEqual({ success: keys, failures: [] });
+    expect(apiClientMock.request).toHaveBeenCalledTimes(2);
+    expect(apiClientMock.request).toHaveBeenNthCalledWith(1, '/storage/buckets/photos/objects', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ keys: keys.slice(0, 1000) }),
+    });
+    expect(apiClientMock.request).toHaveBeenNthCalledWith(2, '/storage/buckets/photos/objects', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer token' },
+      body: JSON.stringify({ keys: ['file-1000.txt'] }),
+    });
+  });
+
+  it('returns structured failures when a batch request fails', async () => {
+    apiClientMock.request.mockRejectedValue(new Error('HTTP 500'));
+
+    const result = await storageService.deleteObjects('photos', ['a.txt', 'b.txt']);
+
+    expect(result.success).toEqual([]);
+    expect(result.failures).toEqual([
+      { key: 'a.txt', error: new Error('HTTP 500') },
+      { key: 'b.txt', error: new Error('HTTP 500') },
+    ]);
+  });
 });

--- a/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
+++ b/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
@@ -19,9 +19,11 @@ describe('storageService', () => {
 
   it('deletes objects with one batch DELETE request', async () => {
     apiClientMock.request.mockResolvedValue({
-      deleted: ['a.txt'],
-      notFound: ['missing.txt'],
-      failed: [{ key: 'blocked.txt', message: 'Access denied' }],
+      results: [
+        { key: 'a.txt', status: 'deleted' },
+        { key: 'missing.txt', status: 'notFound' },
+        { key: 'blocked.txt', status: 'failed', message: 'Access denied' },
+      ],
     });
 
     const result = await storageService.deleteObjects('photos', [
@@ -59,14 +61,13 @@ describe('storageService', () => {
   it('chunks deletes into batches of 1000 objects', async () => {
     apiClientMock.request
       .mockResolvedValueOnce({
-        deleted: Array.from({ length: 1000 }, (_, index) => `file-${index}.txt`),
-        notFound: [],
-        failed: [],
+        results: Array.from({ length: 1000 }, (_, index) => ({
+          key: `file-${index}.txt`,
+          status: 'deleted',
+        })),
       })
       .mockResolvedValueOnce({
-        deleted: ['file-1000.txt'],
-        notFound: [],
-        failed: [],
+        results: [{ key: 'file-1000.txt', status: 'deleted' }],
       });
     const keys = Array.from({ length: 1001 }, (_, index) => `file-${index}.txt`);
 

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -158,14 +158,20 @@ export const storageService = {
       }
 
       const response = result.value.response;
-      success.push(...response.deleted);
-      failures.push(
-        ...response.notFound.map((key) => ({ key, error: new Error('Object not found') })),
-        ...response.failed.map((failure) => ({
-          key: failure.key,
-          error: new Error(failure.message),
-        }))
-      );
+      response.results.forEach((deleteResult) => {
+        if (deleteResult.status === 'deleted') {
+          success.push(deleteResult.key);
+          return;
+        }
+        failures.push({
+          key: deleteResult.key,
+          error: new Error(
+            deleteResult.status === 'notFound'
+              ? 'Object not found'
+              : (deleteResult.message ?? 'Failed to delete object')
+          ),
+        });
+      });
     });
 
     return {

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -11,6 +11,12 @@ export interface ListObjectsParams {
   offset?: number;
 }
 
+interface DeleteObjectsResponse {
+  deleted: string[];
+  notFound: string[];
+  failed: Array<{ key: string; message: string }>;
+}
+
 export const storageService = {
   // List all buckets
   async listBuckets(): Promise<StorageBucketSchema[]> {
@@ -120,21 +126,29 @@ export const storageService = {
     bucketName: string,
     objectKeys: string[]
   ): Promise<{ success: string[]; failures: { key: string; error: Error }[] }> {
-    const results = await Promise.allSettled(
-      objectKeys.map((key) => this.deleteObject(bucketName, key))
-    );
-    const success: string[] = [];
-    const failures: { key: string; error: Error }[] = [];
+    if (objectKeys.length === 0) {
+      return { success: [], failures: [] };
+    }
 
-    results.forEach((result, index) => {
-      if (result.status === 'fulfilled') {
-        success.push(objectKeys[index]);
-      } else {
-        failures.push({ key: objectKeys[index], error: result.reason as Error });
+    const response: DeleteObjectsResponse = await apiClient.request(
+      `/storage/buckets/${encodeURIComponent(bucketName)}/objects`,
+      {
+        method: 'DELETE',
+        headers: apiClient.withAccessToken(),
+        body: JSON.stringify({ keys: objectKeys }),
       }
-    });
+    );
 
-    return { success, failures };
+    return {
+      success: response.deleted,
+      failures: [
+        ...response.notFound.map((key) => ({ key, error: new Error('Object not found') })),
+        ...response.failed.map((failure) => ({
+          key: failure.key,
+          error: new Error(failure.message),
+        })),
+      ],
+    };
   },
 
   // Create a new bucket

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -1,8 +1,10 @@
 import { apiClient } from '#lib/api/client';
 import {
+  DELETE_OBJECTS_MAX_KEYS,
   StorageFileSchema,
   StorageBucketSchema,
   ListObjectsResponseSchema,
+  type DeleteObjectsResponse,
 } from '@insforge/shared-schemas';
 
 export interface ListObjectsParams {
@@ -10,14 +12,6 @@ export interface ListObjectsParams {
   limit?: number;
   offset?: number;
 }
-
-interface DeleteObjectsResponse {
-  deleted: string[];
-  notFound: string[];
-  failed: Array<{ key: string; message: string }>;
-}
-
-const DELETE_OBJECTS_BATCH_SIZE = 1000;
 
 export const storageService = {
   // List all buckets
@@ -133,8 +127,8 @@ export const storageService = {
     }
 
     const batches: string[][] = [];
-    for (let index = 0; index < objectKeys.length; index += DELETE_OBJECTS_BATCH_SIZE) {
-      batches.push(objectKeys.slice(index, index + DELETE_OBJECTS_BATCH_SIZE));
+    for (let index = 0; index < objectKeys.length; index += DELETE_OBJECTS_MAX_KEYS) {
+      batches.push(objectKeys.slice(index, index + DELETE_OBJECTS_MAX_KEYS));
     }
 
     const results = await Promise.allSettled(

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -17,6 +17,8 @@ interface DeleteObjectsResponse {
   failed: Array<{ key: string; message: string }>;
 }
 
+const DELETE_OBJECTS_BATCH_SIZE = 1000;
+
 export const storageService = {
   // List all buckets
   async listBuckets(): Promise<StorageBucketSchema[]> {
@@ -130,24 +132,51 @@ export const storageService = {
       return { success: [], failures: [] };
     }
 
-    const response: DeleteObjectsResponse = await apiClient.request(
-      `/storage/buckets/${encodeURIComponent(bucketName)}/objects`,
-      {
-        method: 'DELETE',
-        headers: apiClient.withAccessToken(),
-        body: JSON.stringify({ keys: objectKeys }),
-      }
+    const batches: string[][] = [];
+    for (let index = 0; index < objectKeys.length; index += DELETE_OBJECTS_BATCH_SIZE) {
+      batches.push(objectKeys.slice(index, index + DELETE_OBJECTS_BATCH_SIZE));
+    }
+
+    const results = await Promise.allSettled(
+      batches.map(async (keys) => {
+        const response: DeleteObjectsResponse = await apiClient.request(
+          `/storage/buckets/${encodeURIComponent(bucketName)}/objects`,
+          {
+            method: 'DELETE',
+            headers: apiClient.withAccessToken(),
+            body: JSON.stringify({ keys }),
+          }
+        );
+        return { keys, response };
+      })
     );
 
-    return {
-      success: response.deleted,
-      failures: [
+    const success: string[] = [];
+    const failures: { key: string; error: Error }[] = [];
+
+    results.forEach((result, index) => {
+      const keys = batches[index];
+      if (result.status === 'rejected') {
+        const error =
+          result.reason instanceof Error ? result.reason : new Error(String(result.reason));
+        failures.push(...keys.map((key) => ({ key, error })));
+        return;
+      }
+
+      const response = result.value.response;
+      success.push(...response.deleted);
+      failures.push(
         ...response.notFound.map((key) => ({ key, error: new Error('Object not found') })),
         ...response.failed.map((failure) => ({
           key: failure.key,
           error: new Error(failure.message),
-        })),
-      ],
+        }))
+      );
+    });
+
+    return {
+      success,
+      failures,
     };
   },
 

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { storageConfigSchema, storageFileSchema } from './storage.schema.js';
 
 export const DELETE_OBJECTS_MAX_KEYS = 1000;
+export const DELETE_OBJECT_FAILURE_MESSAGE = 'Failed to delete object';
 
 export const createBucketRequestSchema = z.object({
   bucketName: z.string().min(1, 'Bucket name cannot be empty'),

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { storageConfigSchema, storageFileSchema } from './storage.schema.js';
 
+export const DELETE_OBJECTS_MAX_KEYS = 1000;
+
 export const createBucketRequestSchema = z.object({
   bucketName: z.string().min(1, 'Bucket name cannot be empty'),
   isPublic: z.boolean().default(true),
@@ -23,7 +25,10 @@ export const deleteObjectsRequestSchema = z.object({
   keys: z
     .array(z.string().min(1, 'Object key cannot be empty'))
     .min(1, 'At least one object key is required')
-    .max(1000, 'Cannot delete more than 1000 objects at once'),
+    .max(
+      DELETE_OBJECTS_MAX_KEYS,
+      `Cannot delete more than ${DELETE_OBJECTS_MAX_KEYS} objects at once`
+    ),
 });
 
 export const deleteObjectsResponseSchema = z.object({

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -19,6 +19,24 @@ export const listObjectsResponseSchema = z.object({
   }),
 });
 
+export const deleteObjectsRequestSchema = z.object({
+  keys: z
+    .array(z.string().min(1, 'Object key cannot be empty'))
+    .min(1, 'At least one object key is required')
+    .max(1000, 'Cannot delete more than 1000 objects at once'),
+});
+
+export const deleteObjectsResponseSchema = z.object({
+  deleted: z.array(z.string()),
+  notFound: z.array(z.string()),
+  failed: z.array(
+    z.object({
+      key: z.string(),
+      message: z.string(),
+    })
+  ),
+});
+
 // Upload strategy schemas
 export const uploadStrategyRequestSchema = z.object({
   filename: z.string().min(1, 'Filename cannot be empty'),
@@ -66,6 +84,8 @@ export const getStorageConfigResponseSchema = storageConfigSchema;
 export type CreateBucketRequest = z.infer<typeof createBucketRequestSchema>;
 export type UpdateBucketRequest = z.infer<typeof updateBucketRequestSchema>;
 export type ListObjectsResponseSchema = z.infer<typeof listObjectsResponseSchema>;
+export type DeleteObjectsRequest = z.infer<typeof deleteObjectsRequestSchema>;
+export type DeleteObjectsResponse = z.infer<typeof deleteObjectsResponseSchema>;
 export type UploadStrategyRequest = z.infer<typeof uploadStrategyRequestSchema>;
 export type UploadStrategyResponse = z.infer<typeof uploadStrategyResponseSchema>;
 export type DownloadStrategyResponse = z.infer<typeof downloadStrategyResponseSchema>;

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -32,15 +32,14 @@ export const deleteObjectsRequestSchema = z.object({
     ),
 });
 
+export const deleteObjectResultSchema = z.object({
+  key: z.string(),
+  status: z.enum(['deleted', 'notFound', 'failed']),
+  message: z.string().optional(),
+});
+
 export const deleteObjectsResponseSchema = z.object({
-  deleted: z.array(z.string()),
-  notFound: z.array(z.string()),
-  failed: z.array(
-    z.object({
-      key: z.string(),
-      message: z.string(),
-    })
-  ),
+  results: z.array(deleteObjectResultSchema),
 });
 
 // Upload strategy schemas
@@ -91,6 +90,7 @@ export type CreateBucketRequest = z.infer<typeof createBucketRequestSchema>;
 export type UpdateBucketRequest = z.infer<typeof updateBucketRequestSchema>;
 export type ListObjectsResponseSchema = z.infer<typeof listObjectsResponseSchema>;
 export type DeleteObjectsRequest = z.infer<typeof deleteObjectsRequestSchema>;
+export type DeleteObjectResult = z.infer<typeof deleteObjectResultSchema>;
 export type DeleteObjectsResponse = z.infer<typeof deleteObjectsResponseSchema>;
 export type UploadStrategyRequest = z.infer<typeof uploadStrategyRequestSchema>;
 export type UploadStrategyResponse = z.infer<typeof uploadStrategyResponseSchema>;


### PR DESCRIPTION
Closes #1598 

This PR adds native batch deletion for storage objects so the dashboard can delete multiple files with a single API call instead of looping over one DELETE request per object.

  Changes:

  - Adds DELETE /api/storage/buckets/:bucketName/objects with { keys: [...] }
  - Implements batch delete in StorageService with the existing RLS-safe DB-first flow
  - Extends local and S3 storage providers with batch deletion support
  - Updates the dashboard storage service to use the new batch endpoint
  - Adds unit tests for the backend, providers, route, and dashboard service
  - Documents the new endpoint in OpenAPI


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add safe batch delete for storage objects (1–1000 keys) with RLS-first DB deletes and per-key statuses; single deletes now reuse this reconciliation. Fulfills #1598 for the dashboard and standardizes request/response contracts and limits in `@insforge/shared-schemas`.

- New Features
  - Endpoint: DELETE `/api/storage/buckets/:bucketName/objects` with `{ keys: string[] }`; validates 1–1000; responds with `{ results: Array<{ key, status: 'deleted' | 'notFound' | 'failed', message? }> }`; invalid input returns 400.
  - Service: DB-first deletes via RLS or root for admin/API key; de-dupes keys; reconciles provider outcomes; partial provider failures are per-key `failed` (no 500s); `deleteObject` now delegates to this path; validation uses `STORAGE_INVALID_PARAMETER`.
  - Providers: add `deleteObjects`; Local (concurrency 25, missing files treated as deleted); S3 (chunks of 1000, `Quiet: true`, maps keyed errors back to original keys, tolerates unkeyed S3 errors).
  - Dashboard: uses the batch endpoint, chunks by `DELETE_OBJECTS_MAX_KEYS`, maps `notFound` to "Object not found", attributes batch HTTP errors per key, skips empty lists.
  - Schemas/docs/tests: centralized request/response and constants (`DELETE_OBJECTS_MAX_KEYS`, `DELETE_OBJECT_FAILURE_MESSAGE`) in `@insforge/shared-schemas`; OpenAPI updated; unit tests added for route, service, providers, and dashboard.

<sup>Written for commit c17b0b89ec7c232244d52bfab224901e22227ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add batch delete endpoint for storage objects
> - Adds a `DELETE /buckets/:bucketName/objects` route that accepts up to 1000 keys and returns per-key statuses (`deleted`, `notFound`, or `failed`).
> - `StorageService.deleteObjects` validates and deduplicates keys, enforces authorization via a SQL `DELETE ... RETURNING key`, then delegates to the storage provider for the confirmed keys.
> - Both `LocalStorageProvider` and `S3StorageProvider` implement `deleteObjects`: local uses `Promise.allSettled` with concurrency of 25; S3 uses `DeleteObjectsCommand` chunked at 1000 keys per AWS limits.
> - The frontend `storageService.deleteObjects` is rewritten to call the new endpoint in batches of `DELETE_OBJECTS_MAX_KEYS` and aggregate per-key results.
> - `StorageService.deleteObject` (single-key) is refactored to delegate to `deleteObjects` internally.
> - Behavioral Change: validation errors for bucket names and keys now throw a structured `AppError` (HTTP 400, `STORAGE_INVALID_PARAMETER`) instead of a generic `Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c17b0b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added bulk object deletion for storage (single request, up to 1,000 keys) with per-key outcomes: **deleted**, **notFound**, and **failed**.
  * Updated the dashboard storage flow to use the new bulk-delete API.
* **Bug Fixes**
  * Improved input validation and standardized “invalid parameter” and permission-denied errors.
  * Ensures partial failures are reported per key without blocking successful deletions.
* **Documentation**
  * Updated the storage OpenAPI spec with the new bulk-delete endpoint, request/response shape, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->