### PR TITLE
fix: upgrade axios for Vanta advisories

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
     "@types/multer": "^1.4.13",
     "@types/pg": "^8.15.4",
     "adm-zip": "^0.6.0",
-    "axios": "^1.16.1",
+    "axios": "^1.18.1",
     "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@types/multer": "^1.4.13",
         "@types/pg": "^8.15.4",
         "adm-zip": "^0.6.0",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "bcryptjs": "^3.0.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -8643,9 +8643,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dompurify": "3.4.12",
     "follow-redirects": "^1.16.0",
     "uuid": "^14.0.0",
-    "axios": "^1.16.1",
+    "axios": "1.18.1",
     "ws": "^8.21.0",
     "qs": "^6.15.2",
     "minimatch@10": {


### PR DESCRIPTION
## Summary
- Upgrade backend axios dependency to 1.18.1.
- Pin root axios override to 1.18.1 so transitive consumers resolve outside the reported vulnerable ranges.
- Refresh package-lock resolution for axios.

## Test Plan
- [x] npm audit --omit=optional
- [x] lockfile check: axios 1.18.1, qs 6.15.2 in InsForge
- [x] npm run typecheck

## Notes
- The remaining qs Vanta item is for a separate repository: insforge-oauth-example. Current InsForge resolves qs to 6.15.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `axios` to 1.18.1 and pin it at the root to address Vanta security advisories and ensure safe transitive installs. Refreshed the lockfile to enforce the new resolution.

- **Dependencies**
  - Upgrade backend `axios` to `^1.18.1`
  - Pin root `axios` to `1.18.1`
  - Update `package-lock.json` to resolve `axios@1.18.1`

<sup>Written for commit 9131f35bca8adaadfb9bd20fb9ff61c060a49f7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade axios to 1.18.1 to resolve Vanta security advisories
> Updates axios from `^1.16.1` to `1.18.1` in both the root and backend [package.json](https://github.com/InsForge/InsForge/pull/1762/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to address Vanta security advisories. The root package pins to exactly `1.18.1` while the backend uses `^1.18.1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9131f35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying network communication components to a newer supported version.
  - Maintains compatibility and reliability without changing application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->