### PR TITLE
feat(compute): add scaleToZero opt-out for always-on services

### DIFF
--- a/backend/src/infra/database/migrations/058_compute-services-add-scale-to-zero.sql
+++ b/backend/src/infra/database/migrations/058_compute-services-add-scale-to-zero.sql
@@ -1,0 +1,26 @@
+-- Add `scale_to_zero` column to compute.services.
+--
+-- true (default) is the existing behaviour — machines are launched with
+-- Fly autostop 'stop' + min_machines_running 0, so Fly's edge proxy stops
+-- them when idle and cold-starts them on the next request. false keeps the
+-- machine running 24/7 (autostop 'off' + min_machines_running 1) for
+-- services that can't tolerate cold-start latency.
+--
+-- Idempotent four-step pattern (same as 047_compute-services-add-protocol):
+-- `ADD COLUMN IF NOT EXISTS ... NOT NULL DEFAULT true` does not apply the
+-- constraints when the column already exists — only when it creates it —
+-- so we split.
+
+ALTER TABLE compute.services
+  ADD COLUMN IF NOT EXISTS scale_to_zero BOOLEAN;
+
+-- Backfill any rows where scale_to_zero is NULL (only possible if the
+-- column pre-existed without our DEFAULT). The NOT NULL constraint at the
+-- end would otherwise fail.
+UPDATE compute.services SET scale_to_zero = true WHERE scale_to_zero IS NULL;
+
+ALTER TABLE compute.services
+  ALTER COLUMN scale_to_zero SET DEFAULT true;
+
+ALTER TABLE compute.services
+  ALTER COLUMN scale_to_zero SET NOT NULL;

--- a/backend/src/providers/compute/compute.provider.ts
+++ b/backend/src/providers/compute/compute.provider.ts
@@ -17,6 +17,12 @@ export interface LaunchMachineParams {
    * raw TCP services. Omitting the field is identical to `'http'`.
    */
   protocol?: 'http' | 'tcp';
+  /**
+   * Scale-to-zero. `true`/omitted (default) lets Fly stop the machine when
+   * idle and cold-start it on the next request. `false` keeps one machine
+   * running 24/7 (autostop off) for latency-sensitive services.
+   */
+  scaleToZero?: boolean;
 }
 
 export interface UpdateMachineParams {
@@ -36,6 +42,11 @@ export interface UpdateMachineParams {
    * for back-compat HTTP behavior.
    */
   protocol?: 'http' | 'tcp';
+  /**
+   * Scale-to-zero — same semantics as LaunchMachineParams.scaleToZero. Omit
+   * for back-compat scale-to-zero behavior.
+   */
+  scaleToZero?: boolean;
 }
 
 export interface MachineSummary {

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -197,17 +197,29 @@ export class FlyProvider implements ComputeProvider {
     await this.request(`/apps/${appId}`, { method: 'DELETE' });
   }
 
-  // Scale-to-zero is v1's only mode — see compute-deploy.md in the skill
-  // for the rationale. Callers don't pass autostop overrides today. When
-  // we do want to expose `--autostop` / `--min-machines` CLI flags later,
-  // this is the one spot to plumb them through: extend `ScaleOptions` and
-  // pass it from launchMachine/updateMachine. The defaults stay correct
-  // regardless of how callers evolve.
+  // Scale-to-zero is the default mode — see compute-deploy.md in the skill
+  // for the rationale. Callers opt out per-service via the boolean
+  // `scaleToZero: false` on launch/update (surfaced as `--always-on` in the
+  // CLI); `scaleOptions` maps that onto the Fly autostop block. The defaults
+  // stay correct regardless of how callers evolve.
   private static readonly SCALE_TO_ZERO: ScaleOptions = {
     autostop: 'stop',
     autostart: true,
     min_machines_running: 0,
   };
+
+  // `min_machines_running: 1` (not just autostop 'off') so Fly restarts the
+  // machine if it exits — always-on services should survive crashes, not
+  // just skip the idle stop.
+  private static readonly ALWAYS_ON: ScaleOptions = {
+    autostop: 'off',
+    autostart: true,
+    min_machines_running: 1,
+  };
+
+  private static scaleOptions(scaleToZero: boolean | undefined): ScaleOptions {
+    return scaleToZero === false ? FlyProvider.ALWAYS_ON : FlyProvider.SCALE_TO_ZERO;
+  }
 
   // Single source of truth for the per-machine service block. Both launch
   // and update need to send the same shape, including the autostop fields:
@@ -262,6 +274,7 @@ export class FlyProvider implements ComputeProvider {
     envVars: Record<string, string>;
     region: string;
     protocol?: 'http' | 'tcp';
+    scaleToZero?: boolean;
   }): Promise<{ machineId: string }> {
     const guest = this.mapCpuTier(params.cpu, params.memory);
     const result = await this.requestJson<{ id: string }>(`/apps/${params.appId}/machines`, {
@@ -271,7 +284,13 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [this.serviceConfig(params.port, params.protocol ?? 'http')],
+          services: [
+            this.serviceConfig(
+              params.port,
+              params.protocol ?? 'http',
+              FlyProvider.scaleOptions(params.scaleToZero)
+            ),
+          ],
         },
         region: params.region,
       }),
@@ -288,6 +307,7 @@ export class FlyProvider implements ComputeProvider {
     memory: number;
     envVars: Record<string, string>;
     protocol?: 'http' | 'tcp';
+    scaleToZero?: boolean;
   }): Promise<void> {
     const guest = this.mapCpuTier(params.cpu, params.memory);
     await this.request(`/apps/${params.appId}/machines/${params.machineId}`, {
@@ -297,7 +317,13 @@ export class FlyProvider implements ComputeProvider {
           image: params.image,
           guest,
           env: params.envVars,
-          services: [this.serviceConfig(params.port, params.protocol ?? 'http')],
+          services: [
+            this.serviceConfig(
+              params.port,
+              params.protocol ?? 'http',
+              FlyProvider.scaleOptions(params.scaleToZero)
+            ),
+          ],
         },
       }),
     });

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -39,6 +39,11 @@ export interface CreateServiceInput {
    * the DB column defaults to `'http'`.
    */
   protocol?: 'http' | 'tcp';
+  /**
+   * Scale-to-zero — `true` (default) lets Fly stop the machine when idle,
+   * `false` keeps it running 24/7. Optional; the DB column defaults to true.
+   */
+  scaleToZero?: boolean;
 }
 
 export interface UpdateServiceInput {
@@ -61,6 +66,8 @@ export interface UpdateServiceInput {
   envVarsPatch?: { set?: Record<string, string>; unset?: string[] };
   /** Edge protocol — same semantics as CreateServiceInput.protocol. */
   protocol?: 'http' | 'tcp';
+  /** Scale-to-zero — same semantics as CreateServiceInput.scaleToZero. */
+  scaleToZero?: boolean;
 }
 
 /**
@@ -80,6 +87,7 @@ export interface DeletedServiceSnapshot {
   memory: number;
   region: string;
   protocol: 'http' | 'tcp';
+  scaleToZero: boolean;
   flyAppId: string | null;
   flyMachineId: string | null;
   endpointUrl: string | null;
@@ -101,6 +109,10 @@ interface ServiceRow {
   // column will see undefined here; mapRowToSchema normalizes to 'http' so the
   // response shape's required `protocol` field never goes out as undefined.
   protocol: 'http' | 'tcp';
+  // Backfilled to true for pre-existing rows by the 058 migration, NOT NULL
+  // going forward. mapRowToSchema normalizes undefined to true for rows read
+  // from a pre-migration DB.
+  scale_to_zero: boolean;
   fly_app_id: string | null;
   fly_machine_id: string | null;
   status: string;
@@ -125,6 +137,7 @@ function mapRowToSchema(row: ServiceRow): ServiceSchema {
     // serviceSchema would reject `undefined`. Fall back to 'http' so a stale
     // schema doesn't break the response.
     protocol: (row.protocol ?? 'http') as ServiceSchema['protocol'],
+    scaleToZero: row.scale_to_zero ?? true,
     flyAppId: row.fly_app_id,
     flyMachineId: row.fly_machine_id,
     status: row.status as ServiceSchema['status'],
@@ -348,8 +361,8 @@ export class ComputeServicesService {
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, env_vars_encrypted, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'creating')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, env_vars_encrypted, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'creating')
          RETURNING *`,
         [
           input.projectId,
@@ -360,6 +373,7 @@ export class ComputeServicesService {
           input.memory,
           input.region,
           input.protocol ?? 'http',
+          input.scaleToZero ?? true,
           envVarsEncrypted,
         ]
       );
@@ -397,6 +411,7 @@ export class ComputeServicesService {
         envVars: input.envVars ?? {},
         region: input.region,
         protocol: input.protocol,
+        scaleToZero: input.scaleToZero,
       });
       flyMachineId = machineId;
 
@@ -465,8 +480,8 @@ export class ComputeServicesService {
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, env_vars_encrypted, fly_app_id, endpoint_url, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'deploying')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, env_vars_encrypted, fly_app_id, endpoint_url, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'deploying')
          RETURNING *`,
         [
           input.projectId,
@@ -477,6 +492,7 @@ export class ComputeServicesService {
           input.memory,
           input.region,
           input.protocol ?? 'http',
+          input.scaleToZero ?? true,
           envVarsEncrypted,
           flyAppName,
           endpointUrl,
@@ -606,6 +622,10 @@ export class ComputeServicesService {
       updates.push(`protocol = $${paramIdx++}`);
       values.push(data.protocol);
     }
+    if (data.scaleToZero !== undefined) {
+      updates.push(`scale_to_zero = $${paramIdx++}`);
+      values.push(data.scaleToZero);
+    }
 
     if (updates.length === 0) {
       return existing;
@@ -615,7 +635,16 @@ export class ComputeServicesService {
     // Only commit to DB after Fly accepts the new config to avoid stale DB state.
     // `protocol` is a deploy field — switching http<->tcp swaps the Fly edge
     // handlers entirely, so it has to propagate to Fly to take effect.
-    const deployFields = ['imageUrl', 'port', 'cpu', 'memory', 'envVars', 'protocol'] as const;
+    // `scaleToZero` likewise lives in the Fly service block (autostop config).
+    const deployFields = [
+      'imageUrl',
+      'port',
+      'cpu',
+      'memory',
+      'envVars',
+      'protocol',
+      'scaleToZero',
+    ] as const;
     const hasDeployChange = deployFields.some((f) => data[f] !== undefined);
 
     // env_vars merge is needed by both Fly-touching branches (updateMachine
@@ -651,6 +680,7 @@ export class ComputeServicesService {
           memory: data.memory ?? existing.memory,
           envVars: mergedEnvVars ?? {},
           protocol: data.protocol ?? existing.protocol,
+          scaleToZero: data.scaleToZero ?? existing.scaleToZero,
         });
         logger.info('Compute service machine updated', { id });
       } catch (error) {
@@ -671,6 +701,7 @@ export class ComputeServicesService {
           envVars: mergedEnvVars ?? {},
           region: data.region ?? existing.region,
           protocol: data.protocol ?? existing.protocol,
+          scaleToZero: data.scaleToZero ?? existing.scaleToZero,
         });
         justLaunchedMachineId = machineId;
         // Persist machine id + flip status alongside the field updates below.
@@ -814,6 +845,7 @@ export class ComputeServicesService {
       memory: row.memory,
       region: row.region,
       protocol: (row.protocol ?? 'http') as 'http' | 'tcp',
+      scaleToZero: row.scale_to_zero ?? true,
       flyAppId: row.fly_app_id,
       flyMachineId: row.fly_machine_id,
       endpointUrl: row.endpoint_url,

--- a/backend/tests/unit/compute/compute-services-schemas.test.ts
+++ b/backend/tests/unit/compute/compute-services-schemas.test.ts
@@ -142,6 +142,45 @@ describe('createServiceSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // --always-on CLI flag: scaleToZero: false keeps the machine running 24/7
+  // instead of Fly stopping it when idle.
+  it('accepts scaleToZero: false', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-api',
+      imageUrl: 'node:20',
+      port: 8080,
+      scaleToZero: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.scaleToZero).toBe(false);
+    }
+  });
+
+  it('omitting scaleToZero is valid (back-compat default applied downstream)', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-api',
+      imageUrl: 'node:20',
+      port: 8080,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The schema itself leaves it undefined; services.service.ts is what
+      // falls back to true at INSERT/Fly-call time.
+      expect(result.data.scaleToZero).toBeUndefined();
+    }
+  });
+
+  it('rejects non-boolean scaleToZero', () => {
+    const result = createServiceSchema.safeParse({
+      name: 'my-svc',
+      imageUrl: 'node:20',
+      port: 8080,
+      scaleToZero: 'no',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('listServicesResponseSchema', () => {
@@ -216,6 +255,18 @@ describe('updateServiceSchema', () => {
 
   it('rejects invalid protocol on update', () => {
     const result = updateServiceSchema.safeParse({ protocol: 'quic' });
+    expect(result.success).toBe(false);
+  });
+
+  // scaleToZero is updateable so an existing service can be flipped between
+  // scale-to-zero and always-on without a delete + redeploy.
+  it('accepts scaleToZero: false on update', () => {
+    const result = updateServiceSchema.safeParse({ scaleToZero: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-boolean scaleToZero on update', () => {
+    const result = updateServiceSchema.safeParse({ scaleToZero: 'always' });
     expect(result.success).toBe(false);
   });
 });

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -187,6 +187,60 @@ describe('FlyProvider', () => {
       expect(body.region).toBe('iad');
     });
 
+    // scaleToZero: false flips the autostop block to always-on. min_machines_running
+    // must be 1 (not just autostop 'off') so Fly restarts the machine if it
+    // exits — always-on services should survive crashes, not just skip the
+    // idle stop.
+    it('scaleToZero: false sends autostop off with one machine kept running', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 'machine-always-on' })),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.launchMachine({
+        appId: 'my-app',
+        image: 'registry.fly.io/my-app:latest',
+        port: 8080,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'iad',
+        scaleToZero: false,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.config.services[0].autostop).toBe('off');
+      expect(body.config.services[0].autostart).toBe(true);
+      expect(body.config.services[0].min_machines_running).toBe(1);
+    });
+
+    // scaleToZero: true must be byte-identical to omitting the field — only
+    // an explicit `false` may change the wire format.
+    it('scaleToZero: true keeps the scale-to-zero defaults', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 'machine-stz' })),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await provider.launchMachine({
+        appId: 'my-app',
+        image: 'registry.fly.io/my-app:latest',
+        port: 8080,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'iad',
+        scaleToZero: true,
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.config.services[0].autostop).toBe('stop');
+      expect(body.config.services[0].autostart).toBe(true);
+      expect(body.config.services[0].min_machines_running).toBe(0);
+    });
+
     // INS-271: protocol: 'tcp' switches the edge-handler shape from the
     // HTTP-terminating 443/80 pair to a single direct-passthrough port that
     // matches internal_port with empty L7 handlers. Without this, raw TCP

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -389,6 +389,141 @@ describe('ComputeServicesService', () => {
       expect(launchCall.protocol).toBeUndefined();
     });
 
+    // --always-on: end-to-end pass-through of `scaleToZero: false` from
+    // createService input → INSERT column list → launchMachine params, same
+    // shape as the protocol pass-through above.
+    it('forwards scaleToZero: false to INSERT and launchMachine when supplied', async () => {
+      const serviceId = 'svc-always-on';
+      const alwaysOnInput = { ...input, scaleToZero: false, name: 'my-always-on' };
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: alwaysOnInput.projectId,
+            name: alwaysOnInput.name,
+            image_url: alwaysOnInput.imageUrl,
+            port: alwaysOnInput.port,
+            cpu: alwaysOnInput.cpu,
+            memory: alwaysOnInput.memory,
+            region: alwaysOnInput.region,
+            protocol: 'http',
+            scale_to_zero: false,
+            fly_app_id: null,
+            fly_machine_id: null,
+            status: 'creating',
+            endpoint_url: null,
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockCreateApp.mockResolvedValue({ appId: 'my-always-on-proj-123' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'mach-always-on' });
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: alwaysOnInput.projectId,
+            name: alwaysOnInput.name,
+            image_url: alwaysOnInput.imageUrl,
+            port: alwaysOnInput.port,
+            cpu: alwaysOnInput.cpu,
+            memory: alwaysOnInput.memory,
+            region: alwaysOnInput.region,
+            protocol: 'http',
+            scale_to_zero: false,
+            fly_app_id: 'my-always-on-proj-123',
+            fly_machine_id: 'mach-always-on',
+            status: 'running',
+            endpoint_url: 'https://my-always-on-proj-123.fly.dev',
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await service.createService(alwaysOnInput);
+
+      // INSERT must include the column AND the value (positional bind).
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[0]).toContain('scale_to_zero');
+      expect(insertCall[1]).toContain(false);
+
+      // launchMachine must receive scaleToZero: false so the provider flips
+      // the Fly autostop block to always-on.
+      expect(mockLaunchMachine).toHaveBeenCalledWith(
+        expect.objectContaining({ scaleToZero: false })
+      );
+
+      // Response shape echoes the persisted value (via mapRowToSchema).
+      expect(result.scaleToZero).toBe(false);
+    });
+
+    // Back-compat — omitting scaleToZero persists the default (true) but must
+    // NOT inject a positive value into the launchMachine call; the provider
+    // applies its own scale-to-zero default.
+    it('omitting scaleToZero persists true and does not inject a value into launchMachine', async () => {
+      const serviceId = 'svc-default-stz';
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: input.projectId,
+            name: input.name,
+            image_url: input.imageUrl,
+            port: input.port,
+            cpu: input.cpu,
+            memory: input.memory,
+            region: input.region,
+            fly_app_id: null,
+            fly_machine_id: null,
+            status: 'creating',
+            endpoint_url: null,
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockCreateApp.mockResolvedValue({ appId: 'my-api-proj-123' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'mach-default-stz' });
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: serviceId,
+            project_id: input.projectId,
+            name: input.name,
+            image_url: input.imageUrl,
+            port: input.port,
+            cpu: input.cpu,
+            memory: input.memory,
+            region: input.region,
+            fly_app_id: 'my-api-proj-123',
+            fly_machine_id: 'mach-default-stz',
+            status: 'running',
+            endpoint_url: 'https://my-api-proj-123.fly.dev',
+            env_vars_encrypted: null,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await service.createService(input); // input has no `scaleToZero`
+
+      // INSERT falls back to true (`input.scaleToZero ?? true`).
+      const insertCall = mockQuery.mock.calls[0];
+      expect(insertCall[0]).toContain('scale_to_zero');
+      expect(insertCall[1]).toContain(true);
+
+      const launchCall = mockLaunchMachine.mock.calls[0][0];
+      expect(launchCall.scaleToZero).toBeUndefined();
+    });
+
     it('passes through structured cloud errors (quota, invalid input, etc.) instead of swallowing as generic 502', async () => {
       // Reproduces the bug found by stress-testing against staging:
       // when the cloud backend returns 403 COMPUTE_QUOTA_EXCEEDED with a clear
@@ -553,6 +688,9 @@ describe('ComputeServicesService', () => {
         // migration). The fixture above doesn't set `protocol`, so this is
         // the back-compat default surfacing.
         protocol: 'http',
+        // Same back-compat fallback: fixture has no scale_to_zero column, so
+        // the snapshot surfaces the default (true).
+        scaleToZero: true,
         flyAppId: 'app-del-proj-123',
         flyMachineId: 'machine-del',
         endpointUrl: 'https://app-del-proj-123.fly.dev',
@@ -1090,6 +1228,62 @@ describe('ComputeServicesService', () => {
       await service.updateService('svc-pa-1', { memory: 1024 });
 
       expect(mockUpdateMachine).toHaveBeenCalledWith(expect.objectContaining({ protocol: 'tcp' }));
+    });
+
+    // --always-on: updateService forwards scaleToZero through to updateMachine
+    // on the redeploy path so an existing service can be flipped to always-on
+    // (or back) without delete + redeploy.
+    it('forwards scaleToZero: false to updateMachine on redeploy', async () => {
+      const deployedRow = {
+        ...baseRow,
+        fly_machine_id: 'mach-existing',
+        status: 'running',
+        scale_to_zero: true,
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] }); // getService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
+      mockUpdateMachine.mockResolvedValue(undefined);
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ...deployedRow, scale_to_zero: false }],
+      });
+
+      const result = await service.updateService('svc-pa-1', { scaleToZero: false });
+
+      expect(mockUpdateMachine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appId: 'my-api-proj-123',
+          machineId: 'mach-existing',
+          scaleToZero: false,
+        })
+      );
+
+      // SQL UPDATE persists the new value.
+      const updateCall = mockQuery.mock.calls[2];
+      expect(updateCall[0]).toContain('scale_to_zero');
+      expect(updateCall[1]).toContain(false);
+      expect(result.scaleToZero).toBe(false);
+    });
+
+    // Back-compat — a field-only update keeps the persisted always-on setting
+    // flowing to Fly (`data.scaleToZero ?? existing.scaleToZero`), so a plain
+    // redeploy doesn't silently flip an always-on service back to scale-to-zero.
+    it('preserves existing scaleToZero: false when update omits the field', async () => {
+      const deployedRow = {
+        ...baseRow,
+        fly_machine_id: 'mach-existing',
+        status: 'running',
+        scale_to_zero: false,
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] }); // getService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
+      mockUpdateMachine.mockResolvedValue(undefined);
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] });
+
+      await service.updateService('svc-pa-1', { memory: 1024 });
+
+      expect(mockUpdateMachine).toHaveBeenCalledWith(
+        expect.objectContaining({ scaleToZero: false })
+      );
     });
 
     it('regression: existing machine + imageUrl takes the redeploy path (updateMachine, no launch, no optimistic lock)', async () => {

--- a/packages/shared-schemas/src/compute-services-api.schema.ts
+++ b/packages/shared-schemas/src/compute-services-api.schema.ts
@@ -47,6 +47,14 @@ export const createServiceSchema = z.object({
    * sending `'http'` at every fallback site downstream.
    */
   protocol: z.enum(['http', 'tcp']).optional(),
+  /**
+   * Scale-to-zero. `true` (default) is the existing behaviour — Fly stops the
+   * machine when idle and cold-starts it on the next request. `false` keeps
+   * the machine running 24/7 (Fly autostop 'off', one machine always warm)
+   * for services that can't tolerate cold-start latency. Optional and
+   * back-compat: omitting the field is identical to sending `true`.
+   */
+  scaleToZero: z.boolean().optional(),
 });
 
 export const updateServiceSchema = z
@@ -109,6 +117,11 @@ export const updateServiceSchema = z
      * on update; omitting it leaves the existing service's protocol in place.
      */
     protocol: z.enum(['http', 'tcp']).optional(),
+    /**
+     * Scale-to-zero — same semantics as createServiceSchema.scaleToZero.
+     * Optional on update; omitting it leaves the existing setting in place.
+     */
+    scaleToZero: z.boolean().optional(),
   })
   .refine((data) => !(data.envVars !== undefined && data.envVarsPatch !== undefined), {
     message:

--- a/packages/shared-schemas/src/compute-services.schema.ts
+++ b/packages/shared-schemas/src/compute-services.schema.ts
@@ -34,6 +34,10 @@ export const serviceSchema = z.object({
   // migration backfills `'http'` for pre-INS-271 rows). Defaults are only
   // optional on the *input* schemas.
   protocol: z.enum(['http', 'tcp']),
+  // Required on the response shape (the migration backfills `true` for
+  // pre-existing rows). true = Fly stops the machine when idle and
+  // cold-starts it on the next request (the default); false = always-on.
+  scaleToZero: z.boolean(),
   flyAppId: z.string().nullable(),
   flyMachineId: z.string().nullable(),
   status: serviceStatusEnum,


### PR DESCRIPTION
## What

Adds an opt-out from compute scale-to-zero. **Default is unchanged** — services still scale to zero when idle (Fly `autostop: 'stop'`, `min_machines_running: 0`). Passing `scaleToZero: false` on create/update launches the machine with `autostop: 'off'` + `min_machines_running: 1` so it runs 24/7 and gets restarted if it crashes — for services that can't tolerate ~1s cold-start latency.

## How

Mirrors the `protocol` field end-to-end (the freshest precedent for a pass-through machine option):

- `createServiceSchema` / `updateServiceSchema`: optional `scaleToZero: boolean`
- Migration 058: `compute.services.scale_to_zero BOOLEAN NOT NULL DEFAULT true` (idempotent backfill pattern from 047)
- `services.service.ts`: INSERTs, update SET list, `deployFields`, and both Fly calls (`data.scaleToZero ?? existing.scaleToZero` so a field-only redeploy doesn't flip an always-on service back)
- `FlyProvider`: maps `scaleToZero: false` → ALWAYS_ON autostop block in `serviceConfig`
- `CloudComputeProvider` forwards params verbatim — cloud-managed mode needs the small companion change in insforge-cloud-backend (reads `scaleToZero` from the machines route body → existing `scale` option in its fly-client); PR linked from there
- CLI flag (`--always-on` / `--scale-to-zero` on `compute deploy`) ships in the CLI repo PR

## Back-compat

- Omitting the field keeps today's wire format byte-for-byte (undefined dropped by `JSON.stringify`) — pinned by tests
- Response shape gains required `scaleToZero`; `mapRowToSchema` falls back to `true` for pre-migration rows

## Validation

- `npx turbo run typecheck` — 8/8 green
- `npx turbo run test` — backend 1728 passed (one flaky-timing rerun of deno-subhosting-429, unrelated)
- `npx turbo run build` — green
- `npx eslint <changed files>` — clean
- New tests: Fly autostop mapping (off/1 vs stop/0), schema accept/reject, create+update pass-through, snapshot/back-compat defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtvPScrRiH2k5RT7tNPXah

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-out for compute scale-to-zero so services can run always-on when needed. Default behavior stays the same; only services with scaleToZero: false run 24/7.

- **New Features**
  - API: add optional scaleToZero on create/update; responses now include scaleToZero.
  - DB: add compute.services.scale_to_zero (BOOLEAN NOT NULL DEFAULT true) with backfill (migration 058).
  - Fly mapping: scaleToZero false → autostop 'off' + min_machines_running 1; true/omitted → 'stop' + 0. Create/update pass-through; redeploys preserve the existing setting if the field is omitted.
  - Providers: `FlyProvider` maps the autostop block; cloud provider forwards the field. Tests cover schemas, mapping, and pass-through.

- **Migration**
  - Run migration 058.
  - API responses now include the required scaleToZero field. No client changes needed unless validating the response shape strictly.

<sup>Written for commit 239ec77939ef76bfef3b6f18d19d8e704732a1b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `scaleToZero` opt-out to compute services for always-on Fly machine configuration
> - Adds an optional `scaleToZero` boolean to the create/update service APIs (default `true`); setting it to `false` configures the Fly machine with `autostop: off` and `min_machines_running: 1`.
> - Persists the setting in a new `scale_to_zero` column on `compute.services` (backfilled to `true` for existing rows) via [058_compute-services-add-scale-to-zero.sql](https://github.com/InsForge/InsForge/pull/1638/files#diff-057dc5353a1f8a98e54998758907309cfc0187150fff884e84f15164a40308c1).
> - Changing `scaleToZero` on an existing service triggers a redeploy; omitting the field on update preserves the prior value.
> - Service GET responses and delete snapshots now include the `scaleToZero` field, defaulting to `true` for legacy rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 239ec77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing whether compute services scale to zero or stay always on.
  * Service details and API requests now include this setting, with backward-compatible defaults for existing services.
* **Bug Fixes**
  * Preserved previous behavior for older records by treating missing values as scale-to-zero enabled.
* **Tests**
  * Added coverage for service creation, updates, deletion snapshots, and machine launch behavior across both scaling modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->