### PR TITLE
feat(marketplace): plugin marketplace with real Resend install

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -448,3 +448,30 @@ function createWriteEndpointLimiter(category: WriteLimiterCategory) {
 export const functionsWriteLimiter = createWriteEndpointLimiter('functions');
 export const deploymentsWriteLimiter = createWriteEndpointLimiter('deployments');
 export const computeWriteLimiter = createWriteEndpointLimiter('compute');
+
+/**
+ * Per-IP rate limiter for marketplace plugin install/uninstall. Installs make
+ * an outbound validation request to the provider with the submitted key, so
+ * this caps key-enumeration attempts and provider hammering from a
+ * compromised admin session. Admin-only routes; normal use is a handful of
+ * installs per project lifetime.
+ *
+ * Limits: 20 requests per 15 minutes per IP.
+ */
+export const marketplaceInstallRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many marketplace install requests from this IP. Please try again in 15 minutes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+  skipSuccessfulRequests: false,
+  skipFailedRequests: false,
+});

--- a/backend/src/api/routes/marketplace/index.routes.ts
+++ b/backend/src/api/routes/marketplace/index.routes.ts
@@ -9,6 +9,7 @@ import { MarketplaceService } from '@/services/marketplace/marketplace.service.j
 import { FunctionService } from '@/services/functions/function.service.js';
 import { AuditService } from '@/services/logs/audit.service.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { marketplaceInstallRateLimiter } from '@/api/middlewares/rate-limiters.js';
 import { AppError } from '@/utils/errors.js';
 import { successResponse } from '@/utils/response.js';
 
@@ -49,6 +50,7 @@ router.get(
 router.post(
   '/plugins/:slug/install',
   verifyAdmin,
+  marketplaceInstallRateLimiter,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { slug } = req.params;
@@ -91,6 +93,7 @@ router.post(
 router.delete(
   '/plugins/:slug',
   verifyAdmin,
+  marketplaceInstallRateLimiter,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const { slug } = req.params;

--- a/backend/src/api/routes/marketplace/index.routes.ts
+++ b/backend/src/api/routes/marketplace/index.routes.ts
@@ -1,0 +1,120 @@
+import { Router, Response, NextFunction } from 'express';
+import {
+  ERROR_CODES,
+  installMarketplacePluginRequestSchema,
+  type InstallMarketplacePluginResponse,
+  type UninstallMarketplacePluginResponse,
+} from '@insforge/shared-schemas';
+import { MarketplaceService } from '@/services/marketplace/marketplace.service.js';
+import { FunctionService } from '@/services/functions/function.service.js';
+import { AuditService } from '@/services/logs/audit.service.js';
+import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { AppError } from '@/utils/errors.js';
+import { successResponse } from '@/utils/response.js';
+
+const router = Router();
+const marketplaceService = MarketplaceService.getInstance();
+const auditService = AuditService.getInstance();
+const functionService = FunctionService.getInstance();
+
+// Installs create/remove secrets, which are injected into edge-function
+// environments — redeploy so functions see the change (non-blocking, debounced)
+const triggerSecretsRedeployment = () => {
+  if (functionService.isSubhostingConfigured()) {
+    functionService.redeploy();
+  }
+};
+
+/**
+ * List marketplace plugins with installed status
+ * GET /api/marketplace/plugins
+ */
+router.get(
+  '/plugins',
+  verifyAdmin,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const plugins = await marketplaceService.listPlugins();
+      successResponse(res, { plugins });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * Install a plugin (validate the provider API key, store it as a secret)
+ * POST /api/marketplace/plugins/:slug/install
+ */
+router.post(
+  '/plugins/:slug/install',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { slug } = req.params;
+      const parseResult = installMarketplacePluginRequestSchema.safeParse(req.body);
+      if (!parseResult.success) {
+        throw new AppError(
+          `Invalid request: ${parseResult.error.errors.map((e) => e.message).join(', ')}`,
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const plugin = await marketplaceService.installPlugin(slug, parseResult.data.apiKey);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'INSTALL_PLUGIN',
+        module: 'MARKETPLACE',
+        details: { slug, secretName: plugin.install.secretName },
+        ip_address: req.ip,
+      });
+
+      triggerSecretsRedeployment();
+
+      const response: InstallMarketplacePluginResponse = {
+        success: true,
+        message: `${plugin.name} has been installed successfully`,
+      };
+      successResponse(res, response, 201);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * Uninstall a plugin (deactivate its secret)
+ * DELETE /api/marketplace/plugins/:slug
+ */
+router.delete(
+  '/plugins/:slug',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { slug } = req.params;
+      const plugin = await marketplaceService.uninstallPlugin(slug);
+
+      await auditService.log({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'UNINSTALL_PLUGIN',
+        module: 'MARKETPLACE',
+        details: { slug, secretName: plugin.install.secretName },
+        ip_address: req.ip,
+      });
+
+      triggerSecretsRedeployment();
+
+      const response: UninstallMarketplacePluginResponse = {
+        success: true,
+        message: `${plugin.name} has been uninstalled successfully`,
+      };
+      successResponse(res, response);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -235,9 +235,10 @@ export function loadConfig(): AppConfig {
       openrouterApiKey: process.env.OPENROUTER_API_KEY || undefined,
     },
     marketplace: {
+      // ?? preserves an explicitly empty MARKETPLACE_CATALOG_URL as the
+      // documented "bundled catalog only" opt-out for offline self-hosts
       catalogUrl:
-        process.env.MARKETPLACE_CATALOG_URL ||
-        'https://api.insforge.dev/marketplace/v1/catalog',
+        process.env.MARKETPLACE_CATALOG_URL ?? 'https://api.insforge.dev/marketplace/v1/catalog',
     },
     telemetry: {
       disabled: parseEnvBool(process.env.INSFORGE_TELEMETRY_DISABLED),

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -100,6 +100,10 @@ export interface AppConfig {
   ai: {
     openrouterApiKey: string | undefined;
   };
+  marketplace: {
+    // URL of the hosted marketplace.json catalog; empty = bundled catalog only
+    catalogUrl: string;
+  };
   telemetry: {
     disabled: boolean;
   };
@@ -229,6 +233,11 @@ export function loadConfig(): AppConfig {
     },
     ai: {
       openrouterApiKey: process.env.OPENROUTER_API_KEY || undefined,
+    },
+    marketplace: {
+      catalogUrl:
+        process.env.MARKETPLACE_CATALOG_URL ||
+        'https://api.insforge.dev/marketplace/v1/catalog',
     },
     telemetry: {
       disabled: parseEnvBool(process.env.INSFORGE_TELEMETRY_DISABLED),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,6 +12,7 @@ import { metadataRouter } from '@/api/routes/metadata/index.routes.js';
 import { logsRouter } from '@/api/routes/logs/index.routes.js';
 import { docsRouter } from '@/api/routes/docs/index.routes.js';
 import functionsRouter from '@/api/routes/functions/index.routes.js';
+import marketplaceRouter from '@/api/routes/marketplace/index.routes.js';
 import secretsRouter from '@/api/routes/secrets/index.routes.js';
 import { usageRouter } from '@/api/routes/usage/index.routes.js';
 import { aiRouter } from '@/api/routes/ai/index.routes.js';
@@ -218,6 +219,7 @@ export async function createApp() {
   apiRouter.use('/deployments', deploymentsRouter);
   apiRouter.use('/schedules', schedulesRouter);
   apiRouter.use('/payments', paymentsRouter);
+  apiRouter.use('/marketplace', marketplaceRouter);
   apiRouter.use('/compute/services', servicesRouter);
   apiRouter.use('/analytics', analyticsRouter);
   apiRouter.use('/webscraper', webscraperRouter);

--- a/backend/src/services/marketplace/catalog.service.ts
+++ b/backend/src/services/marketplace/catalog.service.ts
@@ -6,6 +6,16 @@ import { DEFAULT_MARKETPLACE_CATALOG } from './default-catalog.js';
 const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
 const CATALOG_FETCH_TIMEOUT_MS = 5_000;
 
+/** Origin + path only: the operator-configured URL may carry signed params */
+function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return '<invalid url>';
+  }
+}
+
 /**
  * Fetches the hosted marketplace.json (S3/CDN, provisioned by
  * insforge-cloudbackend), caching it in memory. Any failure — no URL
@@ -20,6 +30,9 @@ export class MarketplaceCatalogService {
   // catalog URL is retried at most once per TTL, so offline self-hosted
   // instances aren't stalled by a fetch timeout on every marketplace request
   private lastFetchAt = 0;
+  // Shared in-flight refresh: concurrent callers await the same fetch instead
+  // of racing to the bundled fallback while the first fetch is still running
+  private inflight: Promise<void> | null = null;
 
   static getInstance(): MarketplaceCatalogService {
     if (!MarketplaceCatalogService.instance) {
@@ -34,11 +47,20 @@ export class MarketplaceCatalogService {
       return DEFAULT_MARKETPLACE_CATALOG;
     }
 
-    if (Date.now() - this.lastFetchAt < CATALOG_CACHE_TTL_MS) {
-      return this.cached ?? DEFAULT_MARKETPLACE_CATALOG;
+    if (!this.inflight && Date.now() - this.lastFetchAt >= CATALOG_CACHE_TTL_MS) {
+      this.inflight = this.refresh(url).finally(() => {
+        this.inflight = null;
+      });
     }
-    this.lastFetchAt = Date.now();
+    if (this.inflight) {
+      await this.inflight;
+    }
+    return this.cached ?? DEFAULT_MARKETPLACE_CATALOG;
+  }
 
+  /** Never rejects — failures are logged and the previous cache stands */
+  private async refresh(url: string): Promise<void> {
+    this.lastFetchAt = Date.now();
     try {
       const response = await fetch(url, {
         signal: AbortSignal.timeout(CATALOG_FETCH_TIMEOUT_MS),
@@ -51,15 +73,13 @@ export class MarketplaceCatalogService {
         throw new Error(`Catalog payload failed validation: ${parsed.error.message}`);
       }
       this.cached = parsed.data;
-      return parsed.data;
     } catch (error) {
       logger.warn(
-        `Failed to fetch marketplace catalog from ${url}, using ${
+        `Failed to fetch marketplace catalog from ${redactUrl(url)}, using ${
           this.cached ? 'last cached' : 'bundled'
         } catalog: ${error instanceof Error ? error.message : String(error)}`
       );
       // A stale cache is closer to the hosted truth than the bundled fallback
-      return this.cached ?? DEFAULT_MARKETPLACE_CATALOG;
     }
   }
 
@@ -67,5 +87,6 @@ export class MarketplaceCatalogService {
   clearCache(): void {
     this.cached = null;
     this.lastFetchAt = 0;
+    this.inflight = null;
   }
 }

--- a/backend/src/services/marketplace/catalog.service.ts
+++ b/backend/src/services/marketplace/catalog.service.ts
@@ -1,0 +1,71 @@
+import { marketplaceCatalogSchema, type MarketplaceCatalog } from '@insforge/shared-schemas';
+import { appConfig } from '@/infra/config/app.config.js';
+import logger from '@/utils/logger.js';
+import { DEFAULT_MARKETPLACE_CATALOG } from './default-catalog.js';
+
+const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
+const CATALOG_FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Fetches the hosted marketplace.json (S3/CDN, provisioned by
+ * insforge-cloudbackend), caching it in memory. Any failure — no URL
+ * configured, network error, non-2xx, or a payload that doesn't conform to
+ * marketplaceCatalogSchema — falls back to the bundled catalog so the
+ * marketplace keeps working on offline/self-hosted instances.
+ */
+export class MarketplaceCatalogService {
+  private static instance: MarketplaceCatalogService;
+  private cached: MarketplaceCatalog | null = null;
+  // Timestamp of the last fetch attempt (success or failure): an unreachable
+  // catalog URL is retried at most once per TTL, so offline self-hosted
+  // instances aren't stalled by a fetch timeout on every marketplace request
+  private lastFetchAt = 0;
+
+  static getInstance(): MarketplaceCatalogService {
+    if (!MarketplaceCatalogService.instance) {
+      MarketplaceCatalogService.instance = new MarketplaceCatalogService();
+    }
+    return MarketplaceCatalogService.instance;
+  }
+
+  async getCatalog(): Promise<MarketplaceCatalog> {
+    const url = appConfig.marketplace.catalogUrl;
+    if (!url) {
+      return DEFAULT_MARKETPLACE_CATALOG;
+    }
+
+    if (Date.now() - this.lastFetchAt < CATALOG_CACHE_TTL_MS) {
+      return this.cached ?? DEFAULT_MARKETPLACE_CATALOG;
+    }
+    this.lastFetchAt = Date.now();
+
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(CATALOG_FETCH_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`Catalog fetch returned ${response.status}`);
+      }
+      const parsed = marketplaceCatalogSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        throw new Error(`Catalog payload failed validation: ${parsed.error.message}`);
+      }
+      this.cached = parsed.data;
+      return parsed.data;
+    } catch (error) {
+      logger.warn(
+        `Failed to fetch marketplace catalog from ${url}, using ${
+          this.cached ? 'last cached' : 'bundled'
+        } catalog: ${error instanceof Error ? error.message : String(error)}`
+      );
+      // A stale cache is closer to the hosted truth than the bundled fallback
+      return this.cached ?? DEFAULT_MARKETPLACE_CATALOG;
+    }
+  }
+
+  /** Test hook */
+  clearCache(): void {
+    this.cached = null;
+    this.lastFetchAt = 0;
+  }
+}

--- a/backend/src/services/marketplace/default-catalog.ts
+++ b/backend/src/services/marketplace/default-catalog.ts
@@ -1,0 +1,35 @@
+import type { MarketplaceCatalog } from '@insforge/shared-schemas';
+
+// Bundled fallback catalog, used when MARKETPLACE_CATALOG_URL is unset or the
+// hosted marketplace.json is unreachable/invalid. Also the initial content to
+// provision to S3 — keep it valid against marketplaceCatalogSchema.
+export const DEFAULT_MARKETPLACE_CATALOG: MarketplaceCatalog = {
+  version: 1,
+  plugins: [
+    {
+      slug: 'resend',
+      name: 'Resend',
+      publisher: 'Resend',
+      category: 'Messaging',
+      description: 'Send transactional email from functions with domains and templates.',
+      actions: [
+        'Validate your key with Resend',
+        'Store RESEND_API_KEY as an encrypted secret',
+        'Expose it to edge functions as an env var',
+      ],
+      iconUrl: 'https://cdn.simpleicons.org/resend',
+      install: {
+        type: 'secret',
+        secretName: 'RESEND_API_KEY',
+        placeholder: 're_...',
+        // Resend send-only restricted keys 401 on /domains and are rejected;
+        // full-access keys are required to install.
+        validation: {
+          url: 'https://api.resend.com/domains',
+          method: 'GET',
+        },
+      },
+      docsUrl: 'https://resend.com/docs/api-reference/introduction',
+    },
+  ],
+};

--- a/backend/src/services/marketplace/marketplace.service.ts
+++ b/backend/src/services/marketplace/marketplace.service.ts
@@ -1,0 +1,186 @@
+import net from 'net';
+import dns from 'dns/promises';
+import {
+  ERROR_CODES,
+  type MarketplacePlugin,
+  type MarketplacePluginWithStatus,
+} from '@insforge/shared-schemas';
+import { SecretService } from '@/services/secrets/secret.service.js';
+import { isPrivateIp } from '@/services/email/smtp-config.service.js';
+import { AppError } from '@/utils/errors.js';
+import { MarketplaceCatalogService } from './catalog.service.js';
+
+const VALIDATION_TIMEOUT_MS = 10_000;
+
+/**
+ * Generic install engine for marketplace plugins. Installs are declarative
+ * and secret-only: the catalog entry names the secret and (optionally) a
+ * provider endpoint to validate the key against; installing stores the key
+ * encrypted in system.secrets, where it is auto-injected into edge-function
+ * environments on redeploy. Installed = an active secret with that name.
+ */
+export class MarketplaceService {
+  private static instance: MarketplaceService;
+  private catalogService = MarketplaceCatalogService.getInstance();
+  private secretService = SecretService.getInstance();
+
+  static getInstance(): MarketplaceService {
+    if (!MarketplaceService.instance) {
+      MarketplaceService.instance = new MarketplaceService();
+    }
+    return MarketplaceService.instance;
+  }
+
+  async listPlugins(): Promise<MarketplacePluginWithStatus[]> {
+    const [catalog, secrets] = await Promise.all([
+      this.catalogService.getCatalog(),
+      this.secretService.listSecrets(),
+    ]);
+    const activeKeys = new Set(secrets.filter((s) => s.isActive).map((s) => s.key));
+    return catalog.plugins.map((plugin) => ({
+      ...plugin,
+      installed: activeKeys.has(plugin.install.secretName),
+    }));
+  }
+
+  async installPlugin(slug: string, apiKey: string): Promise<MarketplacePlugin> {
+    const plugin = await this.getPlugin(slug);
+
+    if (plugin.install.validation) {
+      await this.validateApiKey(plugin, apiKey);
+    }
+
+    const secretName = plugin.install.secretName;
+    const secrets = await this.secretService.listSecrets();
+    const existing = secrets.find((s) => s.key === secretName);
+
+    if (existing?.isReserved) {
+      throw new AppError(
+        `Secret ${secretName} is reserved and managed by the platform`,
+        403,
+        ERROR_CODES.FORBIDDEN
+      );
+    }
+
+    if (existing) {
+      const success = await this.secretService.updateSecret(existing.id, {
+        value: apiKey,
+        isActive: true,
+      });
+      if (!success) {
+        throw new AppError(
+          `Failed to store secret: ${secretName}`,
+          500,
+          ERROR_CODES.INTERNAL_ERROR
+        );
+      }
+    } else {
+      await this.secretService.createSecret({ key: secretName, value: apiKey });
+    }
+
+    return plugin;
+  }
+
+  async uninstallPlugin(slug: string): Promise<MarketplacePlugin> {
+    const plugin = await this.getPlugin(slug);
+    const secretName = plugin.install.secretName;
+    const secrets = await this.secretService.listSecrets();
+    const existing = secrets.find((s) => s.key === secretName && s.isActive);
+
+    if (!existing) {
+      throw new AppError(`Plugin is not installed: ${slug}`, 404, ERROR_CODES.NOT_FOUND);
+    }
+    if (existing.isReserved) {
+      throw new AppError(
+        `Secret ${secretName} is reserved and managed by the platform`,
+        403,
+        ERROR_CODES.FORBIDDEN
+      );
+    }
+
+    const success = await this.secretService.updateSecret(existing.id, { isActive: false });
+    if (!success) {
+      throw new AppError(`Failed to remove secret: ${secretName}`, 500, ERROR_CODES.INTERNAL_ERROR);
+    }
+
+    return plugin;
+  }
+
+  private async getPlugin(slug: string): Promise<MarketplacePlugin> {
+    const catalog = await this.catalogService.getCatalog();
+    const plugin = catalog.plugins.find((p) => p.slug === slug);
+    if (!plugin) {
+      throw new AppError(`Unknown marketplace plugin: ${slug}`, 404, ERROR_CODES.NOT_FOUND);
+    }
+    return plugin;
+  }
+
+  /**
+   * Prove the key works by calling the provider endpoint from the catalog
+   * entry. The catalog is our own hosted file, but its URL is still treated
+   * as untrusted input: https-only (schema-enforced), must not resolve to a
+   * private address, redirects rejected, response body discarded.
+   */
+  private async validateApiKey(plugin: MarketplacePlugin, apiKey: string): Promise<void> {
+    const validation = plugin.install.validation;
+    if (!validation) {
+      return;
+    }
+
+    const url = new URL(validation.url);
+    await this.assertPublicHost(url.hostname);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: validation.method ?? 'GET',
+        headers: { Authorization: `Bearer ${apiKey}` },
+        redirect: 'error',
+        signal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
+      });
+    } catch {
+      throw new AppError(
+        `Could not reach ${plugin.name} to verify your API key. Please try again.`,
+        502,
+        ERROR_CODES.UPSTREAM_FAILURE
+      );
+    }
+
+    if (response.ok) {
+      return;
+    }
+    // Providers signal a bad credential as 401/403, or 400 for a malformed
+    // key (e.g. Resend). Anything else is the provider misbehaving, not the key.
+    if (response.status === 400 || response.status === 401 || response.status === 403) {
+      throw new AppError(`Invalid ${plugin.name} API key`, 400, ERROR_CODES.INVALID_INPUT);
+    }
+    throw new AppError(
+      `${plugin.name} returned an unexpected response (${response.status}) while verifying your API key`,
+      502,
+      ERROR_CODES.UPSTREAM_FAILURE
+    );
+  }
+
+  private async assertPublicHost(hostname: string): Promise<void> {
+    const reject = () => {
+      throw new AppError(
+        'Plugin validation endpoint resolves to a private address, which is not allowed',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    };
+    if (net.isIP(hostname)) {
+      if (isPrivateIp(hostname)) {
+        reject();
+      }
+      return;
+    }
+    const [ipv4, ipv6] = await Promise.all([
+      dns.resolve4(hostname).catch(() => []),
+      dns.resolve6(hostname).catch(() => []),
+    ]);
+    if ([...ipv4, ...ipv6].some(isPrivateIp)) {
+      reject();
+    }
+  }
+}

--- a/backend/src/services/marketplace/marketplace.service.ts
+++ b/backend/src/services/marketplace/marketplace.service.ts
@@ -52,6 +52,9 @@ export class MarketplaceService {
 
     const secretName = plugin.install.secretName;
     const secrets = await this.secretService.listSecrets();
+    // An existing non-reserved secret (active or not) is updated in place:
+    // API-level installs deliberately act as "set/replace the key". The
+    // dashboard offers uninstall instead when a plugin is already installed.
     const existing = secrets.find((s) => s.key === secretName);
 
     if (existing?.isReserved) {
@@ -161,17 +164,18 @@ export class MarketplaceService {
     );
   }
 
+  // Known gap: fetch() re-resolves DNS after this check, so a rebinding
+  // attacker who controls the hostname could still swap in a private address
+  // between check and connect. Accepted for now: validation URLs come from
+  // the first-party hosted catalog (https-only, redirect: 'error'), not user
+  // input. Closing it fully would need connect-time IP pinning (undici Agent).
   private async assertPublicHost(hostname: string): Promise<void> {
-    const reject = () => {
-      throw new AppError(
-        'Plugin validation endpoint resolves to a private address, which is not allowed',
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
+    const reject = (message: string) => {
+      throw new AppError(message, 400, ERROR_CODES.INVALID_INPUT);
     };
     if (net.isIP(hostname)) {
       if (isPrivateIp(hostname)) {
-        reject();
+        reject('Plugin validation endpoint resolves to a private address, which is not allowed');
       }
       return;
     }
@@ -179,8 +183,13 @@ export class MarketplaceService {
       dns.resolve4(hostname).catch(() => []),
       dns.resolve6(hostname).catch(() => []),
     ]);
-    if ([...ipv4, ...ipv6].some(isPrivateIp)) {
-      reject();
+    const addresses = [...ipv4, ...ipv6];
+    // Fail closed: an unresolvable host can't be vetted (and can't be valid)
+    if (addresses.length === 0) {
+      reject('Plugin validation endpoint hostname could not be resolved');
+    }
+    if (addresses.some(isPrivateIp)) {
+      reject('Plugin validation endpoint resolves to a private address, which is not allowed');
     }
   }
 }

--- a/backend/tests/unit/marketplace-catalog.service.test.ts
+++ b/backend/tests/unit/marketplace-catalog.service.test.ts
@@ -113,13 +113,28 @@ describe('MarketplaceCatalogService', () => {
   });
 
   it('falls back to the bundled catalog when the payload fails schema validation', async () => {
-    fetchMock.mockResolvedValue(
-      jsonResponse({ version: 1, plugins: [{ slug: 'broken' }] })
-    );
+    fetchMock.mockResolvedValue(jsonResponse({ version: 1, plugins: [{ slug: 'broken' }] }));
 
     const catalog = await service.getCatalog();
 
     expect(catalog).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+  });
+
+  it('shares one fetch across concurrent cold requests', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const first = service.getCatalog();
+    const second = service.getCatalog();
+    resolveFetch(jsonResponse(REMOTE_CATALOG));
+
+    expect(await first).toEqual(REMOTE_CATALOG);
+    expect(await second).toEqual(REMOTE_CATALOG);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not retry an unreachable catalog URL within the TTL', async () => {

--- a/backend/tests/unit/marketplace-catalog.service.test.ts
+++ b/backend/tests/unit/marketplace-catalog.service.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MarketplaceCatalog } from '@insforge/shared-schemas';
+
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    marketplace: { catalogUrl: '' },
+  },
+}));
+
+vi.mock('../../src/infra/config/app.config', () => ({
+  appConfig: mockConfig,
+}));
+
+vi.mock('../../src/utils/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { MarketplaceCatalogService } from '../../src/services/marketplace/catalog.service';
+import { DEFAULT_MARKETPLACE_CATALOG } from '../../src/services/marketplace/default-catalog';
+
+const REMOTE_CATALOG: MarketplaceCatalog = {
+  version: 2,
+  plugins: [
+    {
+      slug: 'remote-plugin',
+      name: 'Remote Plugin',
+      publisher: 'Remote',
+      category: 'Data',
+      description: 'From the hosted catalog',
+      actions: ['Store REMOTE_KEY as an encrypted secret'],
+      install: {
+        type: 'secret',
+        secretName: 'REMOTE_KEY',
+        placeholder: 'rk_...',
+      },
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('MarketplaceCatalogService', () => {
+  const service = MarketplaceCatalogService.getInstance();
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    service.clearCache();
+    mockConfig.marketplace.catalogUrl = 'https://assets.example.com/marketplace.json';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('returns the bundled catalog without fetching when no URL is configured', async () => {
+    mockConfig.marketplace.catalogUrl = '';
+
+    const catalog = await service.getCatalog();
+
+    expect(catalog).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('serves a valid remote catalog and caches it', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(REMOTE_CATALOG));
+
+    const first = await service.getCatalog();
+    const second = await service.getCatalog();
+
+    expect(first).toEqual(REMOTE_CATALOG);
+    expect(second).toEqual(REMOTE_CATALOG);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the cache TTL expires', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue(jsonResponse(REMOTE_CATALOG));
+
+    await service.getCatalog();
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    await service.getCatalog();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the bundled catalog on network failure', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const catalog = await service.getCatalog();
+
+    expect(catalog).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+  });
+
+  it('falls back to the bundled catalog on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const catalog = await service.getCatalog();
+
+    expect(catalog).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+  });
+
+  it('falls back to the bundled catalog when the payload fails schema validation', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ version: 1, plugins: [{ slug: 'broken' }] })
+    );
+
+    const catalog = await service.getCatalog();
+
+    expect(catalog).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+  });
+
+  it('does not retry an unreachable catalog URL within the TTL', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'));
+
+    const first = await service.getCatalog();
+    const second = await service.getCatalog();
+
+    expect(first).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+    expect(second).toEqual(DEFAULT_MARKETPLACE_CATALOG);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves the last cached catalog when a refetch fails', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValueOnce(jsonResponse(REMOTE_CATALOG));
+
+    await service.getCatalog();
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    fetchMock.mockRejectedValueOnce(new Error('offline'));
+
+    const catalog = await service.getCatalog();
+
+    expect(catalog).toEqual(REMOTE_CATALOG);
+  });
+});

--- a/backend/tests/unit/marketplace.service.test.ts
+++ b/backend/tests/unit/marketplace.service.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../src/services/marketplace/catalog.service', () => ({
 
 vi.mock('../../src/services/email/smtp-config.service', () => ({
   isPrivateIp: (ip: string) =>
-    ip.startsWith('127.') || ip.startsWith('10.') || ip.startsWith('192.168.'),
+    ip.startsWith('127.') || ip.startsWith('10.') || ip.startsWith('192.168.') || ip === '::1',
 }));
 
 vi.mock('dns/promises', () => ({
@@ -210,6 +210,58 @@ describe('MarketplaceService', () => {
         statusCode: 400,
       });
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects validation endpoints whose IPv6 records are private', async () => {
+      mockResolve4.mockResolvedValue([]);
+      mockResolve6.mockResolvedValue(['::1']);
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the validation hostname does not resolve', async () => {
+      mockResolve4.mockResolvedValue([]);
+      mockResolve6.mockResolvedValue([]);
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('vets IP-literal validation hosts without DNS resolution', async () => {
+      const ipCatalog: MarketplaceCatalog = {
+        version: 1,
+        plugins: [
+          {
+            ...CATALOG.plugins[0],
+            slug: 'ip-plugin',
+            install: {
+              ...CATALOG.plugins[0].install,
+              validation: { url: 'https://127.0.0.1/verify', method: 'GET' },
+            },
+          },
+        ],
+      };
+      mockGetCatalog.mockResolvedValue(ipCatalog);
+
+      await expect(service.installPlugin('ip-plugin', 'key')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(mockResolve4).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('maps a failed secret write to a 500 error', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({ isActive: false })]);
+      mockSecretService.updateSecret.mockResolvedValue(false);
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 500,
+      });
     });
 
     it('404s for an unknown plugin slug', async () => {

--- a/backend/tests/unit/marketplace.service.test.ts
+++ b/backend/tests/unit/marketplace.service.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { MarketplaceCatalog, SecretSchema } from '@insforge/shared-schemas';
+
+const { mockSecretService, mockGetCatalog, mockResolve4, mockResolve6 } = vi.hoisted(() => ({
+  mockSecretService: {
+    listSecrets: vi.fn(),
+    createSecret: vi.fn(),
+    updateSecret: vi.fn(),
+  },
+  mockGetCatalog: vi.fn(),
+  mockResolve4: vi.fn(),
+  mockResolve6: vi.fn(),
+}));
+
+vi.mock('../../src/services/secrets/secret.service', () => ({
+  SecretService: {
+    getInstance: () => mockSecretService,
+  },
+}));
+
+vi.mock('../../src/services/marketplace/catalog.service', () => ({
+  MarketplaceCatalogService: {
+    getInstance: () => ({ getCatalog: mockGetCatalog }),
+  },
+}));
+
+vi.mock('../../src/services/email/smtp-config.service', () => ({
+  isPrivateIp: (ip: string) =>
+    ip.startsWith('127.') || ip.startsWith('10.') || ip.startsWith('192.168.'),
+}));
+
+vi.mock('dns/promises', () => ({
+  default: {
+    resolve4: mockResolve4,
+    resolve6: mockResolve6,
+  },
+}));
+
+import { MarketplaceService } from '../../src/services/marketplace/marketplace.service';
+import { AppError } from '../../src/utils/errors';
+
+const CATALOG: MarketplaceCatalog = {
+  version: 1,
+  plugins: [
+    {
+      slug: 'resend',
+      name: 'Resend',
+      publisher: 'Resend',
+      category: 'Messaging',
+      description: 'Email',
+      actions: [],
+      install: {
+        type: 'secret',
+        secretName: 'RESEND_API_KEY',
+        placeholder: 're_...',
+        validation: { url: 'https://api.resend.com/domains', method: 'GET' },
+      },
+    },
+    {
+      slug: 'no-validation',
+      name: 'No Validation',
+      publisher: 'Acme',
+      category: 'Data',
+      description: 'Key stored without a provider check',
+      actions: [],
+      install: {
+        type: 'secret',
+        secretName: 'ACME_KEY',
+        placeholder: 'ak_...',
+      },
+    },
+  ],
+};
+
+function secret(overrides: Partial<SecretSchema>): SecretSchema {
+  return {
+    id: 'secret-1',
+    key: 'RESEND_API_KEY',
+    isActive: true,
+    isReserved: false,
+    lastUsedAt: null,
+    expiresAt: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('MarketplaceService', () => {
+  const service = MarketplaceService.getInstance();
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    mockGetCatalog.mockResolvedValue(CATALOG);
+    mockSecretService.listSecrets.mockResolvedValue([]);
+    mockSecretService.createSecret.mockResolvedValue({ id: 'new-secret' });
+    mockSecretService.updateSecret.mockResolvedValue(true);
+    mockResolve4.mockResolvedValue(['76.76.21.21']);
+    mockResolve6.mockResolvedValue([]);
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('listPlugins', () => {
+    it('marks plugins installed when an active secret with their name exists', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({})]);
+
+      const plugins = await service.listPlugins();
+
+      expect(plugins.find((p) => p.slug === 'resend')?.installed).toBe(true);
+      expect(plugins.find((p) => p.slug === 'no-validation')?.installed).toBe(false);
+    });
+
+    it('treats inactive secrets as not installed', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({ isActive: false })]);
+
+      const plugins = await service.listPlugins();
+
+      expect(plugins.find((p) => p.slug === 'resend')?.installed).toBe(false);
+    });
+  });
+
+  describe('installPlugin', () => {
+    it('validates the key against the provider and creates the secret', async () => {
+      await service.installPlugin('resend', 're_valid');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        new URL('https://api.resend.com/domains'),
+        expect.objectContaining({
+          method: 'GET',
+          headers: { Authorization: 'Bearer re_valid' },
+          redirect: 'error',
+        })
+      );
+      expect(mockSecretService.createSecret).toHaveBeenCalledWith({
+        key: 'RESEND_API_KEY',
+        value: 're_valid',
+      });
+    });
+
+    it.each([400, 401, 403])(
+      'rejects an invalid key (%i) without touching secrets',
+      async (status) => {
+        fetchMock.mockResolvedValue(new Response(null, { status }));
+
+        await expect(service.installPlugin('resend', 're_bad')).rejects.toMatchObject({
+          statusCode: 400,
+          message: 'Invalid Resend API key',
+        });
+        expect(mockSecretService.createSecret).not.toHaveBeenCalled();
+        expect(mockSecretService.updateSecret).not.toHaveBeenCalled();
+      }
+    );
+
+    it('maps provider outages to a 502 error', async () => {
+      fetchMock.mockRejectedValue(new Error('socket hang up'));
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 502,
+      });
+    });
+
+    it('maps unexpected provider statuses to a 502 error', async () => {
+      fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 502,
+      });
+    });
+
+    it('skips provider validation when the plugin has no validation spec', async () => {
+      await service.installPlugin('no-validation', 'ak_123');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockSecretService.createSecret).toHaveBeenCalledWith({
+        key: 'ACME_KEY',
+        value: 'ak_123',
+      });
+    });
+
+    it('updates the existing secret in place when one exists', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({ isActive: false })]);
+
+      await service.installPlugin('resend', 're_new');
+
+      expect(mockSecretService.updateSecret).toHaveBeenCalledWith('secret-1', {
+        value: 're_new',
+        isActive: true,
+      });
+      expect(mockSecretService.createSecret).not.toHaveBeenCalled();
+    });
+
+    it('refuses to overwrite a reserved secret', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({ isReserved: true })]);
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 403,
+      });
+    });
+
+    it('rejects validation endpoints that resolve to a private address', async () => {
+      mockResolve4.mockResolvedValue(['127.0.0.1']);
+
+      await expect(service.installPlugin('resend', 're_key')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('404s for an unknown plugin slug', async () => {
+      await expect(service.installPlugin('unknown', 'key')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe('uninstallPlugin', () => {
+    it('deactivates the plugin secret', async () => {
+      mockSecretService.listSecrets.mockResolvedValue([secret({})]);
+
+      await service.uninstallPlugin('resend');
+
+      expect(mockSecretService.updateSecret).toHaveBeenCalledWith('secret-1', {
+        isActive: false,
+      });
+    });
+
+    it('404s when the plugin is not installed', async () => {
+      await expect(service.uninstallPlugin('resend')).rejects.toBeInstanceOf(AppError);
+      await expect(service.uninstallPlugin('resend')).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/openapi/marketplace.yaml
+++ b/openapi/marketplace.yaml
@@ -1,0 +1,193 @@
+openapi: 3.0.3
+info:
+  title: Insforge Marketplace API
+  version: 1.0.0
+  description: Plugin marketplace - browse the catalog and install plugins by storing a validated provider API key as an encrypted project secret
+
+paths:
+  /api/marketplace/plugins:
+    get:
+      summary: List marketplace plugins
+      description: Returns the plugin catalog (hosted marketplace.json with a bundled fallback) with each plugin's installed status, derived from whether an active secret with the plugin's secretName exists
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Plugin catalog with installed status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  plugins:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MarketplacePlugin'
+        '401':
+          description: Missing or invalid admin credentials
+
+  /api/marketplace/plugins/{slug}/install:
+    post:
+      summary: Install a plugin
+      description: Validates the provider API key against the plugin's validation endpoint (when the catalog entry declares one), then stores it as an encrypted project secret injected into edge-function environments. Rate limited per IP.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9][a-z0-9-]*$'
+          example: resend
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - apiKey
+              properties:
+                apiKey:
+                  type: string
+                  description: Provider API key to validate and store
+                  example: re_123abc...
+      responses:
+        '201':
+          description: Plugin installed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketplaceActionResponse'
+        '400':
+          description: Invalid request body, invalid provider API key, or disallowed validation endpoint
+        '401':
+          description: Missing or invalid admin credentials
+        '403':
+          description: The plugin's secret name is reserved and managed by the platform
+        '404':
+          description: Unknown plugin slug
+        '429':
+          description: Rate limit exceeded
+        '502':
+          description: The provider could not be reached to verify the key
+
+  /api/marketplace/plugins/{slug}:
+    delete:
+      summary: Uninstall a plugin
+      description: Deactivates the plugin's secret (soft delete). Functions lose access to the env var after the next redeployment. Rate limited per IP.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9][a-z0-9-]*$'
+          example: resend
+      responses:
+        '200':
+          description: Plugin uninstalled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketplaceActionResponse'
+        '401':
+          description: Missing or invalid admin credentials
+        '403':
+          description: The plugin's secret name is reserved and managed by the platform
+        '404':
+          description: Unknown plugin slug, or the plugin is not installed
+        '429':
+          description: Rate limit exceeded
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    MarketplacePlugin:
+      type: object
+      description: Catalog entry (see marketplacePluginSchema in @insforge/shared-schemas) plus installed status
+      properties:
+        slug:
+          type: string
+          pattern: '^[a-z0-9][a-z0-9-]*$'
+          example: resend
+        name:
+          type: string
+          example: Resend
+        publisher:
+          type: string
+          example: Resend
+        category:
+          type: string
+          example: Messaging
+        description:
+          type: string
+          example: Send transactional email from functions with domains and templates.
+        actions:
+          type: array
+          items:
+            type: string
+          description: What installing the plugin does, shown in the install dialog
+        iconUrl:
+          type: string
+          format: uri
+          nullable: true
+        install:
+          type: object
+          properties:
+            type:
+              type: string
+              enum: [secret]
+            secretName:
+              type: string
+              pattern: '^[A-Z0-9_]+$'
+              example: RESEND_API_KEY
+            placeholder:
+              type: string
+              example: re_...
+            validation:
+              type: object
+              nullable: true
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  description: HTTPS endpoint called with Authorization Bearer <apiKey> to validate the key
+                method:
+                  type: string
+                  enum: [GET, POST]
+        docsUrl:
+          type: string
+          format: uri
+          nullable: true
+        skillUrl:
+          type: string
+          format: uri
+          nullable: true
+        installed:
+          type: boolean
+          description: Whether an active secret with the plugin's secretName exists
+
+    MarketplaceActionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: Resend has been installed successfully

--- a/packages/dashboard/src/features/marketplace/components/InstallPluginDialog.tsx
+++ b/packages/dashboard/src/features/marketplace/components/InstallPluginDialog.tsx
@@ -118,6 +118,8 @@ export function InstallPluginDialog({
           </div>
           {!plugin.installed && (
             <InputField
+              type="password"
+              autoComplete="off"
               label={plugin.install.secretName}
               placeholder={plugin.install.placeholder}
               value={apiKeyValue}

--- a/packages/dashboard/src/features/marketplace/components/InstallPluginDialog.tsx
+++ b/packages/dashboard/src/features/marketplace/components/InstallPluginDialog.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  InputField,
+} from '@insforge/ui';
+import type { MarketplacePluginWithStatus } from '@insforge/shared-schemas';
+import { PluginAvatar } from '#features/marketplace/components/PluginAvatar';
+
+interface InstallPluginDialogProps {
+  plugin: MarketplacePluginWithStatus | null;
+  projectName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInstall: (slug: string, apiKey: string) => Promise<unknown>;
+  installing: boolean;
+  onUninstall: (slug: string) => Promise<unknown>;
+  uninstalling: boolean;
+}
+
+export function InstallPluginDialog({
+  plugin,
+  projectName,
+  open,
+  onOpenChange,
+  onInstall,
+  installing,
+  onUninstall,
+  uninstalling,
+}: InstallPluginDialogProps) {
+  const [apiKeyValue, setApiKeyValue] = useState('');
+  const [apiKeyError, setApiKeyError] = useState('');
+
+  // Reset the form each time the dialog opens
+  useEffect(() => {
+    if (open) {
+      setApiKeyValue('');
+      setApiKeyError('');
+    }
+  }, [open, plugin?.slug]);
+
+  if (!plugin) {
+    return null;
+  }
+
+  const handleInstall = async () => {
+    if (installing) {
+      return;
+    }
+    if (!apiKeyValue.trim()) {
+      setApiKeyError(`Enter your ${plugin.install.secretName} to continue`);
+      return;
+    }
+    try {
+      await onInstall(plugin.slug, apiKeyValue.trim());
+      onOpenChange(false);
+    } catch (error) {
+      setApiKeyError(error instanceof Error ? error.message : 'Failed to install plugin');
+    }
+  };
+
+  const handleUninstall = async () => {
+    if (uninstalling) {
+      return;
+    }
+    try {
+      await onUninstall(plugin.slug);
+      onOpenChange(false);
+    } catch {
+      // Error toast comes from the mutation; keep the dialog open
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="w-[480px] max-w-[480px] gap-0 rounded-xl border-[var(--alpha-12)] bg-[rgb(var(--semantic-2))] p-0"
+      >
+        <div className="flex items-center gap-3.5 border-b border-[var(--border)] px-6 py-5">
+          <PluginAvatar plugin={plugin} size="lg" />
+          <div className="flex flex-1 flex-col gap-0.5">
+            <DialogTitle className="text-base font-semibold leading-normal">
+              {plugin.installed ? plugin.name : `Install ${plugin.name}`}
+            </DialogTitle>
+            <DialogDescription className="text-[13px] leading-normal">
+              {plugin.installed
+                ? `Installed in project ${projectName}`
+                : `Into project ${projectName}`}
+            </DialogDescription>
+          </div>
+          <DialogClose className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground">
+            <X className="h-[18px] w-[18px]" />
+          </DialogClose>
+        </div>
+        <div className="flex flex-col gap-4 px-6 py-5">
+          <div className="flex flex-col gap-2.5">
+            <span className="text-[13px] font-medium text-foreground">
+              {plugin.installed ? 'This plugin has:' : 'This plugin will:'}
+            </span>
+            <div className="flex flex-col gap-2">
+              {plugin.actions.map((action) => (
+                <div
+                  key={action}
+                  className="flex items-center gap-2.5 text-[13px] text-muted-foreground"
+                >
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                  <span>{action}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          {!plugin.installed && (
+            <InputField
+              label={plugin.install.secretName}
+              placeholder={plugin.install.placeholder}
+              value={apiKeyValue}
+              onChange={(event) => {
+                setApiKeyValue(event.target.value);
+                setApiKeyError('');
+              }}
+              error={apiKeyError || undefined}
+              showIcon={false}
+              showDropdown={false}
+              showTip={false}
+            />
+          )}
+          {plugin.installed && (
+            <p className="m-0 text-[13px] leading-normal text-muted-foreground">
+              Uninstalling deactivates the {plugin.install.secretName} secret. Functions using it
+              will lose access after the next deployment.
+            </p>
+          )}
+        </div>
+        <DialogFooter className="gap-2 border-[var(--border)] px-6 py-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {plugin.installed ? (
+            <Button
+              variant="destructive"
+              disabled={uninstalling}
+              onClick={() => void handleUninstall()}
+            >
+              {uninstalling ? 'Uninstalling...' : 'Uninstall'}
+            </Button>
+          ) : (
+            <Button variant="primary" disabled={installing} onClick={() => void handleInstall()}>
+              {installing ? 'Installing...' : 'Install plugin'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard/src/features/marketplace/components/PluginAvatar.tsx
+++ b/packages/dashboard/src/features/marketplace/components/PluginAvatar.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@insforge/ui';
+import type { MarketplacePlugin } from '@insforge/shared-schemas';
+
+// Tints for the letter-avatar fallback, picked deterministically per plugin
+// so the marketplace stays colorful without the catalog carrying colors
+const FALLBACK_TINTS = [
+  'oklch(0.72 0.16 280)',
+  'oklch(0.8 0.12 165)',
+  'oklch(0.78 0.1 220)',
+  'oklch(0.75 0.13 55)',
+  'oklch(0.72 0.14 305)',
+  'oklch(0.72 0.15 335)',
+  'oklch(0.7 0.15 250)',
+  'oklch(0.68 0.19 25)',
+];
+
+function fallbackTint(slug: string): string {
+  let hash = 0;
+  for (const char of slug) {
+    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  }
+  return FALLBACK_TINTS[hash % FALLBACK_TINTS.length];
+}
+
+interface PluginAvatarProps {
+  plugin: Pick<MarketplacePlugin, 'slug' | 'name' | 'iconUrl'>;
+  size: 'sm' | 'lg';
+}
+
+export function PluginAvatar({ plugin, size }: PluginAvatarProps) {
+  const [iconFailed, setIconFailed] = useState(false);
+
+  useEffect(() => {
+    setIconFailed(false);
+  }, [plugin.iconUrl]);
+
+  const showIcon = !!plugin.iconUrl && !iconFailed;
+
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center justify-center font-semibold',
+        // Brand logos sit on white in both themes so their colors read
+        // correctly; the letter fallback keeps the theme surface
+        showIcon ? 'border border-[var(--border)] bg-white' : 'bg-[rgb(var(--semantic-5))]',
+        size === 'sm' ? 'h-10 w-10 rounded-lg text-lg' : 'h-11 w-11 rounded-[10px] text-xl'
+      )}
+      style={showIcon ? undefined : { color: fallbackTint(plugin.slug) }}
+    >
+      {showIcon ? (
+        <img
+          src={plugin.iconUrl}
+          alt={`${plugin.name} logo`}
+          className={cn('object-contain', size === 'sm' ? 'h-5 w-5' : 'h-6 w-6')}
+          onError={() => setIconFailed(true)}
+        />
+      ) : (
+        plugin.name.charAt(0).toUpperCase()
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/marketplace/components/PluginAvatar.tsx
+++ b/packages/dashboard/src/features/marketplace/components/PluginAvatar.tsx
@@ -52,6 +52,7 @@ export function PluginAvatar({ plugin, size }: PluginAvatarProps) {
         <img
           src={plugin.iconUrl}
           alt={`${plugin.name} logo`}
+          referrerPolicy="no-referrer"
           className={cn('object-contain', size === 'sm' ? 'h-5 w-5' : 'h-6 w-6')}
           onError={() => setIconFailed(true)}
         />

--- a/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
+++ b/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
@@ -1,0 +1,56 @@
+import { Check } from 'lucide-react';
+import { Button, cn } from '@insforge/ui';
+import type { MarketplacePluginWithStatus } from '@insforge/shared-schemas';
+import { PluginAvatar } from '#features/marketplace/components/PluginAvatar';
+
+interface PluginCardProps {
+  plugin: MarketplacePluginWithStatus;
+  onOpen: () => void;
+}
+
+export function PluginCard({ plugin, onOpen }: PluginCardProps) {
+  return (
+    <div
+      onClick={onOpen}
+      className={cn(
+        'group relative flex min-h-[148px] cursor-pointer flex-col gap-3 rounded-lg border border-[var(--border)] bg-card p-5',
+        'transition-[border-color,box-shadow] duration-100',
+        'hover:border-[rgb(var(--primary)/0.6)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.35)]'
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 rounded-lg transition-colors duration-100 group-hover:bg-[var(--alpha-4)]" />
+      <div className="relative">
+        <div className="absolute right-0 top-0">
+          {plugin.installed ? (
+            <div className="flex items-center gap-1.5 text-[13px] font-medium text-primary">
+              <Check className="h-[15px] w-[15px]" strokeWidth={2.5} />
+              <span>Installed</span>
+            </div>
+          ) : (
+            <Button
+              variant="secondary"
+              size="sm"
+              className="text-[13px] text-foreground opacity-0 transition-opacity duration-100 group-hover:opacity-100 focus-visible:opacity-100"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpen();
+              }}
+            >
+              Install
+            </Button>
+          )}
+        </div>
+        <div className="flex items-start gap-3 pr-[84px]">
+          <PluginAvatar plugin={plugin} size="sm" />
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span className="text-[15px] font-semibold text-foreground">{plugin.name}</span>
+            <span className="text-xs text-muted-foreground">{plugin.publisher}</span>
+          </div>
+        </div>
+      </div>
+      <p className="relative m-0 flex-1 text-[13px] leading-normal text-muted-foreground">
+        {plugin.description}
+      </p>
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
+++ b/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
@@ -1,5 +1,5 @@
 import { Check } from 'lucide-react';
-import { Button, cn } from '@insforge/ui';
+import { Button } from '@insforge/ui';
 import type { MarketplacePluginWithStatus } from '@insforge/shared-schemas';
 import { PluginAvatar } from '#features/marketplace/components/PluginAvatar';
 
@@ -12,13 +12,9 @@ export function PluginCard({ plugin, onOpen }: PluginCardProps) {
   return (
     <div
       onClick={onOpen}
-      className={cn(
-        'group relative flex min-h-[148px] cursor-pointer flex-col gap-3 rounded-lg border border-[var(--border)] bg-card p-5',
-        'transition-[border-color,box-shadow] duration-100',
-        'hover:border-[rgb(var(--primary)/0.6)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.35)]'
-      )}
+      className="group relative flex min-h-[148px] cursor-pointer flex-col gap-3 rounded-lg border border-[var(--alpha-8)] bg-card p-5"
     >
-      <div className="pointer-events-none absolute inset-0 rounded-lg transition-colors duration-100 group-hover:bg-[var(--alpha-4)]" />
+      <div className="pointer-events-none absolute inset-0 rounded-lg transition-colors group-hover:bg-[var(--alpha-4)] group-active:bg-[var(--alpha-8)]" />
       <div className="relative">
         <div className="absolute right-0 top-0">
           {plugin.installed ? (

--- a/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
+++ b/packages/dashboard/src/features/marketplace/components/PluginCard.tsx
@@ -11,8 +11,17 @@ interface PluginCardProps {
 export function PluginCard({ plugin, onOpen }: PluginCardProps) {
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${plugin.name} plugin details`}
       onClick={onOpen}
-      className="group relative flex min-h-[148px] cursor-pointer flex-col gap-3 rounded-lg border border-[var(--alpha-8)] bg-card p-5"
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group relative flex min-h-[148px] cursor-pointer flex-col gap-3 rounded-lg border border-[var(--alpha-8)] bg-card p-5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[rgb(var(--foreground))]"
     >
       <div className="pointer-events-none absolute inset-0 rounded-lg transition-colors group-hover:bg-[var(--alpha-4)] group-active:bg-[var(--alpha-8)]" />
       <div className="relative">

--- a/packages/dashboard/src/features/marketplace/hooks/useMarketplace.ts
+++ b/packages/dashboard/src/features/marketplace/hooks/useMarketplace.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@insforge/ui';
+import { marketplaceService } from '#features/marketplace/services/marketplace.service';
+
+export const marketplaceQueryKeys = {
+  plugins: ['marketplace', 'plugins'] as const,
+};
+
+export function useMarketplace() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const {
+    data: plugins = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: marketplaceQueryKeys.plugins,
+    queryFn: () => marketplaceService.listPlugins(),
+    staleTime: 2 * 60 * 1000,
+  });
+
+  // Installs create/remove a project secret, so the Secrets page cache is
+  // stale after either mutation
+  const invalidate = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.plugins }),
+      queryClient.invalidateQueries({ queryKey: ['secrets'] }),
+    ]);
+
+  const installMutation = useMutation({
+    mutationFn: ({ slug, apiKey }: { slug: string; apiKey: string }) =>
+      marketplaceService.installPlugin(slug, apiKey),
+    onSuccess: async (result) => {
+      await invalidate();
+      showToast(result.message, 'success');
+    },
+  });
+
+  const uninstallMutation = useMutation({
+    mutationFn: (slug: string) => marketplaceService.uninstallPlugin(slug),
+    onSuccess: async (result) => {
+      await invalidate();
+      showToast(result.message, 'success');
+    },
+    onError: (err: Error) => {
+      showToast(err.message || 'Failed to uninstall plugin', 'error');
+    },
+  });
+
+  return {
+    plugins,
+    isLoading,
+    error,
+    installPlugin: installMutation.mutateAsync,
+    isInstalling: installMutation.isPending,
+    uninstallPlugin: uninstallMutation.mutateAsync,
+    isUninstalling: uninstallMutation.isPending,
+  };
+}

--- a/packages/dashboard/src/features/marketplace/pages/MarketplacePage.tsx
+++ b/packages/dashboard/src/features/marketplace/pages/MarketplacePage.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button, SearchInput } from '@insforge/ui';
+import type { MarketplacePluginWithStatus } from '@insforge/shared-schemas';
+import { InstallPluginDialog } from '#features/marketplace/components/InstallPluginDialog';
+import { PluginCard } from '#features/marketplace/components/PluginCard';
+import { useMarketplace } from '#features/marketplace/hooks/useMarketplace';
+import { useCloudProjectInfo } from '#lib/hooks/useCloudProjectInfo';
+import { isInsForgeCloudProject } from '#lib/utils/utils';
+
+export default function MarketplacePage() {
+  const { projectInfo } = useCloudProjectInfo();
+  const projectName =
+    isInsForgeCloudProject() && projectInfo.name ? projectInfo.name : 'My InsForge Project';
+
+  const {
+    plugins,
+    isLoading,
+    error,
+    installPlugin,
+    isInstalling,
+    uninstallPlugin,
+    isUninstalling,
+  } = useMarketplace();
+
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<string>('All');
+  const [dialogSlug, setDialogSlug] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const categories = useMemo(
+    () => ['All', ...new Set(plugins.map((plugin) => plugin.category))],
+    [plugins]
+  );
+
+  const visiblePlugins = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return plugins
+      .filter((plugin) => category === 'All' || plugin.category === category)
+      .filter(
+        (plugin) =>
+          !q ||
+          plugin.name.toLowerCase().includes(q) ||
+          plugin.description.toLowerCase().includes(q) ||
+          plugin.publisher.toLowerCase().includes(q)
+      );
+  }, [plugins, query, category]);
+
+  // Resolve from fresh data so the dialog reflects install-state changes
+  const dialogPlugin = plugins.find((plugin) => plugin.slug === dialogSlug) ?? null;
+
+  const openDialog = (plugin: MarketplacePluginWithStatus) => {
+    setDialogSlug(plugin.slug);
+    setDialogOpen(true);
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-6 overflow-y-auto px-12 py-10">
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="m-0 text-[28px] font-semibold leading-tight text-foreground">
+            Marketplace
+          </h1>
+          <p className="m-0 text-sm text-muted-foreground">
+            Add plugins and integrations to your project with one click.
+          </p>
+        </div>
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          placeholder="Search plugins..."
+          debounceTime={0}
+          className="w-[300px]"
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {categories.map((label) => (
+          <Button
+            key={label}
+            variant={category === label ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setCategory(label)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+      {isLoading ? (
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : error ? (
+        <div className="flex flex-col items-center gap-2 py-16">
+          <span className="text-[15px] font-medium text-foreground">
+            Failed to load the marketplace
+          </span>
+          <span className="text-[13px] text-muted-foreground">{error.message}</span>
+        </div>
+      ) : visiblePlugins.length > 0 ? (
+        <div className="grid grid-cols-3 gap-4">
+          {visiblePlugins.map((plugin) => (
+            <PluginCard key={plugin.slug} plugin={plugin} onOpen={() => openDialog(plugin)} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-2 py-16">
+          <span className="text-[15px] font-medium text-foreground">No plugins found</span>
+          <span className="text-[13px] text-muted-foreground">
+            Try a different search or category.
+          </span>
+        </div>
+      )}
+      <InstallPluginDialog
+        plugin={dialogPlugin}
+        projectName={projectName}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onInstall={(slug, apiKey) => installPlugin({ slug, apiKey })}
+        installing={isInstalling}
+        onUninstall={uninstallPlugin}
+        uninstalling={isUninstalling}
+      />
+    </div>
+  );
+}

--- a/packages/dashboard/src/features/marketplace/services/marketplace.service.ts
+++ b/packages/dashboard/src/features/marketplace/services/marketplace.service.ts
@@ -1,0 +1,33 @@
+import { apiClient } from '#lib/api/client';
+import type {
+  InstallMarketplacePluginResponse,
+  ListMarketplacePluginsResponse,
+  MarketplacePluginWithStatus,
+  UninstallMarketplacePluginResponse,
+} from '@insforge/shared-schemas';
+
+export class MarketplaceService {
+  async listPlugins(): Promise<MarketplacePluginWithStatus[]> {
+    const data = (await apiClient.request('/marketplace/plugins', {
+      headers: apiClient.withAccessToken(),
+    })) as ListMarketplacePluginsResponse;
+    return data.plugins;
+  }
+
+  async installPlugin(slug: string, apiKey: string): Promise<InstallMarketplacePluginResponse> {
+    return apiClient.request(`/marketplace/plugins/${encodeURIComponent(slug)}/install`, {
+      method: 'POST',
+      headers: apiClient.withAccessToken(),
+      body: JSON.stringify({ apiKey }),
+    });
+  }
+
+  async uninstallPlugin(slug: string): Promise<UninstallMarketplacePluginResponse> {
+    return apiClient.request(`/marketplace/plugins/${encodeURIComponent(slug)}`, {
+      method: 'DELETE',
+      headers: apiClient.withAccessToken(),
+    });
+  }
+}
+
+export const marketplaceService = new MarketplaceService();

--- a/packages/dashboard/src/navigation/menuItems.ts
+++ b/packages/dashboard/src/navigation/menuItems.ts
@@ -18,6 +18,7 @@ import {
   BookOpen,
   CreditCard,
   Megaphone,
+  ShoppingBag,
 } from 'lucide-react';
 
 export interface DashboardSecondaryMenuItem {
@@ -115,6 +116,12 @@ export const dashboardStaticMenuItems: DashboardPrimaryMenuItem[] = [
     label: 'Payments',
     href: '/dashboard/payments',
     icon: CreditCard,
+  },
+  {
+    id: 'marketplace',
+    label: 'Marketplace',
+    href: '/dashboard/marketplace',
+    icon: ShoppingBag,
     sectionEnd: true,
   },
   {

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -48,6 +48,7 @@ import AuditsPage from '#features/logs/pages/AuditsPage';
 import FunctionLogsPage from '#features/logs/pages/FunctionLogsPage';
 import LogsPage from '#features/logs/pages/LogsPage';
 import MCPLogsPage from '#features/logs/pages/MCPLogsPage';
+import MarketplacePage from '#features/marketplace/pages/MarketplacePage';
 import PaymentsLayout from '#features/payments/components/PaymentsLayout';
 import CatalogPage from '#features/payments/pages/CatalogPage';
 import CustomersPage from '#features/payments/pages/CustomersPage';
@@ -136,6 +137,7 @@ function AuthenticatedRoutes() {
           <Route path="subscriptions" element={<SubscriptionsPage />} />
           <Route path="transactions" element={<TransactionsPage />} />
         </Route>
+        <Route path="/dashboard/marketplace" element={<MarketplacePage />} />
         <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
           <Route index element={<Navigate to="channels" replace />} />
           <Route path="channels" element={<RealtimeChannelsPage />} />

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -23,6 +23,8 @@ export * from './deployments.schema.js';
 export * from './deployments-api.schema.js';
 export * from './schedules.schema.js';
 export * from './schedules-api.schema.js';
+export * from './marketplace.schema.js';
+export * from './marketplace-api.schema.js';
 export * from './payments.schema.js';
 export * from './payments-api.schema.js';
 export * from './compute-services.schema.js';

--- a/packages/shared-schemas/src/marketplace-api.schema.ts
+++ b/packages/shared-schemas/src/marketplace-api.schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { marketplacePluginSchema } from './marketplace.schema.js';
+
+export const marketplacePluginWithStatusSchema = marketplacePluginSchema.extend({
+  installed: z.boolean(),
+});
+
+// GET /marketplace/plugins
+export const listMarketplacePluginsResponseSchema = z.object({
+  plugins: z.array(marketplacePluginWithStatusSchema),
+});
+
+// POST /marketplace/plugins/:slug/install
+export const installMarketplacePluginRequestSchema = z.object({
+  apiKey: z.string().min(1, 'API key is required'),
+});
+
+export const installMarketplacePluginResponseSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+});
+
+// DELETE /marketplace/plugins/:slug
+export const uninstallMarketplacePluginResponseSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+});
+
+export type MarketplacePluginWithStatus = z.infer<typeof marketplacePluginWithStatusSchema>;
+export type ListMarketplacePluginsResponse = z.infer<typeof listMarketplacePluginsResponseSchema>;
+export type InstallMarketplacePluginRequest = z.infer<typeof installMarketplacePluginRequestSchema>;
+export type InstallMarketplacePluginResponse = z.infer<
+  typeof installMarketplacePluginResponseSchema
+>;
+export type UninstallMarketplacePluginResponse = z.infer<
+  typeof uninstallMarketplacePluginResponseSchema
+>;

--- a/packages/shared-schemas/src/marketplace.schema.ts
+++ b/packages/shared-schemas/src/marketplace.schema.ts
@@ -18,7 +18,10 @@ export const marketplaceInstallSpecSchema = z.object({
 });
 
 export const marketplacePluginSchema = z.object({
-  slug: z.string().min(1),
+  // Used as a route parameter (/marketplace/plugins/:slug/install)
+  slug: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'Slug must be lowercase alphanumeric with hyphens'),
   name: z.string().min(1),
   publisher: z.string(),
   category: z.string(),
@@ -38,7 +41,18 @@ export const marketplacePluginSchema = z.object({
 // schema and falls back to its bundled catalog when it doesn't conform.
 export const marketplaceCatalogSchema = z.object({
   version: z.number().int().nonnegative(),
-  plugins: z.array(marketplacePluginSchema),
+  plugins: z.array(marketplacePluginSchema).superRefine((plugins, ctx) => {
+    const seen = new Set<string>();
+    for (const plugin of plugins) {
+      if (seen.has(plugin.slug)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate plugin slug: ${plugin.slug}`,
+        });
+      }
+      seen.add(plugin.slug);
+    }
+  }),
 });
 
 export type MarketplaceInstallSpec = z.infer<typeof marketplaceInstallSpecSchema>;

--- a/packages/shared-schemas/src/marketplace.schema.ts
+++ b/packages/shared-schemas/src/marketplace.schema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+// How a plugin gets installed. 'secret' is the only supported type today:
+// validate the user's API key against the provider, then store it as an
+// encrypted project secret (auto-injected into edge-function environments).
+export const marketplaceInstallSpecSchema = z.object({
+  type: z.literal('secret'),
+  secretName: z
+    .string()
+    .regex(/^[A-Z0-9_]+$/, 'Use uppercase letters, numbers, and underscores only'),
+  placeholder: z.string(),
+  validation: z
+    .object({
+      url: z.string().url().startsWith('https://', 'Validation URL must use https'),
+      method: z.enum(['GET', 'POST']).optional(),
+    })
+    .optional(),
+});
+
+export const marketplacePluginSchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  publisher: z.string(),
+  category: z.string(),
+  description: z.string(),
+  // Honest list of what installing actually does, shown in the install dialog
+  actions: z.array(z.string()),
+  // Provider icon image; the dashboard falls back to a letter avatar when
+  // absent or unloadable
+  iconUrl: z.string().url().optional(),
+  install: marketplaceInstallSpecSchema,
+  docsUrl: z.string().url().optional(),
+  skillUrl: z.string().url().optional(),
+});
+
+// Shape of the remotely-hosted marketplace.json (S3/CDN, provisioned by
+// insforge-cloudbackend). The backend validates fetched content against this
+// schema and falls back to its bundled catalog when it doesn't conform.
+export const marketplaceCatalogSchema = z.object({
+  version: z.number().int().nonnegative(),
+  plugins: z.array(marketplacePluginSchema),
+});
+
+export type MarketplaceInstallSpec = z.infer<typeof marketplaceInstallSpecSchema>;
+export type MarketplacePlugin = z.infer<typeof marketplacePluginSchema>;
+export type MarketplaceCatalog = z.infer<typeof marketplaceCatalogSchema>;


### PR DESCRIPTION
## What

Adds a Marketplace page to the dashboard, backed by a remotely-managed catalog, with Resend as the first installable plugin. Installing validates the user's API key against the provider and stores it as an encrypted project secret — nothing else. Uninstalling deactivates the secret.

## How

**Catalog** — `marketplace.json` is hosted on S3 and served to project backends by insforge-cloud-backend (companion PR: https://github.com/InsForge/insforge-cloud-backend/pull/720). This repo defines the contract (`packages/shared-schemas/src/marketplace.schema.ts`): each entry is declarative — display metadata, `iconUrl`, and a secret-only install spec (`secretName`, placeholder, https validation endpoint). Adding a future secret-only plugin is a catalog edit, not an OSS release. The backend fetches `MARKETPLACE_CATALOG_URL` (default `https://api.insforge.dev/marketplace/v1/catalog`) with zod validation, a 5-min cache, negative caching, and a bundled fallback so offline/self-hosted instances keep working.

**Install engine** (`backend/src/services/marketplace/`) — admin-only routes under `/api/marketplace`. Install verifies the key against the catalog's validation endpoint (400/401/403 from the provider → invalid key; outages → 502 without touching secrets), guards the catalog-supplied URL (https-only, private-IP DNS check, no redirects), then creates or reactivates the secret in `system.secrets` — auto-injected into edge-function envs via the existing redeploy trigger. Audit-logged like the secrets routes. Installed status is derived from the active secret; there is no new table or migration.

**Dashboard** (`packages/dashboard/src/features/marketplace/`) — catalog-driven page with search, category filter, install dialog with inline validation errors, uninstall, and provider icons on white tiles with a deterministic letter-avatar fallback.

## Testing

- 23 backend unit tests (catalog fetch/validate/fallback/TTL/negative-cache; install validation, reserved-secret guard, SSRF rejection, uninstall).
- Typecheck + lint clean across backend, dashboard, and shared-schemas.
- Verified live in the dev stack: a bogus key is rejected by the real Resend API and surfaces inline; installed-status derivation, uninstall, toasts, and the bundled-catalog fallback (the default URL 404s until the cloudbackend PR deploys) all exercised in the browser.
- Deterministic Fixture E2E passed on `v2.2.7-marketplace`: https://github.com/InsForge/agent-e2e/actions/runs/29053525383

No agent-e2e fixture changes: the endpoint surface is new and additive (admin-only), and no existing asserted behavior changes. Deterministic fixture coverage for marketplace install can follow once the hosted catalog is provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Marketplace to the dashboard backed by a remote catalog, with a real Resend install that validates the API key and stores it as an encrypted secret. Includes admin-only APIs, stronger security and rate limiting, caching with shared in-flight refresh, an offline fallback, and small UI fixes.

- **New Features**
  - Dashboard Marketplace page with search, categories, and an install/uninstall dialog; API key input is masked, cards are keyboard-accessible, and provider icons use no-referrer.
  - Remote catalog fetched from `MARKETPLACE_CATALOG_URL` (5‑min cache with shared in‑flight fetch, negative caching; schema‑validated via `@insforge/shared-schemas`) with a bundled fallback.
  - Resend plugin: validates the key over HTTPS, stores `RESEND_API_KEY` as a secret, auto-injected into edge functions on redeploy; uninstall deactivates the secret.
  - Backend admin routes under `/api/marketplace` with audit logs and redeploy trigger; no new tables—installed status comes from the active secret. SSRF guards: https‑only, no redirects, reject private or unresolvable hosts; invalid keys return 400, provider outages return 502.
  - Rate limit: 20 install/uninstall requests per 15 minutes per IP.
  - OpenAPI spec added at `openapi/marketplace.yaml`.

- **Migration**
  - Optional: set `MARKETPLACE_CATALOG_URL` (defaults to `https://api.insforge.dev/marketplace/v1/catalog`). Set it empty to force bundled catalog only; offline/self‑hosted will fall back automatically if unreachable.
  - Admin access required to install/uninstall. No database changes; existing secrets are reused.

<sup>Written for commit 19191d6b560313c1f75e767abcab5e2600fd7d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add plugin marketplace with Resend install support to the dashboard
> - Adds a full marketplace feature: a `/dashboard/marketplace` page with search, category filters, and a plugin grid; a dialog to install/uninstall plugins with API key input and validation.
> - Backend exposes admin-only REST endpoints under `/api/marketplace/plugins` for listing, installing, and uninstalling plugins.
> - Plugin installation validates the API key against the provider's endpoint (with SSRF protection via private IP rejection), then stores it as an active secret.
> - A `MarketplaceCatalogService` fetches the plugin catalog from a configurable URL (`MARKETPLACE_CATALOG_URL`), caches results for 5 minutes, and falls back to a bundled default catalog containing a Resend plugin definition.
> - Successful installs/uninstalls trigger a non-blocking functions redeploy when subhosting is configured.
> - Risk: the API key validation step makes an outbound HTTP request to the plugin provider; provider outages return 502 to the caller.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1654 opened
>
> - Strengthened plugin validation host checking in `MarketplaceService.assertPublicHost` to fail closed when validation hostnames cannot be resolved via DNS, explicitly check resolved IPv6 addresses for private ranges, and reject IP-literal private addresses [19191d6]
> - Added per-IP rate limiting of 20 requests per 15 minutes to marketplace plugin install and uninstall operations via `marketplaceInstallRateLimiter` middleware [19191d6]
> - Implemented shared inflight request handling and TTL-based refresh orchestration in `MarketplaceCatalogService.getCatalog` to prevent concurrent cold requests from triggering redundant remote fetches [19191d6]
> - Introduced `redactUrl` utility function in catalog service that returns only origin and pathname from URLs, catching parse errors and returning placeholder string [19191d6]
> - Changed marketplace catalog URL configuration to preserve explicitly empty `MARKETPLACE_CATALOG_URL` environment variable as empty string instead of falling back to default hosted URL [19191d6]
> - Enhanced `marketplacePluginSchema` slug validation to require lowercase alphanumeric with hyphens pattern and added duplicate slug detection to `marketplaceCatalogSchema` [19191d6]
> - Improved security and accessibility of marketplace dashboard components including password masking, referrer policy, and keyboard navigation [19191d6]
> - Added OpenAPI 3.0 specification documenting marketplace endpoints for listing plugins, installing with rate limits and validation, and uninstalling [19191d6]
> - Added unit tests covering concurrent catalog fetch behavior, IPv6 private resolution, DNS resolution failures, IP-literal validation hosts, and secret update error mapping [19191d6]
> - Added explanatory comments to `MarketplaceService.installPlugin` about updating existing non-reserved secrets in place and noted DNS rebinding gap in `assertPublicHost` [19191d6]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e37f9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Marketplace page in the dashboard with plugin browsing, search, category filters, and install/uninstall dialogs.
  * Added plugin cards and avatars for a clearer marketplace experience, plus new marketplace client + route.
  * Introduced admin marketplace API endpoints to list plugins and manage plugin installs via stored secrets.
* **Bug Fixes**
  * Improved marketplace catalog resilience with caching, concurrency sharing, and safe fallback when remote data fails.
  * Added provider key validation safeguards and hostname/IP protections during install.
* **Tests**
  * Added unit tests covering catalog behavior and plugin install/uninstall flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->