### PR TITLE
fix(migration): make 060 email-OTP backfill strictly idempotent

### DIFF
--- a/backend/src/infra/database/migrations/060_add-email-otp-sign-in.sql
+++ b/backend/src/infra/database/migrations/060_add-email-otp-sign-in.sql
@@ -15,9 +15,12 @@ ALTER TABLE auth.email_otps
   ADD COLUMN IF NOT EXISTS otp_type TEXT NOT NULL DEFAULT 'NUMERIC_CODE';
 
 -- Backfill existing rows: bcrypt hashes begin with '$2'; SHA-256 hex tokens do not.
+-- The otp_type guard keeps re-runs a true no-op (0 rows) so the migration is
+-- strictly idempotent and never re-writes already-labeled rows.
 UPDATE auth.email_otps
   SET otp_type = 'HASH_TOKEN'
-  WHERE otp_hash NOT LIKE '$2%';
+  WHERE otp_hash NOT LIKE '$2%'
+    AND otp_type IS DISTINCT FROM 'HASH_TOKEN';
 
 -- OTP sign-in looks up users case-insensitively (auth.users.email may be stored
 -- mixed-case for OAuth accounts), so serve the WHERE lower(email) = $1 FOR UPDATE

--- a/backend/tests/unit/email-otp-sign-in-migration.test.ts
+++ b/backend/tests/unit/email-otp-sign-in-migration.test.ts
@@ -18,9 +18,11 @@ describe('060_add-email-otp-sign-in migration', () => {
     );
   });
 
-  it('adds a delivery-type discriminator and backfills existing rows', () => {
+  it('adds a delivery-type discriminator and backfills existing rows idempotently', () => {
     expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS otp_type TEXT NOT NULL DEFAULT 'NUMERIC_CODE'/i);
-    expect(sql).toMatch(/SET otp_type = 'HASH_TOKEN'\s+WHERE otp_hash NOT LIKE '\$2%'/i);
+    expect(sql).toMatch(
+      /SET otp_type = 'HASH_TOKEN'\s+WHERE otp_hash NOT LIKE '\$2%'\s+AND otp_type IS DISTINCT FROM 'HASH_TOKEN'/i
+    );
   });
 
   it('adds a functional index for case-insensitive user lookup idempotently', () => {


### PR DESCRIPTION
## Summary

Follow-up to the email OTP sign-in feature ([#1798](https://github.com/InsForge/InsForge/pull/1798)). Migration 060 re-runs cleanly, but the `otp_type` backfill wasn't *strictly* idempotent: on a re-run it re-wrote every already-labeled `HASH_TOKEN` row (same value, but a real row write that bumps `updated_at` via the table trigger) instead of a no-op.

Add the reviewer-suggested guard so the backfill matches 0 rows once labeling is done:

```sql
UPDATE auth.email_otps
  SET otp_type = 'HASH_TOKEN'
  WHERE otp_hash NOT LIKE '$2%'
    AND otp_type IS DISTINCT FROM 'HASH_TOKEN';
```

Editing **060 in place** rather than adding a new migration, since 060 is merged to `main` but not yet in a released build — so environments get the improved version on first apply, and re-applying the old vs new form converges to the same state (no divergence risk).

The migration's other statements were already idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, template seed `ON CONFLICT (template_type) DO NOTHING`).

## Validation

- Migration unit test updated to assert the guarded backfill; `email-otp-sign-in-migration.test.ts` passes.
- `format:check` clean; no duplicate migration numbers.
- Verified against real Postgres: a mislabeled token row is fixed on the **first** run (`UPDATE 1`), a **second** run is a no-op (`UPDATE 0`), and a bcrypt numeric-code row is correctly left `NUMERIC_CODE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make migration 060’s email OTP backfill strictly idempotent. The UPDATE now skips already-labeled rows, so re-runs do nothing and don’t bump updated_at.

- **Bug Fixes**
  - Guard the backfill with AND otp_type IS DISTINCT FROM 'HASH_TOKEN' to avoid rewriting labeled rows.
  - Update the migration unit test to assert the guarded UPDATE pattern.

<sup>Written for commit 83b8e32643414e8215b2aac52691bf3ed40cd738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix migration 060 email-OTP backfill to be strictly idempotent
> The `UPDATE` guard in [060_add-email-otp-sign-in.sql](https://github.com/InsForge/InsForge/pull/1814/files#diff-fad07ec2617f011e7d99b04226145928d5076d19a43bc4dd650962d4bc7a1310) now adds `AND otp_type IS DISTINCT FROM 'HASH_TOKEN'` alongside the existing `otp_hash` prefix check, so rows already labeled on a previous run are not rewritten. The unit test in [email-otp-sign-in-migration.test.ts](https://github.com/InsForge/InsForge/pull/1814/files#diff-3dbe222e871370946a6bfdb4fee1fdbe5b7f54c444f4ee2da6156061f1e39364) is updated to assert this predicate is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83b8e32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email OTP data migration reliability by preventing previously classified records from being overwritten when migrations are re-run.

* **Tests**
  * Added coverage confirming the migration safely skips records already marked with the correct OTP type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->