### PR TITLE
fix(dashboard): default project info when dashboard runs outside an iframe

### DIFF
--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -294,7 +294,7 @@ export function useCloudHosting() {
   const [projectInfo, setProjectInfo] = useState<DashboardProjectInfo | undefined>(() =>
     getParentWindow()
       ? undefined
-      : { id: getCurrentOrigin(), name: 'Project', region: '', instanceType: '' }
+      : { id: currentOrigin, name: 'Project', region: '', instanceType: '' }
   );
   const parentOriginRef = useRef<string | null>(getParentOrigin());
   const openerOriginRef = useRef<string | null>(null);

--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -286,7 +286,16 @@ function normalizeProjectInfo(
 
 export function useCloudHosting() {
   const currentOrigin = getCurrentOrigin();
-  const [projectInfo, setProjectInfo] = useState<DashboardProjectInfo>();
+  // PROJECT_INFO can only arrive from a parent iframe: REQUEST_PROJECT_INFO is
+  // posted to the parent window, and opener messages are restricted to the
+  // authorization-code types. When the dashboard runs in its own tab (partner
+  // new-tab flow), start from a default so consumers that wait on project info
+  // (e.g. the cloud login redirect) don't block forever.
+  const [projectInfo, setProjectInfo] = useState<DashboardProjectInfo | undefined>(() =>
+    getParentWindow()
+      ? undefined
+      : { id: getCurrentOrigin(), name: 'Project', region: '', instanceType: '' }
+  );
   const parentOriginRef = useRef<string | null>(getParentOrigin());
   const openerOriginRef = useRef<string | null>(null);
   const parentOriginTrustedRef = useRef(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "insforge",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "insforge",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insforge",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "InsForge - Open source backend-as-a-service with PostgreSQL and MCP integration",
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Problem

Partner deployments (Zeabur) that open the dashboard in a new tab and post the authorization code from the opener window hang forever on "Preparing dashboard..." after a successful code exchange.

The cloud login page waits for `project` to be defined before redirecting (added in commit f81ffb1c6 for branch-project routing, active for the `d_test` dashboard variant, which now serves 100% of users). But `PROJECT_INFO` can only be delivered by a parent iframe: `REQUEST_PROJECT_INFO` is posted to `window.parent`, and opener messages are restricted to the authorization-code types. In a new tab there is no parent window, so `projectInfo` stays `undefined` forever and the redirect never fires.

## Fix

Initialize `projectInfo` with the existing default shape (`{ id: origin, name: 'Project', region: '', instanceType: '' }`, same fallback `normalizeProjectInfo` uses) when there is no parent window. Iframe behavior is unchanged: with a parent present, the state still starts `undefined` and waits for the parent's `PROJECT_INFO`.

## Verification

- Frontend typecheck, eslint, and production build pass.
- Audited all `project` consumers (`useCloudProjectInfo`, `DashboardPage`, DTest components): all handle the placeholder values with existing fallbacks; the only visible difference in new-tab mode is the generic "Project" name where nothing rendered before.
- Deterministic Fixture E2E passed on the current head with test image `v2.2.5-newtab-project-info-2`: https://github.com/InsForge/agent-e2e/actions/runs/28717340786 (earlier run on the initial commit: https://github.com/InsForge/agent-e2e/actions/runs/28716673761) (no `agent-e2e` fixture changes needed — the fix is dashboard-shell behavior in the partner opener flow, not an API/SDK contract change).

## Rollout note

The Zeabur template pins `insforge-oss:v2.0.0` in-repo, but affected deployments run ≥ v2.1.5 (where the login gate first shipped). Delivering this fix to partners requires a new release and a template tag bump, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `projectInfo` in `useCloudHosting` when dashboard runs outside an iframe
> When no parent window is present (new-tab flow), `projectInfo` was left undefined. The hook now initializes it with a default object using the current origin as `id`, `'Project'` as `name`, and empty strings for `region` and `instanceType`. In iframe contexts, behavior is unchanged — `projectInfo` remains undefined until populated by the parent.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1632 opened
>
> - Replaced direct `getCurrentOrigin()` function call with previously computed `currentOrigin` constant in the `projectInfo` state default initializer within the `useCloudHosting` hook [6f396b7]
> - Bumped package version from 2.2.4 to 2.2.5 [a8a332c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31c6e14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project startup behavior when running outside an embedded parent window.
  * Projects now initialize with sensible default details instead of waiting for external configuration.
  * Embedded setups continue to wait for project information from the parent window as before.
* **Chores**
  * Bumped the application version to 2.2.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
