### PR TITLE
chore(deploy): point Zeabur template insforge-oss image at latest

### DIFF
--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -871,7 +871,7 @@ spec:
           template: PREBUILT_V2
           spec:
             source:
-                image: ghcr.io/insforge/insforge-oss:v2.2.5
+                image: ghcr.io/insforge/insforge-oss:latest
             ports:
                 - id: web
                   port: 7130

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -871,7 +871,7 @@ spec:
           template: PREBUILT_V2
           spec:
             source:
-                image: ghcr.io/insforge/insforge-oss:v2.0.0
+                image: ghcr.io/insforge/insforge-oss:v2.2.5
             ports:
                 - id: web
                   port: 7130


### PR DESCRIPTION
Changes the Zeabur template's `insforge-oss` image from the stale `v2.0.0` pin to `latest`, so new template deployments always pull the newest release (currently v2.2.6, which includes the partner new-tab login fix) without a per-release template bump.

`latest` is maintained automatically: the Build and Push Docker Image workflow re-tags it on every clean release tag push (verified: `latest` currently resolves to the same manifests as `v2.2.6`). Test-tag dispatch builds do not touch it.

Other service pins (`postgres`, `postgrest`, `deno`) already match the canonical docker-compose stack and are unchanged.

Reminder for the Zeabur registry push (`npx zeabur template update -c Q82M3Y -f template.yml`): diff against the live template first — it has been edited out-of-band before. This affects new deployments only; existing projects still need their insforge service rolled forward.

E2E gate: not run — deploy-config-only change; `template.yml` is not part of the built image or the deterministic fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Changes the Zeabur template's `insforge-oss` image from the stale `v2.0.0` pin to `latest`, so new template deployments always pull the newest release (currently v2.2.6, which includes the partner new-tab login fix) without a per-release template bump.
>
> `latest` is maintained automatically: the Build and Push Docker Image workflow re-tags it on every clean release tag push (verified: `latest` currently resolves to the same manifests as `v2.2.6`). Test-tag dispatch builds do not touch it.
>
> Other service pins (`postgres`, `postgrest`, `deno`) already match the canonical docker-compose stack and are unchanged.
>
> Reminder for the Zeabur registry push (`npx zeabur template update -c Q82M3Y -f template.yml`): diff against the live template first — it has been edited out-of-band before. This affects new deployments only; existing projects still need their insforge service rolled forward.
>
> E2E gate: not run — deploy-config-only change; `template.yml` is not part of the built image or the deterministic fixtures.
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #1634 opened
>
> - Updated `insforge` service container image tag from `v2.2.5` to `latest` in Zeabur deployment template [22cfc0b]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployed service container image to use the `latest` tag, ensuring the deployment automatically pulls the most recent bundled improvements and fixes available for the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->