### PR TITLE
fix: prevent Model Gateway credential errors from logging out admins

### DIFF
--- a/backend/src/providers/ai/openrouter.provider.ts
+++ b/backend/src/providers/ai/openrouter.provider.ts
@@ -256,7 +256,7 @@ export class OpenRouterProvider {
       if (response.status === 401 || response.status === 403) {
         throw new AppError(
           'Invalid OpenRouter API Key',
-          401,
+          400,
           ERROR_CODES.AI_INVALID_API_KEY,
           'Check your OpenRouter key and try again.'
         );

--- a/backend/tests/unit/openrouter-overview.test.ts
+++ b/backend/tests/unit/openrouter-overview.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const environmentMock = vi.hoisted(() => ({
+  isCloud: false,
+}));
+
 vi.mock('../../src/utils/environment.js', () => ({
-  isCloudEnvironment: () => false,
+  isCloudEnvironment: () => environmentMock.isCloud,
 }));
 
 vi.mock('../../src/utils/logger.js', () => ({
@@ -9,6 +13,18 @@ vi.mock('../../src/utils/logger.js', () => ({
 }));
 
 import { OpenRouterProvider } from '../../src/providers/ai/openrouter.provider.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+type ProviderState = OpenRouterProvider & {
+  cloudCredentials?: unknown;
+  fetchPromise: Promise<string> | null;
+};
+
+function resetProviderState(provider: OpenRouterProvider) {
+  const state = provider as unknown as ProviderState;
+  state.cloudCredentials = undefined;
+  state.fetchPromise = null;
+}
 
 describe('OpenRouterProvider.getOverview', () => {
   let provider: OpenRouterProvider;
@@ -30,14 +46,17 @@ describe('OpenRouterProvider.getOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    environmentMock.isCloud = false;
     vi.useFakeTimers();
     vi.setSystemTime(fixedNow);
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
     provider = OpenRouterProvider.getInstance();
+    resetProviderState(provider);
   });
 
   afterEach(() => {
+    resetProviderState(provider);
     vi.useRealTimers();
   });
 
@@ -226,4 +245,40 @@ describe('OpenRouterProvider.getOverview', () => {
     expect(overview.key.observabilityAvailable).toBe(false);
     expect(overview.charts.spend).toEqual([]);
   });
+
+  it.each([
+    { mode: 'self-hosting', isCloud: false, upstreamStatus: 401 },
+    { mode: 'cloud-hosting', isCloud: true, upstreamStatus: 403 },
+  ])(
+    'returns a business error instead of $upstreamStatus for an invalid $mode key',
+    async ({ isCloud, upstreamStatus }) => {
+      environmentMock.isCloud = isCloud;
+
+      if (isCloud) {
+        vi.stubEnv('PROJECT_ID', 'project_123');
+        vi.stubEnv('JWT_SECRET', 'test-secret-long-enough-for-signing-32chars');
+        vi.stubEnv('CLOUD_API_HOST', 'https://cloud.example');
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              openrouter: { api_key: 'sk-or-cloud-invalid', limit_remaining: 10 },
+            }),
+        });
+      } else {
+        vi.stubEnv('OPENROUTER_API_KEY', 'sk-or-self-hosted-invalid');
+      }
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: upstreamStatus,
+      });
+
+      await expect(provider.getOverview()).rejects.toMatchObject({
+        statusCode: 400,
+        code: ERROR_CODES.AI_INVALID_API_KEY,
+        message: 'Invalid OpenRouter API Key',
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- normalize OpenRouter key-info 401/403 responses to `400 AI_INVALID_API_KEY`
- preserve normal dashboard administrator 401 refresh/logout behavior
- add regression coverage for invalid cloud-managed and self-hosted OpenRouter keys

## Root cause

`GET /api/ai/overview` calls OpenRouter's `/api/v1/key` endpoint after resolving the project key. When OpenRouter rejected that downstream key, `OpenRouterProvider` returned HTTP 401 to the dashboard. The dashboard correctly treats all 401 responses as an expired administrator session, so it attempted token refresh and could log out an otherwise valid administrator.

The downstream credential failure is now represented as a 400 business error while retaining the existing `AI_INVALID_API_KEY` code and actionable message. Genuine administrator authentication failures remain 401 and continue using the normal refresh flow.

## Impact

Model Gateway overview failures caused by invalid OpenRouter credentials now render as page errors instead of logging administrators out. The shared provider path covers both cloud-hosting and self-hosting.

## Validation

- `npx vitest run tests/unit/openrouter-overview.test.ts` — 6 passed
- regression red/green check — both new cases fail with the original 401 mapping and pass with the fix
- `npm run lint` (backend) — passed
- `npm run typecheck` (backend) — passed
- `npm test` (backend) — 1,801 passed, 17 skipped
- `npm run build` (backend) — passed
- independent code review — ready to merge, no findings
- [Build and Push Docker Image](https://github.com/InsForge/InsForge/actions/runs/29440386104) — passed
- [Deterministic Fixture E2E](https://github.com/InsForge/agent-e2e/actions/runs/29440619591) — passed

## E2E fixture decision

No `InsForge/agent-e2e` change is needed. Its AI fixture already covers successful linked-project key setup and secret redaction; reproducing this regression requires injecting an upstream OpenRouter 401/403, which is covered deterministically at the provider boundary in the new unit cases.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize OpenRouter credential failures in Model Gateway to a 400 business error so invalid keys show a page error instead of logging admins out. Real admin auth failures remain 401 and keep the normal refresh/logout flow.

- **Bug Fixes**
  - Map OpenRouter `/api/v1/key` 401/403 to 400 `AI_INVALID_API_KEY` with the existing message.
  - Add unit tests for invalid keys in both cloud-hosted and self-hosted modes (uses `@insforge/shared-schemas` error codes).
  - Scope change to the overview fetch path; no other behavior changes.

<sup>Written for commit f5cecdedab5f531f3a3cb43ee75f75ee0f03a452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Model Gateway credential errors to return HTTP 400 instead of 401
> When OpenRouter returns a 401 or 403 for an invalid API key, `OpenRouterProvider.fetchCurrentKeyInfo` now throws an `AppError` with HTTP 400 (`AI_INVALID_API_KEY`) instead of 401. This prevents the frontend from interpreting credential validation failures as session expiry and logging out admins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5cecde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->