### PR TITLE
fix: API crashes on Postgres restart via unhandled pg client 'error' events

### DIFF
--- a/backend/src/infra/database/database.manager.ts
+++ b/backend/src/infra/database/database.manager.ts
@@ -56,6 +56,14 @@ export class DatabaseManager {
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 2000,
     });
+
+    // pg emits 'error' on the pool when an IDLE client's connection drops
+    // (e.g. Postgres restart). Without this listener that event is an
+    // unhandled 'error' and crashes the process; the pool already discards
+    // the broken client and creates a fresh one on next checkout.
+    this.pool.on('error', (error) => {
+      logger.error('Postgres pool idle client error', { error: error.message });
+    });
   }
 
   static async getColumnTypeMap(

--- a/backend/src/infra/realtime/realtime.manager.ts
+++ b/backend/src/infra/realtime/realtime.manager.ts
@@ -50,27 +50,30 @@ export class RealtimeManager {
     // Create a dedicated client for LISTEN (cannot use pooled connections)
     this.listenerClient = DatabaseManager.getInstance().createClient();
 
+    // Attach handlers BEFORE connect(): a client whose connect() fails can
+    // still emit 'error' asynchronously afterwards ("Connection terminated
+    // unexpectedly"), and an unhandled 'error' event crashes the process.
+    this.listenerClient.on('notification', (msg) => {
+      if (msg.channel === 'realtime_message' && msg.payload) {
+        void this.handlePGNotification(msg.payload);
+      }
+    });
+
+    this.listenerClient.on('error', (error) => {
+      logger.error('RealtimeManager connection error', { error: error.message });
+      this.handleDisconnect();
+    });
+
+    this.listenerClient.on('end', () => {
+      logger.warn('RealtimeManager connection ended');
+      this.handleDisconnect();
+    });
+
     try {
       await this.listenerClient.connect();
       await this.listenerClient.query('LISTEN realtime_message');
       this.isConnected = true;
       this.reconnectAttempts = 0;
-
-      this.listenerClient.on('notification', (msg) => {
-        if (msg.channel === 'realtime_message' && msg.payload) {
-          void this.handlePGNotification(msg.payload);
-        }
-      });
-
-      this.listenerClient.on('error', (error) => {
-        logger.error('RealtimeManager connection error', { error: error.message });
-        this.handleDisconnect();
-      });
-
-      this.listenerClient.on('end', () => {
-        logger.warn('RealtimeManager connection ended');
-        this.handleDisconnect();
-      });
 
       logger.info('RealtimeManager initialized and listening');
     } catch (error) {
@@ -197,6 +200,9 @@ export class RealtimeManager {
 
     if (this.listenerClient) {
       this.listenerClient.removeAllListeners();
+      // The dead client's socket can emit one more 'error' after teardown;
+      // without a listener that late event crashes the process.
+      this.listenerClient.on('error', () => {});
       this.listenerClient = null;
     }
 


### PR DESCRIPTION
## Symptom

On a prod nano (v2.2.6), every Postgres container restart also crashed the API container (`RestartCount=5` from repeated DB restarts). Log sequence: RealtimeManager logs its handled connection error, then the process dies with:

```
Error: Connection terminated unexpectedly
Emitted 'error' event on Client instance at Client._handleErrorEvent (pg/lib/client.js:411)
```

So a ~10s DB blip becomes a full API outage on top of it (compounded by npm-wrapper restart latency — see #1707).

## Root causes (3 small holes, same class)

1. `realtime.manager.ts` attached `.on('error')` only **after** `await connect()` + `LISTEN` succeed — during the reconnect loop a client whose `connect()` rejects has no handler when its socket later emits the async 'error'.
2. `handleDisconnect()` calls `removeAllListeners()` on the dead client, which can still emit one more late 'error'.
3. The shared `Pool` had no `'error'` listener — pg emits pool-level 'error' when an **idle** client's connection drops (exactly what a DB restart does to a 20-max idle pool).

## Fix

- Attach notification/error/end handlers before `connect()` (reconnect flow unchanged; `handleDisconnect` is already re-entrant safe: null-check + single `reconnectTimeout`).
- Leave a no-op 'error' listener on torn-down clients.
- `pool.on('error')` → log; the pool already discards broken clients and creates fresh ones on next checkout.

## Tested

`tsc --noEmit` clean, plus a live restart test: built the runner image from this branch, booted it against ghcr.io/insforge/postgres:v15.13.4, then `docker restart`ed the postgres container while the API was up.

- API container survived: same `StartedAt`, `RestartCount=0`, `/api/health` back to 200 after the blip.
- Logs show the previously-fatal events now handled: `RealtimeManager connection error` + **3x `Postgres pool idle client error`** ("terminating connection due to administrator command") — the idle-pool events were the unhandled crash pre-fix.

Pre-fix control: the same postgres-restart on prod v2.2.6 crashed the API every time (observed RestartCount=5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9NtiFkU34HQQgRSffNb4k

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix API crashes on Postgres restart by handling unhandled `error` events in database and realtime managers
> - Adds an `error` event listener to the pg `Pool` in [`DatabaseManager.initialize`](https://github.com/InsForge/InsForge/pull/1708/files#diff-87be7972af532e332149b821a1998be60387341564cef1030f7f2f3ff8337dc9) so idle client disconnects are logged rather than crashing the process.
> - Moves `error`, `end`, and `notification` listeners on the dedicated pg `Client` in [`RealtimeManager.initialize`](https://github.com/InsForge/InsForge/pull/1708/files#diff-2d3467ffb00774b71934a939ac1284bb1654b9380fecf443ad5dfecc47fc3dc3) to before `connect()`, so errors during connection are caught and trigger the reconnection flow.
> - Adds a no-op `error` listener in `RealtimeManager.handleDisconnect` after `removeAllListeners()` to swallow any late errors from the torn-down socket before nulling the client reference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ed1227.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection error handling to prevent unexpected application crashes.
  * Stabilized real-time connection failures by safely handling asynchronous errors and cleanup events.
  * Preserved automatic reconnection behavior when real-time connections are interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->