### PR TITLE
feat: make PostgREST proxy pool configurable and tighten retry policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ MAX_URLENCODED_BODY_SIZE=10mb
 # backend so clients never reuse a connection the server has already closed.
 KEEP_ALIVE_TIMEOUT_MS=65000
 
+# Max concurrent connections from the backend to PostgREST (default: 50)
+# Tune per instance size, and keep it aligned with PostgREST's database pool
+# (PGRST_DB_POOL): raising it beyond the pool only moves queuing into PostgREST.
+POSTGREST_MAX_SOCKETS=50
+
+# Idle keep-alive connections retained toward PostgREST (default: 10)
+POSTGREST_MAX_FREE_SOCKETS=10
+
 # -----------------------------------------------------------------------------
 # PostgreSQL Configuration
 # -----------------------------------------------------------------------------

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -64,6 +64,8 @@ export interface AppConfig {
     password: string;
     dir: string;
     postgrestBaseUrl: string;
+    postgrestMaxSockets: number;
+    postgrestMaxFreeSockets: number;
   };
   auth: {
     rootAdminUsername: string;
@@ -192,6 +194,11 @@ export function loadConfig(): AppConfig {
       password: process.env.POSTGRES_PASSWORD || 'postgres',
       dir: process.env.DATABASE_DIR || path.join(__dirname, '../../data'),
       postgrestBaseUrl: process.env.POSTGREST_BASE_URL || 'http://localhost:5430',
+      // HTTP agent pool for the PostgREST proxy. Keep max sockets aligned with
+      // PostgREST's own db pool (PGRST_DB_POOL): sockets beyond it only move
+      // the queue from PostgREST back into this process.
+      postgrestMaxSockets: parseEnvInt(process.env.POSTGREST_MAX_SOCKETS, 50),
+      postgrestMaxFreeSockets: parseEnvInt(process.env.POSTGREST_MAX_FREE_SOCKETS, 10),
     },
     auth: {
       rootAdminUsername: process.env.ROOT_ADMIN_USERNAME || process.env.ADMIN_EMAIL || '',

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -9,20 +9,25 @@ import { ERROR_CODES } from '@insforge/shared-schemas';
 
 const postgrestUrl = appConfig.database.postgrestBaseUrl;
 
-// Connection pooling for PostgREST
+// Connection pooling for PostgREST. maxSockets caps concurrency toward
+// PostgREST; requests beyond it queue inside the agent, and queue time counts
+// against the axios timeout below.
+const maxSockets = appConfig.database.postgrestMaxSockets;
+const maxFreeSockets = Math.min(appConfig.database.postgrestMaxFreeSockets, maxSockets);
+
 const httpAgent = new http.Agent({
   keepAlive: true,
   keepAliveMsecs: 5000,
-  maxSockets: 20,
-  maxFreeSockets: 5,
+  maxSockets,
+  maxFreeSockets,
   timeout: 10000,
 });
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
   keepAliveMsecs: 5000,
-  maxSockets: 20,
-  maxFreeSockets: 5,
+  maxSockets,
+  maxFreeSockets,
   timeout: 10000,
 });
 
@@ -61,6 +66,16 @@ const EXCLUDED_HEADERS = new Set([
   'content-encoding',
 ]);
 
+/**
+ * Timeout-class errors are never retried: by the time the 10s budget is spent
+ * the request may already be executing in PostgREST (retrying a write risks a
+ * duplicate), and re-running it amplifies load exactly when the database is
+ * saturated. Connection-class errors (ECONNREFUSED, ECONNRESET from a
+ * keep-alive socket closed while idle, DNS failures) mean the request was
+ * never processed, so those remain retryable.
+ */
+const TIMEOUT_ERROR_CODES = new Set(['ECONNABORTED', 'ETIMEDOUT']);
+
 export class PostgrestProxyService {
   private static instance: PostgrestProxyService;
   private tokenManager = TokenManager.getInstance();
@@ -77,6 +92,19 @@ export class PostgrestProxyService {
       PostgrestProxyService.instance = new PostgrestProxyService();
     }
     return PostgrestProxyService.instance;
+  }
+
+  /**
+   * A request may be retried only when PostgREST never received it: a
+   * network-level failure (no HTTP response) that is not a timeout. Any
+   * response — including 5xx — and any timeout is surfaced to the caller
+   * instead of retried.
+   */
+  static isRetryableError(error: unknown): boolean {
+    if (!axios.isAxiosError(error) || error.response) {
+      return false;
+    }
+    return !TIMEOUT_ERROR_CODES.has(error.code ?? '');
   }
 
   /**
@@ -196,11 +224,12 @@ export class PostgrestProxyService {
         break;
       } catch (error) {
         lastError = error;
-        const shouldRetry = axios.isAxiosError(error) && !error.response && attempt < maxRetries;
+        const shouldRetry = attempt < maxRetries && PostgrestProxyService.isRetryableError(error);
 
         if (shouldRetry) {
           logger.warn(`PostgREST request failed, retrying (attempt ${attempt}/${maxRetries})`, {
             url: targetUrl,
+            method: request.method,
             errorCode: (error as NodeJS.ErrnoException).code,
             message: (error as Error).message,
           });

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -87,11 +87,17 @@ const CONNECTION_NOT_ESTABLISHED_CODES = new Set([
 ]);
 
 /**
+ * Network errors where the request may or may not have reached PostgREST: an
+ * ECONNRESET is usually a keep-alive socket closed while idle, but it can
+ * also arrive mid-response after a write already committed, and the two are
+ * indistinguishable here. A missing code is treated the same way.
+ */
+const AMBIGUOUS_NETWORK_CODES = new Set(['ECONNRESET', 'EPIPE']);
+
+/**
  * Methods safe to replay even when the request may have reached PostgREST.
  * Everything else (POST/PATCH/PUT/DELETE) only retries errors from
- * CONNECTION_NOT_ESTABLISHED_CODES: an ECONNRESET is usually a keep-alive
- * socket closed while idle, but it can also arrive mid-response after the
- * write already committed, and the two are indistinguishable here.
+ * CONNECTION_NOT_ESTABLISHED_CODES.
  */
 const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
@@ -116,10 +122,11 @@ export class PostgrestProxyService {
   /**
    * A request may be retried only when replaying it cannot duplicate work in
    * PostgREST. Any HTTP response — including 5xx — and any timeout is
-   * surfaced to the caller instead of retried. Among the remaining network
-   * errors, connection-never-established failures are retryable for every
-   * method, while ambiguous ones (ECONNRESET, EPIPE, missing code) are
-   * retryable only for idempotent methods.
+   * surfaced to the caller instead of retried. Among the remaining errors,
+   * connection-never-established failures are retryable for every method,
+   * ambiguous network errors (ECONNRESET, EPIPE, missing code) only for
+   * idempotent methods, and anything else (cancellation, bad config) never —
+   * those fail identically on replay.
    */
   static isRetryableError(error: unknown, method: string): boolean {
     if (!axios.isAxiosError(error) || error.response) {
@@ -132,7 +139,10 @@ export class PostgrestProxyService {
     if (CONNECTION_NOT_ESTABLISHED_CODES.has(code)) {
       return true;
     }
-    return IDEMPOTENT_METHODS.has(method.toUpperCase());
+    if (code === '' || AMBIGUOUS_NETWORK_CODES.has(code)) {
+      return IDEMPOTENT_METHODS.has(method.toUpperCase());
+    }
+    return false;
   }
 
   /**

--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -70,11 +70,30 @@ const EXCLUDED_HEADERS = new Set([
  * Timeout-class errors are never retried: by the time the 10s budget is spent
  * the request may already be executing in PostgREST (retrying a write risks a
  * duplicate), and re-running it amplifies load exactly when the database is
- * saturated. Connection-class errors (ECONNREFUSED, ECONNRESET from a
- * keep-alive socket closed while idle, DNS failures) mean the request was
- * never processed, so those remain retryable.
+ * saturated.
  */
 const TIMEOUT_ERROR_CODES = new Set(['ECONNABORTED', 'ETIMEDOUT']);
+
+/**
+ * Errors that prove the connection was never established, so the request
+ * cannot have reached PostgREST and is safe to retry for any method.
+ */
+const CONNECTION_NOT_ESTABLISHED_CODES = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+]);
+
+/**
+ * Methods safe to replay even when the request may have reached PostgREST.
+ * Everything else (POST/PATCH/PUT/DELETE) only retries errors from
+ * CONNECTION_NOT_ESTABLISHED_CODES: an ECONNRESET is usually a keep-alive
+ * socket closed while idle, but it can also arrive mid-response after the
+ * write already committed, and the two are indistinguishable here.
+ */
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 export class PostgrestProxyService {
   private static instance: PostgrestProxyService;
@@ -95,16 +114,25 @@ export class PostgrestProxyService {
   }
 
   /**
-   * A request may be retried only when PostgREST never received it: a
-   * network-level failure (no HTTP response) that is not a timeout. Any
-   * response — including 5xx — and any timeout is surfaced to the caller
-   * instead of retried.
+   * A request may be retried only when replaying it cannot duplicate work in
+   * PostgREST. Any HTTP response — including 5xx — and any timeout is
+   * surfaced to the caller instead of retried. Among the remaining network
+   * errors, connection-never-established failures are retryable for every
+   * method, while ambiguous ones (ECONNRESET, EPIPE, missing code) are
+   * retryable only for idempotent methods.
    */
-  static isRetryableError(error: unknown): boolean {
+  static isRetryableError(error: unknown, method: string): boolean {
     if (!axios.isAxiosError(error) || error.response) {
       return false;
     }
-    return !TIMEOUT_ERROR_CODES.has(error.code ?? '');
+    const code = error.code ?? '';
+    if (TIMEOUT_ERROR_CODES.has(code)) {
+      return false;
+    }
+    if (CONNECTION_NOT_ESTABLISHED_CODES.has(code)) {
+      return true;
+    }
+    return IDEMPOTENT_METHODS.has(method.toUpperCase());
   }
 
   /**
@@ -224,7 +252,8 @@ export class PostgrestProxyService {
         break;
       } catch (error) {
         lastError = error;
-        const shouldRetry = attempt < maxRetries && PostgrestProxyService.isRetryableError(error);
+        const shouldRetry =
+          attempt < maxRetries && PostgrestProxyService.isRetryableError(error, request.method);
 
         if (shouldRetry) {
           logger.warn(`PostgREST request failed, retrying (attempt ${attempt}/${maxRetries})`, {

--- a/backend/tests/unit/app.config.test.ts
+++ b/backend/tests/unit/app.config.test.ts
@@ -351,7 +351,9 @@ describe('config.database', () => {
       'POSTGRES_USER',
       'POSTGRES_PASSWORD',
       'DATABASE_DIR',
-      'POSTGREST_BASE_URL'
+      'POSTGREST_BASE_URL',
+      'POSTGREST_MAX_SOCKETS',
+      'POSTGREST_MAX_FREE_SOCKETS'
     );
     const c = loadConfig();
 
@@ -361,6 +363,8 @@ describe('config.database', () => {
     expect(c.database.user).toBe('postgres');
     expect(c.database.password).toBe('postgres');
     expect(c.database.postgrestBaseUrl).toBe('http://localhost:5430');
+    expect(c.database.postgrestMaxSockets).toBe(50);
+    expect(c.database.postgrestMaxFreeSockets).toBe(10);
     expect(typeof c.database.dir).toBe('string');
   });
 
@@ -371,6 +375,8 @@ describe('config.database', () => {
     process.env.POSTGRES_USER = 'dbuser';
     process.env.POSTGRES_PASSWORD = 'securepass';
     process.env.POSTGREST_BASE_URL = 'http://postgrest:3000';
+    process.env.POSTGREST_MAX_SOCKETS = '100';
+    process.env.POSTGREST_MAX_FREE_SOCKETS = '25';
     const c = loadConfig();
 
     expect(c.database.host).toBe('db.internal');
@@ -379,6 +385,17 @@ describe('config.database', () => {
     expect(c.database.user).toBe('dbuser');
     expect(c.database.password).toBe('securepass');
     expect(c.database.postgrestBaseUrl).toBe('http://postgrest:3000');
+    expect(c.database.postgrestMaxSockets).toBe(100);
+    expect(c.database.postgrestMaxFreeSockets).toBe(25);
+  });
+
+  it('falls back to defaults for invalid PostgREST pool sizes', () => {
+    process.env.POSTGREST_MAX_SOCKETS = 'not-a-number';
+    process.env.POSTGREST_MAX_FREE_SOCKETS = '-3';
+    const c = loadConfig();
+
+    expect(c.database.postgrestMaxSockets).toBe(50);
+    expect(c.database.postgrestMaxFreeSockets).toBe(10);
   });
 
   it('parses POSTGRES_PORT as integer', () => {

--- a/backend/tests/unit/postgrest-proxy-agent-config.test.ts
+++ b/backend/tests/unit/postgrest-proxy-agent-config.test.ts
@@ -1,0 +1,58 @@
+/**
+ * postgrest-proxy-agent-config.test.ts
+ *
+ * Verifies the HTTP agent construction of the PostgREST proxy: pool sizes
+ * come from app config, and maxFreeSockets is clamped to maxSockets when
+ * misconfigured (e.g. POSTGREST_MAX_FREE_SOCKETS=25 with
+ * POSTGREST_MAX_SOCKETS=10).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import axios from 'axios';
+import http from 'http';
+import https from 'https';
+
+vi.mock('@/infra/config/app.config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/infra/config/app.config')>();
+  return {
+    ...actual,
+    appConfig: {
+      ...actual.appConfig,
+      database: {
+        ...actual.appConfig.database,
+        postgrestMaxSockets: 10,
+        postgrestMaxFreeSockets: 25,
+      },
+    },
+  };
+});
+
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      create: vi.fn(() => vi.fn()),
+    },
+  };
+});
+
+describe('PostgREST proxy agent construction', () => {
+  it('clamps maxFreeSockets to maxSockets on both agents', async () => {
+    await import('../../src/services/database/postgrest-proxy.service');
+
+    const createMock = vi.mocked(axios.create);
+    const call = createMock.mock.calls.find(([options]) => options && 'httpAgent' in options);
+    expect(call).toBeDefined();
+
+    const { httpAgent, httpsAgent } = call![0] as {
+      httpAgent: http.Agent;
+      httpsAgent: https.Agent;
+    };
+    expect(httpAgent.maxSockets).toBe(10);
+    expect(httpAgent.maxFreeSockets).toBe(10);
+    expect(httpsAgent.maxSockets).toBe(10);
+    expect(httpsAgent.maxFreeSockets).toBe(10);
+  });
+});

--- a/backend/tests/unit/postgrest-proxy-retry.test.ts
+++ b/backend/tests/unit/postgrest-proxy-retry.test.ts
@@ -15,7 +15,8 @@
  *   - Ambiguous network errors (ECONNRESET, EPIPE, missing code) are retried
  *     only for idempotent methods (GET/HEAD/OPTIONS) — for writes the request
  *     may already have committed.
- *   - Non-axios errors are NOT retried.
+ *   - Response-less non-network axios errors (cancellation, bad config) and
+ *     non-axios errors are NOT retried.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -80,6 +81,14 @@ describe('PostgrestProxyService.isRetryableError', () => {
     expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined, 504), 'GET')).toBe(
       false
     );
+  });
+
+  it('does not retry response-less non-network axios errors for any method', () => {
+    for (const code of ['ERR_CANCELED', 'ERR_BAD_OPTION_VALUE', 'ERR_FR_TOO_MANY_REDIRECTS']) {
+      for (const method of ALL_METHODS) {
+        expect(PostgrestProxyService.isRetryableError(makeAxiosError(code), method)).toBe(false);
+      }
+    }
   });
 
   it('does not retry non-axios errors', () => {

--- a/backend/tests/unit/postgrest-proxy-retry.test.ts
+++ b/backend/tests/unit/postgrest-proxy-retry.test.ts
@@ -6,11 +6,15 @@
  *
  * Policy under test:
  *   - Any error carrying an HTTP response (4xx/5xx) is NOT retried.
- *   - Timeout-class errors (ECONNABORTED, ETIMEDOUT) are NOT retried: the
- *     request may already be executing in PostgREST, so retrying risks
- *     duplicate writes and amplifies load while the database is saturated.
- *   - Connection-class errors without a response (ECONNREFUSED, ECONNRESET,
- *     DNS failures) ARE retried: the request never reached PostgREST.
+ *   - Timeout-class errors (ECONNABORTED, ETIMEDOUT) are NOT retried for any
+ *     method: the request may already be executing in PostgREST, so retrying
+ *     risks duplicate writes and amplifies load while the database is
+ *     saturated.
+ *   - Connection-never-established errors (ECONNREFUSED, DNS failures) ARE
+ *     retried for every method: the request cannot have reached PostgREST.
+ *   - Ambiguous network errors (ECONNRESET, EPIPE, missing code) are retried
+ *     only for idempotent methods (GET/HEAD/OPTIONS) — for writes the request
+ *     may already have committed.
  *   - Non-axios errors are NOT retried.
  */
 
@@ -27,35 +31,60 @@ function makeAxiosError(code?: string, status?: number): AxiosError {
   return new AxiosError(`test error ${code ?? status}`, code, config, {}, response);
 }
 
+const ALL_METHODS = ['GET', 'HEAD', 'OPTIONS', 'POST', 'PATCH', 'PUT', 'DELETE'];
+const WRITE_METHODS = ['POST', 'PATCH', 'PUT', 'DELETE'];
+const IDEMPOTENT_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
 describe('PostgrestProxyService.isRetryableError', () => {
-  it('retries connection-class errors where the request never reached PostgREST', () => {
-    for (const code of ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN']) {
-      expect(PostgrestProxyService.isRetryableError(makeAxiosError(code))).toBe(true);
+  it('retries connection-never-established errors for every method', () => {
+    for (const code of ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'EHOSTUNREACH', 'ENETUNREACH']) {
+      for (const method of ALL_METHODS) {
+        expect(PostgrestProxyService.isRetryableError(makeAxiosError(code), method)).toBe(true);
+      }
     }
   });
 
-  it('does not retry timeout-class errors', () => {
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ECONNABORTED'))).toBe(false);
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ETIMEDOUT'))).toBe(false);
+  it('retries ambiguous network errors only for idempotent methods', () => {
+    for (const code of ['ECONNRESET', 'EPIPE', undefined]) {
+      for (const method of IDEMPOTENT_METHODS) {
+        expect(PostgrestProxyService.isRetryableError(makeAxiosError(code), method)).toBe(true);
+      }
+      for (const method of WRITE_METHODS) {
+        expect(PostgrestProxyService.isRetryableError(makeAxiosError(code), method)).toBe(false);
+      }
+    }
+  });
+
+  it('matches methods case-insensitively', () => {
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ECONNRESET'), 'get')).toBe(true);
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ECONNRESET'), 'post')).toBe(
+      false
+    );
+  });
+
+  it('does not retry timeout-class errors for any method', () => {
+    for (const code of ['ECONNABORTED', 'ETIMEDOUT']) {
+      for (const method of ALL_METHODS) {
+        expect(PostgrestProxyService.isRetryableError(makeAxiosError(code), method)).toBe(false);
+      }
+    }
   });
 
   it('does not retry errors that carry an HTTP response', () => {
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_RESPONSE', 500))).toBe(
+    expect(
+      PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_RESPONSE', 500), 'GET')
+    ).toBe(false);
+    expect(
+      PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_REQUEST', 400), 'GET')
+    ).toBe(false);
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined, 504), 'GET')).toBe(
       false
     );
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_REQUEST', 400))).toBe(
-      false
-    );
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined, 504))).toBe(false);
-  });
-
-  it('retries network errors without a specific code', () => {
-    expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined))).toBe(true);
   });
 
   it('does not retry non-axios errors', () => {
-    expect(PostgrestProxyService.isRetryableError(new Error('boom'))).toBe(false);
-    expect(PostgrestProxyService.isRetryableError(undefined)).toBe(false);
-    expect(PostgrestProxyService.isRetryableError('ECONNRESET')).toBe(false);
+    expect(PostgrestProxyService.isRetryableError(new Error('boom'), 'GET')).toBe(false);
+    expect(PostgrestProxyService.isRetryableError(undefined, 'GET')).toBe(false);
+    expect(PostgrestProxyService.isRetryableError('ECONNRESET', 'GET')).toBe(false);
   });
 });

--- a/backend/tests/unit/postgrest-proxy-retry.test.ts
+++ b/backend/tests/unit/postgrest-proxy-retry.test.ts
@@ -1,0 +1,61 @@
+/**
+ * postgrest-proxy-retry.test.ts
+ *
+ * Unit tests for PostgrestProxyService.isRetryableError — the retry policy of
+ * the PostgREST proxy.
+ *
+ * Policy under test:
+ *   - Any error carrying an HTTP response (4xx/5xx) is NOT retried.
+ *   - Timeout-class errors (ECONNABORTED, ETIMEDOUT) are NOT retried: the
+ *     request may already be executing in PostgREST, so retrying risks
+ *     duplicate writes and amplifies load while the database is saturated.
+ *   - Connection-class errors without a response (ECONNREFUSED, ECONNRESET,
+ *     DNS failures) ARE retried: the request never reached PostgREST.
+ *   - Non-axios errors are NOT retried.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { PostgrestProxyService } from '../../src/services/database/postgrest-proxy.service';
+
+function makeAxiosError(code?: string, status?: number): AxiosError {
+  const config = { headers: {} } as InternalAxiosRequestConfig;
+  const response =
+    status !== undefined
+      ? ({ status, data: {}, headers: {}, config, statusText: '' } as AxiosResponse)
+      : undefined;
+  return new AxiosError(`test error ${code ?? status}`, code, config, {}, response);
+}
+
+describe('PostgrestProxyService.isRetryableError', () => {
+  it('retries connection-class errors where the request never reached PostgREST', () => {
+    for (const code of ['ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ENOTFOUND', 'EAI_AGAIN']) {
+      expect(PostgrestProxyService.isRetryableError(makeAxiosError(code))).toBe(true);
+    }
+  });
+
+  it('does not retry timeout-class errors', () => {
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ECONNABORTED'))).toBe(false);
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ETIMEDOUT'))).toBe(false);
+  });
+
+  it('does not retry errors that carry an HTTP response', () => {
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_RESPONSE', 500))).toBe(
+      false
+    );
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError('ERR_BAD_REQUEST', 400))).toBe(
+      false
+    );
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined, 504))).toBe(false);
+  });
+
+  it('retries network errors without a specific code', () => {
+    expect(PostgrestProxyService.isRetryableError(makeAxiosError(undefined))).toBe(true);
+  });
+
+  it('does not retry non-axios errors', () => {
+    expect(PostgrestProxyService.isRetryableError(new Error('boom'))).toBe(false);
+    expect(PostgrestProxyService.isRetryableError(undefined)).toBe(false);
+    expect(PostgrestProxyService.isRetryableError('ECONNRESET')).toBe(false);
+  });
+});

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -26,6 +26,8 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: ${POSTGREST_OPENAPI_SERVER_PROXY_URI:-http://localhost:3000}
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
+      # Keep in sync with the backend's POSTGREST_MAX_SOCKETS (default 50)
+      PGRST_DB_POOL: ${PGRST_DB_POOL:-50}
       PGRST_JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
       PGRST_DB_CHANNEL_ENABLED: "true"
       PGRST_DB_CHANNEL: pgrst

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -68,6 +68,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       POSTGREST_BASE_URL: http://postgrest:3000
+      POSTGREST_MAX_SOCKETS: ${POSTGREST_MAX_SOCKETS:-}
+      POSTGREST_MAX_FREE_SOCKETS: ${POSTGREST_MAX_FREE_SOCKETS:-}
       DENO_RUNTIME_URL: http://deno:7133
       LOGS_DIR: /insforge-logs
       STORAGE_DIR: /insforge-storage

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
+      - POSTGREST_MAX_SOCKETS=${POSTGREST_MAX_SOCKETS:-}
+      - POSTGREST_MAX_FREE_SOCKETS=${POSTGREST_MAX_FREE_SOCKETS:-}
       # Deno Runtime URL for serverless functions
       - DENO_RUNTIME_URL=http://deno:7133
       - DENO_DEPLOY_TOKEN=${DENO_DEPLOY_TOKEN:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,8 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
+      # Keep in sync with the backend's POSTGREST_MAX_SOCKETS (default 50)
+      PGRST_DB_POOL: ${PGRST_DB_POOL:-50}
       PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-please-change-in-production}
     ports:
       - "${POSTGREST_PORT:-5430}:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000
       PGRST_DB_SCHEMA: public
       PGRST_DB_ANON_ROLE: anon
+      # Keep in sync with the backend's POSTGREST_MAX_SOCKETS (default 50)
+      PGRST_DB_POOL: ${PGRST_DB_POOL:-50}
       PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-please-change-in-production}
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
+      - POSTGREST_MAX_SOCKETS=${POSTGREST_MAX_SOCKETS:-}
+      - POSTGREST_MAX_FREE_SOCKETS=${POSTGREST_MAX_FREE_SOCKETS:-}
       # Deno Runtime URL for serverless functions
       - DENO_RUNTIME_URL=http://deno:7133
       # Deno Deploy Configuration


### PR DESCRIPTION
## Summary

The backend's HTTP agent pool toward PostgREST was hardcoded at `maxSockets: 20` / `maxFreeSockets: 5`, which caps data-API concurrency below PostgREST's own db pool (`PGRST_DB_POOL`) and cannot be tuned per instance size.

The failure mode under load: requests beyond `maxSockets` queue inside the Node agent, and since axios ≥ 1.18 uses a wall-clock timer on the `maxRedirects: 0` path, **queue wait counts against the 10s timeout**. Saturation therefore surfaced as `ECONNABORTED` timeouts, which the old retry condition (`!error.response`) retried up to 3×, amplifying load exactly when the database was saturated — and risking duplicate writes, since a timed-out request may already be executing in PostgREST.

### Changes

- **Configurable pool**: `POSTGREST_MAX_SOCKETS` (default 50, aligned with PostgREST's db pool) and `POSTGREST_MAX_FREE_SOCKETS` (default 10), read via `appConfig.database`; `maxFreeSockets` is clamped to `maxSockets`. With sockets ≥ the PostgREST pool, overload queues inside PostgREST and returns clean 504s (which carry a response and are never retried) instead of timing out in the agent queue.
- **Tightened retry policy** (`PostgrestProxyService.isRetryableError`): timeout-class errors (`ECONNABORTED`, `ETIMEDOUT`) are no longer retried for any method; connection-class errors (`ECONNREFUSED`, `ECONNRESET` from idle keep-alive races, DNS failures) — where the request never reached PostgREST — remain retryable. Any HTTP response still short-circuits retries as before.
- **Env plumbing**: new vars documented in `.env.example` and passed through the backend service in `docker-compose.yml`, `docker-compose.prod.yml`, and `docker-compose.dokploy.yml`.
- Retry warn log now includes the HTTP method.

## Validation

- `npx turbo run typecheck` — 8/8 pass
- `npx turbo run lint` — pass
- `cd backend && npm test` — 1862 passed; new tests cover config defaults/overrides/invalid-value fallback and the retry classifier (`tests/unit/postgrest-proxy-retry.test.ts`)
  - Pre-existing, unrelated: 8 failures in `tests/unit/deployment-direct-flow.test.ts` (`this.s3Provider.initialize is not a function`) reproduce identically on unmodified `origin/main` when `AWS_S3_BUCKET` is set in the local env; not touched by this PR
- `npx turbo run build` — pass
- Deterministic Fixture E2E gate passed with test image `v2.2.8-postgrest-proxy-pool`: https://github.com/InsForge/agent-e2e/actions/runs/30033183504 (no agent-e2e fixture change needed — no API-contract or SDK-visible behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the PostgREST proxy pool configurable and tightens retries to avoid retrying timeouts and non‑network errors, cutting load spikes and duplicate writes. Defaults align with PostgREST’s DB pool; compose files set `PGRST_DB_POOL` to match.

- **New Features**
  - Add `POSTGREST_MAX_SOCKETS` (default 50) and `POSTGREST_MAX_FREE_SOCKETS` (default 10); clamp free ≤ max and read via app config.
  - Plumb new env vars in `.env.example` and all `docker-compose*`; set `PGRST_DB_POOL` default to 50 to match backend.
  - Pool sizing avoids Node agent queues so overload returns clean 504s instead of `axios` timeouts.

- **Bug Fixes**
  - Stop retrying timeout errors (`ECONNABORTED`, `ETIMEDOUT`).
  - Method-aware retries: retry `ECONNREFUSED`/DNS for all methods; retry only `ECONNRESET`/`EPIPE`/missing code for idempotent methods; do not retry non-network `axios` errors (e.g., `ERR_CANCELED`, bad config).
  - Retry warning log now includes the HTTP method.

<sup>Written for commit 673f2b751570463fee25f8b24f2c1725c1ef56fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make PostgREST proxy HTTP agent pool configurable and exclude timeouts from retries
> - The HTTP/HTTPS agent pool sizes in `PostgrestProxyService` are now configurable via `POSTGREST_MAX_SOCKETS` (default 50) and `POSTGREST_MAX_FREE_SOCKETS` (default 10), replacing hardcoded values of 20/5.
> - Adds `PostgrestProxyService.isRetryableError` to classify errors: connection-level errors without a response are retried, but timeout errors (`ECONNABORTED`, `ETIMEDOUT`) and errors with an HTTP response are not.
> - Behavioral Change: timeout errors are no longer retried, which changes behavior for slow or unresponsive PostgREST connections.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1792 opened
>
> - Refined retry logic in `PostgrestProxyService` to distinguish between connection-never-established errors and ambiguous network errors, making retry decisions dependent on HTTP method [0d7aaed]
> - Added `PGRST_DB_POOL` environment variable configuration to PostgREST service across all docker-compose deployment files [0d7aaed]
> - Added comprehensive test coverage for method-aware retry policy in `PostgrestProxyService` [0d7aaed]
> - Added test coverage validating agent configuration clamps `maxFreeSockets` to `maxSockets` value [0d7aaed]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4354d63.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgREST HTTP connection-pooling configuration with defaults for maximum concurrent sockets and retained idle (keep-alive) sockets, available across local and container deployments.
* **Bug Fixes**
  * Improved PostgREST proxy connection handling by clamping idle connection limits to never exceed the maximum sockets.
  * Refined retry logic to avoid retries for timeouts and HTTP error responses, and to retry only when appropriate for idempotent requests.
* **Tests**
  * Expanded unit coverage for configuration defaults/validation and the updated retry/agent pooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->