### PR TITLE
Document project upgrade and deletion in CLI harness docs

### DIFF
--- a/docs/agent-native/cli-harness.mdx
+++ b/docs/agent-native/cli-harness.mdx
@@ -37,7 +37,7 @@ npx @insforge/cli projects delete --project <id>
 
 `projects update-version` moves the project to the latest InsForge backend version. It targets the linked project by default (pass `--project <id>` to pick another) and restarts the instance, so expect a brief downtime; add `--wait` to block until the update finishes.
 
-`projects delete` permanently deletes the project: its database, storage, and every other resource, including its backend branches. Here `--project` is required and never falls back to the linked project, so a stray ambient value can't point the deletion at the wrong one. Both commands ask for confirmation before acting, and deletion is one prompt an agent should never bypass: it is irreversible.
+`projects delete` permanently deletes the project: its database, storage, and every other resource, including its backend branches. Here `--project` is required and never falls back to the linked project, so a stray ambient value can't point the deletion at the wrong one. Both commands confirm before acting, but only in interactive mode: `--yes` and `--json` each skip the prompt, so `projects delete --project <id> --json` deletes immediately. Deletion is irreversible. Never pass `--yes` here, and have a human verify the exact project id before the command runs.
 
 To do either from the dashboard instead, both live under **Settings → General**.
 

--- a/docs/agent-native/cli-harness.mdx
+++ b/docs/agent-native/cli-harness.mdx
@@ -19,7 +19,7 @@ A dashboard is built for a human pointer; a CLI is built for anything that can w
 | Area | Commands |
 |------|----------|
 | Auth & context | `login`, `logout`, `whoami`, `current`, `list` |
-| Project | `create`, `link` |
+| Project | `create`, `link`, `projects update-version`, `projects delete` |
 | Schema | `db migrations new`, `db migrations up`, `db migrations list` |
 | Config as code | `config plan`, `config apply`, `config export` |
 | Branching | `branch create`, `branch merge`, `branch reset`, `branch delete` |
@@ -27,6 +27,19 @@ A dashboard is built for a human pointer; a CLI is built for anything that can w
 | Diagnose | `diagnose`, `diagnose advisor`, `diagnose db`, `diagnose logs`, `metadata` |
 
 Run `npx @insforge/cli help <command>` for the flags on any of these.
+
+## Upgrading and deleting a project
+
+```bash
+npx @insforge/cli projects update-version
+npx @insforge/cli projects delete --project <id>
+```
+
+`projects update-version` moves the project to the latest InsForge backend version. It targets the linked project by default (pass `--project <id>` to pick another) and restarts the instance, so expect a brief downtime; add `--wait` to block until the update finishes.
+
+`projects delete` permanently deletes the project: its database, storage, and every other resource, including its backend branches. Here `--project` is required and never falls back to the linked project, so a stray ambient value can't point the deletion at the wrong one. Both commands ask for confirmation before acting, and deletion is one prompt an agent should never bypass: it is irreversible.
+
+To do either from the dashboard instead, both live under **Settings → General**.
 
 ## A typical agent run
 


### PR DESCRIPTION
The public docs never mention how to delete or upgrade a project. This adds an "Upgrading and deleting a project" section to the CLI harness page, right below the command surface table:

- `projects update-version`: targets the linked project by default, restarts the instance (brief downtime), `--wait` to block until done
- `projects delete`: requires an explicit `--project <id>` (never falls back to the linked project), irreversible, cascades to backend branches
- One-line pointer to the dashboard path (Settings → General) for doing either from the UI

Also adds both commands to the Project row of the command surface table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to upgrade or delete a project in the CLI harness and add both commands to the Project command table. Clarifies defaults, downtime, required flags, and when confirmations are skipped.

Explains `projects update-version` (targets linked project by default; overridable with `--project`; restarts with brief downtime; supports `--wait`) and `projects delete` (requires `--project <id>`; irreversible; cascades to backend branches; confirms only in interactive mode—`--yes` or `--json` skip and delete immediately). Adds a pointer to the dashboard path (Settings → General) for doing either from the UI.

<sup>Written for commit 198a6434d3de89bd6d0274adc97d302a0d92e44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `projects update-version` and `projects delete` commands in CLI harness docs
> Adds a new 'Upgrading and deleting a project' section to [cli-harness.mdx](https://github.com/InsForge/InsForge/pull/1698/files#diff-def154254f5b80fae9d0ec3cff04a3a5d917ccae4b311c0dd2ff5a3d79dd8c85) covering two CLI commands. Documents that `projects update-version` targets the linked project by default (overridable with `--project`), restarts the instance, and supports `--wait`. Documents that `projects delete` requires an explicit `--project` flag and is irreversible. Both commands prompt for confirmation before executing.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1698 opened
>
> - Clarified confirmation behavior for `projects delete` and `projects update-version` commands [198a643]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 206d74f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the CLI “Command surface” to include two new Project subcommands: `projects update-version` and `projects delete`.
  - Added an “Upgrading and deleting a project” section with example usage, including default targeting behavior for updates and required `--project <id>` for deletes.
  - Documented upgrade downtime expectations, irreversible deletion semantics, and confirmation/skip prompt behavior with `--yes` and `--json`, plus corresponding dashboard guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->