### PR TITLE
fix(secrets): quarantine undecryptable secrets at boot instead of aborting seeding

### DIFF
--- a/backend/src/services/secrets/secret.service.ts
+++ b/backend/src/services/secrets/secret.service.ts
@@ -167,6 +167,56 @@ export class SecretService {
   }
 
   /**
+   * Quarantine secrets whose ciphertext cannot be decrypted with this
+   * instance's encryption key.
+   *
+   * This happens when a database backup taken on one instance is restored
+   * onto another (e.g. disaster recovery into a fresh project): every
+   * system.secrets row is AES-GCM ciphertext under the SOURCE instance's
+   * ENCRYPTION_KEY/JWT_SECRET, so every read throws — and a single throw
+   * aborts seedBackend(), leaving the restored instance with no usable
+   * ANON_KEY/API_KEY and a 500 on every secrets read.
+   *
+   * Undecryptable rows are renamed to `<KEY>_UNRECOVERABLE_<timestamp>` and
+   * deactivated — never deleted — so the reserved-secret initializers can
+   * regenerate fresh values under this instance's key, while an operator who
+   * still has the source instance's key can recover the original values from
+   * the renamed rows offline.
+   *
+   * Returns the original key names that were quarantined.
+   */
+  async quarantineUndecryptableSecrets(): Promise<string[]> {
+    const result = await this.getPool().query(
+      `SELECT id, key, value_ciphertext FROM system.secrets WHERE is_active = true`
+    );
+
+    const quarantined: string[] = [];
+    for (const row of result.rows) {
+      try {
+        EncryptionManager.decrypt(row.value_ciphertext);
+      } catch {
+        const quarantineKey = `${row.key}_UNRECOVERABLE_${Date.now()}`;
+        await this.getPool().query(
+          `UPDATE system.secrets SET key = $1, is_active = false, updated_at = NOW() WHERE id = $2`,
+          [quarantineKey, row.id]
+        );
+        quarantined.push(row.key);
+      }
+    }
+
+    if (quarantined.length) {
+      logger.warn(
+        "Quarantined secrets that cannot be decrypted with this instance's encryption key " +
+          '(likely a backup restored from another instance); reserved secrets will be regenerated, ' +
+          'user-defined secrets must be re-entered',
+        { keys: quarantined }
+      );
+    }
+
+    return quarantined;
+  }
+
+  /**
    * List all secrets (without decrypting values)
    */
   async listSecrets(): Promise<SecretSchema[]> {

--- a/backend/src/utils/seed.ts
+++ b/backend/src/utils/seed.ts
@@ -179,6 +179,19 @@ export async function seedBackend(): Promise<void> {
   try {
     logger.info(`\n🚀 Insforge Backend Starting...`);
 
+    // A backup restored from another instance leaves system.secrets full of
+    // ciphertext this instance's key cannot decrypt; quarantine those rows
+    // first so the initializers below regenerate reserved secrets instead of
+    // the first decrypt failure aborting seeding entirely. Non-fatal: on a
+    // healthy database this is a no-op.
+    try {
+      await secretService.quarantineUndecryptableSecrets();
+    } catch (error) {
+      logger.warn('Undecryptable-secret sweep failed; continuing seeding', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     // Initialize API key (from env or generate)
     const apiKey = await secretService.initializeApiKey();
 

--- a/backend/tests/unit/secret-quarantine-undecryptable.test.ts
+++ b/backend/tests/unit/secret-quarantine-undecryptable.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPoolQuery, mockConnect } = vi.hoisted(() => {
+  return {
+    mockPoolQuery: vi.fn(),
+    mockConnect: vi.fn(),
+  };
+});
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({
+        query: mockPoolQuery,
+        connect: mockConnect,
+      }),
+    }),
+  },
+}));
+
+// Ciphertexts prefixed with `foreign:` simulate rows restored from another
+// instance (encrypted under a different key): decryption throws on them.
+vi.mock('../../src/infra/security/encryption.manager.js', () => ({
+  EncryptionManager: {
+    encrypt: (value: string) => `enc:${value}`,
+    decrypt: (value: string) => {
+      if (value.startsWith('foreign:')) {
+        throw new Error('Unsupported state or unable to authenticate data');
+      }
+      return value.replace(/^enc:/, '');
+    },
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+async function loadSecretService() {
+  const { SecretService } = await import('../../src/services/secrets/secret.service.js');
+  return SecretService.getInstance();
+}
+
+describe('SecretService.quarantineUndecryptableSecrets', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockPoolQuery.mockReset();
+    mockConnect.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renames and deactivates undecryptable rows, leaving healthy rows untouched', async () => {
+    mockPoolQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, key, value_ciphertext')) {
+        return Promise.resolve({
+          rows: [
+            { id: 'id-1', key: 'ANON_KEY', value_ciphertext: 'foreign:anon' },
+            { id: 'id-2', key: 'HEALTHY_KEY', value_ciphertext: 'enc:fine' },
+            { id: 'id-3', key: 'CRON_SECRET', value_ciphertext: 'foreign:cron' },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const service = await loadSecretService();
+    const quarantined = await service.quarantineUndecryptableSecrets();
+
+    expect(quarantined).toEqual(['ANON_KEY', 'CRON_SECRET']);
+
+    const updates = mockPoolQuery.mock.calls.filter(([sql]) =>
+      (sql as string).includes('UPDATE system.secrets SET key =')
+    );
+    expect(updates).toHaveLength(2);
+
+    const [firstKey, firstId] = updates[0][1] as [string, string];
+    expect(firstKey).toMatch(/^ANON_KEY_UNRECOVERABLE_\d+$/);
+    expect(firstId).toBe('id-1');
+    expect(updates[0][0]).toContain('is_active = false');
+
+    const [secondKey, secondId] = updates[1][1] as [string, string];
+    expect(secondKey).toMatch(/^CRON_SECRET_UNRECOVERABLE_\d+$/);
+    expect(secondId).toBe('id-3');
+
+    // The healthy row must not be touched.
+    expect(updates.some(([, params]) => (params as string[])[1] === 'id-2')).toBe(false);
+  });
+
+  it('is a no-op when every row decrypts', async () => {
+    mockPoolQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id, key, value_ciphertext')) {
+        return Promise.resolve({
+          rows: [
+            { id: 'id-1', key: 'ANON_KEY', value_ciphertext: 'enc:anon' },
+            { id: 'id-2', key: 'API_KEY', value_ciphertext: 'enc:api' },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const service = await loadSecretService();
+    const quarantined = await service.quarantineUndecryptableSecrets();
+
+    expect(quarantined).toEqual([]);
+    const updates = mockPoolQuery.mock.calls.filter(([sql]) =>
+      (sql as string).includes('UPDATE system.secrets')
+    );
+    expect(updates).toHaveLength(0);
+  });
+
+  it('is a no-op on an empty secrets table', async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+
+    const service = await loadSecretService();
+    await expect(service.quarantineUndecryptableSecrets()).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Restoring a database backup from one instance onto another (the disaster-recovery path for an accidentally deleted project: create a fresh project, load the old project's `pg_dump`) leaves every `system.secrets` row as AES-GCM ciphertext under the **source** instance's `ENCRYPTION_KEY`/`JWT_SECRET`. On the target instance:

- every `getSecretByKey`/`getSecretById` throws (`Failed to get secret`),
- `seedBackend()` wraps all seeding in one try/catch, so the **first** throw aborts everything — no ANON_KEY, no reserved secrets regenerated,
- the dashboard can't display the anon key and `GET /api/secrets/:key` returns 500 `INTERNAL_ERROR`.

Hit in production on 2026-07-18 while recovering a Pro customer's deleted project from its daily backup.

## Fix

Add `SecretService.quarantineUndecryptableSecrets()` and call it at the top of `seedBackend()`:

- attempts decryption of every active `system.secrets` row,
- rows that fail are renamed to `<KEY>_UNRECOVERABLE_<timestamp>` and deactivated — **never deleted**, so an operator who still has the source instance's key can recover the original values offline (mirrors the existing `API_KEY_OLD_<ts>` rotation idiom),
- the existing initializers then regenerate `ANON_KEY`, `API_KEY`, `JWT_SECRET`, JWT keypair, and base URLs under the target instance's key,
- a warning log lists the quarantined key names so user-defined secrets can be re-entered,
- on a healthy database the sweep is a no-op; the call is wrapped so a sweep failure never blocks seeding.

## Testing

- New unit tests: quarantines undecryptable rows (rename + deactivate + returned key list), leaves healthy rows untouched, no-op on all-healthy and empty tables.
- Full backend unit suite passes (152 files / 1806 tests), `tsc --noEmit` and eslint clean.
- The equivalent remediation (quarantine + reseed) was executed manually on the affected production instance and restored anon-key visibility and secrets API behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkX1oD4cF79TtFGBNv1Uyd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quarantine undecryptable secrets at boot so restores from another instance don’t abort seeding. This lets reserved secrets regenerate and keeps the secrets API and dashboard working.

- **Bug Fixes**
  - Added `quarantineUndecryptableSecrets()` to sweep active `system.secrets`; undecryptable rows are renamed to `<KEY>_UNRECOVERABLE_<timestamp>` and deactivated (never deleted).
  - Run the sweep at the start of `seedBackend()`; errors don’t block seeding. Reserved secrets (ANON_KEY, API_KEY, JWT secrets/keypair) are regenerated under the current instance key.
  - Warn-log quarantined keys so user-defined secrets can be re-entered.
  - Added unit tests covering quarantine behavior and no-op cases.

<sup>Written for commit 84a4143538e9a85ce54b54887f7cb7c396c5fbbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Quarantine undecryptable secrets at boot instead of aborting seeding
> - Adds `SecretService.quarantineUndecryptableSecrets()` in [secret.service.ts](https://github.com/InsForge/InsForge/pull/1755/files#diff-aa7cb5aae16f70b2262ae68a1b939191e06a4d6ebf1a7080e78581c1f98f031b), which scans active secrets, attempts decryption, and for any that fail renames the key to `<KEY>_UNRECOVERABLE_<timestamp>` and sets `is_active` to false.
> - Calls this method as a pre-seeding step in [seed.ts](https://github.com/InsForge/InsForge/pull/1755/files#diff-63196e4b85e26873baaf8f4688c0de418f99bafec3af5143fdae6a9d44f6e9b7); if the quarantine step itself throws, a warning is logged and seeding continues normally.
> - Behavioral Change: previously, an undecryptable secret would abort the seeding process; now it is deactivated and renamed in place, and seeding proceeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84a4143.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->