### PR TITLE
docs(mcp): add MCP server tool capability table

### DIFF
--- a/docs/mcp-setup.mdx
+++ b/docs/mcp-setup.mdx
@@ -10,6 +10,20 @@ The InsForge MCP server gives your AI coding assistant direct access to your bac
 
 Follow the instructions below for your AI client. Don't see your tool? Browse the [agent directory](https://insforge.dev/agents) for the full list of tested integrations.
 
+## What the MCP server can do
+
+Once connected, the InsForge MCP server exposes these tools to your AI assistant. All run against your own project; write and admin actions require your admin API key.
+
+| Area | Tools | What it does |
+|---|---|---|
+| Database | `get-table-schema`, `run-raw-sql`, `bulk-upsert` | Read schema, run raw SQL (strict mode, admin only), bulk insert/upsert |
+| Storage | `create-bucket`, `list-buckets`, `delete-bucket` | Manage storage buckets |
+| Functions | `create-function`, `get-function`, `update-function`, `delete-function` | Manage Deno edge functions |
+| Deployment | `create-deployment`, `start-deployment`, `get-container-logs` | Deploy your app and read container logs |
+| Setup & docs | `fetch-docs`, `get-anon-key`, `get-backend-metadata` | Pull docs, generate an anon key, index backend metadata |
+
+Raw SQL runs through the same [strict-mode endpoint](/sdks/rest/database) as the REST API: admin key required, system tables and `auth.users` blocked.
+
 ## Prerequisites
 
 - An **AI coding assistant** (Cursor, Claude Code, GitHub Copilot, etc.)

--- a/docs/mcp-setup.mdx
+++ b/docs/mcp-setup.mdx
@@ -22,7 +22,9 @@ Once connected, the InsForge MCP server exposes these tools to your AI assistant
 | Deployment | `create-deployment`, `start-deployment`, `get-container-logs` | Deploy your app and read container logs |
 | Setup & docs | `fetch-docs`, `get-anon-key`, `get-backend-metadata` | Pull docs, generate an anon key, index backend metadata |
 
-Raw SQL runs through the same [strict-mode endpoint](/sdks/rest/database) as the REST API: admin key required, system tables and `auth.users` blocked.
+<Note>
+  Raw SQL runs through the same [strict-mode endpoint](/sdks/rest/database) as the REST API: admin key required, system tables and `auth.users` blocked.
+</Note>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Adds a concise "What the MCP server can do" capability table to `mcp-setup.mdx`. The page previously described MCP access only as a vague one-liner ("database queries, schema management, storage, and more") and listed no tools, so Ask AI could not connect "MCP" to concrete capabilities and wrongly denied that MCP can run raw SQL. The table gives the retrievable capability anchors.

## Scope
- English default `docs/mcp-setup.mdx` only (v1). es/zh/zh-Hant left as follow-up.
- 5 category rows (Database / Storage / Functions / Deployment / Setup & docs), one line each, tools named but not expanded into full API reference.
- Single internal link to the existing `/sdks/rest/database` strict-mode raw SQL section; `run-raw-sql` annotated as admin-only + strict.
- No exposure concern: the insforge-mcp repo is public (Apache-2.0), the REST endpoint is already documented, and every connected client sees the tool list via `tools/list`.

## Verification
- Confirmed all listed tools exist in `insforge-mcp/src/shared/tools/*.ts` (`registerTool` calls).
- Confirmed link target `docs/sdks/rest/database.mdx` exists and documents `POST /api/database/advance/rawsql`.
- `git diff --check` clean; +14 lines, single file.
- No build/lint run (docs-only Mintlify MDX change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “What the MCP server can do” table to docs/mcp-setup.mdx, listing tools by area (Database, Storage, Functions, Deployment, Setup & docs) with brief descriptions and noting that write/admin actions need an admin API key. The raw SQL strict-mode (admin-only) note is now a Note callout with a link to the REST database strict-mode docs.

<sup>Written for commit 8e4dfa743a5e18093115fb297d82edbf628ac88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MCP server tool capability table to docs
> Adds a 'What the MCP server can do' section to [mcp-setup.mdx](https://github.com/InsForge/InsForge/pull/1728/files#diff-5df7338013badb2957ccf16ead5139f2340aa4a9b884fb076e68002325bb512b) listing available tools across Database, Storage, Functions, Deployment, and Setup & docs categories. Includes a note that the Raw SQL tool uses the strict-mode REST database endpoint, which requires an admin key and blocks access to system tables and `auth.users`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1728 opened
>
> - Wrapped existing documentation content about Raw SQL and the strict-mode endpoint in a `<Note>` block within the `mcp-setup.mdx` documentation [8e4dfa7]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23c442c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an overview section describing what the MCP server can do, including database, storage, functions, deployment, and setup/docs tools.
  * Listed the available tool names and clarified that raw SQL uses the same strict-mode database endpoint as the REST API, including required access and blocked system tables (including `auth.users`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->