### PR TITLE
fix(auth): implement constant-time comparison for admin login (CWE-208)

### DIFF
--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -81,6 +81,12 @@ export class AuthService {
       );
     }
 
+    if (this.adminUsername.length > 4096 || this.adminPassword.length > 4096) {
+      throw new Error(
+        'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD must not exceed 4096 characters to prevent DoS vulnerabilities.'
+      );
+    }
+
     this.adminUsernameHash = crypto.createHash('sha256').update(this.adminUsername).digest();
     this.adminPasswordHash = crypto.createHash('sha256').update(this.adminPassword).digest();
 
@@ -662,7 +668,7 @@ export class AuthService {
    * Admin login (validates against env variables only)
    */
   adminLogin(username: string, password: string): CreateAdminSessionResponse {
-    if (username.length > 256 || password.length > 256) {
+    if (username.length > 4096 || password.length > 4096) {
       throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }
 

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -657,8 +657,15 @@ export class AuthService {
    * Admin login (validates against env variables only)
    */
   adminLogin(username: string, password: string): CreateAdminSessionResponse {
-    // Simply validate against environment variables
-    if (username !== this.adminUsername || password !== this.adminPassword) {
+    const hashedUserProvided = crypto.createHash('sha256').update(username).digest();
+    const hashedUserActual = crypto.createHash('sha256').update(this.adminUsername).digest();
+    const hashedPassProvided = crypto.createHash('sha256').update(password).digest();
+    const hashedPassActual = crypto.createHash('sha256').update(this.adminPassword).digest();
+
+    const usernameMatch = crypto.timingSafeEqual(hashedUserProvided, hashedUserActual);
+    const passwordMatch = crypto.timingSafeEqual(hashedPassProvided, hashedPassActual);
+
+    if (!usernameMatch || !passwordMatch) {
       throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }
 

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -56,6 +56,8 @@ export class AuthService {
   private static instance: AuthService;
   private adminUsername: string;
   private adminPassword: string;
+  private adminUsernameHash: Buffer;
+  private adminPasswordHash: Buffer;
   private pool: Pool | null = null;
   private tokenManager: TokenManager;
 
@@ -78,6 +80,9 @@ export class AuthService {
         'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD environment variables are required'
       );
     }
+
+    this.adminUsernameHash = crypto.createHash('sha256').update(this.adminUsername).digest();
+    this.adminPasswordHash = crypto.createHash('sha256').update(this.adminPassword).digest();
 
     // Initialize token manager
     this.tokenManager = TokenManager.getInstance();
@@ -657,13 +662,15 @@ export class AuthService {
    * Admin login (validates against env variables only)
    */
   adminLogin(username: string, password: string): CreateAdminSessionResponse {
-    const hashedUserProvided = crypto.createHash('sha256').update(username).digest();
-    const hashedUserActual = crypto.createHash('sha256').update(this.adminUsername).digest();
-    const hashedPassProvided = crypto.createHash('sha256').update(password).digest();
-    const hashedPassActual = crypto.createHash('sha256').update(this.adminPassword).digest();
+    if (username.length > 256 || password.length > 256) {
+      throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
 
-    const usernameMatch = crypto.timingSafeEqual(hashedUserProvided, hashedUserActual);
-    const passwordMatch = crypto.timingSafeEqual(hashedPassProvided, hashedPassActual);
+    const hashedUserProvided = crypto.createHash('sha256').update(username).digest();
+    const hashedPassProvided = crypto.createHash('sha256').update(password).digest();
+
+    const usernameMatch = crypto.timingSafeEqual(hashedUserProvided, this.adminUsernameHash);
+    const passwordMatch = crypto.timingSafeEqual(hashedPassProvided, this.adminPasswordHash);
 
     if (!usernameMatch || !passwordMatch) {
       throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -54,8 +54,6 @@ import {
  */
 export class AuthService {
   private static instance: AuthService;
-  private adminUsername: string;
-  private adminPassword: string;
   private adminUsernameHash: Buffer;
   private adminPasswordHash: Buffer;
   private pool: Pool | null = null;
@@ -72,23 +70,23 @@ export class AuthService {
   private appleOAuthProvider: AppleOAuthProvider;
 
   private constructor() {
-    this.adminUsername = appConfig.auth.rootAdminUsername;
-    this.adminPassword = appConfig.auth.rootAdminPassword;
+    const adminUsername = appConfig.auth.rootAdminUsername;
+    const adminPassword = appConfig.auth.rootAdminPassword;
 
-    if (!this.adminUsername || !this.adminPassword) {
+    if (!adminUsername || !adminPassword) {
       throw new Error(
         'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD environment variables are required'
       );
     }
 
-    if (this.adminUsername.length > 4096 || this.adminPassword.length > 4096) {
+    if (adminUsername.length > 4096 || adminPassword.length > 4096) {
       throw new Error(
         'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD must not exceed 4096 characters to prevent DoS vulnerabilities.'
       );
     }
 
-    this.adminUsernameHash = crypto.createHash('sha256').update(this.adminUsername).digest();
-    this.adminPasswordHash = crypto.createHash('sha256').update(this.adminPassword).digest();
+    this.adminUsernameHash = crypto.createHash('sha256').update(adminUsername).digest();
+    this.adminPasswordHash = crypto.createHash('sha256').update(adminPassword).digest();
 
     // Initialize token manager
     this.tokenManager = TokenManager.getInstance();
@@ -668,6 +666,7 @@ export class AuthService {
    * Admin login (validates against env variables only)
    */
   adminLogin(username: string, password: string): CreateAdminSessionResponse {
+    // input-sanity guard (defense-in-depth against route validation bypasses)
     if (username.length > 4096 || password.length > 4096) {
       throw new AppError('Invalid admin credentials', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
     }

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -132,6 +132,19 @@ describe('AuthService.adminLogin', () => {
     authService = AuthService.getInstance();
   });
 
+  function expectAdminLoginError(username: string, password: string) {
+    try {
+      authService.adminLogin(username, password);
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  }
+
   it('successfully logs in with correct credentials', () => {
     const result = authService.adminLogin('admin@test.com', 'admin-password');
     expect(result).toEqual({
@@ -145,70 +158,31 @@ describe('AuthService.adminLogin', () => {
   });
 
   it('throws AppError when username is incorrect but password is correct', () => {
-    try {
-      authService.adminLogin('wrong-admin@test.com', 'admin-password');
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+    expectAdminLoginError('wrong-admin@test.com', 'admin-password');
   });
 
   it('throws AppError when password is incorrect but username is correct', () => {
-    try {
-      authService.adminLogin('admin@test.com', 'wrong-password');
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+    expectAdminLoginError('admin@test.com', 'wrong-password');
   });
 
   it('throws AppError when both username and password are incorrect', () => {
-    try {
-      authService.adminLogin('wrong-admin@test.com', 'wrong-password');
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+    expectAdminLoginError('wrong-admin@test.com', 'wrong-password');
   });
 
   it('throws AppError when inputs are empty strings', () => {
-    try {
-      authService.adminLogin('', '');
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+    expectAdminLoginError('', '');
   });
 
-  it('handles credentials of significantly different lengths safely without crashing', () => {
-    const longUsername = 'a'.repeat(1000);
-    const longPassword = 'b'.repeat(1000);
+  it('handles credentials of different lengths safely up to 256 characters', () => {
+    const longUsername = 'a'.repeat(256);
+    const longPassword = 'b'.repeat(256);
+    expectAdminLoginError(longUsername, longPassword);
+  });
 
-    try {
-      authService.adminLogin(longUsername, longPassword);
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+  it('immediately rejects credentials exceeding 256 characters', () => {
+    const hugeUsername = 'a'.repeat(257);
+    const hugePassword = 'b'.repeat(257);
+    expectAdminLoginError(hugeUsername, 'admin-password');
+    expectAdminLoginError('admin@test.com', hugePassword);
   });
 });

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppError } from '../../src/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+// Required env vars before any imports
+process.env.ROOT_ADMIN_USERNAME = 'admin@test.com';
+process.env.ROOT_ADMIN_PASSWORD = 'admin-password';
+
+const { mockPool, mockTokenManager, mockOAuthProvider } = vi.hoisted(() => ({
+  mockPool: {
+    connect: vi.fn(),
+    query: vi.fn(),
+  },
+  mockTokenManager: {
+    generateAccessToken: vi.fn().mockReturnValue('test-access-token'),
+  },
+  mockOAuthProvider: {
+    getInstance: () => ({}),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getAuthConfig: vi.fn(),
+      validateRedirectUrl: vi.fn().mockResolvedValue(true),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-otp.service.js', () => ({
+  AuthOTPService: {
+    getInstance: () => ({
+      generateOTP: vi.fn().mockResolvedValue('123456'),
+    }),
+  },
+  OTPPurpose: { VERIFY_EMAIL: 'VERIFY_EMAIL' },
+  OTPType: { CODE: 'CODE' },
+}));
+
+vi.mock('../../src/services/auth/oauth-config.service.js', () => ({
+  OAuthConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/auth/custom-oauth-config.service.js', () => ({
+  CustomOAuthConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/email/email.service.js', () => ({
+  EmailService: {
+    getInstance: () => ({
+      sendMail: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock('bcryptjs', () => ({
+  default: {
+    hash: vi.fn().mockResolvedValue('hashed-password'),
+  },
+}));
+
+vi.mock('../../src/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => mockTokenManager,
+  },
+}));
+
+vi.mock('../../src/providers/oauth/google.provider.js', () => ({ GoogleOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/github.provider.js', () => ({ GitHubOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/discord.provider.js', () => ({ DiscordOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/linkedin.provider.js', () => ({ LinkedInOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/facebook.provider.js', () => ({ FacebookOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/microsoft.provider.js', () => ({ MicrosoftOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/x.provider.js', () => ({ XOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/apple.provider.js', () => ({ AppleOAuthProvider: mockOAuthProvider }));
+
+vi.mock('../../src/infra/config/app.config.js', () => {
+  const c = {
+    app: { jwtSecret: 'test-secret', name: 'test' },
+    cloud: { projectId: null },
+    auth: { rootAdminUsername: 'admin@test.com', rootAdminPassword: 'admin-password' },
+  };
+  return {
+    config: c,
+    appConfig: c,
+    getApiBaseUrl: () => 'http://localhost:3000',
+  };
+});
+
+import { AuthService } from '../../src/services/auth/auth.service.js';
+
+describe('AuthService.adminLogin', () => {
+  let authService: AuthService;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockTokenManager.generateAccessToken.mockReturnValue('test-access-token');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (AuthService as any).instance = undefined;
+    authService = AuthService.getInstance();
+  });
+
+  it('successfully logs in with correct credentials', () => {
+    const result = authService.adminLogin('admin@test.com', 'admin-password');
+    expect(result).toEqual({
+      admin: { sub: 'local:admin@test.com' },
+      accessToken: 'test-access-token',
+    });
+    expect(mockTokenManager.generateAccessToken).toHaveBeenCalledWith({
+      sub: 'local:admin@test.com',
+      role: 'project_admin',
+    });
+  });
+
+  it('throws AppError when username is incorrect but password is correct', () => {
+    try {
+      authService.adminLogin('wrong-admin@test.com', 'admin-password');
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  });
+
+  it('throws AppError when password is incorrect but username is correct', () => {
+    try {
+      authService.adminLogin('admin@test.com', 'wrong-password');
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  });
+
+  it('throws AppError when both username and password are incorrect', () => {
+    try {
+      authService.adminLogin('wrong-admin@test.com', 'wrong-password');
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  });
+
+  it('throws AppError when inputs are empty strings', () => {
+    try {
+      authService.adminLogin('', '');
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  });
+
+  it('handles credentials of significantly different lengths safely without crashing', () => {
+    const longUsername = 'a'.repeat(1000);
+    const longPassword = 'b'.repeat(1000);
+
+    try {
+      authService.adminLogin(longUsername, longPassword);
+      expect.fail('Should have thrown an error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AppError);
+      const appErr = error as AppError;
+      expect(appErr.message).toBe('Invalid admin credentials');
+      expect(appErr.statusCode).toBe(401);
+      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
+    }
+  });
+});

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -83,14 +83,28 @@ vi.mock('../../src/infra/security/token.manager.js', () => ({
   },
 }));
 
-vi.mock('../../src/providers/oauth/google.provider.js', () => ({ GoogleOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/github.provider.js', () => ({ GitHubOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/discord.provider.js', () => ({ DiscordOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/linkedin.provider.js', () => ({ LinkedInOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/facebook.provider.js', () => ({ FacebookOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/microsoft.provider.js', () => ({ MicrosoftOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/google.provider.js', () => ({
+  GoogleOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/github.provider.js', () => ({
+  GitHubOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/discord.provider.js', () => ({
+  DiscordOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/linkedin.provider.js', () => ({
+  LinkedInOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/facebook.provider.js', () => ({
+  FacebookOAuthProvider: mockOAuthProvider,
+}));
+vi.mock('../../src/providers/oauth/microsoft.provider.js', () => ({
+  MicrosoftOAuthProvider: mockOAuthProvider,
+}));
 vi.mock('../../src/providers/oauth/x.provider.js', () => ({ XOAuthProvider: mockOAuthProvider }));
-vi.mock('../../src/providers/oauth/apple.provider.js', () => ({ AppleOAuthProvider: mockOAuthProvider }));
+vi.mock('../../src/providers/oauth/apple.provider.js', () => ({
+  AppleOAuthProvider: mockOAuthProvider,
+}));
 
 vi.mock('../../src/infra/config/app.config.js', () => {
   const c = {

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -190,7 +190,7 @@ describe('AuthService.adminLogin', () => {
   it('throws a fatal error during initialization if root admin credentials exceed 4096 characters', () => {
     const originalUsername = appConfig.auth.rootAdminUsername;
     appConfig.auth.rootAdminUsername = 'a'.repeat(4097);
-    
+
     try {
       // Clear instance to force re-instantiation and constructor execution
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -186,7 +186,7 @@ describe('AuthService.adminLogin', () => {
   it('throws a fatal error during initialization if root admin username exceeds 4096 characters', () => {
     const originalUsername = appConfig.auth.rootAdminUsername;
     appConfig.auth.rootAdminUsername = 'a'.repeat(4097);
-    
+
     try {
       // Clear instance to force re-instantiation and constructor execution
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -210,7 +210,7 @@ describe('AuthService.adminLogin', () => {
   it('throws a fatal error during initialization if root admin password exceeds 4096 characters', () => {
     const originalPassword = appConfig.auth.rootAdminPassword;
     appConfig.auth.rootAdminPassword = 'b'.repeat(4097);
-    
+
     try {
       // Clear instance to force re-instantiation and constructor execution
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -119,6 +119,7 @@ vi.mock('../../src/infra/config/app.config.js', () => {
   };
 });
 
+import { appConfig } from '../../src/infra/config/app.config.js';
 import { AuthService } from '../../src/services/auth/auth.service.js';
 
 describe('AuthService.adminLogin', () => {
@@ -173,16 +174,40 @@ describe('AuthService.adminLogin', () => {
     expectAdminLoginError('', '');
   });
 
-  it('handles credentials of different lengths safely up to 256 characters', () => {
-    const longUsername = 'a'.repeat(256);
-    const longPassword = 'b'.repeat(256);
+  it('handles credentials of different lengths safely up to 4096 characters', () => {
+    const longUsername = 'a'.repeat(4096);
+    const longPassword = 'b'.repeat(4096);
     expectAdminLoginError(longUsername, longPassword);
   });
 
-  it('immediately rejects credentials exceeding 256 characters', () => {
-    const hugeUsername = 'a'.repeat(257);
-    const hugePassword = 'b'.repeat(257);
+  it('immediately rejects credentials exceeding 4096 characters', () => {
+    const hugeUsername = 'a'.repeat(5000);
+    const hugePassword = 'b'.repeat(5000);
     expectAdminLoginError(hugeUsername, 'admin-password');
     expectAdminLoginError('admin@test.com', hugePassword);
+  });
+
+  it('throws a fatal error during initialization if root admin credentials exceed 4096 characters', () => {
+    const originalUsername = appConfig.auth.rootAdminUsername;
+    appConfig.auth.rootAdminUsername = 'a'.repeat(4097);
+    
+    try {
+      // Clear instance to force re-instantiation and constructor execution
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (AuthService as any).instance = undefined;
+      AuthService.getInstance();
+      expect.fail('Should have thrown a fatal error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(Error);
+      const err = error as Error;
+      expect(err.message).toBe(
+        'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD must not exceed 4096 characters to prevent DoS vulnerabilities.'
+      );
+    } finally {
+      // Restore config state
+      appConfig.auth.rootAdminUsername = originalUsername;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (AuthService as any).instance = undefined;
+    }
   });
 });

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AppError } from '../../src/utils/errors.js';
 import { ERROR_CODES } from '@insforge/shared-schemas';
 
 // Required env vars before any imports
@@ -134,16 +133,13 @@ describe('AuthService.adminLogin', () => {
   });
 
   function expectAdminLoginError(username: string, password: string) {
-    try {
-      authService.adminLogin(username, password);
-      expect.fail('Should have thrown an error');
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(AppError);
-      const appErr = error as AppError;
-      expect(appErr.message).toBe('Invalid admin credentials');
-      expect(appErr.statusCode).toBe(401);
-      expect(appErr.code).toBe(ERROR_CODES.AUTH_UNAUTHORIZED);
-    }
+    expect(() => authService.adminLogin(username, password)).toThrow(
+      expect.objectContaining({
+        message: 'Invalid admin credentials',
+        statusCode: 401,
+        code: ERROR_CODES.AUTH_UNAUTHORIZED,
+      })
+    );
   }
 
   it('successfully logs in with correct credentials', () => {
@@ -187,10 +183,10 @@ describe('AuthService.adminLogin', () => {
     expectAdminLoginError('admin@test.com', hugePassword);
   });
 
-  it('throws a fatal error during initialization if root admin credentials exceed 4096 characters', () => {
+  it('throws a fatal error during initialization if root admin username exceeds 4096 characters', () => {
     const originalUsername = appConfig.auth.rootAdminUsername;
     appConfig.auth.rootAdminUsername = 'a'.repeat(4097);
-
+    
     try {
       // Clear instance to force re-instantiation and constructor execution
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -206,6 +202,30 @@ describe('AuthService.adminLogin', () => {
     } finally {
       // Restore config state
       appConfig.auth.rootAdminUsername = originalUsername;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (AuthService as any).instance = undefined;
+    }
+  });
+
+  it('throws a fatal error during initialization if root admin password exceeds 4096 characters', () => {
+    const originalPassword = appConfig.auth.rootAdminPassword;
+    appConfig.auth.rootAdminPassword = 'b'.repeat(4097);
+    
+    try {
+      // Clear instance to force re-instantiation and constructor execution
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (AuthService as any).instance = undefined;
+      AuthService.getInstance();
+      expect.fail('Should have thrown a fatal error');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(Error);
+      const err = error as Error;
+      expect(err.message).toBe(
+        'ROOT_ADMIN_USERNAME and ROOT_ADMIN_PASSWORD must not exceed 4096 characters to prevent DoS vulnerabilities.'
+      );
+    } finally {
+      // Restore config state
+      appConfig.auth.rootAdminPassword = originalPassword;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (AuthService as any).instance = undefined;
     }


### PR DESCRIPTION
## Security Patch: Admin Login Timing Attack (CWE-208)

Closes #1659

### Description
This pull request resolves a Timing Attack vulnerability in the `adminLogin` flow. Previously, the authentication service used standard equality operators (`!==`) to verify the admin username and password. Because V8's string comparison fails fast, this created a timing side-channel that could allow an attacker to extract the admin credentials character-by-character over thousands of requests.

### Architectural Fix
This patch implements constant-time comparison for the admin credentials:
1. **Buffer Length Normalization:** Both the provided inputs and the stored secrets are hashed via `SHA-256` first. This prevents `crypto.timingSafeEqual` from throwing a fatal `TypeError` due to buffer length mismatches, and entirely eliminates Length Oracle vulnerabilities.
2. **Sequential Execution:** The hashes are compared sequentially (`usernameMatch` then `passwordMatch`) before evaluating the overall boolean failure. This guarantees the execution path takes the exact same amount of CPU time regardless of whether the username or password fails first.
3. **Contract Parity:** The existing `AppError`, `401` HTTP status, and `ERROR_CODES.AUTH_UNAUTHORIZED` have been preserved to avoid breaking client-side error handling.

### Verification & Testing
- **New Unit Tests**: Created `backend/tests/unit/admin-login.test.ts` covering 6 scenarios (valid credentials, invalid username/password, empty strings, and severe length mismatch inputs to prove buffer safety).
- **Test Suite Result**: `150 passed, 1777 tests passed` (`npm run test:backend`).
- **Type/Lint Safety**: `npx turbo run typecheck` and `eslint` completed cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timing attack in admin login using constant-time credential checks. Stores only hashed admin credentials in memory, preserves 401 error contract, and caps inputs/env secrets at 4096 chars to prevent CPU DoS.

- **Bug Fixes**
  - Pre-hash stored admin username/password with `SHA-256` at startup; hash inputs per request, then compare via `crypto.timingSafeEqual`.
  - Compute both username and password matches before branching to keep timing consistent.
  - Enforce 4096-char max for provided and configured credentials; per-request rejects return `AppError` 401 with `ERROR_CODES.AUTH_UNAUTHORIZED`, startup throws if config too long. Tests cover success, mismatches, boundary (4096), oversize, and init-failure.

- **Refactors**
  - Avoid retaining plaintext credentials in process memory and use idiomatic test assertions.

<sup>Written for commit e05c99247b9ac3928030af815e923a871c00f8e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timing attack vulnerability in `AuthService.adminLogin` (CWE-208)
> - Replaces direct string equality checks in `adminLogin` with SHA-256 hashing of user-supplied credentials and `crypto.timingSafeEqual` comparison against pre-hashed stored values.
> - Adds a 4096-character length guard on both login inputs and configured credentials, rejecting overlong values with a 401 error or constructor throw respectively.
> - Stores only SHA-256 hashes of `ROOT_ADMIN_USERNAME` and `ROOT_ADMIN_PASSWORD` in memory instead of plaintext strings.
> - Adds a unit test suite in [admin-login.test.ts](https://github.com/InsForge/InsForge/pull/1660/files#diff-0aba188d565df7bba41a339d89bc7d1bcbcb5e3a96b26d4cc99b8fcb7772ae26) covering correct/incorrect credentials, edge cases, and length limits.
> - Behavioral Change: `AuthService.getInstance()` now throws if configured credentials exceed 4096 characters; `adminLogin` returns 401 for inputs over that limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c3333c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened administrator login by hashing configured root credentials and using timing-safe comparison.
  * Added input size limits for administrator username/password to reject overly large values.
  * Enforced maximum configured root credential lengths at startup to reduce denial-of-service risk.
* **Bug Fixes**
  * Kept invalid administrator login responses consistent (wrong, empty, and too-long inputs all return the same unauthorized error).
* **Tests**
  * Expanded unit tests to cover successful login, all failure cases, and boundary length enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->