### PR TITLE
fix(ai): stop a stale credential read from repopulating the invalidated cache

### DIFF
--- a/backend/src/services/ai/model-gateway-config.service.ts
+++ b/backend/src/services/ai/model-gateway-config.service.ts
@@ -42,6 +42,10 @@ export class ModelGatewayConfigUpdateError extends Error {
 export class ModelGatewayConfigService {
   private static instance: ModelGatewayConfigService;
   private storedCredentialCache = new Map<ModelGatewayCredentialKey, StoredCredentialCache>();
+  // Bumped on every invalidation. Clearing the map cannot cancel a read that is
+  // already awaiting the secret store, so `getStoredCredential` captures this
+  // before its await and declines to cache a value fetched under an older epoch.
+  private storedCredentialCacheEpoch = 0;
 
   constructor(private readonly secretService: SecretStore = SecretService.getInstance()) {}
 
@@ -93,7 +97,15 @@ export class ModelGatewayConfigService {
       });
     }
 
+    // Seeding wrote a credential, so drop the cached entry and retire any read
+    // already in flight along with it.
+    this.storedCredentialCacheEpoch += 1;
     this.storedCredentialCache.delete(OPENROUTER_API_KEY_SECRET);
+  }
+
+  private invalidateStoredCredentialCache(): void {
+    this.storedCredentialCacheEpoch += 1;
+    this.storedCredentialCache.clear();
   }
 
   async getConfig(): Promise<ModelGatewayConfig> {
@@ -162,7 +174,7 @@ export class ModelGatewayConfigService {
     } finally {
       // The credentials are independent and may update independently. Always invalidate both
       // cache entries so a partial failure is reconciled on the next read.
-      this.storedCredentialCache.clear();
+      this.invalidateStoredCredentialCache();
     }
 
     try {
@@ -179,12 +191,20 @@ export class ModelGatewayConfigService {
       return cached.value;
     }
 
+    const epoch = this.storedCredentialCacheEpoch;
+
     try {
       const value = this.normalizeCredential(await this.secretService.getSecretByKey(key));
-      this.storedCredentialCache.set(key, {
-        value,
-        expiresAt: Date.now() + STORED_CREDENTIAL_CACHE_TTL_MS,
-      });
+      // An update invalidated the cache while this read was in flight, so the value
+      // it just fetched is already stale. Hand it back to this caller, but leave the
+      // cache alone — writing it here would clobber the post-update value with the
+      // superseded credential for a further TTL window.
+      if (epoch === this.storedCredentialCacheEpoch) {
+        this.storedCredentialCache.set(key, {
+          value,
+          expiresAt: Date.now() + STORED_CREDENTIAL_CACHE_TTL_MS,
+        });
+      }
       return value;
     } catch (error) {
       logger.warn('Unable to load a Model Gateway credential', {

--- a/backend/tests/unit/model-gateway-config.service.test.ts
+++ b/backend/tests/unit/model-gateway-config.service.test.ts
@@ -300,4 +300,35 @@ describe('ModelGatewayConfigService', () => {
       cause: conflict,
     } satisfies Partial<ModelGatewayConfigUpdateError>);
   });
+  it('ignores an in-flight credential read that resolves after an update invalidated the cache', async () => {
+    const secretStore = createSecretStore();
+    secretStore.listSecrets.mockResolvedValue([{ id: 'api-id', key: 'OPENROUTER_API_KEY' }]);
+    secretStore.updateSecret.mockResolvedValue(true);
+
+    // Hold the first read open so it settles only after updateConfig has cleared
+    // and refilled the cache — the interleaving a slow secret-store read produces
+    // under connection-pool contention.
+    let releaseStaleRead!: (value: string) => void;
+    const staleRead = new Promise<string>((resolve) => {
+      releaseStaleRead = resolve;
+    });
+    secretStore.getSecretByKey
+      .mockImplementationOnce(() => staleRead)
+      .mockImplementation(() => Promise.resolve('new-api-key'));
+
+    const service = new ModelGatewayConfigService(
+      secretStore as unknown as ConfigServiceSecretStore
+    );
+
+    const inFlightRead = service.getApiKey();
+    await service.updateConfig({ apiKey: 'new-api-key' });
+
+    releaseStaleRead('old-api-key');
+    // The read itself still returns what it fetched; that is not what regressed.
+    await expect(inFlightRead).resolves.toBe('old-api-key');
+
+    // It must not have written that pre-update value back over the fresh cache,
+    // which would serve the revoked key for a further TTL window.
+    await expect(service.getApiKey()).resolves.toBe('new-api-key');
+  });
 });


### PR DESCRIPTION
## Summary

`getStoredCredential()` caches unconditionally **after** awaiting the secret store, while `updateConfig()` invalidates the cache in its `finally` block. Clearing a `Map` cannot cancel a read that is already in flight, so a read that started before an update and resolves after it writes the **superseded** credential back into the cache with a fresh 60s TTL — landing *after* `updateConfig`'s own read-back has already stored the new value.

For up to a minute the gateway then authenticates with the previous key (401s right after an admin fixed it), and `GET /api/ai/config` reports a masked key that contradicts the body the `PUT` just returned. Every AI path funnels through this cache via `OpenRouterProvider.getApiKeyWithSource()`, and the provider rebuilds its OpenAI client whenever the resolved key changes — so a stale resolution silently re-installs the old key.

This defeats the invariant the code documents: *"Always invalidate both cache entries so a partial failure is reconciled on the next read."*

**Fix:** track a monotonic cache epoch, capture it before the `await`, and only write to the cache when the epoch is unchanged. The read still returns what it fetched — it just no longer writes it back. `seedApiKeyFromEnv()` bumps the epoch alongside its `delete()` for the same reason.

Closes #1785

### Honest scoping
This is a **race, not an every-time failure**: the in-flight read has to outlast the update's own `listSecrets` + `updateSecret` round-trips. On an idle box that is the less likely interleaving; it becomes realistic under connection-pool contention or a slow/loaded Postgres, and the dashboard's own concurrent `GET /api/ai/config` widens the window. Impact is bounded and self-heals after the 60s TTL. I'm raising it as a correctness-of-invariant fix rather than a high-frequency outage — happy to close it if you'd rather not carry the extra field.

### Changes
- `backend/src/services/ai/model-gateway-config.service.ts` — add `storedCredentialCacheEpoch`; guard the cache write; route invalidation through a small `invalidateStoredCredentialCache()` helper.
- `backend/tests/unit/model-gateway-config.service.test.ts` — regression test.

## How did you test this change?

Added a deterministic regression test to the existing suite (reuses the `createSecretStore()` fake — no timers, no network, no sleeps). It holds the first `getSecretByKey` open with a manually-resolved promise so the read settles *after* `updateConfig` cleared and refilled the cache:

1. start `service.getApiKey()` without awaiting,
2. `await service.updateConfig({ apiKey: 'new-api-key' })`,
3. release the held read with `old-api-key`,
4. assert the in-flight read still returns `old-api-key` (its own return value is not what regressed), and that the **next** `service.getApiKey()` returns `new-api-key`.

It **fails on `main`** with `AssertionError: expected 'old-api-key' to be 'new-api-key'`, and passes with the fix.

Commands run:
- `npx vitest run tests/unit/model-gateway-config.service.test.ts` → **13 passed** (12 existing + 1 new).
- AI gateway + error-middleware suites (11 files) → **129 passed**; secrets suites (3 files) → **25 passed**. No regressions.
- `tsc --noEmit` → clean · `eslint` → clean · `prettier --check` → clean.

Note the existing `invalidates cached credentials after an allowed partial update` test is strictly sequential (`await` read → `await` update → `await` read), so it could not catch this interleaving.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the model gateway credential cache that let an in-flight read repopulate a revoked key after an update, causing temporary 401s and mismatched config responses. Adds an epoch guard so stale reads no longer write back after cache invalidation.

- **Bug Fixes**
  - Track a monotonic cache epoch; capture it before awaiting the secret store and only write to cache if unchanged.
  - Centralize invalidation in invalidateStoredCredentialCache; bump the epoch on updates and when seeding from env.
  - Add a regression test that simulates the in-flight read and confirms the cache keeps the new key.

<sup>Written for commit 7109c6064d2c2ec95cd177eb3d97213598089aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale credential reads from repopulating the invalidated cache in `ModelGatewayConfigService`
> Introduces a cache invalidation epoch counter (`storedCredentialCacheEpoch`) to `ModelGatewayConfigService`. Before awaiting a secret store read, `getStoredCredential` captures the current epoch; after fetching, it only writes to the cache if the epoch is unchanged. `updateConfig` and `seedApiKeyFromEnv` both bump the epoch on invalidation, retiring any in-flight reads. A unit test covering the race condition is added in [model-gateway-config.service.test.ts](https://github.com/InsForge/InsForge/pull/1786/files#diff-85e1de31624df6a97d0ec726398301cc4f6d0bed9e6063ad87b22dc428e08fe2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7109c60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential caching during configuration updates to prevent outdated values from replacing newly saved credentials.
  * Ensured subsequent credential lookups consistently return the latest configured value.

* **Tests**
  * Added coverage for concurrent credential reads and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->