### PR TITLE
docs: FAQ entries for project pausing and restart

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -24,4 +24,22 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
 
     Regla rápida: ¿solo mueves datos de entrada y salida? Es la base de datos (REST automática). ¿Escribes lógica que se ejecuta y termina? Edge function. ¿Necesitas algo funcionando todo el tiempo? Custom compute.
   </Accordion>
+
+  <Accordion title="¿Por qué se pausó mi proyecto y cómo evito que se pause?">
+    La pausa solo ocurre en el plan Free, por dos motivos:
+
+    - **Inactividad.** Un proyecto free se pausa tras 7 días sin ninguna petición. Te avisamos por correo antes, y cualquier petición reinicia el contador de 7 días.
+    - **Límite de uso.** Si tu organización supera los límites de uso del plan Free, sus proyectos siguen pausados hasta que la actualices.
+
+    En ambos casos tus datos quedan intactos. Para que los proyectos no se pausen nunca, actualiza la organización a Pro. Consulta [Pricing](/pricing).
+  </Accordion>
+
+  <Accordion title="Mi proyecto está pausado. ¿Cómo lo reinicio?">
+    Abre el proyecto en el dashboard y haz clic en **Restore Project**. Vuelve en unos minutos con tus datos intactos. Ten en cuenta un par de casos:
+
+    - Puedes restaurar un proyecto free desde el dashboard hasta **30 días** después de que se pause. Pasado ese plazo se archiva y solo puedes descargar la copia de la base de datos y los archivos de Storage (sin pérdida de datos).
+    - Si se pausó porque la organización alcanzó su límite de uso, haz **Upgrade to Pro** para restaurarlo.
+
+    ¿Sigues atascado? Pregunta en nuestro [Discord](https://discord.com/invite/DvBtaEc9Jz) para la respuesta más rápida.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -24,4 +24,22 @@ description: "Answers to common questions about how InsForge works."
 
     Quick rule: just moving data in and out? That's the database (auto REST). Writing logic that runs and finishes? Edge function. Need something running all the time? Custom compute.
   </Accordion>
+
+  <Accordion title="Why did my project get paused, and how do I keep it from pausing?">
+    Pausing only happens on the Free plan, for two reasons:
+
+    - **Inactivity.** A free project is paused after 7 days with no requests. We email a heads-up first, and any request resets the 7-day clock.
+    - **Usage limit.** If your organization goes over the Free usage limits, its projects stay paused until you upgrade.
+
+    Your data stays intact either way. To stop projects from pausing at all, upgrade the organization to Pro. See [Pricing](/pricing).
+  </Accordion>
+
+  <Accordion title="My project is paused. How do I restart it?">
+    Open the project in the dashboard and click **Restore Project**. It comes back in a few minutes with your data intact. A couple of cases to know:
+
+    - You can restore a free project from the dashboard for up to **30 days** after it pauses. After that it's archived and you can only download the database backup and storage files (still no data loss).
+    - If it was paused because the organization hit its usage limit, **Upgrade to Pro** to restore it.
+
+    Still stuck? Ask in our [Discord](https://discord.com/invite/DvBtaEc9Jz) for the fastest response.
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -24,4 +24,22 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     一句話判斷：只是讀寫資料，就走資料庫（自動 REST）；要寫一段跑完就結束的邏輯，用 Edge Function；要一直執行，用 Custom Compute。
   </Accordion>
+
+  <Accordion title="為什麼我的專案被暫停了？要怎麼避免被暫停？">
+    只有 Free 方案會出現暫停，原因有兩種：
+
+    - **閒置**：free 專案連續 7 天沒有任何請求後會被暫停。我們會先寄信提醒，任何一次請求都會重置這 7 天的計時。
+    - **超出用量**：如果你的 organization 超過 Free 的用量額度，底下的專案會一直保持暫停，直到你升級。
+
+    無論哪種情況，你的資料都完好無損。想徹底不再被暫停，把 organization 升級到 Pro。參見 [Pricing](/pricing)。
+  </Accordion>
+
+  <Accordion title="我的專案被暫停了，要怎麼重新啟動？">
+    在 dashboard 裡打開這個專案，點 **Restore Project**，幾分鐘後就會帶著完整資料恢復。有幾種情況要注意：
+
+    - free 專案在暫停後的 **30 天內**都可以在 dashboard 直接恢復。超過之後專案會被封存，你只能下載資料庫備份和 Storage 檔案（資料仍然不會遺失）。
+    - 如果是因為 organization 超出用量而暫停，需要 **Upgrade to Pro** 才能恢復。
+
+    還是卡住？到我們的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提問，回應最快。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -24,4 +24,22 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     一句话判断：只是读写数据，就走数据库（自动 REST）；要写一段跑完就结束的逻辑，用 Edge Function；要一直运行，用 Custom Compute。
   </Accordion>
+
+  <Accordion title="为什么我的项目被暂停了？怎么避免被暂停？">
+    只有 Free 计划会出现暂停，原因有两种：
+
+    - **闲置**：free 项目连续 7 天没有任何请求后会被暂停。我们会先发邮件提醒，任意一次请求都会重置这 7 天的计时。
+    - **超出用量**：如果你的 organization 超过了 Free 的用量额度，它下面的项目会一直保持暂停，直到你升级。
+
+    无论哪种情况，你的数据都完好无损。想彻底不再被暂停，把 organization 升级到 Pro。参见 [Pricing](/pricing)。
+  </Accordion>
+
+  <Accordion title="我的项目被暂停了，怎么重新启动？">
+    在 dashboard 里打开这个项目，点 **Restore Project**，几分钟后就会带着完整数据恢复。有几种情况要注意：
+
+    - free 项目在暂停后的 **30 天内**都可以在 dashboard 直接恢复。超过之后项目会被归档，你只能下载数据库备份和 Storage 文件（数据仍然不会丢失）。
+    - 如果是因为 organization 超出用量而暂停，需要 **Upgrade to Pro** 才能恢复。
+
+    还是卡住？到我们的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提问，响应最快。
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Adds two FAQ accordions to `docs/faq.mdx` (and the es / zh / zh-Hant translations), based on the actual cloud behavior in code rather than the older "contact admin" phrasing.

**Why did my project get paused, and how do I keep it from pausing?**
- Pausing is Free-plan only, two triggers: 7 days of inactivity (`inactiveLimitDays: 7`, warning email first, any request resets the clock) and exceeding Free usage limits (org blocked → projects stay paused until upgrade).
- Data stays intact; upgrade to Pro to stop pausing entirely.

**My project is paused. How do I restart it?**
- Self-serve **Restore Project** in the dashboard (the `PausedProjectBox` flow), within 30 days.
- After 30 days (`permanentlyFreezeDays: 30`) the project is archived → backup download only.
- Usage-limit pause → Upgrade to Pro to restore.
- Links to Discord for fastest response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two FAQ entries explaining when Free plan projects are paused and how to restore them, across `docs/faq.mdx` and translations. Aligns guidance with current cloud behavior and the self-serve Restore Project flow.

- **New Features**
  - Added “Why did my project get paused…” and “My project is paused. How do I restart it?” accordions in EN, ES, ZH, and ZH-Hant.
  - Clarifies triggers: 7-day inactivity (email warning; any request resets) and exceeding Free usage limits (projects stay paused until upgrade).
  - Details restore flow: dashboard “Restore Project” within 30 days; after 30 days project is archived with backup download; data is preserved; upgrade to Pro stops pausing and restores usage-limit pauses.

<sup>Written for commit f55d99439af18545d100c05b4ca7ce1fb3b91a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entries for Free plan project pausing and restoration
> Adds two new FAQ accordion entries across English, Spanish, Simplified Chinese, and Traditional Chinese versions of the docs. One entry covers when Free plan projects are paused (7 days of inactivity or exceeding Free usage limits) and how to prevent it by upgrading to Pro. The other explains how to restore a paused project from the dashboard within a 30-day window before archival, including the upgrade requirement if paused due to usage limits and a Discord support link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f55d994.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance explaining why Free-plan projects may be paused, including inactivity and usage limits.
  * Documented how to restore paused projects from the dashboard, restoration timeframes, and upgrade requirements.
  * Updated FAQ content in English, Spanish, Simplified Chinese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->