### PR TITLE
fix(database): broadcast realtime events for PATCH and PUT

### DIFF
--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -118,7 +118,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     }
 
     // Broadcast socket events for mutations
-    if (['POST', 'DELETE'].includes(method)) {
+    if (['POST', 'DELETE', 'PATCH', 'PUT'].includes(method)) {
       const socket = SocketManager.getInstance();
       socket.broadcastToRoom(
         'role:project_admin',


### PR DESCRIPTION
Closes #1737

## Summary

This PR adds `PATCH` and `PUT` to the array of HTTP methods that broadcast `DATA_UPDATE` socket events in `records.routes.ts`. 

Previously, `records.routes.ts` only broadcasted socket events for `POST` and `DELETE`. As a result, when users updated rows in the dashboard (which triggers a `PATCH` request via PostgREST), other users viewing the same table would not receive the real-time UI update, and their data grid would become stale until a manual refresh. This PR ensures that `PATCH` and `PUT` mutations trigger the same `DATA_UPDATE` event, keeping all connected clients correctly synchronized. 

*(This also brings `records.routes.ts` into parity with the behavior already present in `admin.routes.ts`, which correctly broadcasted updates for `router.patch`.)*

## How did you test this change?

- Verified the code changes locally to ensure the syntax matches the existing socket broadcast logic.
- Analyzed the routing flow for PostgREST proxies (`records.routes.ts`) versus bespoke endpoints (`admin.routes.ts`) to confirm this change resolves the inconsistency between the two endpoints.
- Confirmed that `PATCH` and `PUT` correctly fall into the mutation bucket for the `DATA_UPDATE` event type without unintended side-effects.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadcast `DATA_UPDATE` realtime events for `PATCH` and `PUT` in `records.routes.ts` so PostgREST-driven updates sync immediately across clients. Fixes #1737 and brings behavior in line with `admin.routes.ts`.

<sup>Written for commit ae9b6752371d4680893570675e815bd58f19cf47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Real-time updates are now broadcast for database records modified through both partial updates and full replacements.
  * Existing behavior for creating and deleting records remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->