### PR TITLE
docs: add FAQ on browserless CLI authentication

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -59,4 +59,29 @@ description: "Answers to common questions about how InsForge works."
 
     Still stuck? Ask in our [Discord](https://discord.com/invite/DvBtaEc9Jz) for the fastest response.
   </Accordion>
+
+  <Accordion title="How do I authenticate the CLI without a browser?">
+    `npx @insforge/cli login` opens a browser to sign in. On a headless machine, a remote server, or CI, use the setup prompt from the dashboard instead. It signs the CLI in with a user API key, no browser needed.
+
+    <Steps>
+      <Step title="Open the Install page">
+        Open your project in the dashboard and go to the **Install** page.
+      </Step>
+      <Step title="Pick your coding agent">
+        Under **Install in Agent**, click the agent you use, then open the **CLI** tab.
+      </Step>
+      <Step title="Copy the prompt">
+        Copy the setup prompt and paste it into your agent. It signs the CLI in and links the project in one step.
+      </Step>
+    </Steps>
+
+    The prompt fills in a login command scoped to your account, followed by the link command:
+
+    ```bash
+    npx @insforge/cli login --user-api-key <your-user-api-key>
+    npx @insforge/cli link --project-id <your-project-id>
+    ```
+
+    In CI, store the key as a secret and run these directly; add `--json` for machine-readable output. The key grants full access to your account, so keep it secret and rotate it if it leaks.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -61,7 +61,9 @@ description: "Answers to common questions about how InsForge works."
   </Accordion>
 
   <Accordion title="How do I authenticate the CLI without a browser?">
-    `npx @insforge/cli login` opens a browser to sign in. On a headless machine, a remote server, or CI, use the setup prompt from the dashboard instead. It signs the CLI in with a user API key, no browser needed.
+    `npx @insforge/cli login` opens a browser to sign in. On a headless machine, a remote server, or CI, use a user API key instead. No browser needed.
+
+    The quickest way is the setup prompt from the dashboard, which signs in and links the project for you:
 
     <Steps>
       <Step title="Open the Install page">
@@ -82,6 +84,8 @@ description: "Answers to common questions about how InsForge works."
     npx @insforge/cli link --project-id <your-project-id>
     ```
 
-    In CI, store the key as a secret and run these directly; add `--json` for machine-readable output. The key grants full access to your account, so keep it secret and rotate it if it leaks.
+    If you only need the key, for example to run the CLI in CI, open your account menu and go to **Profile → API Keys**, then create a key (set an expiry, or **Never**). Store it as a CI secret and run `login --user-api-key` with it. Add `--json` for machine-readable output.
+
+    The key grants full access to your account, so keep it secret and rotate it if it leaks.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Adds a FAQ entry answering "how do I authenticate the CLI without a browser?" (headless machines, remote servers, CI).

The recommended path routes users through the dashboard **Install** page: pick your coding agent, open the CLI tab, and copy the setup prompt. The prompt runs a headless `login --user-api-key` (no OAuth browser flow) followed by `link`. Also shows the underlying commands for CI and notes the key is full-scope, so keep it secret.

This gap surfaced from a support question. Previously the docs only covered the browser OAuth `login`.

Follow-ups (not in this PR):
- `quickstart.mdx` skips the login step entirely.
- `cli-harness.mdx` documents only browser OAuth login.
- zh / zh-Hant / es FAQ translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an FAQ on authenticating the `@insforge/cli` without a browser for headless machines and CI. It points to the dashboard Install prompt that signs in and links your project, and explains the underlying commands.

- New Features
  - Documented where to create a user API key (Profile → API Keys) and CI steps: store the key as a secret, run `npx @insforge/cli login --user-api-key <key>` then `npx @insforge/cli link --project-id <id>`, use `--json` for machine-readable output, and set expiry/rotate keys (full access).

<sup>Written for commit 7c9b358380b3cbe5a3e32298c94e425d7748243e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entry for CLI authentication without a browser
> Adds a new accordion entry to [docs/faq.mdx](https://github.com/InsForge/InsForge/pull/1720/files#diff-5cbca333c2bdfa75c496729159085552024a5b484a6e797c51c1804439c12a73) covering headless/CI login using a user API key. The section walks through copying a setup prompt from the dashboard, running `npx @insforge/cli login --user-api-key <key>` and `npx @insforge/cli link --project-id <id>`, using `--json` for machine-readable output, and guidance on keeping the key secret.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1720 opened
>
> - Revised the primary authentication recommendation for headless and CI usage from dashboard setup prompt to user API key [7c9b358]
> - Expanded CI authentication instructions with detailed steps for user API key creation and configuration [7c9b358]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b57ce2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance for authenticating the CLI without a browser.
  * Documented headless/remote/CI setup steps, including the appropriate login/link commands using a user API key.
  * Added CI tips for machine-readable output and instructions to create an API key, including an emphasis that the key grants full account access and must be kept secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->