### PR TITLE
docs: FAQ entry on inviting another admin / teammate

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -24,4 +24,21 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
 
     Regla rápida: ¿solo mueves datos de entrada y salida? Es la base de datos (REST automática). ¿Escribes lógica que se ejecuta y termina? Edge function. ¿Necesitas algo funcionando todo el tiempo? Custom compute.
   </Accordion>
+
+  <Accordion title="¿Cómo comparto un proyecto con otro administrador o invito a un compañero de equipo?">
+    El acceso se comparte a nivel de **organización**, no por proyecto. Invitas a alguien a la organización propietaria de tus proyectos y obtiene acceso a todos los proyectos que contiene. No existe un flujo aparte para "compartir solo este proyecto".
+
+    Para invitar a alguien:
+
+    1. En el dashboard, abre la organización propietaria del proyecto usando el selector de organización en la esquina superior izquierda.
+    2. Haz clic en **Members** en la barra lateral izquierda.
+    3. Haz clic en **Invite Member**, introduce su email y elige un rol:
+       - **Administrator** tiene control total: gestionar proyectos, además de invitar, eliminar y cambiar los roles de otros miembros.
+       - **Developer** tiene acceso normal a los proyectos de la organización, pero no puede gestionar miembros.
+    4. Reciben una invitación por email válida durante 7 días. Cuando inician sesión en InsForge **con esa misma dirección de email** y la aceptan, se unen a la organización con el rol que elegiste.
+
+    Para añadir otro administrador en concreto, elige el rol **Administrator** al invitar, o cambia su rol más tarde desde la lista de Members. Solo los Administrators pueden invitar o gestionar miembros.
+
+    Transferir la organización por completo a un nuevo **owner** es una acción distinta de invitar miembros.
+  </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -39,6 +39,6 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
 
     Para añadir otro administrador en concreto, elige el rol **Administrator** al invitar, o cambia su rol más tarde desde la lista de Members. Solo los Administrators pueden invitar o gestionar miembros.
 
-    Transferir la organización por completo a un nuevo **Owner** es una acción distinta de invitar miembros.
+    Transferir la organización por completo a un nuevo **Owner** es una acción distinta de invitar miembros. Para hacerlo, abre **Organization Settings** y usa **Transfer Ownership** (solo el owner actual puede iniciarlo, y el destinatario debe ser un usuario verificado de InsForge que acepte la solicitud enviada por email).
   </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -39,6 +39,6 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
 
     Para añadir otro administrador en concreto, elige el rol **Administrator** al invitar, o cambia su rol más tarde desde la lista de Members. Solo los Administrators pueden invitar o gestionar miembros.
 
-    Transferir la organización por completo a un nuevo **owner** es una acción distinta de invitar miembros.
+    Transferir la organización por completo a un nuevo **Owner** es una acción distinta de invitar miembros.
   </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -24,4 +24,21 @@ description: "Answers to common questions about how InsForge works."
 
     Quick rule: just moving data in and out? That's the database (auto REST). Writing logic that runs and finishes? Edge function. Need something running all the time? Custom compute.
   </Accordion>
+
+  <Accordion title="How do I share a project with another admin, or invite a teammate?">
+    Access is shared at the **organization** level, not per project. You invite someone to the organization that owns your projects, and they get access to every project inside it. There is no separate "share just this one project" flow.
+
+    To invite someone:
+
+    1. In the dashboard, open the organization that owns the project using the org switcher in the top-left.
+    2. Click **Members** in the left sidebar.
+    3. Click **Invite Member**, enter their email, and pick a role:
+       - **Administrator** has full control: manage projects, plus invite, remove, and change the roles of other members.
+       - **Developer** has normal access to the organization's projects but cannot manage members.
+    4. They get an email invite that is valid for 7 days. When they sign in to InsForge **with that same email address** and accept it, they join the organization with the role you chose.
+
+    To add another admin specifically, choose the **Administrator** role when inviting, or change their role later from the Members list. Only Administrators can invite or manage members.
+
+    Handing the organization over to a new **owner** entirely is a separate action from inviting members.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -39,6 +39,6 @@ description: "Answers to common questions about how InsForge works."
 
     To add another admin specifically, choose the **Administrator** role when inviting, or change their role later from the Members list. Only Administrators can invite or manage members.
 
-    Handing the organization over to a new **Owner** entirely is a separate action from inviting members.
+    Handing the organization over to a new **Owner** entirely is a separate action from inviting members. To do that, open **Organization Settings** and use **Transfer Ownership** (only the current owner can start it, and the recipient must be a verified InsForge user who accepts the emailed request).
   </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -39,6 +39,6 @@ description: "Answers to common questions about how InsForge works."
 
     To add another admin specifically, choose the **Administrator** role when inviting, or change their role later from the Members list. Only Administrators can invite or manage members.
 
-    Handing the organization over to a new **owner** entirely is a separate action from inviting members.
+    Handing the organization over to a new **Owner** entirely is a separate action from inviting members.
   </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -39,6 +39,6 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     想專門加一個管理員，邀請時選 **Administrator** 即可，之後也能在 Members 列表裡改角色。只有 Administrator 能邀請和管理成員。
 
-    把整個組織「移交給新 Owner」是另一個獨立操作，跟邀請成員不是一回事。
+    把整個組織「移交給新 Owner」是另一個獨立操作，跟邀請成員不是一回事。要移交的話，打開 **Organization Settings**，用裡面的 **Transfer Ownership**（只有目前的 owner 能發起，且對方必須是已驗證的 InsForge 使用者並接受郵件裡的請求）。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -39,6 +39,6 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     想專門加一個管理員，邀請時選 **Administrator** 即可，之後也能在 Members 列表裡改角色。只有 Administrator 能邀請和管理成員。
 
-    把整個組織「移交給新 Owner」是另一個獨立操作，跟邀請成員不是一回事。要移交的話，打開 **Organization Settings**，用裡面的 **Transfer Ownership**（只有目前的 owner 能發起，且對方必須是已驗證的 InsForge 使用者並接受郵件裡的請求）。
+    把整個組織「移交給新 Owner」是另一個獨立操作，跟邀請成員不是一回事。要移交的話，打開 **Organization Settings**，用裡面的 **Transfer Ownership**（只有目前的 Owner 能發起，且對方必須是已驗證的 InsForge 使用者並接受郵件裡的請求）。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -24,4 +24,21 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     一句話判斷：只是讀寫資料，就走資料庫（自動 REST）；要寫一段跑完就結束的邏輯，用 Edge Function；要一直執行，用 Custom Compute。
   </Accordion>
+
+  <Accordion title="怎麼把專案分享給另一個管理員，或者邀請隊友？">
+    存取權限是按 **organization（組織）** 共享的，不是按單個 project。你是把人邀請進擁有這些 project 的組織，他就能存取組織下的所有 project，沒有「只分享某一個 project」的入口。
+
+    邀請步驟：
+
+    1. 在 dashboard 裡，用左上角的組織切換器打開擁有該 project 的組織。
+    2. 點左側欄的 **Members**。
+    3. 點 **Invite Member**，填對方信箱，選一個角色：
+       - **Administrator（管理員）**：完全控制，既能管理 project，也能邀請、移除成員、修改成員角色。
+       - **Developer（開發者）**：能正常存取組織的 project，但不能管理成員。
+    4. 對方會收到一封邀請郵件（7 天內有效）。他用「收到邀請的那個信箱」登入 InsForge 並接受後，就以你選的角色加入組織。
+
+    想專門加一個管理員，邀請時選 **Administrator** 即可，之後也能在 Members 列表裡改角色。只有 Administrator 能邀請和管理成員。
+
+    把整個組織「移交給新 owner」是另一個獨立操作，跟邀請成員不是一回事。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -39,6 +39,6 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     想專門加一個管理員，邀請時選 **Administrator** 即可，之後也能在 Members 列表裡改角色。只有 Administrator 能邀請和管理成員。
 
-    把整個組織「移交給新 owner」是另一個獨立操作，跟邀請成員不是一回事。
+    把整個組織「移交給新 Owner」是另一個獨立操作，跟邀請成員不是一回事。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -39,6 +39,6 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     想专门加一个管理员，邀请时选 **Administrator** 即可，之后也能在 Members 列表里改角色。只有 Administrator 能邀请和管理成员。
 
-    把整个组织「移交给新 Owner」是另一个独立操作，跟邀请成员不是一回事。要移交的话，打开 **Organization Settings**，用里面的 **Transfer Ownership**（只有当前 owner 能发起，且对方必须是已验证的 InsForge 用户并接受邮件里的请求）。
+    把整个组织「移交给新 Owner」是另一个独立操作，跟邀请成员不是一回事。要移交的话，打开 **Organization Settings**，用里面的 **Transfer Ownership**（只有当前 Owner 能发起，且对方必须是已验证的 InsForge 用户并接受邮件里的请求）。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -39,6 +39,6 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     想专门加一个管理员，邀请时选 **Administrator** 即可，之后也能在 Members 列表里改角色。只有 Administrator 能邀请和管理成员。
 
-    把整个组织「移交给新 owner」是另一个独立操作，跟邀请成员不是一回事。
+    把整个组织「移交给新 Owner」是另一个独立操作，跟邀请成员不是一回事。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -24,4 +24,21 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     一句话判断：只是读写数据，就走数据库（自动 REST）；要写一段跑完就结束的逻辑，用 Edge Function；要一直运行，用 Custom Compute。
   </Accordion>
+
+  <Accordion title="怎么把项目分享给另一个管理员，或者邀请队友？">
+    访问权限是按 **organization（组织）** 共享的，不是按单个 project。你是把人邀请进拥有这些 project 的组织，他就能访问组织下的所有 project，没有「只分享某一个 project」的入口。
+
+    邀请步骤：
+
+    1. 在 dashboard 里，用左上角的组织切换器打开拥有该 project 的组织。
+    2. 点左侧栏的 **Members**。
+    3. 点 **Invite Member**，填对方邮箱，选一个角色：
+       - **Administrator（管理员）**：完全控制，既能管理 project，也能邀请、移除成员、修改成员角色。
+       - **Developer（开发者）**：能正常访问组织的 project，但不能管理成员。
+    4. 对方会收到一封邀请邮件（7 天内有效）。他用「收到邀请的那个邮箱」登录 InsForge 并接受后，就以你选的角色加入组织。
+
+    想专门加一个管理员，邀请时选 **Administrator** 即可，之后也能在 Members 列表里改角色。只有 Administrator 能邀请和管理成员。
+
+    把整个组织「移交给新 owner」是另一个独立操作，跟邀请成员不是一回事。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -39,6 +39,6 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     想专门加一个管理员，邀请时选 **Administrator** 即可，之后也能在 Members 列表里改角色。只有 Administrator 能邀请和管理成员。
 
-    把整个组织「移交给新 Owner」是另一个独立操作，跟邀请成员不是一回事。
+    把整个组织「移交给新 Owner」是另一个独立操作，跟邀请成员不是一回事。要移交的话，打开 **Organization Settings**，用里面的 **Transfer Ownership**（只有当前 owner 能发起，且对方必须是已验证的 InsForge 用户并接受邮件里的请求）。
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Adds a FAQ accordion answering "How do I share a project with another admin?" — a support-style question Ask AI couldn't answer because docs had no coverage.

Key points (verified against cloud frontend + cloud-backend):
- Sharing is at the **organization** level, not per project. Inviting someone to the org grants access to all its projects.
- Path: org switcher → **Members** → **Invite Member** → email + role (**Administrator** / **Developer**).
- Email invite, valid 7 days; invitee must sign in with that same email to accept.
- Only Administrators can invite/manage members; org ownership transfer is a separate flow.

Added to all four locales: en / zh / zh-Hant / es. No nav changes (FAQ page + nav already on main).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new FAQ on inviting admins/teammates, clarifying org-level access and linking to Organization Settings → Transfer Ownership. Available in en, zh, zh‑Hant, and es; standardized capitalization of Owner across locales; no nav changes.

- **New Features**
  - Steps: org switcher → Members → Invite Member; enter email and pick role (Administrator or Developer).
  - Invites are valid for 7 days and must be accepted with the same email.
  - Only Administrators can invite/manage members; transfer org to a new Owner via Organization Settings → Transfer Ownership (only the current Owner can start it; recipient must be verified and accept the emailed request).

- **Refactors**
  - Capitalized Owner for role-name consistency, including the zh/zh‑Hant transfer clause.

<sup>Written for commit 2ddeae7fe7344ce27f5b09959bd419f04851095b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entry on inviting teammates and administrators to an organization
> Adds a new FAQ accordion section across four locales (English, Spanish, Simplified Chinese, Traditional Chinese) explaining how to invite members to an organization. Covers the invitation workflow, role selection (Administrator vs Developer), 7-day invite validity, and a note that transferring organization ownership is a separate action.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1717 opened
>
> - Standardized capitalization of the role term from `owner` to `Owner` across all localized versions of the FAQ documentation [f7cc4e9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8134ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ accordion item (English, Spanish, Simplified Chinese, Traditional Chinese) explaining how to invite teammates or share admin access.
  * Clarified that access is managed at the **organization** level (not by sharing a single project).
  * Documented the invite flow (switch to the correct organization → **Members** → **Invite Member** → enter email and choose **Administrator** or **Developer**), including 7-day email validity and acceptance after signing in with the same email.
  * Clarified role capabilities and that inviting is separate from **Transfer Ownership**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->