### PR TITLE
fix(email): reject anonymous clients from send-raw

### DIFF
--- a/backend/src/api/routes/email/index.routes.ts
+++ b/backend/src/api/routes/email/index.routes.ts
@@ -17,6 +17,17 @@ router.post(
   verifyUser,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
+      // Anonymous clients (anon key, role 'anon') must not be able to send
+      // arbitrary emails. Authenticated users and admin API keys are allowed;
+      // an admin API key leaves req.user undefined, so only 'anon' is blocked.
+      if (req.user?.role === 'anon') {
+        throw new AppError(
+          'Sending emails requires an authenticated user',
+          401,
+          ERROR_CODES.AUTH_INVALID_CREDENTIALS
+        );
+      }
+
       const validation = sendRawEmailRequestSchema.safeParse(req.body);
       if (!validation.success) {
         throw new AppError(JSON.stringify(validation.error.issues), 400, ERROR_CODES.INVALID_INPUT);


### PR DESCRIPTION
## Problem

Anonymous SDK clients authenticate with the anon key (`Bearer anon_...`), which passes `verifyUser` as role `anon`. The `/api/email/send-raw` route only required `verifyUser`, so unauthenticated clients could send arbitrary emails and received `{ error: null }` instead of an auth error.

This is the backend cause of the failing SDK integration test `should reject unauthenticated email send` — see InsForge/InsForge-sdk-js#86.

## Fix

Block role `anon` at the route, mirroring the existing `customer-portal.service.ts` precedent. Authenticated JWT users and admin API keys remain allowed (an API key leaves `req.user` undefined), so only anon is rejected with a 401.

## Testing

- `npx tsc --noEmit` clean (pre-existing unrelated `razorpay` module error aside)
- All 18 existing email unit tests pass

Fixes InsForge/InsForge-sdk-js#86

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block anonymous clients from `/api/email/send-raw` to prevent unauthenticated email sends and return a 401 instead of a silent success. Fixes the SDK test “should reject unauthenticated email send” (InsForge/InsForge-sdk-js#86).

- **Bug Fixes**
  - Reject `anon` role at the route with `AUTH_INVALID_CREDENTIALS` (401).
  - Keep behavior for authenticated JWT users and admin API keys unchanged.

<sup>Written for commit 51bb12a10a6d0a135b23bf6b590a93d61e01cc90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject anonymous users from POST /api/email/send-raw with 401
> Adds an early auth guard in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1629/files#diff-84f8c559fdb77489095a534b51b2e385b7d19d2ef34db8af266cf53c370d13ee) that checks if `req.user.role === 'anon'` and throws a 401 `AUTH_INVALID_CREDENTIALS` error before any input validation or email sending occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51bb12a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous clients can no longer use the raw email sending endpoint.
  * Requests from authenticated users continue to work as expected.
  * Unauthorized attempts now return a clear 401 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->