### PR TITLE
fix(ai): return the mapped status when a streamed completion fails pre-stream

### DIFF
--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -290,11 +290,36 @@ router.post(
           // Send completion signal
           res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
         } catch (streamError) {
-          // If error occurs during streaming, send it in SSE format
           logger.error('Stream error during chat completion', {
             error: streamError instanceof Error ? streamError.message : String(streamError),
             stack: streamError instanceof Error ? streamError.stack : undefined,
           });
+
+          // The upstream call is made on the first pull of the generator, so a
+          // failure can happen before a single byte is streamed. In that case the
+          // status line is still open: surface the mapped upstream status (402 out
+          // of credits, 429 rate limited, 401 auth) exactly like the non-streaming
+          // path does. Writing an SSE frame here instead would flush the response
+          // as 200, and a client checking `response.ok` would read a billing or
+          // rate-limit failure as success.
+          if (!res.headersSent) {
+            res.removeHeader('Content-Type');
+            res.removeHeader('Cache-Control');
+            res.removeHeader('Connection');
+            next(
+              streamError instanceof AppError
+                ? streamError
+                : new AppError(
+                    streamError instanceof Error ? streamError.message : String(streamError),
+                    500,
+                    ERROR_CODES.INTERNAL_ERROR
+                  )
+            );
+            return;
+          }
+
+          // Mid-stream the headers are already flushed, so the status can no longer
+          // change — report the failure in-band and close the stream.
           res.write(
             `data: ${JSON.stringify({ error: true, message: streamError instanceof Error ? streamError.message : String(streamError) })}\n\n`
           );

--- a/backend/tests/unit/ai-streaming-error-status.test.ts
+++ b/backend/tests/unit/ai-streaming-error-status.test.ts
@@ -1,0 +1,164 @@
+import express, { type ErrorRequestHandler } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { AppError } from '../../src/utils/errors.js';
+
+const chatServiceMock = vi.hoisted(() => ({ streamChat: vi.fn(), chat: vi.fn() }));
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+vi.mock('../../src/utils/environment.js', () => ({
+  isCloudEnvironment: () => false,
+}));
+
+vi.mock('../../src/api/middlewares/auth.js', () => ({
+  verifyAdmin: (req: { user?: { id: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 'admin-1' };
+    next();
+  },
+  verifyUser: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../src/services/ai/chat-completion.service.js', () => ({
+  ChatCompletionService: { getInstance: () => chatServiceMock },
+}));
+
+vi.mock('../../src/services/ai/image-generation.service.js', () => ({
+  ImageGenerationService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/ai/embedding.service.js', () => ({
+  EmbeddingService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/providers/ai/openrouter.provider.js', () => ({
+  OpenRouterProvider: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/ai/model-gateway-config.service.js', () => ({
+  ModelGatewayConfigService: { getInstance: () => ({}) },
+  ModelGatewayConfigUpdateError: class extends Error {},
+}));
+
+vi.mock('../../src/services/logs/audit.service.js', () => ({
+  AuditService: { getInstance: () => ({ log: vi.fn() }) },
+}));
+
+const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  void _next;
+  const statusCode =
+    error instanceof Error && 'statusCode' in error && typeof error.statusCode === 'number'
+      ? error.statusCode
+      : 500;
+  const code =
+    error instanceof Error && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : undefined;
+  res.status(statusCode).json({
+    message: error instanceof Error ? error.message : 'Error',
+    ...(code ? { code } : {}),
+  });
+};
+
+async function createApp() {
+  const { aiRouter } = await import('../../src/api/routes/ai/index.routes.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/ai', aiRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const streamingRequest = {
+  model: 'openai/gpt-4o',
+  messages: [{ role: 'user', content: 'Hello' }],
+  stream: true,
+};
+
+// Mirrors the real service: the upstream request is issued when the generator is
+// first advanced, so the failure surfaces before any byte is streamed. The
+// trailing `yield` is unreachable and exists only to satisfy `require-yield`.
+function failsOnFirstPull(error: unknown) {
+  return async function* (): AsyncGenerator<Record<string, unknown>> {
+    await Promise.resolve();
+    throw error;
+    yield {};
+  };
+}
+
+describe('POST /api/ai/chat/completion - streaming error status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // NOTE: no vi.resetModules() here. The route resolves AppError through the
+    // same module instance this file imports, and resetting the registry between
+    // the two would hand the router a second AppError class, breaking the
+    // `instanceof` check the handler relies on.
+  });
+
+  it('surfaces the mapped upstream status when the stream fails before any chunk', async () => {
+    // The upstream call happens on the first pull of the generator, so an
+    // out-of-credits failure surfaces before a single byte is streamed.
+    chatServiceMock.streamChat.mockImplementation(
+      failsOnFirstPull(
+        new AppError('AI credit limit reached.', 402, ERROR_CODES.BILLING_INSUFFICIENT_BALANCE)
+      )
+    );
+
+    const response = await request(await createApp())
+      .post('/api/ai/chat/completion')
+      .send(streamingRequest);
+
+    // Regression guard: this used to flush a 200 with an SSE error frame, so a
+    // client checking `response.ok` read a billing failure as success.
+    expect(response.status).toBe(402);
+    expect(response.body.code).toBe(ERROR_CODES.BILLING_INSUFFICIENT_BALANCE);
+    expect(response.text).not.toContain('data: ');
+  });
+
+  it('maps a rate-limit failure to 429 rather than 200', async () => {
+    chatServiceMock.streamChat.mockImplementation(
+      failsOnFirstPull(
+        new AppError('AI provider rate limit exceeded.', 429, ERROR_CODES.RATE_LIMITED)
+      )
+    );
+
+    const response = await request(await createApp())
+      .post('/api/ai/chat/completion')
+      .send(streamingRequest);
+
+    expect(response.status).toBe(429);
+    expect(response.body.code).toBe(ERROR_CODES.RATE_LIMITED);
+  });
+
+  it('falls back to 500 for a non-AppError failure before streaming starts', async () => {
+    chatServiceMock.streamChat.mockImplementation(failsOnFirstPull(new Error('socket hang up')));
+
+    const response = await request(await createApp())
+      .post('/api/ai/chat/completion')
+      .send(streamingRequest);
+
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe('socket hang up');
+  });
+
+  it('keeps reporting mid-stream failures in-band once headers are flushed', async () => {
+    // Once a chunk has been written the status line is already committed, so the
+    // failure must still be reported as an SSE frame on the open 200 response.
+    chatServiceMock.streamChat.mockImplementation(async function* () {
+      yield { chunk: 'Hello' };
+      throw new AppError('AI provider rate limit exceeded.', 429, ERROR_CODES.RATE_LIMITED);
+    });
+
+    const response = await request(await createApp())
+      .post('/api/ai/chat/completion')
+      .send(streamingRequest);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/event-stream');
+    expect(response.text).toContain('"chunk":"Hello"');
+    expect(response.text).toContain('"error":true');
+  });
+});

--- a/backend/tests/unit/ai-streaming-error-status.test.ts
+++ b/backend/tests/unit/ai-streaming-error-status.test.ts
@@ -1,8 +1,9 @@
-import express, { type ErrorRequestHandler } from 'express';
+import express from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ERROR_CODES } from '@insforge/shared-schemas';
 import { AppError } from '../../src/utils/errors.js';
+import { errorMiddleware } from '../../src/api/middlewares/error.js';
 
 const chatServiceMock = vi.hoisted(() => ({ streamChat: vi.fn(), chat: vi.fn() }));
 
@@ -47,28 +48,20 @@ vi.mock('../../src/services/logs/audit.service.js', () => ({
   AuditService: { getInstance: () => ({ log: vi.fn() }) },
 }));
 
-const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
-  void _next;
-  const statusCode =
-    error instanceof Error && 'statusCode' in error && typeof error.statusCode === 'number'
-      ? error.statusCode
-      : 500;
-  const code =
-    error instanceof Error && 'code' in error && typeof error.code === 'string'
-      ? error.code
-      : undefined;
-  res.status(statusCode).json({
-    message: error instanceof Error ? error.message : 'Error',
-    ...(code ? { code } : {}),
-  });
-};
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
 
+// Mount the real production error middleware rather than a stand-in, so these
+// tests assert the actual error-response contract clients receive
+// ({ error, message, statusCode }) and not a shape invented by the test.
 async function createApp() {
   const { aiRouter } = await import('../../src/api/routes/ai/index.routes.js');
   const app = express();
   app.use(express.json());
   app.use('/api/ai', aiRouter);
-  app.use(errorHandler);
+  app.use(errorMiddleware);
   return app;
 }
 
@@ -114,7 +107,9 @@ describe('POST /api/ai/chat/completion - streaming error status', () => {
     // Regression guard: this used to flush a 200 with an SSE error frame, so a
     // client checking `response.ok` read a billing failure as success.
     expect(response.status).toBe(402);
-    expect(response.body.code).toBe(ERROR_CODES.BILLING_INSUFFICIENT_BALANCE);
+    expect(response.body.error).toBe(ERROR_CODES.BILLING_INSUFFICIENT_BALANCE);
+    expect(response.body.statusCode).toBe(402);
+    expect(response.headers['content-type']).toContain('application/json');
     expect(response.text).not.toContain('data: ');
   });
 
@@ -130,7 +125,8 @@ describe('POST /api/ai/chat/completion - streaming error status', () => {
       .send(streamingRequest);
 
     expect(response.status).toBe(429);
-    expect(response.body.code).toBe(ERROR_CODES.RATE_LIMITED);
+    expect(response.body.error).toBe(ERROR_CODES.RATE_LIMITED);
+    expect(response.body.statusCode).toBe(429);
   });
 
   it('falls back to 500 for a non-AppError failure before streaming starts', async () => {
@@ -141,6 +137,7 @@ describe('POST /api/ai/chat/completion - streaming error status', () => {
       .send(streamingRequest);
 
     expect(response.status).toBe(500);
+    expect(response.body.error).toBe(ERROR_CODES.INTERNAL_ERROR);
     expect(response.body.message).toBe('socket hang up');
   });
 


### PR DESCRIPTION
## Summary

For `stream: true`, the upstream request is issued on the **first pull** of the async generator — so an out-of-credits (402), rate-limit (429) or auth (401) failure can happen before a single byte is streamed. The streaming `catch` wrote an SSE error frame with `res.write()`, and because nothing had been written yet that call flushed the still-open status line as the **default 200**, discarding the status `OpenRouterProvider.sendRequest` had already mapped.

The result: a client doing `if (!response.ok)` read a billing or rate-limit failure as **success**, and could not tell 402 from 429 from 500. The non-streaming path on the same endpoint already surfaces the status via `next(error)`.

This branches the streaming `catch` on `res.headersSent`:

- **Nothing streamed yet** → drop the staged SSE headers and delegate to the error handler, so the mapped status is returned (matching `stream: false`).
- **Already streaming** → the status line is committed and can no longer change, so genuine mid-stream failures keep reporting in-band exactly as before.

Removing the staged headers matters: `res.json()` only sets `Content-Type` when one isn't already present, so leaving `text/event-stream` staged would send the JSON error body with an SSE content type.

Closes #1782

### Changes
- `backend/src/api/routes/ai/index.routes.ts` — branch the streaming catch on `res.headersSent` (+ explanatory comment).
- `backend/tests/unit/ai-streaming-error-status.test.ts` — new end-to-end regression tests.

### Deliberately out of scope
The mid-stream SSE error frame still carries only `{ error, message }` — it does not include the error code. Adding that changes the SSE payload shape, so I left it alone to keep this PR focused on the status bug. Happy to follow up if you'd like it.

## How did you test this change?

Added `backend/tests/unit/ai-streaming-error-status.test.ts` — supertest against a real Express app with the router mounted and an error handler, so these assert the **actual HTTP status** end to end (same harness style as `ai-routes.test.ts`):

1. Pre-stream 402 → responds `402` with `BILLING_INSUFFICIENT_BALANCE`, and no `data:` frame is emitted.
2. Pre-stream 429 → responds `429` with `RATE_LIMITED`.
3. Pre-stream non-`AppError` → falls back to `500` with the original message.
4. **Mid-stream** failure after a chunk → still `200`, `text/event-stream`, with both the streamed chunk and the in-band `"error":true` frame (guards that existing behavior is preserved).

Tests 1–3 **fail on `main`** — `expected 200 to be 402`, `expected 200 to be 429`, `expected 200 to be 500` — and pass with the fix. Test 4 passes both before and after, confirming no mid-stream regression.

Commands run:
- `npx vitest run tests/unit/ai-streaming-error-status.test.ts` → **4 passed**.
- Full AI gateway suite (`ai-*`, `openrouter-*` — 9 files) → **111 passed**, no regressions.
- `tsc --noEmit` → clean · `eslint` → clean · `prettier --check` → clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the streamed completion endpoint to return the correct HTTP status when the upstream fails before any bytes are sent. Prevents false 200 OKs and aligns behavior with the non-streaming path.

- **Bug Fixes**
  - If no data has been sent (`!res.headersSent`), remove staged SSE headers and forward the error to the handler so the mapped status (402/429/401/500) is returned; non-`AppError` cases are wrapped as 500 `INTERNAL_ERROR`.
  - If already streaming, keep reporting failures in-band via SSE and close the stream; status stays 200.
  - Tests now mount the production error middleware and assert the real contract (`{ error, message, statusCode }`) and JSON content type; cover pre-stream 402/429/500 and a mid-stream failure.

<sup>Written for commit a559e86a43d546ac4fccdf2aa690fadbeb10c64e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix streaming chat completion to return mapped HTTP error status on pre-stream failure
> - Pre-stream failures in `POST /chat/completion` (stream=true) previously returned HTTP 200 with an SSE error frame; they now return the correct HTTP status (e.g. 402, 429, 401, 500) with a JSON error body.
> - The fix checks `res.headersSent` in the catch block: if no bytes have been flushed, SSE headers are removed and the error is forwarded to Express error middleware, preserving `AppError` status codes or mapping unknown errors to 500.
> - Mid-stream failures (headers already sent) continue to be reported in-band via SSE error frames on the open 200 response.
> - Behavioral Change: clients handling `stream=true` requests must now handle non-200 HTTP responses for pre-stream failures rather than always expecting a 200 with an SSE error frame.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a559e86.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for streaming chat responses.
  * Failures before any SSE headers are sent now map to the correct HTTP status and return a non-SSE error response.
  * Mid-stream failures now preserve already-delivered content while sending an in-stream SSE error payload.
  * Prevented failed requests from being misrepresented as successful streaming responses.

* **Tests**
  * Added unit coverage for streaming chat failure scenarios, including pre-stream mapped errors (rate-limits and unexpected errors) and mid-stream exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->