### PR TITLE
fix(build): inline file-type into the server bundle so it resolves at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,15 +123,8 @@ RUN npm install -g "tsx@^4.7.1" && npm cache clean --force
 
 # --- Stable layers first (change only when dependencies change) ---
 
-# Production node_modules. Most deps hoist to the root, but npm nests a few
-# under backend/node_modules when a version can't be shared with the root tree
-# (e.g. file-type + its strtok3/token-types, and @aws-sdk/* pinned to a newer
-# minor than the hoisted copy). Copying only the root drops those, so backend
-# imports crash (file-type) or silently resolve the wrong version (client-s3).
-# The two dirs never collide (separate paths) and Node's upward resolution keeps
-# each importer on its intended version, so copy both.
+# Production node_modules (hoisted by npm workspaces)
 COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
-COPY --from=prod-deps --chown=node:node /app/backend/node_modules ./backend/node_modules
 
 # --- Volatile layers last (change every release) ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,8 +123,15 @@ RUN npm install -g "tsx@^4.7.1" && npm cache clean --force
 
 # --- Stable layers first (change only when dependencies change) ---
 
-# Production node_modules (hoisted by npm workspaces)
+# Production node_modules. Most deps hoist to the root, but npm nests a few
+# under backend/node_modules when a version can't be shared with the root tree
+# (e.g. file-type + its strtok3/token-types, and @aws-sdk/* pinned to a newer
+# minor than the hoisted copy). Copying only the root drops those, so backend
+# imports crash (file-type) or silently resolve the wrong version (client-s3).
+# The two dirs never collide (separate paths) and Node's upward resolution keeps
+# each importer on its intended version, so copy both.
 COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=node:node /app/backend/node_modules ./backend/node_modules
 
 # --- Volatile layers last (change every release) ---
 

--- a/backend/tsup.config.ts
+++ b/backend/tsup.config.ts
@@ -9,13 +9,16 @@ export default defineConfig({
   clean: false, // Don't clean the whole dist folder (frontend is there)
   sourcemap: true,
   // Don't bundle node_modules, only our code and shared-schemas.
-  // Exception: `lru-cache` — our SigV4 verifier's hot-path cache. Npm nests
-  // it under backend/node_modules/ because a devDep transitive pins the
-  // older v5 at the root and the workspace conflict can't be hoisted. The
-  // Docker runner only ships the hoisted root node_modules/, so Node can't
-  // resolve it at runtime. Inline it into the bundle instead of teaching
-  // the Dockerfile to merge nested module layers.
-  noExternal: [/@insforge\/shared-schemas/, 'lru-cache'],
+  // Exceptions — deps npm nests under backend/node_modules/ instead of hoisting
+  // to the root, so the Docker runner (which only ships the hoisted root
+  // node_modules/) can't resolve them at runtime. Inline them into the bundle
+  // instead of teaching the Dockerfile to merge nested module layers:
+  //   - `lru-cache`: our SigV4 verifier's hot-path cache; a devDep transitive
+  //     pins the older v5 at the root so the workspace copy can't hoist.
+  //   - `file-type`: used by utils/mime-guard; nests under backend/node_modules
+  //     (with its strtok3/token-types deps) alongside the @aws-sdk copies that
+  //     pin a newer minor than the root tree.
+  noExternal: [/@insforge\/shared-schemas/, 'lru-cache', 'file-type'],
   esbuildOptions(options) {
     options.alias = {
       '@': './src',


### PR DESCRIPTION
> Supersedes #1650 (closed when its head branch was renamed). Same commit, correct branch name.

## Problem

The production image crash-loops with `ERR_MODULE_NOT_FOUND` for `file-type`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'file-type'
  imported from /app/dist/server.js
```

Migrations complete, then the server crashes on every boot (repro'd on the `v2.2.7-depsnotfound` test build).

## Root cause

- `file-type` is imported by `backend/src/utils/mime-guard.ts` and, with the current lockfile, npm **nests** it (plus its `strtok3` / `token-types` deps) under `backend/node_modules/` instead of hoisting to the root — it can't share the root tree alongside the `@aws-sdk/*` copies pinned to a newer minor.
- tsup emits the server bundle to **`/app/dist/server.js`** and leaves `node_modules` **external** (resolved at runtime).
- Node resolves a bare `file-type` import from the importing file upward: `/app/dist/node_modules` -> `/app/node_modules` -> `/node_modules`. It never looks in `/app/backend/node_modules`.
- The Docker runner only ships the hoisted **root** `node_modules/`, so the nested `file-type` is absent from the server's resolution path -> crash.

This is the **exact** problem the codebase already documents for `lru-cache` in `backend/tsup.config.ts`, where the chosen remedy is to inline the dep into the bundle rather than teach the Dockerfile to merge nested module layers.

## Fix

Add `file-type` to tsup's `noExternal`, matching the `lru-cache` precedent. esbuild then inlines `file-type` and its `strtok3` / `token-types` deps into `dist/server.js`, so no runtime resolution is needed.

No Dockerfile change and no root-`package.json` change (the root deliberately declares zero runtime deps). `@aws-sdk/client-s3` stays external — it resolves fine from the root tree.

## Verification

Built the bundle in the worktree and grepped `dist/*.js`:
- `file-type`, `strtok3`, `token-types` — **no** external `from '...'` / `require('...')` references remain (fully inlined).
- `lru-cache` — also inlined (consistent with the existing precedent).
- `@aws-sdk/client-s3` — still external (correct; present in root `node_modules`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle `file-type` inline in the server build to fix runtime resolution
> Adds `file-type` to the `noExternal` array in [tsup.config.ts](https://github.com/InsForge/InsForge/pull/1651/files#diff-35e5e801da8c4a814697b4b7bde83d0fe94d62f362a1a7b5e2467bf66990d1ed) so it is inlined into the server bundle rather than resolved from `node_modules` at runtime. This mirrors the existing treatment of `lru-cache`, which is also an ESM-only package that requires bundling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38a736b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline `file-type` into the server bundle to fix a production crash (ERR_MODULE_NOT_FOUND) caused by it being nested under `backend/node_modules`. This mirrors the existing `lru-cache` workaround and removes the need for runtime resolution.

- **Bug Fixes**
  - Added `file-type` to tsup `noExternal` so it (and `strtok3`/`token-types`) is bundled.
  - `@aws-sdk/client-s3` remains external and resolves from the root `node_modules`.

<sup>Written for commit 38a736b466922fba2cfab4faf65715f1c7434bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility in bundled deployments, helping the app load dependencies more reliably in containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->