### PR TITLE
docs: distinguish deploying your app (Sites) from self-hosting InsForge

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -4,12 +4,9 @@ Vocab = Mintlify
 [*.{md,mdx}]
 Vale.Spelling = YES
 
-# Localized docs are validated by native review, not the English speller —
-# Vale.Spelling would flag every zh/zh-TW/es word as a misspelling. Globs are
-# listed both relative to this file and repo-root-prefixed so the disable
-# applies regardless of vale's working directory.
-[{zh,zh-Hant,es}/**]
-Vale.Spelling = NO
-
-[docs/{zh,zh-Hant,es}/**]
+# Localized docs are validated by native review, not the English speller;
+# Vale.Spelling would flag every zh/zh-TW/es word as a misspelling. The leading
+# **/ matches the locale segment under any path prefix, including the absolute
+# paths Mintlify's hosted runner passes (relative-only globs miss those).
+[**/{zh,zh-Hant,es}/**]
 Vale.Spelling = NO

--- a/docs/core-concepts/sites/overview.mdx
+++ b/docs/core-concepts/sites/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "Deploy frontend apps from your project, powered by Vercel."
 ---
 
-Use InsForge Sites to ship the browser-facing app that belongs to your project. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production deployment. The dashboard tracks the URL, status, deployment history, environment variables, and domains.
+Use InsForge Sites to deploy, publish, ship, or go live with the browser-facing app you built on InsForge. If you are asking "can I deploy my app?" or "how do I take my app live?", Sites is the answer. The InsForge CLI uploads your frontend source through InsForge, which creates a Vercel production deployment. The dashboard tracks the URL, status, deployment history, environment variables, and domains.
 
 <Frame caption="Sites dashboard: status, domains, env vars, and deployment history.">
   <img src="/images/dashboard-sites.png" alt="InsForge Sites dashboard" />
@@ -12,6 +12,10 @@ Use InsForge Sites to ship the browser-facing app that belongs to your project. 
 
 <Note>
   **Need to deploy a container or backend service?** Use [Compute](/core-concepts/compute/overview) for workers, queues, WebSocket servers, and long-running services. Sites are for frontend websites and framework builds that produce a hosted web app.
+</Note>
+
+<Note>
+  **Trying to run InsForge itself on your own servers?** That is self-hosting the InsForge platform, not deploying your app. See [Self-Hosting](/deployment/deployment-security-guide) (AWS EC2, GCP, Azure, and any Linux VPS). Sites deploys the app you built; self-hosting deploys the InsForge backend that your app runs on.
 </Note>
 
 ```mermaid

--- a/docs/core-concepts/sites/overview.mdx
+++ b/docs/core-concepts/sites/overview.mdx
@@ -15,7 +15,7 @@ Use InsForge Sites to deploy, publish, ship, or go live with the browser-facing 
 </Note>
 
 <Note>
-  **Trying to run InsForge itself on your own servers?** That is self-hosting the InsForge platform, not deploying your app. See [Self-Hosting](/deployment/deployment-security-guide) (AWS EC2, GCP, Azure, and any Linux VPS). Sites deploys the app you built; self-hosting deploys the InsForge backend that your app runs on.
+  **Trying to run InsForge itself on your own servers?** That is self-hosting the InsForge platform, not deploying your app. See the self-hosting guides for [AWS EC2](/deployment/deploy-to-aws-ec2), [GCP](/deployment/deploy-to-google-cloud-compute-engine), [Azure](/deployment/deploy-to-azure-virtual-machines), or any [Linux VPS](/deployment/deployment-security-guide). Sites deploys the app you built; self-hosting deploys the InsForge backend that your app runs on.
 </Note>
 
 ```mermaid

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,6 +1,8 @@
 # InsForge Deployment Guides
 
-This directory contains deployment guides for self-hosting InsForge on various platforms.
+This directory contains deployment guides for self-hosting the InsForge platform on various platforms.
+
+> Looking to deploy the app you built on InsForge (take it live)? That is [Sites](../core-concepts/sites/overview), not self-hosting. The guides below are for running the InsForge backend on infrastructure you control.
 
 ## 📚 Available Guides
 

--- a/docs/deployment/deploy-to-aws-ec2.md
+++ b/docs/deployment/deploy-to-aws-ec2.md
@@ -1,11 +1,15 @@
 ---
-title: "Deploy InsForge to AWS EC2"
-description: "Step-by-step guide to deploy InsForge on an AWS EC2 instance using Docker Compose, including SSH setup, domain config, and TLS termination."
+title: "Self-Host InsForge on AWS EC2"
+description: "Step-by-step guide to self-host the InsForge platform on an AWS EC2 instance using Docker Compose, including SSH setup, domain config, and TLS termination."
 ---
 
-# Deploy InsForge to AWS EC2
+# Self-Host InsForge on AWS EC2
 
-This guide will walk you through deploying InsForge on an AWS EC2 instance using Docker Compose.
+This guide will walk you through self-hosting the InsForge platform on an AWS EC2 instance using Docker Compose.
+
+<Note>
+  **This deploys InsForge itself, not the app you built.** If you just want to take your app live, use [Sites](/core-concepts/sites/overview) instead. This guide is for running the InsForge backend on your own infrastructure.
+</Note>
 
 <Note>
   This cloud walkthrough is community-maintained and can lag the latest InsForge release. The canonical, always-current setup is the `deploy/docker-compose/` directory in the [InsForge repo](https://github.com/InsForge/InsForge).

--- a/docs/deployment/deploy-to-azure-virtual-machines.md
+++ b/docs/deployment/deploy-to-azure-virtual-machines.md
@@ -1,6 +1,15 @@
-# 📖 Deploying InsForge to Azure Virtual Machines (Extended Guide)
+---
+title: "Self-Host InsForge on Azure Virtual Machines"
+description: "Self-host the InsForge platform on an Azure Virtual Machine using Docker Compose, covering SSH access, custom domains, HTTPS, and production hardening."
+---
 
-This guide provides comprehensive, step-by-step instructions for deploying, managing, and securing InsForge on an Azure Virtual Machine (VM) using Docker Compose.
+# 📖 Self-Hosting InsForge on Azure Virtual Machines (Extended Guide)
+
+This guide provides comprehensive, step-by-step instructions for self-hosting, managing, and securing the InsForge platform on an Azure Virtual Machine (VM) using Docker Compose.
+
+<Note>
+  **This deploys InsForge itself, not the app you built.** If you just want to take your app live, use [Sites](/core-concepts/sites/overview) instead. This guide is for running the InsForge backend on your own infrastructure.
+</Note>
 
 <Note>
   This cloud walkthrough is community-maintained and can lag the latest InsForge release. The canonical, always-current setup is the `deploy/docker-compose/` directory in the [InsForge repo](https://github.com/InsForge/InsForge).

--- a/docs/deployment/deploy-to-containarium.md
+++ b/docs/deployment/deploy-to-containarium.md
@@ -1,11 +1,15 @@
 ---
-title: "Deploy InsForge to Containarium"
-description: "Run InsForge on a Containarium LXC host with per-tenant containers, ZFS snapshots, and MCP-driven provisioning for agent-native deployments."
+title: "Self-Host InsForge on Containarium"
+description: "Self-host the InsForge platform on a Containarium LXC host with per-tenant containers, ZFS snapshots, and MCP-driven provisioning for agent-native deployments."
 ---
 
-# Deploy InsForge to Containarium
+# Self-Host InsForge on Containarium
 
-This guide walks through deploying InsForge on a [Containarium](https://github.com/footprintai/containarium) host. Containarium is an open-source, self-hostable platform that gives each tenant a persistent Linux container (LXC) with first-class SSH, MCP, and TLS-on-a-hostname primitives — a natural fit for agent-driven InsForge deployments.
+This guide walks through self-hosting the InsForge platform on a [Containarium](https://github.com/footprintai/containarium) host. Containarium is an open-source, self-hostable platform that gives each tenant a persistent Linux container (LXC) with first-class SSH, MCP, and TLS-on-a-hostname primitives, a natural fit for agent-driven InsForge deployments.
+
+<Note>
+  **This deploys InsForge itself, not the app you built.** If you just want to take your app live, use [Sites](/core-concepts/sites/overview) instead. This guide is for running the InsForge backend on your own infrastructure.
+</Note>
 
 <Note>
   This guide is community-maintained and can lag the latest InsForge release. The canonical, always-current setup is the `deploy/docker-compose/` directory in the [InsForge repo](https://github.com/InsForge/InsForge).

--- a/docs/deployment/deploy-to-google-cloud-compute-engine.md
+++ b/docs/deployment/deploy-to-google-cloud-compute-engine.md
@@ -1,11 +1,15 @@
 ---
-title: "Deploy InsForge to Google Cloud Compute Engine"
-description: "Deploy InsForge on a Google Cloud Compute Engine VM with Docker Compose, covering firewall rules, SSH access, custom domains, and HTTPS setup."
+title: "Self-Host InsForge on Google Cloud Compute Engine"
+description: "Self-host the InsForge platform on a Google Cloud Compute Engine VM with Docker Compose, covering firewall rules, SSH access, custom domains, and HTTPS setup."
 ---
 
-# Deploy InsForge to Google Cloud Compute Engine
+# Self-Host InsForge on Google Cloud Compute Engine
 
-This guide will walk you through deploying InsForge on Google Cloud Compute Engine using Docker Compose.
+This guide will walk you through self-hosting the InsForge platform on Google Cloud Compute Engine using Docker Compose.
+
+<Note>
+  **This deploys InsForge itself, not the app you built.** If you just want to take your app live, use [Sites](/core-concepts/sites/overview) instead. This guide is for running the InsForge backend on your own infrastructure.
+</Note>
 
 <Note>
   This cloud walkthrough is community-maintained and can lag the latest InsForge release. The canonical, always-current setup is the `deploy/docker-compose/` directory in the [InsForge repo](https://github.com/InsForge/InsForge).

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -5,6 +5,10 @@ description: "Deploy InsForge on a generic Linux VPS, harden it with firewall, S
 
 # Deployment & Security Guide for VPS Installation
 
+<Note>
+  **This deploys the InsForge platform itself onto your own server (self-hosting), not the app you built.** If you just want to take your app live, use [Sites](/core-concepts/sites/overview) instead. Read on only if you want to run the InsForge backend on infrastructure you control.
+</Note>
+
 This comprehensive guide covers deploying InsForge on a generic VPS (Virtual Private Server) for production, hardening your instance with security best practices, and maintaining it over time with safe updates and rollback procedures.
 
 > **Scope**: This guide is provider-agnostic. It works on any Linux VPS — Ubuntu/Debian recommended — from providers such as DigitalOcean, Hetzner, Linode, Vultr, OVH, or a bare-metal server. For cloud-specific guides (AWS EC2, GCP, Azure, Render), see the other guides in this section.


### PR DESCRIPTION
## Problem

In Ask AI, a user who built an app on InsForge asked **"can I deploy"** and got routed to the self-hosting guides (AWS EC2 / GCP / Azure), suggesting they stand up their own VPS. The right answer was **Sites** (`npx @insforge/cli deployments deploy ./frontend`).

Root cause: the word "deploy" was owned by the wrong pages. The self-hosting guides had slugs `deploy-to-*` and titles "Deploy InsForge to X" (highest "deploy" keyword density), while the actual go-live feature is titled "Sites" with no "deploy" in its slug/title. Nothing disambiguated the two.

## Changes

- **Sites overview**: intro now uses deploy/publish/ship/go-live language and answers "can I deploy my app?" directly; adds a Note pointing to Self-Hosting for the platform-hosting case.
- **Self-hosting guides** (AWS EC2, GCP, Azure, Containarium): retitled `Deploy InsForge to X` → `Self-Host InsForge on X` to lower "deploy" keyword weight; each gets a Note clarifying "this deploys InsForge itself, not your app → use Sites." Azure page also gains proper frontmatter title/description.
- **VPS security guide + section README**: same reverse disambiguation Note routing app-deploy intent to Sites.

Slugs are unchanged (existing redirect covers URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the difference between deploying your app with Sites and self-hosting the InsForge platform, so “can I deploy?” routes to Sites. Also improves spellcheck config to ignore localized docs even with absolute paths.

- **Refactors**
  - Sites overview uses deploy/go-live language and adds a Note linking directly to self-hosting guides for AWS EC2, GCP, Azure, and a generic Linux VPS.
  - Retitled self-hosting guides to “Self-Host InsForge on X” and added a note that they deploy the platform, not your app; fixed Azure frontmatter.
  - Updated deployment README and VPS security guide with the same clarification. Slugs unchanged.
  - Vale config now uses a single `**/{zh,zh-Hant,es}/**` glob to disable spelling on localized docs, matching absolute paths from Mintlify’s runner.

<sup>Written for commit 903f13438b803f8baf0ce5b9cd6f5808d64037b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Distinguish app deployment via Sites from self-hosting the InsForge platform in docs
> Users were conflating Sites (deploying their app) with self-hosting InsForge (running the backend on their own servers). This PR clarifies the distinction across the deployment and Sites documentation.
>
> - Updates [sites/overview.mdx](https://github.com/InsForge/InsForge/pull/1710/files#diff-e9d84cdf0c8f084dc96a7fa10e4175e3eec43b6c702382a4e9ddd885c2dd29d1) to frame Sites explicitly as app publishing, with a Note linking to Self-Hosting for platform-level deployments
> - Adds redirecting blockquotes and Notes to [deployment/README.md](https://github.com/InsForge/InsForge/pull/1710/files#diff-0046e25d3c5e1fff8d8a39d2e65f24aa9cb1b9bb533ac9bfcf06a39bd0380796) and all cloud-specific guides (AWS EC2, Azure, GCE, Containarium) pointing app-deployment users to Sites
> - Renames titles and headings across deployment guides to use "Self-Host InsForge on ..." phrasing consistently
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b389e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Broadened the Sites overview to clearly cover publishing/going live while contrasting it with self-hosting the InsForge platform.
  * Reframed multiple deployment guides (AWS EC2, Azure VMs, Containarium, Google Compute Engine) as self-hosting, including notes that these steps deploy the platform—not the built app—and point readers to the Sites workflow for taking the app live.
  * Added an upfront distinction note to the deployment/security guide.
* **Chores**
  * Updated Vale configuration to disable spelling checks for localized documentation only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->