### PR TITLE
docs: FAQ on using the CLI for project-specific issues

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -160,4 +160,18 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
 
     En InsForge Cloud nunca tocas esto. El compute está gestionado por nosotros, y el resto de la plataforma (base de datos, autenticación, Storage, edge functions) no necesita ningún token de Fly.
   </Accordion>
+
+  <Accordion title="¿Este asistente puede ayudarme con algo específico de mi propio proyecto?">
+    En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, mirar tus datos ni responder nada relacionado con tu propio backend o configuración. Para cualquier cosa específica de tu proyecto, usa la CLI: lee tu backend en vivo y puede pasar los resultados a la IA:
+
+    ```bash
+    # Informe de salud completo: hallazgos del advisor, salud de la BD, métricas, registros de error recientes
+    npx @insforge/cli diagnose
+
+    # Pregunta sobre tu backend real, con tus propias palabras
+    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
+    ```
+
+    `diagnose --ai` acepta cualquier pregunta y basa la respuesta en las señales reales de tu proyecto, así que sirve igual para errores, datos y configuración. Consulta [Diagnostics & advisor](/agent-native/diagnostics) para comprobaciones puntuales como `diagnose advisor`, `diagnose db`, `diagnose metrics` y `diagnose logs`.
+  </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -162,16 +162,6 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
   </Accordion>
 
   <Accordion title="¿Este asistente puede ayudarme con algo específico de mi propio proyecto?">
-    En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, mirar tus datos ni responder nada relacionado con tu propio backend o configuración. Para cualquier cosa específica de tu proyecto, usa la CLI: lee tu backend en vivo y puede pasar los resultados a la IA:
-
-    ```bash
-    # Informe de salud completo: hallazgos del advisor, salud de la BD, métricas, registros de error recientes
-    npx @insforge/cli diagnose
-
-    # Pregunta sobre tu backend real, con tus propias palabras
-    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
-    ```
-
-    `diagnose --ai` acepta cualquier pregunta y basa la respuesta en las señales reales de tu proyecto, así que sirve igual para errores, datos y configuración. Consulta [Diagnostics & advisor](/agent-native/diagnostics) para comprobaciones puntuales como `diagnose advisor`, `diagnose db`, `diagnose metrics` y `diagnose logs`.
+    En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, leer tus datos ni revisar tu configuración. Lleva cualquier cosa específica de tu propio proyecto a tu agente de programación. Conectado a InsForge a través de la CLI (y MCP), tu agente puede leer tu backend en vivo, el esquema, los datos y los logs, y depurar el problema directamente. Solo descríbelo con tus propias palabras. Para un informe de salud y errores que puedes ejecutar tú mismo, usa `npx @insforge/cli diagnose`. Consulta [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -162,6 +162,6 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
   </Accordion>
 
   <Accordion title="¿Este asistente puede ayudarme con algo específico de mi propio proyecto?">
-    En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, leer tus datos ni revisar tu configuración. Lleva cualquier cosa específica de tu propio proyecto a tu agente de programación. Conectado a InsForge a través de la CLI (y MCP), tu agente puede leer tu backend en vivo, el esquema, los datos y los logs, y depurar el problema directamente. Solo descríbelo con tus propias palabras. Para un informe de salud y errores que puedes ejecutar tú mismo, usa `npx @insforge/cli diagnose`. Consulta [Diagnostics & advisor](/agent-native/diagnostics).
+    En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, leer tus datos ni revisar tu configuración. Lleva cualquier cosa específica de tu propio proyecto a tu agente de programación. Conectado a InsForge a través de la CLI o MCP, tu agente puede leer tu backend en vivo, el esquema, los datos y los logs, y depurar el problema directamente. Solo descríbelo con tus propias palabras. Para un informe de salud y errores que puedes ejecutar tú mismo, usa `npx @insforge/cli diagnose`. Consulta [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -162,16 +162,6 @@ description: "Answers to common questions about how InsForge works."
   </Accordion>
 
   <Accordion title="Can this assistant help with something specific to my own project?">
-    Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, look at your data, or answer anything tied to your own backend or configuration. For anything specific to your project, use the CLI. It reads your live backend and can hand the results to AI:
-
-    ```bash
-    # Full health report: advisor findings, DB health, metrics, recent error logs
-    npx @insforge/cli diagnose
-
-    # Ask about your actual backend, in your own words
-    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
-    ```
-
-    `diagnose --ai` takes any question and grounds the answer in your project's real signals, so it works for errors, data, and config questions alike. See [Diagnostics & advisor](/agent-native/diagnostics) for targeted checks like `diagnose advisor`, `diagnose db`, `diagnose metrics`, and `diagnose logs`.
+    Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, read your data, or check your configuration. Take anything specific to your own project to your coding agent instead. Connected to InsForge through the CLI (and MCP), your agent can read your live backend, schema, data, and logs and debug the problem directly. Just describe it in plain words. For a backend health and error report you can run yourself, use `npx @insforge/cli diagnose`. See [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -160,4 +160,18 @@ description: "Answers to common questions about how InsForge works."
 
     On InsForge Cloud you never touch this. Compute is managed for you, and the rest of the platform (database, auth, storage, edge functions) needs no Fly token at all.
   </Accordion>
+
+  <Accordion title="Can this assistant help with something specific to my own project?">
+    Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, look at your data, or answer anything tied to your own backend or configuration. For anything specific to your project, use the CLI. It reads your live backend and can hand the results to AI:
+
+    ```bash
+    # Full health report: advisor findings, DB health, metrics, recent error logs
+    npx @insforge/cli diagnose
+
+    # Ask about your actual backend, in your own words
+    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
+    ```
+
+    `diagnose --ai` takes any question and grounds the answer in your project's real signals, so it works for errors, data, and config questions alike. See [Diagnostics & advisor](/agent-native/diagnostics) for targeted checks like `diagnose advisor`, `diagnose db`, `diagnose metrics`, and `diagnose logs`.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -162,6 +162,6 @@ description: "Answers to common questions about how InsForge works."
   </Accordion>
 
   <Accordion title="Can this assistant help with something specific to my own project?">
-    Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, read your data, or check your configuration. Take anything specific to your own project to your coding agent instead. Connected to InsForge through the CLI (and MCP), your agent can read your live backend, schema, data, and logs and debug the problem directly. Just describe it in plain words. For a backend health and error report you can run yourself, use `npx @insforge/cli diagnose`. See [Diagnostics & advisor](/agent-native/diagnostics).
+    Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, read your data, or check your configuration. Take anything specific to your own project to your coding agent instead. Connected to InsForge through the CLI or MCP, your agent can read your live backend, schema, data, and logs and debug the problem directly. Just describe it in plain words. For a backend health and error report you can run yourself, use `npx @insforge/cli diagnose`. See [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -162,16 +162,6 @@ description: "關於 InsForge 運作方式的常見問題解答。"
   </Accordion>
 
   <Accordion title="這個助手能幫我解決我自己專案裡的具體問題嗎？">
-    基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也看不到你的資料，更沒辦法回答任何跟你自己後端或設定相關的問題。凡是跟你專案相關的，都用 CLI，它會讀取你的即時後端，還能把結果交給 AI 分析：
-
-    ```bash
-    # 完整健康報告：advisor 發現、資料庫健康、指標、最近的錯誤日誌
-    npx @insforge/cli diagnose
-
-    # 用你自己的話，問你真實的後端
-    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
-    ```
-
-    `diagnose --ai` 能接受任何問題，並根據你專案的真實訊號來回答，所以錯誤、資料、設定類問題都管用。想做單項檢查（`diagnose advisor`、`diagnose db`、`diagnose metrics`、`diagnose logs`），參見 [Diagnostics & advisor](/agent-native/diagnostics)。
+    基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也讀不到你的資料，更查不了你的設定。凡是跟你自己專案相關的，交給你的編碼 agent 來處理。你的 agent 透過 CLI（和 MCP）連著 InsForge，能讀到你的即時後端、結構、資料和日誌，直接幫你除錯，用白話描述問題就行。想自己拿一份後端健康和報錯報告，跑 `npx @insforge/cli diagnose`。參見 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -160,4 +160,18 @@ description: "關於 InsForge 運作方式的常見問題解答。"
 
     在 InsForge Cloud 上你完全不用碰這個。Compute 由平台代管，平台其餘部分（資料庫、認證、Storage、Edge Functions）都不需要任何 Fly token。
   </Accordion>
+
+  <Accordion title="這個助手能幫我解決我自己專案裡的具體問題嗎？">
+    基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也看不到你的資料，更沒辦法回答任何跟你自己後端或設定相關的問題。凡是跟你專案相關的，都用 CLI，它會讀取你的即時後端，還能把結果交給 AI 分析：
+
+    ```bash
+    # 完整健康報告：advisor 發現、資料庫健康、指標、最近的錯誤日誌
+    npx @insforge/cli diagnose
+
+    # 用你自己的話，問你真實的後端
+    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
+    ```
+
+    `diagnose --ai` 能接受任何問題，並根據你專案的真實訊號來回答，所以錯誤、資料、設定類問題都管用。想做單項檢查（`diagnose advisor`、`diagnose db`、`diagnose metrics`、`diagnose logs`），參見 [Diagnostics & advisor](/agent-native/diagnostics)。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -162,6 +162,6 @@ description: "關於 InsForge 運作方式的常見問題解答。"
   </Accordion>
 
   <Accordion title="這個助手能幫我解決我自己專案裡的具體問題嗎？">
-    基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也讀不到你的資料，更查不了你的設定。凡是跟你自己專案相關的，交給你的編碼 agent 來處理。你的 agent 透過 CLI（和 MCP）連著 InsForge，能讀到你的即時後端、結構、資料和日誌，直接幫你除錯，用白話描述問題就行。想自己拿一份後端健康和報錯報告，跑 `npx @insforge/cli diagnose`。參見 [Diagnostics & advisor](/agent-native/diagnostics)。
+    基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也讀不到你的資料，更查不了你的設定。凡是跟你自己專案相關的，交給你的編碼 agent 來處理。你的 agent 透過 CLI 或 MCP 連著 InsForge，能讀到你的即時後端、結構、資料和日誌，直接幫你除錯，用白話描述問題就行。想自己拿一份後端健康和報錯報告，跑 `npx @insforge/cli diagnose`。參見 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -162,16 +162,6 @@ description: "关于 InsForge 工作方式的常见问题解答。"
   </Accordion>
 
   <Accordion title="这个助手能帮我解决我自己项目里的具体问题吗？">
-    基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也看不到你的数据，更没法回答任何跟你自己后端或配置相关的问题。凡是跟你项目相关的，都用 CLI，它会读取你的实时后端，还能把结果交给 AI 分析：
-
-    ```bash
-    # 完整健康报告：advisor 发现、数据库健康、指标、最近的错误日志
-    npx @insforge/cli diagnose
-
-    # 用你自己的话，问你真实的后端
-    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
-    ```
-
-    `diagnose --ai` 能接受任意问题，并基于你项目的真实信号来回答，所以报错、数据、配置类问题都管用。想做单项检查（`diagnose advisor`、`diagnose db`、`diagnose metrics`、`diagnose logs`），参见 [Diagnostics & advisor](/agent-native/diagnostics)。
+    基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也读不到你的数据，更查不了你的配置。凡是跟你自己项目相关的，交给你的编码 agent 来处理。你的 agent 通过 CLI（和 MCP）连着 InsForge，能读到你的实时后端、结构、数据和日志，直接帮你调试，用大白话描述问题就行。想自己拿一份后端健康和报错报告，跑 `npx @insforge/cli diagnose`。参见 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -162,6 +162,6 @@ description: "关于 InsForge 工作方式的常见问题解答。"
   </Accordion>
 
   <Accordion title="这个助手能帮我解决我自己项目里的具体问题吗？">
-    基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也读不到你的数据，更查不了你的配置。凡是跟你自己项目相关的，交给你的编码 agent 来处理。你的 agent 通过 CLI（和 MCP）连着 InsForge，能读到你的实时后端、结构、数据和日志，直接帮你调试，用大白话描述问题就行。想自己拿一份后端健康和报错报告，跑 `npx @insforge/cli diagnose`。参见 [Diagnostics & advisor](/agent-native/diagnostics)。
+    基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也读不到你的数据，更查不了你的配置。凡是跟你自己项目相关的，交给你的编码 agent 来处理。你的 agent 通过 CLI 或 MCP 连着 InsForge，能读到你的实时后端、结构、数据和日志，直接帮你调试，用大白话描述问题就行。想自己拿一份后端健康和报错报告，跑 `npx @insforge/cli diagnose`。参见 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -160,4 +160,18 @@ description: "关于 InsForge 工作方式的常见问题解答。"
 
     在 InsForge Cloud 上你完全不用碰这个。Compute 由平台托管，平台其余部分（数据库、认证、Storage、Edge Functions）都不需要任何 Fly token。
   </Accordion>
+
+  <Accordion title="这个助手能帮我解决我自己项目里的具体问题吗？">
+    基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也看不到你的数据，更没法回答任何跟你自己后端或配置相关的问题。凡是跟你项目相关的，都用 CLI，它会读取你的实时后端，还能把结果交给 AI 分析：
+
+    ```bash
+    # 完整健康报告：advisor 发现、数据库健康、指标、最近的错误日志
+    npx @insforge/cli diagnose
+
+    # 用你自己的话，问你真实的后端
+    npx @insforge/cli diagnose --ai "why is this insert returning 401?"
+    ```
+
+    `diagnose --ai` 能接受任意问题，并基于你项目的真实信号来回答，所以报错、数据、配置类问题都管用。想做单项检查（`diagnose advisor`、`diagnose db`、`diagnose metrics`、`diagnose logs`），参见 [Diagnostics & advisor](/agent-native/diagnostics)。
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
Users paste project-specific errors and details into the docs Ask AI, which answers only from public docs and can't see their backend. Adds one catch-all FAQ accordion (en / es / zh / zh-Hant) that routes any project-specific question to the CLI instead of trying to answer blind.

## Scope
- `docs/faq.mdx` + 3 translations: new accordion "Can this assistant help with something specific to my own project?"
- Framed broadly (errors, data, config, project details), not tied to a specific error, so Ask AI retrieves it for the whole long tail.
- Points to `npx @insforge/cli diagnose` (full health report) and `diagnose --ai "<question>"` (grounds any question in the project's real signals), and links the existing [Diagnostics & advisor](/agent-native/diagnostics) page.

## Verification
- CLI surface checked against source: `diagnose` (no subcommand = full report), `--ai <question>` flag, and subcommands `advisor` / `db` / `metrics` / `logs` all exist in `CLI/src/commands/diagnose/`.
- `/agent-native/diagnostics` link target registered in `docs.json` for all four locales.
- Chinese body uses fullwidth punctuation; halfwidth kept only inside markdown link syntax and code.
- No docs build run locally; content-only change to an existing page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an FAQ that routes project‑specific questions away from the docs assistant to the user’s coding agent. Also shows how to run `npx @insforge/cli diagnose` for a self‑serve health report and links to Diagnostics & advisor.

- **New Features**
  - New accordion in English, Spanish, Simplified Chinese, and Traditional Chinese.
  - Clarifies the agent connects to InsForge via the CLI or MCP.

<sup>Written for commit 75add595593b3f8fe29032bca016d18d3daf7e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entry directing users to CLI `diagnose` commands for project-specific issues
> Adds a new accordion section to the FAQ in English, Spanish, Simplified Chinese, and Traditional Chinese explaining that the assistant cannot access user-specific projects and directing users to the `diagnose` and `diagnose --ai` CLI commands, with a link to the Diagnostics & advisor page.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1730 opened
>
> - Changed the description of InsForge connection methods in FAQ documentation across all language versions from indicating CLI and MCP as combined options to CLI or MCP as alternative options [75add59]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c12821.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ accordion clarifying the assistant can only answer from public documentation and cannot access or debug project-specific errors, data, schema, or configuration.
  * Expanded guidance to use a coding agent via CLI (and MCP) for troubleshooting with live backend insights (structure, data, and logs).
  * Added instructions to run `npx `@insforge/cli` diagnose` and linked to the “Diagnostics & advisor” page in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->