### PR TITLE
fix(openapi): add apiKey security scheme to email, functions, and logs specs

### DIFF
--- a/openapi/email.yaml
+++ b/openapi/email.yaml
@@ -8,7 +8,7 @@ paths:
   /api/email/send-raw:
     post:
       summary: Send raw HTML email
-      description: Send a custom HTML email to one or more recipients. Requires user authentication.
+      description: Send a custom HTML email to one or more recipients. Requires user authentication or a valid admin API key.
       tags:
         - Client
       security:

--- a/openapi/email.yaml
+++ b/openapi/email.yaml
@@ -13,6 +13,7 @@ paths:
         - Client
       security:
         - bearerAuth: []
+        - apiKey: []
       requestBody:
         required: true
         content:
@@ -57,6 +58,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
 
   schemas:
     SendRawEmailRequest:

--- a/openapi/functions.yaml
+++ b/openapi/functions.yaml
@@ -13,6 +13,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       responses:
         '200':
           description: List of functions
@@ -57,6 +58,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       requestBody:
         required: true
         content:
@@ -162,6 +164,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       parameters:
         - name: slug
           in: path
@@ -221,6 +224,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       parameters:
         - name: slug
           in: path
@@ -299,6 +303,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       parameters:
         - name: slug
           in: path
@@ -538,6 +543,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
 
   schemas:
     FunctionMetadata:

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -11,6 +11,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       parameters:
         - name: limit
           in: query
@@ -104,6 +105,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       parameters:
         - name: before
           in: query
@@ -144,6 +146,7 @@ paths:
         - Admin
       security:
         - bearerAuth: []
+        - apiKey: []
       responses:
         '200':
           description: Logs statistics
@@ -199,6 +202,10 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
   
   schemas:
     ErrorResponse:


### PR DESCRIPTION
Closes #1757

## Summary

Three OpenAPI specs only declared `bearerAuth` on operations whose handlers also accept admin API keys via `x-api-key` header. This aligns them with the other 10 specs that already declare both schemes.

## What changed

- **email.yaml**: add `apiKey` scheme + list on 1 operation (`POST /api/email/send-raw`)
- **functions.yaml**: add `apiKey` scheme + list on 5 admin operations
- **logs.yaml**: add `apiKey` scheme + list on 3 admin operations

## How did you test this change?

- YAML validated locally (valid OpenAPI 3.0.3)
- Verified scheme definition matches existing pattern (e.g., `payments.yaml`)
- No `bearerAuth` entries removed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented admin API key support in the email, functions, and logs OpenAPI specs, and clarified the email send-raw description.

- **Bug Fixes**
  - Declared `apiKey` in components and added to operations (email: 1, functions: 5 admin, logs: 3 admin); updated email endpoint description to state user auth or an admin API key is accepted.
  - Kept `bearerAuth`; all three specs validate as OpenAPI 3.0.3.

<sup>Written for commit 6ed3a852aaf475564414251894efc686ed5db6b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `apiKey` security scheme to email, functions, and logs OpenAPI specs
> Adds `x-api-key` header authentication as an alternative to `bearerAuth` across all operations in [email.yaml](https://github.com/InsForge/InsForge/pull/1778/files#diff-d2219caec13e8fd991022858399cab9390559ac04026666fedf7a10eff7a9b28), [functions.yaml](https://github.com/InsForge/InsForge/pull/1778/files#diff-f714b12cd227f27aefeee49e6682b71a37444548f5e9c7f1e5e5639187c92caa), and [logs.yaml](https://github.com/InsForge/InsForge/pull/1778/files#diff-f2f0e5f57346dd2651901bfea03c34fa9241dc092650deebede07407a45357f8). Each spec gains a new `apiKey` security scheme in `components.securitySchemes` and the scheme is added to every operation's security array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3a94c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to support API-key authentication through the `x-api-key` header.
  * Added API-key authentication requirements to email sending, function management, and log administration endpoints.
  * Existing JWT bearer authentication remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->