### PR TITLE
INS-435: oss backend advisor remove false positive for secdef

### DIFF
--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -7,6 +7,15 @@ import { PoolClient } from 'pg';
 // Internal/system schemas that advisor rules never report on. Kept as a single
 // source of truth so the exclusion list can't drift between rule queries.
 const ADVISOR_EXCLUDED_SCHEMAS = [
+  'ai',
+  'compute',
+  'deployments',
+  'email',
+  'functions',
+  'memory',
+  'payments',
+  'schedules',
+  'system',
   '_timescaledb_cache',
   '_timescaledb_catalog',
   '_timescaledb_config',
@@ -323,6 +332,11 @@ export class DatabaseAdvisorService {
             ) r
             WHERE p.prosecdef = true
               AND pg_catalog.has_function_privilege(role_name, p.oid, 'EXECUTE')
+              -- Trigger / event-trigger functions cannot be invoked directly via SQL
+              -- (Postgres rejects the call by return type), so an anon/authenticated
+              -- EXECUTE grant is inert and confers no escalation path. Skip them to
+              -- avoid false positives such as system.on_schema_ddl().
+              AND p.prorettype NOT IN ('pg_catalog.trigger'::regtype, 'pg_catalog.event_trigger'::regtype)
               AND n.nspname = ANY(ARRAY(SELECT trim(UNNEST(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
               AND n.nspname NOT IN (
                 ${ADVISOR_EXCLUDED_SCHEMAS}

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -332,14 +332,15 @@ export class DatabaseAdvisorService {
             ) r
             WHERE p.prosecdef = true
               AND pg_catalog.has_function_privilege(role_name, p.oid, 'EXECUTE')
-              -- Event-trigger functions fire only on DDL, can only be installed by a
-              -- superuser, and cannot be invoked by anon/authenticated at all, so an
-              -- EXECUTE grant on them is inert (this is what false-flagged
-              -- system.on_schema_ddl()). Regular row/statement trigger functions are
-              -- NOT excluded: a SECURITY DEFINER trigger on a table that anon/
-              -- authenticated can write to still runs with definer privileges via DML,
-              -- which is a real escalation path worth surfacing.
-              AND p.prorettype <> 'pg_catalog.event_trigger'::regtype
+              -- Skip trigger and event-trigger functions: neither can be invoked
+              -- directly via SQL (Postgres rejects the call by return type), so the
+              -- anon/authenticated EXECUTE grant this rule keys on is inert — that is
+              -- what false-flagged system.on_schema_ddl(). Mirrors the cloud advisor's
+              -- returnsTrigger filter. Known limitation: a SECURITY DEFINER row/
+              -- statement trigger on a table anon/authenticated can write to still runs
+              -- with definer privileges via DML; that reachability path is not modeled
+              -- by an EXECUTE-based check and would need a dedicated pg_trigger rule.
+              AND p.prorettype NOT IN ('pg_catalog.trigger'::regtype, 'pg_catalog.event_trigger'::regtype)
               AND n.nspname = ANY(ARRAY(SELECT trim(UNNEST(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
               AND n.nspname NOT IN (
                 ${ADVISOR_EXCLUDED_SCHEMAS}

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -332,11 +332,14 @@ export class DatabaseAdvisorService {
             ) r
             WHERE p.prosecdef = true
               AND pg_catalog.has_function_privilege(role_name, p.oid, 'EXECUTE')
-              -- Trigger / event-trigger functions cannot be invoked directly via SQL
-              -- (Postgres rejects the call by return type), so an anon/authenticated
-              -- EXECUTE grant is inert and confers no escalation path. Skip them to
-              -- avoid false positives such as system.on_schema_ddl().
-              AND p.prorettype NOT IN ('pg_catalog.trigger'::regtype, 'pg_catalog.event_trigger'::regtype)
+              -- Event-trigger functions fire only on DDL, can only be installed by a
+              -- superuser, and cannot be invoked by anon/authenticated at all, so an
+              -- EXECUTE grant on them is inert (this is what false-flagged
+              -- system.on_schema_ddl()). Regular row/statement trigger functions are
+              -- NOT excluded: a SECURITY DEFINER trigger on a table that anon/
+              -- authenticated can write to still runs with definer privileges via DML,
+              -- which is a real escalation path worth surfacing.
+              AND p.prorettype <> 'pg_catalog.event_trigger'::regtype
               AND n.nspname = ANY(ARRAY(SELECT trim(UNNEST(string_to_array(coalesce(current_setting('pgrst.db_schemas', 't'), 'public'), ',')))))
               AND n.nspname NOT IN (
                 ${ADVISOR_EXCLUDED_SCHEMAS}


### PR DESCRIPTION
## Problem

The database advisor's `security/dangerous-function` rule flags any SECURITY DEFINER function callable by `anon`/`authenticated`, without checking whether the grant is actually exploitable. This produces false positives on InsForge's own internal DDL-sync functions (e.g. `system.on_schema_ddl()` / `system.sync_postgrest_exposed_schemas()` from migration 056), which carry the default PUBLIC EXECUTE grant but are not developer-remediable and, for the event-trigger handler, cannot be invoked directly via SQL at all.

Reported by a user who saw a "Public Can Execute SECURITY DEFINER Function" warning right after creating a test project, with the advice to REVOKE — which would break internal DDL sync. Cloud fixed the same class of false positive in insforge-cloud-backend#708; this brings the OSS advisor in line.

Today the only thing preventing the false positive on OSS is the dynamic `pgrst.db_schemas` filter, which is fragile: the moment `system` ends up in the scanning session's `db_schemas` (role/GUC mismatch), both DDL functions get flagged. Root cause is two out-of-sync deny-lists — migration 056 treats `system` (and the other InsForge internal schemas) as internal, but `ADVISOR_EXCLUDED_SCHEMAS` did not list them.

## Fix

Two inert-grant classes are now skipped in `database-advisor.service.ts`:

- **Internal schemas**: add the InsForge platform-managed schemas (`ai, compute, deployments, email, functions, memory, payments, schedules, system`) to `ADVISOR_EXCLUDED_SCHEMAS`, mirroring the `insforge.internal_schemas` GUC from migration 056 (`auth`, `realtime`, `storage` were already present). This is the shared deny-list used by all advisor rules, so it fixes the whole class regardless of what `pgrst.db_schemas` resolves to.
- **Trigger / event-trigger functions**: add `AND p.prorettype NOT IN ('pg_catalog.trigger'::regtype, 'pg_catalog.event_trigger'::regtype)` to the `dangerous-function` query — such functions cannot be invoked directly via SQL, so an EXECUTE grant is inert.

## Verification

- `advisor.test.ts` — 11/11 pass.
- SQL-level before/after against a real InsForge DB with three representative functions: pre-fix flags 5 rows (incl. both false positives), post-fix flags only the genuinely dangerous `public` void SECDEF function.
- Real dashboard advisor UI: before-fix Security = 11 (surfaces the internal + event-trigger functions), after-fix Security = 7 (only the genuine danger remains). Genuine detection preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop flagging inert SECURITY DEFINER grants by excluding InsForge internal schemas and skipping trigger-returning functions from the scan. This removes fresh-project false positives while keeping callable SECDEF routines in scope.

- **Bug Fixes**
  - Added internal schemas (`ai`, `compute`, `deployments`, `email`, `functions`, `memory`, `payments`, `schedules`, `system`) to `ADVISOR_EXCLUDED_SCHEMAS`.
  - Updated the dangerous-function rule to exclude trigger and event-trigger functions (`prorettype IN ('pg_catalog.trigger', 'pg_catalog.event_trigger')`), since they cannot be invoked directly via SQL.

<sup>Written for commit 7e02d3512d1de3e0d362081959ef6eb84d3f767b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `exposed-security-definer` advisor rule to exclude trigger functions
> - The `exposed-security-definer` rule in [database-advisor.service.ts](https://github.com/InsForge/InsForge/pull/1636/files#diff-4ce0784cd58ec904ea6814795a6d1388a489c7b65717cb10159e593cb81c90cf) was incorrectly flagging `SECURITY DEFINER` trigger and event-trigger functions as dangerous exposures to `anon`/`authenticated` roles.
> - Adds a `WHERE` filter to exclude functions with a return type of `trigger` or `event_trigger`, since these cannot be invoked directly via SQL.
> - Also expands `ADVISOR_EXCLUDED_SCHEMAS` with internal schemas (`ai`, `compute`, `deployments`, `email`, `functions`, `memory`, `payments`, `schedules`, `system`) to suppress false positives for those namespaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e02d35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives in database advisor results by also ignoring additional internal/system schemas.
  * Improved “dangerous function” detection so event-trigger routines are no longer reported as callable functions.
  * Advisor findings should now be more relevant and easier to act on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->