### PR TITLE
docs: document default email sender domain

### DIFF
--- a/docs/es/sdks/typescript/email.mdx
+++ b/docs/es/sdks/typescript/email.mdx
@@ -18,11 +18,11 @@ Envía correos electrónicos HTML personalizados a uno o más destinatarios.
 - `html` (string, required) - Contenido HTML del correo electrónico
 - `cc` (string | string[], optional) - Destinatarios CC, máximo 50 destinatarios
 - `bcc` (string | string[], optional) - Destinatarios BCC, máximo 50 destinatarios
-- `from` (string, optional) - Nombre personalizado del remitente, máximo 100 caracteres
+- `from` (string, optional) - Nombre visible mostrado junto a la dirección del remitente, máximo 100 caracteres (se ignora cuando SMTP Personalizado está habilitado)
 - `replyTo` (string, optional) - Dirección de correo electrónico de respuesta, debe ser una dirección de correo válida
 
 <Note>
-Cuando [SMTP Personalizado](/core-concepts/messaging/custom-smtp) está habilitado para tu proyecto, el campo `from` se ignora. El nombre del remitente y el correo electrónico siempre se toman de tu configuración SMTP para evitar spoofing a través de tu servidor.
+De forma predeterminada, los correos se envían desde `noreply@<tu-proyecto>.send.insforge.dev`, un subdominio por proyecto que InsForge Cloud aprovisiona y verifica por ti, por lo que no se requiere ninguna configuración de dominio. El campo `from` solo establece el nombre visible que aparece junto a esa dirección; con el proveedor predeterminado no puedes cambiar la dirección ni el dominio. Para enviar desde tu propio dominio, configura [SMTP Personalizado](/core-concepts/messaging/custom-smtp). Cuando SMTP Personalizado está habilitado, el campo `from` se ignora por completo y el nombre del remitente y el correo electrónico se toman de tu configuración SMTP para evitar spoofing a través de tu servidor.
 </Note>
 
 ### Devoluciones

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -18,15 +18,11 @@ Send custom HTML emails to one or more recipients.
 - `html` (string, required) - HTML content of the email
 - `cc` (string | string[], optional) - CC recipient(s), max 50 recipients
 - `bcc` (string | string[], optional) - BCC recipient(s), max 50 recipients
-- `from` (string, optional) - Custom sender name, max 100 characters
+- `from` (string, optional) - Display name shown next to the sender address, max 100 characters (ignored when Custom SMTP is enabled)
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
 <Note>
-By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp).
-</Note>
-
-<Note>
-When [Custom SMTP](/core-concepts/messaging/custom-smtp) is enabled for your project, the `from` field is ignored. The sender name and email are always taken from your SMTP configuration to prevent spoofing through your server.
+By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp). When Custom SMTP is enabled the `from` field is ignored entirely, and the sender name and email are taken from your SMTP configuration to prevent spoofing through your server.
 </Note>
 
 ### Returns

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -22,6 +22,10 @@ Send custom HTML emails to one or more recipients.
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
 <Note>
+By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp).
+</Note>
+
+<Note>
 When [Custom SMTP](/core-concepts/messaging/custom-smtp) is enabled for your project, the `from` field is ignored. The sender name and email are always taken from your SMTP configuration to prevent spoofing through your server.
 </Note>
 

--- a/docs/zh-Hant/sdks/typescript/email.mdx
+++ b/docs/zh-Hant/sdks/typescript/email.mdx
@@ -18,11 +18,11 @@ import Installation from '/snippets/sdk-installation.mdx';
 - `html` (string, required) - 電子郵件的 HTML 內容
 - `cc` (string | string[], optional) - 副本收件人，最多 50 個收件人
 - `bcc` (string | string[], optional) - 密件副本收件人，最多 50 個收件人
-- `from` (string, optional) - 自訂寄件者名稱，最多 100 個字元
+- `from` (string, optional) - 顯示在寄件地址旁的顯示名稱，最多 100 個字元（啟用自訂 SMTP 時會被忽略）
 - `replyTo` (string, optional) - 回覆電子郵件地址，必須是有效的電子郵件地址
 
 <Note>
-當為您的專案啟用[自訂 SMTP](/core-concepts/messaging/custom-smtp) 時，`from` 欄位將被忽略。寄件者名稱和電子郵件一律取自您的 SMTP 組態，以防止透過您的伺服器進行詐騙。
+預設情況下，郵件從 `noreply@<你的專案>.send.insforge.dev` 寄出，這是 InsForge Cloud 為您的每個專案佈建並驗證的專屬子網域，因此無需任何網域設定。`from` 欄位只設定顯示在該地址旁的顯示名稱；使用預設寄件服務時，您無法變更寄件地址或網域。若要從自己的網域寄信，請設定[自訂 SMTP](/core-concepts/messaging/custom-smtp)。啟用自訂 SMTP 後，`from` 欄位會被完全忽略，寄件者名稱和電子郵件皆取自您的 SMTP 組態，以防止透過您的伺服器進行詐騙。
 </Note>
 
 ### 傳回

--- a/docs/zh/sdks/typescript/email.mdx
+++ b/docs/zh/sdks/typescript/email.mdx
@@ -18,11 +18,11 @@ import Installation from '/snippets/sdk-installation.mdx';
 - `html` (string, required) - 电子邮件的 HTML 内容
 - `cc` (string | string[], optional) - 抄送收件人，最多 50 个收件人
 - `bcc` (string | string[], optional) - 密送收件人，最多 50 个收件人
-- `from` (string, optional) - 自定义发件人名称，最多 100 个字符
+- `from` (string, optional) - 显示在发件地址旁的显示名，最多 100 个字符（启用自定义 SMTP 时会被忽略）
 - `replyTo` (string, optional) - 回复电子邮件地址，必须是有效的电子邮件地址
 
 <Note>
-当为您的项目启用[自定义 SMTP](/core-concepts/messaging/custom-smtp) 时，`from` 字段将被忽略。发件人名称和电子邮件始终取自您的 SMTP 配置，以防止通过您的服务器进行欺骗。
+默认情况下，邮件从 `noreply@<你的项目>.send.insforge.dev` 发出，这是 InsForge Cloud 为你的每个项目预置并验证的专属子域，因此无需任何域名配置。`from` 字段只设置显示在该地址旁的显示名；使用默认发件服务时，你无法更改发件地址或域名。若要从自己的域名发信，请配置[自定义 SMTP](/core-concepts/messaging/custom-smtp)。启用自定义 SMTP 后，`from` 字段会被完全忽略，发件人名称和电子邮件均取自你的 SMTP 配置，以防止通过你的服务器进行欺骗。
 </Note>
 
 ### 返回


### PR DESCRIPTION
## Summary
Adds a note to the Email SDK reference documenting the default sender address so users who send transactional email through InsForge Cloud (no custom provider) can see what recipients get and what `from` actually controls. Prompted by a Mintlify Ask AI conversation where a user asked repeatedly whether any setup was needed to send default emails, and the docs had no answer.

## Scope
- `docs/sdks/typescript/email.mdx` only: one Note stating emails default to `noreply@<your-project>.send.insforge.dev` (a per-project subdomain InsForge Cloud provisions and verifies, no domain setup required), that `from` only sets the display name, and to use Custom SMTP for your own domain.
- English canonical page only. Translated copies (es/zh/zh-Hant) and a separate paid-plan-gate note were flagged but left out of this PR.

## Verification
- Ground-truth checked against `insforge-cloud-backend`: `ses-tenant.service.ts` builds `"<name>" <noreply@<appKey>.send.insforge.dev>`, and `app.config.ts` sets `SES_TENANT_DOMAIN` default `send.insforge.dev`.
- Docs-only change; no build/tests run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the default sender for InsForge Cloud email on the TypeScript Email SDK page and sync the note to es/zh/zh‑Hant, merging duplicate notes. Emails send from `noreply@<your-project>.send.insforge.dev` by default; `from` only sets the display name, you need Custom SMTP to use your own domain, and with Custom SMTP the `from` field is ignored.

<sup>Written for commit d9a2087a0929f4d241a2d19a87b2a5f3f95590c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document default email sender domain and `from` field behavior in email SDK docs
> Updates the `from` parameter description and Note section across all locale variants of the email SDK docs (English, Spanish, Traditional Chinese, Simplified Chinese).
>
> - Clarifies that `from` sets only the display name shown next to the sender address, not the actual sending address
> - Documents the default sender address format as `noreply@<your-project>.send.insforge.dev`
> - Explains that the sending address and domain cannot be changed without Custom SMTP
> - Notes that when Custom SMTP is enabled, the `from` field is ignored entirely and sender details come from SMTP configuration
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9a2087.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `emails.send()` documentation for the TypeScript email SDK to more clearly define the `from` field as a display name (not a sender address) on the default InsForge-provisioned sender.
  * Expanded the note to include the default sender address (`noreply@<your-project>.send.insforge.dev`) and to clarify limitations with the default provider.
  * Confirmed that when Custom SMTP is enabled, the `from` field is fully ignored and sender identity comes from SMTP settings to prevent spoofing (updated across supported language docs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->