### PR TITLE
fix(realtime): in-band socket re-auth and presence reconnect docs

### DIFF
--- a/backend/src/infra/socket/socket.manager.ts
+++ b/backend/src/infra/socket/socket.manager.ts
@@ -399,15 +399,9 @@ export class SocketManager {
     ack?: (response: RealtimeAuthResponse) => void
   ): void {
     try {
+      // verifyToken enforces signature + expiry and guarantees a role
+      // (defaults to 'authenticated')
       const tokenPayload = tokenManager.verifyToken(payload.token);
-
-      if (!tokenPayload.role) {
-        ack?.({
-          ok: false,
-          error: { code: ERROR_CODES.AUTH_INVALID_CREDENTIALS, message: 'Token is missing role' },
-        });
-        return;
-      }
 
       const currentUserId = socket.data.user?.id;
       if (currentUserId !== tokenPayload.sub) {
@@ -421,6 +415,8 @@ export class SocketManager {
         return;
       }
 
+      const previousRole = socket.data.user?.role;
+
       socket.data.user = {
         id: tokenPayload.sub,
         email: tokenPayload.email,
@@ -430,6 +426,14 @@ export class SocketManager {
       const metadata = this.socketMetadata.get(socket.id);
       if (metadata) {
         metadata.role = tokenPayload.role;
+      }
+
+      // Role-scoped rooms (e.g. role:project_admin DATA_UPDATE broadcasts)
+      // must track the refreshed claims, or a downgraded socket keeps
+      // receiving privileged broadcasts until it reconnects
+      if (previousRole && previousRole !== tokenPayload.role) {
+        void socket.leave(`role:${previousRole}`);
+        void socket.join(`role:${tokenPayload.role}`);
       }
 
       logger.debug('Socket re-authenticated', { socketId: socket.id, userId: tokenPayload.sub });

--- a/backend/src/infra/socket/socket.manager.ts
+++ b/backend/src/infra/socket/socket.manager.ts
@@ -12,6 +12,8 @@ import {
   type SubscribeResponse,
   type UnsubscribeChannelPayload,
   type PresenceMember,
+  type RealtimeAuthPayload,
+  type RealtimeAuthResponse,
 } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 import { AppError } from '@/utils/errors.js';
@@ -215,12 +217,10 @@ export class SocketManager {
       void socket.join(`role:${metadata.role}`);
     }
 
-    // Log connection with reconnection status
     logger.info('Socket client connected', {
       socketId: socket.id,
       userId: metadata.userId,
       role: metadata.role,
-      restoredSubscriptions: metadata.subscriptions.size,
     });
   }
 
@@ -288,6 +288,14 @@ export class SocketManager {
     socket.on(ClientEvents.REALTIME_PUBLISH, (payload: PublishEventPayload) => {
       void this.handleRealtimePublish(socket, payload);
     });
+
+    // Handle in-band re-authentication after a token refresh
+    socket.on(
+      ClientEvents.REALTIME_AUTH,
+      (payload: RealtimeAuthPayload, ack: (response: RealtimeAuthResponse) => void) => {
+        this.handleRealtimeAuth(socket, payload, ack);
+      }
+    );
 
     // Update last activity on any event
     socket.onAny(() => {
@@ -374,6 +382,62 @@ export class SocketManager {
         ok: false,
         channel,
         error: { code: ERROR_CODES.INTERNAL_ERROR, message: 'Failed to subscribe to channel' },
+      });
+    }
+  }
+
+  /**
+   * Handle in-band re-authentication with a refreshed token.
+   * Keeps the server's view of the user's claims current on long-lived
+   * connections without a disconnect/reconnect cycle. Only tokens for the
+   * same subject are accepted — identity changes require a new handshake so
+   * rooms and presence are rebuilt under the new identity.
+   */
+  private handleRealtimeAuth(
+    socket: Socket,
+    payload: RealtimeAuthPayload,
+    ack?: (response: RealtimeAuthResponse) => void
+  ): void {
+    try {
+      const tokenPayload = tokenManager.verifyToken(payload.token);
+
+      if (!tokenPayload.role) {
+        ack?.({
+          ok: false,
+          error: { code: ERROR_CODES.AUTH_INVALID_CREDENTIALS, message: 'Token is missing role' },
+        });
+        return;
+      }
+
+      const currentUserId = socket.data.user?.id;
+      if (currentUserId !== tokenPayload.sub) {
+        ack?.({
+          ok: false,
+          error: {
+            code: ERROR_CODES.REALTIME_UNAUTHORIZED,
+            message: 'Token subject does not match the connection identity; reconnect instead',
+          },
+        });
+        return;
+      }
+
+      socket.data.user = {
+        id: tokenPayload.sub,
+        email: tokenPayload.email,
+        role: tokenPayload.role,
+      };
+
+      const metadata = this.socketMetadata.get(socket.id);
+      if (metadata) {
+        metadata.role = tokenPayload.role;
+      }
+
+      logger.debug('Socket re-authenticated', { socketId: socket.id, userId: tokenPayload.sub });
+      ack?.({ ok: true });
+    } catch {
+      ack?.({
+        ok: false,
+        error: { code: ERROR_CODES.AUTH_INVALID_CREDENTIALS, message: 'Invalid token' },
       });
     }
   }

--- a/backend/src/types/socket.ts
+++ b/backend/src/types/socket.ts
@@ -25,6 +25,7 @@ export enum ClientEvents {
   REALTIME_SUBSCRIBE = 'realtime:subscribe',
   REALTIME_UNSUBSCRIBE = 'realtime:unsubscribe',
   REALTIME_PUBLISH = 'realtime:publish',
+  REALTIME_AUTH = 'realtime:auth',
 }
 
 /**

--- a/backend/tests/unit/socket-realtime-auth.test.ts
+++ b/backend/tests/unit/socket-realtime-auth.test.ts
@@ -40,6 +40,8 @@ vi.mock('@/services/realtime/realtime-presence.service.js', () => ({
 interface FakeSocket {
   id: string;
   data: { user?: { id: string; email?: string; role?: string } };
+  join: ReturnType<typeof vi.fn>;
+  leave: ReturnType<typeof vi.fn>;
 }
 
 type AuthHandler = (
@@ -69,6 +71,8 @@ function connectedSocket(userId = 'user-1'): FakeSocket {
   return {
     id: 'socket-1',
     data: { user: { id: userId, email: `${userId}@example.com`, role: 'authenticated' } },
+    join: vi.fn(),
+    leave: vi.fn(),
   };
 }
 
@@ -94,6 +98,30 @@ describe('SocketManager realtime:auth', () => {
       email: 'user-1@example.com',
       role: 'project_admin',
     });
+  });
+
+  it('moves the socket between role rooms when the refreshed token changes role', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: userToken('user-1', 'project_admin') }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ ok: true });
+    expect(socket.leave).toHaveBeenCalledWith('role:authenticated');
+    expect(socket.join).toHaveBeenCalledWith('role:project_admin');
+  });
+
+  it('does not touch role rooms when the refreshed token keeps the same role', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: userToken('user-1', 'authenticated') }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ ok: true });
+    expect(socket.leave).not.toHaveBeenCalled();
+    expect(socket.join).not.toHaveBeenCalled();
   });
 
   it('rejects a token for a different subject without touching the socket claims', async () => {

--- a/backend/tests/unit/socket-realtime-auth.test.ts
+++ b/backend/tests/unit/socket-realtime-auth.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+import type { RealtimeAuthPayload, RealtimeAuthResponse } from '@insforge/shared-schemas';
+
+const TEST_JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({ verifyApiKey: vi.fn(), verifyAnonKey: vi.fn() }),
+  },
+}));
+
+vi.mock('@/services/realtime/realtime-auth.service.js', () => ({
+  RealtimeAuthService: {
+    getInstance: () => ({ checkSubscribePermission: vi.fn() }),
+  },
+}));
+
+vi.mock('@/services/realtime/realtime-message.service.js', () => ({
+  RealtimeMessageService: {
+    getInstance: () => ({ insertMessage: vi.fn() }),
+  },
+}));
+
+vi.mock('@/services/realtime/realtime-presence.service.js', () => ({
+  RealtimePresenceService: {
+    getInstance: () => ({
+      trackMember: vi.fn(),
+      removeSocketFromRoom: vi.fn(),
+      removeSocketFromAllRooms: vi.fn(() => []),
+      clear: vi.fn(),
+    }),
+  },
+}));
+
+interface FakeSocket {
+  id: string;
+  data: { user?: { id: string; email?: string; role?: string } };
+}
+
+type AuthHandler = (
+  socket: FakeSocket,
+  payload: RealtimeAuthPayload,
+  ack?: (response: RealtimeAuthResponse) => void
+) => void;
+
+async function loadHandler(): Promise<{ handleRealtimeAuth: AuthHandler; manager: object }> {
+  vi.stubEnv('JWT_SECRET', TEST_JWT_SECRET);
+  const { SocketManager } = await import('../../src/infra/socket/socket.manager');
+  const manager = SocketManager.getInstance();
+  const handleRealtimeAuth = (
+    manager as unknown as { handleRealtimeAuth: AuthHandler }
+  ).handleRealtimeAuth.bind(manager) as AuthHandler;
+  return { handleRealtimeAuth, manager };
+}
+
+function userToken(sub: string, role = 'authenticated', expiresInSeconds = 900): string {
+  return jwt.sign({ sub, email: `${sub}@example.com`, role }, TEST_JWT_SECRET, {
+    algorithm: 'HS256',
+    expiresIn: expiresInSeconds,
+  });
+}
+
+function connectedSocket(userId = 'user-1'): FakeSocket {
+  return {
+    id: 'socket-1',
+    data: { user: { id: userId, email: `${userId}@example.com`, role: 'authenticated' } },
+  };
+}
+
+describe('SocketManager realtime:auth', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts a refreshed token for the same subject and updates the socket claims', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: userToken('user-1', 'project_admin') }, ack);
+
+    expect(ack).toHaveBeenCalledWith({ ok: true });
+    expect(socket.data.user).toEqual({
+      id: 'user-1',
+      email: 'user-1@example.com',
+      role: 'project_admin',
+    });
+  });
+
+  it('rejects a token for a different subject without touching the socket claims', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const original = { ...socket.data.user };
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: userToken('user-2') }, ack);
+
+    expect(ack).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.objectContaining({ code: 'REALTIME_UNAUTHORIZED' }),
+    });
+    expect(socket.data.user).toEqual(original);
+  });
+
+  it('rejects an expired token', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: userToken('user-1', 'authenticated', -10) }, ack);
+
+    expect(ack).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.objectContaining({ code: 'AUTH_INVALID_CREDENTIALS' }),
+    });
+  });
+
+  it('rejects a malformed token', async () => {
+    const { handleRealtimeAuth } = await loadHandler();
+    const socket = connectedSocket('user-1');
+    const ack = vi.fn();
+
+    handleRealtimeAuth(socket, { token: 'not-a-jwt' }, ack);
+
+    expect(ack).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.objectContaining({ code: 'AUTH_INVALID_CREDENTIALS' }),
+    });
+  });
+});

--- a/docs/sdks/typescript/realtime.mdx
+++ b/docs/sdks/typescript/realtime.mdx
@@ -317,6 +317,8 @@ If you render directly from `getPresenceState()`, `presence:sync` is simply your
 
 When the signed-in user's access token refreshes, the SDK re-authenticates the live connection in-band — no reconnect, no presence churn for other members. The socket only reconnects when the identity actually changes: sign-in, sign-out, or switching users.
 
+Access *reductions* apply lazily on a live connection: publishing is re-checked against RLS on every message and new subscribes are re-checked at join time, but continued receipt on already-joined channels persists until the client unsubscribes or reconnects.
+
 ## Properties
 
 | Property | Type | Description |

--- a/docs/sdks/typescript/realtime.mdx
+++ b/docs/sdks/typescript/realtime.mdx
@@ -120,6 +120,8 @@ type SubscribeResponse =
 
 `subscribe()` auto-connects if needed. Calling `connect()` explicitly is still recommended so connection event handlers are already attached.
 
+`subscribe()` is idempotent: calling it again for a channel you already joined re-requests the subscription and resolves the server's current presence snapshot. The server tracks presence per logical member, so repeated subscribes never produce duplicate members or spurious `presence:join` events.
+
 ## publish()
 
 Publish an event to a channel.
@@ -166,6 +168,7 @@ Reserved events:
 | `error` | `RealtimeErrorPayload` | Subscribe or publish failed. |
 | `presence:join` | `PresenceJoinMessage` | A logical member became present in a channel. |
 | `presence:leave` | `PresenceLeaveMessage` | A logical member is no longer present in a channel. |
+| `presence:sync` | `PresenceSyncEvent` | A fresh presence snapshot for a channel. Fired on every successful subscribe, including automatic resubscribes after a reconnect. |
 
 ## once()
 
@@ -286,6 +289,34 @@ insforge.realtime.on('presence:leave', (message) => {
 });
 ```
 
+### Reading presence state
+
+The SDK maintains the member list for every subscribed channel — seeded from the subscribe snapshot and kept current from `presence:join`/`presence:leave` deltas and reconnect resyncs. Read it at any time instead of merging deltas yourself:
+
+```typescript
+const members = insforge.realtime.getPresenceState('chat:room-1');
+```
+
+Returns an empty array for channels you are not subscribed to. While the socket is briefly disconnected it holds the last known state, replaced by a fresh snapshot as soon as the channel resubscribes.
+
+### Reconnects
+
+When the connection drops, the SDK automatically resubscribes to every channel on reconnect and emits `presence:sync` with the fresh presence snapshot for each. Members who joined or left while you were disconnected produce no individual `presence:join`/`presence:leave` deltas, so replace — don't merge — any state you keep outside the SDK:
+
+```typescript
+import type { PresenceSyncEvent } from '@insforge/sdk';
+
+insforge.realtime.on<PresenceSyncEvent>('presence:sync', ({ channel, presence }) => {
+  replaceMembers(channel, presence.members);
+});
+```
+
+If you render directly from `getPresenceState()`, `presence:sync` is simply your re-render signal. If a resubscribe is rejected (for example the user's access was revoked while disconnected), the SDK drops the channel and emits `error` instead.
+
+### Token refreshes
+
+When the signed-in user's access token refreshes, the SDK re-authenticates the live connection in-band — no reconnect, no presence churn for other members. The socket only reconnects when the identity actually changes: sign-in, sign-out, or switching users.
+
 ## Properties
 
 | Property | Type | Description |
@@ -294,6 +325,7 @@ insforge.realtime.on('presence:leave', (message) => {
 | `connectionState` | `'disconnected' \| 'connecting' \| 'connected'` | Current SDK connection state. |
 | `socketId` | `string \| undefined` | Socket.IO ID when connected. |
 | `getSubscribedChannels()` | `() => string[]` | Local list of subscribed channels. |
+| `getPresenceState(channel)` | `(channel: string) => PresenceMember[]` | Current members of a subscribed channel, maintained by the SDK. |
 
 ## Error Handling
 

--- a/docs/styles/config/vocabularies/Mintlify/accept.txt
+++ b/docs/styles/config/vocabularies/Mintlify/accept.txt
@@ -95,6 +95,8 @@ Razorpay's
 realtime
 remediations
 repo
+resync
+resyncs
 rmcp
 roocode
 runbook

--- a/packages/shared-schemas/src/realtime.schema.ts
+++ b/packages/shared-schemas/src/realtime.schema.ts
@@ -145,6 +145,35 @@ export const subscribeResponseSchema = z.discriminatedUnion('ok', [
 export type SubscribeResponse = z.infer<typeof subscribeResponseSchema>;
 
 /**
+ * Payload for realtime:auth client event — re-authenticate a live socket with
+ * a refreshed token, without dropping the connection. Only valid for the same
+ * identity; identity changes require a reconnect.
+ */
+export const realtimeAuthPayloadSchema = z.object({
+  token: z.string().min(1),
+});
+
+export type RealtimeAuthPayload = z.infer<typeof realtimeAuthPayloadSchema>;
+
+/**
+ * Response for realtime:auth (used in Socket.IO ack callbacks)
+ */
+export const realtimeAuthResponseSchema = z.discriminatedUnion('ok', [
+  z.object({
+    ok: z.literal(true),
+  }),
+  z.object({
+    ok: z.literal(false),
+    error: z.object({
+      code: z.string().min(1),
+      message: z.string().min(1),
+    }),
+  }),
+]);
+
+export type RealtimeAuthResponse = z.infer<typeof realtimeAuthResponseSchema>;
+
+/**
  * Payload for realtime:error server event (for unsolicited errors like publish failures)
  */
 export const realtimeErrorPayloadSchema = z.object({


### PR DESCRIPTION
Server half of the realtime presence-reconnect fix (SDK half: InsForge/InsForge-sdk-js#100).

## Problem

Every access-token refresh forced the SDK to bounce the socket, because the server only authenticates at handshake — there was no way to refresh a live connection's token. Combined with an SDK bug that fabricated empty presence snapshots after reconnect, every app lost presence state each token TTL.

## Changes

- New `realtime:auth` client event: verifies a refreshed JWT, requires the same subject (identity changes must reconnect so rooms/presence rebuild), updates the socket's claims, and acks ok/error. Additive and backward compatible — old SDKs never send it.
- `RealtimeAuthPayload` / `RealtimeAuthResponse` schemas in shared-schemas.
- Removed the `restoredSubscriptions` field from the connect log: socket metadata is created fresh per connection, so it always logged 0 and implied a server-side restore mechanism that doesn't exist (it sent the bug reporter chasing a red herring).
- Docs (`docs/sdks/typescript/realtime.mdx`): `subscribe()` idempotency, the `presence:sync` reserved event, `getPresenceState()`, and new "Reading presence state" / "Reconnects" / "Token refreshes" sections.

No changes to subscribe/publish/presence behavior — `trackMember` was already idempotent per logical member, which is what makes the SDK-side idempotent resubscribe safe.

## Testing

- New unit suite `backend/tests/unit/socket-realtime-auth.test.ts` (4 tests): same-subject refresh updates claims, different-subject rejected without touching claims, expired token rejected, malformed token rejected.
- Existing realtime unit suites pass; shared-schemas builds; eslint clean on changed files.
- Deterministic Fixture E2E: [passing run](https://github.com/InsForge/agent-e2e/actions/runs/28831119667) with image tag `v2.2.6-rt-presence` built from this branch. No agent-e2e fixture changes needed — the new event is additive and nothing asserted changed; fixture coverage for `realtime:auth` should land alongside the SDK release that exercises it.

Note for reviewers: earlier E2E attempts with the longer tag `v2.2.6-realtime-presence-reconnect` failed at `cloud.restart` before the image booted — insforge-cloud-backend embeds the tag in the SSM SendCommand `Comment`, which AWS caps at 100 chars, so any test tag over 28 chars fails deterministically. Follow-up: truncate that Comment in insforge-cloud-backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Server half of the realtime presence-reconnect fix (SDK half: InsForge/InsForge-sdk-js#100).
>
> ## Problem
>
> Every access-token refresh forced the SDK to bounce the socket, because the server only authenticates at handshake — there was no way to refresh a live connection's token. Combined with an SDK bug that fabricated empty presence snapshots after reconnect, every app lost presence state each token TTL.
>
> ## Changes
>
> - New `realtime:auth` client event: verifies a refreshed JWT, requires the same subject (identity changes must reconnect so rooms/presence rebuild), updates the socket's claims, and acks ok/error. Additive and backward compatible — old SDKs never send it.
> - `RealtimeAuthPayload` / `RealtimeAuthResponse` schemas in shared-schemas.
> - Removed the `restoredSubscriptions` field from the connect log: socket metadata is created fresh per connection, so it always logged 0 and implied a server-side restore mechanism that doesn't exist (it sent the bug reporter chasing a red herring).
> - Docs (`docs/sdks/typescript/realtime.mdx`): `subscribe()` idempotency, the `presence:sync` reserved event, `getPresenceState()`, and new "Reading presence state" / "Reconnects" / "Token refreshes" sections.
>
> No changes to subscribe/publish/presence behavior — `trackMember` was already idempotent per logical member, which is what makes the SDK-side idempotent resubscribe safe.
>
> ## Testing
>
> - New unit suite `backend/tests/unit/socket-realtime-auth.test.ts` (4 tests): same-subject refresh updates claims, different-subject rejected without touching claims, expired token rejected, malformed token rejected.
> - Existing realtime unit suites pass; shared-schemas builds; eslint clean on changed files.
> - Deterministic Fixture E2E: [passing run](https://github.com/InsForge/agent-e2e/actions/runs/28831119667) with image tag `v2.2.6-rt-presence` built from this branch. No agent-e2e fixture changes needed — the new event is additive and nothing asserted changed; fixture coverage for `realtime:auth` should land alongside the SDK release that exercises it.
>
> Note for reviewers: earlier E2E attempts with the longer tag `v2.2.6-realtime-presence-reconnect` failed at `cloud.restart` before the image booted — insforge-cloud-backend embeds the tag in the SSM SendCommand `Comment`, which AWS caps at 100 chars, so any test tag over 28 chars fails deterministically. Follow-up: truncate that Comment in insforge-cloud-backend.
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #1635 opened
>
> - Implemented in-band role transitions during socket re-authentication in `SocketManager.handleRealtimeAuth` [b1800d9]
> - Added test coverage for socket room transitions during re-authentication with role changes [b1800d9]
> - Clarified lazy enforcement of access reductions for live realtime connections in documentation [b1800d9]
> - Added vocabulary terms to Mintlify acceptance list [e8b8b26]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added realtime in-band authentication refresh (`realtime:auth`) so sessions can stay valid without reconnecting.

* **Bug Fixes**
  * Realtime auth now verifies identity consistency and rejects expired/malformed/invalid tokens with clear failure responses.
  * Automatically switches role-based channels when the user’s role changes during auth refresh.

* **Documentation**
  * Updated TypeScript realtime SDK docs for idempotent resubscription behavior and clarified `presence:sync`/`getPresenceState(channel)` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
