### PR TITLE
docs: add database backups page

### DIFF
--- a/docs/core-concepts/database/backups.mdx
+++ b/docs/core-concepts/database/backups.mdx
@@ -1,0 +1,67 @@
+---
+title: "Database backups"
+description: "Automated daily backups on InsForge Cloud, plus manual backup and restore on every deployment"
+---
+
+Every InsForge database can be backed up and restored from the dashboard under **Database → Backups**. InsForge Cloud runs automated daily backups; manual backup and restore work on both Cloud and self-hosted deployments.
+
+## Automated daily backups
+
+InsForge Cloud backs up every active project on a paid plan once a day at 3:00 AM UTC. Each backup is a full compressed SQL dump of the project database, stored in S3 and retained for 7 days. Older scheduled backups are cleaned up automatically.
+
+Scheduled backups appear in the dashboard alongside manual ones. Creating a manual backup does not affect the daily schedule.
+
+## Manual backups
+
+Create a backup any time from **Database → Backups** in the dashboard. Backups run in the background; the list shows each backup's status (`running`, `completed`, or `failed`), size, and creation time. You can name, rename, and delete backups. Only one backup runs at a time.
+
+## Restore
+
+Restore any completed backup from the same page. A restore replaces the current database contents with the backup. On self-hosted deployments the restore runs in a single transaction, so a failed restore rolls back and leaves the database untouched.
+
+## Self-hosting
+
+Self-hosted backups use `pg_dump` (custom format) and store the archive with the rest of your storage:
+
+- Local storage: `${STORAGE_DIR}/_database_backups/`
+- S3 storage configured: `<app-key>/_database_backups/` in your bucket
+
+The official Docker image ships the PostgreSQL client tools. If you run the backend outside the image, install them so `pg_dump` and `pg_restore` are on the `PATH`.
+
+Backups are kept until you delete them — there is no automatic retention on self-hosted deployments.
+
+### API
+
+All endpoints require admin credentials (an admin session or your `ACCESS_API_KEY`).
+
+```bash
+# List backups
+curl http://localhost:7130/api/database/backups \
+  -H "Authorization: Bearer $ACCESS_API_KEY"
+
+# Create a backup (name is optional)
+curl -X POST http://localhost:7130/api/database/backups \
+  -H "Authorization: Bearer $ACCESS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "before-schema-change"}'
+
+# Restore a backup
+curl -X POST http://localhost:7130/api/database/backups/<backup-id>/restore \
+  -H "Authorization: Bearer $ACCESS_API_KEY"
+```
+
+Rename with `PATCH /api/database/backups/<backup-id>` and delete with `DELETE /api/database/backups/<backup-id>`.
+
+### Scheduling daily backups
+
+Self-hosted deployments do not include a built-in scheduler. Point a cron job at the API to get the same daily cadence as Cloud:
+
+```bash
+0 3 * * * curl -s -X POST http://localhost:7130/api/database/backups -H "Authorization: Bearer $ACCESS_API_KEY"
+```
+
+## More resources
+
+- [Database overview](/core-concepts/database/overview) for how the database is exposed to your app.
+- [Database migrations](/core-concepts/database/migrations) to version schema changes instead of restoring to undo them.
+- [Database branching](/agent-native/branching) to rehearse risky changes on a copy.

--- a/docs/core-concepts/database/backups.mdx
+++ b/docs/core-concepts/database/backups.mdx
@@ -1,64 +1,36 @@
 ---
 title: "Database backups"
-description: "Automated daily backups on InsForge Cloud, plus manual backup and restore on every deployment"
+description: "Back up and restore your database from the dashboard, with automated daily backups on InsForge Cloud"
 ---
 
-Every InsForge database can be backed up and restored from the dashboard under **Database → Backups**. InsForge Cloud runs automated daily backups; manual backup and restore work on both Cloud and self-hosted deployments.
+Back up and restore your database from the dashboard under **Database → Backup & Restore**. InsForge Cloud also backs up your project automatically every day, so you always have a recent copy to roll back to.
 
-## Automated daily backups
+## Scheduled backups
 
-InsForge Cloud backs up every active project on a paid plan once a day at 3:00 AM UTC. Each backup is a full compressed SQL dump of the project database, stored in S3 and retained for 7 days. Older scheduled backups are cleaned up automatically.
+InsForge Cloud backs up every active project on a paid plan once a day. Each backup is a full dump of the project database. Scheduled backups are retained for 7 days — the **Scheduled Backups** list shows when each one expires — and can be restored at any time.
 
-Scheduled backups appear in the dashboard alongside manual ones. Creating a manual backup does not affect the daily schedule.
+Creating a manual backup does not affect the daily schedule.
 
 ## Manual backups
 
-Create a backup any time from **Database → Backups** in the dashboard. Backups run in the background; the list shows each backup's status (`running`, `completed`, or `failed`), size, and creation time. You can name, rename, and delete backups. Only one backup runs at a time.
+Take a backup any time before a risky change:
+
+1. Open **Database → Backup & Restore** in the dashboard.
+2. Click **Create a Backup** and optionally give it a name.
+
+The backup runs in the background; the list shows its status, size, and creation time. You can rename or delete a backup from the same list. On InsForge Cloud, the Free plan includes 1 manual backup slot and paid plans include 5; manual backups are kept until you delete them.
 
 ## Restore
 
-Restore any completed backup from the same page. A restore replaces the current database contents with the backup. On self-hosted deployments the restore runs in a single transaction, so a failed restore rolls back and leaves the database untouched.
+Click **Restore** next to any completed backup — scheduled or manual. Restoring replaces the current database contents with the backup:
+
+- Your project is offline during the restore.
+- Any data created after the backup was taken is lost.
+- The restore cannot be undone, so consider taking a manual backup first.
 
 ## Self-hosting
 
-Self-hosted backups use `pg_dump` (custom format) and store the archive with the rest of your storage:
-
-- Local storage: `${STORAGE_DIR}/_database_backups/`
-- S3 storage configured: `<app-key>/_database_backups/` in your bucket
-
-The official Docker image ships the PostgreSQL client tools. If you run the backend outside the image, install them so `pg_dump` and `pg_restore` are on the `PATH`.
-
-Backups are kept until you delete them — there is no automatic retention on self-hosted deployments.
-
-### API
-
-All endpoints require admin credentials (an admin session or your `ACCESS_API_KEY`).
-
-```bash
-# List backups
-curl http://localhost:7130/api/database/backups \
-  -H "Authorization: Bearer $ACCESS_API_KEY"
-
-# Create a backup (name is optional)
-curl -X POST http://localhost:7130/api/database/backups \
-  -H "Authorization: Bearer $ACCESS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "before-schema-change"}'
-
-# Restore a backup
-curl -X POST http://localhost:7130/api/database/backups/<backup-id>/restore \
-  -H "Authorization: Bearer $ACCESS_API_KEY"
-```
-
-Rename with `PATCH /api/database/backups/<backup-id>` and delete with `DELETE /api/database/backups/<backup-id>`.
-
-### Scheduling daily backups
-
-Self-hosted deployments do not include a built-in scheduler. Point a cron job at the API to get the same daily cadence as Cloud:
-
-```bash
-0 3 * * * curl -s -X POST http://localhost:7130/api/database/backups -H "Authorization: Bearer $ACCESS_API_KEY"
-```
+Self-hosted deployments have the same **Backup & Restore** page in the dashboard for manual backups and restores. Backup archives are stored with the rest of your storage — under `${STORAGE_DIR}/_database_backups/` on local storage, or in your S3 bucket when S3 storage is configured — and are kept until you delete them. The official Docker image includes everything needed; no extra setup is required.
 
 ## More resources
 

--- a/docs/core-concepts/database/backups.mdx
+++ b/docs/core-concepts/database/backups.mdx
@@ -3,34 +3,25 @@ title: "Database backups"
 description: "Back up and restore your database from the dashboard, with automated daily backups on InsForge Cloud"
 ---
 
-Back up and restore your database from the dashboard under **Database → Backup & Restore**. InsForge Cloud also backs up your project automatically every day, so you always have a recent copy to roll back to.
+Back up and restore your database from **Database → Backup & Restore** in the dashboard. InsForge Cloud also backs up your project automatically every day, so you always have a recent copy to roll back to.
+
+Backups cover the database only — files uploaded to Storage are not included.
 
 ## Scheduled backups
 
-InsForge Cloud backs up every active project on a paid plan once a day. Each backup is a full dump of the project database. Scheduled backups are retained for 7 days — the **Scheduled Backups** list shows when each one expires — and can be restored at any time.
-
-Creating a manual backup does not affect the daily schedule.
+InsForge Cloud takes a full backup of every active project on a paid plan once a day, retained for 7 days. The **Scheduled Backups** list shows when each backup expires, and any of them can be restored at any time. Manual backups don't affect the daily schedule.
 
 ## Manual backups
 
-Take a backup any time before a risky change:
-
-1. Open **Database → Backup & Restore** in the dashboard.
-2. Click **Create a Backup** and optionally give it a name.
-
-The backup runs in the background; the list shows its status, size, and creation time. You can rename or delete a backup from the same list. On InsForge Cloud, the Free plan includes 1 manual backup slot and paid plans include 5; manual backups are kept until you delete them.
+Click **Create a Backup** before a risky change and optionally give it a name. The backup runs in the background; the list shows its status, size, and creation time, and lets you rename or delete it. The Free plan includes 1 manual backup slot, paid plans include 5, and manual backups are kept until you delete them.
 
 ## Restore
 
-Click **Restore** next to any completed backup — scheduled or manual. Restoring replaces the current database contents with the backup:
-
-- Your project is offline during the restore.
-- Any data created after the backup was taken is lost.
-- The restore cannot be undone, so consider taking a manual backup first.
+Click **Restore** next to any completed backup — scheduled or manual. Restoring replaces the current database with the backup: the project is offline during the restore, data created after the backup is lost, and the action can't be undone, so take a manual backup first if you're unsure.
 
 ## Self-hosting
 
-Self-hosted deployments have the same **Backup & Restore** page in the dashboard for manual backups and restores. Backups are stored alongside the rest of your project's storage — on disk, or in your S3 bucket when S3 storage is configured — and are kept until you delete them. The official Docker image includes everything needed; no extra setup is required.
+Self-hosted deployments have the same **Backup & Restore** page for manual backups and restores. Backups are stored alongside your project's storage (local disk, or your S3 bucket when configured) and kept until you delete them. The official Docker image needs no extra setup.
 
 ## More resources
 

--- a/docs/core-concepts/database/backups.mdx
+++ b/docs/core-concepts/database/backups.mdx
@@ -30,7 +30,7 @@ Click **Restore** next to any completed backup — scheduled or manual. Restorin
 
 ## Self-hosting
 
-Self-hosted deployments have the same **Backup & Restore** page in the dashboard for manual backups and restores. Backup archives are stored with the rest of your storage — under `${STORAGE_DIR}/_database_backups/` on local storage, or in your S3 bucket when S3 storage is configured — and are kept until you delete them. The official Docker image includes everything needed; no extra setup is required.
+Self-hosted deployments have the same **Backup & Restore** page in the dashboard for manual backups and restores. Backups are stored alongside the rest of your project's storage — on disk, or in your S3 bucket when S3 storage is configured — and are kept until you delete them. The official Docker image includes everything needed; no extra setup is required.
 
 ## More resources
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,6 +50,7 @@
                 "pages": [
                   "core-concepts/database/overview",
                   "core-concepts/database/migrations",
+                  "core-concepts/database/backups",
                   "core-concepts/database/pgvector"
                 ]
               },


### PR DESCRIPTION
## What

Adds a **Database backups** docs page (`docs/core-concepts/database/backups.mdx`) and wires it into the Database group in `docs.json` — closing the gap vs. [Supabase's backups guide](https://supabase.com/docs/guides/platform/backups): InsForge has daily database backups, and now the docs say so.

## Content

High-level and dashboard-first (no CLI/API/code examples, per feedback):

- **Scheduled backups** — InsForge Cloud backs up paid-plan projects daily, 7-day retention, restorable any time.
- **Manual backups** — created from **Database → Backup & Restore**; 1 slot on Free, 5 on paid plans.
- **Restore** — replaces current data, project offline during restore, not undoable.
- **Self-hosting** — same dashboard page works on self-hosted deployments; no extra setup with the official Docker image.
- Notes that backups cover the database only (Storage files excluded), mirroring Supabase's guidance.

All claims verified against the dashboard UI strings, `database-backup.service.ts` / `backups.routes.ts` in this repo, and the cloud daily-backup job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5fb1LjR62bjbw3kR7RPTA


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database backups documentation page
> Adds [backups.mdx](https://github.com/InsForge/InsForge/pull/1675/files#diff-2bf0d1b0c3ecc41ed365e3b934a266fde61b6e86e13a48ec414e5ad0f442f741) covering dashboard-based and scheduled backups, manual backups, restore behavior, and self-hosting notes. Updates [docs.json](https://github.com/InsForge/InsForge/pull/1675/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9) to include the new page in site navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c21e6a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for backing up and restoring databases through the dashboard.
  * Documented scheduled and manual backup retention, storage, plan limits, and restore behavior.
  * Added the new database backups page to the Getting Started documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->