### PR TITLE
fix(ai): accept assistant tool-call messages that omit content

### DIFF
--- a/backend/tests/unit/ai-tool-calling-schemas.test.ts
+++ b/backend/tests/unit/ai-tool-calling-schemas.test.ts
@@ -129,6 +129,22 @@ describe('Tool Calling Schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    it('accepts an assistant tool_calls message that omits content entirely', () => {
+      // OpenAI treats assistant `content` as optional when `tool_calls` is present,
+      // and clients following that convention omit the field rather than send null.
+      const result = chatMessageSchema.safeParse({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'call_abc123',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"Tokyo"}' },
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('still accepts regular messages without tool fields', () => {
       const result = chatMessageSchema.safeParse({
         role: 'user',
@@ -178,6 +194,31 @@ describe('Tool Calling Schemas', () => {
 
     it('accepts request without any tool fields (backward compatible)', () => {
       const result = chatCompletionRequestSchema.safeParse(baseRequest);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a multi-turn tool conversation where the assistant message omits content', () => {
+      // Mirrors an OpenAI-compatible client replaying a tool call: the assistant
+      // turn carries only `tool_calls` (no `content` key), followed by the tool
+      // result. This must not be rejected with INVALID_INPUT before it reaches the
+      // provider.
+      const result = chatCompletionRequestSchema.safeParse({
+        model: 'openai/gpt-4',
+        messages: [
+          { role: 'user', content: 'What is the weather in Tokyo?' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'get_weather', arguments: '{"city":"Tokyo"}' },
+              },
+            ],
+          },
+          { role: 'tool', content: '{"temp":"22°C"}', tool_call_id: 'call_1' },
+        ],
+      });
       expect(result.success).toBe(true);
     });
   });

--- a/backend/tests/unit/ai-tool-calling-schemas.test.ts
+++ b/backend/tests/unit/ai-tool-calling-schemas.test.ts
@@ -145,6 +145,30 @@ describe('Tool Calling Schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    it('rejects a tool message that omits content (content is only optional on assistant)', () => {
+      const result = chatMessageSchema.safeParse({
+        role: 'tool',
+        tool_call_id: 'call_abc123',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a user message that omits content', () => {
+      const result = chatMessageSchema.safeParse({ role: 'user' });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts null content for a non-assistant role', () => {
+      // The fix only permits omitting content on assistant; null stays valid for
+      // every role, unchanged from the prior schema.
+      const result = chatMessageSchema.safeParse({
+        role: 'tool',
+        content: null,
+        tool_call_id: 'call_abc123',
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('still accepts regular messages without tool fields', () => {
       const result = chatMessageSchema.safeParse({
         role: 'user',

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -95,22 +95,35 @@ export const toolCallSchema = z.object({
 });
 
 // Chat message supports both OpenAI format and legacy format for backward compatibility
-export const chatMessageSchema = z.object({
-  role: z.enum(['user', 'assistant', 'system', 'tool']),
-  // Content can be a string or an array of content parts (OpenAI-compatible).
-  // Nullable AND optional: OpenAI treats assistant `content` as optional when
-  // `tool_calls` is present, so clients following that convention omit the field
-  // entirely. `.nullish()` (string | array | null | undefined) keeps those valid
-  // tool-call messages from being rejected; `formatMessages` already coerces a
-  // missing assistant content to null.
-  content: z.union([z.string(), z.array(contentSchema)]).nullish(),
-  // Legacy format: separate images field (deprecated but supported for backward compatibility)
-  images: z.array(z.object({ url: z.string() })).optional(),
-  // Tool calls made by the assistant
-  tool_calls: z.array(toolCallSchema).optional(),
-  // Tool call ID for tool response messages
-  tool_call_id: z.string().optional(),
-});
+export const chatMessageSchema = z
+  .object({
+    role: z.enum(['user', 'assistant', 'system', 'tool']),
+    // Content can be a string or an array of content parts (OpenAI-compatible).
+    // Nullable AND optional so an assistant tool-call message may omit it (per the
+    // per-role rule enforced below); `formatMessages` coerces a missing assistant
+    // content to null.
+    content: z.union([z.string(), z.array(contentSchema)]).nullish(),
+    // Legacy format: separate images field (deprecated but supported for backward compatibility)
+    images: z.array(z.object({ url: z.string() })).optional(),
+    // Tool calls made by the assistant
+    tool_calls: z.array(toolCallSchema).optional(),
+    // Tool call ID for tool response messages
+    tool_call_id: z.string().optional(),
+  })
+  .superRefine((message, ctx) => {
+    // OpenAI only makes `content` optional on assistant messages (it may be
+    // omitted when `tool_calls` is present). user / system / tool messages must
+    // still carry the field, so an omitted `content` on those roles is rejected
+    // here rather than silently reaching the provider as `undefined`. `null` stays
+    // allowed for every role, matching the prior behavior.
+    if (message.role !== 'assistant' && message.content === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['content'],
+        message: `content is required for ${message.role} messages`,
+      });
+    }
+  });
 
 // Web Search Plugin configuration for OpenRouter
 export const webSearchPluginSchema = z.object({

--- a/packages/shared-schemas/src/ai-api.schema.ts
+++ b/packages/shared-schemas/src/ai-api.schema.ts
@@ -97,8 +97,13 @@ export const toolCallSchema = z.object({
 // Chat message supports both OpenAI format and legacy format for backward compatibility
 export const chatMessageSchema = z.object({
   role: z.enum(['user', 'assistant', 'system', 'tool']),
-  // New format: content can be string or array of content parts (OpenAI-compatible)
-  content: z.union([z.string(), z.array(contentSchema)]).nullable(),
+  // Content can be a string or an array of content parts (OpenAI-compatible).
+  // Nullable AND optional: OpenAI treats assistant `content` as optional when
+  // `tool_calls` is present, so clients following that convention omit the field
+  // entirely. `.nullish()` (string | array | null | undefined) keeps those valid
+  // tool-call messages from being rejected; `formatMessages` already coerces a
+  // missing assistant content to null.
+  content: z.union([z.string(), z.array(contentSchema)]).nullish(),
   // Legacy format: separate images field (deprecated but supported for backward compatibility)
   images: z.array(z.object({ url: z.string() })).optional(),
   // Tool calls made by the assistant


### PR DESCRIPTION
## Summary

The Model Gateway is OpenAI-compatible, but `chatMessageSchema.content` was declared `.nullable()` — which allows `null` but still **requires the `content` key to be present**. OpenAI treats assistant `content` as **optional when `tool_calls` is present**, so OpenAI-compatible clients that omit the field entirely (hand-rolled JSON, Go `omitempty`, trimmed payloads) were rejected with `400 INVALID_INPUT` before the request ever reached the provider — even though the identical request with `"content": null` succeeded.

This relaxes `content` to `.nullish()` (nullable **and** optional). It matches OpenAI's contract, stays consistent with the schema's existing permissiveness (it already accepts `content: null` for any role), and `formatMessages` already coerces a missing assistant content to `null`, so no downstream change is required.

Closes #1748

### Changes
- `packages/shared-schemas/src/ai-api.schema.ts` — `chatMessageSchema.content`: `.nullable()` → `.nullish()` (+ explanatory comment).
- `backend/tests/unit/ai-tool-calling-schemas.test.ts` — regression tests (schema-level and request-level).

## How did you test this change?

Added two regression tests to `ai-tool-calling-schemas.test.ts`:

1. `chatMessageSchema` accepts an assistant `tool_calls` message that omits `content` entirely.
2. `chatCompletionRequestSchema` accepts a full multi-turn tool conversation whose assistant turn omits `content`.

Both **fail on `main`** (`Required` at `messages[...].content`) and **pass with the fix**.

Commands run:
- `npx vitest run tests/unit/ai-tool-calling-schemas.test.ts` → **26 passed** (24 existing + 2 new).
- AI gateway suite (`ai-tool-calling-*`, `ai-routes`, `ai-helpers`, `ai-model.service`) → **69 passed**, no regressions; `formatMessages` behavior unchanged.
- `tsc --noEmit` on `packages/shared-schemas` and `backend` → clean (the now-optional `content` type breaks no consumers).
- `eslint` on the changed files → clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept assistant tool-call messages that omit `content`, while keeping `content` required for other roles. Adds role-aware validation to match OpenAI and prevent 400 INVALID_INPUT or silent provider errors.

- **Bug Fixes**
  - In `packages/shared-schemas/src/ai-api.schema.ts`, changed `chatMessageSchema.content` to `.nullish()` and added a role-aware `superRefine` so only `assistant` may omit `content`; `null` stays allowed for all roles.
  - Updated `backend/tests/unit/ai-tool-calling-schemas.test.ts` to cover accepted assistant cases (schema and request) and reject missing `content` on `user`/`tool` messages.

<sup>Written for commit 602cfcf5ed6f2032b3b8538eec62d6f739ead0d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `chatMessageSchema` to accept assistant messages that omit `content`
> Changes the `content` field in `chatMessageSchema` from `.nullable()` to `.nullish()` in [ai-api.schema.ts](https://github.com/InsForge/InsForge/pull/1749/files#diff-b337ceae5cba47edcb003641f623c0fda08c1249dd6b57720f960f0af21fc78c), so that assistant messages with `tool_calls` but no `content` key pass validation. This matches the OpenAI API behavior where `content` may be absent (not just `null`) when tool calls are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d94e685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI-compatible tool-calling conversations.
  * Assistant tool-calling messages can now omit `content` (not required when `tool_calls` are present).
  * Validation now correctly handles `content` being `null` or missing across roles, rejecting missing `content` for non-assistant turns.
  * Multi-turn conversations from assistant tool calls to matching tool responses are validated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->