### PR TITLE
fix(dashboard): coalesce realtime query invalidations

### DIFF
--- a/packages/dashboard/src/lib/contexts/SocketContext.tsx
+++ b/packages/dashboard/src/lib/contexts/SocketContext.tsx
@@ -9,7 +9,7 @@ import {
   useMemo,
 } from 'react';
 import { io, Socket } from 'socket.io-client';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { apiClient } from '#lib/api/client';
 import { useAuth } from './AuthContext';
 import { getDashboardBackendUrl } from '#lib/config/runtime';
@@ -32,6 +32,13 @@ export enum ServerEvents {
   DATA_UPDATE = 'data:update',
   MCP_CONNECTED = 'mcp:connected',
 }
+
+/**
+ * Window over which realtime query invalidations are coalesced. A burst of
+ * writes to the same table within this window collapses into a single refetch,
+ * capping refetch rate while keeping the dashboard live (max staleness ~= this).
+ */
+const INVALIDATION_DEBOUNCE_MS = 300;
 
 // ============================================================================
 // Payload Types
@@ -108,12 +115,49 @@ export function SocketProvider({ children }: SocketProviderProps) {
   // Refs
   const socketRef = useRef<Socket | null>(null);
 
+  // Pending query invalidations from realtime events, deduped by serialized
+  // key. Flushed as a single batch by flushInvalidations (see scheduleInvalidate).
+  const pendingInvalidationsRef = useRef<Map<string, QueryKey>>(new Map());
+  const invalidationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   /**
    * Update state helper
    */
   const updateState = useCallback((updates: Partial<SocketState>) => {
     setState((prev) => ({ ...prev, ...updates }));
   }, []);
+
+  /**
+   * Flush all pending invalidations queued since the timer was armed. Each
+   * unique query key is invalidated once, regardless of how many events touched it.
+   */
+  const flushInvalidations = useCallback(() => {
+    invalidationTimerRef.current = null;
+    const pending = pendingInvalidationsRef.current;
+    if (pending.size === 0) {
+      return;
+    }
+    const queryKeys = Array.from(pending.values());
+    pending.clear();
+    for (const queryKey of queryKeys) {
+      void queryClient.invalidateQueries({ queryKey });
+    }
+  }, [queryClient]);
+
+  /**
+   * Queue a query key for invalidation, coalescing keys received within
+   * INVALIDATION_DEBOUNCE_MS into one flush. This throttles refetches under
+   * high write volume instead of firing one per DATA_UPDATE event.
+   */
+  const scheduleInvalidate = useCallback(
+    (queryKey: QueryKey) => {
+      pendingInvalidationsRef.current.set(JSON.stringify(queryKey), queryKey);
+      if (invalidationTimerRef.current === null) {
+        invalidationTimerRef.current = setTimeout(flushInvalidations, INVALIDATION_DEBOUNCE_MS);
+      }
+    },
+    [flushInvalidations]
+  );
 
   /**
    * Create and configure socket connection
@@ -228,6 +272,16 @@ export function SocketProvider({ children }: SocketProviderProps) {
     };
   }, [disconnect]);
 
+  // Clear any pending invalidation timer on unmount
+  useEffect(() => {
+    return () => {
+      if (invalidationTimerRef.current !== null) {
+        clearTimeout(invalidationTimerRef.current);
+        invalidationTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // Send onboarding success only after 2+ MCP connections
   const onMcpConnectedSuccess = useCallback(
     (toolName: string) => {
@@ -249,7 +303,9 @@ export function SocketProvider({ children }: SocketProviderProps) {
       return;
     }
 
-    // Handle DATA_UPDATE events - invalidate relevant queries
+    // Handle DATA_UPDATE events - invalidate relevant queries. Invalidations are
+    // coalesced (see scheduleInvalidate) so a burst of writes to the same table
+    // collapses into a single refetch instead of one per event.
     const handleDataUpdate = (message: SocketMessage) => {
       const resource = message.resource as DataUpdateResourceType;
 
@@ -266,67 +322,63 @@ export function SocketProvider({ children }: SocketProviderProps) {
             switch (change.type) {
               case 'tables':
                 // CREATE TABLE / DROP TABLE - affects table list
-                void queryClient.invalidateQueries({ queryKey: ['database', 'tables'] });
-                void queryClient.invalidateQueries({ queryKey: ['metadata', 'full'] });
+                scheduleInvalidate(['database', 'tables']);
+                scheduleInvalidate(['metadata', 'full']);
                 break;
               case 'table':
                 // ALTER TABLE / RENAME - affects specific table and list
-                void queryClient.invalidateQueries({ queryKey: ['database', 'tables'] });
+                scheduleInvalidate(['database', 'tables']);
                 if (change.name) {
                   const { schemaName, tableName } = parseDatabaseTableReference(change.name);
-                  void queryClient.invalidateQueries({
-                    queryKey: databaseTableQueryKeys.tableSchema(schemaName, tableName),
-                  });
+                  scheduleInvalidate(databaseTableQueryKeys.tableSchema(schemaName, tableName));
                 }
                 break;
               case 'records':
                 // INSERT / UPDATE / DELETE - affects records for specific table
                 if (change.name) {
                   const { schemaName, tableName } = parseDatabaseTableReference(change.name);
-                  void queryClient.invalidateQueries({
-                    queryKey: ['records', schemaName, tableName],
-                  });
+                  scheduleInvalidate(['records', schemaName, tableName]);
                 }
                 // Record count changed — refresh metadata so dashboard steps update
-                void queryClient.invalidateQueries({ queryKey: ['metadata', 'full'] });
+                scheduleInvalidate(['metadata', 'full']);
                 break;
               case 'index':
-                void queryClient.invalidateQueries({ queryKey: ['database', 'indexes'] });
+                scheduleInvalidate(['database', 'indexes']);
                 break;
               case 'trigger':
-                void queryClient.invalidateQueries({ queryKey: ['database', 'triggers'] });
+                scheduleInvalidate(['database', 'triggers']);
                 break;
               case 'policy':
-                void queryClient.invalidateQueries({ queryKey: ['database', 'policies'] });
+                scheduleInvalidate(['database', 'policies']);
                 break;
               case 'function':
-                void queryClient.invalidateQueries({ queryKey: ['database', 'functions'] });
+                scheduleInvalidate(['database', 'functions']);
                 break;
               case 'extension':
                 // Extensions are not supported yet
                 break;
               case 'migration':
-                void queryClient.invalidateQueries({ queryKey: ['database', 'migrations'] });
+                scheduleInvalidate(['database', 'migrations']);
                 break;
             }
           }
           break;
         }
         case DataUpdateResourceType.BUCKETS:
-          void queryClient.invalidateQueries({ queryKey: ['storage', 'buckets'] });
-          void queryClient.invalidateQueries({ queryKey: ['metadata', 'full'] });
+          scheduleInvalidate(['storage', 'buckets']);
+          scheduleInvalidate(['metadata', 'full']);
           break;
         case DataUpdateResourceType.USERS:
-          void queryClient.invalidateQueries({ queryKey: ['users'] });
+          scheduleInvalidate(['users']);
           break;
         case DataUpdateResourceType.FUNCTIONS:
-          void queryClient.invalidateQueries({ queryKey: ['functions'] });
+          scheduleInvalidate(['functions']);
           break;
         case DataUpdateResourceType.DEPLOYMENTS:
-          void queryClient.invalidateQueries({ queryKey: ['deployment-metadata'] });
+          scheduleInvalidate(['deployment-metadata']);
           break;
         case DataUpdateResourceType.REALTIME:
-          void queryClient.invalidateQueries({ queryKey: ['realtime'] });
+          scheduleInvalidate(['realtime']);
           break;
       }
     };
@@ -347,7 +399,7 @@ export function SocketProvider({ children }: SocketProviderProps) {
       socket.off(ServerEvents.DATA_UPDATE, handleDataUpdate);
       socket.off(ServerEvents.MCP_CONNECTED, handleMcpConnected);
     };
-  }, [state.isConnected, queryClient, onMcpConnectedSuccess]);
+  }, [state.isConnected, queryClient, onMcpConnectedSuccess, scheduleInvalidate]);
 
   // Context value
   const contextValue = useMemo<SocketContextValue>(


### PR DESCRIPTION
## Summary

The dashboard's `DATA_UPDATE` socket handler ([SocketContext.tsx](packages/dashboard/src/lib/contexts/SocketContext.tsx)) invalidated React Query keys **synchronously, once per event**. Since #1738 made every `POST`/`DELETE`/`PATCH`/`PUT` on the records proxy broadcast a `DATA_UPDATE`, a burst of writes to a hot table now triggers one refetch per event against PostgREST — a refetch storm that scales with write volume × number of open dashboards.

This PR routes all invalidations through a small coalescing scheduler:

- `scheduleInvalidate(queryKey)` queues keys in a `Map` deduped by serialized key, arming a single timer.
- `flushInvalidations()` fires once per window, invalidating each unique key exactly once, then clears the batch.

Semantics are **throttle, not pure debounce** — a queued key always flushes within `INVALIDATION_DEBOUNCE_MS` (300ms), so a continuous write stream keeps the grid live (max staleness ~300ms) while capping refetch rate at ~3×/sec instead of one-per-event. The timer is cleared on unmount.

Applies to every `DATA_UPDATE` resource type (records, tables, buckets, users, functions, deployments, realtime), not just records. Redundant keys within a single message collapse too (e.g. `['metadata','full']` queued several times → invalidated once). The low-frequency MCP handler is left untouched.

This is the client-side half of the scaling discussion around #1738. A follow-up can move the change signal from the API proxy route to the database (statement-level triggers via the existing `LISTEN`/`NOTIFY` loop) so edits from the SQL editor, functions, and triggers also refresh the grid.

## How did you test this change?

- `tsc --noEmit`: no errors on the changed file.
- `eslint`: clean on the changed file.
- Full end-to-end verification (live socket under a write burst) was not run — deps aren't installed in this worktree and the behavior needs a running backend to observe. The change is a self-contained refactor of invalidation timing with no change to which keys are invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces realtime query invalidations to stop refetch storms under heavy writes. Batches and dedupes React Query keys for `DATA_UPDATE` events within a 300ms window, keeping data fresh while capping refetch rate.

- **Bug Fixes**
  - Route all invalidations through a small scheduler (`INVALIDATION_DEBOUNCE_MS=300`), flushing each unique key once per window.
  - Collapse redundant keys within a single message; applies to records, tables, buckets, users, functions, deployments, and `realtime`.
  - Clear the timer on unmount to avoid stray flushes.

<sup>Written for commit 832bf8d5e750e295394c2e3f7321ec8620782abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce realtime query invalidations in `SocketProvider` with a 300ms debounce
> Multiple `DATA_UPDATE` socket events arriving in quick succession previously triggered an immediate `queryClient.invalidateQueries` call per event. This change batches invalidations using a debounce window so each unique query key is invalidated at most once per 300ms. Pending timers are cleared on component unmount to avoid stale updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 832bf8d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved realtime data updates by grouping rapid changes into fewer refresh operations.
  * Reduced redundant updates while ensuring affected data remains current.
* **Bug Fixes**
  * Improved consistency when refreshing related metadata and full-data views after realtime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->