### PR TITLE
docs(openapi): add missing endpoints across auth, secrets, storage, a…

### DIFF
--- a/openapi/ai.yaml
+++ b/openapi/ai.yaml
@@ -54,13 +54,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: provider
-          in: path
-          required: true
-          schema:
-            type: string
-            enum: [openrouter]
-          description: AI provider identifier
+        - $ref: '#/components/parameters/AIProvider'
       responses:
         '200':
           description: Active provider API key details
@@ -84,13 +78,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: provider
-          in: path
-          required: true
-          schema:
-            type: string
-            enum: [openrouter]
-          description: AI provider identifier
+        - $ref: '#/components/parameters/AIProvider'
       responses:
         '200':
           description: API key rotated successfully
@@ -223,6 +211,16 @@ paths:
           description: Failed to generate embeddings
 
 components:
+  parameters:
+    AIProvider:
+      name: provider
+      in: path
+      required: true
+      schema:
+        type: string
+        enum: [openrouter]
+      description: AI provider identifier
+
   securitySchemes:
     bearerAuth:
       type: http

--- a/openapi/ai.yaml
+++ b/openapi/ai.yaml
@@ -45,27 +45,65 @@ paths:
         '500':
           description: Failed to fetch overview
 
-  /api/ai/openrouter/api-key:
+  /api/ai/{provider}/api-key:
     get:
-      summary: Get active OpenRouter API key
-      description: Returns the active OpenRouter API key details for admin copy workflows.
+      summary: Get active provider API key
+      description: Returns the active provider API key details for admin copy workflows. Currently only `openrouter` is supported.
       tags:
         - Admin
       security:
         - bearerAuth: []
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [openrouter]
+          description: AI provider identifier
       responses:
         '200':
-          description: Active OpenRouter API key details
+          description: Active provider API key details
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OpenRouterKeyResponse'
         '400':
-          description: Missing OpenRouter API key
+          description: Missing or unsupported provider API key
         '401':
           description: Unauthorized
         '500':
           description: Failed to fetch API key details
+
+  /api/ai/{provider}/api-key/rotate:
+    post:
+      summary: Rotate provider API key
+      description: Rotate the active provider API key for cloud-managed Model Gateway credentials. Currently only `openrouter` is supported.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: provider
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [openrouter]
+          description: AI provider identifier
+      responses:
+        '200':
+          description: API key rotated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpenRouterKeyResponse'
+        '400':
+          description: Unsupported provider
+        '401':
+          description: Unauthorized
+        '500':
+          description: Failed to rotate API key
 
   /api/ai/chat/completion:
     post:

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -1921,6 +1921,8 @@ paths:
                     description: Refresh token for mobile/desktop/server clients (null for web clients)
         '400':
           description: Invalid request - unsupported provider or missing token
+        '401':
+          description: Invalid or expired ID token
 
   /api/auth/admin/sessions/current:
     get:

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -1863,6 +1863,240 @@ paths:
                 format: uri
                 description: Redirect URL with authentication parameters
 
+  /api/auth/id-token:
+    post:
+      summary: Sign in with ID token (Google One Tap, native SDKs)
+      description: |
+        Authenticate a user using an ID token obtained from a native SDK (e.g., Google One Tap).
+        Currently only the `google` provider is supported.
+      tags:
+        - Client
+      parameters:
+        - name: client_type
+          in: query
+          schema:
+            type: string
+            enum: [web, mobile, desktop, server]
+            default: web
+          description: |
+            Client type determines how refresh tokens are returned:
+            - web: Refresh token stored in httpOnly cookie, csrfToken returned in response
+            - mobile/desktop/server: refreshToken returned directly in response body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - provider
+                - token
+              properties:
+                provider:
+                  type: string
+                  enum: [google]
+                  description: Identity provider that issued the token
+                token:
+                  type: string
+                  description: Raw ID token from the provider SDK
+      responses:
+        '200':
+          description: Sign-in successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: '#/components/schemas/UserResponse'
+                  accessToken:
+                    type: string
+                  csrfToken:
+                    type: string
+                    nullable: true
+                    description: CSRF token for use with refresh endpoint (web clients only)
+                  refreshToken:
+                    type: string
+                    nullable: true
+                    description: Refresh token for mobile/desktop/server clients (null for web clients)
+        '400':
+          description: Invalid request - unsupported provider or missing token
+
+  /api/auth/admin/sessions/current:
+    get:
+      summary: Get current admin session
+      description: Returns the currently authenticated admin's basic info from the access token.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current admin session info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  admin:
+                    type: object
+                    properties:
+                      sub:
+                        type: string
+                        description: Admin subject identifier
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin access required
+
+  /api/auth/smtp-config:
+    get:
+      summary: Get SMTP configuration
+      description: Get current SMTP email configuration (admin only)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      x-internal: true
+      responses:
+        '200':
+          description: SMTP configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmtpConfig'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
+    put:
+      summary: Update SMTP configuration
+      description: Create or update SMTP email configuration (admin only)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      x-internal: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - enabled
+                - port
+              properties:
+                enabled:
+                  type: boolean
+                host:
+                  type: string
+                port:
+                  type: integer
+                  enum: [25, 465, 587, 2525]
+                username:
+                  type: string
+                password:
+                  type: string
+                  description: SMTP password (optional on update if unchanged)
+                senderEmail:
+                  type: string
+                  format: email
+                senderName:
+                  type: string
+                minIntervalSeconds:
+                  type: integer
+                  minimum: 0
+                  default: 60
+                  description: Minimum interval between emails in seconds
+      responses:
+        '200':
+          description: SMTP configuration updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmtpConfig'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
+  /api/auth/email-templates:
+    get:
+      summary: Get all email templates
+      description: Returns all configurable email templates (admin only)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      x-internal: true
+      responses:
+        '200':
+          description: List of email templates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EmailTemplate'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
+  /api/auth/email-templates/{type}:
+    put:
+      summary: Update email template
+      description: Update a specific email template by type (admin only)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      x-internal: true
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [email-verification-code, email-verification-link, reset-password-code, reset-password-link]
+          description: Template type to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - subject
+                - bodyHtml
+              properties:
+                subject:
+                  type: string
+                  description: Email subject line
+                bodyHtml:
+                  type: string
+                  description: HTML body of the email template
+      responses:
+        '200':
+          description: Template updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailTemplate'
+        '400':
+          description: Invalid template type or request body
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2066,3 +2300,55 @@ components:
           type: string
           description: Suggested action to resolve the error
           example: "Please use a different email address"
+
+    SmtpConfig:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        enabled:
+          type: boolean
+        host:
+          type: string
+        port:
+          type: integer
+        username:
+          type: string
+        hasPassword:
+          type: boolean
+          description: Whether a password is set (actual password is never exposed)
+        senderEmail:
+          type: string
+          format: email
+        senderName:
+          type: string
+        minIntervalSeconds:
+          type: integer
+          minimum: 0
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    EmailTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        templateType:
+          type: string
+          enum: [email-verification-code, email-verification-link, reset-password-code, reset-password-link]
+        subject:
+          type: string
+        bodyHtml:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -1972,7 +1972,10 @@ paths:
 
     put:
       summary: Update SMTP configuration
-      description: Create or update SMTP email configuration (admin only)
+      description: |
+        Create or update SMTP email configuration (admin only).
+        When `enabled` is true, the fields `host`, `username`, `senderEmail`, and `senderName` are required by the backend validation.
+        When `enabled` is false, these fields may be empty.
       tags:
         - Admin
       security:
@@ -1990,21 +1993,26 @@ paths:
               properties:
                 enabled:
                   type: boolean
+                  description: When true, host/username/senderEmail/senderName become required
                 host:
                   type: string
+                  description: Required when enabled is true
                 port:
                   type: integer
                   enum: [25, 465, 587, 2525]
                 username:
                   type: string
+                  description: Required when enabled is true
                 password:
                   type: string
                   description: SMTP password (optional on update if unchanged)
                 senderEmail:
                   type: string
                   format: email
+                  description: Required when enabled is true
                 senderName:
                   type: string
+                  description: Required when enabled is true
                 minIntervalSeconds:
                   type: integer
                   minimum: 0

--- a/openapi/secrets.yaml
+++ b/openapi/secrets.yaml
@@ -300,6 +300,68 @@ paths:
                 message: "Secret not found: INVALID_KEY"
                 statusCode: 404
 
+  /api/secrets/api-key/rotate:
+    post:
+      summary: Rotate API key
+      description: >-
+        Rotate the project's admin API key. A new key is generated and
+        returned; the old key stays valid for the grace period (default 24
+        hours, max 168 / 7 days) so in-flight requests finish gracefully.
+        Admin only.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                gracePeriodHours:
+                  type: integer
+                  minimum: 0
+                  maximum: 168
+                  default: 24
+                  description: How long the old key remains valid after rotation
+      responses:
+        '200':
+          description: API key rotated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  apiKey:
+                    type: string
+                    description: The new API key
+                  oldKeyExpiresAt:
+                    type: string
+                    format: date-time
+                    description: When the previous key stops being accepted
+              example:
+                success: true
+                message: "API key rotated successfully. Old key will remain valid during grace period."
+                apiKey: "sk_1234567890abcdef1234567890abcdef"
+                oldKeyExpiresAt: "2026-07-15T12:00:00.000Z"
+        '400':
+          description: Invalid grace period
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - admin access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/secrets/anon-key/rotate:
     post:
       summary: Rotate anon key

--- a/openapi/secrets.yaml
+++ b/openapi/secrets.yaml
@@ -347,7 +347,7 @@ paths:
               example:
                 success: true
                 message: "API key rotated successfully. Old key will remain valid during grace period."
-                apiKey: "sk_1234567890abcdef1234567890abcdef"
+                apiKey: "ik_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 oldKeyExpiresAt: "2026-07-15T12:00:00.000Z"
         '400':
           description: Invalid grace period

--- a/openapi/secrets.yaml
+++ b/openapi/secrets.yaml
@@ -355,6 +355,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized - missing or invalid admin token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - admin access required
           content:

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -22,8 +22,16 @@ paths:
                 $ref: '#/components/schemas/StorageConfig'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
     put:
       summary: Update storage configuration
@@ -55,10 +63,22 @@ paths:
                 $ref: '#/components/schemas/StorageConfig'
         '400':
           description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/storage/buckets:
     get:
@@ -1329,6 +1349,11 @@ components:
 
     StorageConfig:
       type: object
+      required:
+        - id
+        - maxFileSizeMb
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: string

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -5,6 +5,61 @@ info:
   description: Bucket-based storage system similar to S3
 
 paths:
+  /api/storage/config:
+    get:
+      summary: Get storage configuration
+      description: Returns the current storage configuration including file size limits (admin only)
+      tags:
+        - Admin
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: Storage configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageConfig'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
+    put:
+      summary: Update storage configuration
+      description: Update storage settings such as maximum file size (admin only)
+      tags:
+        - Admin
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - maxFileSizeMb
+              properties:
+                maxFileSizeMb:
+                  type: integer
+                  minimum: 1
+                  maximum: 200
+                  description: Maximum file upload size in megabytes
+      responses:
+        '200':
+          description: Storage configuration updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageConfig'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - Admin only
+
   /api/storage/buckets:
     get:
       summary: List All Buckets
@@ -1271,6 +1326,24 @@ components:
           type: object
           description: Optional headers to include in the download request
           additionalProperties: true
+
+    StorageConfig:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        maxFileSizeMb:
+          type: integer
+          minimum: 1
+          maximum: 200
+          description: Maximum file upload size in megabytes
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
Closes #1686

## What changed

Four OpenAPI specs had undocumented live endpoints. This PR adds them all, matching each spec's existing style:

### auth.yaml
- `POST /api/auth/id-token` — public Google ID-token sign-in
- `GET /api/auth/admin/sessions/current` — current admin session
- `GET/PUT /api/auth/smtp-config` — SMTP config (marked `x-internal`)
- `GET /api/auth/email-templates` + `PUT /api/auth/email-templates/{type}` (marked `x-internal`)
- Added `SmtpConfig` and `EmailTemplate` component schemas

### secrets.yaml
- `POST /api/secrets/api-key/rotate` — mirrors the existing `anon-key/rotate` doc

### storage.yaml
- `GET/PUT /api/storage/config` — storage configuration
- Added `StorageConfig` component schema

### ai.yaml
- Parameterized `GET /api/ai/{provider}/api-key` (was hardcoded to `/openrouter/`)
- Added `POST /api/ai/{provider}/api-key/rotate`

## Acceptance criteria
- Every route in the four routers is now either documented or explicitly `x-internal`
- Request/response shapes match their Zod schemas

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents missing endpoints across auth, secrets, storage, and AI OpenAPI specs so every live route is covered or marked internal. Aligns request/response shapes with server schemas, parameterizes AI provider routes, and includes small spec fixes; closes #1686.

- **New Features**
  - Auth: POST /api/auth/id-token (Google ID token sign-in), GET /api/auth/admin/sessions/current, GET/PUT /api/auth/smtp-config (x-internal), GET /api/auth/email-templates and PUT /api/auth/email-templates/{type} (x-internal); adds SmtpConfig and EmailTemplate schemas.
  - Secrets: POST /api/secrets/api-key/rotate (mirrors anon-key/rotate with optional gracePeriodHours).
  - Storage: GET/PUT /api/storage/config; adds StorageConfig schema.
  - AI: Parameterized GET /api/ai/{provider}/api-key (enum: openrouter) and added POST /api/ai/{provider}/api-key/rotate.

- **Bug Fixes**
  - AI: Extracted provider path param to components.parameters.AIProvider (DRY).
  - Secrets: Fixed API key example to use the correct ik_… prefix.
  - Storage: Marked required fields in StorageConfig and added ErrorResponse refs for 4xx.
  - Auth: Documented conditional SMTP requirements when enabled is true.
  - Auth/Secrets: Added missing 401 responses for POST /api/auth/id-token and POST /api/secrets/api-key/rotate.

<sup>Written for commit 5cf13624f1ff7fcf40dbe3887199cf4160d84182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add missing OpenAPI endpoints for auth, secrets, storage, and AI
> - Adds auth endpoints for ID token sign-in (Google), admin session info, SMTP config CRUD, and email template management in [auth.yaml](https://github.com/InsForge/InsForge/pull/1690/files#diff-213defd0737c8c11fba7cfa9f5af7184fef3ec1133327d9cf3f7655244049a80)
> - Adds provider-scoped API key retrieval and rotation endpoints for AI (currently `openrouter` only) in [ai.yaml](https://github.com/InsForge/InsForge/pull/1690/files#diff-2b65eacde5083d196f894b39f90e94f64baf6dcabc5c0cfd350cfad3868d654b)
> - Adds admin API key rotation with configurable grace period in [secrets.yaml](https://github.com/InsForge/InsForge/pull/1690/files#diff-dbfa4aab17aa75fdf23da474f3fbac80ecf8bfe17c8a408102ae5861806e4fd4)
> - Adds storage config GET/PUT endpoints for managing `maxFileSizeMb` in [storage.yaml](https://github.com/InsForge/InsForge/pull/1690/files#diff-d577afade0093479dfede991f2189a906ea0708dedfcc15581212dfdfd832551)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cf1362.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-parameterized AI API key endpoints for viewing and rotating the active key (currently supports openrouter).
  * Added native Google ID-token sign-in and an endpoint to fetch the current admin session.
  * Added admin API key rotation with configurable grace period.
  * Added storage configuration endpoints with enforced max file size limits.
  * Added administrative SMTP settings and email template management endpoints (including template type updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->