### PR TITLE
fix: harden Docker Compose encryption-key secret handling

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -19,7 +19,9 @@ JWT_SECRET=your-secret-key-here-must-be-32-char-or-above
 ROOT_ADMIN_USERNAME=admin
 ROOT_ADMIN_PASSWORD=change-this-password
 
-# Encryption key for secrets and database encryption (will use JWT_SECRET if not provided)
+# Encryption key for secrets and database encryption (REQUIRED in production).
+# Generate with: openssl rand -base64 32
+# If not set, docker-compose will fail to start.
 ENCRYPTION_KEY=
 
 # Worker timeout in milliseconds (default: 60000 ms) 

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -6,7 +6,9 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+      # ENCRYPTION_KEY is required for schedule header encryption.
+      # In production, set a unique value via .env — do not use the fallback.
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:

--- a/deploy/docker-init/db/encryption.sql
+++ b/deploy/docker-init/db/encryption.sql
@@ -1,11 +1,3 @@
-\set encryption_key `echo "${ENCRYPTION_KEY:-${JWT_SECRET:-}}"` 
-
--- Only set the GUC if a key is available (non-empty).
--- This mirrors the jwt.sql pattern for app.settings.jwt_secret.
-SELECT CASE
-  WHEN :'encryption_key' <> '' THEN
-    (SELECT set_config('app.encryption_key', :'encryption_key', false))
-  ELSE NULL
-END;
+\set encryption_key `echo "${ENCRYPTION_KEY:-${JWT_SECRET:-}}"`
 
 ALTER DATABASE postgres SET "app.encryption_key" TO :'encryption_key';

--- a/deploy/docker-init/db/encryption.sql
+++ b/deploy/docker-init/db/encryption.sql
@@ -1,3 +1,3 @@
-\set encryption_key `echo "${ENCRYPTION_KEY:-${JWT_SECRET:-}}"`
+\set encryption_key `echo "$ENCRYPTION_KEY"`
 
 ALTER DATABASE postgres SET "app.encryption_key" TO :'encryption_key';

--- a/deploy/docker-init/db/encryption.sql
+++ b/deploy/docker-init/db/encryption.sql
@@ -1,0 +1,11 @@
+\set encryption_key `echo "${ENCRYPTION_KEY:-${JWT_SECRET:-}}"` 
+
+-- Only set the GUC if a key is available (non-empty).
+-- This mirrors the jwt.sql pattern for app.settings.jwt_secret.
+SELECT CASE
+  WHEN :'encryption_key' <> '' THEN
+    (SELECT set_config('app.encryption_key', :'encryption_key', false))
+  ELSE NULL
+END;
+
+ALTER DATABASE postgres SET "app.encryption_key" TO :'encryption_key';

--- a/deploy/docker-init/db/encryption.sql
+++ b/deploy/docker-init/db/encryption.sql
@@ -1,3 +1,4 @@
 \set encryption_key `echo "$ENCRYPTION_KEY"`
+\set db_name `echo "${POSTGRES_DB:-insforge}"`
 
-ALTER DATABASE postgres SET "app.encryption_key" TO :'encryption_key';
+ALTER DATABASE :"db_name" SET "app.encryption_key" TO :'encryption_key';

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -57,7 +57,7 @@ services:
       API_BASE_URL: ${API_BASE_URL:-http://localhost:7130}
       VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:7130}
       JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
       ROOT_ADMIN_USERNAME: ${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
       ROOT_ADMIN_PASSWORD: ${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-changeme123}}
       ADMIN_EMAIL: ${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
@@ -114,7 +114,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGREST_BASE_URL: http://postgrest:3000
       WORKER_TIMEOUT_MS: ${WORKER_TIMEOUT_MS:-60000}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
       JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -6,7 +6,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-insforge}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-change-this-encryption-key-32chars}
+      # ENCRYPTION_KEY is required for schedule header encryption.
+      # In production, set a unique value via .env — do not use a shared default.
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,12 +2,12 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET}}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,12 +2,12 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET}}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET}}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:?ENCRYPTION_KEY must be set}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,15 +2,17 @@ services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
 
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./deploy/docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql
+      - ./deploy/docker-init/db/encryption.sql:/docker-entrypoint-initdb.d/03-encryption.sql
       - ./deploy/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf
     ports:
       - "${POSTGRES_PORT:-5432}:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - API_BASE_URL=${API_BASE_URL:-}
       - VITE_API_BASE_URL=${VITE_API_BASE_URL:-}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
       - ROOT_ADMIN_USERNAME=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
       - ROOT_ADMIN_PASSWORD=${ROOT_ADMIN_PASSWORD:-${ADMIN_PASSWORD:-change-this-password}}
       - ADMIN_EMAIL=${ROOT_ADMIN_USERNAME:-${ADMIN_EMAIL:-admin}}
@@ -199,7 +199,7 @@ services:
       # Worker timeout (60 seconds default)
       - WORKER_TIMEOUT_MS=${WORKER_TIMEOUT_MS:-60000}
       # Encryption keys for decrypting function secrets
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
       - JWT_SECRET=${JWT_SECRET:-dev-secret-please-change-in-production}
     volumes:
       - ./functions:/app/functions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
+    # Dev only: falls back to JWT_SECRET for local development convenience.
+    # Production deployments (docker-compose.prod.yml) require ENCRYPTION_KEY explicitly.
     command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET}}'
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET}}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
-    # Dev only: falls back to JWT_SECRET for local development convenience.
-    # Production deployments (docker-compose.prod.yml) require ENCRYPTION_KEY explicitly.
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET}}'
+    # Dev: ENCRYPTION_KEY falls back to JWT_SECRET for local convenience.
+    # The encryption.sql init script persists it via ALTER DATABASE.
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,17 @@
 services:
   postgres:
     image: ghcr.io/insforge/postgres:v15.13.4
-    command: postgres -c config_file=/etc/postgresql/postgresql.conf -c app.encryption_key='${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql
       - ./deploy/docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql
+      - ./deploy/docker-init/db/encryption.sql:/docker-entrypoint-initdb.d/03-encryption.sql
       - ./deploy/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf
     ports:
       - "${POSTGRES_PORT:-5432}:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRES_DB=${POSTGRES_DB:-insforge}
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET}}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-${JWT_SECRET:-dev-secret-please-change-in-production}}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./deploy/docker-init/db/db-init.sql:/docker-entrypoint-initdb.d/01-init.sql


### PR DESCRIPTION
Closes #1781

## Summary

Removes `app.encryption_key` from PostgreSQL command-line arguments (where it's visible in process metadata) and moves it to a protected init SQL file, matching the existing `jwt.sql` pattern.

## What changed

- **New file**: `deploy/docker-init/db/encryption.sql` — sets `app.encryption_key` GUC via `ALTER DATABASE`, sourced from the `ENCRYPTION_KEY` env var (mirrors `jwt.sql` pattern)
- **docker-compose.yml** & **docker-compose.prod.yml**: removed `-c app.encryption_key=...` from command, mount `encryption.sql`, pass `ENCRYPTION_KEY` as env var
- **deploy/docker-compose/docker-compose.yml** & **docker-compose.dokploy.yml**: require `ENCRYPTION_KEY` (fails fast with `?` syntax if missing), removed insecure fallback defaults
- **deploy/docker-compose/.env.example**: document `ENCRYPTION_KEY` as required

## How would you test this change?

- YAML validated locally
- Init SQL follows the proven `jwt.sql` pattern already in production
- Existing schedule encryption/decryption behavior unchanged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Docker Compose encryption‑key handling by moving it to an init SQL and requiring `ENCRYPTION_KEY` in non‑dev configs. Removed command‑line GUC to avoid exposing the key; dev now consistently falls back to `JWT_SECRET` across services.

- **Bug Fixes**
  - Added `deploy/docker-init/db/encryption.sql` to set `app.encryption_key` for `POSTGRES_DB`; mounted in dev and prod.
  - Removed `-c app.encryption_key=...` from Postgres commands; rely on the init SQL for fresh installs. For existing volumes, run the script once to apply.
  - Required `ENCRYPTION_KEY` in `docker-compose.prod.yml`, `deploy/docker-compose/docker-compose.yml`, and `docker-compose.dokploy.yml` (fail fast). Updated `.env.example` with generation guidance and the fail‑fast behavior.
  - Aligned dev `docker-compose.yml` so `postgres`, `insforge`, and `deno` share the same fallback: `ENCRYPTION_KEY` → `JWT_SECRET` (prevents mismatched keys).

<sup>Written for commit a10bd087ff03b576d2b558ffe4fbfd6230dddece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Security**
  - Production Docker Compose variants now require a unique `ENCRYPTION_KEY` (no fallback), and startup will fail if it’s missing.
  - Updated production guidance to require an encryption key and added instructions to generate it (`openssl rand -base64 32`).

- **Configuration**
  - `ENCRYPTION_KEY` is now applied during Postgres initialization via a dedicated init SQL script across supported Compose setups.
  - Compose definitions now consistently supply the encryption key through environment variables rather than command-line injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `ENCRYPTION_KEY` handling in Docker Compose to require explicit values in production
> - Production compose files (`docker-compose.prod.yml`, `docker-compose.dokploy.yml`) now use `${ENCRYPTION_KEY:?...}` syntax, causing compose to fail at startup if `ENCRYPTION_KEY` is unset.
> - Dev compose (`docker-compose.yml`) falls back to `JWT_SECRET` when `ENCRYPTION_KEY` is not set, preserving backward compatibility.
> - Moves `app.encryption_key` configuration out of the postgres command-line args and into a new init SQL script at [`deploy/docker-init/db/encryption.sql`](https://github.com/InsForge/InsForge/pull/1784/files#diff-461ebc00fb0da32a4c4cc3e0a2e1f3825e77005ad69edb08592160d87c40d650), mounted as `docker-entrypoint-initdb.d/03-encryption.sql`.
> - Updates `.env.example` to document `ENCRYPTION_KEY` as required in production with an `openssl` generation command.
> - Behavioral Change: existing production deployments without `ENCRYPTION_KEY` explicitly set will fail to start after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a10bd08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->