### PR TITLE
fix(ai): report token usage for streaming chat completions

### DIFF
--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -364,6 +364,12 @@ export class ChatCompletionService {
         max_tokens: options.maxTokens ?? 4096,
         top_p: options.topP,
         stream: true,
+        // Opt in to usage accounting for streamed responses. Unlike non-streaming
+        // completions (which always carry a `usage` object), a streamed response
+        // omits usage entirely unless `stream_options.include_usage` is set — the
+        // provider then emits one final chunk with `choices: []` and the full token
+        // usage. Without this, streaming requests report zero token usage.
+        stream_options: { include_usage: true },
         plugins: this.buildPlugins(options),
         tools: options.tools,
         tool_choice: options.toolChoice,

--- a/backend/tests/unit/ai-streaming-token-usage.test.ts
+++ b/backend/tests/unit/ai-streaming-token-usage.test.ts
@@ -86,8 +86,12 @@ describe('ChatCompletionService.streamChat - token usage accounting', () => {
       events.push(event);
     }
 
-    const usageEvent = events.find((event) => event.tokenUsage);
-    expect(usageEvent?.tokenUsage).toEqual({
+    // With include_usage the provider emits exactly one usage-bearing chunk (the
+    // final one); intermediate chunks carry `usage: null`. Assert a single event
+    // so a regression that double-counts usage across chunks would be caught.
+    const usageEvents = events.filter((event) => event.tokenUsage);
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0].tokenUsage).toEqual({
       promptTokens: 12,
       completionTokens: 8,
       totalTokens: 20,

--- a/backend/tests/unit/ai-streaming-token-usage.test.ts
+++ b/backend/tests/unit/ai-streaming-token-usage.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
+import type { ChatMessageSchema } from '@insforge/shared-schemas';
+
+// Shared mock for the OpenRouter provider's sendRequest. Hoisted so the vi.mock
+// factory (itself hoisted above the imports) can close over it.
+const { sendRequestMock } = vi.hoisted(() => ({ sendRequestMock: vi.fn() }));
+
+vi.mock('../../src/providers/ai/openrouter.provider.js', () => ({
+  OpenRouterProvider: { getInstance: () => ({ sendRequest: sendRequestMock }) },
+}));
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+type StreamingRequest = OpenAI.Chat.ChatCompletionCreateParamsStreaming;
+
+// Minimal async-iterable stream of OpenRouter/OpenAI streaming chunks.
+async function* fakeStream(chunks: unknown[]): AsyncGenerator<unknown> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+// Wire sendRequest so the service's callback runs against a fake OpenAI client,
+// returning the given chunks. Exposes the request payload the service passed to
+// `client.chat.completions.create` so tests can assert on it.
+function mockStream(chunks: unknown[]): { request?: StreamingRequest } {
+  const captured: { request?: StreamingRequest } = {};
+  sendRequestMock.mockImplementation(async (fn: (client: unknown) => unknown) => {
+    const client = {
+      chat: {
+        completions: {
+          create: (request: StreamingRequest) => {
+            captured.request = request;
+            return fakeStream(chunks);
+          },
+        },
+      },
+    };
+    return { result: await fn(client), source: 'env' };
+  });
+  return captured;
+}
+
+describe('ChatCompletionService.streamChat - token usage accounting', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let service: any;
+
+  beforeEach(async () => {
+    sendRequestMock.mockReset();
+    const mod = await import('../../src/services/ai/chat-completion.service.js');
+    service = mod.ChatCompletionService.getInstance();
+  });
+
+  it('opts in to usage accounting via stream_options.include_usage', async () => {
+    const captured = mockStream([{ choices: [{ delta: { content: 'Hi' } }] }]);
+
+    // Drain the generator so the request is issued.
+    for await (const _event of service.streamChat(
+      [{ role: 'user', content: 'Hello' }] as ChatMessageSchema[],
+      { model: 'openai/gpt-4o' }
+    )) {
+      void _event;
+    }
+
+    // Regression guard: without stream_options.include_usage, OpenRouter omits the
+    // usage chunk entirely and streamed requests report zero token usage.
+    expect(captured.request?.stream).toBe(true);
+    expect(captured.request?.stream_options).toEqual({ include_usage: true });
+  });
+
+  it('emits token usage from the final usage-only chunk', async () => {
+    mockStream([
+      { choices: [{ delta: { content: 'Hello ' } }] },
+      { choices: [{ delta: { content: 'world' } }] },
+      // Final chunk carries the totals with an empty choices array (OpenAI/OpenRouter shape).
+      { choices: [], usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 } },
+    ]);
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of service.streamChat(
+      [{ role: 'user', content: 'Hi' }] as ChatMessageSchema[],
+      { model: 'openai/gpt-4o' }
+    )) {
+      events.push(event);
+    }
+
+    const usageEvent = events.find((event) => event.tokenUsage);
+    expect(usageEvent?.tokenUsage).toEqual({
+      promptTokens: 12,
+      completionTokens: 8,
+      totalTokens: 20,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Streaming chat completions never reported token usage. `ChatCompletionService.streamChat()` built the OpenRouter request without `stream_options: { include_usage: true }`, so — per the OpenAI/OpenRouter streaming contract — the provider omitted the `usage` object from the streamed response entirely. As a result the Model Gateway's **streaming** path reported **0 tokens**, while the **non-streaming** path always reported usage.

This PR sets `stream_options: { include_usage: true }` on streaming requests. The provider then emits a final usage-only chunk (`choices: []`) carrying the token totals; the existing stream loop already accumulates `chunk.usage` and yields a `tokenUsage` event, so no other change was required.

Closes #1739

### Why it matters
- Restores per-project usage and cost tracking for streamed completions, matching the documented guarantee that "every request is logged with model, token count, and cost" (`docs/core-concepts/ai/overview.mdx`), which lists streaming as a supported mode.
- Makes streaming and non-streaming behavior consistent — identical prompts now report usage in both modes.

### Changes
- `backend/src/services/ai/chat-completion.service.ts` — add `stream_options: { include_usage: true }` to the streaming request (one line + explanatory comment).
- `backend/tests/unit/ai-streaming-token-usage.test.ts` — new regression tests.

## How did you test this change?

Added `backend/tests/unit/ai-streaming-token-usage.test.ts` with two tests:

1. Asserts the streaming request is issued with `stream_options: { include_usage: true }`. This test **fails on `main`** (`expected undefined to deeply equal { include_usage: true }`) and **passes with the fix** — so it genuinely guards the regression.
2. Asserts `streamChat()` emits the accumulated `tokenUsage` from the final usage-only chunk (`{ promptTokens, completionTokens, totalTokens }`).

Commands run:
- `npx vitest run tests/unit/ai-streaming-token-usage.test.ts` → **2 passed**.
- Full AI gateway unit suite (`ai-*`, `openrouter-*` — 9 files, **92 tests**) → all pass, no regressions.
- `tsc --noEmit` → clean.
- `eslint` on the changed files → clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing token usage for streaming chat completions by opting into usage accounting with `stream_options: { include_usage: true }`. Streaming and non-streaming requests now report consistent token and cost data.

- **Bug Fixes**
  - Set `stream_options: { include_usage: true }` in `ChatCompletionService.streamChat()` so the provider emits a final usage-only chunk.
  - Added `backend/tests/unit/ai-streaming-token-usage.test.ts` to assert the request payload and verify a single `tokenUsage` event is emitted from the final chunk (prevents double counting).

<sup>Written for commit 8a263bcf4c98053ec1138d20c1e16d69e330bc9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming AI responses now include token usage details (prompt, completion, and total token counts), emitted as part of the streamed output.

* **Bug Fixes**
  * Improved usage reporting for streamed responses by ensuring final usage-only data is captured and surfaced correctly.

* **Tests**
  * Added unit coverage to verify token-usage accounting and that the correct single usage event is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report token usage for streaming chat completions
> Sets `stream_options.include_usage: true` on streaming requests in `ChatCompletionService.streamChat`, causing the upstream provider to emit a final chunk containing token usage data. The service parses this final chunk and yields a token usage event to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a263bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->