### PR TITLE
docs: document querying non-public schemas from the SDK via .schema()

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -26,7 +26,7 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
   </Accordion>
 
   <Accordion title="¿Cómo consulto una tabla en un schema distinto de `public`?">
-    Por defecto todas tus tablas están en `public`. Solo tienes otro schema si creaste uno tú mismo con `CREATE SCHEMA` (los schemas internos de InsForge, como `auth` y `storage`, están ocultos y no se pueden consultar así). Una vez que tienes uno, puedes leerlo y escribirlo desde el dashboard, la REST API y la CLI. El único lugar que hoy solo ve `public` es el constructor de consultas de `@insforge/sdk`.
+    Por defecto todas tus tablas están en `public`. Solo tienes otro schema si creaste uno tú mismo con `CREATE SCHEMA` (los schemas internos de InsForge, como `auth` y `storage`, no están expuestos a la API de datos, así que `.schema()` y `?schema=` no pueden alcanzarlos; como project admin todavía puedes leerlos con SQL directo, por ejemplo `insforge db query` o el editor SQL del dashboard). Una vez que tienes uno, puedes leerlo y escribirlo desde el dashboard, el SDK, la REST API y la CLI.
 
     Los ejemplos de abajo usan un schema que creaste llamado `my_schema`.
 
@@ -53,7 +53,24 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK.** `client.database.from('mytable')` siempre apunta a `public` y todavía no hay opción de schema, así que para otro schema llama directamente al endpoint REST de arriba (con el parámetro `?schema=` o la cabecera `Accept-Profile` / `Content-Profile`) en lugar del constructor de consultas.
+    **SDK.** Encadena `.schema()` antes del constructor de consultas (disponible en la última versión de `@insforge/sdk`). Se traduce a la misma cabecera `Accept-Profile` / `Content-Profile`, así que lecturas, escrituras y RPC se enrutan al schema que indiques:
+
+    ```javascript
+    // lectura
+    const { data } = await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .select('*')
+
+    // escritura
+    await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .insert([{ name: 'hello' }])
+
+    // RPC
+    await client.database.schema('my_schema').rpc('my_function', { day: '2026-01-01' })
+    ```
 
     Un paso más para el acceso por API: un schema propio solo es enrutable, no legible. Los roles `anon` y `authenticated` no tienen privilegios sobre él hasta que se los concedes, sin importar quién sea el propietario de las tablas, así que las llamadas devuelven vacío o permiso denegado hasta que lo hagas. Concede privilegios a cada rol que expongas y luego añade RLS:
 

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -26,7 +26,7 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
   </Accordion>
 
   <Accordion title="¿Cómo consulto una tabla en un schema distinto de `public`?">
-    Por defecto todas tus tablas están en `public`. Solo tienes otro schema si creaste uno tú mismo con `CREATE SCHEMA` (los schemas internos de InsForge, como `auth` y `storage`, no están expuestos a la API de datos, así que `.schema()` y `?schema=` no pueden alcanzarlos; como project admin todavía puedes leerlos con SQL directo, por ejemplo `insforge db query` o el editor SQL del dashboard). Una vez que tienes uno, puedes leerlo y escribirlo desde el dashboard, el SDK, la REST API y la CLI.
+    Por defecto todas tus tablas están en `public`. Solo tienes otro schema si creaste uno tú mismo con `CREATE SCHEMA` (los schemas internos de InsForge, como `auth` y `storage`, no están expuestos a la API de datos, así que `.schema()` y `?schema=` no pueden alcanzarlos; como project admin todavía puedes leerlos con SQL directo, por ejemplo `insforge db query` o el editor SQL del dashboard). Una vez que tienes uno, puedes leerlo y escribirlo desde el dashboard, la REST API, la CLI y el SDK.
 
     Los ejemplos de abajo usan un schema que creaste llamado `my_schema`.
 
@@ -53,7 +53,7 @@ description: "Respuestas a preguntas habituales sobre cómo funciona InsForge."
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK.** Encadena `.schema()` antes del constructor de consultas (disponible en la última versión de `@insforge/sdk`). Se traduce a la misma cabecera `Accept-Profile` / `Content-Profile`, así que lecturas, escrituras y RPC se enrutan al schema que indiques:
+    **SDK.** Encadena `.schema()` antes del constructor de consultas (compatible con `@insforge/sdk`). Se traduce a la misma cabecera `Accept-Profile` / `Content-Profile`, así que lecturas, escrituras y RPC se enrutan al schema que indiques:
 
     ```javascript
     // lectura

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -26,7 +26,7 @@ description: "Answers to common questions about how InsForge works."
   </Accordion>
 
   <Accordion title="How do I query a table in a schema other than `public`?">
-    By default all of your tables live in `public`. You only have another schema if you created one yourself with `CREATE SCHEMA` (InsForge's own internal schemas, like `auth` and `storage`, are hidden and can't be queried this way). Once you have one, you can read and write it from the dashboard, the REST API, and the CLI. The one place that only sees `public` today is the `@insforge/sdk` query builder.
+    By default all of your tables live in `public`. You only have another schema if you created one yourself with `CREATE SCHEMA` (InsForge's own internal schemas, like `auth` and `storage`, aren't exposed to the data API, so `.schema()` and `?schema=` can't reach them; as project admin you can still read them with raw SQL, e.g. `insforge db query` or the dashboard SQL editor). Once you have one, you can read and write it from the dashboard, the SDK, the REST API, and the CLI.
 
     The examples below use a schema you created called `my_schema`.
 
@@ -53,7 +53,24 @@ description: "Answers to common questions about how InsForge works."
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK.** `client.database.from('mytable')` always targets `public` and there is no schema option yet, so for another schema call the REST endpoint above directly (with the `?schema=` param or the `Accept-Profile` / `Content-Profile` header) instead of the query builder.
+    **SDK.** Chain `.schema()` before the query builder (available in the latest `@insforge/sdk`). It maps to the same `Accept-Profile` / `Content-Profile` header, so reads, writes, and RPC all route to the schema you name:
+
+    ```javascript
+    // read
+    const { data } = await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .select('*')
+
+    // write
+    await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .insert([{ name: 'hello' }])
+
+    // RPC
+    await client.database.schema('my_schema').rpc('my_function', { day: '2026-01-01' })
+    ```
 
     One more step for API access: a custom schema is only routable, not readable. The `anon` and `authenticated` roles have no privileges on it until you grant them, no matter who owns the tables, so calls come back empty or permission-denied until you do. Grant each role you expose, then add RLS:
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -26,7 +26,7 @@ description: "Answers to common questions about how InsForge works."
   </Accordion>
 
   <Accordion title="How do I query a table in a schema other than `public`?">
-    By default all of your tables live in `public`. You only have another schema if you created one yourself with `CREATE SCHEMA` (InsForge's own internal schemas, like `auth` and `storage`, aren't exposed to the data API, so `.schema()` and `?schema=` can't reach them; as project admin you can still read them with raw SQL, e.g. `insforge db query` or the dashboard SQL editor). Once you have one, you can read and write it from the dashboard, the SDK, the REST API, and the CLI.
+    By default all of your tables live in `public`. You only have another schema if you created one yourself with `CREATE SCHEMA` (InsForge's own internal schemas, like `auth` and `storage`, aren't exposed to the data API, so `.schema()` and `?schema=` can't reach them; as project admin you can still read them with raw SQL, e.g. `insforge db query` or the dashboard SQL editor). Once you have one, you can read and write it from the dashboard, the REST API, the CLI, and the SDK.
 
     The examples below use a schema you created called `my_schema`.
 
@@ -53,7 +53,7 @@ description: "Answers to common questions about how InsForge works."
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK.** Chain `.schema()` before the query builder (available in the latest `@insforge/sdk`). It maps to the same `Accept-Profile` / `Content-Profile` header, so reads, writes, and RPC all route to the schema you name:
+    **SDK.** Chain `.schema()` before the query builder (supported by `@insforge/sdk`). It maps to the same `Accept-Profile` / `Content-Profile` header, so reads, writes, and RPC all route to the schema you name:
 
     ```javascript
     // read

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -26,7 +26,7 @@ description: "關於 InsForge 運作方式的常見問題解答。"
   </Accordion>
 
   <Accordion title="怎麼查詢 public 以外 schema 裡的表？">
-    預設你所有的表都在 `public` 裡。只有當你自己用 `CREATE SCHEMA` 建過別的 schema，才會有非 `public` 的 schema（InsForge 自己的內部 schema，例如 `auth`、`storage`，不對資料 API 開放，`.schema()` 和 `?schema=` 查不到；但身為 project admin，你仍可以用原始 SQL 讀它們，例如 `insforge db query` 或 dashboard 的 SQL 編輯器）。一旦有了，dashboard、SDK、REST API、CLI 都能讀寫它。
+    預設你所有的表都在 `public` 裡。只有當你自己用 `CREATE SCHEMA` 建過別的 schema，才會有非 `public` 的 schema（InsForge 自己的內部 schema，例如 `auth`、`storage`，不對資料 API 開放，`.schema()` 和 `?schema=` 查不到；但身為 project admin，你仍可以用原始 SQL 讀它們，例如 `insforge db query` 或 dashboard 的 SQL 編輯器）。一旦有了，dashboard、REST API、CLI、SDK 都能讀寫它。
 
     下面的例子用一個你自己建立、名叫 `my_schema` 的 schema。
 
@@ -53,7 +53,7 @@ description: "關於 InsForge 運作方式的常見問題解答。"
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK。** 在查詢建構器前鏈式呼叫 `.schema()`（最新版 `@insforge/sdk` 支援）。它底層對應到同樣的 `Accept-Profile` / `Content-Profile` header，讀、寫、RPC 都會路由到你指定的 schema：
+    **SDK。** 在查詢建構器前鏈式呼叫 `.schema()`（`@insforge/sdk` 支援）。它底層對應到同樣的 `Accept-Profile` / `Content-Profile` header，讀、寫、RPC 都會路由到你指定的 schema：
 
     ```javascript
     // 讀

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -26,7 +26,7 @@ description: "關於 InsForge 運作方式的常見問題解答。"
   </Accordion>
 
   <Accordion title="怎麼查詢 public 以外 schema 裡的表？">
-    預設你所有的表都在 `public` 裡。只有當你自己用 `CREATE SCHEMA` 建過別的 schema，才會有非 `public` 的 schema（InsForge 自己的內部 schema，例如 `auth`、`storage`，是隱藏的，沒辦法這樣查）。一旦有了，dashboard、REST API、CLI 都能讀寫它。目前唯一只認 `public` 的是 `@insforge/sdk` 的查詢建構器。
+    預設你所有的表都在 `public` 裡。只有當你自己用 `CREATE SCHEMA` 建過別的 schema，才會有非 `public` 的 schema（InsForge 自己的內部 schema，例如 `auth`、`storage`，不對資料 API 開放，`.schema()` 和 `?schema=` 查不到；但身為 project admin，你仍可以用原始 SQL 讀它們，例如 `insforge db query` 或 dashboard 的 SQL 編輯器）。一旦有了，dashboard、SDK、REST API、CLI 都能讀寫它。
 
     下面的例子用一個你自己建立、名叫 `my_schema` 的 schema。
 
@@ -53,7 +53,24 @@ description: "關於 InsForge 運作方式的常見問題解答。"
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK。** `client.database.from('mytable')` 永遠指向 `public`，目前沒有指定 schema 的選項，所以要存取別的 schema，請直接呼叫上面的 REST 介面（用 `?schema=` 參數，或 `Accept-Profile` / `Content-Profile` header），而不是用查詢建構器。
+    **SDK。** 在查詢建構器前鏈式呼叫 `.schema()`（最新版 `@insforge/sdk` 支援）。它底層對應到同樣的 `Accept-Profile` / `Content-Profile` header，讀、寫、RPC 都會路由到你指定的 schema：
+
+    ```javascript
+    // 讀
+    const { data } = await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .select('*')
+
+    // 寫
+    await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .insert([{ name: 'hello' }])
+
+    // RPC
+    await client.database.schema('my_schema').rpc('my_function', { day: '2026-01-01' })
+    ```
 
     不管走哪條路，存取 API 都還有一步：自建 schema 只是「可路由」，不等於「可讀」。在你顯式授權之前，`anon` 和 `authenticated` 角色對它沒有任何權限，跟表的 owner 是誰無關，所以授權前呼叫只會回傳空結果或權限不足。給你要開放的每個角色授權，再加 RLS：
 

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -26,7 +26,7 @@ description: "关于 InsForge 工作方式的常见问题解答。"
   </Accordion>
 
   <Accordion title="怎么查询 public 以外 schema 里的表？">
-    默认你所有的表都在 `public` 里。只有当你自己用 `CREATE SCHEMA` 建过别的 schema，才会有非 `public` 的 schema（InsForge 自己的内部 schema，比如 `auth`、`storage`，不对数据 API 开放，`.schema()` 和 `?schema=` 查不到；但作为 project admin，你仍可以用原始 SQL 读它们，比如 `insforge db query` 或 dashboard 的 SQL 编辑器）。一旦有了，dashboard、SDK、REST API、CLI 都能读写它。
+    默认你所有的表都在 `public` 里。只有当你自己用 `CREATE SCHEMA` 建过别的 schema，才会有非 `public` 的 schema（InsForge 自己的内部 schema，比如 `auth`、`storage`，不对数据 API 开放，`.schema()` 和 `?schema=` 查不到；但作为 project admin，你仍可以用原始 SQL 读它们，比如 `insforge db query` 或 dashboard 的 SQL 编辑器）。一旦有了，dashboard、REST API、CLI、SDK 都能读写它。
 
     下面的例子用一个你自己建的、名叫 `my_schema` 的 schema。
 
@@ -53,7 +53,7 @@ description: "关于 InsForge 工作方式的常见问题解答。"
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK。** 在查询构造器前链式调用 `.schema()`（最新版 `@insforge/sdk` 支持）。它底层映射到同样的 `Accept-Profile` / `Content-Profile` header，读、写、RPC 都会路由到你指定的 schema：
+    **SDK。** 在查询构造器前链式调用 `.schema()`（`@insforge/sdk` 支持）。它底层映射到同样的 `Accept-Profile` / `Content-Profile` header，读、写、RPC 都会路由到你指定的 schema：
 
     ```javascript
     // 读

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -26,7 +26,7 @@ description: "关于 InsForge 工作方式的常见问题解答。"
   </Accordion>
 
   <Accordion title="怎么查询 public 以外 schema 里的表？">
-    默认你所有的表都在 `public` 里。只有当你自己用 `CREATE SCHEMA` 建过别的 schema，才会有非 `public` 的 schema（InsForge 自己的内部 schema，比如 `auth`、`storage`，是隐藏的，没法这样查）。一旦有了，dashboard、REST API、CLI 都能读写它。目前唯一只认 `public` 的是 `@insforge/sdk` 的查询构造器。
+    默认你所有的表都在 `public` 里。只有当你自己用 `CREATE SCHEMA` 建过别的 schema，才会有非 `public` 的 schema（InsForge 自己的内部 schema，比如 `auth`、`storage`，不对数据 API 开放，`.schema()` 和 `?schema=` 查不到；但作为 project admin，你仍可以用原始 SQL 读它们，比如 `insforge db query` 或 dashboard 的 SQL 编辑器）。一旦有了，dashboard、SDK、REST API、CLI 都能读写它。
 
     下面的例子用一个你自己建的、名叫 `my_schema` 的 schema。
 
@@ -53,7 +53,24 @@ description: "关于 InsForge 工作方式的常见问题解答。"
     insforge db query "SELECT * FROM my_schema.mytable"
     ```
 
-    **SDK。** `client.database.from('mytable')` 永远指向 `public`，目前没有指定 schema 的选项，所以要访问别的 schema，请直接调用上面的 REST 接口（用 `?schema=` 参数，或 `Accept-Profile` / `Content-Profile` header），而不是用查询构造器。
+    **SDK。** 在查询构造器前链式调用 `.schema()`（最新版 `@insforge/sdk` 支持）。它底层映射到同样的 `Accept-Profile` / `Content-Profile` header，读、写、RPC 都会路由到你指定的 schema：
+
+    ```javascript
+    // 读
+    const { data } = await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .select('*')
+
+    // 写
+    await client.database
+      .schema('my_schema')
+      .from('mytable')
+      .insert([{ name: 'hello' }])
+
+    // RPC
+    await client.database.schema('my_schema').rpc('my_function', { day: '2026-01-01' })
+    ```
 
     不管走哪条路，访问 API 都还有一步：自建 schema 只是「可路由」，不等于「可读」。在你显式授权之前，`anon` 和 `authenticated` 角色对它没有任何权限，跟表的 owner 是谁无关，所以授权前调用只会返回空结果或权限不足。给你要开放的每个角色授权，再加 RLS：
 


### PR DESCRIPTION
## Summary

The FAQ answer for "How do I query a table in a schema other than `public`?" was out of date on the SDK: it said `client.database.from()` always targets `public`, there is no schema option, and callers must drop to the REST endpoint for custom schemas. The latest `@insforge/sdk` (verified against `1.4.5` on npm) exposes `client.database.schema('my_schema')`, which maps to PostgREST's `Accept-Profile` / `Content-Profile` header. The SDK's custom fetch forwards those headers and the backend's `resolvePostgrestSchema` honors them, so the SDK path works end to end. This was the direct cause of Ask AI answering "not documented, contact support" for that question.

Also tightened the note about internal schemas: `auth` / `storage` are excluded from the data API by the migration 056 deny-list (`.schema()` / `?schema=` can't reach them regardless of role), but a project admin can still read them via raw SQL (`insforge db query` / dashboard SQL editor, per migration 055 grants). The old wording ("hidden and can't be queried this way") read as false to the developers who actually ask this.

## Scope

- `docs/faq.mdx`, `docs/zh/faq.mdx`, `docs/zh-Hant/faq.mdx`, `docs/es/faq.mdx` (en + 3 locales)
- Per file: rewrote the **SDK** paragraph to `.schema()` with read/write/RPC examples; corrected the internal-schema parenthetical; added the SDK to the list of ways to reach a custom schema; removed the stale "only sees public" sentence.
- GRANT / RLS guidance unchanged (it was already correct).
- Docs-only, no code changes.

## Verification

- `.schema()` existence + behavior confirmed by unpacking `@insforge/sdk@1.4.5` from npm (`schema(schemaName) => this.postgrest.schema(schemaName)`; custom fetch forwards profile headers).
- Backend chain confirmed on `origin/main`: `resolvePostgrestSchema` honors client-sent profile headers; migration `056` deny-list still contains `auth,storage,...`; migration `055` grants `project_admin` SELECT on internal schemas.
- Rebased onto latest `origin/main` (branch was 28 behind at first commit); `git diff --stat origin/main...HEAD` = 4 files, +76/-8, no unrelated changes.
- Chinese punctuation codepoints checked: prose uses full-width `，；（）`, code keeps half-width.
- Not run: docs build / Vale lint locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the FAQ (en, es, zh, zh‑Hant) to document querying non‑public schemas with `@insforge/sdk` using `client.database.schema('my_schema')`, with read/write/RPC examples. Clarifies that internal schemas like `auth` and `storage` aren’t exposed to the data API (only readable by project admins via SQL), reorders the schema‑access list to include the SDK and match the sections, and removes the SDK version note.

<sup>Written for commit 858e61cbd5b16c76b8067c733ec884ccc9286294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document querying non-public schemas from the SDK via `.schema()`
> Updates FAQ docs across four locales to document `.schema()` chaining support in the latest `@insforge/sdk`, replacing a prior note that the SDK only targets the `public` schema. Adds read, write, and RPC examples routed via `Accept-Profile`/`Content-Profile` headers. Also clarifies that internal schemas like `auth` and `storage` are not exposed to the data API and cannot be accessed via `.schema()` or `?schema=`, though project admins can still query them with raw SQL.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1751 opened
>
> - Reordered interface list in FAQ documentation across all language versions to place SDK last after dashboard, REST API, and CLI [858e61c]
> - Updated SDK version qualifier in FAQ documentation across all language versions to remove specific version references [858e61c]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48899e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified which schemas are accessible via the data API, noting internal schemas are hidden while admins can still inspect them using raw SQL tools.
  - Updated FAQ guidance across English, Spanish, Simplified Chinese, and Traditional Chinese to explain the schema visibility rules.
  - Revised SDK instructions with schema routing via `client.database.schema('my_schema')`, including updated examples for reads, writes, and RPC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->