### PR TITLE
fix(secrets): revive soft-deleted secrets on create instead of failing with 23505

### DIFF
--- a/backend/src/services/secrets/secret.service.ts
+++ b/backend/src/services/secrets/secret.service.ts
@@ -1,9 +1,10 @@
 import { Pool, PoolClient } from 'pg';
 import crypto from 'crypto';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import { EncryptionManager } from '@/infra/security/encryption.manager.js';
-import { SecretSchema, CreateSecretRequest } from '@insforge/shared-schemas';
+import { SecretSchema, CreateSecretRequest, ERROR_CODES } from '@insforge/shared-schemas';
 import { appConfig } from '@/infra/config/app.config.js';
 
 export interface CreateSecretInput extends CreateSecretRequest {
@@ -67,6 +68,27 @@ export class SecretService {
       const encryptedValue = EncryptionManager.encrypt(input.value);
       const executor = client ?? this.getPool();
 
+      // The dashboard's DELETE endpoint deactivates rows instead of removing
+      // them, but UNIQUE(key) counts inactive rows too — so a soft-deleted
+      // row would block every future INSERT of the same key (23505) with no
+      // way to recover from the dashboard. Revive such a row instead.
+      const revived = await executor.query(
+        `UPDATE system.secrets
+         SET value_ciphertext = $2,
+             is_reserved = $3,
+             expires_at = $4,
+             is_active = true,
+             last_used_at = NULL
+         WHERE key = $1 AND is_active = false AND is_reserved = false
+         RETURNING id`,
+        [input.key, encryptedValue, input.isReserved || false, input.expiresAt || null]
+      );
+
+      if (revived.rows.length) {
+        logger.info('Secret revived', { id: revived.rows[0].id, key: input.key });
+        return { id: revived.rows[0].id };
+      }
+
       const result = await executor.query(
         `INSERT INTO system.secrets (key, value_ciphertext, is_reserved, expires_at)
          VALUES ($1, $2, $3, $4)
@@ -78,6 +100,14 @@ export class SecretService {
       return { id: result.rows[0].id };
     } catch (error) {
       logger.error('Failed to create secret', { error, key: input.key });
+      if ((error as { code?: string }).code === '23505') {
+        throw new AppError(
+          `Secret already exists: ${input.key}`,
+          409,
+          ERROR_CODES.SECRET_ALREADY_EXISTS,
+          `A secret named ${input.key} already exists in this project. Update or delete it in the Secrets tab, or use a different name.`
+        );
+      }
       throw new Error('Failed to create secret');
     }
   }

--- a/backend/tests/unit/secret-create-soft-delete-revive.test.ts
+++ b/backend/tests/unit/secret-create-soft-delete-revive.test.ts
@@ -116,10 +116,9 @@ describe('SecretService.createSecret with soft-deleted rows', () => {
       .mockResolvedValueOnce({ rows: [{ id: 'tx-id' }] });
 
     const service = await loadSecretService();
-    const result = await service.createSecret(
-      { key: 'DISCORD_CLIENT_SECRET', value: 'v' },
-      { query: clientQuery } as never
-    );
+    const result = await service.createSecret({ key: 'DISCORD_CLIENT_SECRET', value: 'v' }, {
+      query: clientQuery,
+    } as never);
 
     expect(result).toEqual({ id: 'tx-id' });
     expect(clientQuery).toHaveBeenCalledTimes(2);

--- a/backend/tests/unit/secret-create-soft-delete-revive.test.ts
+++ b/backend/tests/unit/secret-create-soft-delete-revive.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPoolQuery, mockConnect } = vi.hoisted(() => ({
+  mockPoolQuery: vi.fn(),
+  mockConnect: vi.fn(),
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({
+        query: mockPoolQuery,
+        connect: mockConnect,
+      }),
+    }),
+  },
+}));
+
+vi.mock('../../src/infra/security/encryption.manager.js', () => ({
+  EncryptionManager: {
+    encrypt: (value: string) => `enc:${value}`,
+    decrypt: (value: string) => value.replace(/^enc:/, ''),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+async function loadSecretService() {
+  const { SecretService } = await import('../../src/services/secrets/secret.service.js');
+  return SecretService.getInstance();
+}
+
+/**
+ * Regression tests for the soft-delete / UNIQUE(key) dead end:
+ * the dashboard's DELETE endpoint deactivates secrets (is_active = false)
+ * instead of removing the row, but UNIQUE(key) counts inactive rows, so a
+ * blind INSERT of the same key fails with 23505 forever and the user cannot
+ * recover from the dashboard (the list hides inactive rows).
+ */
+describe('SecretService.createSecret with soft-deleted rows', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockPoolQuery.mockReset();
+    mockConnect.mockReset();
+  });
+
+  it('revives a soft-deleted row holding the key instead of inserting', async () => {
+    // First query is the revive UPDATE — it finds the ghost row.
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 'ghost-id' }] });
+
+    const service = await loadSecretService();
+    const result = await service.createSecret({ key: 'GOOGLE_CLIENT_SECRET', value: 's3cret' });
+
+    expect(result).toEqual({ id: 'ghost-id' });
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+
+    const [sql, params] = mockPoolQuery.mock.calls[0];
+    expect(sql).toContain('UPDATE system.secrets');
+    // Only deactivated rows may be revived, and never reserved ones.
+    expect(sql).toContain('is_active = false');
+    expect(sql).toContain('is_reserved = false');
+    expect(params).toEqual(['GOOGLE_CLIENT_SECRET', 'enc:s3cret', false, null]);
+  });
+
+  it('inserts a new row when no soft-deleted row holds the key', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [] }) // revive UPDATE matches nothing
+      .mockResolvedValueOnce({ rows: [{ id: 'new-id' }] }); // INSERT
+
+    const service = await loadSecretService();
+    const result = await service.createSecret({ key: 'STRIPE_API_KEY', value: 'sk_test' });
+
+    expect(result).toEqual({ id: 'new-id' });
+    expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+    expect(mockPoolQuery.mock.calls[1][0]).toContain('INSERT INTO system.secrets');
+  });
+
+  it('maps a unique violation on an active row to a 409 AppError', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [] }) // revive UPDATE matches nothing (row is active)
+      .mockRejectedValueOnce(Object.assign(new Error('duplicate key'), { code: '23505' }));
+
+    const service = await loadSecretService();
+
+    await expect(
+      service.createSecret({ key: 'GOOGLE_CLIENT_SECRET', value: 's3cret' })
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      statusCode: 409,
+      code: 'SECRET_ALREADY_EXISTS',
+      message: expect.stringContaining('GOOGLE_CLIENT_SECRET'),
+    });
+  });
+
+  it('keeps the generic error for non-unique-violation failures', async () => {
+    mockPoolQuery.mockRejectedValueOnce(new Error('connection refused'));
+
+    const service = await loadSecretService();
+
+    await expect(service.createSecret({ key: 'ANY_KEY', value: 'v' })).rejects.toThrow(
+      'Failed to create secret'
+    );
+  });
+
+  it('runs revive and insert on the provided transaction client when given', async () => {
+    const clientQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'tx-id' }] });
+
+    const service = await loadSecretService();
+    const result = await service.createSecret(
+      { key: 'DISCORD_CLIENT_SECRET', value: 'v' },
+      { query: clientQuery } as never
+    );
+
+    expect(result).toEqual({ id: 'tx-id' });
+    expect(clientQuery).toHaveBeenCalledTimes(2);
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Creating an OAuth config (or anything else that stores a secret through `SecretService.createSecret`) fails **permanently with a 500** once a soft-deleted secret row holds the same key — and the user cannot recover from the dashboard.

Hit in production by customer project **Super-agent** (`a6ae103a-a00d-4155-8984-a0dc4e65dda5`): every `POST /api/auth/oauth/configs` for Google returned 500 with `23505 unique_violation` on `system.secrets`, even after the user "deleted" the conflicting secret. Unblocked manually by hard-deleting the ghost rows. Tracked as [INS-449](https://linear.app/insforge/issue/INS-449).

## How to reproduce

1. In the dashboard **Secrets** tab, create a secret named `GOOGLE_CLIENT_SECRET` (any value). *(Users do this when they assume OAuth credentials are configured via secrets.)*
2. Go to **Auth → OAuth** and add a Google config with custom credentials.
   → **500** `Failed to create OAuth configuration`. Logs show `23505`, constraint on `system.secrets(key)`, `Key (key)=(GOOGLE_CLIENT_SECRET) already exists` — `createConfig` blind-INSERTs its own `<PROVIDER>_CLIENT_SECRET` row.
3. Delete `GOOGLE_CLIENT_SECRET` in the Secrets tab and retry step 2.
   → **Identical 500, forever.** `DELETE /api/secrets/:key` is a **soft delete** (`UPDATE ... SET is_active = false` — the log line is literally `"Secret updated"`), but `UNIQUE(key)` (added in migration 035) counts inactive rows too. The ghost row keeps colliding, re-deleting is a no-op, and the secrets list hides inactive rows so there is nothing visible left to delete. Dead end.

The same trap exists for custom OAuth configs, the Vercel provider, and boot seeding — every direct `createSecret` caller.

## Fix

`SecretService.createSecret` now:

1. **Revives** a soft-deleted, non-reserved row holding the key — overwrites `value_ciphertext`, `is_reserved`, `expires_at`, sets `is_active = true`, resets `last_used_at` — and returns its id. This mirrors what `POST /api/secrets` already does at the route layer, so service-layer callers finally get the same semantics.
2. Falls back to plain INSERT when no ghost row exists.
3. Maps a residual `23505` (an **active** row genuinely holds the key) to a **409 `SECRET_ALREADY_EXISTS`** with actionable `nextActions`, instead of the generic 500. `OAuthConfigService`/`CustomOAuthConfigService` already rethrow `AppError` as-is, so the 409 reaches the client unchanged.

### Deliberate non-changes (constraints)

- **Shared-key OAuth state untouched** — `use_shared_key` configs create no secrets and don't enter this path.
- **Individually-set secrets are never silently overwritten** — an *active* row is never revived/updated; it produces the 409. Only rows the user already deleted (invisible, unreadable — every read path filters `is_active = true`) are revived.
- **Reserved secrets protected** — `is_reserved = true` rows are never revived.
- **Dashboard UI and soft-delete semantics unchanged** — no route or schema changes, no migration.

## Testing

- New unit suite `backend/tests/unit/secret-create-soft-delete-revive.test.ts` (5 tests): revive path, insert path, 409 mapping, generic-error preservation, transaction-client passthrough.
- Ran alongside neighbouring suites (`secret-anon-key`, `secrets-deduplicate-and-unique-migration`, `auth-oauth-unsupported-provider`, `seed-jwt-secret`): **51/51 pass**.
- `npm run lint` clean. `npm run typecheck` failures in this environment are pre-existing missing optional deps (`stripe`, `razorpay`, `xml2js`) unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016254FuSur9u9Z8S2SZ79dY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revives soft-deleted secrets on create to prevent 23505 unique violations and returns a clear 409 when an active secret exists. Fixes OAuth config creation failures and related flows; addresses INS-449.

- **Bug Fixes**
  - `SecretService.createSecret` now revives a soft-deleted, non-reserved row for the key (updates ciphertext/flags/expiry, sets `is_active = true`, clears `last_used_at`); otherwise inserts.
  - Maps `23505` to 409 `SECRET_ALREADY_EXISTS` with guidance, surfaced unchanged by OAuth config services.
  - Never overwrites active secrets and never revives reserved rows; shared-key OAuth configs are unaffected.

<sup>Written for commit 0c35e1b9fcdbd039517b3e01aaf6c3589b28edca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revive soft-deleted secrets on create instead of failing with a unique violation
> - In `SecretService.createSecret`, before inserting, attempts to UPDATE an existing soft-deleted (`is_active=false`), non-reserved secret with the same key, reactivating it with new ciphertext and clearing `last_used_at`; skips INSERT if a row is revived.
> - Maps Postgres unique violation (code 23505) to an `AppError` with HTTP 409 and `SECRET_ALREADY_EXISTS` instead of a generic error message.
> - Behavioral Change: creating a secret whose key previously existed as a soft-deleted row now revives that row rather than inserting a new one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c35e1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a secret now reuses an existing soft-deleted secret when possible, instead of failing or duplicating entries.
  * Duplicate secret keys now return a clearer conflict message, including the secret key and a 409 response.
  * Other secret-creation failures still return a generic error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->