### PR TITLE
fix: remove hard min-width from page headers so search stays visible in narrow views

### DIFF
--- a/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
+++ b/packages/dashboard/src/features/database/pages/SQLEditorPage.tsx
@@ -241,7 +241,7 @@ export default function SQLEditorPage() {
   return (
     <div className="flex flex-col h-full bg-[rgb(var(--semantic-1))] overflow-hidden">
       {/* Tab Header: Figma h-56, items-center, bg #1b1b1b, border-b */}
-      <div className="flex items-center h-14 min-w-[800px] bg-[rgb(var(--semantic-1))] border-b border-[var(--alpha-8)] shrink-0">
+      <div className="flex items-center h-14 bg-[rgb(var(--semantic-1))] border-b border-[var(--alpha-8)] shrink-0">
         {/* Title: h-full, px-16, py-12 */}
         <div className="flex items-center h-full overflow-clip px-4 py-3 shrink-0">
           <span className="text-base font-medium leading-7 text-black dark:text-white whitespace-nowrap">

--- a/packages/dashboard/src/features/functions/pages/FunctionsPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/FunctionsPage.tsx
@@ -336,7 +336,6 @@ export default function FunctionsPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
-        className="min-w-[800px]"
         leftContent={
           <div className="flex flex-1 items-center overflow-clip">
             <h1 className="shrink-0 text-base font-medium leading-7 text-foreground">

--- a/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
@@ -201,7 +201,6 @@ export default function SchedulesPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
-        className="min-w-[800px]"
         leftContent={
           <div className="flex flex-1 items-center overflow-clip">
             <h1 className="shrink-0 text-base font-medium leading-7 text-foreground">Schedules</h1>

--- a/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SecretsPage.tsx
@@ -43,7 +43,6 @@ export default function SecretsPage() {
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
         title="Secrets"
-        className="min-w-[960px]"
         searchValue={searchQuery}
         onSearchChange={setSearchQuery}
         searchDebounceTime={300}

--- a/packages/dashboard/src/features/realtime/pages/RealtimeChannelsPage.tsx
+++ b/packages/dashboard/src/features/realtime/pages/RealtimeChannelsPage.tsx
@@ -118,7 +118,6 @@ export default function RealtimeChannelsPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
-        className="min-w-[800px]"
         leftContent={
           <div className="flex flex-1 items-center overflow-clip">
             <h1 className="shrink-0 text-base font-medium leading-7 text-foreground">Channels</h1>

--- a/packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx
+++ b/packages/dashboard/src/features/realtime/pages/RealtimeMessagesPage.tsx
@@ -150,7 +150,6 @@ export default function RealtimeMessagesPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
-        className="min-w-[800px]"
         leftContent={
           <div className="flex flex-1 items-center overflow-clip gap-1">
             <h1 className="shrink-0 text-base font-medium leading-7 text-foreground">Messages</h1>

--- a/packages/dashboard/src/features/realtime/pages/RealtimePermissionsPage.tsx
+++ b/packages/dashboard/src/features/realtime/pages/RealtimePermissionsPage.tsx
@@ -162,7 +162,6 @@ export default function RealtimePermissionsPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden bg-[rgb(var(--semantic-1))]">
       <TableHeader
-        className="min-w-[800px]"
         leftContent={
           <div className="flex flex-1 items-center overflow-clip">
             <h1 className="shrink-0 text-base font-medium leading-7 text-foreground">


### PR DESCRIPTION
## Background Context

When the dashboard is embedded in a narrow container (e.g. the cloud shell opens its Ask AI side panel, or simply a small browser window), seven pages hard-code a min-width on their header bar. The page container is overflow-hidden, so instead of shrinking, the header gets clipped on the right, hiding the search input and action buttons.

Pages affected (all copied from the same original hand-written header, which is where the min-width came from):

- Edge Functions (`min-w-[800px]`, clips "Search functions")
- Schedules (`min-w-[800px]`)
- Secrets (`min-w-[960px]`, clips "Search secrets")
- Realtime Channels / Messages / Permissions (`min-w-[800px]`)
- SQL Editor hand-written header (`min-w-[800px]`)

## Change

Remove the min-width overrides. `TableHeader` is already responsive on its own (left content truncates via min-w-0 + overflow-hidden, right-side search/actions are shrink-0), which is why Users, Records, Policies and every other page that omits the min-width behaves correctly at any width. The SQL Editor header's tab strip already has its own overflow-x-auto, so it scrolls instead of clipping.

No behavior change at normal widths; typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed hard min-widths from several page headers so search and action buttons stay visible in narrow containers. Headers now shrink or scroll instead of clipping.

- **Bug Fixes**
  - Removed `min-w-*` constraints from headers on Functions, Schedules, Secrets, Realtime (Channels/Messages/Permissions), and SQL Editor to prevent clipping in tight layouts.
  - Uses `TableHeader`’s built-in responsiveness; SQL Editor tabs already scroll via overflow-x-auto. No visual changes at normal widths.

<sup>Written for commit e27ab88b8ec18e039e06cc8c3adb84a1f89bfdc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove hard min-width from page headers so search stays visible in narrow views
> Removes hardcoded `min-w-[800px]` (and `min-w-[960px]` in one case) classes from page header containers across the SQL editor, Functions, Schedules, Secrets, and Realtime pages. Headers now follow default container width behavior and shrink on narrower viewports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e27ab88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard page layouts by removing rigid minimum-width constraints from SQL editor, functions, schedules, secrets, and realtime section headers.
  * Headers now adapt more naturally to available screen space, improving usability on narrower windows and reducing unnecessary horizontal scrolling.
  * Existing search, filtering, table, and data interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->