### PR TITLE
docs: add FAQ on the service_role-equivalent API key for server-side RLS bypass

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -65,6 +65,32 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
     La visibilidad de filas queda gobernada por RLS como siempre. Que el project-admin sea propietario solo le permite gestionar y consultar las tablas directamente (por ejemplo desde el editor SQL del dashboard); no da acceso a los roles de la API.
   </Accordion>
 
+  <Accordion title="¿InsForge tiene una `service_role` key / `INSFORGE_SERVICE_ROLE_KEY`?">
+    No con ese nombre. El equivalente en InsForge es la **API Key** de tu proyecto (empieza por `ik_`), la clave de administrador con acceso total. Cada proyecto tiene dos claves:
+
+    - **Anon Key**: pública, para el navegador. Las peticiones se ejecutan con el rol `anon`, limitadas por RLS. Es la que provoca `permission denied for schema storage`.
+    - **API Key**: clave de administrador con acceso total, solo para el servidor. Omite RLS.
+
+    Encuentra la API Key en el panel, en **Project Settings → General** (la fila **API Key**, marcada con "acceso total... no la expongas en tu frontend"), o ejecuta `npx @insforge/cli secrets get API_KEY`.
+
+    Úsala desde código de servidor de confianza a través de `createAdminClient`, nunca desde el navegador:
+
+    ```javascript
+    import { createAdminClient } from '@insforge/sdk'
+
+    const admin = createAdminClient({
+      baseUrl: process.env.INSFORGE_URL,
+      apiKey: process.env.INSFORGE_API_KEY, // clave admin (ik_...), omite RLS
+    })
+
+    const { data, error } = await admin.storage
+      .from('post-images')
+      .upload('posts/post-123/cover.jpg', fileObject)
+    ```
+
+    Mantenla en una variable de entorno solo de servidor, nunca una expuesta al navegador (sin prefijo `NEXT_PUBLIC_`, `VITE_` ni `PUBLIC_`).
+  </Accordion>
+
   <Accordion title="¿Cómo comparto un proyecto con otro administrador o invito a un compañero de equipo?">
     El acceso se comparte a nivel de **organización**, no por proyecto. Invitas a alguien a la organización propietaria de tus proyectos y obtiene acceso a todos los proyectos que contiene. No existe un flujo aparte para "compartir solo este proyecto".
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -65,6 +65,32 @@ description: "Answers to common questions about how InsForge works."
     Row visibility is then gated by RLS as usual. Project-admin ownership only lets the admin manage and directly query the tables (for example from the dashboard SQL editor); it does not give the API roles access.
   </Accordion>
 
+  <Accordion title="Does InsForge have a `service_role` key / `INSFORGE_SERVICE_ROLE_KEY`?">
+    Not under that name. InsForge's equivalent is your project's **API Key** (it starts with `ik_`), the full-access admin key. Every project has two keys:
+
+    - **Anon Key**: public, for the browser. Requests run as the `anon` role, gated by RLS. This is the one that hits `permission denied for schema storage`.
+    - **API Key**: full-access admin key, server-only. Bypasses RLS.
+
+    Find the API Key in the dashboard under **Project Settings → General** (the **API Key** row, marked "full access control... do not expose in your frontend"), or run `npx @insforge/cli secrets get API_KEY`.
+
+    Use it from trusted server code through `createAdminClient`, never the browser:
+
+    ```javascript
+    import { createAdminClient } from '@insforge/sdk'
+
+    const admin = createAdminClient({
+      baseUrl: process.env.INSFORGE_URL,
+      apiKey: process.env.INSFORGE_API_KEY, // admin key (ik_...), bypasses RLS
+    })
+
+    const { data, error } = await admin.storage
+      .from('post-images')
+      .upload('posts/post-123/cover.jpg', fileObject)
+    ```
+
+    Keep it in a server-only env var, never one exposed to the browser (no `NEXT_PUBLIC_`, `VITE_`, or `PUBLIC_` prefix).
+  </Accordion>
+
   <Accordion title="How do I share a project with another admin, or invite a teammate?">
     Access is shared at the **organization** level, not per project. You invite someone to the organization that owns your projects, and they get access to every project inside it. There is no separate "share just this one project" flow.
 

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -65,6 +65,32 @@ description: "關於 InsForge 運作方式的常見問題解答。"
     之後列級可見性照常由 RLS 控制。project_admin 擁有表，只是讓它能管理並直接查詢這些表（例如在 dashboard 的 SQL 編輯器裡），並不會給 API 角色存取權限。
   </Accordion>
 
+  <Accordion title="InsForge 有 `service_role` key / `INSFORGE_SERVICE_ROLE_KEY` 嗎？">
+    沒有叫這個名字的。InsForge 裡的等價物是你專案的 **API Key**（以 `ik_` 開頭），也就是全權限的管理員 key。每個專案有兩個 key：
+
+    - **Anon Key**：公開的，給瀏覽器用。請求以 `anon` 角色執行，受 RLS 管，`permission denied for schema storage` 就是它撞出來的。
+    - **API Key**：全權限管理員 key，只在伺服器端用，繞過 RLS。
+
+    在 dashboard 的 **Project Settings → General** 裡找 API Key（標著 **API Key** 的那一行，寫明「對專案有完全控制權限，不要暴露在前端」），或者執行 `npx @insforge/cli secrets get API_KEY`。
+
+    在可信的伺服器端程式碼裡透過 `createAdminClient` 使用，絕不要放到瀏覽器：
+
+    ```javascript
+    import { createAdminClient } from '@insforge/sdk'
+
+    const admin = createAdminClient({
+      baseUrl: process.env.INSFORGE_URL,
+      apiKey: process.env.INSFORGE_API_KEY, // ik_... 管理員 key，繞過 RLS
+    })
+
+    const { data, error } = await admin.storage
+      .from('post-images')
+      .upload('posts/post-123/cover.jpg', fileObject)
+    ```
+
+    把它放在只有伺服器端能讀的環境變數裡，絕不要用會暴露給瀏覽器的變數（不要帶 `NEXT_PUBLIC_`、`VITE_` 或 `PUBLIC_` 前綴）。
+  </Accordion>
+
   <Accordion title="怎麼把專案分享給另一個管理員，或者邀請隊友？">
     存取權限是按 **organization（組織）** 共享的，不是按單個 project。你是把人邀請進擁有這些 project 的組織，他就能存取組織下的所有 project，沒有「只分享某一個 project」的入口。
 

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -65,6 +65,32 @@ description: "关于 InsForge 工作方式的常见问题解答。"
     之后行级可见性照常由 RLS 控制。project_admin 拥有表，只是让它能管理并直接查询这些表（比如在 dashboard 的 SQL 编辑器里），并不会给 API 角色访问权限。
   </Accordion>
 
+  <Accordion title="InsForge 有 `service_role` key / `INSFORGE_SERVICE_ROLE_KEY` 吗？">
+    没有叫这个名字的。InsForge 里的等价物是你项目的 **API Key**（以 `ik_` 开头），也就是全权限的管理员 key。每个项目有两个 key：
+
+    - **Anon Key**：公开的，给浏览器用。请求以 `anon` 角色运行，受 RLS 管，`permission denied for schema storage` 就是它撞出来的。
+    - **API Key**：全权限管理员 key，只在服务端用，绕过 RLS。
+
+    在 dashboard 的 **Project Settings → General** 里找 API Key（标着 **API Key** 的那一行，写明"对项目有完全控制权限，不要暴露在前端"），或者运行 `npx @insforge/cli secrets get API_KEY`。
+
+    在可信的服务端代码里通过 `createAdminClient` 使用，绝不要放到浏览器：
+
+    ```javascript
+    import { createAdminClient } from '@insforge/sdk'
+
+    const admin = createAdminClient({
+      baseUrl: process.env.INSFORGE_URL,
+      apiKey: process.env.INSFORGE_API_KEY, // ik_... 管理员 key，绕过 RLS
+    })
+
+    const { data, error } = await admin.storage
+      .from('post-images')
+      .upload('posts/post-123/cover.jpg', fileObject)
+    ```
+
+    把它放在只有服务端能读的环境变量里，绝不要用会暴露给浏览器的变量（不要带 `NEXT_PUBLIC_`、`VITE_` 或 `PUBLIC_` 前缀）。
+  </Accordion>
+
   <Accordion title="怎么把项目分享给另一个管理员，或者邀请队友？">
     访问权限是按 **organization（组织）** 共享的，不是按单个 project。你是把人邀请进拥有这些 project 的组织，他就能访问组织下的所有 project，没有「只分享某一个 project」的入口。
 


### PR DESCRIPTION
## Summary

Adds a FAQ entry answering "Does InsForge have a `service_role` key / `INSFORGE_SERVICE_ROLE_KEY`?" This is a recurring gap: developers coming from Supabase (often hitting `permission denied for schema storage` when uploading server-side) search for a service-role key by that name, don't find it, and get stuck. The entry maps the concept to InsForge's **API Key** (the full-access admin key, `ik_` prefix), shows how to use it via `createAdminClient`, and points to where to find it.

The title deliberately includes the exact terms developers search (`service_role`, `INSFORGE_SERVICE_ROLE_KEY`) so Ask AI / search can match.

## Scope

- `docs/faq.mdx` (EN) plus `docs/zh/`, `docs/zh-Hant/`, `docs/es/` translations, one new `<Accordion>` each.
- Content only: the two-key distinction (Anon Key vs API Key), where the API Key lives (**Project Settings → General**), CLI retrieval (`npx @insforge/cli secrets get API_KEY`), a `createAdminClient` example, and the server-only warning.
- No code / config / other pages touched.

## Verification

- `createAdminClient({ apiKey })` confirmed to exist on the SDK `origin/main` (`@insforge/sdk` `src/index.ts`); apiKey is sent as the Bearer token, so it authenticates as project admin and bypasses RLS.
- API Key location + `ik_` prefix confirmed from source: dashboard **Project Settings → General** renders the `API Key` row with the exact note "full access control... do not expose this key in your frontend code" (`ProjectSettingsMenuDialog.tsx`); `ik_` bearer routing confirmed in backend auth middleware tests.
- Accordion open/close tags balanced 8/8 in all 4 files; `→` already used across 30 EN docs.
- Chinese prose punctuation verified full-width (U+FF08/FF09/FF0C/FF1A), no stray half-width.
- Not run: Mintlify build / Vale lint (not set up locally); change is small and matches existing FAQ formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a multi-language FAQ explaining that the Supabase-style `service_role`/`INSFORGE_SERVICE_ROLE_KEY` maps to the project `API Key` (`ik_`) and how to use it server-side with `createAdminClient` from `@insforge/sdk` to bypass RLS. Includes where to find the key, the `npx @insforge/cli secrets get API_KEY` command, and a clear “do not expose in the browser” warning.

<sup>Written for commit 7726184f8c28e5681d213098367d989dc84817ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entry clarifying the `service_role`-equivalent API key for server-side RLS bypass
> Adds a new FAQ entry across English, Spanish, Simplified Chinese, and Traditional Chinese docs explaining that InsForge uses an API Key (prefix `ik_`) instead of a `service_role` key. The entry covers the difference between the Anon Key and API Key, where to find the API Key, and how to use `createAdminClient` safely from server-side code only, with a JavaScript code example.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7726184.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance explaining the InsForge API Key as the server-side alternative to a `service_role` key.
  * Clarified the differences between Anon Keys and API Keys, including access permissions and RLS behavior.
  * Documented where to retrieve API Keys and how to use them in trusted server-side code.
  * Added security guidance to keep API Keys in server-only environment variables and out of browser-exposed code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->