### PR TITLE
2026-07-13 fix mintlify docs

### DIFF
--- a/docs/core-concepts/database/overview.mdx
+++ b/docs/core-concepts/database/overview.mdx
@@ -60,6 +60,10 @@ Native vector search for embeddings, with HNSW and IVFFlat indexes. See [pgvecto
 
 Postgres RLS policies enforce access at the row level. Policies read the auth JWT, so the same rule applies to REST queries, SDK calls, realtime subscriptions, and storage requests.
 
+### Connection string
+
+Point external Postgres tools — `psql`, a BI dashboard, an ORM, or a worker running on a VM — straight at your project's database with a standard `postgresql://` connection string. Open your project in the [dashboard](https://insforge.dev), click **Connect** (the same section also lives under **Project Settings**), and read **Connection String**. You get the full URL plus the individual parameters — host, database, user, port, and password — with a show/hide toggle to reveal the password before you copy it. This is a direct connection, best for persistent, long-lived clients such as virtual machines and long-running containers. Your app code rarely needs it, since every table is already a REST and SDK endpoint, but it's there whenever a tool needs raw Postgres access.
+
 ## Concepts
 
 <CardGroup cols={2}>

--- a/docs/es/core-concepts/database/overview.mdx
+++ b/docs/es/core-concepts/database/overview.mdx
@@ -60,6 +60,10 @@ Búsqueda de vectores nativos para incrustaciones, con índices HNSW e IVFFlat. 
 
 Las políticas RLS de Postgres aplican acceso a nivel de fila. Las políticas leen el JWT de autenticación, por lo que la misma regla se aplica a consultas REST, llamadas SDK, suscripciones en tiempo real y solicitudes de almacenamiento.
 
+### Cadena de conexión
+
+Apunta herramientas de Postgres externas — `psql`, un panel de BI, un ORM o un worker corriendo en una VM — directamente a la base de datos de tu proyecto con una cadena de conexión `postgresql://` estándar. Abre tu proyecto en el [dashboard](https://insforge.dev), haz clic en **Connect** (la misma sección también está en **Project Settings**) y consulta **Connection String**. Obtienes la URL completa más los parámetros individuales — host, database, user, port y password — con un botón para mostrar/ocultar la contraseña antes de copiarla. Es una conexión directa, ideal para clientes persistentes y de larga duración como máquinas virtuales y contenedores de larga ejecución. El código de tu app rara vez la necesita, ya que cada tabla ya es un endpoint REST y SDK, pero está ahí siempre que una herramienta necesite acceso Postgres en crudo.
+
 ## Conceptos
 
 <CardGroup cols={2}>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -143,6 +143,20 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
     ¿Sigues atascado? Pregunta en nuestro [Discord](https://discord.com/invite/DvBtaEc9Jz) para la respuesta más rápida.
   </Accordion>
 
+  <Accordion title="¿Cómo elimino un proyecto?">
+    Eliminar un proyecto es permanente. Destruye la base de datos del proyecto, los buckets de almacenamiento, las edge functions, el sitio desplegado y todos los demás recursos del backend, y cualquier app o integración que apunte a él deja de funcionar de inmediato. No hay deshacer, así que si podrías necesitar los datos más adelante, descarga primero una [copia de seguridad](/core-concepts/database/backups).
+
+    **Dashboard.** Abre el proyecto, ve a **Project Settings** y usa la opción de eliminar. Se te pedirá confirmación.
+
+    **CLI.** Pasa el id del proyecto de forma explícita — `projects delete` nunca recurre a tu proyecto vinculado, así que no puede apuntar al equivocado por accidente:
+
+    ```bash
+    npx @insforge/cli projects delete --project <project-id>
+    ```
+
+    Pide confirmación en modo interactivo; `--yes` y `--json` omiten el aviso y eliminan de inmediato, así que no los pases a menos que hayas verificado el id. Consulta el [CLI harness](/agent-native/cli-harness) para la referencia completa de comandos.
+  </Accordion>
+
   <Accordion title="¿Cómo autentico la CLI sin navegador?">
     `npx @insforge/cli login` abre un navegador para iniciar sesión. En una máquina sin interfaz, un servidor remoto o CI, usa una user API key en su lugar. No hace falta navegador.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -143,6 +143,20 @@ description: "Answers to common InsForge questions on database calls, edge funct
     Still stuck? Ask in our [Discord](https://discord.com/invite/DvBtaEc9Jz) for the fastest response.
   </Accordion>
 
+  <Accordion title="How do I delete a project?">
+    Deleting a project is permanent. It destroys the project's database, storage buckets, edge functions, deployed site, and every other backend resource, and any app or integration pointing at it breaks immediately. There's no undo, so if you might need the data later, download a [backup](/core-concepts/database/backups) first.
+
+    **Dashboard.** Open the project, go to **Project Settings**, and use the delete option. You'll be asked to confirm.
+
+    **CLI.** Pass the project id explicitly — `projects delete` never falls back to your linked project, so it can't target the wrong one by accident:
+
+    ```bash
+    npx @insforge/cli projects delete --project <project-id>
+    ```
+
+    It prompts for confirmation in interactive mode; `--yes` and `--json` skip the prompt and delete immediately, so don't pass them unless you've double-checked the id. See the [CLI harness](/agent-native/cli-harness) for the full command reference.
+  </Accordion>
+
   <Accordion title="How do I authenticate the CLI without a browser?">
     `npx @insforge/cli login` opens a browser to sign in. On a headless machine, a remote server, or CI, use a user API key instead. No browser needed.
 

--- a/docs/zh-Hant/core-concepts/database/overview.mdx
+++ b/docs/zh-Hant/core-concepts/database/overview.mdx
@@ -60,6 +60,10 @@ graph TB
 
 Postgres RLS 原則在列級別強制執行存取。原則讀取驗證 JWT，因此相同的規則適用於 REST 查詢、SDK 呼叫、即時訂閱和儲存請求。
 
+### 連線字串
+
+用標準的 `postgresql://` 連線字串，讓外部 Postgres 工具（`psql`、BI 儀表板、ORM，或執行在虛擬機上的 worker）直接連到你專案的資料庫。在 [dashboard](https://insforge.dev) 打開專案，點 **Connect**（同樣的內容也在 **Project Settings** 裡），查看 **Connection String**。你會拿到完整的 URL，以及各個參數——host、database、user、port 和 password——密碼旁有顯示/隱藏開關，複製前可以先顯示出來。這是直連，最適合虛擬機、長時間執行的容器這類持久、長連線的用戶端。你的應用程式碼通常用不到它，因為每張資料表本身就是 REST 和 SDK 端點，但當某個工具需要原生 Postgres 存取時，它隨時可用。
+
 ## 概念
 
 <CardGroup cols={2}>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -143,6 +143,20 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
     還是卡住？到我們的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提問，回應最快。
   </Accordion>
 
+  <Accordion title="怎麼刪除一個專案？">
+    刪除專案是永久性的。它會銷毀專案的資料庫、Storage bucket、Edge Function、已部署的站點，以及其他所有後端資源，任何指向它的應用或整合都會立刻失效。沒有復原操作，所以如果你之後可能還要用這些資料，請先下載[備份](/core-concepts/database/backups)。
+
+    **Dashboard。** 打開專案，進入 **Project Settings**，使用刪除選項。系統會要求你確認。
+
+    **CLI。** 明確傳入專案 id——`projects delete` 絕不會回退到你已 link 的專案，因此不會誤刪其他專案：
+
+    ```bash
+    npx @insforge/cli projects delete --project <project-id>
+    ```
+
+    在互動模式下它會要求確認；`--yes` 和 `--json` 會跳過確認直接刪除，所以除非你已核對過 id，否則不要加這兩個參數。完整命令參考見 [CLI harness](/agent-native/cli-harness)。
+  </Accordion>
+
   <Accordion title="不打開瀏覽器，怎麼幫 CLI 登入驗證？">
     `npx @insforge/cli login` 會打開瀏覽器登入。在無介面機器、遠端伺服器或 CI 上，改用 user API key，不需要瀏覽器。
 

--- a/docs/zh/core-concepts/database/overview.mdx
+++ b/docs/zh/core-concepts/database/overview.mdx
@@ -60,6 +60,10 @@ graph TB
 
 Postgres RLS 策略在行级别强制执行访问。策略读取身份验证 JWT，因此相同的规则适用于 REST 查询、SDK 调用、实时订阅和存储请求。
 
+### 连接字符串
+
+用标准的 `postgresql://` 连接字符串，让外部 Postgres 工具（`psql`、BI 面板、ORM，或运行在虚拟机上的 worker）直接连到你项目的数据库。在 [dashboard](https://insforge.dev) 打开项目，点 **Connect**（同样的内容也在 **Project Settings** 里），查看 **Connection String**。你会得到完整的 URL，以及各个参数——host、database、user、port 和 password——密码旁有显示/隐藏开关，复制前可以先显示出来。这是直连，最适合虚拟机、长时间运行的容器这类持久、长连接的客户端。你的应用代码通常用不到它，因为每张表本身就是 REST 和 SDK 端点，但当某个工具需要原生 Postgres 访问时，它随时可用。
+
 ## 概念
 
 <CardGroup cols={2}>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -143,6 +143,20 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
     还是卡住？到我们的 [Discord](https://discord.com/invite/DvBtaEc9Jz) 提问，响应最快。
   </Accordion>
 
+  <Accordion title="怎么删除一个项目？">
+    删除项目是永久性的。它会销毁项目的数据库、Storage bucket、Edge Function、已部署的站点，以及其它所有后端资源，任何指向它的应用或集成都会立刻失效。没有撤销操作，所以如果你以后可能还要用这些数据，请先下载[备份](/core-concepts/database/backups)。
+
+    **Dashboard。** 打开项目，进入 **Project Settings**，使用删除选项。系统会要求你确认。
+
+    **CLI。** 显式传入项目 id——`projects delete` 绝不会回退到你已 link 的项目，因此不会误删其它项目：
+
+    ```bash
+    npx @insforge/cli projects delete --project <project-id>
+    ```
+
+    在交互模式下它会要求确认；`--yes` 和 `--json` 会跳过确认直接删除，所以除非你已核对过 id，否则不要加这两个参数。完整命令参考见 [CLI harness](/agent-native/cli-harness)。
+  </Accordion>
+
   <Accordion title="不打开浏览器，怎么给 CLI 登录鉴权？">
     `npx @insforge/cli login` 会打开浏览器登录。在无界面机器、远程服务器或 CI 上，改用 user API key，不需要浏览器。
 


### PR DESCRIPTION
Fills documentation gaps surfaced by unanswered Ask AI conversations on 2026-07-13. ADD-only changes across all four locales (`en`, `zh`, `zh-Hant`, `es`).

## Added

### Database connection string
- **Where:** `core-concepts/database/overview.mdx` (+ `zh`, `zh-Hant`, `es`) — new `### Connection string` section under Features.
- **Conversations:** `01KXDRWY6Q76RKQHJJ62D03SFP`
- **Why it was unanswered:** The direct Postgres connection string is a real, prominent product feature (dashboard **Connect** modal + **Project Settings → Connection String**, with host/database/user/port/password parameters), but it was undocumented, so the assistant had nothing to cite. Docs now explain where to find it and what it's for.

### How do I delete a project?
- **Where:** `faq.mdx` (+ `zh`, `zh-Hant`, `es`) — new FAQ accordion after the project-restart entry.
- **Conversations:** `01KXCDR264PYCXPV27W42VGRMV`, `01KXE978920M5GXAZ0P60779TE`
- **Why it was unanswered:** Project deletion exists in both the dashboard (`useDeleteProject`) and CLI (`projects delete`), but it was only buried in a table cell in the CLI harness reference, so a plain "how do I delete a project" question was undiscoverable. Two separate users asked and both were bounced to the contact form. FAQ now covers dashboard + CLI paths and the permanence warning.

## Skipped

| Conversation(s) | Topic | Reason |
|---|---|---|
| 01KXCD6F7YP0K35JQPQ0R55WDD | "how do I choices the site contents" | not-a-doc-question (vague/no actionable ask) |
| 01KXCDBNSVBX840QF1TVPCK33Q | "where is my source code for the site" | project-specific (source lives in the user's own repo; no export feature) |
| 01KXEXEN52X00FJ3GDCQDVSY7B | "remove deployed site" | missing-feature (no per-site removal; a site is tied to its project) |
| 01KXCDYDDJTWRZY8986CS5BW3G | "more workspaces" | missing-feature (InsForge has organizations/projects, no "workspaces" concept) |
| 01KXCE3GM4B90CTJ2EWVE36FZY | "monetizing" | not-a-doc-question (monetization inquiry, no such platform feature) |
| 01KXCE8P5HRN0SAYRTB6VNGE14 | "Partner integration" | already-covered (`partnership.mdx`) |
| 01KXCN5J2G5RQ6553Z9GBBCYDH | "dsa" | not-a-doc-question (gibberish) |
| 01KXCQJJ234ECSMXZC1SRA5SXF | "set up google ai studio" | missing-feature (AI routes through OpenRouter, not Google AI Studio) |
| 01KXD07JDBWZ0DDEB290ETEYYV | "use HS256" | already-covered (`integrations/clerk.mdx` documents HS256) |
| 01KXD09G3PWWS4HZAFSB8SDMGN | "secret for Clerk" | already-covered (`integrations/clerk.mdx` documents the JWT_SECRET for Clerk) |
| 01KXDSXJFM122ST0JN163N4D0B | Veo 3.1 video seconds / model price labels | missing-feature (video duration is OpenRouter-owned; the price-label question was already answered from the API reference) |
| 01KXDZ76MJJDMC5A500KCHW2FX | LLM identity / IaC / Jenkins | not-a-doc-question + missing-feature (chit-chat; no IaC/Jenkins support) |
| 01KXDZZHF5MD2XGMCJN98WVVMK | "uninstall" | not-a-doc-question (single ambiguous word) |
| 01KXE0VS4FEZMAKS41ZVY11S9H | npm UNABLE_TO_VERIFY_LEAF_SIGNATURE | project-specific (local TLS/root-CA environment issue, not InsForge behavior) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing docs for the Postgres connection string and project deletion across `en`, `zh`, `zh-Hant`, and `es`. Improves discoverability for direct DB access and safe project removal.

- New Features
  - Database connection string: Added a “Connection string” section to `core-concepts/database/overview.mdx` explaining where to find the `postgresql://` URL in the dashboard (Connect and Project Settings), available parameters, and when to use it.
  - Project deletion: Added a new FAQ covering dashboard steps and the CLI command (`npx @insforge/cli projects delete --project <project-id>`), confirmation behavior, permanence warning, and links to backups and the CLI harness.

<sup>Written for commit df207866eecd12f0ac32d40df8b7ad394f4e1e8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add connection string and project deletion sections to docs in all supported languages
> - Adds a 'Connection string' section to the database overview docs explaining how to connect external Postgres tools using a standard `postgresql://` URL, where to find credentials in the dashboard, and when to use direct connections.
> - Adds a 'How do I delete a project?' FAQ entry covering permanent deletion via Dashboard and CLI, including an example command and notes on confirmation prompts.
> - Both additions are mirrored across English, Spanish, Traditional Chinese, and Simplified Chinese versions of the docs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df20786.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->