### PR TITLE
feat(shared-schemas): type presence member events

### DIFF
--- a/backend/src/infra/socket/socket.manager.ts
+++ b/backend/src/infra/socket/socket.manager.ts
@@ -12,6 +12,7 @@ import {
   type SubscribeResponse,
   type UnsubscribeChannelPayload,
   type PresenceMember,
+  type PresenceMemberEvent,
 } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 import { AppError } from '@/utils/errors.js';
@@ -627,7 +628,7 @@ export class SocketManager {
       return;
     }
 
-    const message = this.buildSocketMessage(
+    const message: PresenceMemberEvent = this.buildSocketMessage(
       { member },
       {
         channel,

--- a/packages/shared-schemas/src/realtime.schema.ts
+++ b/packages/shared-schemas/src/realtime.schema.ts
@@ -212,3 +212,6 @@ export const presenceLeaveMessageSchema = socketMessageSchema.extend({
 });
 
 export type PresenceLeaveMessage = z.infer<typeof presenceLeaveMessageSchema>;
+
+/** A presence membership delta sent for either `presence:join` or `presence:leave`. */
+export type PresenceMemberEvent = PresenceJoinMessage | PresenceLeaveMessage;


### PR DESCRIPTION
## Summary
- add PresenceMemberEvent as the shared union for presence join and leave payloads
- type the backend presence emitter with that shared event contract

## Verification
- npm run typecheck
- npm run format:check
- npm run lint

Paired SDK PR: https://github.com/InsForge/InsForge-sdk-js/pull/101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `PresenceMemberEvent` as the shared union for presence join/leave messages, and type the backend presence emitter to use it. This standardizes presence payloads and improves type safety across `@insforge/shared-schemas` and the backend.

<sup>Written for commit 0173c293c6e8c64b1195d69ef23923803a8d34e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type consistency for real-time presence join and leave events.
  * No user-facing behavior or control-flow changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->