### PR TITLE
fix(dashboard): prevent useConfirm promise from hanging on concurrent calls

### DIFF
--- a/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
@@ -1,0 +1,181 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useConfirm } from '#lib/hooks/useConfirm';
+
+describe('useConfirm', () => {
+  it('opens the dialog and resolves to true when confirmed', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise!).resolves.toBe(true);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('opens the dialog and resolves to false when cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await expect(promise!).resolves.toBe(false);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('returns the same promise when confirm is called while a dialog is already pending', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    let promise2: Promise<boolean>;
+    act(() => {
+      promise2 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(promise1!).toBe(promise2!);
+
+    // Should honor the first caller's options
+    expect(result.current.confirmDialogProps.title).toBe('First?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+    await expect(promise2!).resolves.toBe(true);
+  });
+
+  it('passes confirm options through to confirmDialogProps', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    act(() => {
+      result.current.confirm({
+        title: 'Delete Project',
+        description: 'This action is irreversible.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      });
+    });
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: true,
+      title: 'Delete Project',
+      description: 'This action is irreversible.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+  });
+
+  it('allows a new confirm dialog after the previous one is resolved', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+    expect(result.current.confirmDialogProps.title).toBe('Second?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('allows a new confirm dialog after the previous one is cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('provides default empty title and description before confirm is called', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: false,
+      title: '',
+      description: '',
+    });
+  });
+});

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 interface ConfirmOptions {
   title: string;
@@ -14,26 +14,36 @@ export function useConfirm() {
     title: '',
     description: '',
   });
-  const [resolvePromise, setResolvePromise] = useState<((value: boolean) => void) | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
-    setOptions(confirmOptions);
-    setIsOpen(true);
+  const confirm = useCallback(
+    (confirmOptions: ConfirmOptions): Promise<boolean> => {
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current;
+      }
 
-    return new Promise<boolean>((resolve) => {
-      setResolvePromise(() => resolve);
-    });
-  };
+      setOptions(confirmOptions);
+      setIsOpen(true);
 
-  const handleConfirm = () => {
-    resolvePromise?.(true);
+      const promise = new Promise<boolean>((resolve) => {
+        resolveRef.current = resolve;
+      });
+      pendingPromiseRef.current = promise;
+      return promise;
+    },
+    [],
+  );
+
+  const resolve = useCallback((value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    pendingPromiseRef.current = null;
     setIsOpen(false);
-  };
+  }, []);
 
-  const handleCancel = () => {
-    resolvePromise?.(false);
-    setIsOpen(false);
-  };
+  const handleConfirm = useCallback(() => resolve(true), [resolve]);
+  const handleCancel = useCallback(() => resolve(false), [resolve]);
 
   return {
     confirm,


### PR DESCRIPTION
## Summary

Fixes a bug in `useConfirm()` where calling `confirm()` while a confirmation dialog is already pending causes the first promise to **never resolve**, resulting in a permanently hanging promise.

## Root Cause

The `resolve` callback was stored in React state via `useState`. When `confirm()` was called a second time before the dialog was dismissed, `setResolvePromise(() => resolve)` **overwrote** the previous resolve function, orphaning the first promise forever.

Additionally, `handleConfirm`/`handleCancel` read `resolvePromise` from the render closure rather than from a ref, risking stale closure issues.

## Changes

### `useConfirm.ts`
- **`useState` → `useRef` for resolve callback**: No unnecessary re-renders, no stale closures.
- **Guard against concurrent calls**: If `confirm()` is called while a dialog is already pending, the existing promise is returned instead of creating a new one. Both callers receive the same result when the user responds.
- **`useCallback` wrapping**: `confirm`, `handleConfirm`, and `handleCancel` are wrapped with `useCallback` for stable references.
- **Extracted `resolve` helper**: Centralizes cleanup (clear refs + close dialog).

### `useConfirm.test.tsx` (new)
7 tests covering confirm/cancel, concurrent calls, option propagation, and sequential usage.

Closes #1733

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in `useConfirm` where calling `confirm()` while a dialog is already open caused the first promise to hang. Concurrent calls now share one pending promise and resolve together.

- **Bug Fixes**
  - Store the resolve callback in a `useRef` to avoid stale closures and overwrites.
  - Return the existing pending promise on concurrent `confirm()` calls.
  - Use `useCallback` for stable handlers and a shared `resolve` helper to centralize cleanup.

<sup>Written for commit 4ee605dfb1577b84f298df1e958651ab550b92ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useConfirm` hook to return existing promise on concurrent confirm calls
> - Replaces `resolvePromise` state with `resolveRef` and `pendingPromiseRef` refs in [useConfirm.ts](https://github.com/InsForge/InsForge/pull/1734/files#diff-42f8c5643f56a165f33cf04ceeea70451f5e1fafdf1b4d5dd3c189320d8b4954) so that calling `confirm` while a dialog is already open returns the same pending promise instead of overriding it.
> - `handleConfirm`, `handleCancel`, and `confirm` are now wrapped in `useCallback`, making them referentially stable across renders.
> - Adds a test suite in [useConfirm.test.tsx](https://github.com/InsForge/InsForge/pull/1734/files#diff-0d702b01947daa97452b81c3fdb1bfdeb2c7dfcc6324921290eeeec3cd862a0b) covering concurrent calls, resolution, cancellation, and options passthrough.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ee605d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation dialogs to reliably resolve as confirmed or cancelled.
  * Prevented duplicate confirmation requests while a dialog is already pending.
  * Ensured new confirmation requests can be opened correctly after the previous one completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->