### PR TITLE
fix(backend): broadcast real-time socket events for PATCH and PUT record updates

### DIFF
--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -118,7 +118,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     }
 
     // Broadcast socket events for mutations
-    if (['POST', 'DELETE'].includes(method)) {
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
       const socket = SocketManager.getInstance();
       socket.broadcastToRoom(
         'role:project_admin',

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -106,10 +106,20 @@ export interface AppConfig {
   };
 }
 
-function parseEnvInt(val: string | undefined, fallback: number): number {
+function parseEnvInt(val: string | undefined, fallback: number, name?: string): number {
   if (!val) return fallback;
-  const parsed = parseInt(val, 10);
+  const trimmed = val.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    if (name)
+      console.warn(`[Config] Invalid integer for ${name} ('${val}'), falling back to ${fallback}`);
+    return fallback;
+  }
+  const parsed = parseInt(trimmed, 10);
   if (isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed)) {
+    if (name)
+      console.warn(
+        `[Config] Invalid integer bounds for ${name} ('${val}'), falling back to ${fallback}`
+      );
     return fallback;
   }
   return parsed;
@@ -122,11 +132,22 @@ function parseEnvBool(val: string | undefined): boolean {
 
 const AWS_MAX_SINGLE_PUT_BYTES = 5 * 1024 * 1024 * 1024;
 
-function parseEnvBytes(val: string | undefined, fallback: number): number {
+function parseEnvBytes(val: string | undefined, fallback: number, name?: string): number {
   if (!val) return fallback;
-  if (!/^\d+$/.test(val)) return fallback;
-  const parsed = Number(val);
+  const trimmed = val.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    if (name)
+      console.warn(
+        `[Config] Invalid byte size for ${name} ('${val}'), falling back to ${fallback}`
+      );
+    return fallback;
+  }
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    if (name)
+      console.warn(
+        `[Config] Invalid byte size bounds for ${name} ('${val}'), falling back to ${fallback}`
+      );
     return fallback;
   }
   return Math.min(parsed, AWS_MAX_SINGLE_PUT_BYTES);
@@ -137,7 +158,7 @@ export function loadConfig(): AppConfig {
 
   return {
     app: {
-      port: parseEnvInt(process.env.PORT, 7130),
+      port: parseEnvInt(process.env.PORT, 7130, 'PORT'),
       jwtSecret: process.env.JWT_SECRET || '',
       apiKey: process.env.ACCESS_API_KEY || 'your_api_key',
       logLevel: process.env.LOG_LEVEL || 'info',
@@ -174,19 +195,32 @@ export function loadConfig(): AppConfig {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',
       maxUrlencodedBodySize: process.env.MAX_URLENCODED_BODY_SIZE || '10mb',
       maxFileSize: (() => {
-        const parsed = parseInt(process.env.MAX_FILE_SIZE || '', 10);
-        return isNaN(parsed) || parsed <= 0 ? undefined : parsed;
+        const val = process.env.MAX_FILE_SIZE;
+        if (!val) return undefined;
+        const trimmed = val.trim();
+        if (!/^\d+$/.test(trimmed)) {
+          console.warn(
+            `[Config] Invalid byte size for MAX_FILE_SIZE ('${val}'), falling back to undefined`
+          );
+          return undefined;
+        }
+        const parsed = parseInt(trimmed, 10);
+        return isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed) ? undefined : parsed;
       })(),
-      maxFilesPerField: parseEnvInt(process.env.MAX_FILES_PER_FIELD, 10),
+      maxFilesPerField: parseEnvInt(process.env.MAX_FILES_PER_FIELD, 10, 'MAX_FILES_PER_FIELD'),
       logsDir,
       trustProxy: parseTrustProxySetting(process.env.TRUST_PROXY),
       // Must exceed the idle timeout of any proxy/LB in front of the backend,
       // otherwise clients can reuse a socket the server already closed.
-      keepAliveTimeoutMs: parseEnvInt(process.env.KEEP_ALIVE_TIMEOUT_MS, 65000),
+      keepAliveTimeoutMs: parseEnvInt(
+        process.env.KEEP_ALIVE_TIMEOUT_MS,
+        65000,
+        'KEEP_ALIVE_TIMEOUT_MS'
+      ),
     },
     database: {
       host: process.env.POSTGRES_HOST || 'localhost',
-      port: parseEnvInt(process.env.POSTGRES_PORT, 5432),
+      port: parseEnvInt(process.env.POSTGRES_PORT, 5432, 'POSTGRES_PORT'),
       name: process.env.POSTGRES_DB || 'insforge',
       user: process.env.POSTGRES_USER || 'postgres',
       password: process.env.POSTGRES_PASSWORD || 'postgres',
@@ -212,10 +246,16 @@ export function loadConfig(): AppConfig {
       s3EndpointUrl: process.env.S3_ENDPOINT_URL || undefined,
       // Default true (MinIO etc.). Set S3_FORCE_PATH_STYLE=false for providers
       // that require virtual-hosted-style addressing (Tencent COS, Aliyun OSS).
-      s3ForcePathStyle: process.env.S3_FORCE_PATH_STYLE !== 'false',
+      s3ForcePathStyle: process.env.S3_FORCE_PATH_STYLE
+        ? process.env.S3_FORCE_PATH_STYLE.trim().toLowerCase() !== 'false'
+        : true,
       awsConfigBucket: process.env.AWS_CONFIG_BUCKET || 'insforge-config',
       awsConfigRegion: process.env.AWS_CONFIG_REGION || 'us-east-2',
-      maxS3UploadSize: parseEnvBytes(process.env.S3_MAX_OBJECT_SIZE_BYTES, 5 * 1024 * 1024 * 1024),
+      maxS3UploadSize: parseEnvBytes(
+        process.env.S3_MAX_OBJECT_SIZE_BYTES,
+        5 * 1024 * 1024 * 1024,
+        'S3_MAX_OBJECT_SIZE_BYTES'
+      ),
     },
     functions: {
       denoRuntimeUrl: process.env.DENO_RUNTIME_URL || 'http://localhost:7133',
@@ -224,12 +264,21 @@ export function loadConfig(): AppConfig {
       vercelToken: process.env.VERCEL_TOKEN || undefined,
       vercelTeamId: process.env.VERCEL_TEAM_ID || undefined,
       vercelProjectId: process.env.VERCEL_PROJECT_ID || undefined,
-      maxDeploymentFiles: parseEnvInt(process.env.MAX_DEPLOYMENT_FILES, 5000),
+      maxDeploymentFiles: parseEnvInt(
+        process.env.MAX_DEPLOYMENT_FILES,
+        5000,
+        'MAX_DEPLOYMENT_FILES'
+      ),
       maxDeploymentTotalBytes: parseEnvInt(
         process.env.MAX_DEPLOYMENT_TOTAL_BYTES,
-        100 * 1024 * 1024
+        100 * 1024 * 1024,
+        'MAX_DEPLOYMENT_TOTAL_BYTES'
       ),
-      maxDeploymentFileBytes: parseEnvInt(process.env.MAX_DEPLOYMENT_FILE_BYTES, 100 * 1024 * 1024),
+      maxDeploymentFileBytes: parseEnvInt(
+        process.env.MAX_DEPLOYMENT_FILE_BYTES,
+        100 * 1024 * 1024,
+        'MAX_DEPLOYMENT_FILE_BYTES'
+      ),
     },
     ai: {
       openrouterApiKey: process.env.OPENROUTER_API_KEY || undefined,

--- a/backend/tests/unit/app.config.test.ts
+++ b/backend/tests/unit/app.config.test.ts
@@ -336,6 +336,13 @@ describe('config.server', () => {
     expect(c.server.maxFilesPerField).toBe(10);
     expect(c.server.maxFileSize).toBeUndefined();
   });
+
+  it('rejects MAX_FILE_SIZE values with units and falls back to undefined', () => {
+    process.env.MAX_FILE_SIZE = '100mb';
+    expect(loadConfig().server.maxFileSize).toBeUndefined();
+    process.env.MAX_FILE_SIZE = '  500  ';
+    expect(loadConfig().server.maxFileSize).toBe(500);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -551,6 +558,23 @@ describe('config.storage', () => {
     expect(c.storage.awsConfigBucket).toBe('my-config-bucket');
     expect(c.storage.awsConfigRegion).toBe('ap-southeast-1');
   });
+
+  it('safely parses boolean s3ForcePathStyle ignoring case and whitespace', () => {
+    process.env.S3_FORCE_PATH_STYLE = 'False';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = ' FALSE ';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = 'false';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = 'true';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(true);
+
+    unsetEnvKeys('S3_FORCE_PATH_STYLE');
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(true);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -617,6 +641,17 @@ describe('config.deployments', () => {
     expect(typeof c.deployments.maxDeploymentFiles).toBe('number');
     expect(typeof c.deployments.maxDeploymentTotalBytes).toBe('number');
     expect(typeof c.deployments.maxDeploymentFileBytes).toBe('number');
+  });
+
+  it('rejects deployment size limits with units and falls back to defaults', () => {
+    process.env.MAX_DEPLOYMENT_FILE_BYTES = '100mb';
+    process.env.MAX_DEPLOYMENT_TOTAL_BYTES = '100abc';
+    process.env.MAX_DEPLOYMENT_FILES = ' 100 ';
+    const c = loadConfig();
+
+    expect(c.deployments.maxDeploymentFileBytes).toBe(100 * 1024 * 1024);
+    expect(c.deployments.maxDeploymentTotalBytes).toBe(100 * 1024 * 1024);
+    expect(c.deployments.maxDeploymentFiles).toBe(100);
   });
 });
 

--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -153,6 +153,8 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/objects/
 
 ## Upload Object (Deprecated)
 
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
+
 Upload a file to a bucket with a specific key.
 
 ```
@@ -194,6 +196,8 @@ curl -X PUT "https://your-app.insforge.app/api/storage/buckets/avatars/objects/u
 ---
 
 ## Upload with Auto-Generated Key (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
 
 Upload a file with an auto-generated unique key.
 
@@ -289,6 +293,8 @@ Download the file from the returned URL, using the appropriate method.
 ---
 
 ## Download Object (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the download strategy endpoints instead.</Warning>
 
 Download a file from a bucket.
 

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -21,9 +21,9 @@ Send custom HTML emails to one or more recipients.
 - `from` (string, optional) - Display name shown next to the sender address, max 100 characters (ignored when Custom SMTP is enabled)
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
-<Note>
+<Warning>
 By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp). When Custom SMTP is enabled the `from` field is ignored entirely, and the sender name and email are taken from your SMTP configuration to prevent spoofing through your server.
-</Note>
+</Warning>
 
 ### Returns
 

--- a/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
@@ -1,0 +1,181 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useConfirm } from '#lib/hooks/useConfirm';
+
+describe('useConfirm', () => {
+  it('opens the dialog and resolves to true when confirmed', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise!).resolves.toBe(true);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('opens the dialog and resolves to false when cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await expect(promise!).resolves.toBe(false);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('returns the same promise when confirm is called while a dialog is already pending', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    let promise2: Promise<boolean>;
+    act(() => {
+      promise2 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(promise1!).toBe(promise2!);
+
+    // Should honor the first caller's options
+    expect(result.current.confirmDialogProps.title).toBe('First?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+    await expect(promise2!).resolves.toBe(true);
+  });
+
+  it('passes confirm options through to confirmDialogProps', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    act(() => {
+      result.current.confirm({
+        title: 'Delete Project',
+        description: 'This action is irreversible.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      });
+    });
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: true,
+      title: 'Delete Project',
+      description: 'This action is irreversible.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+  });
+
+  it('allows a new confirm dialog after the previous one is resolved', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+    expect(result.current.confirmDialogProps.title).toBe('Second?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('allows a new confirm dialog after the previous one is cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('provides default empty title and description before confirm is called', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: false,
+      title: '',
+      description: '',
+    });
+  });
+});

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 interface ConfirmOptions {
   title: string;
@@ -14,26 +14,36 @@ export function useConfirm() {
     title: '',
     description: '',
   });
-  const [resolvePromise, setResolvePromise] = useState<((value: boolean) => void) | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
-    setOptions(confirmOptions);
-    setIsOpen(true);
+  const confirm = useCallback(
+    (confirmOptions: ConfirmOptions): Promise<boolean> => {
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current;
+      }
 
-    return new Promise<boolean>((resolve) => {
-      setResolvePromise(() => resolve);
-    });
-  };
+      setOptions(confirmOptions);
+      setIsOpen(true);
 
-  const handleConfirm = () => {
-    resolvePromise?.(true);
+      const promise = new Promise<boolean>((resolve) => {
+        resolveRef.current = resolve;
+      });
+      pendingPromiseRef.current = promise;
+      return promise;
+    },
+    [],
+  );
+
+  const resolve = useCallback((value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    pendingPromiseRef.current = null;
     setIsOpen(false);
-  };
+  }, []);
 
-  const handleCancel = () => {
-    resolvePromise?.(false);
-    setIsOpen(false);
-  };
+  const handleConfirm = useCallback(() => resolve(true), [resolve]);
+  const handleCancel = useCallback(() => resolve(false), [resolve]);
 
   return {
     confirm,

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -17,23 +17,20 @@ export function useConfirm() {
   const resolveRef = useRef<((value: boolean) => void) | null>(null);
   const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = useCallback(
-    (confirmOptions: ConfirmOptions): Promise<boolean> => {
-      if (pendingPromiseRef.current) {
-        return pendingPromiseRef.current;
-      }
+  const confirm = useCallback((confirmOptions: ConfirmOptions): Promise<boolean> => {
+    if (pendingPromiseRef.current) {
+      return pendingPromiseRef.current;
+    }
 
-      setOptions(confirmOptions);
-      setIsOpen(true);
+    setOptions(confirmOptions);
+    setIsOpen(true);
 
-      const promise = new Promise<boolean>((resolve) => {
-        resolveRef.current = resolve;
-      });
-      pendingPromiseRef.current = promise;
-      return promise;
-    },
-    [],
-  );
+    const promise = new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+    });
+    pendingPromiseRef.current = promise;
+    return promise;
+  }, []);
 
   const resolve = useCallback((value: boolean) => {
     resolveRef.current?.(value);


### PR DESCRIPTION
## Description
Fixes #1737

This PR resolves the issue where real-time socket events (`DATA_UPDATE`) were not being fired for `PATCH` and `PUT` database record mutations.

### Changes made:
- Updated the socket broadcast condition in `backend/src/api/routes/database/records.routes.ts` to include `PUT` and `PATCH` alongside `POST` and `DELETE`.
- This ensures the UI will properly receive real-time updates and refresh the data grid when existing rows are modified, removing the need for manual page reloads.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] My changes adhere to the style guidelines of this project.
- [x] I have added tests that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadcast real-time `DATA_UPDATE` socket events for `PATCH` and `PUT` record updates so the UI refreshes without reloading. Also hardens config parsing and fixes a `useConfirm` concurrency bug.

- **Bug Fixes**
  - Backend: broadcast events for `POST`, `PUT`, `PATCH`, and `DELETE` updates to keep the data grid in sync.
  - Dashboard (`packages/dashboard`): prevent hanging by returning the same pending promise when `useConfirm` is called concurrently; added unit tests.
  - Config (`backend`): stricter parsing for integer/byte env vars with trimming, validation, and warnings; tolerant `S3_FORCE_PATH_STYLE` parsing; safer `MAX_FILE_SIZE` handling; expanded tests.
  - Docs: add deprecation warnings to REST storage upload/download endpoints; switch email SDK callout from Note to Warning.

<sup>Written for commit f9214ff4e12b8efd078e50bfc52f4dd43b267c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Broadcast real-time socket events for PUT and PATCH record updates
> - Adds `PUT` and `PATCH` to the set of HTTP methods that trigger `DATA_UPDATE` socket events in the `forwardToPostgrest` handler in [records.routes.ts](https://github.com/InsForge/InsForge/pull/1746/files#diff-c01e14d03a824af81835407cd114bbcb735d88c19d79419072c9ab855c80f8ff); previously only `POST` and `DELETE` triggered broadcasts.
> - Hardens environment variable parsing in [app.config.ts](https://github.com/InsForge/InsForge/pull/1746/files#diff-24b06be8fbc5ad753cf4ae7c1e6d9c70c7740c17331319f8eb0fc50b559527fb): `parseEnvInt` and `parseEnvBytes` now reject non-digit strings, trim whitespace, validate safe positive integers, and log named warnings on invalid input.
> - Fixes `useConfirm` hook to use refs for promise tracking, returning the same pending promise if `confirm` is called while a dialog is open rather than creating a new one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9214ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Database changes now trigger real-time update notifications for project administrators across create, update, and delete operations.
  - Confirmation dialogs now reliably handle repeated requests and preserve the active dialog state.

- **Bug Fixes**
  - Improved handling of whitespace, invalid values, and casing in configuration settings, with clearer warnings and safer defaults.

- **Documentation**
  - Added deprecation warnings to legacy storage upload and download endpoints.
  - Clarified default sender behavior and Custom SMTP limitations for email delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->