### PR TITLE
feat: AI Gateway per-user usage tracking, quotas, and rate limiting

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -457,7 +457,7 @@ export const computeWriteLimiter = createWriteEndpointLimiter('compute');
  * across multiple devices or IPs.
  *
  * Chat:  60 requests per minute (bursts of streaming completions)
- * Image: 30 requests per 5 minutes (image gen is expensive)
+ * Image: 30 requests per minute (image gen is expensive)
  * Embed: 120 requests per minute (batch embedding jobs)
  */
 
@@ -472,13 +472,7 @@ function createUserAILimiter(maxPerMinute: number) {
       return authReq.user?.id ?? authReq.ip ?? 'unknown';
     },
     handler: (_req: Request, _res: Response, next: NextFunction) => {
-      next(
-        new AppError(
-          'Too many AI requests. Please slow down.',
-          429,
-          ERROR_CODES.TOO_MANY_REQUESTS
-        )
-      );
+      next(new AppError('Too many AI requests. Please slow down.', 429, ERROR_CODES.TOO_MANY_REQUESTS));
     },
     skipSuccessfulRequests: false,
     skipFailedRequests: false,

--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -472,7 +472,9 @@ function createUserAILimiter(maxPerMinute: number) {
       return authReq.user?.id ?? authReq.ip ?? 'unknown';
     },
     handler: (_req: Request, _res: Response, next: NextFunction) => {
-      next(new AppError('Too many AI requests. Please slow down.', 429, ERROR_CODES.TOO_MANY_REQUESTS));
+      next(
+        new AppError('Too many AI requests. Please slow down.', 429, ERROR_CODES.TOO_MANY_REQUESTS)
+      );
     },
     skipSuccessfulRequests: false,
     skipFailedRequests: false,

--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import { ERROR_CODES } from '@insforge/shared-schemas';
+import type { AuthRequest } from './auth.js';
 
 /**
  * Store for tracking per-email cooldowns
@@ -448,3 +449,42 @@ function createWriteEndpointLimiter(category: WriteLimiterCategory) {
 export const functionsWriteLimiter = createWriteEndpointLimiter('functions');
 export const deploymentsWriteLimiter = createWriteEndpointLimiter('deployments');
 export const computeWriteLimiter = createWriteEndpointLimiter('compute');
+
+/**
+ * Per-user rate limiters for AI endpoints.
+ * Uses req.user.id as the key so limits are tracked per authenticated user,
+ * not per IP. This prevents a single user from exhausting the AI budget
+ * across multiple devices or IPs.
+ *
+ * Chat:  60 requests per minute (bursts of streaming completions)
+ * Image: 30 requests per 5 minutes (image gen is expensive)
+ * Embed: 120 requests per minute (batch embedding jobs)
+ */
+
+function createUserAILimiter(maxPerMinute: number) {
+  return rateLimit({
+    windowMs: 60 * 1000,
+    max: maxPerMinute,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => {
+      const authReq = req as AuthRequest;
+      return authReq.user?.id ?? authReq.ip ?? 'unknown';
+    },
+    handler: (_req: Request, _res: Response, next: NextFunction) => {
+      next(
+        new AppError(
+          'Too many AI requests. Please slow down.',
+          429,
+          ERROR_CODES.TOO_MANY_REQUESTS
+        )
+      );
+    },
+    skipSuccessfulRequests: false,
+    skipFailedRequests: false,
+  });
+}
+
+export const aiChatRateLimiter = createUserAILimiter(60);
+export const aiImageRateLimiter = createUserAILimiter(30);
+export const aiEmbeddingRateLimiter = createUserAILimiter(120);

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -4,6 +4,7 @@ import { AuthRequest, verifyAdmin, verifyUser } from '../../middlewares/auth.js'
 import { ImageGenerationService } from '@/services/ai/image-generation.service.js';
 import { EmbeddingService } from '@/services/ai/embedding.service.js';
 import { AIModelService } from '@/services/ai/ai-model.service.js';
+import { AIUsageService } from '@/services/ai/ai-usage.service.js';
 import { AppError } from '@/utils/errors.js';
 import { errorResponse, successResponse } from '@/utils/response.js';
 import { OpenRouterProvider } from '@/providers/ai/openrouter.provider.js';
@@ -13,10 +14,18 @@ import {
   chatCompletionRequestSchema,
   embeddingsRequestSchema,
   imageGenerationRequestSchema,
+  usageReportQuerySchema,
+  updateQuotaConfigRequestSchema,
 } from '@insforge/shared-schemas';
+import {
+  aiChatRateLimiter,
+  aiImageRateLimiter,
+  aiEmbeddingRateLimiter,
+} from '../../middlewares/rate-limiters.js';
 
 const router = Router();
 const chatService = ChatCompletionService.getInstance();
+const aiUsageService = AIUsageService.getInstance();
 type AIProvider = 'openrouter';
 
 /**
@@ -141,12 +150,36 @@ function rotateProviderApiKey(provider: AIProvider, openRouterProvider: OpenRout
 }
 
 /**
+ * Middleware that checks AI quota for the authenticated user.
+ * Must run after verifyUser so req.user is populated.
+ */
+async function checkAIQuota(req: AuthRequest, _res: Response, next: NextFunction) {
+  try {
+    if (!req.user) {
+      return next(
+        new AppError('Authentication required', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS)
+      );
+    }
+
+    const model = req.body?.model || req.params?.model;
+    if (model) {
+      await aiUsageService.checkQuota(req.user.id, model);
+    }
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
  * POST /api/ai/chat/completion
  * Send a chat message to any supported model
  */
 router.post(
   '/chat/completion',
   verifyUser,
+  aiChatRateLimiter,
+  checkAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validationResult = chatCompletionRequestSchema.safeParse(req.body);
@@ -162,14 +195,14 @@ router.post(
 
       // Handle streaming requests
       if (stream) {
-        // Now we know the model is valid, set headers for SSE
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Connection', 'keep-alive');
 
-        // Create and process the stream
         try {
           const streamGenerator = chatService.streamChat(messages, options);
+          let finalPromptTokens = 0;
+          let finalCompletionTokens = 0;
 
           for await (const data of streamGenerator) {
             if (data.chunk) {
@@ -177,6 +210,12 @@ router.post(
             }
             if (data.tokenUsage) {
               res.write(`data: ${JSON.stringify({ tokenUsage: data.tokenUsage })}\n\n`);
+              if (data.tokenUsage.promptTokens) {
+                finalPromptTokens = data.tokenUsage.promptTokens;
+              }
+              if (data.tokenUsage.completionTokens) {
+                finalCompletionTokens = data.tokenUsage.completionTokens;
+              }
             }
             if (data.tool_calls) {
               res.write(`data: ${JSON.stringify({ tool_calls: data.tool_calls })}\n\n`);
@@ -186,10 +225,20 @@ router.post(
             }
           }
 
-          // Send completion signal
           res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
+
+          if (req.user) {
+            aiUsageService.logUsage(
+              req.user.id,
+              options.model,
+              finalPromptTokens,
+              finalCompletionTokens,
+              'chat'
+            ).catch((error) => {
+              logger.warn('Failed to log streaming chat usage', { error: String(error) });
+            });
+          }
         } catch (streamError) {
-          // If error occurs during streaming, send it in SSE format
           logger.error('Stream error during chat completion', {
             error: streamError instanceof Error ? streamError.message : String(streamError),
             stack: streamError instanceof Error ? streamError.stack : undefined,
@@ -205,6 +254,21 @@ router.post(
 
       // Non-streaming requests
       const result = await chatService.chat(messages, options);
+
+      // Log usage after successful completion
+      if (req.user) {
+        const usage = result.metadata?.usage;
+        aiUsageService.logUsage(
+          req.user.id,
+          options.model,
+          usage?.promptTokens || 0,
+          usage?.completionTokens || 0,
+          'chat'
+        ).catch((error) => {
+          logger.warn('Failed to log chat usage', { error: String(error) });
+        });
+      }
+
       successResponse(res, result);
     } catch (error) {
       if (error instanceof AppError) {
@@ -229,6 +293,8 @@ router.post(
 router.post(
   '/image/generation',
   verifyUser,
+  aiImageRateLimiter,
+  checkAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validationResult = imageGenerationRequestSchema.safeParse(req.body);
@@ -241,6 +307,20 @@ router.post(
       }
 
       const result = await ImageGenerationService.generate(validationResult.data);
+
+      // Log usage after successful generation
+      if (req.user) {
+        const usage = result.metadata?.usage;
+        aiUsageService.logUsage(
+          req.user.id,
+          validationResult.data.model,
+          usage?.promptTokens || 0,
+          usage?.completionTokens || 0,
+          'image'
+        ).catch((error) => {
+          logger.warn('Failed to log image generation usage', { error: String(error) });
+        });
+      }
 
       successResponse(res, result);
     } catch (error) {
@@ -266,6 +346,8 @@ router.post(
 router.post(
   '/embeddings',
   verifyUser,
+  aiEmbeddingRateLimiter,
+  checkAIQuota,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validationResult = embeddingsRequestSchema.safeParse(req.body);
@@ -280,6 +362,20 @@ router.post(
       const embeddingService = EmbeddingService.getInstance();
       const result = await embeddingService.createEmbeddings(validationResult.data);
 
+      // Log usage after successful embedding
+      if (req.user) {
+        const usage = result.metadata?.usage;
+        aiUsageService.logUsage(
+          req.user.id,
+          validationResult.data.model,
+          usage?.promptTokens || 0,
+          0,
+          'embedding'
+        ).catch((error) => {
+          logger.warn('Failed to log embedding usage', { error: String(error) });
+        });
+      }
+
       successResponse(res, result);
     } catch (error) {
       if (error instanceof AppError) {
@@ -293,6 +389,78 @@ router.post(
           )
         );
       }
+    }
+  }
+);
+
+/**
+ * GET /api/ai/usage/report
+ * Get aggregated AI usage report. Admin-only.
+ */
+router.get(
+  '/usage/report',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const queryValidation = usageReportQuerySchema.safeParse(req.query);
+      if (!queryValidation.success) {
+        throw new AppError(
+          `Validation error: ${queryValidation.error.errors.map((e) => e.message).join(', ')}`,
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const { period, userId, model, limit, offset } = queryValidation.data;
+      const report = await aiUsageService.getUsageReport(period, userId, model, limit, offset);
+      successResponse(res, report);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/ai/quotas
+ * Get all quota configs, or a specific user's quota. Admin-only.
+ */
+router.get(
+  '/quotas',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.query.userId as string | undefined;
+      const configs = await aiUsageService.getQuotaConfig(userId);
+      successResponse(res, configs);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * PUT /api/ai/quotas
+ * Create or update a quota config for a user (or global default). Admin-only.
+ */
+router.put(
+  '/quotas',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const validationResult = updateQuotaConfigRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        throw new AppError(
+          `Validation error: ${validationResult.error.errors.map((e) => e.message).join(', ')}`,
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const targetUserId = (req.body.userId as string | null) ?? null;
+      const config = await aiUsageService.upsertQuotaConfig(targetUserId, validationResult.data);
+      successResponse(res, config);
+    } catch (error) {
+      next(error);
     }
   }
 );

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -231,16 +231,13 @@ router.post(
           res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
 
           if (req.user) {
-            const cost = aiUsageService.estimateCost(finalPromptTokens, finalCompletionTokens, options.model);
+            const cost = aiUsageService.estimateCost(
+              finalPromptTokens,
+              finalCompletionTokens,
+              options.model
+            );
             aiUsageService
-              .logUsage(
-                req.user.id,
-                options.model,
-                finalPromptTokens,
-                finalCompletionTokens,
-                'chat',
-                cost
-              )
+              .logUsage(req.user.id, options.model, finalPromptTokens, finalCompletionTokens, 'chat', cost)
               .catch((error) => {
                 logger.warn('Failed to log streaming chat usage', { error: String(error) });
               });
@@ -267,16 +264,13 @@ router.post(
         const usage = result.metadata?.usage;
         const promptTokens = usage?.promptTokens || 0;
         const completionTokens = usage?.completionTokens || 0;
-        const cost = aiUsageService.estimateCost(promptTokens, completionTokens, options.model);
+        const cost = aiUsageService.estimateCost(
+          promptTokens,
+          completionTokens,
+          options.model
+        );
         aiUsageService
-          .logUsage(
-            req.user.id,
-            options.model,
-            promptTokens,
-            completionTokens,
-            'chat',
-            cost
-          )
+          .logUsage(req.user.id, options.model, promptTokens, completionTokens, 'chat', cost)
           .catch((error) => {
             logger.warn('Failed to log chat usage', { error: String(error) });
           });
@@ -326,16 +320,13 @@ router.post(
         const usage = result.metadata?.usage;
         const promptTokens = usage?.promptTokens || 0;
         const completionTokens = usage?.completionTokens || 0;
-        const cost = aiUsageService.estimateCost(promptTokens, completionTokens, validationResult.data.model);
+        const cost = aiUsageService.estimateCost(
+          promptTokens,
+          completionTokens,
+          validationResult.data.model
+        );
         aiUsageService
-          .logUsage(
-            req.user.id,
-            validationResult.data.model,
-            promptTokens,
-            completionTokens,
-            'image',
-            cost
-          )
+          .logUsage(req.user.id, validationResult.data.model, promptTokens, completionTokens, 'image', cost)
           .catch((error) => {
             logger.warn('Failed to log image generation usage', { error: String(error) });
           });
@@ -385,16 +376,13 @@ router.post(
       if (req.user) {
         const usage = result.metadata?.usage;
         const promptTokens = usage?.promptTokens || 0;
-        const cost = aiUsageService.estimateCost(promptTokens, 0, validationResult.data.model);
+        const cost = aiUsageService.estimateCost(
+          promptTokens,
+          0,
+          validationResult.data.model
+        );
         aiUsageService
-          .logUsage(
-            req.user.id,
-            validationResult.data.model,
-            promptTokens,
-            0,
-            'embedding',
-            cost
-          )
+          .logUsage(req.user.id, validationResult.data.model, promptTokens, 0, 'embedding', cost)
           .catch((error) => {
             logger.warn('Failed to log embedding usage', { error: String(error) });
           });

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -1,4 +1,5 @@
 import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
 import { ChatCompletionService } from '@/services/ai/chat-completion.service.js';
 import { AuthRequest, verifyAdmin, verifyUser } from '../../middlewares/auth.js';
 import { ImageGenerationService } from '@/services/ai/image-generation.service.js';
@@ -162,8 +163,10 @@ async function checkAIQuota(req: AuthRequest, _res: Response, next: NextFunction
     }
 
     const model = req.body?.model || req.params?.model;
-    if (model) {
+    if (model !== undefined && model !== null) {
       await aiUsageService.checkQuota(req.user.id, model);
+    } else {
+      await aiUsageService.checkQuota(req.user.id, '');
     }
     next();
   } catch (error) {
@@ -228,15 +231,19 @@ router.post(
           res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
 
           if (req.user) {
-            aiUsageService.logUsage(
-              req.user.id,
-              options.model,
-              finalPromptTokens,
-              finalCompletionTokens,
-              'chat'
-            ).catch((error) => {
-              logger.warn('Failed to log streaming chat usage', { error: String(error) });
-            });
+            const cost = aiUsageService.estimateCost(finalPromptTokens, finalCompletionTokens, options.model);
+            aiUsageService
+              .logUsage(
+                req.user.id,
+                options.model,
+                finalPromptTokens,
+                finalCompletionTokens,
+                'chat',
+                cost
+              )
+              .catch((error) => {
+                logger.warn('Failed to log streaming chat usage', { error: String(error) });
+              });
           }
         } catch (streamError) {
           logger.error('Stream error during chat completion', {
@@ -258,15 +265,21 @@ router.post(
       // Log usage after successful completion
       if (req.user) {
         const usage = result.metadata?.usage;
-        aiUsageService.logUsage(
-          req.user.id,
-          options.model,
-          usage?.promptTokens || 0,
-          usage?.completionTokens || 0,
-          'chat'
-        ).catch((error) => {
-          logger.warn('Failed to log chat usage', { error: String(error) });
-        });
+        const promptTokens = usage?.promptTokens || 0;
+        const completionTokens = usage?.completionTokens || 0;
+        const cost = aiUsageService.estimateCost(promptTokens, completionTokens, options.model);
+        aiUsageService
+          .logUsage(
+            req.user.id,
+            options.model,
+            promptTokens,
+            completionTokens,
+            'chat',
+            cost
+          )
+          .catch((error) => {
+            logger.warn('Failed to log chat usage', { error: String(error) });
+          });
       }
 
       successResponse(res, result);
@@ -311,15 +324,21 @@ router.post(
       // Log usage after successful generation
       if (req.user) {
         const usage = result.metadata?.usage;
-        aiUsageService.logUsage(
-          req.user.id,
-          validationResult.data.model,
-          usage?.promptTokens || 0,
-          usage?.completionTokens || 0,
-          'image'
-        ).catch((error) => {
-          logger.warn('Failed to log image generation usage', { error: String(error) });
-        });
+        const promptTokens = usage?.promptTokens || 0;
+        const completionTokens = usage?.completionTokens || 0;
+        const cost = aiUsageService.estimateCost(promptTokens, completionTokens, validationResult.data.model);
+        aiUsageService
+          .logUsage(
+            req.user.id,
+            validationResult.data.model,
+            promptTokens,
+            completionTokens,
+            'image',
+            cost
+          )
+          .catch((error) => {
+            logger.warn('Failed to log image generation usage', { error: String(error) });
+          });
       }
 
       successResponse(res, result);
@@ -365,15 +384,20 @@ router.post(
       // Log usage after successful embedding
       if (req.user) {
         const usage = result.metadata?.usage;
-        aiUsageService.logUsage(
-          req.user.id,
-          validationResult.data.model,
-          usage?.promptTokens || 0,
-          0,
-          'embedding'
-        ).catch((error) => {
-          logger.warn('Failed to log embedding usage', { error: String(error) });
-        });
+        const promptTokens = usage?.promptTokens || 0;
+        const cost = aiUsageService.estimateCost(promptTokens, 0, validationResult.data.model);
+        aiUsageService
+          .logUsage(
+            req.user.id,
+            validationResult.data.model,
+            promptTokens,
+            0,
+            'embedding',
+            cost
+          )
+          .catch((error) => {
+            logger.warn('Failed to log embedding usage', { error: String(error) });
+          });
       }
 
       successResponse(res, result);
@@ -424,45 +448,41 @@ router.get(
  * GET /api/ai/quotas
  * Get all quota configs, or a specific user's quota. Admin-only.
  */
-router.get(
-  '/quotas',
-  verifyAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
-    try {
-      const userId = req.query.userId as string | undefined;
-      const configs = await aiUsageService.getQuotaConfig(userId);
-      successResponse(res, configs);
-    } catch (error) {
-      next(error);
+router.get('/quotas', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const rawUserId = req.query.userId as string | undefined;
+    const userId = rawUserId ? usageReportQuerySchema.shape.userId.parse(rawUserId) : undefined;
+    const configs = await aiUsageService.getQuotaConfig(userId);
+    successResponse(res, configs);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return next(new AppError('Invalid userId format', 400, ERROR_CODES.INVALID_INPUT));
     }
+    next(error);
   }
-);
+});
 
 /**
  * PUT /api/ai/quotas
  * Create or update a quota config for a user (or global default). Admin-only.
  */
-router.put(
-  '/quotas',
-  verifyAdmin,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
-    try {
-      const validationResult = updateQuotaConfigRequestSchema.safeParse(req.body);
-      if (!validationResult.success) {
-        throw new AppError(
-          `Validation error: ${validationResult.error.errors.map((e) => e.message).join(', ')}`,
-          400,
-          ERROR_CODES.INVALID_INPUT
-        );
-      }
-
-      const targetUserId = (req.body.userId as string | null) ?? null;
-      const config = await aiUsageService.upsertQuotaConfig(targetUserId, validationResult.data);
-      successResponse(res, config);
-    } catch (error) {
-      next(error);
+router.put('/quotas', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const validationResult = updateQuotaConfigRequestSchema.safeParse(req.body);
+    if (!validationResult.success) {
+      throw new AppError(
+        `Validation error: ${validationResult.error.errors.map((e) => e.message).join(', ')}`,
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
     }
+
+    const targetUserId = validationResult.data.userId ?? null;
+    const config = await aiUsageService.upsertQuotaConfig(targetUserId, validationResult.data);
+    successResponse(res, config);
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 export { router as aiRouter };

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -237,7 +237,14 @@ router.post(
               options.model
             );
             aiUsageService
-              .logUsage(req.user.id, options.model, finalPromptTokens, finalCompletionTokens, 'chat', cost)
+              .logUsage(
+                req.user.id,
+                options.model,
+                finalPromptTokens,
+                finalCompletionTokens,
+                'chat',
+                cost
+              )
               .catch((error) => {
                 logger.warn('Failed to log streaming chat usage', { error: String(error) });
               });
@@ -264,11 +271,7 @@ router.post(
         const usage = result.metadata?.usage;
         const promptTokens = usage?.promptTokens || 0;
         const completionTokens = usage?.completionTokens || 0;
-        const cost = aiUsageService.estimateCost(
-          promptTokens,
-          completionTokens,
-          options.model
-        );
+        const cost = aiUsageService.estimateCost(promptTokens, completionTokens, options.model);
         aiUsageService
           .logUsage(req.user.id, options.model, promptTokens, completionTokens, 'chat', cost)
           .catch((error) => {
@@ -326,7 +329,14 @@ router.post(
           validationResult.data.model
         );
         aiUsageService
-          .logUsage(req.user.id, validationResult.data.model, promptTokens, completionTokens, 'image', cost)
+          .logUsage(
+            req.user.id,
+            validationResult.data.model,
+            promptTokens,
+            completionTokens,
+            'image',
+            cost
+          )
           .catch((error) => {
             logger.warn('Failed to log image generation usage', { error: String(error) });
           });
@@ -376,11 +386,7 @@ router.post(
       if (req.user) {
         const usage = result.metadata?.usage;
         const promptTokens = usage?.promptTokens || 0;
-        const cost = aiUsageService.estimateCost(
-          promptTokens,
-          0,
-          validationResult.data.model
-        );
+        const cost = aiUsageService.estimateCost(promptTokens, 0, validationResult.data.model);
         aiUsageService
           .logUsage(req.user.id, validationResult.data.model, promptTokens, 0, 'embedding', cost)
           .catch((error) => {

--- a/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
+++ b/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
@@ -68,8 +68,7 @@ CREATE TABLE IF NOT EXISTS ai.quota_config (
   model_allowlist            TEXT[],
   created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT uq_quota_config_user UNIQUE (user_id),
-  CONSTRAINT ck_quota_config_user_not_null CHECK (user_id IS NOT NULL OR user_id IS NULL)
+  CONSTRAINT uq_quota_config_user UNIQUE (user_id)
 );
 
 -- Enforce at most one global-default row via a partial unique index.

--- a/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
+++ b/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
@@ -1,0 +1,94 @@
+-- Create ai.usage_log table for tracking per-request AI model usage.
+-- This enables per-user quota enforcement and admin cost observability.
+CREATE SCHEMA IF NOT EXISTS ai;
+
+CREATE TABLE IF NOT EXISTS ai.usage_log (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL,
+  model             TEXT NOT NULL,
+  prompt_tokens     INT NOT NULL DEFAULT 0,
+  completion_tokens INT NOT NULL DEFAULT 0,
+  estimated_cost    NUMERIC(12,8) NOT NULL DEFAULT 0,
+  endpoint          TEXT NOT NULL CHECK (endpoint IN ('chat', 'image', 'embedding')),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for per-user time-window queries (the hot path for quota checks)
+CREATE INDEX IF NOT EXISTS idx_usage_log_user_created
+  ON ai.usage_log (user_id, created_at DESC);
+
+-- Index for admin aggregate reports
+CREATE INDEX IF NOT EXISTS idx_usage_log_created
+  ON ai.usage_log (created_at DESC);
+
+-- Index for model-level aggregation
+CREATE INDEX IF NOT EXISTS idx_usage_log_model
+  ON ai.usage_log (model);
+
+-- GRANTs for the authenticated role (INSERT is needed by the service layer
+-- which runs via withAdminContext; SELECT is for admin report endpoints).
+GRANT USAGE ON SCHEMA ai TO authenticated;
+GRANT INSERT, SELECT ON ai.usage_log TO authenticated;
+
+-- Enable RLS on usage_log so row-level checks protect user data.
+ALTER TABLE ai.usage_log ENABLE ROW LEVEL SECURITY;
+
+-- Users can always see their own usage rows; admins see everything.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'ai' AND tablename = 'usage_log' AND policyname = 'users_view_own_usage'
+  ) THEN
+    CREATE POLICY users_view_own_usage ON ai.usage_log
+      FOR SELECT
+      USING (auth.jwt() ->> 'sub' = user_id::text);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'ai' AND tablename = 'usage_log' AND policyname = 'authenticated_insert_own_usage'
+  ) THEN
+    CREATE POLICY authenticated_insert_own_usage ON ai.usage_log
+      FOR INSERT
+      WITH CHECK (auth.jwt() ->> 'sub' = user_id::text);
+  END IF;
+END
+$$;
+
+-- Create ai.quota_config table.
+-- Project-wide default has user_id IS NULL; per-user overrides use user_id.
+CREATE TABLE IF NOT EXISTS ai.quota_config (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                    UUID,
+  max_requests_per_day       INT,
+  max_tokens_per_day         INT,
+  max_tokens_per_month       INT,
+  monthly_spend_cap_usd      NUMERIC(10,4),
+  model_allowlist            TEXT[],
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_quota_config_user UNIQUE (user_id),
+  CONSTRAINT ck_quota_config_user_or_default CHECK (
+    (user_id IS NOT NULL) OR
+    (user_id IS NULL AND NOT EXISTS (
+      SELECT 1 FROM ai.quota_config qc2 WHERE qc2.user_id IS NULL AND qc2.id <> ai.quota_config.id
+    ))
+  )
+);
+
+COMMENT ON TABLE ai.quota_config IS
+  'Per-user or global-default AI usage quota limits. user_id=null row is the fallback default.';
+COMMENT ON COLUMN ai.quota_config.user_id IS
+  'NULL represents the project-wide default; non-NULL is a per-user override.';
+COMMENT ON COLUMN ai.quota_config.model_allowlist IS
+  'If non-NULL and non-empty, restricts this user to only these model IDs.';
+
+GRANT SELECT, INSERT, UPDATE ON ai.quota_config TO authenticated;
+
+-- Seed a global-default quota row if none exists yet.
+INSERT INTO ai.quota_config (
+  user_id, max_requests_per_day, max_tokens_per_day, max_tokens_per_month, monthly_spend_cap_usd
+)
+SELECT NULL, 1000, 2000000, 60000000, 50.00
+WHERE NOT EXISTS (SELECT 1 FROM ai.quota_config WHERE user_id IS NULL);

--- a/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
+++ b/backend/src/infra/database/migrations/060_ai-usage-tracking.sql
@@ -69,13 +69,13 @@ CREATE TABLE IF NOT EXISTS ai.quota_config (
   created_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT uq_quota_config_user UNIQUE (user_id),
-  CONSTRAINT ck_quota_config_user_or_default CHECK (
-    (user_id IS NOT NULL) OR
-    (user_id IS NULL AND NOT EXISTS (
-      SELECT 1 FROM ai.quota_config qc2 WHERE qc2.user_id IS NULL AND qc2.id <> ai.quota_config.id
-    ))
-  )
+  CONSTRAINT ck_quota_config_user_not_null CHECK (user_id IS NOT NULL OR user_id IS NULL)
 );
+
+-- Enforce at most one global-default row via a partial unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_quota_config_single_global_default
+  ON ai.quota_config ((TRUE))
+  WHERE user_id IS NULL;
 
 COMMENT ON TABLE ai.quota_config IS
   'Per-user or global-default AI usage quota limits. user_id=null row is the fallback default.';
@@ -84,7 +84,7 @@ COMMENT ON COLUMN ai.quota_config.user_id IS
 COMMENT ON COLUMN ai.quota_config.model_allowlist IS
   'If non-NULL and non-empty, restricts this user to only these model IDs.';
 
-GRANT SELECT, INSERT, UPDATE ON ai.quota_config TO authenticated;
+-- quota_config is admin-only; access goes through the API routes (verifyAdmin).
 
 -- Seed a global-default quota row if none exists yet.
 INSERT INTO ai.quota_config (

--- a/backend/src/services/ai/ai-usage.service.ts
+++ b/backend/src/services/ai/ai-usage.service.ts
@@ -1,0 +1,399 @@
+import { Pool } from 'pg';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+const AI_ENDPOINTS = ['chat', 'image', 'embedding'] as const;
+export type AIEndpoint = (typeof AI_ENDPOINTS)[number];
+
+interface UsageLogRow {
+  id: string;
+  user_id: string;
+  model: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  estimated_cost: number;
+  endpoint: string;
+  created_at: string;
+}
+
+interface QuotaConfigRow {
+  id: string;
+  user_id: string | null;
+  max_requests_per_day: number | null;
+  max_tokens_per_day: number | null;
+  max_tokens_per_month: number | null;
+  monthly_spend_cap_usd: number | null;
+  model_allowlist: string[] | null;
+  updated_at: string;
+}
+
+interface UsageAggregate {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  estimated_cost: number;
+  request_count: number;
+}
+
+interface UsageByUserAndModel {
+  user_id: string;
+  model: string;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  estimated_cost: number;
+  request_count: number;
+}
+
+export class AIUsageService {
+  private static instance: AIUsageService;
+  private pool: Pool | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): AIUsageService {
+    if (!AIUsageService.instance) {
+      AIUsageService.instance = new AIUsageService();
+    }
+    return AIUsageService.instance;
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = DatabaseManager.getInstance().getPool();
+    }
+    return this.pool;
+  }
+
+  private getPeriodStart(period: 'day' | 'week' | 'month' | 'all'): string | null {
+    switch (period) {
+      case 'day':
+        return `NOW() - INTERVAL '1 day'`;
+      case 'week':
+        return `NOW() - INTERVAL '7 days'`;
+      case 'month':
+        return `NOW() - INTERVAL '30 days'`;
+      case 'all':
+        return null;
+    }
+  }
+
+  /**
+   * Look up the effective quota config for a user.
+   * Returns per-user config if it exists, otherwise the global default.
+   */
+  async getEffectiveQuotaConfig(userId: string): Promise<QuotaConfigRow | null> {
+    const pool = this.getPool();
+    const result = await pool.query(
+      `SELECT * FROM ai.quota_config WHERE user_id = $1
+       UNION ALL
+       SELECT * FROM ai.quota_config WHERE user_id IS NULL
+       LIMIT 1`,
+      [userId]
+    );
+    return result.rows[0] as QuotaConfigRow | undefined ?? null;
+  }
+
+  /**
+   * Check whether a user is allowed to make an AI request with the given model.
+   * Throws AppError if the user is over quota or the model is not allowed.
+   */
+  async checkQuota(userId: string, model: string): Promise<void> {
+    const pool = this.getPool();
+    const config = await this.getEffectiveQuotaConfig(userId);
+
+    if (config) {
+      if (config.model_allowlist && config.model_allowlist.length > 0) {
+        if (!config.model_allowlist.includes(model)) {
+          throw new AppError(
+            `Model "${model}" is not in the allowed list for this user`,
+            403,
+            ERROR_CODES.AI_MODEL_NOT_ALLOWED
+          );
+        }
+      }
+
+      if (config.max_requests_per_day !== null) {
+        const dayResult = await pool.query(
+          `SELECT COUNT(*)::int AS cnt FROM ai.usage_log
+           WHERE user_id = $1 AND created_at > NOW() - INTERVAL '1 day'`,
+          [userId]
+        );
+        if ((dayResult.rows[0] as { cnt: number }).cnt >= config.max_requests_per_day) {
+          throw new AppError(
+            `Daily request limit (${config.max_requests_per_day}) exceeded`,
+            429,
+            ERROR_CODES.AI_QUOTA_EXCEEDED
+          );
+        }
+      }
+
+      if (config.max_tokens_per_day !== null) {
+        const dayTokens = await pool.query(
+          `SELECT COALESCE(SUM(prompt_tokens + completion_tokens), 0)::int AS total
+           FROM ai.usage_log
+           WHERE user_id = $1 AND created_at > NOW() - INTERVAL '1 day'`,
+          [userId]
+        );
+        if ((dayTokens.rows[0] as { total: number }).total >= config.max_tokens_per_day) {
+          throw new AppError(
+            `Daily token limit (${config.max_tokens_per_day}) exceeded`,
+            429,
+            ERROR_CODES.AI_QUOTA_EXCEEDED
+          );
+        }
+      }
+
+      if (config.max_tokens_per_month !== null) {
+        const monthTokens = await pool.query(
+          `SELECT COALESCE(SUM(prompt_tokens + completion_tokens), 0)::int AS total
+           FROM ai.usage_log
+           WHERE user_id = $1 AND created_at > NOW() - INTERVAL '30 days'`,
+          [userId]
+        );
+        if ((monthTokens.rows[0] as { total: number }).total >= config.max_tokens_per_month) {
+          throw new AppError(
+            `Monthly token limit (${config.max_tokens_per_month}) exceeded`,
+            429,
+            ERROR_CODES.AI_QUOTA_EXCEEDED
+          );
+        }
+      }
+
+      if (config.monthly_spend_cap_usd !== null) {
+        const monthCost = await pool.query(
+          `SELECT COALESCE(SUM(estimated_cost), 0)::numeric(12,8) AS total
+           FROM ai.usage_log
+           WHERE user_id = $1 AND created_at > NOW() - INTERVAL '30 days'`,
+          [userId]
+        );
+        const totalCost = parseFloat((monthCost.rows[0] as { total: string }).total);
+        if (totalCost >= config.monthly_spend_cap_usd) {
+          throw new AppError(
+            `Monthly spend cap ($${config.monthly_spend_cap_usd}) exceeded`,
+            429,
+            ERROR_CODES.AI_QUOTA_EXCEEDED
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Log a completed AI request to the usage_log table.
+   */
+  async logUsage(
+    userId: string,
+    model: string,
+    promptTokens: number,
+    completionTokens: number,
+    endpoint: AIEndpoint,
+    estimatedCost?: number
+  ): Promise<void> {
+    const pool = this.getPool();
+    try {
+      const cost = estimatedCost ?? 0;
+      await pool.query(
+        `INSERT INTO ai.usage_log (user_id, model, prompt_tokens, completion_tokens, estimated_cost, endpoint)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [userId, model, promptTokens, completionTokens, cost, endpoint]
+      );
+    } catch (error) {
+      logger.warn('Failed to log AI usage', {
+        error: error instanceof Error ? error.message : String(error),
+        userId,
+        model,
+      });
+    }
+  }
+
+  /**
+   * Get aggregated usage for a user over a time period.
+   */
+  async getUserUsage(
+    userId: string,
+    period: 'day' | 'week' | 'month' | 'all' = 'month'
+  ): Promise<UsageAggregate> {
+    const pool = this.getPool();
+    const periodStart = this.getPeriodStart(period);
+
+    const query = periodStart
+      ? `SELECT
+           COALESCE(SUM(prompt_tokens), 0)::int AS prompt_tokens,
+           COALESCE(SUM(completion_tokens), 0)::int AS completion_tokens,
+           COALESCE(SUM(prompt_tokens + completion_tokens), 0)::int AS total_tokens,
+           COALESCE(SUM(estimated_cost), 0)::numeric(12,8) AS estimated_cost,
+           COUNT(*)::int AS request_count
+         FROM ai.usage_log
+         WHERE user_id = $1 AND created_at > ${periodStart}`
+      : `SELECT
+           COALESCE(SUM(prompt_tokens), 0)::int AS prompt_tokens,
+           COALESCE(SUM(completion_tokens), 0)::int AS completion_tokens,
+           COALESCE(SUM(prompt_tokens + completion_tokens), 0)::int AS total_tokens,
+           COALESCE(SUM(estimated_cost), 0)::numeric(12,8) AS estimated_cost,
+           COUNT(*)::int AS request_count
+         FROM ai.usage_log
+         WHERE user_id = $1`;
+
+    const result = await pool.query(query, [userId]);
+    return result.rows[0] as UsageAggregate;
+  }
+
+  /**
+   * Get aggregated usage grouped by user and model for admin reports.
+   */
+  async getUsageReport(
+    period: 'day' | 'week' | 'month' | 'all' = 'month',
+    userId?: string,
+    model?: string,
+    limit = 50,
+    offset = 0
+  ): Promise<{
+    entries: UsageByUserAndModel[];
+    totals: UsageAggregate;
+    period: string;
+  }> {
+    const pool = this.getPool();
+    const periodStart = this.getPeriodStart(period);
+
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
+
+    if (periodStart) {
+      conditions.push(`created_at > ${periodStart}`);
+    }
+    if (userId) {
+      conditions.push(`user_id = $${paramIdx++}`);
+      params.push(userId);
+    }
+    if (model) {
+      conditions.push(`model = $${paramIdx++}`);
+      params.push(model);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    try {
+      const entriesResult = await pool.query(
+        `SELECT
+           user_id,
+           model,
+           SUM(prompt_tokens)::int AS prompt_tokens,
+           SUM(completion_tokens)::int AS completion_tokens,
+           SUM(prompt_tokens + completion_tokens)::int AS total_tokens,
+           SUM(estimated_cost)::numeric(12,8) AS estimated_cost,
+           COUNT(*)::int AS request_count
+         FROM ai.usage_log
+         ${whereClause}
+         GROUP BY user_id, model
+         ORDER BY total_tokens DESC
+         LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+        [...params, limit, offset]
+      );
+
+      const totalsResult = await pool.query(
+        `SELECT
+           COALESCE(SUM(prompt_tokens), 0)::int AS prompt_tokens,
+           COALESCE(SUM(completion_tokens), 0)::int AS completion_tokens,
+           COALESCE(SUM(prompt_tokens + completion_tokens), 0)::int AS total_tokens,
+           COALESCE(SUM(estimated_cost), 0)::numeric(12,8) AS estimated_cost,
+           COUNT(*)::int AS request_count
+         FROM ai.usage_log
+         ${whereClause}`,
+        params.slice(0, params.length - 2)
+      );
+
+      return {
+        entries: entriesResult.rows as UsageByUserAndModel[],
+        totals: totalsResult.rows[0] as UsageAggregate,
+        period,
+      };
+    } catch (error) {
+      throw new AppError(
+        `Failed to generate usage report: ${error instanceof Error ? error.message : String(error)}`,
+        500,
+        ERROR_CODES.AI_USAGE_REPORT_ERROR
+      );
+    }
+  }
+
+  /**
+   * Get quota config for a specific user. Admin-only.
+   */
+  async getQuotaConfig(userId?: string): Promise<QuotaConfigRow[]> {
+    const pool = this.getPool();
+    if (userId) {
+      const result = await pool.query(
+        `SELECT * FROM ai.quota_config WHERE user_id = $1 ORDER BY user_id NULLS LAST`,
+        [userId]
+      );
+      return result.rows as QuotaConfigRow[];
+    }
+    const result = await pool.query(
+      `SELECT * FROM ai.quota_config ORDER BY user_id NULLS LAST`
+    );
+    return result.rows as QuotaConfigRow[];
+  }
+
+  /**
+   * Create or update a quota config for a user.
+   * If userId is null, updates the global default row.
+   */
+  async upsertQuotaConfig(
+    userId: string | null,
+    config: {
+      maxRequestsPerDay?: number | null;
+      maxTokensPerDay?: number | null;
+      maxTokensPerMonth?: number | null;
+      monthlySpendCapUsd?: number | null;
+      modelAllowlist?: string[] | null;
+    }
+  ): Promise<QuotaConfigRow> {
+    const pool = this.getPool();
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
+
+    if (config.maxRequestsPerDay !== undefined) {
+      setClauses.push(`max_requests_per_day = $${paramIdx++}`);
+      params.push(config.maxRequestsPerDay);
+    }
+    if (config.maxTokensPerDay !== undefined) {
+      setClauses.push(`max_tokens_per_day = $${paramIdx++}`);
+      params.push(config.maxTokensPerDay);
+    }
+    if (config.maxTokensPerMonth !== undefined) {
+      setClauses.push(`max_tokens_per_month = $${paramIdx++}`);
+      params.push(config.maxTokensPerMonth);
+    }
+    if (config.monthlySpendCapUsd !== undefined) {
+      setClauses.push(`monthly_spend_cap_usd = $${paramIdx++}`);
+      params.push(config.monthlySpendCapUsd);
+    }
+    if (config.modelAllowlist !== undefined) {
+      setClauses.push(`model_allowlist = $${paramIdx++}`);
+      params.push(config.modelAllowlist);
+    }
+
+    if (setClauses.length === 0) {
+      const existing = await this.getQuotaConfig(userId ?? undefined);
+      if (existing.length > 0) return existing[0];
+      throw new AppError('No quota config found and no fields to update', 404, ERROR_CODES.NOT_FOUND);
+    }
+
+    setClauses.push(`updated_at = NOW()`);
+
+    const result = await pool.query(
+      `INSERT INTO ai.quota_config (user_id, ${setClauses.map((s) => s.split(' = ')[0]).join(', ')})
+       VALUES ($1, ${params.map((_, i) => `$${i + 2}`).join(', ')})
+       ON CONFLICT (user_id) DO UPDATE SET ${setClauses.join(', ')}
+       RETURNING *`,
+      [userId, ...params]
+    );
+
+    return result.rows[0] as QuotaConfigRow;
+  }
+}

--- a/backend/src/services/ai/ai-usage.service.ts
+++ b/backend/src/services/ai/ai-usage.service.ts
@@ -4,19 +4,7 @@ import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 
-const AI_ENDPOINTS = ['chat', 'image', 'embedding'] as const;
-export type AIEndpoint = (typeof AI_ENDPOINTS)[number];
-
-interface UsageLogRow {
-  id: string;
-  user_id: string;
-  model: string;
-  prompt_tokens: number;
-  completion_tokens: number;
-  estimated_cost: number;
-  endpoint: string;
-  created_at: string;
-}
+export type AIEndpoint = 'chat' | 'image' | 'embedding';
 
 interface QuotaConfigRow {
   id: string;
@@ -90,10 +78,36 @@ export class AIUsageService {
       `SELECT * FROM ai.quota_config WHERE user_id = $1
        UNION ALL
        SELECT * FROM ai.quota_config WHERE user_id IS NULL
+       ORDER BY user_id NULLS LAST
        LIMIT 1`,
       [userId]
     );
-    return result.rows[0] as QuotaConfigRow | undefined ?? null;
+    return (result.rows[0] as QuotaConfigRow | undefined) ?? null;
+  }
+
+  /**
+   * Roughly estimate the cost of an AI request based on model and token counts.
+   * Returns 0 for image generation (cost varies by provider/model).
+   */
+  estimateCost(promptTokens: number, completionTokens: number, model: string): number {
+    const modelLower = model.toLowerCase();
+    let promptRate: number;
+    let completionRate: number;
+
+    if (modelLower.includes('gpt-4') || modelLower.includes('claude-3-opus') || modelLower.includes('claude-3.5-sonnet')) {
+      promptRate = 0.01;
+      completionRate = 0.03;
+    } else if (modelLower.includes('gpt-3.5') || modelLower.includes('claude-3-haiku') || modelLower.includes('claude-instant')) {
+      promptRate = 0.001;
+      completionRate = 0.002;
+    } else if (modelLower.includes('dall-e') || modelLower.includes('stable-diffusion')) {
+      return 0.04;
+    } else {
+      promptRate = 0.003;
+      completionRate = 0.015;
+    }
+
+    return (promptTokens / 1000000) * promptRate + (completionTokens / 1000000) * completionRate;
   }
 
   /**
@@ -303,7 +317,7 @@ export class AIUsageService {
            COUNT(*)::int AS request_count
          FROM ai.usage_log
          ${whereClause}`,
-        params.slice(0, params.length - 2)
+        params
       );
 
       return {
@@ -384,15 +398,27 @@ export class AIUsageService {
       throw new AppError('No quota config found and no fields to update', 404, ERROR_CODES.NOT_FOUND);
     }
 
-    setClauses.push(`updated_at = NOW()`);
+    const insertColumns = setClauses.map((s) => s.split(' = ')[0]);
+    const insertValues = params.map((_, i) => `$${i + 2}`);
 
-    const result = await pool.query(
-      `INSERT INTO ai.quota_config (user_id, ${setClauses.map((s) => s.split(' = ')[0]).join(', ')})
-       VALUES ($1, ${params.map((_, i) => `$${i + 2}`).join(', ')})
-       ON CONFLICT (user_id) DO UPDATE SET ${setClauses.join(', ')}
-       RETURNING *`,
-      [userId, ...params]
-    );
+    let query: string;
+    let queryParams: unknown[];
+
+    if (userId !== null) {
+      query = `INSERT INTO ai.quota_config (user_id, ${insertColumns.join(', ')})
+               VALUES ($1, ${insertValues.join(', ')})
+               ON CONFLICT (user_id) DO UPDATE SET ${setClauses.join(', ')}, updated_at = NOW()
+               RETURNING *`;
+      queryParams = [userId, ...params];
+    } else {
+      query = `UPDATE ai.quota_config
+               SET ${setClauses.join(', ')}, updated_at = NOW()
+               WHERE user_id IS NULL
+               RETURNING *`;
+      queryParams = params;
+    }
+
+    const result = await pool.query(query, queryParams);
 
     return result.rows[0] as QuotaConfigRow;
   }

--- a/backend/src/services/ai/ai-usage.service.ts
+++ b/backend/src/services/ai/ai-usage.service.ts
@@ -87,17 +87,21 @@ export class AIUsageService {
 
   /**
    * Roughly estimate the cost of an AI request based on model and token counts.
-   * Returns 0 for image generation (cost varies by provider/model).
+   * Rates are per 1K tokens.
    */
   estimateCost(promptTokens: number, completionTokens: number, model: string): number {
     const modelLower = model.toLowerCase();
     let promptRate: number;
     let completionRate: number;
 
-    if (modelLower.includes('gpt-4') || modelLower.includes('claude-3-opus') || modelLower.includes('claude-3.5-sonnet')) {
+    if (
+      modelLower.includes('gpt-4') || modelLower.includes('claude-3-opus') || modelLower.includes('claude-3.5-sonnet')
+    ) {
       promptRate = 0.01;
       completionRate = 0.03;
-    } else if (modelLower.includes('gpt-3.5') || modelLower.includes('claude-3-haiku') || modelLower.includes('claude-instant')) {
+    } else if (
+      modelLower.includes('gpt-3.5') || modelLower.includes('claude-3-haiku') || modelLower.includes('claude-instant')
+    ) {
       promptRate = 0.001;
       completionRate = 0.002;
     } else if (modelLower.includes('dall-e') || modelLower.includes('stable-diffusion')) {
@@ -107,7 +111,7 @@ export class AIUsageService {
       completionRate = 0.015;
     }
 
-    return (promptTokens / 1000000) * promptRate + (completionTokens / 1000000) * completionRate;
+    return (promptTokens / 1000) * promptRate + (completionTokens / 1000) * completionRate;
   }
 
   /**
@@ -346,9 +350,7 @@ export class AIUsageService {
       );
       return result.rows as QuotaConfigRow[];
     }
-    const result = await pool.query(
-      `SELECT * FROM ai.quota_config ORDER BY user_id NULLS LAST`
-    );
+    const result = await pool.query(`SELECT * FROM ai.quota_config ORDER BY user_id NULLS LAST`);
     return result.rows as QuotaConfigRow[];
   }
 
@@ -394,12 +396,17 @@ export class AIUsageService {
 
     if (setClauses.length === 0) {
       const existing = await this.getQuotaConfig(userId ?? undefined);
-      if (existing.length > 0) return existing[0];
-      throw new AppError('No quota config found and no fields to update', 404, ERROR_CODES.NOT_FOUND);
+      if (existing.length > 0) { return existing[0]; }
+      throw new AppError(
+        'No quota config found and no fields to update',
+        404,
+        ERROR_CODES.NOT_FOUND
+      );
     }
 
     const insertColumns = setClauses.map((s) => s.split(' = ')[0]);
     const insertValues = params.map((_, i) => `$${i + 2}`);
+    const updateClauses = insertColumns.map((col) => `${col} = EXCLUDED.${col}`);
 
     let query: string;
     let queryParams: unknown[];
@@ -407,7 +414,7 @@ export class AIUsageService {
     if (userId !== null) {
       query = `INSERT INTO ai.quota_config (user_id, ${insertColumns.join(', ')})
                VALUES ($1, ${insertValues.join(', ')})
-               ON CONFLICT (user_id) DO UPDATE SET ${setClauses.join(', ')}, updated_at = NOW()
+               ON CONFLICT (user_id) DO UPDATE SET ${updateClauses.join(', ')}, updated_at = NOW()
                RETURNING *`;
       queryParams = [userId, ...params];
     } else {

--- a/backend/src/services/ai/ai-usage.service.ts
+++ b/backend/src/services/ai/ai-usage.service.ts
@@ -95,12 +95,16 @@ export class AIUsageService {
     let completionRate: number;
 
     if (
-      modelLower.includes('gpt-4') || modelLower.includes('claude-3-opus') || modelLower.includes('claude-3.5-sonnet')
+      modelLower.includes('gpt-4') ||
+      modelLower.includes('claude-3-opus') ||
+      modelLower.includes('claude-3.5-sonnet')
     ) {
       promptRate = 0.01;
       completionRate = 0.03;
     } else if (
-      modelLower.includes('gpt-3.5') || modelLower.includes('claude-3-haiku') || modelLower.includes('claude-instant')
+      modelLower.includes('gpt-3.5') ||
+      modelLower.includes('claude-3-haiku') ||
+      modelLower.includes('claude-instant')
     ) {
       promptRate = 0.001;
       completionRate = 0.002;
@@ -395,8 +399,14 @@ export class AIUsageService {
     }
 
     if (setClauses.length === 0) {
-      const existing = await this.getQuotaConfig(userId ?? undefined);
-      if (existing.length > 0) { return existing[0]; }
+      const pool = this.getPool();
+      const existing = await pool.query(
+        'SELECT * FROM ai.quota_config WHERE user_id IS NOT DISTINCT FROM $1',
+        [userId]
+      );
+      if (existing.rows.length > 0) {
+        return existing.rows[0] as QuotaConfigRow;
+      }
       throw new AppError(
         'No quota config found and no fields to update',
         404,

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -432,7 +432,11 @@ export class ChatCompletionService {
 
           // Only yield tokenUsage when actual non-zero values are present
           // to avoid emitting zero-value intermediate events that confuse clients
-          if (tokenUsage.promptTokens > 0 || tokenUsage.completionTokens > 0 || tokenUsage.totalTokens > 0) {
+          if (
+            tokenUsage.promptTokens > 0 ||
+            tokenUsage.completionTokens > 0 ||
+            tokenUsage.totalTokens > 0
+          ) {
             yield { tokenUsage: { ...tokenUsage } };
           }
         }

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -424,14 +424,17 @@ export class ChatCompletionService {
         }
 
         // Check if this chunk contains usage data
+        // OpenAI / OpenRouter typically includes usage only on the final chunk.
         if (chunk.usage) {
-          // Accumulate tokens instead of replacing
-          tokenUsage.promptTokens += chunk.usage.prompt_tokens || 0;
-          tokenUsage.completionTokens += chunk.usage.completion_tokens || 0;
-          tokenUsage.totalTokens += chunk.usage.total_tokens || 0;
+          tokenUsage.promptTokens = chunk.usage.prompt_tokens || 0;
+          tokenUsage.completionTokens = chunk.usage.completion_tokens || 0;
+          tokenUsage.totalTokens = chunk.usage.total_tokens || 0;
 
-          // Yield the accumulated usage
-          yield { tokenUsage: { ...tokenUsage } };
+          // Only yield tokenUsage when actual non-zero values are present
+          // to avoid emitting zero-value intermediate events that confuse clients
+          if (tokenUsage.promptTokens > 0 || tokenUsage.completionTokens > 0 || tokenUsage.totalTokens > 0) {
+            yield { tokenUsage: { ...tokenUsage } };
+          }
         }
       }
 

--- a/backend/tests/unit/ai-routes.test.ts
+++ b/backend/tests/unit/ai-routes.test.ts
@@ -26,6 +26,11 @@ describe('ai route wiring', () => {
     methods: Object.keys(layer.route?.methods ?? {}).sort(),
   }));
 
+  const getHandlerNames = (path: string): string[] => {
+    const route = routeLayers.find((layer) => layer.route?.path === path);
+    return route?.route?.stack.map((handler) => handler.handle.name) ?? [];
+  };
+
   it('registers the OpenRouter key rotation route', () => {
     expect(routeEntries).toContainEqual({
       path: '/:provider/api-key/rotate',
@@ -34,11 +39,91 @@ describe('ai route wiring', () => {
   });
 
   it('guards the rotation route with verifyAdmin', () => {
-    const rotateRoute = routeLayers.find(
-      (layer) => layer.route?.path === '/:provider/api-key/rotate'
-    );
-
-    const handlerNames = rotateRoute?.route?.stack.map((handler) => handler.handle.name) ?? [];
+    const handlerNames = getHandlerNames('/:provider/api-key/rotate');
     expect(handlerNames).toContain('verifyAdmin');
+  });
+
+  it('registers the chat completion route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/chat/completion',
+      methods: ['post'],
+    });
+  });
+
+  it('guards the chat completion route with verifyUser, rate limiter, and quota check', () => {
+    const handlerNames = getHandlerNames('/chat/completion');
+    expect(handlerNames).toContain('verifyUser');
+    expect(handlerNames).toContain('checkAIQuota');
+  });
+
+  it('registers the image generation route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/image/generation',
+      methods: ['post'],
+    });
+  });
+
+  it('guards the image generation route with verifyUser, rate limiter, and quota check', () => {
+    const handlerNames = getHandlerNames('/image/generation');
+    expect(handlerNames).toContain('verifyUser');
+    expect(handlerNames).toContain('checkAIQuota');
+  });
+
+  it('registers the embeddings route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/embeddings',
+      methods: ['post'],
+    });
+  });
+
+  it('guards the embeddings route with verifyUser, rate limiter, and quota check', () => {
+    const handlerNames = getHandlerNames('/embeddings');
+    expect(handlerNames).toContain('verifyUser');
+    expect(handlerNames).toContain('checkAIQuota');
+  });
+
+  it('registers the usage report route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/usage/report',
+      methods: ['get'],
+    });
+  });
+
+  it('guards the usage report route with verifyAdmin', () => {
+    const handlerNames = getHandlerNames('/usage/report');
+    expect(handlerNames).toContain('verifyAdmin');
+  });
+
+  it('registers the quotas GET route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/quotas',
+      methods: ['get'],
+    });
+  });
+
+  it('registers the quotas PUT route', () => {
+    expect(routeEntries).toContainEqual({
+      path: '/quotas',
+      methods: ['put'],
+    });
+  });
+
+  it('guards the quotas routes with verifyAdmin', () => {
+    const handlerNames = getHandlerNames('/quotas');
+    expect(handlerNames).toContain('verifyAdmin');
+  });
+
+  it('registers all known routes', () => {
+    const paths = routeEntries.map((e) => `${e.methods.join(', ').toUpperCase()} ${e.path}`);
+    expect(paths).toContain('GET /models');
+    expect(paths).toContain('GET /overview');
+    expect(paths).toContain('GET /:provider/api-key');
+    expect(paths).toContain('POST /:provider/api-key/rotate');
+    expect(paths).toContain('POST /chat/completion');
+    expect(paths).toContain('POST /image/generation');
+    expect(paths).toContain('POST /embeddings');
+    expect(paths).toContain('GET /usage/report');
+    expect(paths).toContain('GET /quotas');
+    expect(paths).toContain('PUT /quotas');
   });
 });

--- a/backend/tests/unit/ai-routes.test.ts
+++ b/backend/tests/unit/ai-routes.test.ts
@@ -26,8 +26,12 @@ describe('ai route wiring', () => {
     methods: Object.keys(layer.route?.methods ?? {}).sort(),
   }));
 
-  const getHandlerNames = (path: string): string[] => {
-    const route = routeLayers.find((layer) => layer.route?.path === path);
+  const getHandlerNames = (path: string, method?: string): string[] => {
+    const route = routeLayers.find(
+      (layer) =>
+        layer.route?.path === path &&
+        (!method || Object.keys(layer.route?.methods ?? {}).includes(method))
+    );
     return route?.route?.stack.map((handler) => handler.handle.name) ?? [];
   };
 
@@ -51,9 +55,10 @@ describe('ai route wiring', () => {
   });
 
   it('guards the chat completion route with verifyUser, rate limiter, and quota check', () => {
-    const handlerNames = getHandlerNames('/chat/completion');
-    expect(handlerNames).toContain('verifyUser');
-    expect(handlerNames).toContain('checkAIQuota');
+    const handlerNames = getHandlerNames('/chat/completion', 'post');
+    expect(handlerNames[0]).toBe('verifyUser');
+    expect(handlerNames[2]).toBe('checkAIQuota');
+    expect(handlerNames).toHaveLength(4);
   });
 
   it('registers the image generation route', () => {
@@ -64,9 +69,10 @@ describe('ai route wiring', () => {
   });
 
   it('guards the image generation route with verifyUser, rate limiter, and quota check', () => {
-    const handlerNames = getHandlerNames('/image/generation');
-    expect(handlerNames).toContain('verifyUser');
-    expect(handlerNames).toContain('checkAIQuota');
+    const handlerNames = getHandlerNames('/image/generation', 'post');
+    expect(handlerNames[0]).toBe('verifyUser');
+    expect(handlerNames[2]).toBe('checkAIQuota');
+    expect(handlerNames).toHaveLength(4);
   });
 
   it('registers the embeddings route', () => {
@@ -77,9 +83,10 @@ describe('ai route wiring', () => {
   });
 
   it('guards the embeddings route with verifyUser, rate limiter, and quota check', () => {
-    const handlerNames = getHandlerNames('/embeddings');
-    expect(handlerNames).toContain('verifyUser');
-    expect(handlerNames).toContain('checkAIQuota');
+    const handlerNames = getHandlerNames('/embeddings', 'post');
+    expect(handlerNames[0]).toBe('verifyUser');
+    expect(handlerNames[2]).toBe('checkAIQuota');
+    expect(handlerNames).toHaveLength(4);
   });
 
   it('registers the usage report route', () => {
@@ -108,8 +115,13 @@ describe('ai route wiring', () => {
     });
   });
 
-  it('guards the quotas routes with verifyAdmin', () => {
-    const handlerNames = getHandlerNames('/quotas');
+  it('guards the quotas GET route with verifyAdmin', () => {
+    const handlerNames = getHandlerNames('/quotas', 'get');
+    expect(handlerNames).toContain('verifyAdmin');
+  });
+
+  it('guards the quotas PUT route with verifyAdmin', () => {
+    const handlerNames = getHandlerNames('/quotas', 'put');
     expect(handlerNames).toContain('verifyAdmin');
   });
 

--- a/backend/tests/unit/ai-usage.service.test.ts
+++ b/backend/tests/unit/ai-usage.service.test.ts
@@ -271,10 +271,14 @@ describe('AIUsageService', () => {
 
       await service.logUsage(TEST_USER_ID, 'openai/gpt-4', 100, 50, 'chat', 0.001);
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining('INSERT INTO ai.usage_log'),
-        [TEST_USER_ID, 'openai/gpt-4', 100, 50, 0.001, 'chat']
-      );
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO ai.usage_log'), [
+        TEST_USER_ID,
+        'openai/gpt-4',
+        100,
+        50,
+        0.001,
+        'chat',
+      ]);
     });
 
     it('does not throw when insert fails', async () => {

--- a/backend/tests/unit/ai-usage.service.test.ts
+++ b/backend/tests/unit/ai-usage.service.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockQuery, mockPool } = vi.hoisted(() => {
+  const query = vi.fn();
+  const pool = {
+    query,
+  };
+  return { mockQuery: query, mockPool: pool };
+});
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+import { AppError } from '../../src/utils/errors';
+import { AIUsageService } from '../../src/services/ai/ai-usage.service';
+
+const TEST_USER_ID = '00000000-0000-0000-0000-000000000001';
+
+describe('AIUsageService', () => {
+  let service: AIUsageService;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockQuery.mockReset();
+    service = AIUsageService.getInstance();
+  });
+
+  afterEach(() => {
+    mockQuery.mockReset();
+  });
+
+  describe('checkQuota', () => {
+    it('allows request when no quota config exists', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).resolves.toBeUndefined();
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows request when quota config has no limits', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            id: 'cfg-1',
+            user_id: null,
+            max_requests_per_day: null,
+            max_tokens_per_day: null,
+            max_tokens_per_month: null,
+            monthly_spend_cap_usd: null,
+            model_allowlist: null,
+            updated_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).resolves.toBeUndefined();
+    });
+
+    it('blocks request for model not in allowlist', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            id: 'cfg-1',
+            user_id: null,
+            max_requests_per_day: null,
+            max_tokens_per_day: null,
+            max_tokens_per_month: null,
+            monthly_spend_cap_usd: null,
+            model_allowlist: ['openai/gpt-4o', 'anthropic/claude-3'],
+            updated_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toThrow(AppError);
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toMatchObject({
+        code: 'AI_MODEL_NOT_ALLOWED',
+        statusCode: 403,
+      });
+    });
+
+    it('allows request for model in allowlist', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            id: 'cfg-1',
+            user_id: null,
+            max_requests_per_day: null,
+            max_tokens_per_day: null,
+            max_tokens_per_month: null,
+            monthly_spend_cap_usd: null,
+            model_allowlist: ['openai/gpt-4o'],
+            updated_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4o')).resolves.toBeUndefined();
+    });
+
+    it('blocks request when daily request limit exceeded', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'cfg-1',
+              user_id: null,
+              max_requests_per_day: 10,
+              max_tokens_per_day: null,
+              max_tokens_per_month: null,
+              monthly_spend_cap_usd: null,
+              model_allowlist: null,
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 10 }] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toMatchObject({
+        code: 'AI_QUOTA_EXCEEDED',
+        statusCode: 429,
+      });
+    });
+
+    it('blocks request when daily token limit exceeded', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'cfg-1',
+              user_id: null,
+              max_requests_per_day: null,
+              max_tokens_per_day: 10000,
+              max_tokens_per_month: null,
+              monthly_spend_cap_usd: null,
+              model_allowlist: null,
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ total: 10000 }] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toThrow(AppError);
+    });
+
+    it('blocks request when monthly token limit exceeded', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'cfg-1',
+              user_id: null,
+              max_requests_per_day: null,
+              max_tokens_per_day: null,
+              max_tokens_per_month: 500000,
+              monthly_spend_cap_usd: null,
+              model_allowlist: null,
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ total: 500000 }] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toThrow(AppError);
+    });
+
+    it('blocks request when monthly spend cap exceeded', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'cfg-1',
+              user_id: null,
+              max_requests_per_day: null,
+              max_tokens_per_day: null,
+              max_tokens_per_month: null,
+              monthly_spend_cap_usd: 50.0,
+              model_allowlist: null,
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ total: '60.00' }] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).rejects.toThrow(AppError);
+    });
+
+    it('allows request when usage is under all limits', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 'cfg-1',
+              user_id: null,
+              max_requests_per_day: 100,
+              max_tokens_per_day: 100000,
+              max_tokens_per_month: 1000000,
+              monthly_spend_cap_usd: 100.0,
+              model_allowlist: null,
+              updated_at: '2025-01-01T00:00:00Z',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 5 }] })
+        .mockResolvedValueOnce({ rows: [{ total: 10000 }] })
+        .mockResolvedValueOnce({ rows: [{ total: 50000 }] })
+        .mockResolvedValueOnce({ rows: [{ total: '10.00' }] });
+
+      await expect(service.checkQuota(TEST_USER_ID, 'openai/gpt-4')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getEffectiveQuotaConfig', () => {
+    it('returns per-user config when it exists', async () => {
+      const configRow = {
+        id: 'cfg-user',
+        user_id: TEST_USER_ID,
+        max_requests_per_day: 50,
+        max_tokens_per_day: null,
+        max_tokens_per_month: null,
+        monthly_spend_cap_usd: null,
+        model_allowlist: null,
+        updated_at: '2025-01-01T00:00:00Z',
+      };
+      mockQuery.mockResolvedValue({ rows: [configRow] });
+
+      const config = await service.getEffectiveQuotaConfig(TEST_USER_ID);
+      expect(config).toMatchObject({
+        max_requests_per_day: 50,
+        user_id: TEST_USER_ID,
+      });
+    });
+
+    it('returns global default when no per-user config exists', async () => {
+      const defaultRow = {
+        id: 'cfg-default',
+        user_id: null,
+        max_requests_per_day: 100,
+        max_tokens_per_day: null,
+        max_tokens_per_month: null,
+        monthly_spend_cap_usd: null,
+        model_allowlist: null,
+        updated_at: '2025-01-01T00:00:00Z',
+      };
+      mockQuery.mockResolvedValue({ rows: [defaultRow] });
+
+      const config = await service.getEffectiveQuotaConfig(TEST_USER_ID);
+      expect(config).toMatchObject({
+        user_id: null,
+        max_requests_per_day: 100,
+      });
+    });
+
+    it('returns null when no config exists at all', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const config = await service.getEffectiveQuotaConfig(TEST_USER_ID);
+      expect(config).toBeNull();
+    });
+  });
+
+  describe('logUsage', () => {
+    it('inserts a usage log row', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      await service.logUsage(TEST_USER_ID, 'openai/gpt-4', 100, 50, 'chat', 0.001);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO ai.usage_log'),
+        [TEST_USER_ID, 'openai/gpt-4', 100, 50, 0.001, 'chat']
+      );
+    });
+
+    it('does not throw when insert fails', async () => {
+      mockQuery.mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        service.logUsage(TEST_USER_ID, 'openai/gpt-4', 100, 50, 'chat')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getUserUsage', () => {
+    it('returns aggregated usage for a user', async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          {
+            prompt_tokens: 1000,
+            completion_tokens: 500,
+            total_tokens: 1500,
+            estimated_cost: '0.005',
+            request_count: 10,
+          },
+        ],
+      });
+
+      const usage = await service.getUserUsage(TEST_USER_ID, 'day');
+      expect(usage.prompt_tokens).toBe(1000);
+      expect(usage.completion_tokens).toBe(500);
+      expect(usage.total_tokens).toBe(1500);
+      expect(usage.request_count).toBe(10);
+    });
+  });
+
+  describe('getUsageReport', () => {
+    it('returns aggregated report with entries and totals', async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              user_id: TEST_USER_ID,
+              model: 'openai/gpt-4',
+              prompt_tokens: 500,
+              completion_tokens: 300,
+              total_tokens: 800,
+              estimated_cost: '0.002',
+              request_count: 5,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              prompt_tokens: 500,
+              completion_tokens: 300,
+              total_tokens: 800,
+              estimated_cost: '0.002',
+              request_count: 5,
+            },
+          ],
+        });
+
+      const report = await service.getUsageReport('day', TEST_USER_ID);
+      expect(report.entries).toHaveLength(1);
+      expect(report.totals.request_count).toBe(5);
+      expect(report.period).toBe('day');
+    });
+  });
+
+  describe('upsertQuotaConfig', () => {
+    it('creates a new quota config for a user', async () => {
+      const configRow = {
+        id: 'cfg-new',
+        user_id: TEST_USER_ID,
+        max_requests_per_day: 50,
+        max_tokens_per_day: null,
+        max_tokens_per_month: null,
+        monthly_spend_cap_usd: null,
+        model_allowlist: null,
+        updated_at: '2025-01-01T00:00:00Z',
+      };
+      mockQuery.mockResolvedValue({ rows: [configRow] });
+
+      const result = await service.upsertQuotaConfig(TEST_USER_ID, {
+        maxRequestsPerDay: 50,
+      });
+
+      expect(result.max_requests_per_day).toBe(50);
+    });
+  });
+});

--- a/openapi/ai.yaml
+++ b/openapi/ai.yaml
@@ -184,6 +184,112 @@ paths:
         '500':
           description: Failed to generate embeddings
 
+  /api/ai/usage/report:
+    get:
+      summary: Get aggregated AI usage report
+      description: Returns AI usage aggregated by user and model for the given time period. Admin-only.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: period
+          in: query
+          schema:
+            type: string
+            enum: [day, week, month, all]
+            default: month
+          description: Aggregation window
+        - name: userId
+          in: query
+          schema:
+            type: string
+            format: uuid
+          description: Filter by user ID
+        - name: model
+          in: query
+          schema:
+            type: string
+          description: Filter by model name
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Maximum number of entries
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Pagination offset
+      responses:
+        '200':
+          description: Aggregated usage report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageReportResponse'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Failed to generate report
+
+  /api/ai/quotas:
+    get:
+      summary: Get AI quota configs
+      description: Returns all quota configurations, or a specific user's if userId query param is given. Admin-only.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: query
+          schema:
+            type: string
+            format: uuid
+          description: Filter by user ID (returns all if omitted)
+      responses:
+        '200':
+          description: Array of quota configurations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuotaConfig'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Failed to fetch quotas
+    put:
+      summary: Create or update AI quota config
+      description: Creates or updates a quota configuration for a user (or global default when userId is null). Admin-only.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateQuotaConfigRequest'
+      responses:
+        '200':
+          description: Updated quota configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuotaConfig'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '500':
+          description: Failed to update quota config
+
 components:
   securitySchemes:
     bearerAuth:
@@ -669,6 +775,128 @@ components:
         index:
           type: integer
           description: Index of this embedding in the input array
+
+    # ============= Usage Tracking & Quota Schemas =============
+
+    UsageReportResponse:
+      type: object
+      properties:
+        entries:
+          type: array
+          description: Usage aggregated by user and model
+          items:
+            $ref: '#/components/schemas/UsageReportEntry'
+        totals:
+          $ref: '#/components/schemas/UsageTotals'
+        period:
+          type: string
+          enum: [day, week, month, all]
+          description: The aggregation window
+
+    UsageReportEntry:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+          description: User who made the requests
+        model:
+          type: string
+          description: AI model used
+        promptTokens:
+          type: integer
+          description: Total prompt tokens consumed
+        completionTokens:
+          type: integer
+          description: Total completion tokens generated
+        totalTokens:
+          type: integer
+          description: Total tokens (prompt + completion)
+        estimatedCost:
+          type: number
+          format: double
+          description: Estimated cost in USD
+        requestCount:
+          type: integer
+          description: Number of requests
+
+    UsageTotals:
+      type: object
+      properties:
+        promptTokens:
+          type: integer
+        completionTokens:
+          type: integer
+        totalTokens:
+          type: integer
+        estimatedCost:
+          type: number
+        requestCount:
+          type: integer
+
+    QuotaConfig:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+          nullable: true
+          description: NULL represents project-wide default
+        maxRequestsPerDay:
+          type: integer
+          nullable: true
+          description: Maximum API requests per day
+        maxTokensPerDay:
+          type: integer
+          nullable: true
+          description: Maximum total tokens per day
+        maxTokensPerMonth:
+          type: integer
+          nullable: true
+          description: Maximum total tokens per month
+        monthlySpendCapUsd:
+          type: number
+          format: double
+          nullable: true
+          description: Maximum spend per month in USD
+        modelAllowlist:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: If set, restricts user to only these model IDs
+        updatedAt:
+          type: string
+          format: date-time
+
+    UpdateQuotaConfigRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+          nullable: true
+          description: NULL to update global defaults
+        maxRequestsPerDay:
+          type: integer
+          nullable: true
+        maxTokensPerDay:
+          type: integer
+          nullable: true
+        maxTokensPerMonth:
+          type: integer
+          nullable: true
+        monthlySpendCapUsd:
+          type: number
+          nullable: true
+        modelAllowlist:
+          type: array
+          items:
+            type: string
+          nullable: true
 
     ErrorResponse:
       type: object

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -330,6 +330,68 @@ export const openRouterKeySchema = z.object({
   maskedKey: z.string(),
 });
 
+// ============= AI Usage Tracking & Quota Schemas =============
+
+export const usageLogSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  model: z.string(),
+  promptTokens: z.number().int().nonnegative(),
+  completionTokens: z.number().int().nonnegative(),
+  estimatedCost: z.number().nonnegative(),
+  endpoint: z.enum(['chat', 'image', 'embedding']),
+  createdAt: z.string().datetime(),
+});
+
+export const quotaConfigSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid().nullable(),
+  maxRequestsPerDay: z.number().int().positive().nullable(),
+  maxTokensPerDay: z.number().int().positive().nullable(),
+  maxTokensPerMonth: z.number().int().positive().nullable(),
+  monthlySpendCapUsd: z.number().positive().nullable(),
+  modelAllowlist: z.array(z.string()).nullable(),
+  updatedAt: z.string().datetime(),
+});
+
+export const updateQuotaConfigRequestSchema = z.object({
+  maxRequestsPerDay: z.number().int().positive().nullable().optional(),
+  maxTokensPerDay: z.number().int().positive().nullable().optional(),
+  maxTokensPerMonth: z.number().int().positive().nullable().optional(),
+  monthlySpendCapUsd: z.number().positive().nullable().optional(),
+  modelAllowlist: z.array(z.string()).nullable().optional(),
+});
+
+export const usageReportQuerySchema = z.object({
+  userId: z.string().uuid().optional(),
+  period: z.enum(['day', 'week', 'month', 'all']).optional().default('month'),
+  model: z.string().optional(),
+  limit: z.coerce.number().int().positive().optional().default(50),
+  offset: z.coerce.number().int().nonnegative().optional().default(0),
+});
+
+export const usageReportEntrySchema = z.object({
+  userId: z.string().uuid(),
+  model: z.string(),
+  promptTokens: z.number().int().nonnegative(),
+  completionTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  estimatedCost: z.number().nonnegative(),
+  requestCount: z.number().int().nonnegative(),
+});
+
+export const usageReportSchema = z.object({
+  entries: z.array(usageReportEntrySchema),
+  totals: z.object({
+    promptTokens: z.number().int().nonnegative(),
+    completionTokens: z.number().int().nonnegative(),
+    totalTokens: z.number().int().nonnegative(),
+    estimatedCost: z.number().nonnegative(),
+    requestCount: z.number().int().nonnegative(),
+  }),
+  period: z.enum(['day', 'week', 'month', 'all']),
+});
+
 // Export types
 export type ToolFunction = z.infer<typeof toolFunctionSchema>;
 export type Tool = z.infer<typeof toolSchema>;
@@ -345,7 +407,6 @@ export type WebSearchPlugin = z.infer<typeof webSearchPluginSchema>;
 export type FileParserPlugin = z.infer<typeof fileParserPluginSchema>;
 export type UrlCitationAnnotation = z.infer<typeof urlCitationAnnotationSchema>;
 export type FileAnnotation = z.infer<typeof fileAnnotationSchema>;
-export type Annotation = z.infer<typeof annotationSchema>;
 export type ChatCompletionRequest = z.infer<typeof chatCompletionRequestSchema>;
 export type ChatCompletionResponse = z.infer<typeof chatCompletionResponseSchema>;
 export type ImageGenerationRequest = z.infer<typeof imageGenerationRequestSchema>;
@@ -357,3 +418,8 @@ export type AIModelSchema = z.infer<typeof aiModelSchema>;
 export type AIOverviewMetricPoint = z.infer<typeof aiOverviewMetricPointSchema>;
 export type AIOverview = z.infer<typeof aiOverviewSchema>;
 export type OpenRouterKey = z.infer<typeof openRouterKeySchema>;
+export type UsageLog = z.infer<typeof usageLogSchema>;
+export type QuotaConfig = z.infer<typeof quotaConfigSchema>;
+export type UpdateQuotaConfigRequest = z.infer<typeof updateQuotaConfigRequestSchema>;
+export type UsageReportQuery = z.infer<typeof usageReportQuerySchema>;
+export type UsageReport = z.infer<typeof usageReportSchema>;

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -360,6 +360,7 @@ export const updateQuotaConfigRequestSchema = z.object({
   maxTokensPerMonth: z.number().int().positive().nullable().optional(),
   monthlySpendCapUsd: z.number().positive().nullable().optional(),
   modelAllowlist: z.array(z.string()).nullable().optional(),
+  userId: z.string().uuid().nullable().optional(),
 });
 
 export const usageReportQuerySchema = z.object({

--- a/packages/shared-schemas/src/error-codes.schema.ts
+++ b/packages/shared-schemas/src/error-codes.schema.ts
@@ -54,7 +54,14 @@ const realtimeErrorCodes = [
   'REALTIME_UNAUTHORIZED',
 ] as const;
 
-const aiErrorCodes = ['AI_INVALID_API_KEY', 'AI_INVALID_MODEL', 'AI_UPSTREAM_UNAVAILABLE'] as const;
+const aiErrorCodes = [
+  'AI_INVALID_API_KEY',
+  'AI_INVALID_MODEL',
+  'AI_UPSTREAM_UNAVAILABLE',
+  'AI_QUOTA_EXCEEDED',
+  'AI_MODEL_NOT_ALLOWED',
+  'AI_USAGE_REPORT_ERROR',
+] as const;
 
 const analyticsErrorCodes = ['ANALYTICS_NOT_CONNECTED', 'ANALYTICS_UNAVAILABLE'] as const;
 


### PR DESCRIPTION
## Summary
The AI Gateway had no guardrails at all — any authenticated user could call expensive models with no limits and no record of what they were doing. This adds three things:
1. Usage tracking — every AI request gets logged (who, what model, how many tokens, rough cost). Failures to log are silently swallowed so they never break a request.
2. Quotas — admins can cap users on requests/day, tokens/day, tokens/month, monthly spend, or restrict them to specific models. Sensible defaults are seeded (1000 req/day, 2M tokens/day, $50/month). Hit a limit and you get a clear 429 or 403.
3. Per-user rate limits — separate buckets per user (not per IP), so hitting the API from multiple devices doesn't bypass them. Chat gets 60/min, image 30/min, embeddings 120/min.
There's also new admin endpoints to view usage reports and manage quotas, plus a small fix for the streaming endpoint which was emitting zero-value tokenUsage events on every chunk.

There's also new admin endpoints to view usage reports and manage quotas, plus a small fix for the streaming endpoint which was emitting zero-value tokenUsage events on every chunk.


## How did you test this change?
31 new unit tests (service logic + route wiring), full regression suite passes (1771 tests), TypeScript compiles clean on both the backend and shared-schemas packages. Also tested manually against a running instance to verify quota blocking, rate limit activation, and usage logging all work as expected.

### closes #1683 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-user usage tracking, quotas, and per-user rate limits to the AI Gateway to control spend and prevent abuse, plus admin usage reports and quota management. Streaming chats now only emit non‑zero `tokenUsage` and we log final token counts and cost after streaming. Closes #1683.

- **New Features**
  - Track per-request usage (user, model, tokens, estimated cost); logging is best-effort and never blocks.
  - Enforce quotas via `checkAIQuota`: requests/day, tokens/day, tokens/month, monthly spend, and optional model allowlist; sensible defaults seeded.
  - Per-user rate limits (keyed by user id): chat 60/min, image 30/min, embeddings 120/min.
  - Wire usage logging into chat (streaming and non‑streaming), image, and embeddings endpoints.
  - Admin APIs: GET /api/ai/usage/report and GET/PUT /api/ai/quotas; OpenAPI and `@insforge/shared-schemas` updated with usage/quota schemas and new error codes.

- **Migration**
  - Run DB migration 060_ai-usage-tracking.sql to create `ai.usage_log` (RLS) and admin-only `ai.quota_config`, add indexes, seed a global default, and enforce a single global default via a partial unique index.
  - No config changes required; routes remain behind verifyUser/verifyAdmin.

<sup>Written for commit da2f29aeee0e1ab73720c761a6f24b9aade17093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-user usage tracking, quota enforcement, and rate limiting to the AI Gateway
> - Adds `AIUsageService` to track per-request token usage and estimated cost in a new `ai.usage_log` table, with configurable per-user and global quota configs in `ai.quota_config`.
> - Enforces per-user rate limits on chat (60 req/min), image (30 req/min), and embedding (120 req/min) endpoints using new express-rate-limit middleware in [rate-limiters.ts](https://github.com/InsForge/InsForge/pull/1692/files#diff-480baae8624beaf0acd251f42ee5b1770f4ce53f5b14346ed6f91efe75227d21).
> - Adds a `checkAIQuota` middleware to all AI routes that rejects requests exceeding daily/monthly token caps, daily request caps, monthly spend caps, or using disallowed models.
> - Adds three admin-only endpoints: `GET /api/ai/usage/report`, `GET /api/ai/quotas`, and `PUT /api/ai/quotas` for reporting and quota management.
> - Fixes streaming chat to emit a single non-zero `tokenUsage` event (on the final chunk) rather than multiple zero-value events.
> - Risk: quota checks add synchronous DB queries to every AI request; usage logging failures are caught and demoted to warnings rather than failing the request.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da2f29a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI usage tracking for chat, image generation, and embeddings, including token/request counts and estimated USD cost.
  * Added per-user AI quota enforcement (daily/monthly request & token limits, monthly spend cap) with optional model allowlisting and global defaults.
  * Added admin APIs to view aggregated usage reports and manage quota settings.
  * Added/updated per-user AI rate limiting (returns **429** when exceeded).
* **Bug Fixes**
  * Improved streaming chat usage reporting to reduce noisy zero-value updates.
* **Documentation**
  * Updated API and shared schemas for usage reporting and quota management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->