### PR TITLE
fix: expose suppressed status in send-raw

### DIFF
--- a/backend/src/api/routes/email/index.routes.ts
+++ b/backend/src/api/routes/email/index.routes.ts
@@ -33,9 +33,9 @@ router.post(
         throw new AppError(JSON.stringify(validation.error.issues), 400, ERROR_CODES.INVALID_INPUT);
       }
 
-      await emailService.sendRaw(validation.data);
+      const result = await emailService.sendRaw(validation.data);
 
-      successResponse(res, {});
+      successResponse(res, result);
     } catch (error) {
       next(error);
     }

--- a/backend/src/providers/email/base.provider.ts
+++ b/backend/src/providers/email/base.provider.ts
@@ -1,5 +1,5 @@
 import { EmailTemplate } from '@/types/email.js';
-import { SendRawEmailRequest } from '@insforge/shared-schemas';
+import { SendRawEmailRequest, SendEmailResponse } from '@insforge/shared-schemas';
 
 /**
  * Email provider interface
@@ -29,7 +29,7 @@ export interface EmailProvider {
    * Send custom/raw email (optional - not all providers may support this)
    * @param options - Email options (to, subject, html, cc, bcc, from, replyTo)
    */
-  sendRaw?(options: SendRawEmailRequest): Promise<void>;
+  sendRaw?(options: SendRawEmailRequest): Promise<SendEmailResponse>;
 
   /**
    * Check if provider supports template-based emails

--- a/backend/src/providers/email/cloud.provider.ts
+++ b/backend/src/providers/email/cloud.provider.ts
@@ -5,7 +5,7 @@ import logger from '@/utils/logger.js';
 import { AppError } from '@/utils/errors.js';
 import { EmailTemplate } from '@/types/email.js';
 import { EmailProvider } from './base.provider.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
+import { ERROR_CODES, SendRawEmailRequest, SendEmailResponse } from '@insforge/shared-schemas';
 
 /**
  * Cloud email provider for sending emails via Insforge cloud backend
@@ -188,7 +188,7 @@ export class CloudEmailProvider implements EmailProvider {
   /**
    * Send custom/raw email via cloud backend
    */
-  async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  async sendRaw(options: SendRawEmailRequest): Promise<SendEmailResponse> {
     try {
       const projectId = appConfig.cloud.projectId;
       const apiHost = appConfig.cloud.apiHost;
@@ -205,6 +205,9 @@ export class CloudEmailProvider implements EmailProvider {
 
       if (response.data?.success) {
         logger.info('Raw email sent successfully', { projectId });
+        return {
+          suppressed: response.data?.suppressed ?? false,
+        };
       } else {
         throw new AppError(
           'Email service returned unsuccessful response',

--- a/backend/src/providers/email/smtp.provider.ts
+++ b/backend/src/providers/email/smtp.provider.ts
@@ -4,7 +4,7 @@ import { AppError } from '@/utils/errors.js';
 import { EmailTemplate } from '@/types/email.js';
 import { SmtpConfigService, RawSmtpConfig } from '@/services/email/smtp-config.service.js';
 import { EmailTemplateService } from '@/services/email/email-template.service.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
+import { ERROR_CODES, SendRawEmailRequest, SendEmailResponse } from '@insforge/shared-schemas';
 import { EmailProvider } from './base.provider.js';
 import logger from '@/utils/logger.js';
 
@@ -32,11 +32,12 @@ export class SmtpEmailProvider implements EmailProvider {
   }
 
   private createTransporter(config: RawSmtpConfig) {
+    const hasAuth = config.username && config.password;
     return nodemailer.createTransport({
       host: config.host,
       port: config.port,
       secure: config.port === 465,
-      auth: { user: config.username, pass: config.password },
+      auth: hasAuth ? { user: config.username, pass: config.password } : false,
       connectionTimeout: 10000,
     });
   }
@@ -123,7 +124,7 @@ export class SmtpEmailProvider implements EmailProvider {
     );
   }
 
-  async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  async sendRaw(options: SendRawEmailRequest): Promise<SendEmailResponse> {
     const config = await this.getRequiredConfig();
 
     await this.send(
@@ -138,5 +139,9 @@ export class SmtpEmailProvider implements EmailProvider {
       },
       { to: options.to }
     );
+
+    return {
+      suppressed: false,
+    };
   }
 }

--- a/backend/src/providers/email/smtp.provider.ts
+++ b/backend/src/providers/email/smtp.provider.ts
@@ -32,12 +32,15 @@ export class SmtpEmailProvider implements EmailProvider {
   }
 
   private createTransporter(config: RawSmtpConfig) {
-    const hasAuth = config.username && config.password;
+    // Skip auth entirely only when no username is configured (e.g. Mailhog, local
+    // dev SMTP). If a username is present, always send credentials — a blank
+    // password can be intentional and must not suppress the auth header.
+    const hasAuth = !!config.username;
     return nodemailer.createTransport({
       host: config.host,
       port: config.port,
       secure: config.port === 465,
-      auth: hasAuth ? { user: config.username, pass: config.password } : false,
+      ...(hasAuth ? { auth: { user: config.username, pass: config.password } } : {}),
       connectionTimeout: 10000,
     });
   }

--- a/backend/src/services/email/email.service.ts
+++ b/backend/src/services/email/email.service.ts
@@ -5,7 +5,7 @@ import { SmtpConfigService, RawSmtpConfig } from '@/services/email/smtp-config.s
 import { AppError } from '@/utils/errors.js';
 import { EmailTemplate } from '@/types/email.js';
 import logger from '@/utils/logger.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
+import { ERROR_CODES, SendRawEmailRequest, SendEmailResponse } from '@insforge/shared-schemas';
 
 /**
  * Email service — resolves provider per-call so SMTP config changes take effect without restart
@@ -100,7 +100,7 @@ export class EmailService {
     }
   }
 
-  public async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  public async sendRaw(options: SendRawEmailRequest): Promise<SendEmailResponse> {
     const [provider, smtpConfig] = await this.resolveProvider();
 
     const recipients = Array.isArray(options.to) ? options.to : [options.to];
@@ -114,12 +114,14 @@ export class EmailService {
     if (!provider.sendRaw) {
       throw new Error('Current email provider does not support raw email sending');
     }
-    await provider.sendRaw(options);
+    const result = await provider.sendRaw(options);
 
     if (smtpConfig) {
       for (const recipient of recipients) {
         this.recordEmailSent(recipient, smtpConfig.minIntervalSeconds);
       }
     }
+
+    return result;
   }
 }

--- a/backend/src/services/email/smtp-config.service.ts
+++ b/backend/src/services/email/smtp-config.service.ts
@@ -190,10 +190,14 @@ export class SmtpConfigService {
         return null;
       }
 
-      const password = this.getDecryptedPassword(row.password_encrypted);
-      if (password === null) {
-        logger.error('SMTP config has undecryptable credentials — treating as unconfigured');
-        return null;
+      let password = '';
+      if (row.username) {
+        const decrypted = this.getDecryptedPassword(row.password_encrypted);
+        if (decrypted === null) {
+          logger.error('SMTP config has undecryptable credentials — treating as unconfigured');
+          return null;
+        }
+        password = decrypted;
       }
 
       return {
@@ -366,11 +370,12 @@ export class SmtpConfigService {
     input: UpsertSmtpConfigRequest,
     existingPasswordEncrypted: string
   ): Promise<void> {
+    const hasAuth = !!input.username;
     const password = input.password ?? this.getDecryptedPassword(existingPasswordEncrypted) ?? '';
 
-    if (!password) {
+    if (hasAuth && !password && !existingPasswordEncrypted) {
       throw new AppError(
-        'SMTP password is required when enabling SMTP',
+        'SMTP password is required when enabling SMTP with authentication',
         400,
         ERROR_CODES.INVALID_INPUT
       );
@@ -381,7 +386,7 @@ export class SmtpConfigService {
         host: input.host,
         port: input.port,
         secure: input.port === 465,
-        auth: { user: input.username, pass: password },
+        ...(hasAuth ? { auth: { user: input.username, pass: password } } : {}),
         connectionTimeout: 10000,
       });
       await transporter.verify();

--- a/backend/tests/unit/email-routes.test.ts
+++ b/backend/tests/unit/email-routes.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const { mockSendRaw, mockVerifyUser } = vi.hoisted(() => ({
+  mockSendRaw: vi.fn(),
+  mockVerifyUser: vi.fn((req, _res, next) => {
+    req.user = { id: 'user-id', role: 'authenticated' };
+    next();
+  }),
+}));
+
+vi.mock('../../src/services/email/email.service', () => ({
+  EmailService: {
+    getInstance: () => ({
+      sendRaw: mockSendRaw,
+    }),
+  },
+}));
+
+vi.mock('../../src/api/middlewares/auth.js', () => ({
+  verifyUser: mockVerifyUser,
+}));
+
+import { emailRouter } from '../../src/api/routes/email/index.routes';
+
+let app: express.Express;
+
+describe('Email Routes Unit Tests', () => {
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/email', emailRouter);
+    app.use(
+      (
+        err: { statusCode?: number; message?: string },
+        _req: express.Request,
+        res: express.Response,
+        next: express.NextFunction
+      ) => {
+        void next;
+        res.status(err.statusCode || 500).json({ error: err.message });
+      }
+    );
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('POST /api/email/send-raw successfully sends email and returns suppressed status', async () => {
+    mockSendRaw.mockResolvedValue({ suppressed: false });
+
+    const response = await request(app)
+      .post('/api/email/send-raw')
+      .send({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        html: '<p>Hello</p>',
+      })
+      .expect(200);
+
+    expect(response.body).toEqual({ suppressed: false });
+    expect(mockSendRaw).toHaveBeenCalledWith({
+      to: 'recipient@example.com',
+      subject: 'Test Subject',
+      html: '<p>Hello</p>',
+    });
+  });
+
+  it('POST /api/email/send-raw rejects requests from anon role', async () => {
+    mockVerifyUser.mockImplementationOnce((req, _res, next) => {
+      req.user = { id: 'anon-id', role: 'anon' };
+      next();
+    });
+
+    const response = await request(app)
+      .post('/api/email/send-raw')
+      .send({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        html: '<p>Hello</p>',
+      })
+      .expect(401);
+
+    expect(response.body.error).toContain('Sending emails requires an authenticated user');
+  });
+
+  it('POST /api/email/send-raw validation failure', async () => {
+    const response = await request(app)
+      .post('/api/email/send-raw')
+      .send({
+        to: 'invalid-email',
+        subject: '',
+      })
+      .expect(400);
+
+    expect(response.body.error).toBeDefined();
+  });
+});

--- a/backend/tests/unit/email.test.ts
+++ b/backend/tests/unit/email.test.ts
@@ -373,4 +373,34 @@ describe('EmailService', () => {
       });
     });
   });
+
+  describe('sendRaw', () => {
+    it('returns suppressed: false if the backend does not report suppression', async () => {
+      vi.mocked(axios.post).mockResolvedValue({
+        data: { success: true },
+      });
+
+      const response = await emailService.sendRaw({
+        to: 'user@example.com',
+        subject: 'Hello',
+        html: '<p>Hello</p>',
+      });
+
+      expect(response).toEqual({ suppressed: false });
+    });
+
+    it('returns suppressed: true if the backend reports suppression', async () => {
+      vi.mocked(axios.post).mockResolvedValue({
+        data: { success: true, suppressed: true },
+      });
+
+      const response = await emailService.sendRaw({
+        to: 'user@example.com',
+        subject: 'Hello',
+        html: '<p>Hello</p>',
+      });
+
+      expect(response).toEqual({ suppressed: true });
+    });
+  });
 });

--- a/backend/tests/unit/email.test.ts
+++ b/backend/tests/unit/email.test.ts
@@ -402,5 +402,199 @@ describe('EmailService', () => {
 
       expect(response).toEqual({ suppressed: true });
     });
+
+    it('throws error if PROJECT_ID is not configured', async () => {
+      const { appConfig } = await import('../../src/infra/config/app.config');
+      appConfig.cloud.projectId = 'local';
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('PROJECT_ID is not configured');
+
+      appConfig.cloud.projectId = 'test-project-123';
+    });
+
+    it('throws error if JWT_SECRET is not configured', async () => {
+      const { appConfig } = await import('../../src/infra/config/app.config');
+      appConfig.app.jwtSecret = '';
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('JWT_SECRET is not configured');
+
+      appConfig.app.jwtSecret = 'test-jwt-secret';
+    });
+
+    it('throws error if cloud service returns unsuccessful response', async () => {
+      vi.mocked(axios.post).mockResolvedValue({
+        data: { success: false },
+      });
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Email service returned unsuccessful response');
+    });
+
+    it('handles 401 authentication error', async () => {
+      const error = Object.assign(new Error('Request failed'), {
+        isAxiosError: true,
+        response: {
+          status: 401,
+          data: { message: 'Unauthorized' },
+        },
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Authentication failed with cloud email service');
+    });
+
+    it('handles 403 forbidden error', async () => {
+      const error = Object.assign(new Error('Request failed'), {
+        isAxiosError: true,
+        response: {
+          status: 403,
+          data: { message: 'Forbidden' },
+        },
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Custom email service is not available for free plan');
+    });
+
+    it('handles 429 rate limit error', async () => {
+      const error = Object.assign(new Error('Request failed'), {
+        isAxiosError: true,
+        response: {
+          status: 429,
+          data: { message: 'Too many requests' },
+        },
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Email rate limit exceeded');
+    });
+
+    it('handles 400 bad request error', async () => {
+      const error = Object.assign(new Error('Request failed'), {
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: { message: 'Invalid format' },
+        },
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Invalid email request: Invalid format');
+    });
+
+    it('handles generic axios error', async () => {
+      const error = Object.assign(new Error('Request failed'), {
+        isAxiosError: true,
+        response: {
+          status: 500,
+          data: { message: 'Internal error' },
+        },
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Failed to send email: Internal error');
+    });
+
+    it('handles network error without response', async () => {
+      const error = Object.assign(new Error('Network error'), {
+        isAxiosError: true,
+      });
+
+      vi.mocked(axios.post).mockRejectedValue(error);
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Failed to send email: Network error');
+    });
+
+    it('handles non-axios error', async () => {
+      vi.mocked(axios.post).mockRejectedValue(new Error('Unexpected error'));
+
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Failed to send email: Unexpected error');
+    });
+
+    it('throws error if the provider does not support sendRaw', async () => {
+      const service = emailService as unknown as { cloudProvider: unknown };
+      const originalProvider = service.cloudProvider;
+      service.cloudProvider = {
+        supportsTemplates: () => true,
+      };
+      await expect(
+        emailService.sendRaw({
+          to: 'user@example.com',
+          subject: 'Hello',
+          html: '<p>Hello</p>',
+        })
+      ).rejects.toThrow('Current email provider does not support raw email sending');
+      service.cloudProvider = originalProvider;
+    });
   });
 });

--- a/backend/tests/unit/email.test.ts
+++ b/backend/tests/unit/email.test.ts
@@ -407,30 +407,34 @@ describe('EmailService', () => {
       const { appConfig } = await import('../../src/infra/config/app.config');
       appConfig.cloud.projectId = 'local';
 
-      await expect(
-        emailService.sendRaw({
-          to: 'user@example.com',
-          subject: 'Hello',
-          html: '<p>Hello</p>',
-        })
-      ).rejects.toThrow('PROJECT_ID is not configured');
-
-      appConfig.cloud.projectId = 'test-project-123';
+      try {
+        await expect(
+          emailService.sendRaw({
+            to: 'user@example.com',
+            subject: 'Hello',
+            html: '<p>Hello</p>',
+          })
+        ).rejects.toThrow('PROJECT_ID is not configured');
+      } finally {
+        appConfig.cloud.projectId = 'test-project-123';
+      }
     });
 
     it('throws error if JWT_SECRET is not configured', async () => {
       const { appConfig } = await import('../../src/infra/config/app.config');
       appConfig.app.jwtSecret = '';
 
-      await expect(
-        emailService.sendRaw({
-          to: 'user@example.com',
-          subject: 'Hello',
-          html: '<p>Hello</p>',
-        })
-      ).rejects.toThrow('JWT_SECRET is not configured');
-
-      appConfig.app.jwtSecret = 'test-jwt-secret';
+      try {
+        await expect(
+          emailService.sendRaw({
+            to: 'user@example.com',
+            subject: 'Hello',
+            html: '<p>Hello</p>',
+          })
+        ).rejects.toThrow('JWT_SECRET is not configured');
+      } finally {
+        appConfig.app.jwtSecret = 'test-jwt-secret';
+      }
     });
 
     it('throws error if cloud service returns unsuccessful response', async () => {
@@ -587,14 +591,17 @@ describe('EmailService', () => {
       service.cloudProvider = {
         supportsTemplates: () => true,
       };
-      await expect(
-        emailService.sendRaw({
-          to: 'user@example.com',
-          subject: 'Hello',
-          html: '<p>Hello</p>',
-        })
-      ).rejects.toThrow('Current email provider does not support raw email sending');
-      service.cloudProvider = originalProvider;
+      try {
+        await expect(
+          emailService.sendRaw({
+            to: 'user@example.com',
+            subject: 'Hello',
+            html: '<p>Hello</p>',
+          })
+        ).rejects.toThrow('Current email provider does not support raw email sending');
+      } finally {
+        service.cloudProvider = originalProvider;
+      }
     });
   });
 });

--- a/backend/tests/unit/smtp-provider.test.ts
+++ b/backend/tests/unit/smtp-provider.test.ts
@@ -185,4 +185,42 @@ describe('SmtpEmailProvider', () => {
       ).rejects.toThrow(AppError);
     });
   });
+
+  describe('createTransporter options', () => {
+    it('sets auth credentials when username is present', async () => {
+      const nodemailer = await import('nodemailer');
+      getRawSmtpConfigMock.mockResolvedValueOnce({
+        ...mockSmtpConfig,
+        username: 'user@example.com',
+        password: 'password',
+      });
+      await provider.sendRaw({
+        to: 'recipient@example.com',
+        subject: 'Test',
+        html: '<p>Hello</p>',
+      });
+      expect(nodemailer.default.createTransport).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          auth: { user: 'user@example.com', pass: 'password' },
+        })
+      );
+    });
+
+    it('omits auth completely when username is absent', async () => {
+      const nodemailer = await import('nodemailer');
+      getRawSmtpConfigMock.mockResolvedValueOnce({
+        ...mockSmtpConfig,
+        username: '',
+        password: '',
+      });
+      await provider.sendRaw({
+        to: 'recipient@example.com',
+        subject: 'Test',
+        html: '<p>Hello</p>',
+      });
+      const lastCall = vi.mocked(nodemailer.default.createTransport).mock.lastCall?.[0];
+      expect(lastCall).toBeDefined();
+      expect(lastCall).not.toHaveProperty('auth');
+    });
+  });
 });

--- a/backend/tests/unit/smtp-schemas.test.ts
+++ b/backend/tests/unit/smtp-schemas.test.ts
@@ -98,7 +98,7 @@ describe('SMTP Config Request Schema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects empty username', () => {
+  it('accepts empty username (no-auth SMTP)', () => {
     const result = upsertSmtpConfigRequestSchema.safeParse({
       enabled: true,
       host: 'smtp.test.com',
@@ -107,7 +107,7 @@ describe('SMTP Config Request Schema', () => {
       senderEmail: 'test@test.com',
       senderName: 'Test',
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it('rejects empty sender name', () => {

--- a/openapi/email.yaml
+++ b/openapi/email.yaml
@@ -131,7 +131,12 @@ components:
 
     SendEmailResponse:
       type: object
-      description: Empty object on success - extend with optional fields later if needed
+      description: Response object for sent emails
+      properties:
+        suppressed:
+          type: boolean
+          description: Whether the recipient address is suppressed (e.g. unsubscribed)
+          example: false
 
     ErrorResponse:
       type: object

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -440,13 +440,6 @@ export const upsertSmtpConfigRequestSchema = z
         message: 'SMTP host is required',
       });
     }
-    if (data.username.length < 1) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['username'],
-        message: 'SMTP username is required',
-      });
-    }
     if (!z.string().email().safeParse(data.senderEmail).success) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/packages/shared-schemas/src/email-api.schema.ts
+++ b/packages/shared-schemas/src/email-api.schema.ts
@@ -25,6 +25,8 @@ export type SendRawEmailRequest = z.infer<typeof sendRawEmailRequestSchema>;
  * Response for POST /api/email/send-raw
  * Empty on success - extend with optional fields later if needed
  */
-export const sendEmailResponseSchema = z.object({});
+export const sendEmailResponseSchema = z.object({
+  suppressed: z.boolean().optional(),
+});
 
 export type SendEmailResponse = z.infer<typeof sendEmailResponseSchema>;


### PR DESCRIPTION
## Fixes : #1640
Email suppression was completely silent to the sending application. 
After a recipient clicked Unsubscribe, subsequent sends still returned `200 {}`, 
indistinguishable from a successful delivery.

## Root Cause

`CloudEmailProvider.sendRaw` forwarded the request to the cloud backend but only 
checked `response.data.success`, discarding all other fields. `sendEmailResponseSchema` 
was a hard-coded `z.object({})` with a TODO comment ("extend with optional fields later").

## Changes

### `packages/shared-schemas/src/email-api.schema.ts`
- Added optional `suppressed: z.boolean().optional()` field to `sendEmailResponseSchema`

### `backend/src/providers/email/cloud.provider.ts`
- `sendRaw` now reads and returns `response.data.suppressed` from the cloud API response
- Returns `{ suppressed: false }` when the cloud backend doesn't report suppression

### `backend/src/providers/email/base.provider.ts`
- Updated `sendRaw` return type signature to `Promise<SendEmailResponse>`

### `backend/src/providers/email/smtp.provider.ts`
- `sendRaw` now returns `{ suppressed: false }` (SMTP has no suppression mechanism)
- **Bug fix:** Skip PLAIN auth when username/password are empty — previously caused 
  "Missing credentials for PLAIN" errors on no-auth SMTP servers

### `backend/src/services/email/email.service.ts`
- `sendRaw` propagates provider result back to the caller instead of returning void

### `backend/src/api/routes/email/index.routes.ts`
- HTTP response now includes the service result via `successResponse(res, result)`

### `backend/tests/unit/email.test.ts`
- Added test: returns `suppressed: false` when backend does not report suppression
- Added test: returns `suppressed: true` when backend signals address is suppressed

## Before / After

```json
// Before (broken — indistinguishable from success)
POST /api/email/send-raw → 200 {}

// After (suppression now visible)
POST /api/email/send-raw → 200 { "suppressed": false }  // delivered
POST /api/email/send-raw → 200 { "suppressed": true }   // silently dropped

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose suppression status in `/api/email/send-raw` so callers can see when emails are dropped after unsubscribe, and add robust no-auth SMTP support by omitting auth when no username is configured. Addresses #1640.

- **Bug Fixes**
  - `/api/email/send-raw` now returns the provider result including `{ suppressed: boolean }`.
  - Cloud provider forwards `suppressed`; SMTP always returns `{ suppressed: false }`.
  - SMTP auth is included only when a username is set; blank passwords are allowed; password is decrypted/required only if auth is enabled; `transporter.verify` and validation respect this.
  - `EmailProvider.sendRaw` returns `SendEmailResponse`; the service returns it to callers and still records send intervals.
  - Schemas/docs: `@insforge/shared-schemas` `sendEmailResponseSchema` adds optional `suppressed`; `upsertSmtpConfigRequestSchema` no longer requires `username`; OpenAPI `email.yaml` documents `suppressed`.
  - Tests: added route tests for response shape and auth; expanded provider/service tests including axios error handling and no-auth SMTP behavior.

<sup>Written for commit c6d1c6dd75e48ffbc3f8612b16ec625c4e65b1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose suppressed status in `POST /api/email/send-raw` response and support no-auth SMTP
> - The `/api/email/send-raw` route now returns `{ suppressed: boolean }` instead of an empty object, propagated from the provider through `EmailService` and `EmailProvider`.
> - SMTP providers now support no-auth configuration: auth credentials are omitted from the transporter when username is empty, and `upsertSmtpConfigRequestSchema` no longer requires a non-empty username when SMTP is enabled.
> - `SmtpConfigService.getRawSmtpConfig` and `verifySmtpConnection` skip password decryption and auth when no username is set.
> - The OpenAPI spec and `sendEmailResponseSchema` are updated to document the optional `suppressed` field.
> - Behavioral Change: SMTP configs with an empty username are now valid and will connect without auth; previously they were rejected at the schema level.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6d1c6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raw email sending now supports an optional `suppressed` flag in the response.
* **Bug Fixes**
  * The email send endpoint now returns the actual send result instead of an empty response.
  * Improved SMTP handling: authentication is only configured when an SMTP username is provided, and credential decryption/validation is more consistent.
* **Tests**
  * Added/expanded unit coverage for raw send responses, route behavior, validation/auth errors, provider capability checks, and SMTP transporter/auth scenarios.
* **Documentation**
  * Updated OpenAPI and shared schema to document `suppressed` on `SendEmailResponse`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->