### PR TITLE
docs: add FAQ with database vs edge function vs custom compute comparison

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -174,6 +174,12 @@
                   "pricing",
                   "showcase"
                 ]
+              },
+              {
+                "group": "FAQ",
+                "pages": [
+                  "faq"
+                ]
               }
             ]
           },
@@ -464,6 +470,12 @@
                   "zh/alternatives",
                   "zh/pricing",
                   "zh/showcase"
+                ]
+              },
+              {
+                "group": "常见问题",
+                "pages": [
+                  "zh/faq"
                 ]
               }
             ]
@@ -756,6 +768,12 @@
                   "zh-Hant/pricing",
                   "zh-Hant/showcase"
                 ]
+              },
+              {
+                "group": "常見問題",
+                "pages": [
+                  "zh-Hant/faq"
+                ]
               }
             ]
           },
@@ -1046,6 +1064,12 @@
                   "es/alternatives",
                   "es/pricing",
                   "es/showcase"
+                ]
+              },
+              {
+                "group": "Preguntas frecuentes",
+                "pages": [
+                  "es/faq"
                 ]
               }
             ]

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -1,0 +1,27 @@
+---
+title: "Preguntas frecuentes"
+sidebarTitle: "Preguntas frecuentes"
+description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
+---
+
+<AccordionGroup>
+  <Accordion title="¿Leer o escribir en la base de datos es una edge function? ¿Qué diferencia hay entre llamadas a la base de datos, edge functions y custom compute?">
+    No. Cuando lees o escribes una tabla no se ejecuta ninguna función, así que no es una edge function.
+
+    En InsForge tu código habla con el backend de tres formas distintas, y es fácil confundirlas:
+
+    | | Cómo se activa | ¿Sigue en ejecución? | Para qué sirve |
+    |----|----------------|----------------------|----------------|
+    | **Llamada a la base de datos** (REST API autogenerada) | Tu cliente envía una petición SDK o REST | No, está totalmente gestionada | Leer y escribir filas de tablas |
+    | **Edge Function** | Una petición HTTP, una programación cron o un trigger de base de datos | No, se ejecuta una vez y termina | Endpoints propios, webhooks, lógica de triggers, llamar a servicios externos |
+    | **Custom Compute** | Tú inicias un proceso de larga duración | Sí, se mantiene activo | Workers de cola, bucles de inferencia de IA, websockets, cualquier cosa con estado |
+
+    **Llamada a la base de datos.** Defines una tabla y InsForge te da al instante un conjunto de endpoints REST (como `GET /api/database/records/{table}`) y un SDK tipado. Llamar a `select` o `insert` lee y escribe la base de datos directamente, sin nada que desplegar y sin nada en ejecución. Es todo lo que necesitas para el CRUD normal. Consulta [Base de datos](/core-concepts/database/overview).
+
+    **Edge Function.** Úsala cuando la API autogenerada no basta y quieres tu propia lógica de servidor: un webhook de pago, un auth hook, código que se dispara cuando una fila se `INSERT`a, `UPDATE`a o `DELETE`a, o un trabajo programado. La clave es que se ejecuta una vez por petición o evento y luego termina. Consulta [Edge Functions](/core-concepts/functions/overview).
+
+    **Custom Compute.** Úsalo cuando necesitas un proceso que se mantenga activo, como un worker de cola o un bucle de inferencia de IA. Una edge function no puede hacerlo porque no se ejecuta de forma continua. Consulta [Custom Compute](/core-concepts/compute/overview).
+
+    Regla rápida: ¿solo mueves datos de entrada y salida? Es la base de datos (REST automática). ¿Escribes lógica que se ejecuta y termina? Edge function. ¿Necesitas algo funcionando todo el tiempo? Custom compute.
+  </Accordion>
+</AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,0 +1,27 @@
+---
+title: "FAQ"
+sidebarTitle: "FAQ"
+description: "Answers to common questions about how InsForge works."
+---
+
+<AccordionGroup>
+  <Accordion title="Is reading or writing the database an edge function? What's the difference between database calls, edge functions, and custom compute?">
+    No. When you read or write a table, no function runs at all, so it isn't an edge function.
+
+    In InsForge your code talks to the backend in three different ways, and they're easy to mix up:
+
+    | | How it's triggered | Does it keep running? | What it's for |
+    |----|--------------------|-----------------------|---------------|
+    | **Database call** (auto-generated REST API) | Your client sends an SDK or REST request | No, it's fully managed | Reading and writing table rows |
+    | **Edge Function** | An HTTP request, a cron schedule, or a database trigger | No, it runs once and exits | Custom endpoints, webhooks, trigger logic, calling external services |
+    | **Custom Compute** | You start a long-running process | Yes, it stays up | Queue workers, AI inference loops, websockets, anything that holds state |
+
+    **Database call.** Define a table and InsForge instantly gives you a set of REST endpoints (like `GET /api/database/records/{table}`) and a typed SDK. Calling `select` or `insert` reads and writes the database directly, with nothing to deploy and nothing running. This is all you need for ordinary create/read/update/delete. See [Database](/core-concepts/database/overview).
+
+    **Edge Function.** Reach for one when the auto-generated API isn't enough and you want your own server-side logic: a payment webhook, an auth hook, code that fires when a row is `INSERT`ed / `UPDATE`d / `DELETE`d, or a scheduled job. The point is that it runs once per request or event and then exits. See [Edge Functions](/core-concepts/functions/overview).
+
+    **Custom Compute.** Use this when you need a process that stays up, like a queue worker or an AI inference loop. An edge function can't do this because it doesn't run continuously. See [Custom Compute](/core-concepts/compute/overview).
+
+    Quick rule: just moving data in and out? That's the database (auto REST). Writing logic that runs and finishes? Edge function. Need something running all the time? Custom compute.
+  </Accordion>
+</AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -1,0 +1,27 @@
+---
+title: "常見問題"
+sidebarTitle: "常見問題"
+description: "關於 InsForge 運作方式的常見問題解答。"
+---
+
+<AccordionGroup>
+  <Accordion title="讀寫資料庫算 Edge Function 嗎？資料庫、Edge Function、Custom Compute 有什麼差別？">
+    不算。你平常對資料表做增刪改查的時候，其實沒有執行任何函式，當然也就不是 Edge Function。
+
+    在 InsForge 裡，你的程式碼有三種方式跟後端打交道，很容易搞混：
+
+    | | 怎麼觸發 | 會不會一直執行 | 用來做什麼 |
+    |----|---------|--------------|---------|
+    | **讀寫資料庫**（自動產生的 REST API） | 用戶端發一個 SDK 或 REST 請求 | 不用你管，後端託管 | 增刪改查資料表 |
+    | **Edge Function** | HTTP 請求、定時（cron），或資料庫觸發器 | 跑一次就結束 | 自訂 API、webhook、觸發邏輯、呼叫外部服務 |
+    | **Custom Compute** | 你自己啟動一個常駐行程 | 一直開著 | 佇列 worker、AI 推論迴圈、websocket、需要一直保持狀態的工作 |
+
+    **讀寫資料庫。** 你建好一張表，InsForge 自動就給你一套 REST 介面（例如 `GET /api/database/records/{table}`）和一個帶型別的 SDK。你呼叫 `select`、`insert` 這些，就是直接在讀寫資料庫，不用部署也不用跑任何東西。日常的增刪改查用這個就夠了，參見[資料庫](/core-concepts/database/overview)。
+
+    **Edge Function。** 當自動介面滿足不了、你想寫自己的伺服器端邏輯時才用它，例如接付款回呼（webhook）、登入掛鉤、在某列資料發生 `INSERT`/`UPDATE`/`DELETE` 時觸發一段程式碼，或者定時任務。它的特點是跑完一次請求就結束，不會一直待著。參見 [Edge Functions](/core-concepts/functions/overview)。
+
+    **Custom Compute。** 當你需要一個一直開著的行程時才用它，例如佇列 worker 或者 AI 推論迴圈。這種工作 Edge Function 做不到，因為它不常駐。參見 [Custom Compute](/core-concepts/compute/overview)。
+
+    一句話判斷：只是讀寫資料，就走資料庫（自動 REST）；要寫一段跑完就結束的邏輯，用 Edge Function；要一直執行，用 Custom Compute。
+  </Accordion>
+</AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -1,0 +1,27 @@
+---
+title: "常见问题"
+sidebarTitle: "常见问题"
+description: "关于 InsForge 工作方式的常见问题解答。"
+---
+
+<AccordionGroup>
+  <Accordion title="读写数据库算 Edge Function 吗？数据库、Edge Function、Custom Compute 有什么区别？">
+    不算。你平时对数据表做增删改查的时候，其实没有跑任何函数，当然也就不是 Edge Function。
+
+    在 InsForge 里，你的代码有三种方式跟后端打交道，很容易搞混：
+
+    | | 怎么触发 | 会不会一直运行 | 用来做什么 |
+    |----|---------|--------------|---------|
+    | **读写数据库**（自动生成的 REST API） | 客户端发一个 SDK 或 REST 请求 | 不用你管，后端托管 | 增删改查数据表 |
+    | **Edge Function** | HTTP 请求、定时（cron），或数据库触发器 | 跑一次就结束 | 自定义接口、webhook、触发逻辑、调外部服务 |
+    | **Custom Compute** | 你自己起一个常驻进程 | 一直开着 | 队列 worker、AI 推理循环、websocket、需要一直保持状态的活 |
+
+    **读写数据库。** 你建好一张表，InsForge 自动就给你一套 REST 接口（比如 `GET /api/database/records/{table}`）和一个带类型的 SDK。你调 `select`、`insert` 这些，就是直接在读写数据库，不用部署也不用跑任何东西。日常的增删改查用这个就够了，参见[数据库](/core-concepts/database/overview)。
+
+    **Edge Function。** 当自动接口满足不了、你想写自己的服务端逻辑时才用它，比如接支付回调（webhook）、登录钩子、在某行数据发生 `INSERT`/`UPDATE`/`DELETE` 时触发一段代码，或者定时任务。它的特点是跑完一次请求就结束，不会一直待着。参见 [Edge Functions](/core-concepts/functions/overview)。
+
+    **Custom Compute。** 当你需要一个一直开着的进程时才用它，比如队列 worker 或者 AI 推理循环。这种活 Edge Function 干不了，因为它不常驻。参见 [Custom Compute](/core-concepts/compute/overview)。
+
+    一句话判断：只是读写数据，就走数据库（自动 REST）；要写一段跑完就结束的逻辑，用 Edge Function；要一直运行，用 Custom Compute。
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## What

Adds a new **FAQ** section to the docs with the first entry answering a recurring Ask AI question: whether a database call is an edge function, and how database calls, edge functions, and custom compute differ.

The answer uses a Mintlify `AccordionGroup` and a three-layer comparison table (how it's triggered / does it keep running / what it's for), plus a one-line rule of thumb. Written in plain language, not translation-ese.

## Why

Ask AI transcripts show users repeatedly confused at the boundary of "is a DB call a function / an API / an edge function". No existing page compares all three (each overview only has a pairwise callout, and the database layer isn't in any comparison). This gives a single canonical answer.

## Changes

- `docs/faq.mdx` + `docs/zh/faq.mdx`, `docs/zh-Hant/faq.mdx`, `docs/es/faq.mdx` (all four locales, matching the repo's localization structure)
- `docs.json`: new `FAQ` group after `Resources` in each of the four language nav blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new FAQ that explains the difference between database calls, edge functions, and custom compute. Clarifies that database reads/writes use the auto REST API and are not edge functions.

- **New Features**
  - Added `docs/faq.mdx` with an accordion and a simple comparison (trigger, runtime, purpose) plus a quick rule of thumb.
  - Localized FAQ to `es`, `zh`, and `zh-Hant`.
  - Updated `docs/docs.json` to add an `FAQ` nav group in all four locales.

<sup>Written for commit e077549180bffa7b050f413f4f4633ca33ef385b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ page comparing database calls, Edge Functions, and Custom Compute to docs
> Adds a new FAQ section to the documentation sidebar and creates FAQ pages in four locales (English, Simplified Chinese, Traditional Chinese, Spanish). Each page contains an accordion with a comparison table and guidance text explaining when to use database calls, Edge Functions, or Custom Compute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24121e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ section explaining the differences between database operations, Edge Functions, and Custom Compute.
  * Included localized FAQ pages in English, Simplified Chinese, Traditional Chinese, and Spanish.
  * Added FAQ links to the documentation navigation for each supported language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->