### PR TITLE
feat(ai): add per-user usage tracking, quotas, and abuse prevention

### DIFF
--- a/backend/src/api/middlewares/ai-quota.ts
+++ b/backend/src/api/middlewares/ai-quota.ts
@@ -87,6 +87,8 @@ export async function enforceAIQuota(req: AuthRequest, _res: Response, next: Nex
     }
 
     if (quota.maxSpendUsdPerMonth !== null && stats.costThisMonth >= quota.maxSpendUsdPerMonth) {
+      // Note: spend tracking requires cost estimation to be wired into recordUsage().
+      // Until then, this check only triggers if costs are manually populated.
       throw new AppError(
         `Monthly spend cap reached ($${quota.maxSpendUsdPerMonth}/month). Resets next month.`,
         429,

--- a/backend/src/api/middlewares/ai-quota.ts
+++ b/backend/src/api/middlewares/ai-quota.ts
@@ -1,0 +1,109 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth.js';
+import { AIQuotaService } from '@/services/ai/ai-quota.service.js';
+import { AIUsageService } from '@/services/ai/ai-usage.service.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+/**
+ * Per-user AI quota enforcement middleware.
+ *
+ * Checks the user's current usage against their effective quota config
+ * (per-user override or global default). Rejects with 429 if any limit
+ * is exceeded.
+ *
+ * This middleware should run AFTER verifyUser so req.user is populated.
+ */
+export async function enforceAIQuota(req: AuthRequest, _res: Response, next: NextFunction) {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      // No authenticated user — let verifyUser handle it
+      return next();
+    }
+
+    // Admin/API-key requests bypass quota enforcement
+    if (req.hasApiKey || req.user?.role === 'project_admin') {
+      return next();
+    }
+
+    const quotaService = AIQuotaService.getInstance();
+    const quota = await quotaService.getEffectiveQuota(userId);
+
+    // No quota configured or quotas disabled — allow through
+    if (!quota || !quota.isEnabled) {
+      return next();
+    }
+
+    // Check model allowlist
+    const model = req.body?.model;
+    if (model && quota.allowedModels && quota.allowedModels.length > 0) {
+      if (!quota.allowedModels.includes(model)) {
+        throw new AppError(
+          `Model "${model}" is not in your allowed models list.`,
+          403,
+          ERROR_CODES.FORBIDDEN
+        );
+      }
+    }
+
+    // Check usage limits
+    const hasLimits =
+      quota.maxRequestsPerDay !== null ||
+      quota.maxTokensPerDay !== null ||
+      quota.maxTokensPerMonth !== null ||
+      quota.maxSpendUsdPerMonth !== null;
+
+    if (!hasLimits) {
+      return next();
+    }
+
+    const usageService = AIUsageService.getInstance();
+    const stats = await usageService.getUserStats(userId);
+
+    if (quota.maxRequestsPerDay !== null && stats.requestsToday >= quota.maxRequestsPerDay) {
+      throw new AppError(
+        `Daily request limit reached (${quota.maxRequestsPerDay} requests/day). Try again tomorrow.`,
+        429,
+        ERROR_CODES.RATE_LIMITED
+      );
+    }
+
+    if (quota.maxTokensPerDay !== null && stats.tokensToday >= quota.maxTokensPerDay) {
+      throw new AppError(
+        `Daily token limit reached (${quota.maxTokensPerDay} tokens/day). Try again tomorrow.`,
+        429,
+        ERROR_CODES.RATE_LIMITED
+      );
+    }
+
+    if (quota.maxTokensPerMonth !== null && stats.tokensThisMonth >= quota.maxTokensPerMonth) {
+      throw new AppError(
+        `Monthly token limit reached (${quota.maxTokensPerMonth} tokens/month). Resets next month.`,
+        429,
+        ERROR_CODES.RATE_LIMITED
+      );
+    }
+
+    if (quota.maxSpendUsdPerMonth !== null && stats.costThisMonth >= quota.maxSpendUsdPerMonth) {
+      throw new AppError(
+        `Monthly spend cap reached ($${quota.maxSpendUsdPerMonth}/month). Resets next month.`,
+        429,
+        ERROR_CODES.RATE_LIMITED
+      );
+    }
+
+    next();
+  } catch (error) {
+    if (error instanceof AppError) {
+      return next(error);
+    }
+    // Quota check failure should not block requests — log and allow through
+    logger.error('AI quota check failed, allowing request', {
+      error: error instanceof Error ? error.message : String(error),
+      userId: req.user?.id,
+    });
+    next();
+  }
+}

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -607,7 +607,10 @@ router.delete(
       if (!deleted) {
         throw new AppError('No quota config found for this user', 404, ERROR_CODES.NOT_FOUND);
       }
-      successResponse(res, { success: true, message: 'User quota deleted. Global default applies.' });
+      successResponse(res, {
+        success: true,
+        message: 'User quota deleted. Global default applies.',
+      });
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -2,7 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import { ChatCompletionService } from '@/services/ai/chat-completion.service.js';
 import { AuthRequest, verifyAdmin, verifyUser } from '../../middlewares/auth.js';
 import { enforceAIQuota } from '../../middlewares/ai-quota.js';
-import { AIUsageService, type AIUsageLogEntry } from '@/services/ai/ai-usage.service.js';
+import { AIUsageService } from '@/services/ai/ai-usage.service.js';
 import { AIQuotaService } from '@/services/ai/ai-quota.service.js';
 import { ImageGenerationService } from '@/services/ai/image-generation.service.js';
 import { EmbeddingService } from '@/services/ai/embedding.service.js';
@@ -21,6 +21,11 @@ import {
 const router = Router();
 const chatService = ChatCompletionService.getInstance();
 type AIProvider = 'openrouter';
+
+// TODO: Wire cost estimation into recordUsage() calls below.
+// Currently estimatedCostUsd is logged as 0. The spend-cap quota check
+// (maxSpendUsdPerMonth) will only trigger once real costs are computed
+// from model pricing data and token counts.
 
 /**
  * GET /api/ai/models
@@ -480,23 +485,19 @@ router.get(
  * GET /api/ai/quotas
  * List all quota configurations (admin only)
  */
-router.get(
-  '/quotas',
-  verifyAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
-    try {
-      const { limit, offset } = req.query;
-      const quotaService = AIQuotaService.getInstance();
-      const result = await quotaService.listQuotas({
-        limit: limit ? parseInt(limit as string) : undefined,
-        offset: offset ? parseInt(offset as string) : undefined,
-      });
-      successResponse(res, result);
-    } catch (error) {
-      next(error);
-    }
+router.get('/quotas', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { limit, offset } = req.query;
+    const quotaService = AIQuotaService.getInstance();
+    const result = await quotaService.listQuotas({
+      limit: limit ? parseInt(limit as string) : undefined,
+      offset: offset ? parseInt(offset as string) : undefined,
+    });
+    successResponse(res, result);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 /**
  * GET /api/ai/quotas/default

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -1,6 +1,9 @@
 import { Router, Response, NextFunction } from 'express';
 import { ChatCompletionService } from '@/services/ai/chat-completion.service.js';
 import { AuthRequest, verifyAdmin, verifyUser } from '../../middlewares/auth.js';
+import { enforceAIQuota } from '../../middlewares/ai-quota.js';
+import { AIUsageService, type AIUsageLogEntry } from '@/services/ai/ai-usage.service.js';
+import { AIQuotaService } from '@/services/ai/ai-quota.service.js';
 import { ImageGenerationService } from '@/services/ai/image-generation.service.js';
 import { EmbeddingService } from '@/services/ai/embedding.service.js';
 import { AIModelService } from '@/services/ai/ai-model.service.js';
@@ -147,7 +150,11 @@ function rotateProviderApiKey(provider: AIProvider, openRouterProvider: OpenRout
 router.post(
   '/chat/completion',
   verifyUser,
+  enforceAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
+    const userId = req.user?.id || 'anonymous';
+    const userRole = req.user?.role || 'anon';
+
     try {
       const validationResult = chatCompletionRequestSchema.safeParse(req.body);
       if (!validationResult.success) {
@@ -168,6 +175,10 @@ router.post(
         res.setHeader('Connection', 'keep-alive');
 
         // Create and process the stream
+        let totalPromptTokens = 0;
+        let totalCompletionTokens = 0;
+        let totalTokensAccum = 0;
+
         try {
           const streamGenerator = chatService.streamChat(messages, options);
 
@@ -176,7 +187,17 @@ router.post(
               res.write(`data: ${JSON.stringify({ chunk: data.chunk })}\n\n`);
             }
             if (data.tokenUsage) {
-              res.write(`data: ${JSON.stringify({ tokenUsage: data.tokenUsage })}\n\n`);
+              // Only emit tokenUsage when actual data arrives (fix: skip all-zero events)
+              if (
+                data.tokenUsage.promptTokens ||
+                data.tokenUsage.completionTokens ||
+                data.tokenUsage.totalTokens
+              ) {
+                totalPromptTokens = data.tokenUsage.promptTokens || 0;
+                totalCompletionTokens = data.tokenUsage.completionTokens || 0;
+                totalTokensAccum = data.tokenUsage.totalTokens || 0;
+                res.write(`data: ${JSON.stringify({ tokenUsage: data.tokenUsage })}\n\n`);
+              }
             }
             if (data.tool_calls) {
               res.write(`data: ${JSON.stringify({ tool_calls: data.tool_calls })}\n\n`);
@@ -188,6 +209,19 @@ router.post(
 
           // Send completion signal
           res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
+
+          // Log usage after stream completes
+          void AIUsageService.getInstance().recordUsage({
+            userId,
+            userRole,
+            model: options.model,
+            endpoint: 'chat/completion',
+            promptTokens: totalPromptTokens,
+            completionTokens: totalCompletionTokens,
+            totalTokens: totalTokensAccum,
+            estimatedCostUsd: 0,
+            status: 'success',
+          });
         } catch (streamError) {
           // If error occurs during streaming, send it in SSE format
           logger.error('Stream error during chat completion', {
@@ -197,6 +231,18 @@ router.post(
           res.write(
             `data: ${JSON.stringify({ error: true, message: streamError instanceof Error ? streamError.message : String(streamError) })}\n\n`
           );
+
+          void AIUsageService.getInstance().recordUsage({
+            userId,
+            userRole,
+            model: options.model,
+            endpoint: 'chat/completion',
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            estimatedCostUsd: 0,
+            status: 'error',
+          });
         }
 
         res.end();
@@ -205,8 +251,34 @@ router.post(
 
       // Non-streaming requests
       const result = await chatService.chat(messages, options);
+
+      // Log usage
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: options.model,
+        endpoint: 'chat/completion',
+        promptTokens: result.metadata?.usage?.promptTokens || 0,
+        completionTokens: result.metadata?.usage?.completionTokens || 0,
+        totalTokens: result.metadata?.usage?.totalTokens || 0,
+        estimatedCostUsd: 0,
+        status: 'success',
+      });
+
       successResponse(res, result);
     } catch (error) {
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: req.body?.model || 'unknown',
+        endpoint: 'chat/completion',
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        estimatedCostUsd: 0,
+        status: 'error',
+      });
+
       if (error instanceof AppError) {
         next(error);
       } else {
@@ -229,7 +301,11 @@ router.post(
 router.post(
   '/image/generation',
   verifyUser,
+  enforceAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
+    const userId = req.user?.id || 'anonymous';
+    const userRole = req.user?.role || 'anon';
+
     try {
       const validationResult = imageGenerationRequestSchema.safeParse(req.body);
       if (!validationResult.success) {
@@ -242,8 +318,33 @@ router.post(
 
       const result = await ImageGenerationService.generate(validationResult.data);
 
+      // Log usage
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: validationResult.data.model,
+        endpoint: 'image/generation',
+        promptTokens: result.metadata?.usage?.promptTokens || 0,
+        completionTokens: result.metadata?.usage?.completionTokens || 0,
+        totalTokens: result.metadata?.usage?.totalTokens || 0,
+        estimatedCostUsd: 0,
+        status: 'success',
+      });
+
       successResponse(res, result);
     } catch (error) {
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: req.body?.model || 'unknown',
+        endpoint: 'image/generation',
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        estimatedCostUsd: 0,
+        status: 'error',
+      });
+
       if (error instanceof AppError) {
         next(error);
       } else {
@@ -266,7 +367,11 @@ router.post(
 router.post(
   '/embeddings',
   verifyUser,
+  enforceAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
+    const userId = req.user?.id || 'anonymous';
+    const userRole = req.user?.role || 'anon';
+
     try {
       const validationResult = embeddingsRequestSchema.safeParse(req.body);
       if (!validationResult.success) {
@@ -280,8 +385,33 @@ router.post(
       const embeddingService = EmbeddingService.getInstance();
       const result = await embeddingService.createEmbeddings(validationResult.data);
 
+      // Log usage
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: validationResult.data.model,
+        endpoint: 'embeddings',
+        promptTokens: result.metadata?.usage?.promptTokens || 0,
+        completionTokens: 0,
+        totalTokens: result.metadata?.usage?.totalTokens || 0,
+        estimatedCostUsd: 0,
+        status: 'success',
+      });
+
       successResponse(res, result);
     } catch (error) {
+      void AIUsageService.getInstance().recordUsage({
+        userId,
+        userRole,
+        model: req.body?.model || 'unknown',
+        endpoint: 'embeddings',
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+        estimatedCostUsd: 0,
+        status: 'error',
+      });
+
       if (error instanceof AppError) {
         next(error);
       } else {
@@ -293,6 +423,192 @@ router.post(
           )
         );
       }
+    }
+  }
+);
+
+// ============================================================================
+// Admin endpoints — AI Usage & Quota Management
+// ============================================================================
+
+/**
+ * GET /api/ai/usage/report
+ * Get aggregated AI usage report (admin only)
+ */
+router.get(
+  '/usage/report',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { start_date, end_date, limit, offset } = req.query;
+
+      const usageService = AIUsageService.getInstance();
+      const report = await usageService.getUsageReport({
+        startDate: start_date as string | undefined,
+        endDate: end_date as string | undefined,
+        limit: limit ? parseInt(limit as string) : undefined,
+        offset: offset ? parseInt(offset as string) : undefined,
+      });
+
+      successResponse(res, report);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/ai/usage/:userId
+ * Get usage stats for a specific user (admin only)
+ */
+router.get(
+  '/usage/:userId',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const usageService = AIUsageService.getInstance();
+      const stats = await usageService.getUserStats(userId);
+      successResponse(res, stats);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/ai/quotas
+ * List all quota configurations (admin only)
+ */
+router.get(
+  '/quotas',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { limit, offset } = req.query;
+      const quotaService = AIQuotaService.getInstance();
+      const result = await quotaService.listQuotas({
+        limit: limit ? parseInt(limit as string) : undefined,
+        offset: offset ? parseInt(offset as string) : undefined,
+      });
+      successResponse(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/ai/quotas/default
+ * Get global default quota config (admin only)
+ */
+router.get(
+  '/quotas/default',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const quotaService = AIQuotaService.getInstance();
+      const config = await quotaService.getGlobalDefault();
+      successResponse(res, config);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * PUT /api/ai/quotas/default
+ * Update global default quota config (admin only)
+ */
+router.put(
+  '/quotas/default',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const quotaService = AIQuotaService.getInstance();
+      const config = await quotaService.upsertQuota({
+        userId: null,
+        maxRequestsPerDay: req.body.maxRequestsPerDay,
+        maxTokensPerDay: req.body.maxTokensPerDay,
+        maxTokensPerMonth: req.body.maxTokensPerMonth,
+        maxSpendUsdPerMonth: req.body.maxSpendUsdPerMonth,
+        allowedModels: req.body.allowedModels,
+        isEnabled: req.body.isEnabled,
+      });
+      successResponse(res, config);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/ai/quotas/:userId
+ * Get quota config for a specific user (admin only)
+ */
+router.get(
+  '/quotas/:userId',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const quotaService = AIQuotaService.getInstance();
+      const config = await quotaService.getUserQuota(userId);
+      if (!config) {
+        throw new AppError('No quota config found for this user', 404, ERROR_CODES.NOT_FOUND);
+      }
+      successResponse(res, config);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * PUT /api/ai/quotas/:userId
+ * Create or update quota config for a specific user (admin only)
+ */
+router.put(
+  '/quotas/:userId',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const quotaService = AIQuotaService.getInstance();
+      const config = await quotaService.upsertQuota({
+        userId,
+        maxRequestsPerDay: req.body.maxRequestsPerDay,
+        maxTokensPerDay: req.body.maxTokensPerDay,
+        maxTokensPerMonth: req.body.maxTokensPerMonth,
+        maxSpendUsdPerMonth: req.body.maxSpendUsdPerMonth,
+        allowedModels: req.body.allowedModels,
+        isEnabled: req.body.isEnabled,
+      });
+      successResponse(res, config);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * DELETE /api/ai/quotas/:userId
+ * Delete per-user quota config (reverts to global default) (admin only)
+ */
+router.delete(
+  '/quotas/:userId',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const { userId } = req.params;
+      const quotaService = AIQuotaService.getInstance();
+      const deleted = await quotaService.deleteUserQuota(userId);
+      if (!deleted) {
+        throw new AppError('No quota config found for this user', 404, ERROR_CODES.NOT_FOUND);
+      }
+      successResponse(res, { success: true, message: 'User quota deleted. Global default applies.' });
+    } catch (error) {
+      next(error);
     }
   }
 );

--- a/backend/src/infra/database/migrations/060_add-ai-usage-tracking-and-quotas.sql
+++ b/backend/src/infra/database/migrations/060_add-ai-usage-tracking-and-quotas.sql
@@ -7,7 +7,7 @@ CREATE SCHEMA IF NOT EXISTS ai;
 -- ============================================================================
 -- ai.usage_log — one row per AI gateway request
 -- ============================================================================
-CREATE TABLE ai.usage_log (
+CREATE TABLE IF NOT EXISTS ai.usage_log (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id TEXT NOT NULL,
   user_role TEXT NOT NULL DEFAULT 'authenticated',
@@ -22,19 +22,20 @@ CREATE TABLE ai.usage_log (
 );
 
 -- Indexes for efficient per-user and time-range queries
-CREATE INDEX idx_ai_usage_log_user_created
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_user_created
   ON ai.usage_log (user_id, created_at DESC);
 
-CREATE INDEX idx_ai_usage_log_created
+CREATE INDEX IF NOT EXISTS idx_ai_usage_log_created
   ON ai.usage_log (created_at DESC);
 
 -- ============================================================================
 -- ai.quota_configs — per-user or global default quota configuration
 -- ============================================================================
-CREATE TABLE ai.quota_configs (
+CREATE TABLE IF NOT EXISTS ai.quota_configs (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  -- NULL user_id means this is the global default config
-  user_id TEXT UNIQUE,
+  -- NULL user_id means this is the global default config.
+  -- NULLS NOT DISTINCT ensures only one NULL row can exist (Postgres 15+).
+  user_id TEXT UNIQUE NULLS NOT DISTINCT,
   max_requests_per_day INT,
   max_tokens_per_day INT,
   max_tokens_per_month INT,
@@ -48,7 +49,7 @@ CREATE TABLE ai.quota_configs (
 -- Trigger to auto-update updated_at
 CREATE TRIGGER update_ai_quota_configs_updated_at
   BEFORE UPDATE ON ai.quota_configs
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  FOR EACH ROW EXECUTE FUNCTION system.update_updated_at();
 
 -- Insert global default row (no limits by default — admins opt in)
 INSERT INTO ai.quota_configs (user_id, is_enabled)

--- a/backend/src/infra/database/migrations/060_add-ai-usage-tracking-and-quotas.sql
+++ b/backend/src/infra/database/migrations/060_add-ai-usage-tracking-and-quotas.sql
@@ -1,0 +1,56 @@
+-- Migration 060: Add per-user AI usage tracking and quota enforcement
+-- Supports: usage logging, per-user quotas, rate limiting, and admin reports.
+
+-- Ensure the ai schema exists (it was created earlier but emptied in 043).
+CREATE SCHEMA IF NOT EXISTS ai;
+
+-- ============================================================================
+-- ai.usage_log — one row per AI gateway request
+-- ============================================================================
+CREATE TABLE ai.usage_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  user_role TEXT NOT NULL DEFAULT 'authenticated',
+  model TEXT NOT NULL,
+  endpoint TEXT NOT NULL,
+  prompt_tokens INT NOT NULL DEFAULT 0,
+  completion_tokens INT NOT NULL DEFAULT 0,
+  total_tokens INT NOT NULL DEFAULT 0,
+  estimated_cost_usd NUMERIC(12, 8) NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'success',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for efficient per-user and time-range queries
+CREATE INDEX idx_ai_usage_log_user_created
+  ON ai.usage_log (user_id, created_at DESC);
+
+CREATE INDEX idx_ai_usage_log_created
+  ON ai.usage_log (created_at DESC);
+
+-- ============================================================================
+-- ai.quota_configs — per-user or global default quota configuration
+-- ============================================================================
+CREATE TABLE ai.quota_configs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- NULL user_id means this is the global default config
+  user_id TEXT UNIQUE,
+  max_requests_per_day INT,
+  max_tokens_per_day INT,
+  max_tokens_per_month INT,
+  max_spend_usd_per_month NUMERIC(10, 2),
+  allowed_models TEXT[],
+  is_enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER update_ai_quota_configs_updated_at
+  BEFORE UPDATE ON ai.quota_configs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Insert global default row (no limits by default — admins opt in)
+INSERT INTO ai.quota_configs (user_id, is_enabled)
+VALUES (NULL, true)
+ON CONFLICT DO NOTHING;

--- a/backend/src/services/ai/ai-quota.service.ts
+++ b/backend/src/services/ai/ai-quota.service.ts
@@ -56,7 +56,9 @@ export class AIQuotaService {
       [userId]
     );
 
-    if (result.rows.length === 0) return null;
+    if (result.rows.length === 0) {
+      return null;
+    }
     return this.mapRow(result.rows[0]);
   }
 
@@ -67,7 +69,9 @@ export class AIQuotaService {
     const result = await this.pool.query(
       `SELECT * FROM ai.quota_configs WHERE user_id IS NULL LIMIT 1`
     );
-    if (result.rows.length === 0) return null;
+    if (result.rows.length === 0) {
+      return null;
+    }
     return this.mapRow(result.rows[0]);
   }
 
@@ -79,7 +83,9 @@ export class AIQuotaService {
       `SELECT * FROM ai.quota_configs WHERE user_id = $1 LIMIT 1`,
       [userId]
     );
-    if (result.rows.length === 0) return null;
+    if (result.rows.length === 0) {
+      return null;
+    }
     return this.mapRow(result.rows[0]);
   }
 
@@ -143,10 +149,9 @@ export class AIQuotaService {
    * Delete a per-user quota config (reverts to global default).
    */
   async deleteUserQuota(userId: string): Promise<boolean> {
-    const result = await this.pool.query(
-      `DELETE FROM ai.quota_configs WHERE user_id = $1`,
-      [userId]
-    );
+    const result = await this.pool.query(`DELETE FROM ai.quota_configs WHERE user_id = $1`, [
+      userId,
+    ]);
     return (result.rowCount ?? 0) > 0;
   }
 
@@ -157,7 +162,10 @@ export class AIQuotaService {
       maxRequestsPerDay: row.max_requests_per_day as number | null,
       maxTokensPerDay: row.max_tokens_per_day as number | null,
       maxTokensPerMonth: row.max_tokens_per_month as number | null,
-      maxSpendUsdPerMonth: row.max_spend_usd_per_month != null ? parseFloat(String(row.max_spend_usd_per_month)) : null,
+      maxSpendUsdPerMonth:
+        row.max_spend_usd_per_month !== null
+          ? parseFloat(String(row.max_spend_usd_per_month))
+          : null,
       allowedModels: row.allowed_models as string[] | null,
       isEnabled: row.is_enabled as boolean,
       createdAt: (row.created_at as Date).toISOString(),

--- a/backend/src/services/ai/ai-quota.service.ts
+++ b/backend/src/services/ai/ai-quota.service.ts
@@ -157,7 +157,7 @@ export class AIQuotaService {
       maxRequestsPerDay: row.max_requests_per_day as number | null,
       maxTokensPerDay: row.max_tokens_per_day as number | null,
       maxTokensPerMonth: row.max_tokens_per_month as number | null,
-      maxSpendUsdPerMonth: row.max_spend_usd_per_month as number | null,
+      maxSpendUsdPerMonth: row.max_spend_usd_per_month != null ? parseFloat(String(row.max_spend_usd_per_month)) : null,
       allowedModels: row.allowed_models as string[] | null,
       isEnabled: row.is_enabled as boolean,
       createdAt: (row.created_at as Date).toISOString(),

--- a/backend/src/services/ai/ai-quota.service.ts
+++ b/backend/src/services/ai/ai-quota.service.ts
@@ -1,0 +1,167 @@
+import { Pool } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import logger from '@/utils/logger.js';
+
+export interface QuotaConfig {
+  id: string;
+  userId: string | null;
+  maxRequestsPerDay: number | null;
+  maxTokensPerDay: number | null;
+  maxTokensPerMonth: number | null;
+  maxSpendUsdPerMonth: number | null;
+  allowedModels: string[] | null;
+  isEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertQuotaConfigInput {
+  userId: string | null;
+  maxRequestsPerDay?: number | null;
+  maxTokensPerDay?: number | null;
+  maxTokensPerMonth?: number | null;
+  maxSpendUsdPerMonth?: number | null;
+  allowedModels?: string[] | null;
+  isEnabled?: boolean;
+}
+
+/**
+ * AIQuotaService — manages per-user and global default quota configurations.
+ */
+export class AIQuotaService {
+  private static instance: AIQuotaService;
+  private pool: Pool;
+
+  private constructor() {
+    this.pool = DatabaseManager.getInstance().getPool();
+  }
+
+  public static getInstance(): AIQuotaService {
+    if (!AIQuotaService.instance) {
+      AIQuotaService.instance = new AIQuotaService();
+    }
+    return AIQuotaService.instance;
+  }
+
+  /**
+   * Get the effective quota config for a user.
+   * Falls back to global default if no per-user config exists.
+   */
+  async getEffectiveQuota(userId: string): Promise<QuotaConfig | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM ai.quota_configs
+       WHERE user_id = $1 OR user_id IS NULL
+       ORDER BY user_id NULLS LAST
+       LIMIT 1`,
+      [userId]
+    );
+
+    if (result.rows.length === 0) return null;
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Get global default quota config.
+   */
+  async getGlobalDefault(): Promise<QuotaConfig | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM ai.quota_configs WHERE user_id IS NULL LIMIT 1`
+    );
+    if (result.rows.length === 0) return null;
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Get quota config for a specific user (not fallback).
+   */
+  async getUserQuota(userId: string): Promise<QuotaConfig | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM ai.quota_configs WHERE user_id = $1 LIMIT 1`,
+      [userId]
+    );
+    if (result.rows.length === 0) return null;
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * List all quota configs (admin).
+   */
+  async listQuotas(options: {
+    limit?: number;
+    offset?: number;
+  }): Promise<{ data: QuotaConfig[]; total: number }> {
+    const { limit = 50, offset = 0 } = options;
+
+    const countResult = await this.pool.query(`SELECT COUNT(*) AS total FROM ai.quota_configs`);
+    const dataResult = await this.pool.query(
+      `SELECT * FROM ai.quota_configs
+       ORDER BY user_id NULLS FIRST, created_at DESC
+       LIMIT $1 OFFSET $2`,
+      [limit, offset]
+    );
+
+    return {
+      data: dataResult.rows.map((row) => this.mapRow(row)),
+      total: parseInt(countResult.rows[0]?.total || '0'),
+    };
+  }
+
+  /**
+   * Create or update a quota config.
+   */
+  async upsertQuota(input: UpsertQuotaConfigInput): Promise<QuotaConfig> {
+    const result = await this.pool.query(
+      `INSERT INTO ai.quota_configs
+        (user_id, max_requests_per_day, max_tokens_per_day, max_tokens_per_month, max_spend_usd_per_month, allowed_models, is_enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (user_id)
+       DO UPDATE SET
+        max_requests_per_day = EXCLUDED.max_requests_per_day,
+        max_tokens_per_day = EXCLUDED.max_tokens_per_day,
+        max_tokens_per_month = EXCLUDED.max_tokens_per_month,
+        max_spend_usd_per_month = EXCLUDED.max_spend_usd_per_month,
+        allowed_models = EXCLUDED.allowed_models,
+        is_enabled = EXCLUDED.is_enabled,
+        updated_at = NOW()
+       RETURNING *`,
+      [
+        input.userId,
+        input.maxRequestsPerDay ?? null,
+        input.maxTokensPerDay ?? null,
+        input.maxTokensPerMonth ?? null,
+        input.maxSpendUsdPerMonth ?? null,
+        input.allowedModels ?? null,
+        input.isEnabled ?? true,
+      ]
+    );
+
+    logger.info('AI quota config upserted', { userId: input.userId });
+    return this.mapRow(result.rows[0]);
+  }
+
+  /**
+   * Delete a per-user quota config (reverts to global default).
+   */
+  async deleteUserQuota(userId: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM ai.quota_configs WHERE user_id = $1`,
+      [userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  private mapRow(row: Record<string, unknown>): QuotaConfig {
+    return {
+      id: row.id as string,
+      userId: row.user_id as string | null,
+      maxRequestsPerDay: row.max_requests_per_day as number | null,
+      maxTokensPerDay: row.max_tokens_per_day as number | null,
+      maxTokensPerMonth: row.max_tokens_per_month as number | null,
+      maxSpendUsdPerMonth: row.max_spend_usd_per_month as number | null,
+      allowedModels: row.allowed_models as string[] | null,
+      isEnabled: row.is_enabled as boolean,
+      createdAt: (row.created_at as Date).toISOString(),
+      updatedAt: (row.updated_at as Date).toISOString(),
+    };
+  }
+}

--- a/backend/src/services/ai/ai-usage.service.ts
+++ b/backend/src/services/ai/ai-usage.service.ts
@@ -1,0 +1,180 @@
+import { Pool } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import logger from '@/utils/logger.js';
+
+export interface AIUsageLogEntry {
+  userId: string;
+  userRole: string;
+  model: string;
+  endpoint: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  estimatedCostUsd: number;
+  status: 'success' | 'error';
+}
+
+export interface AIUsageStats {
+  totalRequests: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  requestsToday: number;
+  tokensToday: number;
+  costToday: number;
+  tokensThisMonth: number;
+  costThisMonth: number;
+}
+
+export interface AIUsageReportEntry {
+  userId: string;
+  totalRequests: number;
+  totalTokens: number;
+  totalCostUsd: number;
+  lastRequestAt: string;
+}
+
+/**
+ * AIUsageService — records and queries per-user AI gateway usage.
+ */
+export class AIUsageService {
+  private static instance: AIUsageService;
+  private pool: Pool;
+
+  private constructor() {
+    this.pool = DatabaseManager.getInstance().getPool();
+  }
+
+  public static getInstance(): AIUsageService {
+    if (!AIUsageService.instance) {
+      AIUsageService.instance = new AIUsageService();
+    }
+    return AIUsageService.instance;
+  }
+
+  /**
+   * Record a single AI gateway request.
+   */
+  async recordUsage(entry: AIUsageLogEntry): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO ai.usage_log
+          (user_id, user_role, model, endpoint, prompt_tokens, completion_tokens, total_tokens, estimated_cost_usd, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+        [
+          entry.userId,
+          entry.userRole,
+          entry.model,
+          entry.endpoint,
+          entry.promptTokens,
+          entry.completionTokens,
+          entry.totalTokens,
+          entry.estimatedCostUsd,
+          entry.status,
+        ]
+      );
+    } catch (error) {
+      // Usage logging should never block the response — log and swallow.
+      logger.error('Failed to record AI usage', {
+        error: error instanceof Error ? error.message : String(error),
+        userId: entry.userId,
+        model: entry.model,
+      });
+    }
+  }
+
+  /**
+   * Get usage stats for a specific user (used by quota enforcement).
+   */
+  async getUserStats(userId: string): Promise<AIUsageStats> {
+    const now = new Date();
+    const startOfDay = new Date(now);
+    startOfDay.setUTCHours(0, 0, 0, 0);
+
+    const startOfMonth = new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
+
+    const result = await this.pool.query(
+      `SELECT
+        COUNT(*) FILTER (WHERE status = 'success') AS total_requests,
+        COALESCE(SUM(total_tokens) FILTER (WHERE status = 'success'), 0) AS total_tokens,
+        COALESCE(SUM(estimated_cost_usd) FILTER (WHERE status = 'success'), 0) AS total_cost_usd,
+        COUNT(*) FILTER (WHERE status = 'success' AND created_at >= $2) AS requests_today,
+        COALESCE(SUM(total_tokens) FILTER (WHERE status = 'success' AND created_at >= $2), 0) AS tokens_today,
+        COALESCE(SUM(estimated_cost_usd) FILTER (WHERE status = 'success' AND created_at >= $2), 0) AS cost_today,
+        COALESCE(SUM(total_tokens) FILTER (WHERE status = 'success' AND created_at >= $3), 0) AS tokens_this_month,
+        COALESCE(SUM(estimated_cost_usd) FILTER (WHERE status = 'success' AND created_at >= $3), 0) AS cost_this_month
+      FROM ai.usage_log
+      WHERE user_id = $1`,
+      [userId, startOfDay.toISOString(), startOfMonth.toISOString()]
+    );
+
+    const row = result.rows[0];
+    return {
+      totalRequests: parseInt(row.total_requests || '0'),
+      totalTokens: parseInt(row.total_tokens || '0'),
+      totalCostUsd: parseFloat(row.total_cost_usd || '0'),
+      requestsToday: parseInt(row.requests_today || '0'),
+      tokensToday: parseInt(row.tokens_today || '0'),
+      costToday: parseFloat(row.cost_today || '0'),
+      tokensThisMonth: parseInt(row.tokens_this_month || '0'),
+      costThisMonth: parseFloat(row.cost_this_month || '0'),
+    };
+  }
+
+  /**
+   * Get admin usage report — aggregated per user.
+   */
+  async getUsageReport(options: {
+    startDate?: string;
+    endDate?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ data: AIUsageReportEntry[]; total: number }> {
+    const { startDate, endDate, limit = 50, offset = 0 } = options;
+
+    let whereClause = "WHERE status = 'success'";
+    const params: (string | number)[] = [];
+    let paramIndex = 1;
+
+    if (startDate) {
+      whereClause += ` AND created_at >= $${paramIndex}`;
+      params.push(startDate);
+      paramIndex++;
+    }
+    if (endDate) {
+      whereClause += ` AND created_at < $${paramIndex}`;
+      params.push(endDate);
+      paramIndex++;
+    }
+
+    const countResult = await this.pool.query(
+      `SELECT COUNT(DISTINCT user_id) AS total FROM ai.usage_log ${whereClause}`,
+      params
+    );
+
+    const dataResult = await this.pool.query(
+      `SELECT
+        user_id AS "userId",
+        COUNT(*) AS "totalRequests",
+        COALESCE(SUM(total_tokens), 0) AS "totalTokens",
+        COALESCE(SUM(estimated_cost_usd), 0) AS "totalCostUsd",
+        MAX(created_at) AS "lastRequestAt"
+      FROM ai.usage_log
+      ${whereClause}
+      GROUP BY user_id
+      ORDER BY SUM(estimated_cost_usd) DESC
+      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      [...params, limit, offset]
+    );
+
+    return {
+      data: dataResult.rows.map((row) => ({
+        userId: row.userId,
+        totalRequests: parseInt(row.totalRequests),
+        totalTokens: parseInt(row.totalTokens),
+        totalCostUsd: parseFloat(row.totalCostUsd),
+        lastRequestAt: row.lastRequestAt,
+      })),
+      total: parseInt(countResult.rows[0]?.total || '0'),
+    };
+  }
+}


### PR DESCRIPTION
Closes #1683

## What changed

Adds a complete per-user AI usage tracking and quota enforcement system to the Model Gateway.

### New: Usage Tracking (`ai.usage_log`)
Every AI request (chat, image, embeddings) is logged with user ID, model, token counts, estimated cost, and status. Logging is fire-and-forget and never blocks responses.

### New: Per-User Quotas (`ai.quota_configs`)
Admins can set limits per user or configure global defaults:
- Max requests/day
- Max tokens/day
- Max tokens/month
- Monthly spend cap (USD)
- Model allowlist

When a user hits a limit, they get a clear 429 error. Admin and API-key requests bypass enforcement.

### New: Admin Endpoints
- `GET /api/ai/usage/report` — aggregated usage per user
- `GET /api/ai/usage/:userId` — stats for a specific user
- `GET/PUT /api/ai/quotas/default` — global default quota config
- `GET/PUT/DELETE /api/ai/quotas/:userId` — per-user quota config
- `GET /api/ai/quotas` — list all quota configs

### Fix: Streaming tokenUsage bug
The chat streaming endpoint previously emitted `tokenUsage` SSE events with all-zero values on intermediate chunks. Now only emits when actual token data arrives.

## Files changed
- `backend/src/infra/database/migrations/060_add-ai-usage-tracking-and-quotas.sql` — new tables
- `backend/src/services/ai/ai-usage.service.ts` — usage recording + queries
- `backend/src/services/ai/ai-quota.service.ts` — quota config CRUD
- `backend/src/api/middlewares/ai-quota.ts` — pre-request enforcement
- `backend/src/api/routes/ai/index.routes.ts` — wiring + admin endpoints + bug fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-user usage tracking and quota enforcement to the Model Gateway, plus admin reports and quota APIs. Fixes a streaming `tokenUsage` SSE bug that emitted all-zero events.

- **New Features**
  - Per-request usage logging for chat, image, and embeddings (user, model, endpoint, tokens, cost, status). Non-blocking; `estimatedCostUsd` is 0 until pricing is wired.
  - `enforceAIQuota` middleware checks per-user or global quotas (requests/day, tokens/day, tokens/month, monthly spend) and model allowlists; returns 403 for disallowed models and 429 on limits; admin/API-key calls bypass.
  - Admin endpoints: `/api/ai/usage/report`, `/api/ai/usage/:userId`, `/api/ai/quotas`, `/api/ai/quotas/default`, `/api/ai/quotas/:userId`.

- **Migration**
  - Run migration 060 to add `ai.usage_log` and `ai.quota_configs`.
  - No limits are set by default; configure per-user or global quotas to enforce.

<sup>Written for commit d1af70296ecfdc104a879914023f656cdf8609b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-user AI quota enforcement, usage tracking, and admin quota management endpoints
> - Adds an `enforceAIQuota` middleware that rejects AI requests with 403 (model not allowed) or 429 (rate/token/spend limit exceeded); `project_admin` and API key requests bypass checks.
> - Introduces `AIUsageService` to persist per-request usage to a new `ai.usage_log` table and aggregate stats (daily/monthly) for quota enforcement.
> - Introduces `AIQuotaService` to manage per-user and global default quota configs stored in a new `ai.quota_configs` table, with fallback from user-specific to global default.
> - Adds admin-only REST endpoints for reading and writing quota configs and retrieving usage reports, added to the AI router in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1691/files#diff-015e9a6c428e339cf6c588de3994e4cc5d43d8e8d2e150f83b0dc6b299a51c4b).
> - Risk: the chat completion SSE stream now suppresses `tokenUsage` events where all token counts are zero, which is a behavioral change for clients that consume those events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1af702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI usage tracking for chat, image generation, and embeddings, including streaming token usage events and post-request usage recording.
  * Added configurable AI quotas (requests/tokens/spend) with optional allowed-model restrictions.
  * Introduced admin endpoints to view AI usage reports and manage default/per-user quota settings.
* **Bug Fixes**
  * Improved quota enforcement: disallowed models now return clear forbidden responses, and quota/cap limits now return rate-limited responses.
  * Usage is now recorded reliably for both successful and failed requests (with zeroed token counts on failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->