### PR TITLE
2026-07-15 fix mintlify docs

### DIFF
--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -111,6 +111,8 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
 
     <Warning>
       **Desactivar** RLS elimina todo el filtrado a nivel de fila: cualquier rol con privilegios sobre la tabla (como `authenticated`, y `anon` donde se le haya concedido) puede leer y escribir todas las filas a través de la API de datos. Es preferible escribir políticas RLS antes que desactivar RLS. Las solicitudes de administrador hechas con la API Key (`ik_...`) omiten RLS de todos modos.
+
+      **Activar** RLS en una tabla que no tiene políticas aplica el rechazo por defecto de PostgreSQL: `anon` y `authenticated` pierden todo acceso a ella a través de la API de datos (se bloquea cada `SELECT`/`INSERT`/`UPDATE`/`DELETE`) hasta que agregues al menos una política. Crea las políticas que necesites antes de activar RLS, o justo después.
     </Warning>
   </Accordion>
 

--- a/docs/es/faq.mdx
+++ b/docs/es/faq.mdx
@@ -82,6 +82,38 @@ description: "Respuestas sobre llamadas a la base de datos, edge functions, cust
     La visibilidad de filas queda gobernada por RLS como siempre. Que el project-admin sea propietario solo le permite gestionar y consultar las tablas directamente (por ejemplo desde el editor SQL del dashboard); no da acceso a los roles de la API.
   </Accordion>
 
+  <Accordion title="¿Cómo activo o desactivo la seguridad a nivel de fila (RLS) en una tabla?">
+    Las tablas nuevas tienen RLS **activado** por defecto. Cuando creas una tabla (desde el dashboard, `POST /api/database/tables` o el SDK), RLS queda habilitado a menos que pases explícitamente `rlsEnabled: false`.
+
+    El endpoint update-table-schema (`PATCH /api/database/tables/{table}/schema`) no tiene ningún campo para alternar RLS: solo gestiona columnas, claves foráneas y renombrados. Para cambiar RLS en una tabla **existente**, ejecuta una sola sentencia SQL:
+
+    ```sql
+    -- desactivar RLS
+    ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY;
+
+    -- volver a activar RLS
+    ALTER TABLE public.mytable ENABLE ROW LEVEL SECURITY;
+    ```
+
+    Ejecuta ese SQL de cualquier forma en que ejecutes SQL de administrador; todas requieren acceso de project owner / admin:
+
+    ```bash
+    # puntual, mediante la CLI
+    insforge db query "ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY"
+
+    # o registrarlo como una migración
+    npx @insforge/cli db migrations new disable-rls-on-mytable
+    # coloca la sentencia ALTER TABLE en el archivo .sql generado y luego:
+    npx @insforge/cli db migrations up --all
+    ```
+
+    También puedes ejecutarlo desde el editor SQL del dashboard, la herramienta `run-raw-sql` de MCP, o el endpoint REST de SQL directo (`POST /api/database/advance/rawsql/unrestricted`).
+
+    <Warning>
+      **Desactivar** RLS elimina todo el filtrado a nivel de fila: cualquier rol con privilegios sobre la tabla (como `authenticated`, y `anon` donde se le haya concedido) puede leer y escribir todas las filas a través de la API de datos. Es preferible escribir políticas RLS antes que desactivar RLS. Las solicitudes de administrador hechas con la API Key (`ik_...`) omiten RLS de todos modos.
+    </Warning>
+  </Accordion>
+
   <Accordion title="¿InsForge tiene una `service_role` key / `INSFORGE_SERVICE_ROLE_KEY`?">
     No con ese nombre. El equivalente en InsForge es la **API Key** de tu proyecto (empieza por `ik_`), la clave de administrador con acceso total. Cada proyecto tiene dos claves:
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -111,6 +111,8 @@ description: "Answers to common InsForge questions on database calls, edge funct
 
     <Warning>
       Turning RLS **off** removes all row-level filtering: any role with table privileges (such as `authenticated`, and `anon` where granted) can read and write every row through the data API. Prefer writing RLS policies over disabling RLS. Admin requests made with the API Key (`ik_...`) bypass RLS either way.
+
+      Turning RLS **on** for a table that has no policies applies PostgreSQL's default-deny: `anon` and `authenticated` lose all access to it through the data API (every `SELECT`/`INSERT`/`UPDATE`/`DELETE` is blocked) until you add at least one policy. Add the policies you need before, or right after, enabling RLS.
     </Warning>
   </Accordion>
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -82,6 +82,38 @@ description: "Answers to common InsForge questions on database calls, edge funct
     Row visibility is then gated by RLS as usual. Project-admin ownership only lets the admin manage and directly query the tables (for example from the dashboard SQL editor); it does not give the API roles access.
   </Accordion>
 
+  <Accordion title="How do I turn row-level security (RLS) on or off for a table?">
+    New tables have RLS **on** by default. When you create a table (from the dashboard, `POST /api/database/tables`, or the SDK), RLS is enabled unless you explicitly pass `rlsEnabled: false`.
+
+    There is no field to toggle RLS on the update-table-schema endpoint (`PATCH /api/database/tables/{table}/schema`) — it only handles columns, foreign keys, and renames. To change RLS on an **existing** table, run one SQL statement:
+
+    ```sql
+    -- turn RLS off
+    ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY;
+
+    -- turn RLS back on
+    ALTER TABLE public.mytable ENABLE ROW LEVEL SECURITY;
+    ```
+
+    Run that SQL any way you run admin SQL, all of which require project-owner / admin access:
+
+    ```bash
+    # one-off, via the CLI
+    insforge db query "ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY"
+
+    # or track it as a migration
+    npx @insforge/cli db migrations new disable-rls-on-mytable
+    # put the ALTER TABLE statement in the generated .sql file, then:
+    npx @insforge/cli db migrations up --all
+    ```
+
+    You can also run it from the dashboard SQL editor, the MCP `run-raw-sql` tool, or the raw SQL REST endpoint (`POST /api/database/advance/rawsql/unrestricted`).
+
+    <Warning>
+      Turning RLS **off** removes all row-level filtering: any role with table privileges (such as `authenticated`, and `anon` where granted) can read and write every row through the data API. Prefer writing RLS policies over disabling RLS. Admin requests made with the API Key (`ik_...`) bypass RLS either way.
+    </Warning>
+  </Accordion>
+
   <Accordion title="Does InsForge have a `service_role` key / `INSFORGE_SERVICE_ROLE_KEY`?">
     Not under that name. InsForge's equivalent is your project's **API Key** (it starts with `ik_`), the full-access admin key. Every project has two keys:
 

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -82,6 +82,38 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
     之後列級可見性照常由 RLS 控制。project_admin 擁有表，只是讓它能管理並直接查詢這些表（例如在 dashboard 的 SQL 編輯器裡），並不會給 API 角色存取權限。
   </Accordion>
 
+  <Accordion title="怎麼幫一張表開啟或關閉列級安全性（RLS）？">
+    新建的表預設**開啟** RLS。建立表時（在 dashboard、`POST /api/database/tables`，或用 SDK），除非你明確傳 `rlsEnabled: false`，否則都會啟用 RLS。
+
+    update-table-schema 端點（`PATCH /api/database/tables/{table}/schema`）沒有切換 RLS 的欄位——它只處理欄、外鍵和重新命名。要改**已存在**表的 RLS，執行一條 SQL 即可：
+
+    ```sql
+    -- 關閉 RLS
+    ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY;
+
+    -- 重新開啟 RLS
+    ALTER TABLE public.mytable ENABLE ROW LEVEL SECURITY;
+    ```
+
+    用任何你執行管理員 SQL 的方式都可以執行它，這些方式都需要 project owner / admin 權限：
+
+    ```bash
+    # 一次性執行，透過 CLI
+    insforge db query "ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY"
+
+    # 或者作為 migration 追蹤
+    npx @insforge/cli db migrations new disable-rls-on-mytable
+    # 把 ALTER TABLE 語句寫進產生的 .sql 檔案裡，然後：
+    npx @insforge/cli db migrations up --all
+    ```
+
+    也可以在 dashboard 的 SQL 編輯器、MCP 的 `run-raw-sql` 工具，或原始 SQL 的 REST 端點（`POST /api/database/advance/rawsql/unrestricted`）裡執行。
+
+    <Warning>
+      **關閉** RLS 會移除所有列級過濾：任何擁有表權限的角色（例如 `authenticated`，以及被授權的 `anon`）都能透過資料 API 讀寫每一列。相比關閉 RLS，更推薦撰寫 RLS 原則。用 API Key（`ik_...`）發起的管理員請求本來就會繞過 RLS。
+    </Warning>
+  </Accordion>
+
   <Accordion title="InsForge 有 `service_role` key / `INSFORGE_SERVICE_ROLE_KEY` 嗎？">
     沒有叫這個名字的。InsForge 裡的等價物是你專案的 **API Key**（以 `ik_` 開頭），也就是全權限的管理員 key。每個專案有兩個 key：
 

--- a/docs/zh-Hant/faq.mdx
+++ b/docs/zh-Hant/faq.mdx
@@ -111,6 +111,8 @@ description: "解答 InsForge 常見問題：資料庫呼叫、Edge Function 與
 
     <Warning>
       **關閉** RLS 會移除所有列級過濾：任何擁有表權限的角色（例如 `authenticated`，以及被授權的 `anon`）都能透過資料 API 讀寫每一列。相比關閉 RLS，更推薦撰寫 RLS 原則。用 API Key（`ik_...`）發起的管理員請求本來就會繞過 RLS。
+
+      給一張沒有任何原則的表**開啟** RLS 會觸發 PostgreSQL 的預設拒絕：在你至少加一條原則之前，`anon` 和 `authenticated` 透過資料 API 對它的所有存取都會被拒絕（每個 `SELECT`/`INSERT`/`UPDATE`/`DELETE` 都被擋下）。請在開啟 RLS 之前，或緊接著，補上需要的原則。
     </Warning>
   </Accordion>
 

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -111,6 +111,8 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
 
     <Warning>
       **关闭** RLS 会移除所有行级过滤：任何拥有表权限的角色（比如 `authenticated`，以及被授权的 `anon`）都能通过数据 API 读写每一行。相比关闭 RLS，更推荐编写 RLS 策略。用 API Key（`ik_...`）发起的管理员请求本来就会绕过 RLS。
+
+      给一张没有任何策略的表**开启** RLS 会触发 PostgreSQL 的默认拒绝：在你至少加一条策略之前，`anon` 和 `authenticated` 通过数据 API 对它的所有访问都会被拒绝（每个 `SELECT`/`INSERT`/`UPDATE`/`DELETE` 都被拦下）。请在开启 RLS 之前，或紧接着，补上需要的策略。
     </Warning>
   </Accordion>
 

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -82,6 +82,38 @@ description: "解答 InsForge 常见问题：数据库调用、Edge Function 与
     之后行级可见性照常由 RLS 控制。project_admin 拥有表，只是让它能管理并直接查询这些表（比如在 dashboard 的 SQL 编辑器里），并不会给 API 角色访问权限。
   </Accordion>
 
+  <Accordion title="怎么给一张表开启或关闭行级安全（RLS）？">
+    新建的表默认**开启** RLS。创建表时（在 dashboard、`POST /api/database/tables`，或用 SDK），除非你显式传 `rlsEnabled: false`，否则都会启用 RLS。
+
+    update-table-schema 端点（`PATCH /api/database/tables/{table}/schema`）没有切换 RLS 的字段——它只处理列、外键和重命名。要改**已存在**表的 RLS，执行一条 SQL 即可：
+
+    ```sql
+    -- 关闭 RLS
+    ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY;
+
+    -- 重新开启 RLS
+    ALTER TABLE public.mytable ENABLE ROW LEVEL SECURITY;
+    ```
+
+    用任何你运行管理员 SQL 的方式都可以执行它，这些方式都需要 project owner / admin 权限：
+
+    ```bash
+    # 一次性执行，通过 CLI
+    insforge db query "ALTER TABLE public.mytable DISABLE ROW LEVEL SECURITY"
+
+    # 或者作为 migration 跟踪
+    npx @insforge/cli db migrations new disable-rls-on-mytable
+    # 把 ALTER TABLE 语句写进生成的 .sql 文件里，然后：
+    npx @insforge/cli db migrations up --all
+    ```
+
+    也可以在 dashboard 的 SQL 编辑器、MCP 的 `run-raw-sql` 工具，或原始 SQL 的 REST 端点（`POST /api/database/advance/rawsql/unrestricted`）里执行。
+
+    <Warning>
+      **关闭** RLS 会移除所有行级过滤：任何拥有表权限的角色（比如 `authenticated`，以及被授权的 `anon`）都能通过数据 API 读写每一行。相比关闭 RLS，更推荐编写 RLS 策略。用 API Key（`ik_...`）发起的管理员请求本来就会绕过 RLS。
+    </Warning>
+  </Accordion>
+
   <Accordion title="InsForge 有 `service_role` key / `INSFORGE_SERVICE_ROLE_KEY` 吗？">
     没有叫这个名字的。InsForge 里的等价物是你项目的 **API Key**（以 `ik_` 开头），也就是全权限的管理员 key。每个项目有两个 key：
 


### PR DESCRIPTION
## Drafted topics

### Enable/disable row-level security (RLS) on an existing table
- **Conversation:** `01KXJDWHRT7MW0EMRVJ9VXA3DH` ("how to disable row-level security")
- **Added:** A new FAQ accordion "How do I turn row-level security (RLS) on or off for a table?" in `docs/faq.mdx` and its `zh`, `zh-Hant`, and `es` translations.
- **What it covers:** New tables get RLS on by default (`rlsEnabled: true` at creation). The `PATCH /api/database/tables/{table}/schema` (update-table-schema) endpoint has no RLS field, so RLS on an existing table is changed with one SQL statement (`ALTER TABLE ... DISABLE/ENABLE ROW LEVEL SECURITY`), runnable via `insforge db query`, a migration, the dashboard SQL editor, MCP `run-raw-sql`, or `POST /api/database/advance/rawsql/unrestricted`. Includes a warning that disabling RLS removes row-level filtering.
- **Why it was unanswered:** The assistant correctly noted the update endpoint can't toggle RLS but concluded there was "no documented way" and suggested contacting support. The raw-SQL path exists in code (create-table `ENABLE ROW LEVEL SECURITY`; CLI risk-registry recognizes `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` as `sql.rls_change`; `db query` and the unrestricted rawsql endpoint are already documented) but was never tied together for this question.

## Skipped

- **`01KXJQ9TQF4W6V5AA4F415RAW9`** — reason: `not-a-doc-question`. Fragmentary/abandoned chat ("i haveing issue to istall this... are you here?") with no answerable documentation request.
- **`01KXK6KFHB8ZKT22PA3AN1W9F3`** — reason: `not-a-doc-question`. Off-topic chit-chat and out-of-scope prompts (who made you, geopolitics, "hack this website", navigate-100-times, meta questions about the assistant). No documentation gap.

## Needs review

- The FAQ references the "dashboard SQL editor" as a place to run the SQL. This term is taken verbatim from existing FAQ entries (schema accordion); no new dashboard UI path was invented. All other methods (CLI `db query`, migrations, MCP `run-raw-sql`, REST endpoint, `rlsEnabled` default) are code-verified.
- Needs review (unverified UI paths): none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an FAQ on how to toggle row‑level security (RLS) on existing tables using `ALTER TABLE ... ENABLE/DISABLE ROW LEVEL SECURITY`, in `docs/faq.mdx` and translations (`es`, `zh`, `zh-Hant`).
Clarifies `PATCH /api/database/tables/{table}/schema` can’t toggle RLS, shows how to run the SQL (CLI `insforge db query`, `@insforge/cli` migrations, dashboard SQL editor, MCP `run-raw-sql`, `POST /api/database/advance/rawsql/unrestricted`), and adds warnings that disabling RLS removes filtering, enabling RLS with no policies default‑denies access, and admin API key requests bypass RLS.

<sup>Written for commit c93fff27888c67213351c8a35eda3c4302d77423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add FAQ entries explaining how to toggle row-level security on existing tables
> Adds a new accordion section to the FAQ docs in English, Spanish, Traditional Chinese, and Simplified Chinese explaining RLS behavior and how to change it via `ALTER TABLE`. Clarifies that `PATCH /api/database/tables/{table}/schema` cannot toggle RLS, and provides examples using the CLI, `@insforge/cli` migrations, the dashboard SQL editor, the MCP `run-raw-sql` tool, and `POST /api/database/advance/rawsql/unrestricted`. Includes a warning that disabling RLS exposes data to all authenticated users and that admin API key requests bypass RLS regardless.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1769 opened
>
> - Added warning paragraph to FAQ documentation across all language versions explaining PostgreSQL RLS default deny behavior [c93fff2]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8a1c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance for enabling or disabling Row Level Security (RLS) on tables.
  * Clarified default RLS behavior for newly created tables and how to manage RLS for existing tables.
  * Explained that the table schema update endpoint can’t toggle RLS, and provided SQL examples using `ALTER TABLE ... ENABLE/DISABLE ROW LEVEL SECURITY`.
  * Included security warnings about implications of disabling RLS and notes on default-deny behavior when enabling RLS without policies.
  * Published updates in English, Spanish, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->