### PR TITLE
fix(build): stop bundling file-type to fix "Dynamic require of tty" prod crash

### DIFF
--- a/backend/tsup.config.ts
+++ b/backend/tsup.config.ts
@@ -9,16 +9,18 @@ export default defineConfig({
   clean: false, // Don't clean the whole dist folder (frontend is there)
   sourcemap: true,
   // Don't bundle node_modules, only our code and shared-schemas.
-  // Exceptions — deps npm nests under backend/node_modules/ instead of hoisting
-  // to the root, so the Docker runner (which only ships the hoisted root
-  // node_modules/) can't resolve them at runtime. Inline them into the bundle
-  // instead of teaching the Dockerfile to merge nested module layers:
-  //   - `lru-cache`: our SigV4 verifier's hot-path cache; a devDep transitive
-  //     pins the older v5 at the root so the workspace copy can't hoist.
-  //   - `file-type`: used by utils/mime-guard; nests under backend/node_modules
-  //     (with its strtok3/token-types deps) alongside the @aws-sdk copies that
-  //     pin a newer minor than the root tree.
-  noExternal: [/@insforge\/shared-schemas/, 'lru-cache', 'file-type'],
+  // Exception — `lru-cache`: our SigV4 verifier's hot-path cache. A devDep
+  // transitive pins the older v5 at the root, so the workspace copy nests
+  // under backend/node_modules/ instead of hoisting. The Docker runner only
+  // ships the hoisted root node_modules/, so bundle lru-cache in rather than
+  // teaching the Dockerfile to merge nested module layers.
+  //
+  // NOTE: `file-type` is intentionally NOT bundled. It hoists cleanly to the
+  // root node_modules/ (shipped by the runner), so it resolves at runtime as
+  // a normal external. Bundling it inlined its transitive `debug` (via
+  // `@tokenizer/inflate`), whose `require('tty')` breaks under esbuild's ESM
+  // `__require` shim — keep it external and let Node load it natively.
+  noExternal: [/@insforge\/shared-schemas/, 'lru-cache'],
   esbuildOptions(options) {
     options.alias = {
       '@': './src',


### PR DESCRIPTION
## Problem

The OSS backend crashes at startup (prod image) with:

```
Error: Dynamic require of "tty" is not supported
    at ../node_modules/debug/src/node.js (dist/server.js)
```

The project can't start at all.

## Root cause

A bundling interaction from a **dependency bump**, not a logic regression:

- #1759 (vanta advisory remediation) bumped `file-type` `^19.0.0` → `^21.3.4`, which added the transitive dep `@tokenizer/inflate`.
- `@tokenizer/inflate/lib/ZipHandler.js` imports `debug`.
- `file-type` was force-**bundled** into the ESM server bundle via tsup `noExternal`, so its whole subtree — now including `debug` — got inlined.
- `debug/src/node.js` calls `require('tty')`, which esbuild's ESM `__require` shim throws on (no `require` in ESM scope).

Reproduced the exact broken bundle locally (same `chunk-XHWXTLMK.js`); the debug import traces to `@tokenizer/inflate`. Confirmed **unrelated to the storage PR #1760** — that touched zero build/dependency files.

## Fix

`file-type` was only in `noExternal` because it used to nest under `backend/node_modules/` (a version conflict with `@aws-sdk`'s tokenizer deps), and the Docker runner only ships the hoisted **root** `node_modules/`. With `file-type ^21` it **hoists cleanly to root** (verified: `file-type@21.3.4`, `@tokenizer/inflate@0.4.1`, `debug@4.4.3` all at root, all in the `--omit=dev` prod tree the runner copies).

So the fix is simply: **stop bundling `file-type`** — drop it from `noExternal` and let Node load it (and its transitive `debug`) natively at runtime. No bundler shims, no config hacks. `lru-cache` stays bundled (it still nests).

## Verification

Rebuilt bundle: no longer inlines `debug`, imports `file-type` as an external, zero `Dynamic require` throwers, code-splitting intact. Starts cleanly (`Backend API service listening` / `RealtimeManager initialized`). Attaching the image build + Deterministic Fixture E2E (container start) to confirm the runner resolves the external at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime module resolution for file handling, particularly in Docker and workspace environments.
  * Prevented compatibility issues that could cause terminal-related functionality to fail when modules are bundled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->