### PR TITLE
fix(infra): bind internal database and runtime ports to localhost

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,11 +13,11 @@ services:
       - ./deploy/docker-init/db/jwt.sql:/docker-entrypoint-initdb.d/02-jwt.sql
       - ./deploy/docker-init/db/postgresql.conf:/etc/postgresql/postgresql.conf
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     networks:
       - insforge-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -42,7 +42,7 @@ services:
       PGRST_DB_POOL: ${PGRST_DB_POOL:-50}
       PGRST_JWT_SECRET: ${JWT_SECRET:-dev-secret-please-change-in-production}
     ports:
-      - "${POSTGREST_PORT:-5430}:3000"
+      - "127.0.0.1:${POSTGREST_PORT:-5430}:3000"
     depends_on:
       postgres:
         condition: service_healthy
@@ -168,7 +168,7 @@ services:
       - postgres
       - postgrest
     ports:
-      - "${DENO_PORT:-7133}:7133"
+      - "127.0.0.1:${DENO_PORT:-7133}:7133"
     environment:
       - PORT=7133
       - DENO_ENV=${DENO_ENV:-production}


### PR DESCRIPTION
Closes #1806 

## Overview
This PR updates `docker-compose.prod.yml` to explicitly bind the internal infrastructure services (postgres, postgrest, and deno) to `127.0.0.1`.

Previously, these ports defaulted to `0.0.0.0`. If deployed on a cloud provider, this inadvertently exposed the raw database and Deno runtime to the public internet, bypassing the main application routing and authentication.

**Impact**
  - Blocks external connections to ports 5432, 5430, and 7133 on production VMs.
  - Internal Docker network routing (`http://deno:7133`, `postgres:5432`) is completely unaffected.
  - Local developer experience is preserved (you can still connect to `localhost:5432` locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind internal Postgres, PostgREST, and Deno ports to 127.0.0.1 in `docker-compose.prod.yml` to prevent public exposure in production. External access to ports 5432, 5430, and 7133 is blocked; internal Docker networking and local localhost usage remain unchanged.

<sup>Written for commit a4089f8c39002af877893683ab3049ee50ed599b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind Postgres, PostgREST, and Deno ports to localhost in production
> Updates [docker-compose.prod.yml](https://github.com/InsForge/InsForge/pull/1807/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3) to prefix all published port bindings with `127.0.0.1`, preventing these services from being accessible on external network interfaces. Risk: any tooling or external clients that previously connected to these ports from outside the host will lose access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4089f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted database and service ports to local host access by default, reducing unintended external exposure.
* **Maintenance**
  * Updated the database health check configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->