### PR TITLE
docs: add FAQ on querying tables in a non-public schema

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -25,6 +25,46 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
     Regla rápida: ¿solo mueves datos de entrada y salida? Es la base de datos (REST automática). ¿Escribes lógica que se ejecuta y termina? Edge function. ¿Necesitas algo funcionando todo el tiempo? Custom compute.
   </Accordion>
 
+  <Accordion title="¿Cómo consulto una tabla en un schema distinto de `public`?">
+    Por defecto todas tus tablas están en `public`. Solo tienes otro schema si creaste uno tú mismo con `CREATE SCHEMA` (los schemas internos de InsForge, como `auth` y `storage`, están ocultos y no se pueden consultar así). Una vez que tienes uno, puedes leerlo y escribirlo desde el dashboard, la REST API y la CLI. El único lugar que hoy solo ve `public` es el constructor de consultas de `@insforge/sdk`.
+
+    Los ejemplos de abajo usan un schema que creaste llamado `my_schema`.
+
+    **Dashboard.** Abre **Database** y usa el selector de schema en la parte superior de la barra lateral. Cualquier schema que creaste aparece junto a `public`, y al elegirlo navegas por las tablas de ese schema.
+
+    **REST API.** El endpoint de records acepta el schema destino como parámetro de query o como cabecera de perfil de PostgREST. Las lecturas usan `Accept-Profile`; las escrituras y RPC usan `Content-Profile`:
+
+    ```bash
+    # lectura: parámetro ?schema=, o cabecera Accept-Profile
+    curl "$PROJECT_URL/api/database/records/mytable?schema=my_schema" \
+      -H "Authorization: Bearer $TOKEN"
+
+    # escritura: envía Content-Profile
+    curl -X POST "$PROJECT_URL/api/database/records/mytable" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Profile: my_schema" \
+      -H "Content-Type: application/json" \
+      -d '{"name": "hello"}'
+    ```
+
+    **CLI.** Usa SQL directo y cualifica la tabla con el schema:
+
+    ```bash
+    insforge db query "SELECT * FROM my_schema.mytable"
+    ```
+
+    **SDK.** `client.database.from('mytable')` siempre apunta a `public` y todavía no hay opción de schema, así que para otro schema llama directamente al endpoint REST de arriba (con el parámetro `?schema=` o la cabecera `Accept-Profile` / `Content-Profile`) en lugar del constructor de consultas.
+
+    Un paso más para el acceso por API: un schema propio solo es enrutable, no legible. Los roles `anon` y `authenticated` no tienen privilegios sobre él hasta que se los concedes, sin importar quién sea el propietario de las tablas, así que las llamadas devuelven vacío o permiso denegado hasta que lo hagas. Concede privilegios a cada rol que expongas y luego añade RLS:
+
+    ```sql
+    GRANT USAGE ON SCHEMA my_schema TO anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_schema TO anon, authenticated;
+    ```
+
+    La visibilidad de filas queda gobernada por RLS como siempre. Que el project-admin sea propietario solo le permite gestionar y consultar las tablas directamente (por ejemplo desde el editor SQL del dashboard); no da acceso a los roles de la API.
+  </Accordion>
+
   <Accordion title="¿Cómo comparto un proyecto con otro administrador o invito a un compañero de equipo?">
     El acceso se comparte a nivel de **organización**, no por proyecto. Invitas a alguien a la organización propietaria de tus proyectos y obtiene acceso a todos los proyectos que contiene. No existe un flujo aparte para "compartir solo este proyecto".
 
@@ -58,5 +98,34 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
     - Si se pausó porque la organización alcanzó su límite de uso, haz **Upgrade to Pro** para restaurarlo.
 
     ¿Sigues atascado? Pregunta en nuestro [Discord](https://discord.com/invite/DvBtaEc9Jz) para la respuesta más rápida.
+  </Accordion>
+
+  <Accordion title="¿Cómo autentico la CLI sin navegador?">
+    `npx @insforge/cli login` abre un navegador para iniciar sesión. En una máquina sin interfaz, un servidor remoto o CI, usa una user API key en su lugar. No hace falta navegador.
+
+    La forma más rápida es el prompt de configuración del dashboard, que inicia sesión y vincula el proyecto por ti:
+
+    <Steps>
+      <Step title="Abre la página Install">
+        Abre tu proyecto en el dashboard y ve a la página **Install**.
+      </Step>
+      <Step title="Elige tu coding agent">
+        En **Install in Agent**, haz clic en el agent que usas y abre la pestaña **CLI**.
+      </Step>
+      <Step title="Copia el prompt">
+        Copia el prompt de configuración y pégalo en tu agent. Inicia sesión en la CLI y vincula el proyecto en un solo paso.
+      </Step>
+    </Steps>
+
+    El prompt rellena un comando de login limitado a tu cuenta, seguido del comando de vinculación:
+
+    ```bash
+    npx @insforge/cli login --user-api-key <your-user-api-key>
+    npx @insforge/cli link --project-id <your-project-id>
+    ```
+
+    Si solo necesitas la key, por ejemplo para ejecutar la CLI en CI, abre el menú de tu cuenta y ve a **Profile → API Keys**, luego crea una key (ponle una caducidad, o **Never**). Guárdala como secreto de CI y ejecuta `login --user-api-key` con ella. Añade `--json` para una salida legible por máquina.
+
+    La key da acceso completo a tu cuenta, así que mantenla en secreto y rótala si se filtra.
   </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -47,7 +47,7 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
       -d '{"name": "hello"}'
     ```
 
-    **CLI.** Usa SQL directo y cualifica la tabla con el schema:
+    **CLI.** La CLI lee y escribe cualquier schema con `db query`, solo cualifica la tabla con el schema:
 
     ```bash
     insforge db query "SELECT * FROM my_schema.mytable"

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -32,17 +32,19 @@ description: "Answers to common questions about how InsForge works."
 
     **Dashboard.** Open **Database** and use the schema selector at the top of the sidebar. Any schema you created is listed alongside `public`, and picking it browses that schema's tables.
 
-    **REST API.** The records endpoint takes the target schema either as a query param or as a PostgREST profile header:
+    **REST API.** The records endpoint takes the target schema either as a query param or as a PostgREST profile header. Reads use `Accept-Profile`, writes and RPC use `Content-Profile`:
 
     ```bash
-    # query param
+    # read: ?schema= param, or an Accept-Profile header
     curl "$PROJECT_URL/api/database/records/mytable?schema=my_schema" \
       -H "Authorization: Bearer $TOKEN"
 
-    # or a profile header: Accept-Profile for reads, Content-Profile for writes and RPC
-    curl "$PROJECT_URL/api/database/records/mytable" \
+    # write: send Content-Profile
+    curl -X POST "$PROJECT_URL/api/database/records/mytable" \
       -H "Authorization: Bearer $TOKEN" \
-      -H "Accept-Profile: my_schema"
+      -H "Content-Profile: my_schema" \
+      -H "Content-Type: application/json" \
+      -d '{"name": "hello"}'
     ```
 
     **CLI.** Use raw SQL and schema-qualify the table:
@@ -53,7 +55,14 @@ description: "Answers to common questions about how InsForge works."
 
     **SDK.** `client.database.from('mytable')` always targets `public` and there is no schema option yet, so for another schema call the REST endpoint above directly (with the `?schema=` param or the `Accept-Profile` / `Content-Profile` header) instead of the query builder.
 
-    One thing to check either way: the schema is reachable, but the `anon` and `authenticated` roles still need privileges on it. If reads come back empty or denied, grant access and add RLS, for example `GRANT USAGE ON SCHEMA my_schema TO authenticated;` plus the table grants and policies. Tables you created as the project admin are owned by it and work without extra grants.
+    One more step for API access: a custom schema is only routable, not readable. The `anon` and `authenticated` roles have no privileges on it until you grant them, no matter who owns the tables, so calls come back empty or permission-denied until you do. Grant each role you expose, then add RLS:
+
+    ```sql
+    GRANT USAGE ON SCHEMA my_schema TO anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_schema TO anon, authenticated;
+    ```
+
+    Row visibility is then gated by RLS as usual. Project-admin ownership only lets the admin manage and directly query the tables (for example from the dashboard SQL editor); it does not give the API roles access.
   </Accordion>
 
   <Accordion title="How do I share a project with another admin, or invite a teammate?">

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -25,6 +25,37 @@ description: "Answers to common questions about how InsForge works."
     Quick rule: just moving data in and out? That's the database (auto REST). Writing logic that runs and finishes? Edge function. Need something running all the time? Custom compute.
   </Accordion>
 
+  <Accordion title="How do I query a table in a schema other than `public`?">
+    By default all of your tables live in `public`. You only have another schema if you created one yourself with `CREATE SCHEMA` (InsForge's own internal schemas, like `auth` and `storage`, are hidden and can't be queried this way). Once you have one, you can read and write it from the dashboard, the REST API, and the CLI. The one place that only sees `public` today is the `@insforge/sdk` query builder.
+
+    The examples below use a schema you created called `my_schema`.
+
+    **Dashboard.** Open **Database** and use the schema selector at the top of the sidebar. Any schema you created is listed alongside `public`, and picking it browses that schema's tables.
+
+    **REST API.** The records endpoint takes the target schema either as a query param or as a PostgREST profile header:
+
+    ```bash
+    # query param
+    curl "$PROJECT_URL/api/database/records/mytable?schema=my_schema" \
+      -H "Authorization: Bearer $TOKEN"
+
+    # or a profile header: Accept-Profile for reads, Content-Profile for writes and RPC
+    curl "$PROJECT_URL/api/database/records/mytable" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Accept-Profile: my_schema"
+    ```
+
+    **CLI.** Use raw SQL and schema-qualify the table:
+
+    ```bash
+    insforge db query "SELECT * FROM my_schema.mytable"
+    ```
+
+    **SDK.** `client.database.from('mytable')` always targets `public` and there is no schema option yet, so for another schema call the REST endpoint above directly (with the `?schema=` param or the `Accept-Profile` / `Content-Profile` header) instead of the query builder.
+
+    One thing to check either way: the schema is reachable, but the `anon` and `authenticated` roles still need privileges on it. If reads come back empty or denied, grant access and add RLS, for example `GRANT USAGE ON SCHEMA my_schema TO authenticated;` plus the table grants and policies. Tables you created as the project admin are owned by it and work without extra grants.
+  </Accordion>
+
   <Accordion title="How do I share a project with another admin, or invite a teammate?">
     Access is shared at the **organization** level, not per project. You invite someone to the organization that owns your projects, and they get access to every project inside it. There is no separate "share just this one project" flow.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -47,7 +47,7 @@ description: "Answers to common questions about how InsForge works."
       -d '{"name": "hello"}'
     ```
 
-    **CLI.** Use raw SQL and schema-qualify the table:
+    **CLI.** The CLI reads and writes any schema through `db query`, just schema-qualify the table:
 
     ```bash
     insforge db query "SELECT * FROM my_schema.mytable"

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -47,7 +47,7 @@ description: "關於 InsForge 運作方式的常見問題解答。"
       -d '{"name": "hello"}'
     ```
 
-    **CLI。** 用 raw SQL，並給表名加上 schema 前綴：
+    **CLI。** CLI 用 `db query` 就能讀寫任意 schema，把表名加上 schema 前綴即可：
 
     ```bash
     insforge db query "SELECT * FROM my_schema.mytable"

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -25,6 +25,46 @@ description: "關於 InsForge 運作方式的常見問題解答。"
     一句話判斷：只是讀寫資料，就走資料庫（自動 REST）；要寫一段跑完就結束的邏輯，用 Edge Function；要一直執行，用 Custom Compute。
   </Accordion>
 
+  <Accordion title="怎麼查詢 public 以外 schema 裡的表？">
+    預設你所有的表都在 `public` 裡。只有當你自己用 `CREATE SCHEMA` 建過別的 schema，才會有非 `public` 的 schema（InsForge 自己的內部 schema，例如 `auth`、`storage`，是隱藏的，沒辦法這樣查）。一旦有了，dashboard、REST API、CLI 都能讀寫它。目前唯一只認 `public` 的是 `@insforge/sdk` 的查詢建構器。
+
+    下面的例子用一個你自己建立、名叫 `my_schema` 的 schema。
+
+    **Dashboard。** 打開 **Database**，用側邊欄頂部的 schema 選擇器。你建的任何 schema 都會和 `public` 並列出現，選中它就能瀏覽該 schema 下的表。
+
+    **REST API。** records 介面既接受 query 參數，也接受 PostgREST 的 profile header。讀用 `Accept-Profile`，寫和 RPC 用 `Content-Profile`：
+
+    ```bash
+    # 讀：?schema= 參數，或 Accept-Profile header
+    curl "$PROJECT_URL/api/database/records/mytable?schema=my_schema" \
+      -H "Authorization: Bearer $TOKEN"
+
+    # 寫：帶上 Content-Profile
+    curl -X POST "$PROJECT_URL/api/database/records/mytable" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Profile: my_schema" \
+      -H "Content-Type: application/json" \
+      -d '{"name": "hello"}'
+    ```
+
+    **CLI。** 用 raw SQL，並給表名加上 schema 前綴：
+
+    ```bash
+    insforge db query "SELECT * FROM my_schema.mytable"
+    ```
+
+    **SDK。** `client.database.from('mytable')` 永遠指向 `public`，目前沒有指定 schema 的選項，所以要存取別的 schema，請直接呼叫上面的 REST 介面（用 `?schema=` 參數，或 `Accept-Profile` / `Content-Profile` header），而不是用查詢建構器。
+
+    不管走哪條路，存取 API 都還有一步：自建 schema 只是「可路由」，不等於「可讀」。在你顯式授權之前，`anon` 和 `authenticated` 角色對它沒有任何權限，跟表的 owner 是誰無關，所以授權前呼叫只會回傳空結果或權限不足。給你要開放的每個角色授權，再加 RLS：
+
+    ```sql
+    GRANT USAGE ON SCHEMA my_schema TO anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_schema TO anon, authenticated;
+    ```
+
+    之後列級可見性照常由 RLS 控制。project_admin 擁有表，只是讓它能管理並直接查詢這些表（例如在 dashboard 的 SQL 編輯器裡），並不會給 API 角色存取權限。
+  </Accordion>
+
   <Accordion title="怎麼把專案分享給另一個管理員，或者邀請隊友？">
     存取權限是按 **organization（組織）** 共享的，不是按單個 project。你是把人邀請進擁有這些 project 的組織，他就能存取組織下的所有 project，沒有「只分享某一個 project」的入口。
 
@@ -58,5 +98,34 @@ description: "關於 InsForge 運作方式的常見問題解答。"
     - 如果是因為 organization 超出用量而暫停，需要 **Upgrade to Pro** 才能恢復。
 
     還是卡住？到我們的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提問，回應最快。
+  </Accordion>
+
+  <Accordion title="不打開瀏覽器，怎麼幫 CLI 登入驗證？">
+    `npx @insforge/cli login` 會打開瀏覽器登入。在無介面機器、遠端伺服器或 CI 上，改用 user API key，不需要瀏覽器。
+
+    最快的方式是用 dashboard 裡的 setup prompt，它會幫你登入並關聯好專案：
+
+    <Steps>
+      <Step title="打開 Install 頁">
+        在 dashboard 裡打開你的專案，進入 **Install** 頁。
+      </Step>
+      <Step title="選擇你的 coding agent">
+        在 **Install in Agent** 下點你在用的 agent，然後切到 **CLI** 分頁。
+      </Step>
+      <Step title="複製 prompt">
+        複製 setup prompt 貼給你的 agent，它會一步搞定登入和專案關聯。
+      </Step>
+    </Steps>
+
+    這個 prompt 會填好一條限定到你帳號的登入命令，後面跟著關聯命令：
+
+    ```bash
+    npx @insforge/cli login --user-api-key <your-user-api-key>
+    npx @insforge/cli link --project-id <your-project-id>
+    ```
+
+    如果你只需要那把 key（例如在 CI 裡跑 CLI），打開帳號選單，進入 **Profile → API Keys**，建立一把 key（設個有效期，或選 **Never**）。把它存成 CI secret，再用它跑 `login --user-api-key`。加上 `--json` 可以得到機器可讀的輸出。
+
+    這把 key 擁有你帳號的完整權限，所以要保密，一旦外洩就輪換掉。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -25,6 +25,46 @@ description: "关于 InsForge 工作方式的常见问题解答。"
     一句话判断：只是读写数据，就走数据库（自动 REST）；要写一段跑完就结束的逻辑，用 Edge Function；要一直运行，用 Custom Compute。
   </Accordion>
 
+  <Accordion title="怎么查询 public 以外 schema 里的表？">
+    默认你所有的表都在 `public` 里。只有当你自己用 `CREATE SCHEMA` 建过别的 schema，才会有非 `public` 的 schema（InsForge 自己的内部 schema，比如 `auth`、`storage`，是隐藏的，没法这样查）。一旦有了，dashboard、REST API、CLI 都能读写它。目前唯一只认 `public` 的是 `@insforge/sdk` 的查询构造器。
+
+    下面的例子用一个你自己建的、名叫 `my_schema` 的 schema。
+
+    **Dashboard。** 打开 **Database**，用侧边栏顶部的 schema 选择器。你建的任何 schema 都会和 `public` 并列出现，选中它就能浏览该 schema 下的表。
+
+    **REST API。** records 接口既接受 query 参数，也接受 PostgREST 的 profile header。读用 `Accept-Profile`，写和 RPC 用 `Content-Profile`：
+
+    ```bash
+    # 读：?schema= 参数，或 Accept-Profile header
+    curl "$PROJECT_URL/api/database/records/mytable?schema=my_schema" \
+      -H "Authorization: Bearer $TOKEN"
+
+    # 写：带上 Content-Profile
+    curl -X POST "$PROJECT_URL/api/database/records/mytable" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Profile: my_schema" \
+      -H "Content-Type: application/json" \
+      -d '{"name": "hello"}'
+    ```
+
+    **CLI。** 用 raw SQL，并给表名加上 schema 前缀：
+
+    ```bash
+    insforge db query "SELECT * FROM my_schema.mytable"
+    ```
+
+    **SDK。** `client.database.from('mytable')` 永远指向 `public`，目前没有指定 schema 的选项，所以要访问别的 schema，请直接调用上面的 REST 接口（用 `?schema=` 参数，或 `Accept-Profile` / `Content-Profile` header），而不是用查询构造器。
+
+    不管走哪条路，访问 API 都还有一步：自建 schema 只是「可路由」，不等于「可读」。在你显式授权之前，`anon` 和 `authenticated` 角色对它没有任何权限，跟表的 owner 是谁无关，所以授权前调用只会返回空结果或权限不足。给你要开放的每个角色授权，再加 RLS：
+
+    ```sql
+    GRANT USAGE ON SCHEMA my_schema TO anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_schema TO anon, authenticated;
+    ```
+
+    之后行级可见性照常由 RLS 控制。project_admin 拥有表，只是让它能管理并直接查询这些表（比如在 dashboard 的 SQL 编辑器里），并不会给 API 角色访问权限。
+  </Accordion>
+
   <Accordion title="怎么把项目分享给另一个管理员，或者邀请队友？">
     访问权限是按 **organization（组织）** 共享的，不是按单个 project。你是把人邀请进拥有这些 project 的组织，他就能访问组织下的所有 project，没有「只分享某一个 project」的入口。
 
@@ -58,5 +98,34 @@ description: "关于 InsForge 工作方式的常见问题解答。"
     - 如果是因为 organization 超出用量而暂停，需要 **Upgrade to Pro** 才能恢复。
 
     还是卡住？到我们的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提问，响应最快。
+  </Accordion>
+
+  <Accordion title="不打开浏览器，怎么给 CLI 登录鉴权？">
+    `npx @insforge/cli login` 会打开浏览器登录。在无界面机器、远程服务器或 CI 上，改用 user API key，不需要浏览器。
+
+    最快的方式是用 dashboard 里的 setup prompt，它会帮你登录并关联好项目：
+
+    <Steps>
+      <Step title="打开 Install 页">
+        在 dashboard 里打开你的项目，进入 **Install** 页。
+      </Step>
+      <Step title="选择你的 coding agent">
+        在 **Install in Agent** 下点你在用的 agent，然后切到 **CLI** 标签。
+      </Step>
+      <Step title="复制 prompt">
+        复制 setup prompt 粘贴给你的 agent，它会一步搞定登录和项目关联。
+      </Step>
+    </Steps>
+
+    这个 prompt 会填好一条限定到你账号的登录命令，后面跟着关联命令：
+
+    ```bash
+    npx @insforge/cli login --user-api-key <your-user-api-key>
+    npx @insforge/cli link --project-id <your-project-id>
+    ```
+
+    如果你只需要那把 key（比如在 CI 里跑 CLI），打开账号菜单，进入 **Profile → API Keys**，创建一把 key（设个有效期，或选 **Never**）。把它存成 CI secret，再用它跑 `login --user-api-key`。加上 `--json` 可以得到机器可读的输出。
+
+    这把 key 拥有你账号的完整权限，所以要保密，一旦泄露就轮换掉。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -47,7 +47,7 @@ description: "关于 InsForge 工作方式的常见问题解答。"
       -d '{"name": "hello"}'
     ```
 
-    **CLI。** 用 raw SQL，并给表名加上 schema 前缀：
+    **CLI。** CLI 用 `db query` 就能读写任意 schema，把表名加上 schema 前缀即可：
 
     ```bash
     insforge db query "SELECT * FROM my_schema.mytable"


### PR DESCRIPTION
Adds a FAQ entry covering how to read/write tables in a schema other than `public`.

Prompted by a support question ('I have tables inside a non-public schema, how do I query them?') that Ask AI couldn't answer, because the only surface that lacks schema selection is the SDK query builder, and that's the one the docs cover.

Covers all four surfaces honestly:
- **Dashboard** — schema selector in the Database sidebar.
- **REST API** — `?schema=` query param or `Accept-Profile`/`Content-Profile` header.
- **CLI** — `insforge db query` with a schema-qualified table.
- **SDK** — `.from()` targets `public` only; use the REST endpoint directly.

Also clarifies that you only have a non-public schema if you created one yourself (internal schemas like `auth`/`storage` stay hidden) and notes the GRANT/RLS step for `anon`/`authenticated`. Uses a placeholder name `my_schema`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add FAQ for querying tables in non‑public schemas, with REST read/write examples (`?schema`, `Accept-Profile`, `Content-Profile`), GRANT/RLS steps, and a note that `@insforge/sdk` targets `public` only; clarify that the CLI can read and write any schema via `insforge db query` with schema‑qualified tables. Also add a headless CLI auth FAQ with `npx @insforge/cli login --user-api-key` and project linking from the Install prompt, plus CI tips (`--json`), translated to es, zh, and zh‑Hant.

<sup>Written for commit a655f6025c9fdcaf25bd4de1d7ebcd188c18a07f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the FAQ with new accordion guidance for querying tables outside `public`, including Dashboard schema selection, REST API `?schema=` plus profile headers for reads/writes/RPC, CLI schema-qualified SQL, and SDK limitations (uses `public` only).
  - Added clear access setup requirements: grant schema/table privileges to `anon`/`authenticated`, configure RLS, and note that admin ownership doesn’t automatically grant API access (with example `GRANT` statements).
  - Added FAQ guidance for non-browser CLI login using user API keys, including CI-friendly commands and `--json` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- Macroscope's changelog starts here -->
> #### Changes since #1722 opened
>
> - Updated CLI guidance in FAQ documentation across all language versions to instruct users to use `db query` with schema-qualified table names for reading and writing any schema [a655f60]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->