### PR TITLE
fix: set app.encryption_key GUC in deploy docker-compose files

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres-all:latest
 
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres-all:latest
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    command: postgres -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -2,6 +2,7 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres-all:latest
     restart: unless-stopped
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-change-this-encryption-key-32chars}'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres-all:latest
     restart: unless-stopped
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-change-this-encryption-key-32chars}'
+    command: postgres -c app.encryption_key='${ENCRYPTION_KEY:-change-this-encryption-key-32chars}'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}


### PR DESCRIPTION
Closes #1763

## Summary

Schedules with HTTP headers fail because `schedules.encrypt_headers()` requires the Postgres GUC `app.encryption_key`, but the deploy compose files never set it.

## Root cause

The root `docker-compose.yml` and `docker-compose.prod.yml` already set the GUC correctly via `postgres -c app.encryption_key=...`, but `deploy/docker-compose/docker-compose.yml` and `docker-compose.dokploy.yml` only pass `ENCRYPTION_KEY` as a container env var — which Postgres doesn't read as a GUC.

## What changed

- `deploy/docker-compose/docker-compose.yml`: add `command:` with `-c app.encryption_key=...`
- `docker-compose.dokploy.yml`: add `command:` with `-c app.encryption_key=...`

Both mirror the existing pattern from the root compose file.

## How did you test this change?

- YAML validated locally
- Verified the fix matches the working pattern in docker-compose.yml and docker-compose.prod.yml
- Header-less schedules remain unaffected (they short-circuit to NULL)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Postgres GUC `app.encryption_key` in deploy compose files so schedules with encrypted HTTP headers work and no longer error. Mirrors the root compose setup. Closes #1763.

- **Bug Fixes**
  - `deploy/docker-compose/docker-compose.yml`: add `command: postgres -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'`
  - `docker-compose.dokploy.yml`: add `command: postgres -c app.encryption_key='${ENCRYPTION_KEY:-change-this-encryption-key-32chars}'`
  - Do not reference a config file; only set the GUC flag since these deploys don’t mount `postgresql.conf`.
  - Schedules without headers are unaffected.

<sup>Written for commit 963f979d7febd32b02196b29442ac7a84f87ac6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup configuration so the application encryption key is consistently provided to PostgreSQL.
  * Added fallback handling when the preferred encryption key setting is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `app.encryption_key` GUC in postgres service in deploy docker-compose files
> Adds a command override to the postgres service in [docker-compose.yml](https://github.com/InsForge/InsForge/pull/1780/files#diff-03bf84599af57a5fcf0f9d11adf30d9cf3ee8a54d5f0cf0f22125c414d7efc69) and [docker-compose.dokploy.yml](https://github.com/InsForge/InsForge/pull/1780/files#diff-25f2cccfb18f085edcadb201b9985f847a27a6ca2fcdee5d0ea07e468bcbaeab) to pass `-c app.encryption_key`, sourced from the `ENCRYPTION_KEY` or `JWT_SECRET` environment variables. Also adds `restart: unless-stopped` to the healthcheck service in the main compose file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 963f979.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->