### PR TITLE
docs: fix readme clone folder case

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Or run from source:
 ```bash
 # Run with Docker
 git clone https://github.com/InsForge/InsForge.git
-cd insforge
+cd InsForge
 cp .env.example .env
 docker compose -f docker-compose.prod.yml up
 ```


### PR DESCRIPTION
Closes #1689

readme quickstart says `cd insforge` after `git clone https://github.com/InsForge/InsForge.git`, but the cloned folder is `InsForge`. fails on case-sensitive filesystems (linux). one-line fix.

(note: CONTRIBUTING.md's own getting-started section has the identical typo — worth a follow-up if maintainers want it fixed too.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker self-hosted quickstart instructions to use the correct repository directory name after `git clone` (including proper capitalization).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->