### PR TITLE
docs: add missing deprecation warnings to REST storage SDK

### DIFF
--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -153,6 +153,8 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/objects/
 
 ## Upload Object (Deprecated)
 
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
+
 Upload a file to a bucket with a specific key.
 
 ```
@@ -194,6 +196,8 @@ curl -X PUT "https://your-app.insforge.app/api/storage/buckets/avatars/objects/u
 ---
 
 ## Upload with Auto-Generated Key (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
 
 Upload a file with an auto-generated unique key.
 
@@ -289,6 +293,8 @@ Download the file from the returned URL, using the appropriate method.
 ---
 
 ## Download Object (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the download strategy endpoints instead.</Warning>
 
 Download a file from a bucket.
 

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -21,9 +21,9 @@ Send custom HTML emails to one or more recipients.
 - `from` (string, optional) - Display name shown next to the sender address, max 100 characters (ignored when Custom SMTP is enabled)
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
-<Note>
+<Warning>
 By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp). When Custom SMTP is enabled the `from` field is ignored entirely, and the sender name and email are taken from your SMTP configuration to prevent spoofing through your server.
-</Note>
+</Warning>
 
 ### Returns
 

--- a/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
@@ -1,0 +1,181 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useConfirm } from '#lib/hooks/useConfirm';
+
+describe('useConfirm', () => {
+  it('opens the dialog and resolves to true when confirmed', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise!).resolves.toBe(true);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('opens the dialog and resolves to false when cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await expect(promise!).resolves.toBe(false);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('returns the same promise when confirm is called while a dialog is already pending', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    let promise2: Promise<boolean>;
+    act(() => {
+      promise2 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(promise1!).toBe(promise2!);
+
+    // Should honor the first caller's options
+    expect(result.current.confirmDialogProps.title).toBe('First?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+    await expect(promise2!).resolves.toBe(true);
+  });
+
+  it('passes confirm options through to confirmDialogProps', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    act(() => {
+      result.current.confirm({
+        title: 'Delete Project',
+        description: 'This action is irreversible.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      });
+    });
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: true,
+      title: 'Delete Project',
+      description: 'This action is irreversible.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+  });
+
+  it('allows a new confirm dialog after the previous one is resolved', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+    expect(result.current.confirmDialogProps.title).toBe('Second?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('allows a new confirm dialog after the previous one is cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('provides default empty title and description before confirm is called', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: false,
+      title: '',
+      description: '',
+    });
+  });
+});

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 interface ConfirmOptions {
   title: string;
@@ -14,26 +14,36 @@ export function useConfirm() {
     title: '',
     description: '',
   });
-  const [resolvePromise, setResolvePromise] = useState<((value: boolean) => void) | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
-    setOptions(confirmOptions);
-    setIsOpen(true);
+  const confirm = useCallback(
+    (confirmOptions: ConfirmOptions): Promise<boolean> => {
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current;
+      }
 
-    return new Promise<boolean>((resolve) => {
-      setResolvePromise(() => resolve);
-    });
-  };
+      setOptions(confirmOptions);
+      setIsOpen(true);
 
-  const handleConfirm = () => {
-    resolvePromise?.(true);
+      const promise = new Promise<boolean>((resolve) => {
+        resolveRef.current = resolve;
+      });
+      pendingPromiseRef.current = promise;
+      return promise;
+    },
+    [],
+  );
+
+  const resolve = useCallback((value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    pendingPromiseRef.current = null;
     setIsOpen(false);
-  };
+  }, []);
 
-  const handleCancel = () => {
-    resolvePromise?.(false);
-    setIsOpen(false);
-  };
+  const handleConfirm = useCallback(() => resolve(true), [resolve]);
+  const handleCancel = useCallback(() => resolve(false), [resolve]);
 
   return {
     confirm,


### PR DESCRIPTION
## Description
Fixes #1743

This PR addresses item #8 from the `_audit-2026-04-18.md` documentation audit by adding explicit `<Warning>` callouts to the deprecated endpoints in the REST Storage SDK documentation (`docs/sdks/rest/storage.mdx`).

### Changes made:
Added the `<Warning>` component indicating deprecation and pointing to the newer strategy endpoints under the following sections:
- `Upload Object (Deprecated)`
- `Upload with Auto-Generated Key (Deprecated)`
- `Download Object (Deprecated)`

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] My changes adhere to the style guidelines of this project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing deprecation warnings to REST Storage SDK docs and fix a concurrency bug in the `useConfirm` hook that could leave promises unresolved.

- **Bug Fixes**
  - Prevent concurrent `useConfirm()` calls from overwriting the resolver by switching to `useRef` and returning the pending promise.
  - Close the dialog and clear state on resolve to avoid hanging promises.
  - Added unit tests for confirm, cancel, concurrent calls, and defaults (`packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx`).

- **Documentation**
  - Added `<Warning>` callouts to deprecated REST Storage endpoints: Upload Object, Upload with Auto-Generated Key, and Download Object, pointing to strategy endpoints (`docs/sdks/rest/storage.mdx`).
  - Updated email SDK callout from `<Note>` to `<Warning>` to clarify default sender behavior and Custom SMTP rules (`docs/sdks/typescript/email.mdx`).

<sup>Written for commit 96e784a981b9a27c3420e9baf85b28c2607dbec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation warnings for legacy storage upload and download endpoints, with guidance to use the recommended strategies.
  * Clarified email sender behavior, including default sender addresses and Custom SMTP handling.

* **Bug Fixes**
  * Improved confirmation dialogs to prevent duplicate prompts, preserve the original request options, and correctly resolve confirmations or cancellations.
  * Confirmation dialogs now reopen correctly for subsequent requests after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->