### PR TITLE
feat(messaging): Phase 1 — PostgreSQL durable queue with LISTEN/NOTIFY worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -320,6 +320,15 @@ PROJECT_ID=
 APP_KEY=
 
 # -----------------------------------------------------------------------------
+# Messaging Queue Configuration
+# -----------------------------------------------------------------------------
+MESSAGING_LEASE_DURATION_SECONDS=60
+MESSAGING_MAX_RETRY_ATTEMPTS=5
+MESSAGING_BACKOFF_BASE_SECONDS=5
+MESSAGING_JITTER_PERCENT=0.2
+
+
+# -----------------------------------------------------------------------------
 # Serverless Functions Configuration
 # -----------------------------------------------------------------------------
 # Deno Deploy - For hosting serverless edge functions

--- a/backend/package.json
+++ b/backend/package.json
@@ -76,6 +76,7 @@
     "stripe": "^22.1.0",
     "typescript": "^5.3.3",
     "winston": "^3.17.0",
+    "uuid": "^14.0.0",
     "xml2js": "^0.6.2",
     "zod": "^3.23.8"
   },
@@ -90,6 +91,7 @@
     "@types/pg-format": "^1.0.5",
     "@types/picomatch": "^4.0.3",
     "@types/supertest": "^7.2.0",
+    "@types/uuid": "^10.0.0",
     "@types/xml2js": "^0.4.14",
     "dotenv-cli": "^10.0.0",
     "insforge-test": "^0.2.0",

--- a/backend/src/api/routes/messaging/index.routes.ts
+++ b/backend/src/api/routes/messaging/index.routes.ts
@@ -1,0 +1,50 @@
+import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { AuthRequest, verifyAdmin } from '@/api/middlewares/auth.js';
+import { MessagingQueueService } from '@/services/messaging/queue.service.js';
+import { successResponse } from '@/utils/response.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
+/**
+ * Express router for administrative messaging queue endpoints.
+ */
+const router = Router();
+const queueService = MessagingQueueService.getInstance();
+
+const sendPayloadSchema = z.object({
+  channel: z.enum(['email', 'sms', 'push']),
+  to: z.string().min(1),
+  subject: z.string().optional(),
+  body: z.string().optional(),
+  idempotencyKey: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+/**
+ * POST /api/messaging/send
+ * Enqueues a raw transactional message for processing. Requires admin authentication.
+ *
+ * @param req - AuthRequest containing user credentials and body payload
+ * @param res - Express Response object
+ * @param next - Express NextFunction
+ */
+router.post('/send', verifyAdmin, async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const validation = sendPayloadSchema.safeParse(req.body);
+    if (!validation.success) {
+      throw new AppError(
+        validation.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
+    const { id: messageId, status } = await queueService.enqueue(validation.data);
+    successResponse(res, { messageId, status }, 202);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -108,6 +108,14 @@ export interface AppConfig {
   telemetry: {
     disabled: boolean;
   };
+  messaging: {
+    leaseDurationSeconds: number;
+    maxRetryAttempts: number;
+    backoffBaseSeconds: number;
+    jitterPercent: number;
+    maxConcurrency: number;
+    reconciliationIntervalSeconds: number;
+  };
 }
 
 function parseEnvInt(val: string | undefined, fallback: number): number {
@@ -258,6 +266,21 @@ export function loadConfig(): AppConfig {
     },
     telemetry: {
       disabled: parseEnvBool(process.env.INSFORGE_TELEMETRY_DISABLED),
+    },
+    messaging: {
+      leaseDurationSeconds: parseEnvInt(process.env.MESSAGING_LEASE_DURATION_SECONDS, 60),
+      maxRetryAttempts: parseEnvInt(process.env.MESSAGING_MAX_RETRY_ATTEMPTS, 5),
+      backoffBaseSeconds: parseEnvInt(process.env.MESSAGING_BACKOFF_BASE_SECONDS, 5),
+      jitterPercent: (() => {
+        const raw = process.env.MESSAGING_JITTER_PERCENT;
+        const val = raw === undefined || raw.trim() === '' ? 0.2 : Number(raw);
+        return !Number.isFinite(val) || val < 0 || val > 1 ? 0.2 : val;
+      })(),
+      maxConcurrency: parseEnvInt(process.env.MESSAGING_MAX_CONCURRENCY, 5),
+      reconciliationIntervalSeconds: parseEnvInt(
+        process.env.MESSAGING_RECONCILIATION_INTERVAL_SECONDS,
+        30
+      ),
     },
   };
 }

--- a/backend/src/infra/database/migrations/065_create-messaging-schema.sql
+++ b/backend/src/infra/database/migrations/065_create-messaging-schema.sql
@@ -1,0 +1,141 @@
+-- Migration 065: Create PostgreSQL-native messaging schema for outbox queue
+
+CREATE SCHEMA IF NOT EXISTS messaging;
+
+-- Outbox queue table
+CREATE TABLE IF NOT EXISTS messaging.outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    channel TEXT NOT NULL CHECK (channel IN ('email', 'sms', 'push')),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'claimed', 'sent', 'failed', 'dead')),
+    payload JSONB NOT NULL,
+    idempotency_key TEXT,
+    claimed_by TEXT,
+    claimed_at TIMESTAMPTZ,
+    lease_expires_at TIMESTAMPTZ,
+    claim_token UUID DEFAULT NULL,
+    retry_count INT NOT NULL DEFAULT 0,
+    max_retries INT NOT NULL DEFAULT 5,
+    next_attempt_at TIMESTAMPTZ DEFAULT NOW(),
+    provider_message_id TEXT,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Unique index for idempotency keys within active outbox
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messaging_outbox_idempotency 
+ON messaging.outbox (idempotency_key) 
+WHERE idempotency_key IS NOT NULL;
+
+-- Index for worker polling and atomic claims
+CREATE INDEX IF NOT EXISTS idx_messaging_outbox_fetch 
+ON messaging.outbox (next_attempt_at ASC, created_at ASC) 
+WHERE status = 'pending';
+
+-- Partial index for lease expiration recovery
+CREATE INDEX IF NOT EXISTS idx_messaging_outbox_lease_expires 
+ON messaging.outbox (lease_expires_at) 
+WHERE status = 'claimed';
+
+-- Delivery attempt log table
+CREATE TABLE IF NOT EXISTS messaging.delivery_attempts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id UUID NOT NULL,
+    attempt_number INT NOT NULL,
+    worker_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    provider_message_id TEXT,
+    error_message TEXT,
+    attempted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    duration_ms INT
+);
+
+CREATE INDEX IF NOT EXISTS idx_messaging_delivery_attempts_msg_id 
+ON messaging.delivery_attempts (message_id);
+
+DROP INDEX IF EXISTS idx_delivery_attempts_unique;
+DROP INDEX IF EXISTS uk_messaging_delivery_attempts_msg_attempt;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_messaging_delivery_attempts_msg_attempt
+ON messaging.delivery_attempts (message_id, attempt_number);
+
+-- Dead letter queue table
+CREATE TABLE IF NOT EXISTS messaging.dead_letter (
+    id UUID PRIMARY KEY,
+    channel TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    idempotency_key TEXT,
+    retry_count INT NOT NULL,
+    max_retries INT NOT NULL,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    moved_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Trigger function for LISTEN / NOTIFY on new job insertion
+CREATE OR REPLACE FUNCTION messaging.notify_new_job()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify('messaging_new_job', NEW.id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_messaging_notify_new_job ON messaging.outbox;
+CREATE TRIGGER trg_messaging_notify_new_job
+AFTER INSERT ON messaging.outbox
+FOR EACH ROW
+WHEN (NEW.status = 'pending')
+EXECUTE FUNCTION messaging.notify_new_job();
+
+-- Reconciliation function to recover expired leases and schedule retries
+CREATE OR REPLACE FUNCTION messaging.reconcile_jobs(
+    p_backoff_base_seconds INT DEFAULT 5,
+    p_jitter_pct FLOAT DEFAULT 0.2
+)
+RETURNS INT AS $$
+DECLARE
+    v_count INT := 0;
+    r RECORD;
+    v_jitter_factor FLOAT;
+    v_delay_seconds FLOAT;
+BEGIN
+    FOR r IN 
+        SELECT id, retry_count, max_retries
+        FROM messaging.outbox
+        WHERE status = 'claimed' 
+          AND lease_expires_at <= NOW()
+        ORDER BY lease_expires_at ASC, id ASC
+        LIMIT 100
+        FOR UPDATE SKIP LOCKED
+    LOOP
+        v_count := v_count + 1;
+        IF r.retry_count + 1 >= r.max_retries THEN
+            -- Promote to dead_letter
+            INSERT INTO messaging.dead_letter (
+                id, channel, payload, idempotency_key, retry_count, max_retries, error_message, created_at, moved_at
+            )
+            SELECT id, channel, payload, idempotency_key, retry_count + 1, max_retries, 'Lease expired (max retries reached)', created_at, NOW()
+            FROM messaging.outbox WHERE id = r.id
+            ON CONFLICT (id) DO NOTHING;
+
+            DELETE FROM messaging.outbox WHERE id = r.id;
+        ELSE
+            v_jitter_factor := 1.0 + ((random() * 2.0 - 1.0) * p_jitter_pct);
+            v_delay_seconds := (p_backoff_base_seconds * power(2, r.retry_count)) * v_jitter_factor;
+
+            UPDATE messaging.outbox
+            SET status = 'pending',
+                retry_count = retry_count + 1,
+                claimed_by = NULL,
+                claimed_at = NULL,
+                lease_expires_at = NULL,
+                claim_token = NULL,
+                next_attempt_at = NOW() + (v_delay_seconds || ' seconds')::INTERVAL,
+                updated_at = NOW()
+            WHERE id = r.id;
+        END IF;
+    END LOOP;
+
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/src/providers/email/base.provider.ts
+++ b/backend/src/providers/email/base.provider.ts
@@ -1,6 +1,8 @@
 import { EmailTemplate } from '@/types/email.js';
 import { SendRawEmailRequest } from '@insforge/shared-schemas';
 
+export type SendRawEmailOptions = SendRawEmailRequest & { idempotencyKey?: string };
+
 /**
  * Email provider interface
  * Defines the contract that all email providers must implement
@@ -27,9 +29,9 @@ export interface EmailProvider {
 
   /**
    * Send custom/raw email (optional - not all providers may support this)
-   * @param options - Email options (to, subject, html, cc, bcc, from, replyTo)
+   * @param options - Email options (to, subject, html, cc, bcc, from, replyTo, idempotencyKey)
    */
-  sendRaw?(options: SendRawEmailRequest): Promise<void>;
+  sendRaw?(options: SendRawEmailOptions, signal?: AbortSignal): Promise<void>;
 
   /**
    * Check if provider supports template-based emails

--- a/backend/src/providers/email/cloud.provider.ts
+++ b/backend/src/providers/email/cloud.provider.ts
@@ -4,8 +4,8 @@ import { appConfig } from '@/infra/config/app.config.js';
 import logger from '@/utils/logger.js';
 import { AppError } from '@/utils/errors.js';
 import { EMAIL_TEMPLATE_TYPES, EmailTemplate } from '@/types/email.js';
-import { EmailProvider } from './base.provider.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
+import { EmailProvider, SendRawEmailOptions } from './base.provider.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
 
 /**
  * Cloud email provider for sending emails via Insforge cloud backend
@@ -182,11 +182,26 @@ export class CloudEmailProvider implements EmailProvider {
   /**
    * Send custom/raw email via cloud backend
    */
-  async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  async sendRaw(options: SendRawEmailOptions, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new AppError(
+        'Email sending aborted due to lost claim',
+        500,
+        ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+      );
+    }
     try {
       const projectId = appConfig.cloud.projectId;
       const apiHost = appConfig.cloud.apiHost;
       const signToken = this.generateSignToken();
+
+      if (signal?.aborted) {
+        throw new AppError(
+          'Email sending aborted due to lost claim',
+          500,
+          ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+        );
+      }
 
       const url = `${apiHost}/email/v1/${projectId}/send-on-demand`;
       const response = await axios.post(url, options, {
@@ -194,6 +209,7 @@ export class CloudEmailProvider implements EmailProvider {
           'Content-Type': 'application/json',
           sign: signToken,
         },
+        signal,
         timeout: 10000,
       });
 
@@ -207,6 +223,14 @@ export class CloudEmailProvider implements EmailProvider {
         );
       }
     } catch (error) {
+      if (axios.isCancel(error) || signal?.aborted) {
+        throw new AppError(
+          'Email sending aborted due to lost claim',
+          500,
+          ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+        );
+      }
+
       if (axios.isAxiosError(error)) {
         const status = error.response?.status;
         const message = error.response?.data?.message || error.message;

--- a/backend/src/providers/email/smtp.provider.ts
+++ b/backend/src/providers/email/smtp.provider.ts
@@ -1,13 +1,20 @@
+import { createHash } from 'crypto';
 import nodemailer from 'nodemailer';
 import type Mail from 'nodemailer/lib/mailer';
 import { AppError } from '@/utils/errors.js';
 import { EmailTemplate } from '@/types/email.js';
 import { SmtpConfigService, RawSmtpConfig } from '@/services/email/smtp-config.service.js';
 import { EmailTemplateService } from '@/services/email/email-template.service.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
-import { EmailProvider } from './base.provider.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { EmailProvider, SendRawEmailOptions } from './base.provider.js';
 import logger from '@/utils/logger.js';
 
+/**
+ * Escapes HTML characters in dynamic template variable values.
+ *
+ * @param value - Unsafe input string
+ * @returns HTML-safe escaped string
+ */
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -17,20 +24,57 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Escapes regex special characters in template search tokens.
+ *
+ * @param str - Input string pattern
+ * @returns Escaped regex string
+ */
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Formats sender name and address for standard RFC 5322 From headers.
+ *
+ * @param name - Display name of sender
+ * @param email - Sender email address
+ * @returns Formatted RFC 5322 address string
+ */
 function formatFromAddress(name: string, email: string): string {
   const safeName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   return `"${safeName}" <${email}>`;
 }
 
+/**
+ * SMTP Email Provider implementation supporting raw message transmission and template rendering.
+ */
 export class SmtpEmailProvider implements EmailProvider {
+  /**
+   * Indicates whether this provider supports system email templates.
+   *
+   * @returns True
+   */
   supportsTemplates(): boolean {
     return true;
   }
 
+  /**
+   * Sanitizes an idempotency key using SHA-256 to generate a deterministic, valid RFC 5322 Message-ID local-part.
+   *
+   * @param key - Raw idempotency key or message identifier
+   * @returns Deterministic SHA-256 hex string
+   */
+  private sanitizeMessageIdKey(key: string): string {
+    return createHash('sha256').update(key).digest('hex');
+  }
+
+  /**
+   * Creates an active Nodemailer transport instance using current SMTP configuration.
+   *
+   * @param config - Decrypted SMTP credentials and settings
+   * @returns Nodemailer Transporter instance
+   */
   private createTransporter(config: RawSmtpConfig) {
     return nodemailer.createTransport({
       host: config.host,
@@ -41,6 +85,13 @@ export class SmtpEmailProvider implements EmailProvider {
     });
   }
 
+  /**
+   * Replaces dynamic tokens in HTML email template bodies.
+   *
+   * @param template - Raw HTML template with variable placeholders
+   * @param variables - Key-value map of variable replacements
+   * @returns Rendered HTML content
+   */
   private renderTemplate(template: string, variables: Record<string, string>): string {
     let rendered = template;
     for (const [key, value] of Object.entries(variables)) {
@@ -58,7 +109,9 @@ export class SmtpEmailProvider implements EmailProvider {
   }
 
   /**
-   * Get SMTP config or throw. Shared by all send methods.
+   * Retrieves active SMTP configuration from database or throws an error.
+   *
+   * @returns Decrypted RawSmtpConfig
    */
   private async getRequiredConfig(): Promise<RawSmtpConfig> {
     const config = await SmtpConfigService.getInstance().getRawSmtpConfig();
@@ -73,33 +126,62 @@ export class SmtpEmailProvider implements EmailProvider {
   }
 
   /**
-   * Send an email via SMTP with error handling and transport cleanup.
+   * Sends an email via SMTP transport with pre-send abort verification and logging.
+   *
+   * @param config - Decrypted SMTP configuration
+   * @param mailOptions - Nodemailer mail options
+   * @param logContext - Context attributes for structured logging
+   * @param signal - Optional AbortSignal checked prior to starting transmission
+   * @returns Promise resolving when transmission succeeds
    */
   private async send(
     config: RawSmtpConfig,
     mailOptions: Mail.Options,
-    logContext: Record<string, unknown>
+    logContext: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<void> {
     const transporter = this.createTransporter(config);
+
     try {
+      if (signal?.aborted) {
+        throw new AppError(
+          'Email sending aborted due to lost claim',
+          500,
+          ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+        );
+      }
+
+      // Phase 1: AbortSignal is checked pre-flight only. In-flight SMTP sends cannot be recalled.
       await transporter.sendMail({
         from: formatFromAddress(config.senderName, config.senderEmail),
         ...mailOptions,
       });
+
       logger.info('Email sent via SMTP', logContext);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown SMTP error';
       logger.error(`Failed to send email via SMTP: ${message}`, logContext);
-      throw new AppError(
-        `Failed to send email via SMTP: ${message}`,
-        500,
-        ERROR_CODES.EMAIL_SMTP_SEND_FAILED
-      );
+      throw error instanceof AppError
+        ? error
+        : new AppError(
+            `Failed to send email via SMTP: ${message}`,
+            500,
+            ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+          );
     } finally {
       transporter.close();
     }
   }
 
+  /**
+   * Sends an email populated from a registered system template.
+   *
+   * @param email - Recipient email address
+   * @param name - Recipient display name
+   * @param template - System template identifier
+   * @param variables - Dynamic variable values
+   * @returns Promise resolving when email is delivered
+   */
   async sendWithTemplate(
     email: string,
     name: string,
@@ -123,8 +205,33 @@ export class SmtpEmailProvider implements EmailProvider {
     );
   }
 
-  async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  /**
+   * Sends a raw email payload directly with optional deterministic Message-ID.
+   *
+   * @param options - Raw email options including recipient, subject, HTML content, and optional idempotency key
+   * @param signal - Optional AbortSignal checked prior to dispatch
+   * @returns Promise resolving when email is delivered
+   */
+  async sendRaw(options: SendRawEmailOptions, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new AppError(
+        'Email sending aborted due to lost claim',
+        500,
+        ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+      );
+    }
     const config = await this.getRequiredConfig();
+    if (signal?.aborted) {
+      throw new AppError(
+        'Email sending aborted due to lost claim',
+        500,
+        ERROR_CODES.EMAIL_SMTP_SEND_FAILED
+      );
+    }
+
+    const messageId = options.idempotencyKey
+      ? `<${this.sanitizeMessageIdKey(options.idempotencyKey)}@insforge.messaging>`
+      : undefined;
 
     await this.send(
       config,
@@ -135,8 +242,10 @@ export class SmtpEmailProvider implements EmailProvider {
         cc: options.cc,
         bcc: options.bcc,
         replyTo: options.replyTo,
+        messageId,
       },
-      { to: options.to }
+      { to: options.to },
+      signal
     );
   }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -51,6 +51,10 @@ import {
 } from '@/services/telemetry/telemetry.service.js';
 import { FeatureUsageCollector } from '@/services/telemetry/feature-usage.collector.js';
 import { TokenManager } from '@/infra/security/token.manager.js';
+import messagingRouter from '@/api/routes/messaging/index.routes.js';
+import { MessagingQueueService } from '@/services/messaging/queue.service.js';
+import { EmailService } from '@/services/email/email.service.js';
+import { MessagingWorker } from '@/services/messaging/worker.service.js';
 import { DatabaseBackupService } from '@/services/database/database-backup.service.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -235,6 +239,7 @@ export async function createApp() {
   apiRouter.use('/memory', memoryRouter);
   apiRouter.use('/realtime', realtimeRouter);
   apiRouter.use('/email', emailRouter);
+  apiRouter.use('/messaging', messagingRouter);
   apiRouter.use('/deployments', deploymentsRouter);
   apiRouter.use('/schedules', schedulesRouter);
   apiRouter.use('/payments', paymentsRouter);
@@ -346,6 +351,8 @@ export async function createApp() {
 // Use PORT from config (already parsed from env, falls back to 7130)
 const PORT = appConfig.app.port;
 
+let messagingWorker: MessagingWorker | null = null;
+
 async function initializeServer() {
   try {
     const app = await createApp();
@@ -376,6 +383,12 @@ async function initializeServer() {
 
     TelemetryService.getInstance().start();
 
+    // Start MessagingWorker
+    const messagingQueueService = MessagingQueueService.getInstance();
+    const emailService = EmailService.getInstance();
+    messagingWorker = new MessagingWorker(messagingQueueService, emailService);
+    await messagingWorker.start();
+
     // Scheduled backups are self-hosting only; the cloud control plane owns
     // backups there (the backup routes are not even mounted in cloud env).
     if (!isCloudEnvironment()) {
@@ -394,6 +407,16 @@ void initializeServer();
 
 async function cleanup() {
   logger.info('Shutting down gracefully...');
+
+  if (messagingWorker) {
+    try {
+      await messagingWorker.stop();
+    } catch (error) {
+      logger.error('Error stopping MessagingWorker', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 
   DatabaseBackupService.getInstance().stopScheduler();
 

--- a/backend/src/services/email/email.service.ts
+++ b/backend/src/services/email/email.service.ts
@@ -1,11 +1,11 @@
-import { EmailProvider } from '@/providers/email/base.provider.js';
+import { EmailProvider, SendRawEmailOptions } from '@/providers/email/base.provider.js';
 import { CloudEmailProvider } from '@/providers/email/cloud.provider.js';
 import { SmtpEmailProvider } from '@/providers/email/smtp.provider.js';
 import { SmtpConfigService, RawSmtpConfig } from '@/services/email/smtp-config.service.js';
 import { AppError } from '@/utils/errors.js';
 import { EmailTemplate } from '@/types/email.js';
 import logger from '@/utils/logger.js';
-import { ERROR_CODES, SendRawEmailRequest } from '@insforge/shared-schemas';
+import { ERROR_CODES } from '@insforge/shared-schemas';
 
 /**
  * Email service — resolves provider per-call so SMTP config changes take effect without restart
@@ -100,7 +100,7 @@ export class EmailService {
     }
   }
 
-  public async sendRaw(options: SendRawEmailRequest): Promise<void> {
+  public async sendRaw(options: SendRawEmailOptions, signal?: AbortSignal): Promise<void> {
     const [provider, smtpConfig] = await this.resolveProvider();
 
     const recipients = Array.isArray(options.to) ? options.to : [options.to];
@@ -114,7 +114,7 @@ export class EmailService {
     if (!provider.sendRaw) {
       throw new Error('Current email provider does not support raw email sending');
     }
-    await provider.sendRaw(options);
+    await provider.sendRaw(options, signal);
 
     if (smtpConfig) {
       for (const recipient of recipients) {

--- a/backend/src/services/messaging/queue.service.ts
+++ b/backend/src/services/messaging/queue.service.ts
@@ -1,0 +1,401 @@
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { MessagePayload, OutboxMessage, MessageStatus } from '@/types/messaging.js';
+import { appConfig } from '@/infra/config/app.config.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import logger from '@/utils/logger.js';
+
+/**
+ * Service for managing PostgreSQL-native outbox queue operations,
+ * including atomic enqueueing with idempotency, locking leases with FOR UPDATE SKIP LOCKED,
+ * delivery confirmations, and retry reconciliations.
+ */
+export class MessagingQueueService {
+  private static instance: MessagingQueueService;
+
+  /**
+   * Constructs the MessagingQueueService instance.
+   *
+   * @param db - DatabaseManager instance providing PostgreSQL pool connections
+   */
+  constructor(private db: DatabaseManager) {}
+
+  /**
+   * Retrieves or creates the singleton instance of MessagingQueueService.
+   *
+   * @returns The active MessagingQueueService singleton instance
+   */
+  public static getInstance(): MessagingQueueService {
+    if (!MessagingQueueService.instance) {
+      MessagingQueueService.instance = new MessagingQueueService(DatabaseManager.getInstance());
+    }
+    return MessagingQueueService.instance;
+  }
+
+  /**
+   * Retrieves the underlying PostgreSQL connection pool.
+   *
+   * @returns PostgreSQL connection pool instance
+   */
+  private getPool() {
+    return this.db.getPool();
+  }
+
+  /**
+   * Performs semantic payload equality comparison between two message payloads.
+   *
+   * @param p1 - First message payload
+   * @param p2 - Second message payload
+   * @returns True if both payloads match in channel, recipient, subject, and body
+   */
+  private isPayloadEqual(p1: MessagePayload, p2: MessagePayload): boolean {
+    return (
+      p1.channel === p2.channel &&
+      p1.to === p2.to &&
+      (p1.subject || '') === (p2.subject || '') &&
+      (p1.body || '') === (p2.body || '')
+    );
+  }
+
+  /**
+   * Resolves the result row returned from an enqueue query or fallback re-query.
+   * Validates that payload matches the original request payload and returns the result object.
+   *
+   * @param row - Database row object from outbox or dead_letter
+   * @param payload - Target message payload
+   * @throws {AppError} Throws 409 Conflict if idempotency key payload differs
+   * @returns Enqueue result object with message id, status, and isDuplicate indicator
+   */
+  private resolveEnqueueResult(
+    row: { id: string; status: string; payload: unknown; is_dead?: boolean },
+    payload: MessagePayload
+  ): { id: string; status: MessageStatus; isDuplicate?: boolean } {
+    const dbPayload = typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload;
+    if (!this.isPayloadEqual(payload, dbPayload)) {
+      throw new AppError(
+        'Idempotency key conflict: different payload',
+        409,
+        ERROR_CODES.DATABASE_DUPLICATE
+      );
+    }
+    return {
+      id: row.id,
+      status: (row.is_dead ? 'dead' : row.status) as MessageStatus,
+      isDuplicate: true,
+    };
+  }
+
+  /**
+   * Enqueues a message payload into the outbox queue atomically.
+   * Handles idempotency key conflicts and returns status.
+   *
+   * @param payload - Message payload containing channel, recipient, subject, and body
+   * @throws {AppError} Throws 400 for invalid input, 501 for unsupported channels, or 409 for idempotency conflicts
+   * @returns Enqueue result with message id, status, and optional isDuplicate flag
+   */
+  async enqueue(
+    payload: MessagePayload
+  ): Promise<{ id: string; status: MessageStatus; isDuplicate?: boolean }> {
+    if (payload.channel === 'sms' || payload.channel === 'push') {
+      throw new AppError(
+        `Channel '${payload.channel}' is not supported in Phase 1`,
+        501,
+        ERROR_CODES.NOT_IMPLEMENTED
+      );
+    }
+    if (payload.channel !== 'email') {
+      throw new AppError('Invalid channel', 400, ERROR_CODES.INVALID_INPUT);
+    }
+    if (!payload.to || !payload.subject || !payload.body) {
+      throw new AppError('Missing required fields', 400, ERROR_CODES.INVALID_INPUT);
+    }
+
+    const pool = this.getPool();
+    const maxRetries = appConfig.messaging.maxRetryAttempts;
+
+    if (payload.idempotencyKey) {
+      const cteSql = `
+        WITH dead_check AS (
+          SELECT 1 FROM messaging.dead_letter WHERE idempotency_key = $3
+        ),
+        inserted AS (
+          INSERT INTO messaging.outbox (channel, status, payload, idempotency_key, retry_count, max_retries, next_attempt_at)
+          SELECT $1, 'pending', $2, $3, 0, $4, NOW()
+          WHERE NOT EXISTS (SELECT 1 FROM dead_check)
+          ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
+          RETURNING *, true AS is_new, false AS is_dead
+        )
+        SELECT id, status, payload, created_at, true AS is_new, false AS is_dead FROM inserted
+        UNION ALL
+        SELECT id, status, payload, created_at, false AS is_new, false AS is_dead FROM messaging.outbox 
+        WHERE idempotency_key = $3 AND idempotency_key IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM inserted)
+        UNION ALL
+        SELECT id, 'dead' AS status, payload, created_at, false AS is_new, true AS is_dead FROM messaging.dead_letter 
+        WHERE idempotency_key = $3
+          AND NOT EXISTS (SELECT 1 FROM inserted);
+      `;
+
+      const res = await pool.query(cteSql, [
+        payload.channel,
+        JSON.stringify(payload),
+        payload.idempotencyKey,
+        maxRetries,
+      ]);
+
+      if (res.rows.length > 0) {
+        const row = res.rows[0];
+        if (row.is_new) {
+          return { id: row.id, status: 'pending' };
+        }
+        return this.resolveEnqueueResult(row, payload);
+      }
+
+      // Re-query outbox for concurrent transaction winner
+      const outboxRes = await pool.query(
+        'SELECT id, status, payload, false AS is_dead FROM messaging.outbox WHERE idempotency_key = $1',
+        [payload.idempotencyKey]
+      );
+      if (outboxRes.rows.length > 0) {
+        return this.resolveEnqueueResult(outboxRes.rows[0], payload);
+      }
+
+      // Re-query dead letter queue for permanently failed messages
+      const deadRes = await pool.query(
+        "SELECT id, 'dead' AS status, payload, true AS is_dead FROM messaging.dead_letter WHERE idempotency_key = $1",
+        [payload.idempotencyKey]
+      );
+      if (deadRes.rows.length > 0) {
+        return this.resolveEnqueueResult(deadRes.rows[0], payload);
+      }
+
+      throw new AppError(
+        'Idempotency key conflict: concurrent request in progress',
+        409,
+        ERROR_CODES.DATABASE_DUPLICATE
+      );
+    }
+
+    const sql = `
+      INSERT INTO messaging.outbox (channel, status, payload, idempotency_key, retry_count, max_retries, next_attempt_at)
+      VALUES ($1, 'pending', $2, NULL, 0, $3, NOW())
+      RETURNING id;
+    `;
+    const res = await pool.query(sql, [payload.channel, JSON.stringify(payload), maxRetries]);
+    return { id: res.rows[0].id, status: 'pending' };
+  }
+
+  /**
+   * Claims a pending outbox job for worker processing using FOR UPDATE SKIP LOCKED.
+   *
+   * @param workerId - Identifier of the worker claiming the job
+   * @param leaseSeconds - Duration of lease lock in seconds
+   * @returns Claimed message object or null if no pending job is available
+   */
+  async claim(
+    workerId: string,
+    leaseSeconds: number = appConfig.messaging.leaseDurationSeconds
+  ): Promise<OutboxMessage | null> {
+    const sql = `
+      UPDATE messaging.outbox
+      SET status = 'claimed',
+          claimed_by = $1,
+          claimed_at = NOW(),
+          lease_expires_at = NOW() + ($2 || ' seconds')::INTERVAL,
+          claim_token = gen_random_uuid(),
+          updated_at = NOW()
+      WHERE id = (
+        SELECT id FROM messaging.outbox
+        WHERE status = 'pending' AND next_attempt_at <= NOW()
+        ORDER BY next_attempt_at ASC, created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *;
+    `;
+    const res = await this.getPool().query(sql, [workerId, leaseSeconds]);
+    if (res.rows.length === 0) {
+      return null;
+    }
+    return this.mapDbToOutboxMessage(res.rows[0]);
+  }
+
+  /**
+   * Marks a claimed job as successfully delivered in outbox.
+   *
+   * @param messageId - Outbox message UUID
+   * @param providerMessageId - Delivery provider message ID
+   * @param workerId - Worker ID matching active claim
+   * @param claimToken - Unique claim token matching active lease
+   * @returns True if successfully marked sent, false if lease was lost
+   */
+  async markSent(
+    messageId: string,
+    providerMessageId: string,
+    workerId: string,
+    claimToken: string
+  ): Promise<boolean> {
+    const sql = `
+      UPDATE messaging.outbox
+      SET status = 'sent',
+          provider_message_id = $2,
+          claimed_by = NULL,
+          claimed_at = NULL,
+          lease_expires_at = NULL,
+          claim_token = NULL,
+          updated_at = NOW()
+      WHERE id = $1 AND claimed_by = $3 AND claim_token = $4::uuid;
+    `;
+    const res = await this.getPool().query(sql, [
+      messageId,
+      providerMessageId,
+      workerId,
+      claimToken,
+    ]);
+    if (res.rowCount === 0) {
+      logger.warn(
+        `markSent no-op: message ${messageId} was reclaimed or dead-lettered by another worker`
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Renews the active lease timeout for an in-flight job.
+   *
+   * @param messageId - Outbox message UUID
+   * @param workerId - Worker ID holding active claim
+   * @param claimToken - Unique claim token holding active lease
+   * @returns True if lease was successfully renewed, false otherwise
+   */
+  async renewLease(messageId: string, workerId: string, claimToken: string): Promise<boolean> {
+    const leaseSeconds = appConfig.messaging.leaseDurationSeconds;
+    const sql = `
+      UPDATE messaging.outbox
+      SET lease_expires_at = NOW() + ($2 || ' seconds')::INTERVAL,
+          updated_at = NOW()
+      WHERE id = $1 AND claimed_by = $3 AND claim_token = $4::uuid AND lease_expires_at > NOW();
+    `;
+    const res = await this.getPool().query(sql, [messageId, leaseSeconds, workerId, claimToken]);
+    return (res.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Marks a job attempt as failed, incrementing retry count or promoting to DLQ.
+   *
+   * @param messageId - Outbox message UUID
+   * @param error - Error instance or message string causing failure
+   * @param workerId - Worker ID holding active claim
+   * @param claimToken - Unique claim token holding active lease
+   * @throws Throws error if transaction fails during failure update
+   */
+  async markFailed(
+    messageId: string,
+    error: Error | string,
+    workerId: string,
+    claimToken: string
+  ): Promise<void> {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const pool = this.getPool();
+    const client = await pool.connect();
+
+    try {
+      await client.query('BEGIN');
+
+      const backoffBase = appConfig.messaging.backoffBaseSeconds;
+      const updateSql = `
+        UPDATE messaging.outbox
+        SET status = CASE WHEN retry_count + 1 >= max_retries THEN 'dead' ELSE 'pending' END,
+            retry_count = retry_count + 1,
+            claimed_by = NULL,
+            claimed_at = NULL,
+            lease_expires_at = NULL,
+            claim_token = NULL,
+            error_message = $3,
+            next_attempt_at = CASE WHEN retry_count + 1 >= max_retries THEN NULL ELSE NOW() + (($4 * power(2, retry_count)) || ' seconds')::INTERVAL END,
+            updated_at = NOW()
+        WHERE id = $1 AND claimed_by = $2 AND claim_token = $5::uuid AND lease_expires_at > NOW()
+        RETURNING id, status, retry_count, max_retries, channel, payload, idempotency_key, error_message, created_at;
+      `;
+
+      const res = await client.query(updateSql, [
+        messageId,
+        workerId,
+        errorMsg,
+        backoffBase,
+        claimToken,
+      ]);
+
+      if (res.rows.length > 0 && res.rows[0].status === 'dead') {
+        const row = res.rows[0];
+        await client.query(
+          `INSERT INTO messaging.dead_letter (id, channel, payload, idempotency_key, retry_count, max_retries, error_message, created_at, moved_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW());`,
+          [
+            row.id,
+            row.channel,
+            row.payload,
+            row.idempotency_key,
+            row.retry_count,
+            row.max_retries,
+            row.error_message,
+            row.created_at,
+          ]
+        );
+        await client.query('DELETE FROM messaging.outbox WHERE id = $1;', [messageId]);
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Reconciles expired leases and schedules retries via PostgreSQL stored procedure.
+   *
+   * @param backoffBase - Base delay in seconds for exponential backoff
+   * @param jitterPct - Jitter percentage for retry randomization
+   * @throws Throws error if reconciliation query fails
+   */
+  async reconcile(backoffBase = 5, jitterPct = 0.2): Promise<void> {
+    await this.getPool().query('SELECT messaging.reconcile_jobs($1, $2);', [
+      backoffBase,
+      jitterPct,
+    ]);
+  }
+
+  /**
+   * Maps a raw PostgreSQL outbox row record to a strongly-typed OutboxMessage entity.
+   *
+   * @param r - Raw database row key-value map
+   * @returns Strongly-typed OutboxMessage instance
+   */
+  private mapDbToOutboxMessage(r: Record<string, unknown>): OutboxMessage {
+    return {
+      id: r.id as string,
+      channel: r.channel as OutboxMessage['channel'],
+      status: r.status as MessageStatus,
+      payload:
+        typeof r.payload === 'string'
+          ? JSON.parse(r.payload)
+          : (r.payload as OutboxMessage['payload']),
+      idempotencyKey: (r.idempotency_key as string) || undefined,
+      claimedBy: (r.claimed_by as string) || undefined,
+      claimedAt: r.claimed_at ? (r.claimed_at as Date).toISOString() : undefined,
+      leaseExpiresAt: r.lease_expires_at ? (r.lease_expires_at as Date).toISOString() : undefined,
+      claimToken: (r.claim_token as string) || undefined,
+      retryCount: r.retry_count as number,
+      maxRetries: r.max_retries as number,
+      nextAttemptAt: r.next_attempt_at ? (r.next_attempt_at as Date).toISOString() : undefined,
+      providerMessageId: (r.provider_message_id as string) || undefined,
+      errorMessage: (r.error_message as string) || undefined,
+      createdAt: (r.created_at as Date).toISOString(),
+      updatedAt: (r.updated_at as Date).toISOString(),
+    };
+  }
+}

--- a/backend/src/services/messaging/worker.service.ts
+++ b/backend/src/services/messaging/worker.service.ts
@@ -58,12 +58,18 @@ export class MessagingWorker {
         }
       );
       if (this.listenClient) {
+        const client = this.listenClient;
+        this.listenClient = null;
+
         try {
-          await this.listenClient.end();
-        } catch (closeErr) {
-          logger.error('Failed to close LISTEN client', { error: closeErr });
-        } finally {
-          this.listenClient = null;
+          await Promise.race([
+            client.end(),
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('LISTEN client close timeout')), 5000)
+            ),
+          ]);
+        } catch (err) {
+          logger.error('Failed to close LISTEN client', { error: err });
         }
       }
       this.scheduleReconnect();
@@ -155,6 +161,9 @@ export class MessagingWorker {
       database: process.env.POSTGRES_DB || 'insforge',
     });
 
+    // Assign EARLY so stop() can reach and close it even during connect()
+    this.listenClient = client;
+
     client.on('notification', (msg) => {
       if (msg.channel === 'messaging_new_job') {
         this.onNotification().catch((err) => {
@@ -169,7 +178,16 @@ export class MessagingWorker {
     });
 
     await client.connect();
-    this.listenClient = client;
+
+    // Guard: if worker was stopped while connect() was in flight, close and bail
+    if (!this.isRunning) {
+      await client.end().catch(() => {});
+      if (this.listenClient === client) {
+        this.listenClient = null;
+      }
+      return;
+    }
+
     await client.query('LISTEN messaging_new_job');
   }
 

--- a/backend/src/services/messaging/worker.service.ts
+++ b/backend/src/services/messaging/worker.service.ts
@@ -1,0 +1,392 @@
+import { Client, type PoolClient } from 'pg';
+import { randomUUID } from 'crypto';
+import { DatabaseManager } from '@/infra/database/database.manager.js';
+import { EmailService } from '@/services/email/email.service.js';
+import { MessagingQueueService } from './queue.service.js';
+import { OutboxMessage } from '@/types/messaging.js';
+import { appConfig } from '@/infra/config/app.config.js';
+import logger from '@/utils/logger.js';
+
+/**
+ * Background worker process responsible for claiming, renewing, and executing
+ * asynchronous messaging jobs using PostgreSQL LISTEN/NOTIFY with fallback polling.
+ */
+export class MessagingWorker {
+  private listenClient: Client | null = null;
+  private pollInterval: NodeJS.Timeout | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private isRunning = false;
+  private activeProcessingCount = 0;
+  private workerId: string;
+  private maxConcurrency: number;
+  private lastReconciledAt = 0;
+
+  /**
+   * Initializes a new MessagingWorker instance.
+   *
+   * @param queueService - The messaging queue service instance
+   * @param emailService - The email service instance for dispatching raw emails
+   */
+  constructor(
+    private queueService: MessagingQueueService,
+    private emailService: EmailService
+  ) {
+    this.workerId = `worker-${randomUUID().substring(0, 8)}`;
+    this.maxConcurrency = appConfig.messaging.maxConcurrency;
+  }
+
+  /**
+   * Starts the messaging worker LISTEN client, periodic polling loop, and orphan reconciliation.
+   * If the LISTEN client fails to connect on startup, the worker logs the error, schedules a reconnect retry,
+   * and continues operating in fallback polling mode without aborting server startup.
+   *
+   * @returns Promise resolving when listener and polling loop are initialized
+   */
+  public async start(): Promise<void> {
+    if (this.isRunning) {
+      return;
+    }
+    this.isRunning = true;
+
+    try {
+      await this.setupListenClient();
+    } catch (err) {
+      logger.error(
+        'Failed to initialize LISTEN client on worker startup; operating in polling fallback mode',
+        {
+          error: err,
+        }
+      );
+      if (this.listenClient) {
+        try {
+          await this.listenClient.end();
+        } catch (closeErr) {
+          logger.error('Failed to close LISTEN client', { error: closeErr });
+        } finally {
+          this.listenClient = null;
+        }
+      }
+      this.scheduleReconnect();
+    }
+
+    const pollIntervalMs = 5000;
+    this.pollInterval = setInterval(() => {
+      this.poll().catch((err) => {
+        logger.error('Error during scheduled worker polling loop', { error: err });
+      });
+    }, pollIntervalMs);
+
+    logger.info(`Messaging worker started: ${this.workerId}`);
+  }
+
+  /**
+   * Stops the messaging worker gracefully, closing LISTEN client and waiting for active jobs to finish.
+   *
+   * @returns Promise resolving when worker has fully stopped
+   */
+  public async stop(): Promise<void> {
+    if (!this.isRunning) {
+      return;
+    }
+    this.isRunning = false;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
+
+    if (this.listenClient) {
+      try {
+        await this.listenClient.query('UNLISTEN messaging_new_job');
+        await this.listenClient.end();
+      } catch (err) {
+        logger.error('Failed to close LISTEN client', { error: err });
+      } finally {
+        this.listenClient = null;
+      }
+    }
+
+    const shutdownDeadline = Date.now() + 30000;
+    while (this.activeProcessingCount > 0 && Date.now() < shutdownDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    logger.info(`Messaging worker stopped gracefully: ${this.workerId}`);
+  }
+
+  /**
+   * Schedules an asynchronous reconnect attempt for the LISTEN client if the worker is running.
+   */
+  private scheduleReconnect(): void {
+    if (!this.isRunning) {
+      return;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectTimer = setTimeout(() => {
+      if (!this.isRunning) {
+        return;
+      }
+      this.setupListenClient().catch((err) => {
+        logger.error('LISTEN reconnect failed, will retry', { error: err });
+        this.scheduleReconnect();
+      });
+    }, 5000);
+  }
+
+  /**
+   * Establishes a dedicated PostgreSQL client connection for LISTEN notifications on the messaging channel.
+   *
+   * @returns Promise resolving when client connection and LISTEN subscription are active
+   */
+  private async setupListenClient(): Promise<void> {
+    const client = new Client({
+      host: process.env.POSTGRES_HOST || 'localhost',
+      port: parseInt(process.env.POSTGRES_PORT || '5432', 10),
+      user: process.env.POSTGRES_USER || 'postgres',
+      password: process.env.POSTGRES_PASSWORD || 'postgres',
+      database: process.env.POSTGRES_DB || 'insforge',
+    });
+
+    client.on('notification', (msg) => {
+      if (msg.channel === 'messaging_new_job') {
+        this.onNotification().catch((err) => {
+          logger.error('Error handling notification wake event', { error: err });
+        });
+      }
+    });
+
+    client.on('error', (err) => {
+      logger.error('LISTEN client encountered network/DB error', { error: err });
+      this.scheduleReconnect();
+    });
+
+    await client.connect();
+    this.listenClient = client;
+    await client.query('LISTEN messaging_new_job');
+  }
+
+  /**
+   * Handles asynchronous job wake notifications from PostgreSQL.
+   *
+   * @returns Promise resolving after notification dispatch
+   */
+  private async onNotification(): Promise<void> {
+    if (this.activeProcessingCount >= this.maxConcurrency) {
+      return;
+    }
+    await this.poll();
+  }
+
+  /**
+   * Reconciles expired leases and schedules exponential retries if the configured interval has elapsed.
+   *
+   * @returns Promise resolving after reconciliation completion
+   */
+  private async reconcileIfNeeded(): Promise<void> {
+    const intervalMs = appConfig.messaging.reconciliationIntervalSeconds * 1000;
+    if (Date.now() - this.lastReconciledAt < intervalMs) {
+      return;
+    }
+    this.lastReconciledAt = Date.now();
+    await this.queueService
+      .reconcile(appConfig.messaging.backoffBaseSeconds, appConfig.messaging.jitterPercent)
+      .catch((err) => {
+        logger.error('Error in worker reconciliation', { error: err });
+      });
+  }
+
+  /**
+   * Claims a single pending job and executes message delivery.
+   *
+   * @returns Promise resolving after the claimed job has completed or when queue is empty
+   */
+  private async poll(): Promise<void> {
+    if (!this.isRunning || this.activeProcessingCount >= this.maxConcurrency) {
+      return;
+    }
+
+    this.activeProcessingCount++;
+    try {
+      await this.reconcileIfNeeded();
+      const message = await this.queueService.claim(this.workerId);
+      if (!message) {
+        return;
+      }
+
+      await this.processMessage(message);
+
+      if (this.activeProcessingCount - 1 < this.maxConcurrency) {
+        setImmediate(() => this.poll().catch(() => {}));
+      }
+    } catch (err) {
+      logger.error('Error in worker poll execution', { error: err });
+    } finally {
+      this.activeProcessingCount--;
+    }
+  }
+
+  /**
+   * Executes delivery for an individual claimed outbox message, manages heartbeat lease renewal,
+   * performs pre-send audit deduplication checks, and records delivery attempts.
+   *
+   * @param message - The claimed OutboxMessage to deliver
+   * @returns Promise resolving when delivery attempt and database state persistence finish
+   */
+  private async processMessage(message: OutboxMessage): Promise<void> {
+    const startTime = Date.now();
+    const claimToken = message.claimToken;
+
+    if (!claimToken) {
+      logger.error(`Message ${message.id} claimed without valid claim_token. Releasing.`);
+      return;
+    }
+
+    const abortController = new AbortController();
+    const leaseDurationMs = appConfig.messaging.leaseDurationSeconds * 1000;
+    const intervalId = setInterval(
+      () => {
+        this.queueService
+          .renewLease(message.id, this.workerId, claimToken)
+          .then((renewed) => {
+            if (!renewed) {
+              logger.warn(`Failed to renew lease for message ${message.id}. Aborting process.`);
+              abortController.abort();
+              clearInterval(intervalId);
+            }
+          })
+          .catch((err) => {
+            logger.error(`Error renewing lease for message ${message.id}`, { error: err });
+            abortController.abort();
+            clearInterval(intervalId);
+          });
+      },
+      Math.floor(leaseDurationMs / 2)
+    );
+
+    let emailSent = false;
+    try {
+      if (message.channel === 'email') {
+        const { to, subject, body } = message.payload;
+        if (!to || !subject || !body) {
+          throw new Error('Invalid email payload structure in worker');
+        }
+
+        // Check if delivery_attempts already records a successful 'sent' audit row
+        const pool = DatabaseManager.getInstance().getPool();
+        const existingAuditRes = await pool.query(
+          "SELECT status FROM messaging.delivery_attempts WHERE message_id = $1 AND status = 'sent' LIMIT 1",
+          [message.id]
+        );
+
+        if (existingAuditRes?.rows && existingAuditRes.rows.length > 0) {
+          logger.info(
+            `Skipping send for message ${message.id}, delivery_attempts already records sent.`
+          );
+          emailSent = true;
+          await this.queueService.markSent(message.id, message.id, this.workerId, claimToken);
+          return;
+        }
+
+        await this.emailService.sendRaw(
+          { to, subject, html: body, idempotencyKey: message.idempotencyKey ?? message.id },
+          abortController.signal
+        );
+        emailSent = true;
+
+        // Log durable audit attempt BEFORE releasing claim in outbox
+        await this.logAttempt(message.id, 'sent', undefined, Date.now() - startTime);
+
+        await this.queueService.markSent(message.id, message.id, this.workerId, claimToken);
+      } else {
+        throw new Error(`Unsupported channel: ${message.channel}`);
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error(`Failed to process message: ${message.id}`, { error: error.message });
+
+      if (!emailSent) {
+        try {
+          await this.queueService.markFailed(message.id, error, this.workerId, claimToken);
+        } catch (markFailedErr) {
+          logger.error(`Failed markFailed for message: ${message.id}`, { error: markFailedErr });
+        }
+
+        try {
+          await this.logAttempt(message.id, 'failed', error, Date.now() - startTime);
+        } catch (logErr) {
+          logger.error(`Failed logAttempt for message: ${message.id}`, { error: logErr });
+        }
+      } else {
+        logger.error(
+          `Database persistence error after successful delivery for message: ${message.id}. Skipping markFailed to prevent duplicate delivery.`,
+          { error: error.message }
+        );
+      }
+    } finally {
+      clearInterval(intervalId);
+    }
+  }
+
+  /**
+   * Persists a delivery attempt record into messaging.delivery_attempts under an advisory lock
+   * within an explicit transaction on a dedicated client connection.
+   *
+   * @param messageId - Target outbox message UUID
+   * @param status - Attempt outcome status ('sent' or 'failed')
+   * @param error - Optional error encountered during attempt
+   * @param durationMs - Total duration of the delivery attempt in milliseconds
+   * @throws Throws error if connection or query execution fails
+   * @returns Promise resolving when attempt record is committed
+   */
+  private async logAttempt(
+    messageId: string,
+    status: OutboxMessage['status'],
+    error?: Error,
+    durationMs?: number
+  ): Promise<void> {
+    let client: PoolClient | undefined;
+    try {
+      const pool = DatabaseManager.getInstance().getPool();
+      client = await pool.connect();
+      await client.query('BEGIN');
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1::text))', [messageId]);
+
+      const sql = `
+        WITH next_num AS (
+          SELECT COALESCE(MAX(attempt_number), 0) + 1 AS attempt_number
+          FROM messaging.delivery_attempts WHERE message_id = $1
+        )
+        INSERT INTO messaging.delivery_attempts (
+          message_id, attempt_number, worker_id, status, provider_message_id, error_message, duration_ms
+        )
+        SELECT $1, attempt_number, $2, $3, $4, $5, $6 FROM next_num
+        RETURNING *;
+      `;
+      await client.query(sql, [
+        messageId,
+        this.workerId,
+        status,
+        status === 'sent' ? messageId : null,
+        error ? error.message : null,
+        durationMs || null,
+      ]);
+      await client.query('COMMIT');
+    } catch (err) {
+      if (client) {
+        await client.query('ROLLBACK').catch(() => {});
+      }
+      logger.error(`Failed to log delivery attempt for message: ${messageId}`, { error: err });
+      throw err;
+    } finally {
+      client?.release();
+    }
+  }
+}

--- a/backend/src/types/messaging.ts
+++ b/backend/src/types/messaging.ts
@@ -1,0 +1,101 @@
+/**
+ * Supported delivery channels for messaging outbox.
+ */
+export type MessageChannel = 'email' | 'sms' | 'push';
+
+/**
+ * Lifecycle status of an outbox message.
+ */
+export type MessageStatus = 'pending' | 'claimed' | 'sent' | 'failed' | 'dead';
+
+/**
+ * Message payload structure for enqueuing jobs.
+ */
+export interface MessagePayload {
+  /** Target message channel */
+  channel: MessageChannel;
+  /** Primary recipient identifier (e.g. email address or phone number) */
+  to: string;
+  /** Subject line for email channel */
+  subject?: string;
+  /** Text or HTML body content */
+  body?: string;
+  /** Client-provided idempotency key for deduplication */
+  idempotencyKey?: string;
+  /** Arbitrary metadata associated with the message */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Full database record representation of a message in messaging.outbox.
+ */
+export interface OutboxMessage {
+  /** Unique UUID identifier */
+  id: string;
+  /** Delivery channel */
+  channel: MessageChannel;
+  /** Current lifecycle status */
+  status: MessageStatus;
+  /** Deserialized message payload */
+  payload: MessagePayload;
+  /** Optional client idempotency key */
+  idempotencyKey?: string;
+  /** Identifier of the worker holding the active claim */
+  claimedBy?: string;
+  /** ISO timestamp when the job was claimed */
+  claimedAt?: string;
+  /** ISO timestamp when the lease expires */
+  leaseExpiresAt?: string;
+  /** Unique UUID token validating worker lease ownership */
+  claimToken?: string;
+  /** Number of delivery attempts made */
+  retryCount: number;
+  /** Maximum number of retries before moving to dead letter queue */
+  maxRetries: number;
+  /** ISO timestamp for the next scheduled attempt */
+  nextAttemptAt?: string;
+  /** Provider-assigned message ID */
+  providerMessageId?: string;
+  /** Last error message encountered during processing */
+  errorMessage?: string;
+  /** ISO timestamp when record was created */
+  createdAt: string;
+  /** ISO timestamp when record was last updated */
+  updatedAt: string;
+}
+
+/**
+ * Delivery attempt audit log record in messaging.delivery_attempts.
+ */
+export interface DeliveryAttempt {
+  /** Unique audit attempt UUID */
+  id: string;
+  /** Associated outbox message UUID */
+  messageId: string;
+  /** Sequential attempt number */
+  attemptNumber: number;
+  /** Worker that executed the attempt */
+  workerId: string;
+  /** Resulting status of attempt */
+  status: MessageStatus;
+  /** Provider message ID if successfully sent */
+  providerMessageId?: string;
+  /** Error message if attempt failed */
+  errorMessage?: string;
+  /** ISO timestamp when attempt took place */
+  attemptedAt: string;
+  /** Total duration of attempt in milliseconds */
+  durationMs?: number;
+}
+
+/**
+ * Worker configuration options.
+ */
+export interface WorkerConfig {
+  /** Identifier for this worker process */
+  workerId?: string;
+  /** Maximum concurrent messages processed simultaneously */
+  maxConcurrency?: number;
+  /** Fallback polling interval in milliseconds */
+  pollIntervalMs?: number;
+}

--- a/backend/tests/unit/messaging.test.ts
+++ b/backend/tests/unit/messaging.test.ts
@@ -1,0 +1,432 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessagingQueueService } from '../../src/services/messaging/queue.service.js';
+import { MessagingWorker } from '../../src/services/messaging/worker.service.js';
+import { EmailService } from '../../src/services/email/email.service.js';
+import { OutboxMessage } from '../../src/types/messaging.js';
+
+const mockClient = vi.hoisted(() => ({
+  query: vi.fn(),
+  release: vi.fn(),
+  on: vi.fn(),
+  connect: vi.fn().mockResolvedValue(undefined),
+  end: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockPool = vi.hoisted(() => ({
+  query: vi.fn(),
+  connect: vi.fn().mockResolvedValue(mockClient),
+}));
+
+vi.mock('pg', () => ({
+  Client: vi.fn(() => mockClient),
+  Pool: vi.fn(() => mockPool),
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+      getConfig: () => ({ host: 'localhost', port: 5432, user: 'postgres', database: 'insforge' }),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/email/email.service.js', () => ({
+  EmailService: {
+    getInstance: () => ({
+      sendRaw: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+describe('Messaging System Phase 1 Consolidated Tests', () => {
+  let queueService: MessagingQueueService;
+  let emailService: any;
+  let worker: MessagingWorker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.query.mockReset();
+    mockClient.query.mockReset();
+    mockPool.connect.mockResolvedValue(mockClient);
+
+    queueService = new MessagingQueueService({ getPool: () => mockPool } as any);
+    emailService = EmailService.getInstance();
+    worker = new MessagingWorker(queueService, emailService);
+  });
+
+  it('Enqueue inserts message into outbox with status pending', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ id: 'msg-101' }] });
+
+    const res = await queueService.enqueue({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Hello',
+      body: 'World',
+    });
+
+    expect(res).toEqual({ id: 'msg-101', status: 'pending' });
+  });
+
+  it('Claim retrieves pending message with FOR UPDATE SKIP LOCKED and generates claim_token', async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'msg-202',
+          channel: 'email',
+          status: 'claimed',
+          payload: { channel: 'email', to: 'user@example.com', subject: 'Hi', body: 'Body' },
+          claim_token: '3c66641c-74a4-44b4-82a8-fdb1284ccbb1',
+          retry_count: 0,
+          max_retries: 5,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+    });
+
+    const claimed = await queueService.claim('worker-alpha');
+    expect(claimed).not.toBeNull();
+    expect(claimed?.id).toBe('msg-202');
+    expect(claimed?.claimToken).toBe('3c66641c-74a4-44b4-82a8-fdb1284ccbb1');
+  });
+
+  it('markSent updates status to sent only when workerId and claim_token match', async () => {
+    mockPool.query.mockResolvedValueOnce({ rowCount: 1 });
+    const matchSuccess = await queueService.markSent(
+      'msg-202',
+      'msg-202',
+      'worker-alpha',
+      '3c66641c-74a4-44b4-82a8-fdb1284ccbb1'
+    );
+    expect(matchSuccess).toBe(true);
+
+    mockPool.query.mockResolvedValueOnce({ rowCount: 0 });
+    const mismatchFailed = await queueService.markSent(
+      'msg-202',
+      'msg-202',
+      'worker-alpha',
+      'wrong-token'
+    );
+    expect(mismatchFailed).toBe(false);
+  });
+
+  it('markFailed increments retry_count and calculates backoff for transient errors', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'msg-303',
+            status: 'pending',
+            retry_count: 1,
+            max_retries: 5,
+          },
+        ],
+      }) // UPDATE
+      .mockResolvedValueOnce({}); // COMMIT
+
+    await queueService.markFailed(
+      'msg-303',
+      new Error('SMTP Timeout'),
+      'worker-alpha',
+      '3c66641c-74a4-44b4-82a8-fdb1284ccbb1'
+    );
+    expect(mockClient.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('markFailed moves message to dead_letter when max retries is reached', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'msg-404',
+            status: 'dead',
+            retry_count: 5,
+            max_retries: 5,
+            channel: 'email',
+            payload: { to: 'user@example.com' },
+            created_at: new Date(),
+          },
+        ],
+      }) // UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // INSERT dead_letter
+      .mockResolvedValueOnce({ rowCount: 1 }) // DELETE outbox
+      .mockResolvedValueOnce({}); // COMMIT
+
+    await queueService.markFailed(
+      'msg-404',
+      new Error('Fatal Error'),
+      'worker-alpha',
+      '3c66641c-74a4-44b4-82a8-fdb1284ccbb1'
+    );
+    expect(mockClient.query).toHaveBeenCalledTimes(5);
+  });
+
+  it('Reconciliation recovers orphaned leases via messaging.reconcile_jobs SQL function', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+    await queueService.reconcile(5, 0.2);
+    expect(mockPool.query).toHaveBeenCalledWith(
+      'SELECT messaging.reconcile_jobs($1, $2);',
+      [5, 0.2]
+    );
+  });
+
+  it('Worker receives notification and dispatches job via emailService.sendRaw()', async () => {
+    const mockMessage: OutboxMessage = {
+      id: 'msg-505',
+      channel: 'email' as const,
+      status: 'claimed' as const,
+      payload: {
+        channel: 'email' as const,
+        to: 'user@example.com',
+        subject: 'Subject',
+        body: 'Body',
+      },
+      claimToken: '3c66641c-74a4-44b4-82a8-fdb1284ccbb1',
+      retryCount: 0,
+      maxRetries: 5,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    vi.spyOn(queueService, 'renewLease').mockResolvedValue(true);
+    vi.spyOn(queueService, 'markSent').mockResolvedValue(true);
+
+    await (worker as any).processMessage(mockMessage);
+
+    expect(emailService.sendRaw).toHaveBeenCalledWith(
+      { to: 'user@example.com', subject: 'Subject', html: 'Body', idempotencyKey: 'msg-505' },
+      expect.any(AbortSignal)
+    );
+    expect(queueService.markSent).toHaveBeenCalledWith(
+      'msg-505',
+      'msg-505',
+      (worker as any).workerId,
+      '3c66641c-74a4-44b4-82a8-fdb1284ccbb1'
+    );
+  });
+
+  it('Enqueue handles atomic CTE idempotency key conflict with 409 error on different payload', async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'msg-existing-1',
+          status: 'pending',
+          payload: { channel: 'email', to: 'test@example.com', subject: 'Old', body: 'Old' },
+          created_at: new Date(),
+          is_new: false,
+          is_dead: false,
+        },
+      ],
+    });
+
+    await expect(
+      queueService.enqueue({
+        channel: 'email',
+        to: 'test@example.com',
+        subject: 'New',
+        body: 'New',
+        idempotencyKey: 'idemp-key-1',
+      })
+    ).rejects.toThrow('Idempotency key conflict: different payload');
+  });
+
+  it('Worker respects maxConcurrency limits when multiple polls trigger', async () => {
+    (worker as any).isRunning = true;
+    (worker as any).activeProcessingCount = 5;
+    (worker as any).maxConcurrency = 5;
+    vi.spyOn(queueService, 'claim');
+
+    await (worker as any).poll();
+    expect(queueService.claim).not.toHaveBeenCalled();
+  });
+
+  it('Worker throttles reconciliation calls based on interval', async () => {
+    (worker as any).lastReconciledAt = Date.now();
+    vi.spyOn(queueService, 'reconcile');
+
+    await (worker as any).reconcileIfNeeded();
+    expect(queueService.reconcile).not.toHaveBeenCalled();
+  });
+
+  it('Enqueue returns dead status and isDuplicate when idempotency key exists in dead_letter', async () => {
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'msg-dead-1',
+          status: 'dead',
+          payload: { channel: 'email', to: 'test@example.com', subject: 'Same', body: 'Same' },
+          created_at: new Date(),
+          is_new: false,
+          is_dead: true,
+        },
+      ],
+    });
+
+    const res = await queueService.enqueue({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Same',
+      body: 'Same',
+      idempotencyKey: 'idemp-key-dead',
+    });
+
+    expect(res).toEqual({
+      id: 'msg-dead-1',
+      status: 'dead',
+      isDuplicate: true,
+    });
+  });
+
+  it('Enqueue fallback: CTE empty -> re-query outbox matching row -> returns existing record', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // CTE empty
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'msg-fallback-1',
+            status: 'pending',
+            payload: { channel: 'email', to: 'test@example.com', subject: 'Same', body: 'Same' },
+          },
+        ],
+      }); // outbox re-query
+
+    const res = await queueService.enqueue({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Same',
+      body: 'Same',
+      idempotencyKey: 'idemp-fallback-1',
+    });
+
+    expect(res).toEqual({
+      id: 'msg-fallback-1',
+      status: 'pending',
+      isDuplicate: true,
+    });
+  });
+
+  it('Enqueue fallback: CTE empty -> re-query outbox different payload -> throws 409', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // CTE empty
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'msg-fallback-1',
+            status: 'pending',
+            payload: { channel: 'email', to: 'test@example.com', subject: 'Old', body: 'Old' },
+          },
+        ],
+      }); // outbox re-query
+
+    await expect(
+      queueService.enqueue({
+        channel: 'email',
+        to: 'test@example.com',
+        subject: 'New',
+        body: 'New',
+        idempotencyKey: 'idemp-fallback-2',
+      })
+    ).rejects.toThrow('Idempotency key conflict: different payload');
+  });
+
+  it('Enqueue fallback: CTE empty -> outbox empty -> dead_letter query finds row -> returns dead record via resolveEnqueueResult', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // CTE empty
+      .mockResolvedValueOnce({ rows: [] }) // outbox re-query empty
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'msg-dead-fallback',
+            status: 'dead',
+            payload: { channel: 'email', to: 'test@example.com', subject: 'Same', body: 'Same' },
+            is_dead: true,
+          },
+        ],
+      }); // dead_letter re-query
+
+    const res = await queueService.enqueue({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Same',
+      body: 'Same',
+      idempotencyKey: 'idemp-fallback-dead',
+    });
+
+    expect(res).toEqual({
+      id: 'msg-dead-fallback',
+      status: 'dead',
+      isDuplicate: true,
+    });
+  });
+
+  it('Enqueue fallback: CTE empty -> outbox empty -> dead_letter empty -> throws 409 concurrent in progress', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // CTE empty
+      .mockResolvedValueOnce({ rows: [] }) // outbox empty
+      .mockResolvedValueOnce({ rows: [] }); // dead_letter empty
+
+    await expect(
+      queueService.enqueue({
+        channel: 'email',
+        to: 'test@example.com',
+        subject: 'Same',
+        body: 'Same',
+        idempotencyKey: 'idemp-fallback-empty',
+      })
+    ).rejects.toThrow('Idempotency key conflict: concurrent request in progress');
+  });
+
+  it('Worker skips sendRaw and calls markSent when delivery_attempts records sent', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ status: 'sent' }] });
+
+    const mockMessage: OutboxMessage = {
+      id: 'msg-audit-sent',
+      channel: 'email' as const,
+      status: 'claimed' as const,
+      payload: { channel: 'email' as const, to: 'user@example.com', subject: 'Sub', body: 'Body' },
+      claimedBy: (worker as any).workerId,
+      claimedAt: new Date().toISOString(),
+      leaseExpiresAt: new Date(Date.now() + 30000).toISOString(),
+      claimToken: 'audit-claim-token',
+      retryCount: 0,
+      maxRetries: 3,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    vi.spyOn(queueService, 'markSent').mockResolvedValue(true);
+    vi.spyOn(emailService, 'sendRaw');
+
+    await (worker as any).processMessage(mockMessage);
+
+    expect(emailService.sendRaw).not.toHaveBeenCalled();
+    expect(queueService.markSent).toHaveBeenCalledWith(
+      'msg-audit-sent',
+      'msg-audit-sent',
+      (worker as any).workerId,
+      'audit-claim-token'
+    );
+  });
+
+  it('Worker start continues in polling fallback mode on setupListenClient failure', async () => {
+    const errorClient = {
+      query: vi.fn(),
+      on: vi.fn(),
+      connect: vi.fn().mockRejectedValue(new Error('DB Connection Refused')),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const { Client } = await import('pg');
+    (Client as any).mockImplementationOnce(function () {
+      return errorClient;
+    });
+
+    await expect(worker.start()).resolves.toBeUndefined();
+    expect((worker as any).isRunning).toBe(true);
+    expect((worker as any).pollInterval).not.toBeNull();
+    await worker.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Part of #1731

This PR introduces the foundational, PostgreSQL-native messaging queue infrastructure for Phase 1.

### What this PR does

- Adds a `messaging` schema with `outbox`, `delivery_attempts`, and `dead_letter` tables
- Introduces an in-process worker using `LISTEN/NOTIFY` for low-latency job execution with a 5s polling fallback
- Implements atomic claim/lease locking using `FOR UPDATE SKIP LOCKED` and unique `claim_token` leases
- Adds stored procedure `messaging.reconcile_jobs()` for orphan recovery and retry scheduling
- Moves permanent failures to `messaging.dead_letter` when `retry_count` reaches `max_retries`
- Routes Phase 1 delivery through existing `EmailService.sendRaw()` path
- Single consolidated unit test suite (`backend/tests/unit/messaging.test.ts`)

> Phase 1 strictly validates core queueing infrastructure. It does not introduce SMS/Push providers, public SDKs, or admin UI endpoints.

---

### What this PR does not do (Deferred Scope)

| Area | Why it is out of scope | Planned phase |
|------|------------------------|---------------|
| Twilio / FCM providers | Validate queue behavior against existing email path first | Phase 3 (SMS), Phase 4 (Push) |
| `insforge.messaging.send()` SDK | Public SDK comes after queue core is stabilized | Phase 5 |
| Dead letter LIST / REVIVE APIs | Admin management UI endpoints | Phase 2 |
| User message status endpoint | Public status query API | Phase 2 |
| Webhook handlers | SendGrid / Mailgun webhook ingestion | Phase 3 |
| Rate-limiting UI / middleware | Internal queue validation doesn't need public rate limiting | Phase 2 |

---

## Database Schema

### 1. `messaging.outbox` — Queue Table

| Column | Type | Purpose |
|--------|------|---------|
| `id` | `UUID PK` | Primary key (`gen_random_uuid()`) |
| `channel` | `TEXT CHECK ('email', 'sms', 'push')` | Channel identifier |
| `status` | `TEXT CHECK ('pending', 'claimed', 'sent', 'failed', 'dead')` | Outbox lifecycle status |
| `payload` | `JSONB` | Message payload (to, subject, body, metadata) |
| `idempotency_key` | `TEXT` | Optional key for deduplication |
| `claimed_by` | `TEXT` | Worker instance ID holding active claim |
| `claimed_at` | `TIMESTAMPTZ` | Timestamp when claimed |
| `lease_expires_at` | `TIMESTAMPTZ` | Deadline for active worker claim |
| `claim_token` | `UUID` | Unique token allocated per lease to prevent race conditions |
| `retry_count` | `INT` | Current retry attempt count |
| `max_retries` | `INT` | Max retry limit before DLQ promotion (default 5) |
| `next_attempt_at` | `TIMESTAMPTZ` | Scheduled retry timestamp |
| `provider_message_id` | `TEXT` | Returned message ID from delivery provider |
| `error_message` | `TEXT` | Last failure error details |
| `created_at`, `updated_at` | `TIMESTAMPTZ` | Record timestamps |

### 2. `messaging.delivery_attempts` — Audit Log

| Column | Type | Purpose |
|--------|------|---------|
| `id` | `UUID PK` | Audit row ID |
| `message_id` | `UUID` | Reference to outbox message |
| `attempt_number` | `INT` | Sequential attempt index |
| `worker_id` | `TEXT` | Worker instance ID |
| `status` | `TEXT` | Outcome status (`sent`, `failed`) |
| `error_message` | `TEXT` | Error details if failed |
| `duration_ms` | `INT` | Attempt execution time |
| `attempted_at` | `TIMESTAMPTZ` | Timestamp of attempt |

### 3. `messaging.dead_letter` — Permanent Failures

| Column | Type | Purpose |
|--------|------|---------|
| `id` | `UUID PK` | Original outbox message ID |
| `channel`, `payload`, `idempotency_key` | Copied columns | Message snapshot |
| `retry_count`, `max_retries` | `INT` | Final retry counters |
| `error_message` | `TEXT` | Cause of permanent failure |
| `created_at`, `moved_at` | `TIMESTAMPTZ` | Timestamps when created and moved to DLQ |

---

## Worker Lifecycle & Flow

1. **Enqueue**: Request hits `POST /api/messaging/send` → validated & inserted into `messaging.outbox` with `status = 'pending'`.
2. **Notification**: Postgres trigger `trg_messaging_notify_new_job` emits `NOTIFY 'messaging_new_job'`.
3. **Claim**: `MessagingWorker` wakes up and executes:
   ```sql
   UPDATE messaging.outbox
   SET status = 'claimed', claimed_by = $1, lease_expires_at = NOW() + INTERVAL '60s', claim_token = gen_random_uuid()
   WHERE id = (
     SELECT id FROM messaging.outbox WHERE status = 'pending' AND next_attempt_at <= NOW()
     ORDER BY next_attempt_at ASC, created_at ASC LIMIT 1 FOR UPDATE SKIP LOCKED
   ) RETURNING *;
4. Dispatch: Worker invokes EmailService.sendRaw(payload, abortSignal).
5. Mark Sent: Worker calls markSent() validating both claimed_by and claim_token.
6. Failure / Retry: If dispatch fails, markFailed() increments retry_count and sets next_attempt_at using exponential backoff. If retry_count + 1 >= max_retries, it atomically moves the record to messaging.dead_letter and deletes it from messaging.outbox.

## Reconciliation Stored Procedure
messaging.reconcile_jobs(p_backoff_base_seconds INT, p_jitter_pct FLOAT) recovers orphaned leases:

- Scans messaging.outbox where status = 'claimed' and lease_expires_at <= NOW().
- If retry_count + 1 >= max_retries, moves record to messaging.dead_letter.
- Otherwise resets status = 'pending', increments retry_count, and schedules next_attempt_at with exponential backoff and jitter.

---

### Known Limitations (Phase 1)

- **At-least-once delivery only.** During in-flight lease loss, duplicate emails are possible despite deterministic Message-ID and pre-send audit checks.
- **SMTP acceptance and PostgreSQL persistence are not atomic.** Exact-once guarantee requires provider webhook confirmation (Phase 3) and is not claimed in this PR.
- **Single-replica worker.** The in-process worker runs inside the existing Express container. Multi-replica deployments share queue state via Postgres, but local fallback markers are not visible across replicas.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces in-request email sends with a PostgreSQL-backed durable outbox and a background worker. Requests now enqueue and return 202; a `LISTEN/NOTIFY` worker delivers with retries and a dead-letter queue for at-least-once delivery (duplicates possible; mitigated by pre-send audit and deterministic Message-ID).

- Database/migration: new `messaging` schema (`outbox`, `delivery_attempts`, `dead_letter`), insert `NOTIFY` trigger, and `messaging.reconcile_jobs()` for lease recovery. Action: run `065_create-messaging-schema.sql`.
- API/behavior: admin-only POST `/api/messaging/send` validates, enqueues, and returns `{messageId, status}`; non-email channels return 501; idempotency conflicts return 409 on payload mismatch; if the key is in DLQ, returns `dead` with `isDuplicate`.
- Worker/runtime: background worker starts on server boot; dedicated `LISTEN` client with 5s polling fallback and auto-reconnect; startup race fix (assign listen client before connect, recheck `isRunning`); `FOR UPDATE SKIP LOCKED` claims with per-lease `claim_token`; periodic lease renewal; throttled reconciliation; max concurrency; graceful shutdown; durable attempt logging before releasing the claim; pre-send audit skips if a prior “sent” exists.
- Providers: `AbortSignal` pre-flight added; SMTP sets deterministic RFC 5322 Message-ID from SHA-256 of the idempotency key (or message id); cloud provider forwards the signal. In-flight SMTP sends cannot be canceled.
- Rollout/config: apply the migration and set env before deploy. Required: `MESSAGING_LEASE_DURATION_SECONDS`, `MESSAGING_MAX_RETRY_ATTEMPTS`, `MESSAGING_BACKOFF_BASE_SECONDS`, `MESSAGING_JITTER_PERCENT`; optional: `MESSAGING_MAX_CONCURRENCY`, `MESSAGING_RECONCILIATION_INTERVAL_SECONDS`.

<sup>Written for commit c6d1705571983151a77e894d8c6469dddc90a3cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PostgreSQL durable outbox queue with LISTEN/NOTIFY background worker for messaging
> - Adds a new `messaging` schema via [065_create-messaging-schema.sql](https://github.com/InsForge/InsForge/pull/1795/files#diff-4d4359576d0738a4b87e6a99ec9307deccb01b87fe05734bd94b7c277dd6bacd) with `outbox`, `delivery_attempts`, and `dead_letter` tables, plus a PostgreSQL trigger that fires `NOTIFY messaging_new_job` on insert.
> - Introduces [MessagingQueueService](https://github.com/InsForge/InsForge/pull/1795/files#diff-07915030289c4908ae132df4d4a48666b084e9d3f0a6b6a34f7ef76c58829d7d) implementing idempotent enqueue, atomic claim/lease via `SKIP LOCKED`, sent/failed state transitions, exponential backoff with jitter, and dead-letter promotion.
> - Adds [MessagingWorker](https://github.com/InsForge/InsForge/pull/1795/files#diff-ad759ffb3291b92a67bc238ea9cd4988d4ebf32e743f993651fb96e2161b4c68) as a background process that listens for notifications, polls as fallback, enforces concurrency limits, renews leases via heartbeat, and aborts in-flight sends on lease loss.
> - Exposes `POST /api/messaging/send` (admin-only) in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1795/files#diff-8102645112bd707bcd458e73dbff68596605d439d735f6c298c3cc0f7e7500e5) returning 202 with `messageId` and status.
> - Email providers now accept `AbortSignal` and an `idempotencyKey` that maps to a deterministic RFC 5322 `Message-ID`.
> - Risk: the worker starts at server boot and requires a dedicated long-lived `pg` client for `LISTEN`; a failure to connect on startup logs an error and falls back to polling only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 401969f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an admin-protected API for submitting email messages.
  * Added reliable queuing with duplicate prevention, retries, recovery, dead-letter handling, and delivery tracking.
  * Added background processing with configurable concurrency and reconciliation.
  * Added cancellation and idempotency support for email delivery.
* **Configuration**
  * Added settings for concurrency, leases, retries, backoff, and jitter.
* **Bug Fixes**
  * Improved handling of interrupted deliveries and transient failures.
* **Tests**
  * Added comprehensive messaging and delivery coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->