### PR TITLE
test(dashboard): fix userEvent timeouts in component tests

### DIFF
--- a/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
+++ b/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
@@ -104,7 +104,7 @@ describe('AIOverviewPage OpenRouter key rotation', () => {
   });
 
   it('confirms before rotating the active OpenRouter key', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
 
     render(
       <MemoryRouter>
@@ -125,7 +125,7 @@ describe('AIOverviewPage OpenRouter key rotation', () => {
   });
 
   it('does not rotate when the confirmation is cancelled', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
 
     render(
       <MemoryRouter>

--- a/packages/dashboard/src/features/compute/components/__tests__/DeleteServiceDialog.test.tsx
+++ b/packages/dashboard/src/features/compute/components/__tests__/DeleteServiceDialog.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { DeleteServiceDialog } from '#features/compute/components/DeleteServiceDialog';
 
 describe('DeleteServiceDialog', () => {
-  it('requires typing the service name before confirming deletion', async () => {
-    const user = userEvent.setup();
+  it('requires typing the service name before confirming deletion', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onConfirm = vi.fn().mockResolvedValue(undefined);
     const onOpenChange = vi.fn();
 

--- a/packages/dashboard/src/features/database/components/__tests__/CreateBackupDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/CreateBackupDialog.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { CreateBackupDialog } from '#features/database/components/CreateBackupDialog';
 
 describe('CreateBackupDialog', () => {
-  it('creates a backup with a trimmed name and closes on success', async () => {
-    const user = userEvent.setup();
+  it('creates a backup with a trimmed name and closes on success', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onCreate = vi.fn().mockResolvedValue(undefined);
     const onOpenChange = vi.fn();
 

--- a/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/RecordFormDialog.test.tsx
@@ -46,8 +46,8 @@ describe('RecordFormDialog', () => {
     expect(screen.queryByText('updated_at')).toBeNull();
   });
 
-  it('keeps footer actions reachable so a record can be submitted with many columns', async () => {
-    const user = userEvent.setup();
+  it('keeps footer actions reachable so a record can be submitted with many columns', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onOpenChange = vi.fn();
     createRecord.mockClear();
 

--- a/packages/dashboard/src/features/database/components/__tests__/RenameBackupDialog.test.tsx
+++ b/packages/dashboard/src/features/database/components/__tests__/RenameBackupDialog.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { RenameBackupDialog } from '#features/database/components/RenameBackupDialog';
 
 describe('RenameBackupDialog', () => {
-  it('saves a trimmed backup name and closes on success', async () => {
-    const user = userEvent.setup();
+  it('saves a trimmed backup name and closes on success', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onSave = vi.fn().mockResolvedValue(undefined);
     const onOpenChange = vi.fn();
 

--- a/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
+++ b/packages/dashboard/src/features/database/pages/__tests__/FunctionsPage.test.tsx
@@ -151,7 +151,7 @@ describe('FunctionsPage pagination', () => {
   });
 
   it('navigates to page 2 when user clicks the page-2 button', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderPage();
     await user.click(screen.getByRole('button', { name: 'Go to page 2' }));
     expect(screen.getByText(/Showing 51 to 100 of 120/i)).toBeInTheDocument();

--- a/packages/dashboard/src/features/database/pages/__tests__/TablesPage.test.tsx
+++ b/packages/dashboard/src/features/database/pages/__tests__/TablesPage.test.tsx
@@ -197,8 +197,8 @@ describe('TablesPage table-switch search behavior', () => {
     });
   });
 
-  it('clears search input and does not use previous search term when switching tables', async () => {
-    const user = userEvent.setup();
+  it('clears search input and does not use previous search term when switching tables', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
 
     render(
       <MemoryRouter initialEntries={['/?table=tableA']}>
@@ -236,8 +236,8 @@ describe('TablesPage table-switch search behavior', () => {
     );
   });
 
-  it('restores previous search value when switching back to a previously searched table', async () => {
-    const user = userEvent.setup();
+  it('restores previous search value when switching back to a previously searched table', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
 
     render(
       <MemoryRouter initialEntries={['/?table=tableA']}>
@@ -277,8 +277,8 @@ describe('TablesPage table-switch search behavior', () => {
     );
   });
 
-  it('shows an empty search input for a table with no prior search', async () => {
-    const user = userEvent.setup();
+  it('shows an empty search input for a table with no prior search', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
 
     render(
       <MemoryRouter initialEntries={['/?table=tableA']}>

--- a/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
+++ b/packages/dashboard/src/features/realtime/components/__tests__/ChannelFormDialog.test.tsx
@@ -5,8 +5,8 @@ import { ChannelFormDialog } from '#features/realtime/components/ChannelFormDial
 import type { RealtimeChannel } from '@insforge/shared-schemas';
 
 describe('ChannelFormDialog', () => {
-  it('creates a channel and filters empty webhook URLs', async () => {
-    const user = userEvent.setup();
+  it('creates a channel and filters empty webhook URLs', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onCreate = vi.fn();
 
     render(<ChannelFormDialog mode="create" open onOpenChange={vi.fn()} onCreate={onCreate} />);
@@ -25,8 +25,8 @@ describe('ChannelFormDialog', () => {
     });
   });
 
-  it('saves only changed edit-mode fields', async () => {
-    const user = userEvent.setup();
+  it('saves only changed edit-mode fields', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onSave = vi.fn();
     const channel: RealtimeChannel = {
       id: '11111111-1111-1111-1111-111111111111',

--- a/packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx
+++ b/packages/dashboard/src/features/realtime/pages/__tests__/RealtimeMessagesPage.test.tsx
@@ -47,7 +47,7 @@ describe('RealtimeMessagesPage', () => {
   });
 
   it('confirms before clearing all realtime messages from the messages toolbar', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const clearMessages = vi.fn().mockResolvedValue({ deleted: 3 });
     mockMessagesPageState({ clearMessages });
 
@@ -67,7 +67,7 @@ describe('RealtimeMessagesPage', () => {
   });
 
   it('does not clear realtime messages when confirmation is cancelled', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const clearMessages = vi.fn().mockResolvedValue({ deleted: 3 });
     mockMessagesPageState({ clearMessages });
 

--- a/packages/dashboard/src/features/storage/components/__tests__/BucketFormDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/BucketFormDialog.test.tsx
@@ -23,8 +23,8 @@ describe('BucketFormDialog', () => {
     bucketMocks.editBucket.mockReset();
   });
 
-  it('creates a bucket with a trimmed name and closes on success', async () => {
-    const user = userEvent.setup();
+  it('creates a bucket with a trimmed name and closes on success', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onOpenChange = vi.fn();
     const onSuccess = vi.fn();
     bucketMocks.createBucket.mockResolvedValue(undefined);

--- a/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/FilePreviewDialog.test.tsx
@@ -92,7 +92,7 @@ describe('FilePreviewDialog', () => {
 
   it('calls onNext when next button is clicked', async () => {
     const onNext = vi.fn();
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
 
     render(
       <FilePreviewDialog
@@ -113,7 +113,7 @@ describe('FilePreviewDialog', () => {
 
   it('calls onPrevious when previous button is clicked', async () => {
     const onPrevious = vi.fn();
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
 
     render(
       <FilePreviewDialog

--- a/packages/dashboard/src/features/storage/components/__tests__/S3AccessKeyCreateDialog.test.tsx
+++ b/packages/dashboard/src/features/storage/components/__tests__/S3AccessKeyCreateDialog.test.tsx
@@ -14,8 +14,8 @@ const createdKey: S3AccessKeyWithSecretSchema = {
 };
 
 describe('S3AccessKeyCreateDialog', () => {
-  it('creates a key, displays the secret, and requires acknowledgement before closing', async () => {
-    const user = userEvent.setup();
+  it('creates a key, displays the secret, and requires acknowledgement before closing', { timeout: 10_000 }, async () => {
+    const user = userEvent.setup({ delay: null });
     const onCreate = vi.fn().mockResolvedValue(createdKey);
     const onOpenChange = vi.fn();
 


### PR DESCRIPTION
### Summary

This PR addresses issue #1679 by hardening the `userEvent.setup()` pattern across the remaining 12 dashboard component test files, following the pattern previously established and merged in #1644 for `UserFormDialog.test.tsx`.

1. Replaced bare `userEvent.setup()` calls with `userEvent.setup({ delay: null })`. This eliminates the default inter-keystroke typing delays that consume precious wall-clock time and cause tests to time out on busy CI runners.
2. Added an extended `{ timeout: 10_000 }` options parameter on test cases that drive multi-step typing or form submissions (similar to the #1644 fix).

### Affected Files
The following component test files were updated:
- `AIOverviewPage.test.tsx`
- `DeleteServiceDialog.test.tsx` (Extended timeout to 10s)
- `CreateBackupDialog.test.tsx` (Extended timeout to 10s)
- `RecordFormDialog.test.tsx` (Extended timeout to 10s)
- `RenameBackupDialog.test.tsx` (Extended timeout to 10s)
- `FunctionsPage.test.tsx`
- `TablesPage.test.tsx` (Extended search test timeouts to 10s)
- `ChannelFormDialog.test.tsx` (Extended timeout to 10s)
- `RealtimeMessagesPage.test.tsx`
- `BucketFormDialog.test.tsx` (Extended timeout to 10s)
- `FilePreviewDialog.test.tsx`
- `S3AccessKeyCreateDialog.test.tsx` (Extended timeout to 10s)

### Verification

#### I verified these changes by running the dashboard test suite locally:
```bash
npx turbo run test --filter=@insforge/dashboard

Results: All 116 tests across 33 test files passed successfully in 18.99s.
```

Closes #1679



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dashboard component test timeouts by disabling `userEvent` typing delays and increasing timeouts for multi-step flows. Addresses #1679.

- **Bug Fixes**
  - Replaced bare `userEvent.setup()` with `userEvent.setup({ delay: null })` across 12 dashboard test files to remove per-keystroke delay.
  - Added `{ timeout: 10_000 }` to tests that involve multi-step typing or submissions to reduce CI flakiness.

<sup>Written for commit 60afa138fb2e18e153295ccb763332d5f6e8019d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix userEvent timeouts in dashboard component tests
> Adds `{ delay: null }` to `userEvent.setup()` calls across multiple test files to remove artificial typing delays. Several tests that involve text input also get an explicit `{ timeout: 10_000 }` option to prevent flaky timeouts in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60afa13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability and consistency of dashboard interaction tests.
  * Reduced simulated interaction delays across AI, compute, database, realtime, and storage scenarios.
  * Added longer timeouts for tests involving complex form submissions, dialogs, pagination, and table switching.
  * Existing assertions and end-user behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->