### PR TITLE
docs(sdks): update callout tag to Warning in email SDK reference

### DIFF
--- a/docs/sdks/typescript/email.mdx
+++ b/docs/sdks/typescript/email.mdx
@@ -21,9 +21,9 @@ Send custom HTML emails to one or more recipients.
 - `from` (string, optional) - Display name shown next to the sender address, max 100 characters (ignored when Custom SMTP is enabled)
 - `replyTo` (string, optional) - Reply-to email address, must be a valid email address
 
-<Note>
+<Warning>
 By default, emails are sent from `noreply@<your-project>.send.insforge.dev`, a per-project subdomain that InsForge Cloud provisions and verifies for you, so no domain setup is required. The `from` field only sets the display name shown next to that address; on the default provider you cannot change the address or domain. To send from your own domain, configure [Custom SMTP](/core-concepts/messaging/custom-smtp). When Custom SMTP is enabled the `from` field is ignored entirely, and the sender name and email are taken from your SMTP configuration to prevent spoofing through your server.
-</Note>
+</Warning>
 
 ### Returns
 


### PR DESCRIPTION
## Summary

In `docs/sdks/typescript/email.mdx`, the callout tag for experimental email sending behavior was using a neutral `<Note>` tag instead of the required `<Warning>` tag.

This PR updates the callout component tag to `<Warning>` to align with repository documentation guidelines for experimental/private preview features.

## Changes

- Updated `docs/sdks/typescript/email.mdx`:
  - Changed `<Note>` to `<Warning>`

Closes #1735

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `docs/sdks/typescript/email.mdx` to use a `<Warning>` callout instead of `<Note>` for the default sender behavior, highlighting sender address limitations and aligning with docs guidelines.

<sup>Written for commit 3e5580fc65980bc7c7274b9f404fd2d490f9143b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade callout tag from Note to Warning in email SDK reference docs
> Updates the callout tag in [email.mdx](https://github.com/InsForge/InsForge/pull/1805/files#diff-580c788d85d133ece68892b7d370828876d6f63f508c0be07d016a3c6e76fa65) for the section describing default sender address behavior and Custom SMTP effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e5580f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the default sender address and `from` field behavior when using Custom SMTP.
  * Highlighted important sender restrictions more prominently to help prevent spoofing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->