### PR TITLE
fix(infra): secure cloud-deploy compose and bind unused auth port

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -11,11 +11,11 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     networks:
       - insforge-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -34,12 +34,12 @@ services:
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst
     ports:
-      - "${POSTGREST_PORT:-5430}:3000"
+      - "127.0.0.1:${POSTGREST_PORT:-5430}:3000"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/3000'"]
+      test: [ "CMD-SHELL", "bash -c '</dev/tcp/localhost/3000'" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -58,7 +58,7 @@ services:
         condition: service_healthy
     ports:
       - "${APP_PORT:-7130}:7130"
-      - "${AUTH_PORT:-7131}:7131"
+      - "127.0.0.1:${AUTH_PORT:-7131}:7131"
     environment:
       - PORT=7130
       - PROJECT_ROOT=/app
@@ -137,7 +137,7 @@ services:
       - postgres
       - postgrest
     ports:
-      - "${DENO_PORT:-7133}:7133"
+      - "127.0.0.1:${DENO_PORT:-7133}:7133"
     environment:
       - PORT=7133
       - DENO_ENV=development
@@ -157,7 +157,7 @@ services:
     volumes:
       - deno_cache:/deno-dir
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7133/health"]
+      test: [ "CMD", "wget", "-q", "--spider", "http://127.0.0.1:7133/health" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - insforge-network
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -33,14 +33,13 @@ services:
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst
-      PGRST_ADMIN_SERVER_PORT: 3001
     ports:
       - "127.0.0.1:${POSTGREST_PORT:-5430}:3000"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "postgrest", "--ready" ]
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/3000'"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -158,7 +157,7 @@ services:
     volumes:
       - deno_cache:/deno-dir
     healthcheck:
-      test: [ "CMD", "wget", "-q", "--spider", "http://127.0.0.1:7133/health" ]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7133/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -33,13 +33,14 @@ services:
       # Enable schema reloading via NOTIFY
       PGRST_DB_CHANNEL_ENABLED: true
       PGRST_DB_CHANNEL: pgrst
+      PGRST_ADMIN_SERVER_PORT: 3001
     ports:
       - "127.0.0.1:${POSTGREST_PORT:-5430}:3000"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "bash -c '</dev/tcp/localhost/3000'" ]
+      test: [ "CMD", "postgrest", "--ready" ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -31,11 +31,12 @@ services:
       PGRST_JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
       PGRST_DB_CHANNEL_ENABLED: "true"
       PGRST_DB_CHANNEL: pgrst
+      PGRST_ADMIN_SERVER_PORT: 3001
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ > /dev/null 2>&1 || exit 1"]
+      test: ["CMD", "postgrest", "--ready"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -31,12 +31,11 @@ services:
       PGRST_JWT_SECRET: ${JWT_SECRET:-change-this-jwt-secret-min-32-characters}
       PGRST_DB_CHANNEL_ENABLED: "true"
       PGRST_DB_CHANNEL: pgrst
-      PGRST_ADMIN_SERVER_PORT: 3001
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "postgrest", "--ready"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ > /dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,7 +63,7 @@ services:
         condition: service_healthy
     ports:
       - "${APP_PORT:-7130}:7130"
-      - "${AUTH_PORT:-7131}:7131"
+      - "127.0.0.1:${AUTH_PORT:-7131}:7131"
     environment:
       - PORT=7130
       - PROJECT_ROOT=/app


### PR DESCRIPTION
## Description:
Closes #1810

## Overview
This is an immediate follow-up to PR #1807, addressing the infrastructure gaps highlighted in the maintainer review:

**Cloud-Deploy Hardening:** The `deploy/docker-compose/docker-compose.yml` file (the canonical file used in the AWS/Azure/GCP deployment guides) has been updated to bind postgres (5432), postgrest (5430), and deno (7133) strictly to 127.0.0.1. This secures cloud deployments out-of-the-box.

**Auth Port Lockdown:** The AUTH_PORT (7131) has been bound to 127.0.0.1 in both compose files, as it is documented as unused for external traffic, eliminating an unnecessary public listener.

## Impact
  - Internal Docker network routing remains unaffected.
  - Local developer experience is preserved via localhost.
  - Cloud deployments using the documented guides are now secured by default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down cloud compose by binding internal service ports to 127.0.0.1 to prevent unintended public access. Keep PostgREST on a shell-based readiness probe for scratch image compatibility.

- **Bug Fixes**
  - Bind 5432 (Postgres), 5430 (PostgREST), 7133 (Deno), and unused 7131 (auth) to 127.0.0.1 in deploy/docker-compose and docker-compose.prod.yml.
  - Use a shell-based PostgREST healthcheck; `PGRST_ADMIN_SERVER_PORT=3001` remains enabled in compose and Dokploy configs.
  - Cloud guides are secure by default; internal Docker networking and local dev are unchanged.

<sup>Written for commit 9c6be16d740f1c8e4028c2c4ebcf00fb4fb61d1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind exposed Docker service ports to 127.0.0.1 in cloud-deploy compose files
> Restricts host port bindings for `postgres`, `postgrest`, `auth` (7131), and `deno` (7133) to `127.0.0.1` in both [docker-compose.yml](https://github.com/InsForge/InsForge/pull/1811/files#diff-03bf84599af57a5fcf0f9d11adf30d9cf3ee8a54d5f0cf0f22125c414d7efc69) and [docker-compose.prod.yml](https://github.com/InsForge/InsForge/pull/1811/files#diff-5f5da9b207eff3d8ec6052cccbc6adf663de1469bca409a90d5a062688961189). Previously these ports were bound to all host interfaces (`0.0.0.0`), making them reachable from external networks on cloud hosts. Behavioral Change: these services are now inaccessible from non-loopback interfaces on the host.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c6be16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted local service ports to the host machine by binding them to `127.0.0.1`.
  * Prevented database, API, authentication, and runtime ports from being exposed on all network interfaces.
  * Applied the same protection to the production authentication port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->