### PR TITLE
2026-07-13 fix mintlify docs

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -199,4 +199,19 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
 
     La cadena se conecta con el rol privilegiado `postgres`, por lo que no está limitada por row-level security e incluye la contraseña de ese rol. Trátala como un secreto: mantenla en el servidor y nunca la envíes al navegador.
   </Accordion>
+
+  <Accordion title="¿Cómo doy de baja o elimino un sitio desplegado?">
+    Un [Site](/core-concepts/sites/overview) pertenece a su proyecto: no hay un comando aparte para "eliminar este despliegue". Para dar de baja un sitio de forma definitiva, elimina el proyecto en el que vive, lo que quita el despliegue junto con la base de datos, el Storage y todo lo demás:
+
+    ```bash
+    npx @insforge/cli projects delete --project <id>
+    ```
+
+    Es irreversible. Desde el dashboard, la eliminación del proyecto está en **Settings → General**. Consulta [el CLI harness](/agent-native/cli-harness) para conocer el comportamiento completo de `projects delete` y sus salvaguardas.
+
+    Dos acciones relacionadas que *no* son lo mismo que eliminar un sitio en vivo:
+
+    - **Cancelar una compilación en curso:** `npx @insforge/cli deployments cancel <id>` detiene un despliegue en progreso; no da de baja un sitio que ya está en vivo.
+    - **Reemplazar lo que está en vivo:** vuelve a desplegar sobre el mismo sitio con `npx @insforge/cli deployments deploy ./frontend` — el despliegue ready más reciente sirve la URL.
+  </Accordion>
 </AccordionGroup>

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -189,7 +189,7 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
     npx @insforge/cli db connection-string
     ```
 
-    También puedes obtenerla desde el dashboard, en **Install → Connection String** (solo para proyectos cloud).
+    También puedes obtenerla desde el dashboard, en **Project Settings → Connect → Connection String** (solo para proyectos cloud).
 
     Devuelve una URL con esta forma:
 
@@ -203,13 +203,9 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
   </Accordion>
 
   <Accordion title="¿Cómo doy de baja o elimino un sitio desplegado?">
-    Un [Site](/core-concepts/sites/overview) pertenece a su proyecto: no hay un comando aparte para "eliminar este despliegue". Para dar de baja un sitio de forma definitiva, elimina el proyecto en el que vive, lo que quita el despliegue junto con la base de datos, el Storage y todo lo demás:
+    Por ahora no hay una forma autoservicio de dar de baja un [Site](/core-concepts/sites/overview) desplegado: no existe un comando `deployments delete` ni una acción en el dashboard para ello. Los sitios desplegados se alojan de forma externa, así que incluso eliminar tu proyecto (`npx @insforge/cli projects delete --project <id>`) borra tus recursos de backend —base de datos, Storage y backend branches— pero *no* quita el sitio alojado.
 
-    ```bash
-    npx @insforge/cli projects delete --project <id>
-    ```
-
-    Es irreversible. Desde el dashboard, la eliminación del proyecto está en **Settings → General**. Consulta [el CLI harness](/agent-native/cli-harness) para conocer el comportamiento completo de `projects delete` y sus salvaguardas.
+    En la práctica esto rara vez importa. Si de verdad necesitas dar de baja un sitio desplegado, escríbele al equipo de InsForge en [Discord](https://discord.com/invite/DvBtaEc9Jz).
 
     Dos acciones relacionadas que *no* son lo mismo que eliminar un sitio en vivo:
 

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -189,6 +189,8 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
     npx @insforge/cli db connection-string
     ```
 
+    También puedes obtenerla desde el dashboard, en **Install → Connection String** (solo para proyectos cloud).
+
     Devuelve una URL con esta forma:
 
     ```text

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -181,4 +181,22 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
   <Accordion title="¿Este asistente puede ayudarme con algo específico de mi propio proyecto?">
     En realidad no. Este asistente responde a partir de la documentación pública de InsForge, así que no puede ver tu proyecto: no puede depurar un error, leer tus datos ni revisar tu configuración. Lleva cualquier cosa específica de tu propio proyecto a tu agente de programación. Conectado a InsForge a través de la CLI o MCP, tu agente puede leer tu backend en vivo, el esquema, los datos y los logs, y depurar el problema directamente. Solo descríbelo con tus propias palabras. Para un informe de salud y errores que puedes ejecutar tú mismo, usa `npx @insforge/cli diagnose`. Consulta [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
+
+  <Accordion title="¿Cómo obtengo la cadena de conexión (connection string) de Postgres de mi base de datos?">
+    Cada proyecto cloud tiene una cadena de conexión de Postgres directa, útil para `psql`, un GUI de base de datos, un ORM (Prisma, Drizzle) o un servicio externo como [Better Auth](/integrations/better-auth) que necesita su propio Postgres. Imprímela con la CLI:
+
+    ```bash
+    npx @insforge/cli db connection-string
+    ```
+
+    Devuelve una URL con esta forma:
+
+    ```text
+    postgresql://postgres:<password>@<appkey>.<region>.database.insforge.app:5432/insforge?sslmode=require
+    ```
+
+    Añade `--json` para obtener `{ "connectionURL": "..." }` en scripts. El comando funciona **solo para proyectos cloud**: en una instancia autoalojada Postgres queda expuesto directamente por tu configuración de `docker-compose`, así que usa las credenciales de Postgres locales (los valores `DATABASE_URL` / `POSTGRES_*` de tu `.env`) en su lugar.
+
+    La cadena se conecta con el rol privilegiado `postgres`, por lo que no está limitada por row-level security e incluye la contraseña de ese rol. Trátala como un secreto: mantenla en el servidor y nunca la envíes al navegador.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -199,4 +199,19 @@ description: "Answers to common InsForge questions on database calls, edge funct
 
     The string connects as the privileged `postgres` role, so it isn't limited by row-level security and it embeds that role's password. Treat it like a secret: keep it server-side and never ship it to the browser.
   </Accordion>
+
+  <Accordion title="How do I take down or remove a deployed site?">
+    A [Site](/core-concepts/sites/overview) belongs to its project — there is no separate "delete this deployment" command. To take a site down for good, delete the project it lives in, which removes the deployment along with the database, storage, and everything else:
+
+    ```bash
+    npx @insforge/cli projects delete --project <id>
+    ```
+
+    This is irreversible. From the dashboard, project deletion lives under **Settings → General**. See [the CLI harness](/agent-native/cli-harness) for the full `projects delete` behavior and safeguards.
+
+    Two related actions that are *not* the same as removing a live site:
+
+    - **Cancel a build that's still running:** `npx @insforge/cli deployments cancel <id>` stops an in-progress deployment; it does not take down a site that is already live.
+    - **Replace what's live:** redeploy over the same site with `npx @insforge/cli deployments deploy ./frontend` — the newest ready deployment serves the URL.
+  </Accordion>
 </AccordionGroup>

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -189,7 +189,7 @@ description: "Answers to common InsForge questions on database calls, edge funct
     npx @insforge/cli db connection-string
     ```
 
-    You can also grab it from the dashboard under **Install → Connection String** (cloud projects only).
+    You can also grab it from the dashboard under **Project Settings → Connect → Connection String** (cloud projects only).
 
     It returns a URL shaped like:
 
@@ -203,13 +203,9 @@ description: "Answers to common InsForge questions on database calls, edge funct
   </Accordion>
 
   <Accordion title="How do I take down or remove a deployed site?">
-    A [Site](/core-concepts/sites/overview) belongs to its project — there is no separate "delete this deployment" command. To take a site down for good, delete the project it lives in, which removes the deployment along with the database, storage, and everything else:
+    There's currently no self-serve way to take down a deployed [Site](/core-concepts/sites/overview) — there's no `deployments delete` command and no dashboard action for it. Deployed sites are hosted externally, so even deleting your project (`npx @insforge/cli projects delete --project <id>`) tears down your backend resources — database, storage, and backend branches — but does *not* remove the hosted site.
 
-    ```bash
-    npx @insforge/cli projects delete --project <id>
-    ```
-
-    This is irreversible. From the dashboard, project deletion lives under **Settings → General**. See [the CLI harness](/agent-native/cli-harness) for the full `projects delete` behavior and safeguards.
+    In practice this rarely matters. If you do need a deployed site taken down, ask the InsForge team in [Discord](https://discord.com/invite/DvBtaEc9Jz).
 
     Two related actions that are *not* the same as removing a live site:
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -189,6 +189,8 @@ description: "Answers to common InsForge questions on database calls, edge funct
     npx @insforge/cli db connection-string
     ```
 
+    You can also grab it from the dashboard under **Install → Connection String** (cloud projects only).
+
     It returns a URL shaped like:
 
     ```text

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -181,4 +181,22 @@ description: "Answers to common InsForge questions on database calls, edge funct
   <Accordion title="Can this assistant help with something specific to my own project?">
     Not really. This assistant answers from InsForge's public docs, so it can't see your project: it can't debug an error, read your data, or check your configuration. Take anything specific to your own project to your coding agent instead. Connected to InsForge through the CLI or MCP, your agent can read your live backend, schema, data, and logs and debug the problem directly. Just describe it in plain words. For a backend health and error report you can run yourself, use `npx @insforge/cli diagnose`. See [Diagnostics & advisor](/agent-native/diagnostics).
   </Accordion>
+
+  <Accordion title="How do I get my database's Postgres connection string?">
+    Every cloud project has a direct Postgres connection string, handy for `psql`, a database GUI, an ORM (Prisma, Drizzle), or an external service like [Better Auth](/integrations/better-auth) that needs its own Postgres. Print it with the CLI:
+
+    ```bash
+    npx @insforge/cli db connection-string
+    ```
+
+    It returns a URL shaped like:
+
+    ```text
+    postgresql://postgres:<password>@<appkey>.<region>.database.insforge.app:5432/insforge?sslmode=require
+    ```
+
+    Add `--json` to get `{ "connectionURL": "..." }` for scripts. The command works for **cloud projects only** — on a self-hosted instance Postgres is exposed directly by your `docker-compose` setup, so use the local Postgres credentials (the `DATABASE_URL` / `POSTGRES_*` values from your `.env`) instead.
+
+    The string connects as the privileged `postgres` role, so it isn't limited by row-level security and it embeds that role's password. Treat it like a secret: keep it server-side and never ship it to the browser.
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -189,7 +189,7 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
     npx @insforge/cli db connection-string
     ```
 
-    你也可以在 dashboard 裡拿到：進入 **Install → Connection String**（僅限 cloud 專案）。
+    你也可以在 dashboard 裡拿到：進入 **Project Settings → Connect → Connection String**（僅限 cloud 專案）。
 
     它回傳的 URL 形如：
 
@@ -203,13 +203,9 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
   </Accordion>
 
   <Accordion title="怎麼下線或刪除已部署的站點（site）？">
-    [Site](/core-concepts/sites/overview) 屬於它所在的專案——沒有單獨的「刪除這個部署」命令。想徹底下線一個站點，就刪除它所在的專案，這會連同資料庫、Storage 以及其他所有資源一起把部署刪掉：
+    目前沒有自助下線已部署 [Site](/core-concepts/sites/overview) 的方式——既沒有 `deployments delete` 命令，dashboard 裡也沒有對應操作。已部署的站點託管在外部，所以即使刪除專案（`npx @insforge/cli projects delete --project <id>`）也只會清掉後端資源——資料庫、Storage 和後端分支——而*不會*移除已託管的站點。
 
-    ```bash
-    npx @insforge/cli projects delete --project <id>
-    ```
-
-    此操作不可逆。在 dashboard 裡，刪除專案位於 **Settings → General**。完整的 `projects delete` 行為和防護措施見 [CLI harness](/agent-native/cli-harness)。
+    實際上這基本不影響使用。如果你確實需要下線某個已部署的站點，請到 [Discord](https://discord.com/invite/DvBtaEc9Jz) 聯繫 InsForge 團隊。
 
     有兩個相關操作，和「下線一個已上線站點」並不是一回事：
 

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -181,4 +181,22 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
   <Accordion title="這個助手能幫我解決我自己專案裡的具體問題嗎？">
     基本上不行。這個助手是根據 InsForge 的公開文件來回答的，看不到你的專案：既沒辦法除錯，也讀不到你的資料，更查不了你的設定。凡是跟你自己專案相關的，交給你的編碼 agent 來處理。你的 agent 透過 CLI 或 MCP 連著 InsForge，能讀到你的即時後端、結構、資料和日誌，直接幫你除錯，用白話描述問題就行。想自己拿一份後端健康和報錯報告，跑 `npx @insforge/cli diagnose`。參見 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
+
+  <Accordion title="怎麼拿到資料庫的 Postgres 連線字串（connection string）？">
+    每個 cloud 專案都有一個直連的 Postgres connection string，方便用 `psql`、資料庫 GUI、ORM（Prisma、Drizzle），或者像 [Better Auth](/integrations/better-auth) 這類需要自帶 Postgres 的外部服務。用 CLI 印出來：
+
+    ```bash
+    npx @insforge/cli db connection-string
+    ```
+
+    它回傳的 URL 形如：
+
+    ```text
+    postgresql://postgres:<password>@<appkey>.<region>.database.insforge.app:5432/insforge?sslmode=require
+    ```
+
+    加上 `--json` 會得到 `{ "connectionURL": "..." }`，方便腳本使用。這個命令**只對 cloud 專案有效**——自行託管的實例其 Postgres 由你的 `docker-compose` 直接暴露，所以請改用本地 Postgres 憑證（`.env` 裡的 `DATABASE_URL` / `POSTGRES_*`）。
+
+    這個字串以擁有完整權限的 `postgres` 角色連線，因此不受行級安全（RLS）限制，而且字串裡嵌了該角色的密碼。請把它當成機密：只在伺服端使用，絕不要發到瀏覽器。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -189,6 +189,8 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
     npx @insforge/cli db connection-string
     ```
 
+    你也可以在 dashboard 裡拿到：進入 **Install → Connection String**（僅限 cloud 專案）。
+
     它回傳的 URL 形如：
 
     ```text

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -199,4 +199,19 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
 
     這個字串以擁有完整權限的 `postgres` 角色連線，因此不受行級安全（RLS）限制，而且字串裡嵌了該角色的密碼。請把它當成機密：只在伺服端使用，絕不要發到瀏覽器。
   </Accordion>
+
+  <Accordion title="怎麼下線或刪除已部署的站點（site）？">
+    [Site](/core-concepts/sites/overview) 屬於它所在的專案——沒有單獨的「刪除這個部署」命令。想徹底下線一個站點，就刪除它所在的專案，這會連同資料庫、Storage 以及其他所有資源一起把部署刪掉：
+
+    ```bash
+    npx @insforge/cli projects delete --project <id>
+    ```
+
+    此操作不可逆。在 dashboard 裡，刪除專案位於 **Settings → General**。完整的 `projects delete` 行為和防護措施見 [CLI harness](/agent-native/cli-harness)。
+
+    有兩個相關操作，和「下線一個已上線站點」並不是一回事：
+
+    - **取消還在跑的建置：** `npx @insforge/cli deployments cancel <id>` 會終止一個進行中的部署；它不會下線一個已經上線的站點。
+    - **替換目前上線的內容：** 用 `npx @insforge/cli deployments deploy ./frontend` 在同一個站點上重新部署——最新一次 ready 的部署會接管這個 URL。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -181,4 +181,22 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
   <Accordion title="这个助手能帮我解决我自己项目里的具体问题吗？">
     基本不行。这个助手是基于 InsForge 的公开文档来回答的，看不到你的项目：既没法调试报错，也读不到你的数据，更查不了你的配置。凡是跟你自己项目相关的，交给你的编码 agent 来处理。你的 agent 通过 CLI 或 MCP 连着 InsForge，能读到你的实时后端、结构、数据和日志，直接帮你调试，用大白话描述问题就行。想自己拿一份后端健康和报错报告，跑 `npx @insforge/cli diagnose`。参见 [Diagnostics & advisor](/agent-native/diagnostics)。
   </Accordion>
+
+  <Accordion title="怎么拿到数据库的 Postgres 连接串（connection string）？">
+    每个 cloud 项目都有一个直连的 Postgres connection string，方便用 `psql`、数据库 GUI、ORM（Prisma、Drizzle），或者像 [Better Auth](/integrations/better-auth) 这类需要自带 Postgres 的外部服务。用 CLI 打印出来：
+
+    ```bash
+    npx @insforge/cli db connection-string
+    ```
+
+    它返回的 URL 形如：
+
+    ```text
+    postgresql://postgres:<password>@<appkey>.<region>.database.insforge.app:5432/insforge?sslmode=require
+    ```
+
+    加上 `--json` 会得到 `{ "connectionURL": "..." }`，方便脚本使用。这个命令**只对 cloud 项目有效**——自托管实例的 Postgres 由你的 `docker-compose` 直接暴露，所以请改用本地 Postgres 凭据（`.env` 里的 `DATABASE_URL` / `POSTGRES_*`）。
+
+    这个串以拥有完整权限的 `postgres` 角色连接，因此不受行级安全（RLS）限制，而且串里嵌了该角色的密码。请把它当成机密：只在服务端使用，绝不要发到浏览器。
+  </Accordion>
 </AccordionGroup>

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -189,7 +189,7 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
     npx @insforge/cli db connection-string
     ```
 
-    你也可以在 dashboard 里拿到：进入 **Install → Connection String**（仅限 cloud 项目）。
+    你也可以在 dashboard 里拿到：进入 **Project Settings → Connect → Connection String**（仅限 cloud 项目）。
 
     它返回的 URL 形如：
 
@@ -203,13 +203,9 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
   </Accordion>
 
   <Accordion title="怎么下线或删除已部署的站点（site）？">
-    [Site](/core-concepts/sites/overview) 属于它所在的项目——没有单独的"删除这个部署"命令。想彻底下线一个站点，就删除它所在的项目，这会连同数据库、Storage 以及其他所有资源一起把部署删掉：
+    目前没有自助下线已部署 [Site](/core-concepts/sites/overview) 的方式——既没有 `deployments delete` 命令，dashboard 里也没有对应操作。已部署的站点托管在外部，所以即使删除项目（`npx @insforge/cli projects delete --project <id>`）也只会清掉后端资源——数据库、Storage 和后端分支——而*不会*移除已托管的站点。
 
-    ```bash
-    npx @insforge/cli projects delete --project <id>
-    ```
-
-    此操作不可逆。在 dashboard 里，删除项目位于 **Settings → General**。完整的 `projects delete` 行为和防护措施见 [CLI harness](/agent-native/cli-harness)。
+    实际上这基本不影响使用。如果你确实需要下线某个已部署的站点，请到 [Discord](https://discord.com/invite/DvBtaEc9Jz) 联系 InsForge 团队。
 
     有两个相关操作，和"下线一个已上线站点"并不是一回事：
 

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -189,6 +189,8 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
     npx @insforge/cli db connection-string
     ```
 
+    你也可以在 dashboard 里拿到：进入 **Install → Connection String**（仅限 cloud 项目）。
+
     它返回的 URL 形如：
 
     ```text

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -199,4 +199,19 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
 
     这个串以拥有完整权限的 `postgres` 角色连接，因此不受行级安全（RLS）限制，而且串里嵌了该角色的密码。请把它当成机密：只在服务端使用，绝不要发到浏览器。
   </Accordion>
+
+  <Accordion title="怎么下线或删除已部署的站点（site）？">
+    [Site](/core-concepts/sites/overview) 属于它所在的项目——没有单独的"删除这个部署"命令。想彻底下线一个站点，就删除它所在的项目，这会连同数据库、Storage 以及其他所有资源一起把部署删掉：
+
+    ```bash
+    npx @insforge/cli projects delete --project <id>
+    ```
+
+    此操作不可逆。在 dashboard 里，删除项目位于 **Settings → General**。完整的 `projects delete` 行为和防护措施见 [CLI harness](/agent-native/cli-harness)。
+
+    有两个相关操作，和"下线一个已上线站点"并不是一回事：
+
+    - **取消还在跑的构建：** `npx @insforge/cli deployments cancel <id>` 会终止一个进行中的部署；它不会下线一个已经上线的站点。
+    - **替换当前上线的内容：** 用 `npx @insforge/cli deployments deploy ./frontend` 在同一个站点上重新部署——最新一次 ready 的部署会接管这个 URL。
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Adds two FAQ entries (all four languages: `en`, `zh`, `zh-Hant`, `es`) for recurring Ask AI questions that the docs did not answer on 2026-07-13.

## Needs review
- **Dashboard path "Settings → General" for project deletion** (both entries) — reused verbatim from `agent-native/cli-harness.mdx`, not confirmed against the live dashboard. Please verify the exact location.

## Drafted topics

1. **Database Postgres connection string** — added FAQ entry to `docs/faq.mdx` (+ `zh`, `zh-Hant`, `es`).
   - Conversation: `01KXDRWY6Q76RKQHJJ62D03SFP` ("what is connetion string of the databas").
   - Why unanswered: `db connection-string` is a real CLI command but was documented nowhere in the docs tree (only an incidental mention in `integrations/better-auth.mdx` about an *external* Postgres). The assistant had nothing to cite.

2. **Take down / remove a deployed site** — added FAQ entry to `docs/faq.mdx` (+ `zh`, `zh-Hant`, `es`).
   - Conversation: `01KXEXEN52X00FJ3GDCQDVSY7B` ("how i can remove deployed site?").
   - Why unanswered: there is no standalone "delete deployment" command; the real path (delete the project, which cascade-removes the site) was documented only under `projects delete`, never connected to the phrase "remove a deployed site", so it was undiscoverable.

## Skipped

| Conversation(s) | Topic | Reason |
|---|---|---|
| 01KXCDR264PYCXPV27W42VGRMV, 01KXE978920M5GXAZ0P60779TE | Delete a project | already-covered — `projects delete` in `agent-native/cli-harness.mdx` |
| 01KXD09G3PWWS4HZAFSB8SDMGN | Clerk JWT secret | already-covered — `integrations/clerk.mdx` (`secrets get JWT_SECRET`) |
| 01KXD07JDBWZ0DDEB290ETEYYV | Use HS256 | already-covered — `integrations/clerk.mdx` (HS256 signing) + `cli-harness.mdx` (`JWT_SECRET` = HS256-signed JWTs) |
| 01KXCE8P5HRN0SAYRTB6VNGE14 | Partner integration | already-covered — `partnership.mdx` |
| 01KXCQJJ234ECSMXZC1SRA5SXF | Set up Google AI Studio | missing-feature — AI is routed only through OpenRouter (Gemini available via OpenRouter); no Google AI Studio integration in code |
| 01KXDSXJFM122ST0JN163N4D0B | Veo 3.1 fast video seconds / model price labels | missing-feature — video duration is OpenRouter-owned, not an InsForge-controlled feature; the "free"/"-" label question was already answered in-thread |
| 01KXE0VS4FEZMAKS41ZVY11S9H | npm UNABLE_TO_VERIFY_LEAF_SIGNATURE | project-specific — generic corporate-proxy/TLS npm issue, not an InsForge feature |
| 01KXCE3GM4B90CTJ2EWVE36FZY | Monetizing | not-a-doc-question — business/pricing chit-chat, no feature |
| 01KXCDYDDJTWRZY8986CS5BW3G | "more workspaces" | not-a-doc-question — too vague, no clear feature ask |
| 01KXCDBNSVBX840QF1TVPCK33Q | "where is my source code for the site" | project-specific — source lives in the user's own local project, not stored by InsForge |
| 01KXCD6F7YP0K35JQPQ0R55WDD | "how do I choices the site contents" | not-a-doc-question — unintelligible/too vague |
| 01KXDZZHF5MD2XGMCJN98WVVMK | "uninstall" | not-a-doc-question — single vague word, no target |
| 01KXDZ76MJJDMC5A500KCHW2FX | "what LLM are you" + DevOps chit-chat | not-a-doc-question |
| 01KXCN5J2G5RQ6553Z9GBBCYDH | "dsa" | not-a-doc-question — gibberish |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entries for retrieving the Postgres connection string and deleting a deployed Site
> Adds two new accordion items to the FAQ across all four locales (English, Spanish, Simplified Chinese, Traditional Chinese):
> - Explains how to get the Postgres connection string via `npx @insforge/cli db connection-string` or the dashboard (Install → Connection String), with a note that this is cloud-only and includes a security warning about the privileged `postgres` role.
> - Explains how to remove a deployed Site by deleting its project via CLI or dashboard, with an irreversible-action warning and clarifications about canceling in-progress deployments vs. redeploying.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1765 opened
>
> - Rewrote the FAQ answer for taking down or removing a deployed Site to remove self-serve project deletion instructions, code blocks, and irreversibility warnings, and replaced with guidance that there is no self-serve deletion for deployments, that deleting a project does not remove the externally hosted site, and that users should contact the InsForge team on Discord for takedown requests [a788763]
> - Updated the dashboard navigation path text from 'Install → Connection String' to 'Project Settings → Connect → Connection String' [a788763]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4dde61.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new FAQ accordion entries (English, Spanish, Traditional Chinese, Chinese) for getting a cloud project’s direct PostgreSQL connection string via the CLI or dashboard, including URL format, optional JSON output, cloud-only limitation, and a security warning about privileged credentials.
  * Added guidance on what to do to remove a deployed hosted site, including the distinction between deleting the project (backend resources) vs canceling a deployment vs replacing content on the live site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->