### PR TITLE
docs: add comparison and pricing FAQ pages

### DIFF
--- a/docs/alternatives.mdx
+++ b/docs/alternatives.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Alternatives"
-description: "How InsForge compares to Supabase, Firebase, and other backends."
+description: "How InsForge compares to Supabase and Firebase."
 ---
 
 InsForge is the **agent-native cloud infrastructure platform**. A coding agent

--- a/docs/alternatives.mdx
+++ b/docs/alternatives.mdx
@@ -1,6 +1,6 @@
 ---
-title: "InsForge vs. Supabase and Firebase"
-description: "How InsForge compares as the agent-native cloud infrastructure platform."
+title: "Alternatives"
+description: "How InsForge compares to Supabase, Firebase, and other backends."
 ---
 
 InsForge is the **agent-native cloud infrastructure platform**. A coding agent

--- a/docs/comparison.mdx
+++ b/docs/comparison.mdx
@@ -1,0 +1,80 @@
+---
+title: "InsForge vs. Supabase and Firebase"
+description: "How InsForge compares as the agent-native cloud infrastructure platform."
+---
+
+InsForge is the **agent-native cloud infrastructure platform**. A coding agent
+gives any app a Postgres database, authentication, storage, edge functions,
+compute, hosting, and an AI model gateway, driven end to end through one CLI. It
+is open source (Apache-2.0).
+
+Its MCP server and CLI expose that infrastructure as structured,
+machine-readable context, so AI coding agents can plan and execute operations
+autonomously within scoped permissions. The shift in the human's role: with
+traditional platforms you **implement and execute**; with InsForge you **define
+intent and review**.
+
+<Note>
+  For the full, always-current write-ups see
+  [InsForge vs Supabase](https://insforge.dev/alternatives/insforge-vs-supabase)
+  and [InsForge vs Firebase](https://insforge.dev/alternatives/insforge-vs-firebase).
+</Note>
+
+## InsForge vs. Supabase
+
+Supabase is an open-source, Postgres-based backend built for human developers.
+InsForge shares the Postgres foundation but is built for AI coding agents as
+first-class operators.
+
+| Dimension | Supabase | InsForge |
+|---|---|---|
+| Primary operator | Human developers | AI coding agents |
+| Configuration model | Explicit UI, SQL, CLI | Agent-executed operations |
+| Permission design | Developer-managed access | Scoped agent autonomy |
+| System context | Implicit, developer-maintained | Structured, machine-readable (MCP) |
+| Payments | Via app code | Built-in Stripe integration |
+| AI model access | External model wiring | Built-in model gateway |
+| Security | Per-integration implementation | Production-ready defaults |
+| Agent readiness | Requires manual wiring | End-to-end operable |
+
+## InsForge vs. Firebase
+
+Firebase targets rapid prototyping on document-oriented NoSQL with human
+operators. InsForge targets agentic coding on relational Postgres.
+
+| Dimension | Firebase | InsForge |
+|---|---|---|
+| Database | Document-oriented NoSQL | Relational Postgres |
+| Data model | Schemaless JSON | Structured tables with relations |
+| Joins | Not natively supported | Native joins and queries |
+| Transactions | Supported with limits | Full ACID transactions |
+| Self-hosting | Not supported | Docker / self-hostable |
+| Primary operator | Human developers | AI coding agents |
+| System context | Implicit, fragmented | Structured, machine-readable (MCP) |
+| AI integration | External setup | Built-in model gateway |
+| Payments | Manual integration | Built-in Stripe primitive |
+
+## Why teams pick InsForge
+
+<CardGroup cols={2}>
+  <Card title="Agent-native by design" icon="robot">
+    One MCP server exposes schemas, permissions, and logs as structured context,
+    so an AI coding agent can provision and operate the whole stack end to end,
+    not just query a database.
+  </Card>
+  <Card title="Production-ready primitives" icon="layer-group">
+    Payments (Stripe), an AI model gateway, and deployment are included out of
+    the box, instead of wiring each integration yourself.
+  </Card>
+  <Card title="Relational Postgres" icon="database">
+    Native joins, full ACID transactions, and schema enforcement, so your data
+    and skills transfer. No proprietary document model to design around.
+  </Card>
+  <Card title="Open source, self-hostable" icon="server">
+    Run it on your own infrastructure with Docker, or use the managed cloud.
+  </Card>
+</CardGroup>
+
+<Card title="Start building" icon="rocket" href="https://insforge.dev/auth/sign-up">
+  Create a project and connect your favorite AI coding agent.
+</Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,6 @@
             "pages": [
               "introduction",
               "products",
-              "comparison",
               {
                 "group": "Quickstart",
                 "expanded": true,
@@ -152,8 +151,9 @@
           {
             "group": "Resources",
             "pages": [
-              "showcase",
-              "pricing"
+              "alternatives",
+              "pricing",
+              "showcase"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,7 @@
             "pages": [
               "introduction",
               "products",
+              "comparison",
               {
                 "group": "Quickstart",
                 "expanded": true,
@@ -151,7 +152,8 @@
           {
             "group": "Resources",
             "pages": [
-              "showcase"
+              "showcase",
+              "pricing"
             ]
           }
         ]

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -8,44 +8,23 @@ production. This page mirrors the [pricing page](https://insforge.dev/pricing).
 
 ## Plans
 
-<CardGroup cols={3}>
-  <Card title="Free — $0/mo" icon="seedling">
-    For prototypes, demos, and side projects.
+|  | Free | Pro | Enterprise |
+|---|---|---|---|
+| **Price** | $0 / mo | $25 / mo | Custom |
+| Best for | Prototypes & side projects | Production apps that scale | Security & compliance |
+| Monthly active users | 50,000 | 100,000 | Custom |
+| Database | 500 MB | 8 GB | Custom |
+| Bandwidth | 5 GB | 250 GB | Custom |
+| File storage | 1 GB | 100 GB | Custom |
+| Edge function calls | 100,000 | 100,000 | Custom |
+| Site build time | 600 min | Unlimited | Unlimited |
+| Custom compute | 120h (default spec) | Billed by usage | Billed by usage |
+| Compute credits included | — | $10 / mo | $10 / mo |
+| SOC2 / HIPAA / SSO | — | — | ✓ |
 
-    - $1 AI model credits
-    - 50,000 monthly active users
-    - 500 MB database size
-    - 5 GB bandwidth
-    - 1 GB file storage
-    - 100,000 edge function calls
-    - 600 minutes of site build time
-    - 120h of custom compute on default spec
-
-    Free projects are paused after 1 week of inactivity.
-  </Card>
-  <Card title="Pro — $25/mo" icon="rocket">
-    Everything in Free, plus ($10 in InsForge Compute credits included):
-
-    - 100,000 monthly active users, then $0.00325 / MAU
-    - 8 GB database size, then $0.125 / GB
-    - 250 GB bandwidth, then $0.09 / GB
-    - 100 GB file storage, then $0.021 / GB
-    - 100,000 edge function calls, then $0.01 / 1,000
-    - Unlimited site build time
-    - Custom compute, billed by usage
-  </Card>
-  <Card title="Enterprise — Custom" icon="building">
-    Everything in Pro, plus:
-
-    - SOC2
-    - HIPAA available as paid add-on
-    - SSO
-    - Unlimited projects
-    - Dedicated technical support
-
-    [Contact us](https://insforge.dev/pricing) for a quote.
-  </Card>
-</CardGroup>
+On Pro, usage beyond the included amounts is pay-as-you-go (see rates in the FAQ
+below). Free projects are paused after 1 week of inactivity.
+[Contact us](https://insforge.dev/pricing) for Enterprise.
 
 ## FAQ
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,0 +1,80 @@
+---
+title: "Pricing FAQ"
+description: "Plans, what's included, and how usage-based billing works."
+---
+
+InsForge has a free tier for prototypes and side projects, and paid plans for
+production. This page mirrors the [pricing page](https://insforge.dev/pricing).
+
+## Plans
+
+<CardGroup cols={3}>
+  <Card title="Free — $0/mo" icon="seedling">
+    For prototypes, demos, and side projects.
+
+    - $1 AI model credits
+    - 50,000 monthly active users
+    - 500 MB database size
+    - 5 GB bandwidth
+    - 1 GB file storage
+    - 100,000 edge function calls
+    - 600 minutes of site build time
+    - 120h of custom compute on default spec
+
+    Free projects are paused after 1 week of inactivity.
+  </Card>
+  <Card title="Pro — $25/mo" icon="rocket">
+    Everything in Free, plus ($10 in InsForge Compute credits included):
+
+    - 100,000 monthly active users, then $0.00325 / MAU
+    - 8 GB database size, then $0.125 / GB
+    - 250 GB bandwidth, then $0.09 / GB
+    - 100 GB file storage, then $0.021 / GB
+    - 100,000 edge function calls, then $0.01 / 1,000
+    - Unlimited site build time
+    - Custom compute, billed by usage
+  </Card>
+  <Card title="Enterprise — Custom" icon="building">
+    Everything in Pro, plus:
+
+    - SOC2
+    - HIPAA available as paid add-on
+    - SSO
+    - Unlimited projects
+    - Dedicated technical support
+
+    [Contact us](https://insforge.dev/pricing) for a quote.
+  </Card>
+</CardGroup>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="What do overages cost on Pro?">
+    Pro includes generous allowances, then bills only for usage beyond them:
+
+    | Resource | Rate beyond the included amount |
+    |---|---|
+    | Monthly active users | $0.00325 / MAU |
+    | Database | $0.125 / GB |
+    | Bandwidth | $0.09 / GB |
+    | File storage | $0.021 / GB |
+    | Edge function calls | $0.01 / 1,000 calls |
+  </Accordion>
+
+  <Accordion title="How does custom compute billing work?">
+    Every project gets **120 hours of custom compute per month on the default
+    spec** for free. Pro also includes **$10 of InsForge Compute credits** each
+    month. Beyond that, custom compute is **billed by usage** — run your own
+    containers and long-running workloads and pay for what you use.
+  </Accordion>
+
+  <Accordion title="What happens after I use up the $10 compute credit?">
+    Nothing stops — the $10 monthly InsForge Compute credit (on Pro) covers the
+    first $10 of compute, and beyond that compute continues on pay-as-you-go.
+  </Accordion>
+</AccordionGroup>
+
+<Card title="See full pricing" icon="tag" href="https://insforge.dev/pricing">
+  Compare plans and subscribe.
+</Card>

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -12,6 +12,7 @@ production. This page mirrors the [pricing page](https://insforge.dev/pricing).
 |---|---|---|---|
 | **Price** | $0 / mo | $25 / mo | Custom |
 | Best for | Prototypes & side projects | Production apps that scale | Security & compliance |
+| AI model credits | $1 | $10 | Custom |
 | Monthly active users | 50,000 | 100,000 | Custom |
 | Database | 500 MB | 8 GB | Custom |
 | Bandwidth | 5 GB | 250 GB | Custom |
@@ -20,7 +21,7 @@ production. This page mirrors the [pricing page](https://insforge.dev/pricing).
 | Site build time | 600 min | Unlimited | Unlimited |
 | Custom compute | 120h (default spec) | Billed by usage | Billed by usage |
 | Compute credits included | — | $10 / mo | $10 / mo |
-| SOC2 / HIPAA / SSO | — | — | ✓ |
+| Compliance & SSO | — | — | SOC2, SSO, HIPAA add-on |
 
 On Pro, usage beyond the included amounts is pay-as-you-go (see rates in the FAQ
 below). Free projects are paused after 1 week of inactivity.
@@ -42,10 +43,10 @@ below). Free projects are paused after 1 week of inactivity.
   </Accordion>
 
   <Accordion title="How does custom compute billing work?">
-    Every project gets **120 hours of custom compute per month on the default
-    spec** for free. Pro also includes **$10 of InsForge Compute credits** each
-    month. Beyond that, custom compute is **billed by usage** — run your own
-    containers and long-running workloads and pay for what you use.
+    The Free plan includes **120 hours of custom compute per month on the
+    default spec**. On Pro, custom compute is **billed by usage**: run your own
+    containers and long-running workloads and pay for what you use. Each month
+    also comes with **$10 of InsForge Compute credits** to offset it.
   </Accordion>
 
   <Accordion title="What happens after I use up the $10 compute credit?">

--- a/docs/styles/config/vocabularies/Mintlify/accept.txt
+++ b/docs/styles/config/vocabularies/Mintlify/accept.txt
@@ -40,6 +40,7 @@ Dokploy
 docker
 dockerfile
 env
+Firebase
 flyctl
 github
 hardcoding
@@ -101,6 +102,7 @@ rmcp
 roocode
 runbook
 runtimes
+Schemaless
 sdk
 SDKs
 select_account
@@ -113,6 +115,7 @@ stderr
 subcommand
 subcommands
 sudo
+Supabase
 systemd
 tmpfs
 transactionally


### PR DESCRIPTION
## What

Adds two documentation pages to close high-frequency, previously-unanswered questions from the docs assistant (competitor comparison and pricing).

- **`docs/comparison.mdx`** — "InsForge vs. Supabase and Firebase". Mirrors the official alternatives pages ([vs Supabase](https://insforge.dev/alternatives/insforge-vs-supabase), [vs Firebase](https://insforge.dev/alternatives/insforge-vs-firebase)): agent-native positioning, per-dimension comparison tables, and "why teams pick InsForge". Links out to the full pages.
- **`docs/pricing.mdx`** — "Pricing FAQ". Mirrors the public [pricing page](https://insforge.dev/pricing) exactly (Free / Pro / Enterprise, included allowances, overage rates, $10 compute credits). No figures beyond what the pricing page states.
- **`docs/docs.json`** — registers `comparison` under Getting Started and `pricing` under Resources.

## Sourcing

- Pricing numbers and plan lineup: taken from the public pricing page (Starter/Team are hidden in the app and are intentionally omitted).
- Comparison framing: the official alternatives pages.
- Nothing internal-only is published (e.g. per-hour compute rate, email allowance) since those are not on the public pricing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Alternatives page and a Pricing FAQ to answer common comparison and billing questions. Moves the comparison into `alternatives` under Resources, switches pricing to a horizontal plans table, and aligns both pages with `pricePlans` and review feedback.

- **New Features**
  - `docs/alternatives.mdx`: InsForge vs Supabase/Firebase with per-dimension tables, “Why teams pick InsForge”, and links to full alternatives.
  - `docs/pricing.mdx`: Free/Pro/Enterprise table, Pro overage rates, and compute credit FAQs; mirrors the public pricing page.
  - `docs/docs.json`: Adds navigation entries for `alternatives` and `pricing` under Resources.

- **Refactors**
  - `docs/styles/config/vocabularies/Mintlify/accept.txt`: Allow “Supabase”, “Firebase”, and “Schemaless”.
  - Sync plan copy and tables with `pricePlans`; apply review feedback.

<sup>Written for commit eaac6388ddc17c6e27a76f64c8dcdac1fa751b01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add comparison and pricing FAQ pages to docs
> Adds two new documentation pages: [alternatives.mdx](https://github.com/InsForge/InsForge/pull/1652/files#diff-5ed80602bb218c5705bae03955de4eef6017a4568808199c2f4bdfd72d56936f) compares InsForge with Supabase and Firebase using tables and call-to-action cards, and [pricing.mdx](https://github.com/InsForge/InsForge/pull/1652/files#diff-9947d1f7992671b2f67465ab344460adb9df616025783d010f578d1a862c9d3f) covers plans, allowances, overage rates, and compute billing with tables and accordions. Both pages are registered in [docs.json](https://github.com/InsForge/InsForge/pull/1652/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9), and 'Firebase', 'Supabase', and 'Schemaless' are added to the spell-check vocabulary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaac638.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **Pricing FAQ** page, including plan allowances, usage-based billing notes, and an FAQ covering Pro overages and custom compute behavior.
  * Added a new **Alternatives** page with comparison tables and a “why teams choose” overview.
  * Updated documentation navigation to include the new **Pricing** page.
  * Expanded the docs vocabulary list with additional product/platform terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->