### PR TITLE
test(dashboard): fix UserFormDialog test timeout in full suite

### DIFF
--- a/packages/dashboard/src/features/auth/components/__tests__/UserFormDialog.test.tsx
+++ b/packages/dashboard/src/features/auth/components/__tests__/UserFormDialog.test.tsx
@@ -34,8 +34,12 @@ describe('UserFormDialog', () => {
     hookMocks.showToast.mockReset();
   });
 
-  it('submits a new user and closes the dialog on success', async () => {
-    const user = userEvent.setup();
+  // Extended timeout: this test drives three typed fields through the dialog,
+  // which can be slow on loaded CI runners even without inter-keystroke delay (#1568).
+  it('submits a new user and closes the dialog on success', { timeout: 10_000 }, async () => {
+    // No inter-keystroke delay: with the default delay the ~60 keystrokes below
+    // can exceed the 5s test timeout when the suite runs under load (#1568).
+    const user = userEvent.setup({ delay: null });
     const onOpenChange = vi.fn();
     hookMocks.register.mockResolvedValue(undefined);
     hookMocks.refetch.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

Fixes the flaky timeout in `UserFormDialog > submits a new user and closes the dialog on success` (`packages/dashboard/src/features/auth/components/__tests__/UserFormDialog.test.tsx`), which passes in isolation but times out at 5000ms when the full dashboard suite runs on a loaded machine.

Closes #1568

## Root cause

The test types ~60 characters across three fields via `userEvent.setup()` with the **default inter-keystroke delay**. Every keystroke awaits event-loop ticks (plus a React re-render through the controlled inputs), so on a loaded runner the typing alone approaches or exceeds the 5s default test timeout. That is exactly why it reproduces in the full suite but not in isolation — confirmed by the reporters in #1568.

## Reproduction (before fix)

Simulated a loaded runner by executing 4 concurrent full-suite instances (`npx vitest run` × 4):

| run | duration |
|---|---|
| 1 | 4727ms ✓ |
| 2 | 4958ms ✓ |
| 3 | **5169ms ✗ Test timed out in 5000ms** |
| 4 | 4449ms ✓ |

Unloaded full-suite baseline: 1105ms — thin headroom against the 5000ms limit.

## Fix

1. `userEvent.setup({ delay: null })` — removes the artificial inter-keystroke delay while keeping full per-key event fidelity (keydown/keyup/input still fire for every character).
2. Per-test `timeout: 10_000` — headroom for genuinely slow CI runners; the test's only failure mode in this issue is a timeout, and the cause is addressed by (1).

No assertions or component code changed.

## Verification (after fix)

- Same 4-way contention run: **2932 / 3038 / 3526 / 3907ms — 0 failures**, all 4×112 tests pass
- 10 consecutive full-suite runs: all green, target test 913–1120ms
- `npm run test:component` (62 tests) and `npm run test:unit` (50 tests): pass
- `npx turbo run typecheck --filter=@insforge/dashboard`: pass
- `npx turbo run test --filter=@insforge/dashboard`: pass
- ESLint on the changed file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky timeout in the `UserFormDialog` submit test by removing artificial typing delay and adding headroom to the test timeout. Addresses #1568 and stabilizes full-suite runs on loaded CI.

- **Bug Fixes**
  - Use `userEvent.setup({ delay: null })` to remove inter-keystroke delay while keeping per-key events.
  - Set `{ timeout: 10_000 }` for this test to tolerate slower runners.

<sup>Written for commit e2e155034896d772902541606137d031b63d27fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `UserFormDialog` test timeout in full suite
> Sets a 10s timeout on the "submits a new user" test and switches `userEvent.setup()` to `userEvent.setup({ delay: null })` in [UserFormDialog.test.tsx](https://github.com/InsForge/InsForge/pull/1644/files#diff-928367d8ca849b224956073f02dfcef990664a5e4c9df8fcfae37b28e2b13322) to eliminate artificial inter-keystroke delays that caused the test to time out when run as part of the full suite.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2e1550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of a user form dialog test by increasing its timeout and reducing typing delay, helping it run more consistently in slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->