### PR TITLE
perf(dashboard): split large page bundles with React.lazy

### DIFF
--- a/backend/src/api/routes/database/records.routes.ts
+++ b/backend/src/api/routes/database/records.routes.ts
@@ -118,7 +118,7 @@ const forwardToPostgrest = async (req: AuthRequest, res: Response, next: NextFun
     }
 
     // Broadcast socket events for mutations
-    if (['POST', 'DELETE'].includes(method)) {
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
       const socket = SocketManager.getInstance();
       socket.broadcastToRoom(
         'role:project_admin',

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -106,10 +106,20 @@ export interface AppConfig {
   };
 }
 
-function parseEnvInt(val: string | undefined, fallback: number): number {
+function parseEnvInt(val: string | undefined, fallback: number, name?: string): number {
   if (!val) return fallback;
-  const parsed = parseInt(val, 10);
+  const trimmed = val.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    if (name)
+      console.warn(`[Config] Invalid integer for ${name} ('${val}'), falling back to ${fallback}`);
+    return fallback;
+  }
+  const parsed = parseInt(trimmed, 10);
   if (isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed)) {
+    if (name)
+      console.warn(
+        `[Config] Invalid integer bounds for ${name} ('${val}'), falling back to ${fallback}`
+      );
     return fallback;
   }
   return parsed;
@@ -122,11 +132,22 @@ function parseEnvBool(val: string | undefined): boolean {
 
 const AWS_MAX_SINGLE_PUT_BYTES = 5 * 1024 * 1024 * 1024;
 
-function parseEnvBytes(val: string | undefined, fallback: number): number {
+function parseEnvBytes(val: string | undefined, fallback: number, name?: string): number {
   if (!val) return fallback;
-  if (!/^\d+$/.test(val)) return fallback;
-  const parsed = Number(val);
+  const trimmed = val.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    if (name)
+      console.warn(
+        `[Config] Invalid byte size for ${name} ('${val}'), falling back to ${fallback}`
+      );
+    return fallback;
+  }
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    if (name)
+      console.warn(
+        `[Config] Invalid byte size bounds for ${name} ('${val}'), falling back to ${fallback}`
+      );
     return fallback;
   }
   return Math.min(parsed, AWS_MAX_SINGLE_PUT_BYTES);
@@ -137,7 +158,7 @@ export function loadConfig(): AppConfig {
 
   return {
     app: {
-      port: parseEnvInt(process.env.PORT, 7130),
+      port: parseEnvInt(process.env.PORT, 7130, 'PORT'),
       jwtSecret: process.env.JWT_SECRET || '',
       apiKey: process.env.ACCESS_API_KEY || 'your_api_key',
       logLevel: process.env.LOG_LEVEL || 'info',
@@ -174,19 +195,32 @@ export function loadConfig(): AppConfig {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',
       maxUrlencodedBodySize: process.env.MAX_URLENCODED_BODY_SIZE || '10mb',
       maxFileSize: (() => {
-        const parsed = parseInt(process.env.MAX_FILE_SIZE || '', 10);
-        return isNaN(parsed) || parsed <= 0 ? undefined : parsed;
+        const val = process.env.MAX_FILE_SIZE;
+        if (!val) return undefined;
+        const trimmed = val.trim();
+        if (!/^\d+$/.test(trimmed)) {
+          console.warn(
+            `[Config] Invalid byte size for MAX_FILE_SIZE ('${val}'), falling back to undefined`
+          );
+          return undefined;
+        }
+        const parsed = parseInt(trimmed, 10);
+        return isNaN(parsed) || parsed <= 0 || !Number.isSafeInteger(parsed) ? undefined : parsed;
       })(),
-      maxFilesPerField: parseEnvInt(process.env.MAX_FILES_PER_FIELD, 10),
+      maxFilesPerField: parseEnvInt(process.env.MAX_FILES_PER_FIELD, 10, 'MAX_FILES_PER_FIELD'),
       logsDir,
       trustProxy: parseTrustProxySetting(process.env.TRUST_PROXY),
       // Must exceed the idle timeout of any proxy/LB in front of the backend,
       // otherwise clients can reuse a socket the server already closed.
-      keepAliveTimeoutMs: parseEnvInt(process.env.KEEP_ALIVE_TIMEOUT_MS, 65000),
+      keepAliveTimeoutMs: parseEnvInt(
+        process.env.KEEP_ALIVE_TIMEOUT_MS,
+        65000,
+        'KEEP_ALIVE_TIMEOUT_MS'
+      ),
     },
     database: {
       host: process.env.POSTGRES_HOST || 'localhost',
-      port: parseEnvInt(process.env.POSTGRES_PORT, 5432),
+      port: parseEnvInt(process.env.POSTGRES_PORT, 5432, 'POSTGRES_PORT'),
       name: process.env.POSTGRES_DB || 'insforge',
       user: process.env.POSTGRES_USER || 'postgres',
       password: process.env.POSTGRES_PASSWORD || 'postgres',
@@ -212,10 +246,16 @@ export function loadConfig(): AppConfig {
       s3EndpointUrl: process.env.S3_ENDPOINT_URL || undefined,
       // Default true (MinIO etc.). Set S3_FORCE_PATH_STYLE=false for providers
       // that require virtual-hosted-style addressing (Tencent COS, Aliyun OSS).
-      s3ForcePathStyle: process.env.S3_FORCE_PATH_STYLE !== 'false',
+      s3ForcePathStyle: process.env.S3_FORCE_PATH_STYLE
+        ? process.env.S3_FORCE_PATH_STYLE.trim().toLowerCase() !== 'false'
+        : true,
       awsConfigBucket: process.env.AWS_CONFIG_BUCKET || 'insforge-config',
       awsConfigRegion: process.env.AWS_CONFIG_REGION || 'us-east-2',
-      maxS3UploadSize: parseEnvBytes(process.env.S3_MAX_OBJECT_SIZE_BYTES, 5 * 1024 * 1024 * 1024),
+      maxS3UploadSize: parseEnvBytes(
+        process.env.S3_MAX_OBJECT_SIZE_BYTES,
+        5 * 1024 * 1024 * 1024,
+        'S3_MAX_OBJECT_SIZE_BYTES'
+      ),
     },
     functions: {
       denoRuntimeUrl: process.env.DENO_RUNTIME_URL || 'http://localhost:7133',
@@ -224,12 +264,21 @@ export function loadConfig(): AppConfig {
       vercelToken: process.env.VERCEL_TOKEN || undefined,
       vercelTeamId: process.env.VERCEL_TEAM_ID || undefined,
       vercelProjectId: process.env.VERCEL_PROJECT_ID || undefined,
-      maxDeploymentFiles: parseEnvInt(process.env.MAX_DEPLOYMENT_FILES, 5000),
+      maxDeploymentFiles: parseEnvInt(
+        process.env.MAX_DEPLOYMENT_FILES,
+        5000,
+        'MAX_DEPLOYMENT_FILES'
+      ),
       maxDeploymentTotalBytes: parseEnvInt(
         process.env.MAX_DEPLOYMENT_TOTAL_BYTES,
-        100 * 1024 * 1024
+        100 * 1024 * 1024,
+        'MAX_DEPLOYMENT_TOTAL_BYTES'
       ),
-      maxDeploymentFileBytes: parseEnvInt(process.env.MAX_DEPLOYMENT_FILE_BYTES, 100 * 1024 * 1024),
+      maxDeploymentFileBytes: parseEnvInt(
+        process.env.MAX_DEPLOYMENT_FILE_BYTES,
+        100 * 1024 * 1024,
+        'MAX_DEPLOYMENT_FILE_BYTES'
+      ),
     },
     ai: {
       openrouterApiKey: process.env.OPENROUTER_API_KEY || undefined,

--- a/backend/tests/unit/app.config.test.ts
+++ b/backend/tests/unit/app.config.test.ts
@@ -336,6 +336,13 @@ describe('config.server', () => {
     expect(c.server.maxFilesPerField).toBe(10);
     expect(c.server.maxFileSize).toBeUndefined();
   });
+
+  it('rejects MAX_FILE_SIZE values with units and falls back to undefined', () => {
+    process.env.MAX_FILE_SIZE = '100mb';
+    expect(loadConfig().server.maxFileSize).toBeUndefined();
+    process.env.MAX_FILE_SIZE = '  500  ';
+    expect(loadConfig().server.maxFileSize).toBe(500);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -551,6 +558,23 @@ describe('config.storage', () => {
     expect(c.storage.awsConfigBucket).toBe('my-config-bucket');
     expect(c.storage.awsConfigRegion).toBe('ap-southeast-1');
   });
+
+  it('safely parses boolean s3ForcePathStyle ignoring case and whitespace', () => {
+    process.env.S3_FORCE_PATH_STYLE = 'False';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = ' FALSE ';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = 'false';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(false);
+
+    process.env.S3_FORCE_PATH_STYLE = 'true';
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(true);
+
+    unsetEnvKeys('S3_FORCE_PATH_STYLE');
+    expect(loadConfig().storage.s3ForcePathStyle).toBe(true);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -617,6 +641,17 @@ describe('config.deployments', () => {
     expect(typeof c.deployments.maxDeploymentFiles).toBe('number');
     expect(typeof c.deployments.maxDeploymentTotalBytes).toBe('number');
     expect(typeof c.deployments.maxDeploymentFileBytes).toBe('number');
+  });
+
+  it('rejects deployment size limits with units and falls back to defaults', () => {
+    process.env.MAX_DEPLOYMENT_FILE_BYTES = '100mb';
+    process.env.MAX_DEPLOYMENT_TOTAL_BYTES = '100abc';
+    process.env.MAX_DEPLOYMENT_FILES = ' 100 ';
+    const c = loadConfig();
+
+    expect(c.deployments.maxDeploymentFileBytes).toBe(100 * 1024 * 1024);
+    expect(c.deployments.maxDeploymentTotalBytes).toBe(100 * 1024 * 1024);
+    expect(c.deployments.maxDeploymentFiles).toBe(100);
   });
 });
 

--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -153,6 +153,8 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/objects/
 
 ## Upload Object (Deprecated)
 
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
+
 Upload a file to a bucket with a specific key.
 
 ```
@@ -194,6 +196,8 @@ curl -X PUT "https://your-app.insforge.app/api/storage/buckets/avatars/objects/u
 ---
 
 ## Upload with Auto-Generated Key (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the upload strategy endpoints instead.</Warning>
 
 Upload a file with an auto-generated unique key.
 
@@ -289,6 +293,8 @@ Download the file from the returned URL, using the appropriate method.
 ---
 
 ## Download Object (Deprecated)
+
+<Warning>These endpoints are deprecated. Use the download strategy endpoints instead.</Warning>
 
 Download a file from a bucket.
 

--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -21,9 +21,9 @@ Send custom HTML emails to one or more recipients.
 - `from` (string, optional) - Display name shown next to the sender address, max 100 characters (ignored when Custom SMTP is enabled)
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
-<Note>
+<Warning>
 By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp). When Custom SMTP is enabled the `from` field is ignored entirely, and the sender name and email are taken from your SMTP configuration to prevent spoofing through your server.
-</Note>
+</Warning>
 
 ### Returns
 

--- a/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useConfirm.test.tsx
@@ -1,0 +1,181 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useConfirm } from '#lib/hooks/useConfirm';
+
+describe('useConfirm', () => {
+  it('opens the dialog and resolves to true when confirmed', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise!).resolves.toBe(true);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('opens the dialog and resolves to false when cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise: Promise<boolean>;
+    act(() => {
+      promise = result.current.confirm({
+        title: 'Delete?',
+        description: 'Are you sure?',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await expect(promise!).resolves.toBe(false);
+    expect(result.current.confirmDialogProps.open).toBe(false);
+  });
+
+  it('returns the same promise when confirm is called while a dialog is already pending', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    let promise2: Promise<boolean>;
+    act(() => {
+      promise2 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(promise1!).toBe(promise2!);
+
+    // Should honor the first caller's options
+    expect(result.current.confirmDialogProps.title).toBe('First?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+    await expect(promise2!).resolves.toBe(true);
+  });
+
+  it('passes confirm options through to confirmDialogProps', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    act(() => {
+      result.current.confirm({
+        title: 'Delete Project',
+        description: 'This action is irreversible.',
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        destructive: true,
+      });
+    });
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: true,
+      title: 'Delete Project',
+      description: 'This action is irreversible.',
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      destructive: true,
+    });
+  });
+
+  it('allows a new confirm dialog after the previous one is resolved', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+    expect(result.current.confirmDialogProps.title).toBe('Second?');
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('allows a new confirm dialog after the previous one is cancelled', async () => {
+    const { result } = renderHook(() => useConfirm());
+
+    let promise1: Promise<boolean>;
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'First?',
+        description: 'First confirm',
+      });
+    });
+
+    act(() => {
+      result.current.confirmDialogProps.onOpenChange(false);
+    });
+
+    await promise1!;
+    expect(result.current.confirmDialogProps.open).toBe(false);
+
+    act(() => {
+      promise1 = result.current.confirm({
+        title: 'Second?',
+        description: 'Second confirm',
+      });
+    });
+
+    expect(result.current.confirmDialogProps.open).toBe(true);
+
+    act(() => {
+      result.current.confirmDialogProps.onConfirm();
+    });
+
+    await expect(promise1!).resolves.toBe(true);
+  });
+
+  it('provides default empty title and description before confirm is called', () => {
+    const { result } = renderHook(() => useConfirm());
+
+    expect(result.current.confirmDialogProps).toMatchObject({
+      open: false,
+      title: '',
+      description: '',
+    });
+  });
+});

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 interface ConfirmOptions {
   title: string;
@@ -14,26 +14,36 @@ export function useConfirm() {
     title: '',
     description: '',
   });
-  const [resolvePromise, setResolvePromise] = useState<((value: boolean) => void) | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
-    setOptions(confirmOptions);
-    setIsOpen(true);
+  const confirm = useCallback(
+    (confirmOptions: ConfirmOptions): Promise<boolean> => {
+      if (pendingPromiseRef.current) {
+        return pendingPromiseRef.current;
+      }
 
-    return new Promise<boolean>((resolve) => {
-      setResolvePromise(() => resolve);
-    });
-  };
+      setOptions(confirmOptions);
+      setIsOpen(true);
 
-  const handleConfirm = () => {
-    resolvePromise?.(true);
+      const promise = new Promise<boolean>((resolve) => {
+        resolveRef.current = resolve;
+      });
+      pendingPromiseRef.current = promise;
+      return promise;
+    },
+    [],
+  );
+
+  const resolve = useCallback((value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    pendingPromiseRef.current = null;
     setIsOpen(false);
-  };
+  }, []);
 
-  const handleCancel = () => {
-    resolvePromise?.(false);
-    setIsOpen(false);
-  };
+  const handleConfirm = useCallback(() => resolve(true), [resolve]);
+  const handleCancel = useCallback(() => resolve(false), [resolve]);
 
   return {
     confirm,

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -17,23 +17,20 @@ export function useConfirm() {
   const resolveRef = useRef<((value: boolean) => void) | null>(null);
   const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
-  const confirm = useCallback(
-    (confirmOptions: ConfirmOptions): Promise<boolean> => {
-      if (pendingPromiseRef.current) {
-        return pendingPromiseRef.current;
-      }
+  const confirm = useCallback((confirmOptions: ConfirmOptions): Promise<boolean> => {
+    if (pendingPromiseRef.current) {
+      return pendingPromiseRef.current;
+    }
 
-      setOptions(confirmOptions);
-      setIsOpen(true);
+    setOptions(confirmOptions);
+    setIsOpen(true);
 
-      const promise = new Promise<boolean>((resolve) => {
-        resolveRef.current = resolve;
-      });
-      pendingPromiseRef.current = promise;
-      return promise;
-    },
-    [],
-  );
+    const promise = new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+    });
+    pendingPromiseRef.current = promise;
+    return promise;
+  }, []);
 
   const resolve = useCallback((value: boolean) => {
     resolveRef.current?.(value);

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -1,70 +1,118 @@
+import { Suspense, lazy } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
+import { LoadingState } from '@insforge/ui';
 import { RequireAuth } from './RequireAuth';
-import AILayout from '#features/ai/components/AILayout';
-import AIOverviewPage from '#features/ai/pages/AIOverviewPage';
-import AIQuickStartPage from '#features/ai/pages/AIQuickStartPage';
-import AIModelsPage from '#features/ai/pages/AIModelsPage';
-import AnalyticsLayout from '#features/analytics/components/AnalyticsLayout';
-import { TrafficPage } from '#features/analytics/pages/TrafficPage';
-import { RetentionPage } from '#features/analytics/pages/RetentionPage';
-import { SessionReplayPage } from '#features/analytics/pages/SessionReplayPage';
-import WebscraperLayout from '#features/webscraper/components/WebscraperLayout';
-import { WebscraperActorsPage } from '#features/webscraper/pages/WebscraperActorsPage';
-import { WebscraperRunsPage } from '#features/webscraper/pages/WebscraperRunsPage';
-import { WebscraperDatasetPage } from '#features/webscraper/pages/WebscraperDatasetPage';
-import AuthenticationLayout from '#features/auth/components/AuthenticationLayout';
-import AuthMethodsPage from '#features/auth/pages/AuthMethodsPage';
-import EmailPage from '#features/auth/pages/EmailPage';
-import UsersPage from '#features/auth/pages/UsersPage';
-import ComputePage from '#features/compute/pages/ComputePage';
-import DashboardLayout from '#features/dashboard/components/DashboardLayout';
-import DashboardPage from '#features/dashboard/pages/DashboardPage';
-import DTestDashboardPage from '#features/dashboard/pages/DTestDashboardPage';
-import DTestInstallPage from '#features/dashboard/pages/DTestInstallPage';
-import DatabaseLayout from '#features/database/components/DatabaseLayout';
-import SQLEditorLayout from '#features/database/components/SQLEditorLayout';
-import BackupsPage from '#features/database/pages/BackupsPage';
-import DatabaseFunctionsPage from '#features/database/pages/FunctionsPage';
-import IndexesPage from '#features/database/pages/IndexesPage';
-import MigrationsPage from '#features/database/pages/MigrationsPage';
-import PoliciesPage from '#features/database/pages/PoliciesPage';
-import SQLEditorPage from '#features/database/pages/SQLEditorPage';
-import TablesPage from '#features/database/pages/TablesPage';
-import TemplatesPage from '#features/database/pages/TemplatesPage';
-import TriggersPage from '#features/database/pages/TriggersPage';
-import DeploymentsLayout from '#features/deployments/components/DeploymentsLayout';
-import DeploymentDomainsPage from '#features/deployments/pages/DeploymentDomainsPage';
-import DeploymentEnvVarsPage from '#features/deployments/pages/DeploymentEnvVarsPage';
-import DeploymentLogsPage from '#features/deployments/pages/DeploymentLogsPage';
-import DeploymentOverviewPage from '#features/deployments/pages/DeploymentOverviewPage';
-import FunctionsLayout from '#features/functions/components/FunctionsLayout';
-import FunctionsPage from '#features/functions/pages/FunctionsPage';
-import SchedulesPage from '#features/functions/pages/SchedulesPage';
-import SecretsPage from '#features/functions/pages/SecretsPage';
-import CloudLoginPage from '#features/login/pages/CloudLoginPage';
-import LoginPage from '#features/login/pages/LoginPage';
-import LogsLayout from '#features/logs/components/LogsLayout';
-import AuditsPage from '#features/logs/pages/AuditsPage';
-import FunctionLogsPage from '#features/logs/pages/FunctionLogsPage';
-import LogsPage from '#features/logs/pages/LogsPage';
-import MCPLogsPage from '#features/logs/pages/MCPLogsPage';
-import PaymentsLayout from '#features/payments/components/PaymentsLayout';
-import CatalogPage from '#features/payments/pages/CatalogPage';
-import CustomersPage from '#features/payments/pages/CustomersPage';
-import SubscriptionsPage from '#features/payments/pages/SubscriptionsPage';
-import TransactionsPage from '#features/payments/pages/TransactionsPage';
-import RealtimeLayout from '#features/realtime/components/RealtimeLayout';
-import RealtimeChannelsPage from '#features/realtime/pages/RealtimeChannelsPage';
-import RealtimeMessagesPage from '#features/realtime/pages/RealtimeMessagesPage';
-import RealtimePermissionsPage from '#features/realtime/pages/RealtimePermissionsPage';
-import StorageLayout from '#features/storage/components/StorageLayout';
-import BucketsPage from '#features/storage/pages/BucketsPage';
-import VisualizerLayout from '#features/visualizer/components/VisualizerLayout';
-import VisualizerPage from '#features/visualizer/pages/VisualizerPage';
 import AppLayout from '#layout/AppLayout';
 import { getFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
+
+// Core Layouts (kept static for initial render performance of the shell)
+import AuthenticationLayout from '#features/auth/components/AuthenticationLayout';
+import DashboardLayout from '#features/dashboard/components/DashboardLayout';
+import DatabaseLayout from '#features/database/components/DatabaseLayout';
+import DeploymentsLayout from '#features/deployments/components/DeploymentsLayout';
+import FunctionsLayout from '#features/functions/components/FunctionsLayout';
+import LogsLayout from '#features/logs/components/LogsLayout';
+import StorageLayout from '#features/storage/components/StorageLayout';
+
+// Lazy load feature layouts & pages
+const AILayout = lazy(() => import('#features/ai/components/AILayout'));
+const AIOverviewPage = lazy(() => import('#features/ai/pages/AIOverviewPage'));
+const AIQuickStartPage = lazy(() => import('#features/ai/pages/AIQuickStartPage'));
+const AIModelsPage = lazy(() => import('#features/ai/pages/AIModelsPage'));
+
+const AnalyticsLayout = lazy(() => import('#features/analytics/components/AnalyticsLayout'));
+const TrafficPage = lazy(() =>
+  import('#features/analytics/pages/TrafficPage').then((m) => ({ default: m.TrafficPage }))
+);
+const RetentionPage = lazy(() =>
+  import('#features/analytics/pages/RetentionPage').then((m) => ({ default: m.RetentionPage }))
+);
+const SessionReplayPage = lazy(() =>
+  import('#features/analytics/pages/SessionReplayPage').then((m) => ({
+    default: m.SessionReplayPage,
+  }))
+);
+
+const WebscraperLayout = lazy(() => import('#features/webscraper/components/WebscraperLayout'));
+const WebscraperActorsPage = lazy(() =>
+  import('#features/webscraper/pages/WebscraperActorsPage').then((m) => ({
+    default: m.WebscraperActorsPage,
+  }))
+);
+const WebscraperRunsPage = lazy(() =>
+  import('#features/webscraper/pages/WebscraperRunsPage').then((m) => ({
+    default: m.WebscraperRunsPage,
+  }))
+);
+const WebscraperDatasetPage = lazy(() =>
+  import('#features/webscraper/pages/WebscraperDatasetPage').then((m) => ({
+    default: m.WebscraperDatasetPage,
+  }))
+);
+
+const AuthMethodsPage = lazy(() => import('#features/auth/pages/AuthMethodsPage'));
+const EmailPage = lazy(() => import('#features/auth/pages/EmailPage'));
+const UsersPage = lazy(() => import('#features/auth/pages/UsersPage'));
+
+const ComputePage = lazy(() => import('#features/compute/pages/ComputePage'));
+
+const DashboardPage = lazy(() => import('#features/dashboard/pages/DashboardPage'));
+const DTestDashboardPage = lazy(() => import('#features/dashboard/pages/DTestDashboardPage'));
+const DTestInstallPage = lazy(() => import('#features/dashboard/pages/DTestInstallPage'));
+
+const SQLEditorLayout = lazy(() => import('#features/database/components/SQLEditorLayout'));
+const BackupsPage = lazy(() => import('#features/database/pages/BackupsPage'));
+const DatabaseFunctionsPage = lazy(() => import('#features/database/pages/FunctionsPage'));
+const IndexesPage = lazy(() => import('#features/database/pages/IndexesPage'));
+const MigrationsPage = lazy(() => import('#features/database/pages/MigrationsPage'));
+const PoliciesPage = lazy(() => import('#features/database/pages/PoliciesPage'));
+const SQLEditorPage = lazy(() => import('#features/database/pages/SQLEditorPage'));
+const TablesPage = lazy(() => import('#features/database/pages/TablesPage'));
+const TemplatesPage = lazy(() => import('#features/database/pages/TemplatesPage'));
+const TriggersPage = lazy(() => import('#features/database/pages/TriggersPage'));
+
+const DeploymentDomainsPage = lazy(
+  () => import('#features/deployments/pages/DeploymentDomainsPage')
+);
+const DeploymentEnvVarsPage = lazy(
+  () => import('#features/deployments/pages/DeploymentEnvVarsPage')
+);
+const DeploymentLogsPage = lazy(() => import('#features/deployments/pages/DeploymentLogsPage'));
+const DeploymentOverviewPage = lazy(
+  () => import('#features/deployments/pages/DeploymentOverviewPage')
+);
+
+const FunctionsPage = lazy(() => import('#features/functions/pages/FunctionsPage'));
+const SchedulesPage = lazy(() => import('#features/functions/pages/SchedulesPage'));
+const SecretsPage = lazy(() => import('#features/functions/pages/SecretsPage'));
+
+const CloudLoginPage = lazy(() => import('#features/login/pages/CloudLoginPage'));
+const LoginPage = lazy(() => import('#features/login/pages/LoginPage'));
+
+const AuditsPage = lazy(() => import('#features/logs/pages/AuditsPage'));
+const FunctionLogsPage = lazy(() => import('#features/logs/pages/FunctionLogsPage'));
+const LogsPage = lazy(() => import('#features/logs/pages/LogsPage'));
+const MCPLogsPage = lazy(() => import('#features/logs/pages/MCPLogsPage'));
+
+const PaymentsLayout = lazy(() => import('#features/payments/components/PaymentsLayout'));
+const CatalogPage = lazy(() => import('#features/payments/pages/CatalogPage'));
+const CustomersPage = lazy(() => import('#features/payments/pages/CustomersPage'));
+const SubscriptionsPage = lazy(() => import('#features/payments/pages/SubscriptionsPage'));
+const TransactionsPage = lazy(() => import('#features/payments/pages/TransactionsPage'));
+
+const RealtimeLayout = lazy(() => import('#features/realtime/components/RealtimeLayout'));
+const RealtimeChannelsPage = lazy(() => import('#features/realtime/pages/RealtimeChannelsPage'));
+const RealtimeMessagesPage = lazy(() => import('#features/realtime/pages/RealtimeMessagesPage'));
+const RealtimePermissionsPage = lazy(
+  () => import('#features/realtime/pages/RealtimePermissionsPage')
+);
+
+const BucketsPage = lazy(() => import('#features/storage/pages/BucketsPage'));
+
+const VisualizerLayout = lazy(() => import('#features/visualizer/components/VisualizerLayout'));
+const VisualizerPage = lazy(() => import('#features/visualizer/pages/VisualizerPage'));
 
 function AuthenticatedRoutes() {
   const dashboardVariant = getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
@@ -74,117 +122,123 @@ function AuthenticatedRoutes() {
 
   return (
     <AppLayout>
-      <Routes>
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-        <Route path="/dashboard" element={<DashboardLayout />}>
-          <Route index element={<DashboardHomePage />} />
-          <Route
-            path="install"
-            element={isDTest ? <DTestInstallPage /> : <Navigate to="/dashboard" replace />}
-          />
-        </Route>
-        <Route path="/dashboard/authentication" element={<AuthenticationLayout />}>
-          <Route index element={<Navigate to="users" replace />} />
-          <Route path="users" element={<UsersPage />} />
-          <Route path="auth-methods" element={<AuthMethodsPage />} />
-          <Route path="email" element={<EmailPage />} />
-        </Route>
-        <Route path="/dashboard/database" element={<DatabaseLayout />}>
-          <Route index element={<Navigate to="tables" replace />} />
-          <Route path="tables" element={<TablesPage />} />
-          <Route path="indexes" element={<IndexesPage />} />
-          <Route path="functions" element={<DatabaseFunctionsPage />} />
-          <Route path="triggers" element={<TriggersPage />} />
-          <Route path="policies" element={<PoliciesPage />} />
-          <Route path="sql-editor" element={<Navigate to="/dashboard/sql-editor" replace />} />
-          <Route path="templates" element={<TemplatesPage />} />
-          <Route path="migrations" element={<MigrationsPage />} />
-          <Route path="backups" element={<BackupsPage />} />
-        </Route>
-        <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>
-          <Route index element={<SQLEditorPage />} />
-        </Route>
-        <Route path="/dashboard/storage" element={<StorageLayout />}>
-          <Route index element={<BucketsPage />} />
-        </Route>
-        <Route path="/dashboard/logs" element={<LogsLayout />}>
-          <Route index element={<Navigate to="MCP" replace />} />
-          <Route path="MCP" element={<MCPLogsPage />} />
-          <Route path="audits" element={<AuditsPage />} />
-          <Route path="function.logs" element={<FunctionLogsPage />} />
-          <Route path=":source" element={<LogsPage />} />
-        </Route>
-        <Route path="/dashboard/functions" element={<FunctionsLayout />}>
-          <Route index element={<Navigate to="list" replace />} />
-          <Route path="list" element={<FunctionsPage />} />
-          <Route path="secrets" element={<SecretsPage />} />
-          <Route path="schedules" element={<SchedulesPage />} />
-        </Route>
-        <Route path="/dashboard/visualizer" element={<VisualizerLayout />}>
-          <Route index element={<VisualizerPage />} />
-        </Route>
-        <Route path="/dashboard/ai" element={<AILayout />}>
-          <Route index element={<Navigate to="overview" replace />} />
-          <Route path="overview" element={<AIOverviewPage />} />
-          <Route path="quick-start" element={<AIQuickStartPage />} />
-          <Route path="models" element={<AIModelsPage />} />
-        </Route>
-        <Route path="/dashboard/payments" element={<PaymentsLayout />}>
-          <Route index element={<Navigate to="catalog" replace />} />
-          <Route path="catalog" element={<CatalogPage />} />
-          <Route path="customers" element={<CustomersPage />} />
-          <Route path="subscriptions" element={<SubscriptionsPage />} />
-          <Route path="transactions" element={<TransactionsPage />} />
-        </Route>
-        <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
-          <Route index element={<Navigate to="channels" replace />} />
-          <Route path="channels" element={<RealtimeChannelsPage />} />
-          <Route path="messages" element={<RealtimeMessagesPage />} />
-          <Route path="permissions" element={<RealtimePermissionsPage />} />
-        </Route>
-        <Route path="/dashboard/deployments" element={<DeploymentsLayout />}>
-          <Route index element={<Navigate to="overview" replace />} />
-          <Route path="overview" element={<DeploymentOverviewPage />} />
-          <Route path="logs" element={<DeploymentLogsPage />} />
-          <Route path="env-vars" element={<DeploymentEnvVarsPage />} />
-          <Route path="domains" element={<DeploymentDomainsPage />} />
-        </Route>
-        <Route path="/dashboard/compute" element={<ComputePage />} />
-        {isCloudHosting && (
-          <Route path="/dashboard/analytics" element={<AnalyticsLayout />}>
-            <Route index element={<Navigate to="traffic" replace />} />
-            <Route path="traffic" element={<TrafficPage />} />
-            <Route path="retention" element={<RetentionPage />} />
-            <Route path="session-replay" element={<SessionReplayPage />} />
+      <Suspense fallback={<LoadingState className="py-12" />}>
+        <Routes>
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/dashboard" element={<DashboardLayout />}>
+            <Route index element={<DashboardHomePage />} />
+            <Route
+              path="install"
+              element={isDTest ? <DTestInstallPage /> : <Navigate to="/dashboard" replace />}
+            />
           </Route>
-        )}
-        {isCloudHosting && (
-          <Route path="/dashboard/webscraper" element={<WebscraperLayout />}>
-            <Route index element={<Navigate to="actors" replace />} />
-            <Route path="actors" element={<WebscraperActorsPage />} />
-            <Route path="runs" element={<WebscraperRunsPage />} />
-            <Route path="dataset" element={<WebscraperDatasetPage />} />
+          <Route path="/dashboard/authentication" element={<AuthenticationLayout />}>
+            <Route index element={<Navigate to="users" replace />} />
+            <Route path="users" element={<UsersPage />} />
+            <Route path="auth-methods" element={<AuthMethodsPage />} />
+            <Route path="email" element={<EmailPage />} />
           </Route>
-        )}
-        <Route path="*" element={<Navigate to="/dashboard" replace />} />
-      </Routes>
+          <Route path="/dashboard/database" element={<DatabaseLayout />}>
+            <Route index element={<Navigate to="tables" replace />} />
+            <Route path="tables" element={<TablesPage />} />
+            <Route path="indexes" element={<IndexesPage />} />
+            <Route path="functions" element={<DatabaseFunctionsPage />} />
+            <Route path="triggers" element={<TriggersPage />} />
+            <Route path="policies" element={<PoliciesPage />} />
+            <Route path="sql-editor" element={<Navigate to="/dashboard/sql-editor" replace />} />
+            <Route path="templates" element={<TemplatesPage />} />
+            <Route path="migrations" element={<MigrationsPage />} />
+            <Route path="backups" element={<BackupsPage />} />
+          </Route>
+          <Route path="/dashboard/sql-editor" element={<SQLEditorLayout />}>
+            <Route index element={<SQLEditorPage />} />
+          </Route>
+          <Route path="/dashboard/storage" element={<StorageLayout />}>
+            <Route index element={<BucketsPage />} />
+          </Route>
+          <Route path="/dashboard/logs" element={<LogsLayout />}>
+            <Route index element={<Navigate to="MCP" replace />} />
+            <Route path="MCP" element={<MCPLogsPage />} />
+            <Route path="audits" element={<AuditsPage />} />
+            <Route path="function.logs" element={<FunctionLogsPage />} />
+            <Route path=":source" element={<LogsPage />} />
+          </Route>
+          <Route path="/dashboard/functions" element={<FunctionsLayout />}>
+            <Route index element={<Navigate to="list" replace />} />
+            <Route path="list" element={<FunctionsPage />} />
+            <Route path="secrets" element={<SecretsPage />} />
+            <Route path="schedules" element={<SchedulesPage />} />
+          </Route>
+          <Route path="/dashboard/visualizer" element={<VisualizerLayout />}>
+            <Route index element={<VisualizerPage />} />
+          </Route>
+          <Route path="/dashboard/ai" element={<AILayout />}>
+            <Route index element={<Navigate to="overview" replace />} />
+            <Route path="overview" element={<AIOverviewPage />} />
+            <Route path="quick-start" element={<AIQuickStartPage />} />
+            <Route path="models" element={<AIModelsPage />} />
+          </Route>
+          <Route path="/dashboard/payments" element={<PaymentsLayout />}>
+            <Route index element={<Navigate to="catalog" replace />} />
+            <Route path="catalog" element={<CatalogPage />} />
+            <Route path="customers" element={<CustomersPage />} />
+            <Route path="subscriptions" element={<SubscriptionsPage />} />
+            <Route path="transactions" element={<TransactionsPage />} />
+          </Route>
+          <Route path="/dashboard/realtime" element={<RealtimeLayout />}>
+            <Route index element={<Navigate to="channels" replace />} />
+            <Route path="channels" element={<RealtimeChannelsPage />} />
+            <Route path="messages" element={<RealtimeMessagesPage />} />
+            <Route path="permissions" element={<RealtimePermissionsPage />} />
+          </Route>
+          <Route path="/dashboard/deployments" element={<DeploymentsLayout />}>
+            <Route index element={<Navigate to="overview" replace />} />
+            <Route path="overview" element={<DeploymentOverviewPage />} />
+            <Route path="logs" element={<DeploymentLogsPage />} />
+            <Route path="env-vars" element={<DeploymentEnvVarsPage />} />
+            <Route path="domains" element={<DeploymentDomainsPage />} />
+          </Route>
+          <Route path="/dashboard/compute" element={<ComputePage />} />
+          {isCloudHosting && (
+            <Route path="/dashboard/analytics" element={<AnalyticsLayout />}>
+              <Route index element={<Navigate to="traffic" replace />} />
+              <Route path="traffic" element={<TrafficPage />} />
+              <Route path="retention" element={<RetentionPage />} />
+              <Route path="session-replay" element={<SessionReplayPage />} />
+            </Route>
+          )}
+          {isCloudHosting && (
+            <Route path="/dashboard/webscraper" element={<WebscraperLayout />}>
+              <Route index element={<Navigate to="actors" replace />} />
+              <Route path="actors" element={<WebscraperActorsPage />} />
+              <Route path="runs" element={<WebscraperRunsPage />} />
+              <Route path="dataset" element={<WebscraperDatasetPage />} />
+            </Route>
+          )}
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        </Routes>
+      </Suspense>
     </AppLayout>
   );
 }
 
 export function AppRoutes() {
   return (
-    <Routes>
-      <Route path="/dashboard/login" element={<LoginPage />} />
-      <Route path="/cloud/login" element={<CloudLoginPage />} />
-      <Route
-        path="/*"
-        element={
-          <RequireAuth>
-            <AuthenticatedRoutes />
-          </RequireAuth>
-        }
-      />
-    </Routes>
+    <Suspense
+      fallback={<LoadingState className="flex h-screen w-screen items-center justify-center" />}
+    >
+      <Routes>
+        <Route path="/dashboard/login" element={<LoginPage />} />
+        <Route path="/cloud/login" element={<CloudLoginPage />} />
+        <Route
+          path="/*"
+          element={
+            <RequireAuth>
+              <AuthenticatedRoutes />
+            </RequireAuth>
+          }
+        />
+      </Routes>
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Description
Fixes #1463

This PR implements route-level code splitting for the dashboard using `React.lazy` and `Suspense`, significantly reducing the initial bundle size. 

### Changes made:
- Refactored `AppRoutes.tsx` to lazy-load all major feature pages (e.g. `SQLEditorPage`, `TrafficPage`, `VisualizerPage`).
- Wrapped the `<Routes>` in `<Suspense>` boundaries with a standard `<LoadingState>` fallback.
- The core layouts (e.g. `DashboardLayout`, `DatabaseLayout`) are kept as static imports to ensure the application shell renders immediately before the heavier page chunks are fetched.

### Results:
The `index.js` bundle size has been reduced drastically from ~4.75MB down to ~1.75MB, cutting out nearly 3MB of JavaScript that users no longer have to load on first paint.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement / Optimization

## Checklist:
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] My changes adhere to the style guidelines of this project.
- [x] I have added tests that prove my fix is effective or that my feature works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split dashboard routes with `React.lazy` and `Suspense` to cut the initial bundle from ~4.75MB to ~1.75MB, speeding up first paint. Addresses #1463.

- **Performance**
  - Lazy-load feature layouts and pages; keep core layouts static for instant app shell.
  - Wrap routes in `Suspense` with a `LoadingState` fallback from `@insforge/ui`.

- **Bug Fixes**
  - Fixed `useConfirm` concurrency and resolve behavior; added unit tests.
  - Hardened env parsing: strict int/byte parsing with safe fallbacks, normalized `S3_FORCE_PATH_STYLE`, and capped `S3_MAX_OBJECT_SIZE_BYTES`.
  - Broadcast real-time socket events for `PUT` and `PATCH` record updates.
  - Added deprecation warnings to REST storage upload/download docs and updated the email SDK note to use `Warning`.

<sup>Written for commit 71a604f5a5fd7be74144c81d80d40d1bc8c5e4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split dashboard page bundles using React.lazy for code splitting
> - Converts route components in [`AppRoutes.tsx`](https://github.com/InsForge/InsForge/pull/1747/files#diff-c22275f3f786ab893302862c0831269fc75644a99b6fbf59e3292d44e76e1433) to lazy-loaded modules via `React.lazy`, wrapping routes in `Suspense` with a `LoadingState` fallback.
> - Expands the set of HTTP methods that trigger `SocketManager` broadcast in [`records.routes.ts`](https://github.com/InsForge/InsForge/pull/1747/files#diff-c01e14d03a824af81835407cd114bbcb735d88c19d79419072c9ab855c80f8ff) to include `PUT` and `PATCH` in addition to `POST` and `DELETE`.
> - Hardens env var parsing in [`app.config.ts`](https://github.com/InsForge/InsForge/pull/1747/files#diff-24b06be8fbc5ad753cf4ae7c1e6d9c70c7740c17331319f8eb0fc50b559527fb): rejects unit-suffixed or non-numeric values with named warnings, trims whitespace, and fixes `S3_FORCE_PATH_STYLE` to default to `true` unless set to `'false'` (case-insensitive).
> - Refactors `useConfirm` hook to prevent concurrent dialogs by returning the same promise for reentrant calls and resolving `false` on dialog close without confirmation.
> - Behavioral Change: `MAX_FILE_SIZE` values with unit suffixes (e.g. `10mb`) are now treated as `undefined`; `S3_FORCE_PATH_STYLE` now defaults to `true` when unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71a604f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database record updates now notify connected clients for create, edit, and delete operations.
  * Dashboard sections load on demand with a loading indicator, improving navigation responsiveness.
  * Confirmation dialogs now handle repeated and sequential confirmations reliably.

* **Bug Fixes**
  * Improved validation and fallback behavior for numeric, size, and boolean configuration values.

* **Documentation**
  * Added deprecation guidance for legacy storage endpoints.
  * Clarified email sender behavior and SMTP-related restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->