### PR TITLE
fix(ai): normalize tool result content instead of JSON-stringifying it

### DIFF
--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -99,7 +99,7 @@ export class ChatCompletionService {
         }
         formattedMessages.push({
           role: 'tool',
-          content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
+          content: this.toToolContentText(msg.content),
           tool_call_id: msg.tool_call_id,
         } as OpenAI.Chat.ChatCompletionToolMessageParam);
         continue;
@@ -140,6 +140,23 @@ export class ChatCompletionService {
     }
 
     return formattedMessages;
+  }
+
+  /**
+   * Normalize a tool result into the plain string a tool message has to carry.
+   * The schema accepts `content` as a string, as OpenAI-style content parts, or as
+   * null, and JSON-stringifying the latter two handed the model a raw JSON blob —
+   * or the literal word "null" — in place of the tool's output. Only text parts
+   * have a representation in a tool message, so only they contribute.
+   */
+  private toToolContentText(content: ChatMessageSchema['content']): string {
+    if (typeof content === 'string') {
+      return content;
+    }
+    if (!Array.isArray(content)) {
+      return '';
+    }
+    return content.map((part) => (part.type === 'text' ? part.text : '')).join('');
   }
 
   /**

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -146,8 +146,11 @@ export class ChatCompletionService {
    * Normalize a tool result into the plain string a tool message has to carry.
    * The schema accepts `content` as a string, as OpenAI-style content parts, or as
    * null, and JSON-stringifying the latter two handed the model a raw JSON blob —
-   * or the literal word "null" — in place of the tool's output. Only text parts
-   * have a representation in a tool message, so only they contribute.
+   * or the literal word "null" — in place of the tool's output.
+   *
+   * A tool message has no representation for image/audio/file parts, so those are
+   * rejected rather than dropped: silently discarding them would hand the model an
+   * answerable prompt that is missing the data the caller attached.
    */
   private toToolContentText(content: ChatMessageSchema['content']): string {
     if (typeof content === 'string') {
@@ -156,7 +159,18 @@ export class ChatCompletionService {
     if (!Array.isArray(content)) {
       return '';
     }
-    return content.map((part) => (part.type === 'text' ? part.text : '')).join('');
+    return content
+      .map((part) => {
+        if (part.type !== 'text') {
+          throw new AppError(
+            `Tool message content part of type '${part.type}' is not supported; a tool result must be text`,
+            400,
+            ERROR_CODES.INVALID_INPUT
+          );
+        }
+        return part.text;
+      })
+      .join('');
   }
 
   /**

--- a/backend/tests/unit/ai-tool-calling-format.test.ts
+++ b/backend/tests/unit/ai-tool-calling-format.test.ts
@@ -172,4 +172,21 @@ describe('ChatCompletionService - formatMessages', () => {
     // the tool returned the word null.
     expect(result[0].content).toBe('');
   });
+
+  it('rejects a tool result carrying a non-text content part instead of dropping it', () => {
+    const messages: ChatMessageSchema[] = [
+      {
+        role: 'tool',
+        content: [
+          { type: 'text', text: 'see attached' },
+          { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+        ],
+        tool_call_id: 'call_abc123',
+      },
+    ];
+
+    // A tool message cannot carry an image, so silently discarding it would leave
+    // the model answering without data the caller supplied.
+    expect(() => service.formatMessages(messages)).toThrow(/is not supported/);
+  });
 });

--- a/backend/tests/unit/ai-tool-calling-format.test.ts
+++ b/backend/tests/unit/ai-tool-calling-format.test.ts
@@ -128,4 +128,48 @@ describe('ChatCompletionService - formatMessages', () => {
       'Tool message is missing required tool_call_id'
     );
   });
+  it('normalizes a tool result sent as content parts into plain text', () => {
+    const messages: ChatMessageSchema[] = [
+      {
+        role: 'tool',
+        content: [{ type: 'text', text: '22°C and sunny' }],
+        tool_call_id: 'call_abc123',
+      },
+    ];
+
+    const result = service.formatMessages(messages);
+
+    // Previously JSON.stringify'd, so the model was told the tool returned the
+    // literal string [{"type":"text","text":"22°C and sunny"}].
+    expect(result[0].content).toBe('22°C and sunny');
+  });
+
+  it('joins multiple text parts of a tool result', () => {
+    const messages: ChatMessageSchema[] = [
+      {
+        role: 'tool',
+        content: [
+          { type: 'text', text: '22°C' },
+          { type: 'text', text: ' and sunny' },
+        ],
+        tool_call_id: 'call_abc123',
+      },
+    ];
+
+    const result = service.formatMessages(messages);
+
+    expect(result[0].content).toBe('22°C and sunny');
+  });
+
+  it('represents an absent tool result as an empty string, not the word "null"', () => {
+    const messages: ChatMessageSchema[] = [
+      { role: 'tool', content: null, tool_call_id: 'call_abc123' },
+    ];
+
+    const result = service.formatMessages(messages);
+
+    // JSON.stringify(null) produced the literal string "null", telling the model
+    // the tool returned the word null.
+    expect(result[0].content).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary

`chatMessageSchema` accepts `content` as a string, as OpenAI-style content parts, or as `null` for every role, but the tool branch of `formatMessages` only handled the string case and fell back to `JSON.stringify`:

```ts
content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content),
```

So a tool result sent as content parts reached the model as a raw JSON blob — `[{"type":"text","text":"22°C and sunny"}]` — and a `null` result reached it as the literal word `null`. The model answered from the wrapper instead of the tool's output, with no error surfaced and the request billed as a successful completion. Tool calling is the core agentic path, so this degrades exactly the flow the gateway exists to serve.

This normalizes tool content into the plain string a tool message has to carry: strings pass through unchanged, content parts contribute their text, and an absent result becomes an empty string.

Closes #1787

### Design note
I deliberately **flatten to text rather than forwarding the array**, so the change makes no assumption about whether the provider accepts array-form content on a tool message.

A tool message has no representation for `image_url` / `input_audio` / `file` parts. Those are **rejected with a 400 `INVALID_INPUT`** rather than dropped — matching how the same branch already rejects a tool message with no `tool_call_id`. (My first revision mapped them to an empty string; that swapped a malformed tool result for a silently missing one, which is the same class of silent loss this PR set out to fix. Caught in review.)

### Changes
- `backend/src/services/ai/chat-completion.service.ts` — add a `toToolContentText()` helper and use it in the tool branch.
- `backend/tests/unit/ai-tool-calling-format.test.ts` — regression tests.

## How did you test this change?

Added four regression tests alongside the existing `formatMessages` suite:

1. A tool result sent as content parts normalizes to plain text.
2. Multiple text parts are joined.
3. A `null` tool result becomes an empty string rather than the word `"null"`.
4. A tool result carrying a non-text part is rejected rather than silently dropped.

All four **fail on `main`** (the fourth because `main` stringifies the part instead of rejecting it):

```
AssertionError: expected '[{"type":"text","text":"22°C and sunn…' to be '22°C and sunny'
AssertionError: expected '[{"type":"text","text":"22°C"},{"type…' to be '22°C and sunny'
AssertionError: expected 'null' to be ''
```

and pass with the fix. The existing string-content tool test is unchanged, confirming that path is byte-for-byte identical.

Commands run:
- `npx vitest run tests/unit/ai-tool-calling-format.test.ts` → **10 passed** (6 existing + 4 new).
- AI gateway suite (9 files: `ai-*`, `model-gateway-config`, `openrouter-*`) → **124 passed**, no regressions.
- `tsc --noEmit` → clean · `eslint` → clean · `prettier --check` → clean.

Branch is rebased on current `main`.
