### PR TITLE
Add OpenAPI specification for schedules API

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -285,6 +285,10 @@
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/tables.yaml"
               },
               {
+                "group": "Schedules",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/schedules.yaml"
+              },
+              {
                 "group": "Authentication",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/auth.yaml"
               },
@@ -582,6 +586,10 @@
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/tables.yaml"
               },
               {
+                "group": "Schedules",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/schedules.yaml"
+              },
+              {
                 "group": "身份认证",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/auth.yaml"
               },
@@ -877,6 +885,10 @@
               {
                 "group": "Tables",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/tables.yaml"
+              },
+              {
+                "group": "Schedules",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/schedules.yaml"
               },
               {
                 "group": "身分驗證",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1176,6 +1176,10 @@
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/tables.yaml"
               },
               {
+                "group": "Schedules",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/schedules.yaml"
+              },
+              {
                 "group": "Autenticación",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/auth.yaml"
               },

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -75,6 +75,13 @@ paths:
                   message:
                     type: string
 
+        '404':
+          description: Referenced secret not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
         '400':
           description: Invalid request
           content:
@@ -216,6 +223,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Schedule'
 
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
         '401':
           description: Unauthorized
           content:
@@ -275,6 +289,13 @@ paths:
                     nullable: true
                   message:
                     type: string
+
+        '404':
+          description: Schedule not found or referenced secret not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
         '400':
           description: Invalid request

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -1,0 +1,522 @@
+openapi: 3.0.3
+
+info:
+  title: Insforge Schedules API
+  version: 1.0.0
+  description: Schedule management endpoints
+
+paths:
+  /api/schedules:
+    get:
+      summary: List schedules
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of schedules
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Schedule'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      summary: Create schedule
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScheduleRequest'
+      responses:
+        '201':
+          description: Schedule created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  cronJobId:
+                    type: string
+                  message:
+                    type: string
+
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/schedules/config:
+    get:
+      summary: Get schedules configuration
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Schedules configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchedulesConfig'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      summary: Update schedules configuration
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SchedulesConfig'
+      responses:
+        '200':
+          description: Configuration updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/schedules/{id}:
+    get:
+      summary: Get schedule by ID
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+
+      responses:
+        '200':
+          description: Schedule found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Schedule'
+
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      summary: Update schedule
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateScheduleRequest'
+
+      responses:
+        '200':
+          description: Schedule updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  cronJobId:
+                    type: string
+                  message:
+                    type: string
+
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      summary: Delete schedule
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+
+      responses:
+        '200':
+          description: Schedule deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/schedules/{id}/logs:
+    get:
+      summary: Get execution logs for a schedule
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+
+      responses:
+        '200':
+          description: Schedule execution logs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  logs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ScheduleLog'
+                  totalCount:
+                    type: integer
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        statusCode:
+          type: integer
+
+    Schedule:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        cronSchedule:
+          type: string
+        functionUrl:
+          type: string
+          format: uri
+        httpMethod:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+        headers:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+        body:
+          nullable: true
+        cronJobId:
+          type: string
+          nullable: true
+        lastExecutedAt:
+          type: string
+          format: date-time
+          nullable: true
+        isActive:
+          type: boolean
+        nextRun:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ScheduleLog:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        scheduleId:
+          type: string
+          format: uuid
+        executedAt:
+          type: string
+          format: date-time
+        statusCode:
+          type: integer
+        success:
+          type: boolean
+        durationMs:
+          type: integer
+        message:
+          type: string
+          nullable: true
+
+    SchedulesConfig:
+      type: object
+      properties:
+        retentionDays:
+          type: integer
+          nullable: true
+
+    CreateScheduleRequest:
+      type: object
+      required:
+        - name
+        - cronSchedule
+        - functionUrl
+        - httpMethod
+      properties:
+        name:
+          type: string
+          minLength: 3
+        cronSchedule:
+          type: string
+          description: 5-field cron expression or interval form (1-59 seconds)
+        functionUrl:
+          type: string
+          format: uri
+        httpMethod:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        body:
+          type: object
+
+    UpdateScheduleRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 3
+        cronSchedule:
+          type: string
+        functionUrl:
+          type: string
+          format: uri
+        httpMethod:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        body:
+          type: object
+        isActive:
+          type: boolean

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -38,6 +38,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
     post:
       summary: Create schedule
       description: Creates a new scheduled job.
@@ -64,6 +71,7 @@ paths:
                     format: uuid
                   cronJobId:
                     type: string
+                    nullable: true
                   message:
                     type: string
 
@@ -83,6 +91,13 @@ paths:
 
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -113,6 +128,13 @@ paths:
 
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -163,6 +185,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/schedules/{id}:
     get:
       summary: Get schedule by ID
@@ -187,13 +216,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Schedule'
 
-        '404':
-          description: Schedule not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
         '401':
           description: Unauthorized
           content:
@@ -203,6 +225,13 @@ paths:
 
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -243,18 +272,12 @@ paths:
                     format: uuid
                   cronJobId:
                     type: string
+                    nullable: true
                   message:
                     type: string
 
         '400':
           description: Invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-        '404':
-          description: Schedule not found
           content:
             application/json:
               schema:
@@ -269,6 +292,13 @@ paths:
 
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -300,13 +330,6 @@ paths:
                   message:
                     type: string
 
-        '404':
-          description: Schedule not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
         '401':
           description: Unauthorized
           content:
@@ -316,6 +339,13 @@ paths:
 
         '403':
           description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -385,8 +415,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-        '404':
-          description: Schedule not found
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -413,7 +443,7 @@ components:
           type: string
         statusCode:
           type: integer
-        nextAction:
+        nextActions:
           type: string
 
     Schedule:
@@ -447,8 +477,10 @@ components:
           additionalProperties:
             type: string
         body:
-          type: object
           nullable: true
+          oneOf:
+            - type: string
+            - type: object
         cronJobId:
           type: string
           nullable: true
@@ -523,7 +555,10 @@ components:
           additionalProperties:
             type: string
         body:
-          type: object
+          nullable: true
+          oneOf:
+            - type: string
+            - type: object
 
     UpdateScheduleRequest:
       type: object
@@ -544,6 +579,9 @@ components:
           additionalProperties:
             type: string
         body:
-          type: object
+          nullable: true
+          oneOf:
+            - type: string
+            - type: object
         isActive:
           type: boolean

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -9,6 +9,7 @@ paths:
   /api/schedules:
     get:
       summary: List schedules
+      description: Returns all schedules configured in the system.
       tags:
         - Admin
       security:
@@ -39,6 +40,7 @@ paths:
 
     post:
       summary: Create schedule
+      description: Creates a new scheduled job.
       tags:
         - Admin
       security:
@@ -89,6 +91,7 @@ paths:
   /api/schedules/config:
     get:
       summary: Get schedules configuration
+      description: Returns schedule retention configuration.
       tags:
         - Admin
       security:
@@ -117,6 +120,7 @@ paths:
 
     patch:
       summary: Update schedules configuration
+      description: Updates schedule retention configuration.
       tags:
         - Admin
       security:
@@ -162,6 +166,7 @@ paths:
   /api/schedules/{id}:
     get:
       summary: Get schedule by ID
+      description: Returns a single schedule by identifier.
       tags:
         - Admin
       security:
@@ -205,6 +210,7 @@ paths:
 
     patch:
       summary: Update schedule
+      description: Updates an existing schedule.
       tags:
         - Admin
       security:
@@ -270,6 +276,7 @@ paths:
 
     delete:
       summary: Delete schedule
+      description: Deletes a schedule.
       tags:
         - Admin
       security:
@@ -317,6 +324,7 @@ paths:
   /api/schedules/{id}/logs:
     get:
       summary: Get execution logs for a schedule
+      description: Returns execution history for a schedule with pagination support.
       tags:
         - Admin
       security:
@@ -377,6 +385,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   securitySchemes:
     bearerAuth:
@@ -398,9 +413,20 @@ components:
           type: string
         statusCode:
           type: integer
+        nextAction:
+          type: string
 
     Schedule:
       type: object
+      required:
+        - id
+        - name
+        - cronSchedule
+        - functionUrl
+        - httpMethod
+        - isActive
+        - createdAt
+        - updatedAt
       properties:
         id:
           type: string
@@ -421,6 +447,7 @@ components:
           additionalProperties:
             type: string
         body:
+          type: object
           nullable: true
         cronJobId:
           type: string

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -554,7 +554,6 @@ components:
             type: string
         body:
           type: object
-          nullable: true
 
     UpdateScheduleRequest:
       type: object
@@ -576,6 +575,5 @@ components:
             type: string
         body:
           type: object
-          nullable: true
         isActive:
           type: boolean

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -477,10 +477,8 @@ components:
           additionalProperties:
             type: string
         body:
+          type: object
           nullable: true
-          oneOf:
-            - type: string
-            - type: object
         cronJobId:
           type: string
           nullable: true
@@ -555,10 +553,8 @@ components:
           additionalProperties:
             type: string
         body:
+          type: object
           nullable: true
-          oneOf:
-            - type: string
-            - type: object
 
     UpdateScheduleRequest:
       type: object
@@ -579,9 +575,7 @@ components:
           additionalProperties:
             type: string
         body:
+          type: object
           nullable: true
-          oneOf:
-            - type: string
-            - type: object
         isActive:
           type: boolean

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -159,7 +159,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SchedulesConfig'
+              $ref: '#/components/schemas/UpdateSchedulesConfigRequest'
       responses:
         '200':
           description: Configuration updated successfully
@@ -498,8 +498,10 @@ components:
           additionalProperties:
             type: string
         body:
-          type: object
           nullable: true
+          oneOf:
+            - type: string
+            - type: object
         cronJobId:
           type: string
           nullable: true
@@ -547,6 +549,17 @@ components:
       properties:
         retentionDays:
           type: integer
+          minimum: 1
+          nullable: true
+
+    UpdateSchedulesConfigRequest:
+      type: object
+      required:
+        - retentionDays
+      properties:
+        retentionDays:
+          type: integer
+          minimum: 1
           nullable: true
 
     CreateScheduleRequest:


### PR DESCRIPTION
## Summary

Adds OpenAPI documentation for the schedules module.

### Changes

- Added `openapi/schedules.yaml`
- Documented all 8 schedules endpoints
- Added request and response schemas
- Documented authentication and error responses
- Registered schedules API in `docs/docs.json`

### Verification

- Verified documented routes against `backend/src/api/routes/schedules/index.routes.ts`
- OpenAPI spec validates successfully with swagger-cli
- Repository build completes successfully


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAPI 3.0.3 spec for the Schedules API and registers it across EN, ZH (CN/TW), and ES docs. Covers all endpoints with validator-aligned fields and error responses for accurate docs and client generation.

- **New Features**
  - Added `openapi/schedules.yaml` for 8 endpoints (list/create, config get/patch, CRUD by ID, paginated logs) with standardized errors (400/401/403/404/500 where applicable).
  - Documented JWT bearer auth, schemas (`Schedule`, `ScheduleLog`, `SchedulesConfig`, create/update requests), and rules: name ≥3, cron accepts 5-field or 1–59s interval, HTTP methods enum, logs pagination (limit 1–100 default 50; offset default 0), and correct nullability; registered a new "Schedules" group in `docs/docs.json` across languages.

<sup>Written for commit e9f32c151e93b70bb1519eb0704089dc0e2a3d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added API reference documentation for the Insforge Schedules API, covering schedule listing/creation, schedule configuration (view/update), schedule CRUD by ID, and execution logs with limit/offset pagination.
  * Documented HTTP Bearer JWT authentication and the related request/response and error handling.

* **Documentation**
  * Updated the API Reference navigation to include a new **Schedules** section across supported language tabs, inserted immediately after **Tables**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #1721

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenAPI specification for the schedules API
> Adds [schedules.yaml](https://github.com/InsForge/InsForge/pull/1732/files#diff-d398743a6092ba39085f8d1dde701ec2913544864e222f815ac6a7b177d68483), an OpenAPI 3.0.3 spec covering `GET/POST /api/schedules`, `GET/PATCH /api/schedules/config`, `GET/PATCH/DELETE /api/schedules/{id}`, and `GET /api/schedules/{id}/logs`. Registers the spec in [docs.json](https://github.com/InsForge/InsForge/pull/1732/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9) under four new entries in the `Schedules` group, pointing to the hosted YAML on GitHub.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9f32c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->