### PR TITLE
fix(test): pre-seed vector extension and report migration errors in integration harness

### DIFF
--- a/backend/tests/integration/utils.ts
+++ b/backend/tests/integration/utils.ts
@@ -52,6 +52,7 @@ export const getConnections = (
       await ctx.pg.query(`
         CREATE EXTENSION IF NOT EXISTS pgcrypto;
         CREATE EXTENSION IF NOT EXISTS http;
+        CREATE EXTENSION IF NOT EXISTS vector;
 
         CREATE SCHEMA IF NOT EXISTS cron;
         CREATE TABLE IF NOT EXISTS cron.job (
@@ -75,14 +76,20 @@ export const getConnections = (
           RETURNS boolean LANGUAGE sql AS $$ SELECT true $$;
       `);
     }),
-    // 3. Run the full migration chain (000–048), stripping CREATE EXTENSION
+    // 3. Run the full migration chain (000–048+), stripping CREATE EXTENSION
     //    statements since extensions are already installed or stubbed above.
     seed.fn(async (ctx) => {
       for (const file of migrationFiles) {
         const sql = fs
           .readFileSync(file, 'utf8')
           .replace(/^CREATE EXTENSION IF NOT EXISTS \S+;$/gm, '');
-        await ctx.pg.query(sql);
+        try {
+          await ctx.pg.query(sql);
+        } catch (err) {
+          throw new Error(
+            `Failed to apply migration ${path.basename(file)}: ${(err as Error).message}`
+          );
+        }
       }
     }),
   ]);


### PR DESCRIPTION
## Summary

`backend/tests/integration/utils.ts` seeds test databases by running the full migration chain, but the chain was silently dying at `050_create-memory-schema.sql` because the test database pre-seed did not install the PostgreSQL `vector` extension. Furthermore, errors during the migration seed loop were not caught or surfaced with file context.

This PR fixes both issues:
1. Adds `CREATE EXTENSION IF NOT EXISTS vector;` to the integration test extension pre-seed step in `backend/tests/integration/utils.ts`.
2. Wraps the migration execution loop in a `try...catch` block to fail loudly with the offending migration filename if an error occurs.

## Changes

- Updated `backend/tests/integration/utils.ts`:
  - Added `vector` extension pre-installation.
  - Wrapped `ctx.pg.query(sql)` in a `try...catch` block to report migration filenames on failure.

## Verification

- `npm run typecheck`: Passed cleanly with 0 errors.
- `npm run lint`: Passed with 0 ESLint errors.
- `npm run test`: Passed (157 test files, 1,888 unit tests passed).

Closes #1719

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent failures in the integration test migration seed by pre-installing the PostgreSQL `vector` extension and surfacing the exact migration file on error. Addresses Linear #1719 by allowing migrations to run past 050.

- **Bug Fixes**
  - Pre-seed `vector` extension in the test DB setup.
  - Wrap migration loop in try/catch to throw with the failing migration filename.

<sup>Written for commit ad7a4e89fbe5eb132a4813b11df8ece1ae59136e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-seed `vector` extension and report migration errors in integration test harness
> - Installs the `vector` Postgres extension before running migrations in [`backend/tests/integration/utils.ts`](https://github.com/InsForge/InsForge/pull/1804/files#diff-3dc6764b405deac1c8ca0835c861ed0800fe0a0320ec046204d6e69c2c084852), preventing failures in tests that depend on it.
> - Wraps each migration in a try/catch that rethrows with the failing migration's basename in the error message, making failures easier to diagnose.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad7a4e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test database setup to support vector functionality.
  * Improved migration error reporting by identifying the migration file that failed.
  * Expanded migration-chain coverage for newer migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->