### PR TITLE
fix(db): add IF NOT EXISTS guard to migration 012

### DIFF
--- a/backend/src/infra/database/migrations/012_add-storage-uploaded-by.sql
+++ b/backend/src/infra/database/migrations/012_add-storage-uploaded-by.sql
@@ -2,7 +2,7 @@
 -- This migration adds a foreign key relationship to track which account uploaded each file
 
 ALTER TABLE _storage
-ADD COLUMN uploaded_by UUID REFERENCES _accounts(id) ON DELETE SET NULL;
+ADD COLUMN IF NOT EXISTS uploaded_by UUID REFERENCES _accounts(id) ON DELETE SET NULL;
 
 -- Create an index for better query performance when filtering by uploader
 CREATE INDEX IF NOT EXISTS idx_storage_uploaded_by ON _storage(uploaded_by);


### PR DESCRIPTION
## Summary

Migration `012_add-storage-uploaded-by.sql` mixed an unguarded `ADD COLUMN` with a guarded `CREATE INDEX IF NOT EXISTS`. Re-applying migrations against an already-provisioned database failed with `column "uploaded_by" of relation "_storage" already exists`.

This PR adds the missing `IF NOT EXISTS` guard to the `ADD COLUMN` statement in migration 012, aligning it with corpus conventions across all other migration files.

## Changes

- Updated `backend/src/infra/database/migrations/012_add-storage-uploaded-by.sql`:
  - Changed `ADD COLUMN uploaded_by ...` to `ADD COLUMN IF NOT EXISTS uploaded_by ...`

## Verification

- `npm run migrate:check-duplicates`: Passed (60 unique migration numbers verified).
- `npm run typecheck`: Passed cleanly with 0 errors.
- `npm run lint`: Passed with 0 ESLint errors.
- `npm run test`: Passed (157 test files, 1,888 unit tests passed).

Closes #1702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add IF NOT EXISTS to the `uploaded_by` column in migration 012 to make it safe to re-run on existing databases. This prevents the “column "uploaded_by" of relation "_storage" already exists” error and aligns the migration with our idempotent guard pattern.

<sup>Written for commit f5c0c36d8dbb015dd25ef460b0002f192e4255f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make migration 012 idempotent by adding `IF NOT EXISTS` to `uploaded_by` column addition
> The `ADD COLUMN` statement in [012_add-storage-uploaded-by.sql](https://github.com/InsForge/InsForge/pull/1803/files#diff-814e8a7a26a62c77a16aae51fbaccf264a1d8ab73747c37397dae2784413450b) now uses `IF NOT EXISTS`, so re-running the migration on a database where `uploaded_by` already exists will succeed instead of erroring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5c0c36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage records to safely track the account that uploaded each file.
  * Preserved storage records when an associated account is deleted.
  * Improved performance for queries filtered by uploader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->