### PR TITLE
docs(partnership): document white-label upgrade + restart endpoints

### DIFF
--- a/docs/partnership.mdx
+++ b/docs/partnership.mdx
@@ -85,6 +85,8 @@ Partner platforms can:
 - Query project metadata to leverage the completed backend capabilities.
 - Pause projects
 - Restore projects
+- Upgrade projects (change instance type / grow disk)
+- Restart projects (optionally upgrade the InsForge OSS version)
 - Delete projects
 - Get project's authorization token for access
 - Get project's usage
@@ -286,6 +288,56 @@ Partner platforms can:
         "id": "uuid-string",
         "status": "active"
       }
+    }
+    ```
+
+    ### Upgrade Project
+    Change a project's instance type and/or grow its root volume. At least one of `instance_type` or `volume_size_gib` is required; volumes can only be enlarged. The larger instance/volume is billed to the partner via metered compute.
+
+    ```bash
+    POST /partnership/v1/:partnerId/:projectId/upgrade
+    ```
+
+    **Request Body:**
+    ```json
+    {
+      "instance_type": "small",     // optional — any valid instance type (see Instance Type Values)
+      "volume_size_gib": 16,         // optional — new root volume size in GiB (must be larger than current)
+      "wait_for_completion": false   // optional
+    }
+    ```
+
+    **Response:**
+    ```json
+    {
+      "message": "Project upgrade initiated",
+      "previousInstanceType": "nano",
+      "newInstanceType": "small",
+      "previousVolumeSizeGiB": 8,
+      "newVolumeSizeGiB": 16
+    }
+    ```
+
+    ### Restart Project
+    Restart a project, optionally upgrading its InsForge OSS version. Omit `insforge_oss_version` to restart on the current version.
+
+    ```bash
+    POST /partnership/v1/:partnerId/:projectId/restart
+    ```
+
+    **Request Body:**
+    ```json
+    {
+      "insforge_oss_version": "v2.2.1",  // optional — omit to keep the current version
+      "wait_for_completion": false        // optional
+    }
+    ```
+
+    **Response:**
+    ```json
+    {
+      "message": "Project restart initiated",
+      "insforgeOssVersion": "v2.2.1"
     }
     ```
 


### PR DESCRIPTION
Documents the two new white-label partnership endpoints (backend: insforge-cloud-backend#729) in `docs/partnership.mdx`.

## Added to the White-Label API reference

- **`POST /partnership/v1/:partnerId/:projectId/upgrade`** — change instance type and/or grow the root volume. Body: `instance_type?`, `volume_size_gib?`, `wait_for_completion?` (at least one of instance_type/volume_size_gib required; volumes grow-only).
- **`POST /partnership/v1/:partnerId/:projectId/restart`** — restart a project, optionally bumping its InsForge OSS version. Body: `insforge_oss_version?` (omit to keep the current version), `wait_for_completion?`.

Each block includes the request body and response example, matching the existing pause/restore/delete format. Both are also listed under **White-Label Features**.

Docs-only change (+52 lines, one file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for `POST /partnership/v1/:partnerId/:projectId/upgrade` (change instance type or grow disk) and `POST /partnership/v1/:partnerId/:projectId/restart` (restart, optional InsForge OSS version bump).
Includes request/response examples and lists both under White-Label Features to enable partners to perform these actions via the API.

<sup>Written for commit 99b9598eb817f0c469774eff7ad6570bfbafa9d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document upgrade and restart endpoints in partnership API docs
> Adds two new sections to [partnership.mdx](https://github.com/InsForge/InsForge/pull/1684/files#diff-bb66f37d6612d8af1613152cd777b018d9c6eca05578e2a0dff6989f820b73c3) covering the `POST /partnership/v1/:partnerId/:projectId/upgrade` and `POST /partnership/v1/:partnerId/:projectId/restart` endpoints.
>
> - The upgrade endpoint accepts `instance_type`, `volume_size_gib` (must increase, never decrease), and `wait_for_completion`; at least one of `instance_type` or `volume_size_gib` is required.
> - The restart endpoint accepts an optional `insforge_oss_version` and `wait_for_completion`, and returns the applied OSS version in the response.
> - Also adds capability bullets to the Partner platforms overview listing upgrade and restart as supported operations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99b9598.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded white-label capabilities to include project upgrades and restarts.
  * Added API reference documentation, request examples, optional version upgrade parameters, and response examples for both operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->