### PR TITLE
feat(backend): add database migration dry-run inspector & agent telemetry service

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -459,7 +459,7 @@ export const migrationsDryRunLimiter = rateLimit({
       new AppError(
         'Too many migration dry-run requests. Please try again later.',
         429,
-        ERROR_CODES.RATE_LIMIT_EXCEEDED
+        ERROR_CODES.TOO_MANY_REQUESTS
       )
     );
   },

--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -448,3 +448,19 @@ function createWriteEndpointLimiter(category: WriteLimiterCategory) {
 export const functionsWriteLimiter = createWriteEndpointLimiter('functions');
 export const deploymentsWriteLimiter = createWriteEndpointLimiter('deployments');
 export const computeWriteLimiter = createWriteEndpointLimiter('compute');
+
+export const migrationsDryRunLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many migration dry-run requests. Please try again later.',
+        429,
+        ERROR_CODES.RATE_LIMIT_EXCEEDED
+      )
+    );
+  },
+});

--- a/backend/src/api/routes/analytics/index.routes.ts
+++ b/backend/src/api/routes/analytics/index.routes.ts
@@ -4,10 +4,13 @@ import {
   posthogTimeframeSchema,
   posthogBreakdownSchema,
   posthogMetricSchema,
+  recordAgentToolCallSchema,
 } from '@insforge/shared-schemas';
 import { verifyUser, verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { AppError } from '@/utils/errors.js';
 import { AnalyticsService } from '@/services/analytics/analytics.service.js';
+import { AgentTelemetryService } from '@/services/telemetry/agent-telemetry.service.js';
+import { successResponse } from '@/utils/response.js';
 
 export const analyticsRouter = Router();
 const service = AnalyticsService.getInstance();
@@ -205,3 +208,54 @@ analyticsRouter.post(
     }
   }
 );
+
+analyticsRouter.post(
+  '/agent-telemetry/events',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const validation = recordAgentToolCallSchema.safeParse(req.body);
+      if (!validation.success) {
+        throw new AppError('Invalid agent telemetry event payload', 400, ERROR_CODES.INVALID_INPUT);
+      }
+      const telemetryService = AgentTelemetryService.getInstance();
+      const record = telemetryService.recordToolCall(validation.data);
+      successResponse(res, record, 201);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+analyticsRouter.get(
+  '/agent-telemetry/stats',
+  verifyUser,
+  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const telemetryService = AgentTelemetryService.getInstance();
+      const stats = telemetryService.getSystemAgentStats();
+      successResponse(res, stats);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+analyticsRouter.get(
+  '/agent-telemetry/session/:id',
+  verifyUser,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const sessionId = String(req.params.id || '');
+      const telemetryService = AgentTelemetryService.getInstance();
+      const metrics = telemetryService.getSessionMetrics(sessionId);
+      if (!metrics) {
+        throw new AppError('Agent session not found', 404, ERROR_CODES.NOT_FOUND);
+      }
+      successResponse(res, metrics);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+

--- a/backend/src/api/routes/analytics/index.routes.ts
+++ b/backend/src/api/routes/analytics/index.routes.ts
@@ -212,7 +212,7 @@ analyticsRouter.post(
 analyticsRouter.post(
   '/agent-telemetry/events',
   verifyUser,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validation = recordAgentToolCallSchema.safeParse(req.body);
       if (!validation.success) {
@@ -230,7 +230,7 @@ analyticsRouter.post(
 analyticsRouter.get(
   '/agent-telemetry/stats',
   verifyUser,
-  async (_req: AuthRequest, res: Response, next: NextFunction) => {
+  (_req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const telemetryService = AgentTelemetryService.getInstance();
       const stats = telemetryService.getSystemAgentStats();
@@ -244,7 +244,7 @@ analyticsRouter.get(
 analyticsRouter.get(
   '/agent-telemetry/session/:id',
   verifyUser,
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const sessionId = String(req.params.id || '');
       const telemetryService = AgentTelemetryService.getInstance();
@@ -258,4 +258,3 @@ analyticsRouter.get(
     }
   }
 );
-

--- a/backend/src/api/routes/analytics/index.routes.ts
+++ b/backend/src/api/routes/analytics/index.routes.ts
@@ -218,8 +218,9 @@ analyticsRouter.post(
       if (!validation.success) {
         throw new AppError('Invalid agent telemetry event payload', 400, ERROR_CODES.INVALID_INPUT);
       }
+      const projectId = req.user?.id || 'default';
       const telemetryService = AgentTelemetryService.getInstance();
-      const record = telemetryService.recordToolCall(validation.data);
+      const record = telemetryService.recordToolCall(validation.data, projectId);
       successResponse(res, record, 201);
     } catch (err) {
       next(err);
@@ -230,10 +231,11 @@ analyticsRouter.post(
 analyticsRouter.get(
   '/agent-telemetry/stats',
   verifyUser,
-  (_req: AuthRequest, res: Response, next: NextFunction) => {
+  (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
+      const projectId = req.user?.id || 'default';
       const telemetryService = AgentTelemetryService.getInstance();
-      const stats = telemetryService.getSystemAgentStats();
+      const stats = telemetryService.getSystemAgentStats(projectId);
       successResponse(res, stats);
     } catch (err) {
       next(err);
@@ -247,8 +249,9 @@ analyticsRouter.get(
   (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const sessionId = String(req.params.id || '');
+      const projectId = req.user?.id || 'default';
       const telemetryService = AgentTelemetryService.getInstance();
-      const metrics = telemetryService.getSessionMetrics(sessionId);
+      const metrics = telemetryService.getSessionMetrics(sessionId, projectId);
       if (!metrics) {
         throw new AppError('Agent session not found', 404, ERROR_CODES.NOT_FOUND);
       }

--- a/backend/src/api/routes/database/migrations.routes.ts
+++ b/backend/src/api/routes/database/migrations.routes.ts
@@ -2,6 +2,7 @@ import { Router, Response, NextFunction } from 'express';
 import {
   ERROR_CODES,
   createMigrationRequestSchema,
+  dryRunMigrationRequestSchema,
   type CreateMigrationResponse,
   type DatabaseMigrationsResponse,
 } from '@insforge/shared-schemas';
@@ -82,4 +83,30 @@ router.post(
   }
 );
 
+router.post(
+  '/dry-run',
+  verifyAdmin,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const validation = dryRunMigrationRequestSchema.safeParse(req.body);
+      if (!validation.success) {
+        const issues = validation.error.issues;
+        throw new AppError(
+          issues.length === 1
+            ? issues[0]?.message || 'Invalid dry-run request.'
+            : issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const result = await migrationService.dryRunMigration(validation.data);
+      successResponse(res, result);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 export { router as databaseMigrationsRouter };
+

--- a/backend/src/api/routes/database/migrations.routes.ts
+++ b/backend/src/api/routes/database/migrations.routes.ts
@@ -7,6 +7,7 @@ import {
   type DatabaseMigrationsResponse,
 } from '@insforge/shared-schemas';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
+import { migrationsDryRunLimiter } from '@/api/middlewares/rate-limiters.js';
 import { AppError } from '@/utils/errors.js';
 import { DatabaseMigrationService } from '@/services/database/database-migration.service.js';
 import { AuditService } from '@/services/logs/audit.service.js';
@@ -86,6 +87,7 @@ router.post(
 router.post(
   '/dry-run',
   verifyAdmin,
+  migrationsDryRunLimiter,
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const validation = dryRunMigrationRequestSchema.safeParse(req.body);

--- a/backend/src/api/routes/database/migrations.routes.ts
+++ b/backend/src/api/routes/database/migrations.routes.ts
@@ -109,4 +109,3 @@ router.post(
 );
 
 export { router as databaseMigrationsRouter };
-

--- a/backend/src/services/database/database-migration.service.ts
+++ b/backend/src/services/database/database-migration.service.ts
@@ -18,6 +18,7 @@ import {
   parseSQLStatements,
   type DatabaseResourceUpdate,
 } from '@/utils/sql-parser.js';
+import { parseSync } from 'libpg-query';
 import { withAdminContext } from './user-context.service.js';
 
 interface CreateMigrationResult {
@@ -152,7 +153,27 @@ export class DatabaseMigrationService {
   }
 
   async dryRunMigration(input: DryRunMigrationRequest): Promise<DryRunMigrationResponse> {
-    const statements = parseSQLStatements(input.sql);
+    let statements: string[];
+    try {
+      statements = parseSQLStatements(input.sql);
+    } catch (parseError) {
+      const errMsg = parseError instanceof Error ? parseError.message : String(parseError);
+      return {
+        valid: false,
+        statementCount: 0,
+        statements: [],
+        riskLevel: 'DANGER',
+        riskFactors: [
+          {
+            code: 'SYNTAX_OR_EXECUTION_ERROR',
+            description: errMsg,
+            level: 'DANGER',
+          },
+        ],
+        error: errMsg,
+      };
+    }
+
     if (statements.length === 0) {
       return {
         valid: false,
@@ -193,34 +214,85 @@ export class DatabaseMigrationService {
     const riskFactors: MigrationRiskFactor[] = [];
     let riskLevel: MigrationRiskLevel = 'SAFE';
 
-    for (const statement of statements) {
-      const upperStmt = statement.toUpperCase();
-      if (
-        upperStmt.includes('DROP TABLE') ||
-        upperStmt.includes('DROP DATABASE') ||
-        upperStmt.includes('TRUNCATE')
-      ) {
-        riskFactors.push({
-          code: 'DESTRUCTIVE_DATA_LOSS',
-          description: 'Statement drops tables or truncates data permanently.',
-          level: 'DANGER',
-          statement,
-        });
-        riskLevel = 'DANGER';
-      } else if (
-        upperStmt.includes('DROP COLUMN') ||
-        upperStmt.includes('DROP CONSTRAINT') ||
-        (upperStmt.includes('ALTER TABLE') && upperStmt.includes('DROP'))
-      ) {
-        riskFactors.push({
-          code: 'SCHEMA_BREAKING_CHANGE',
-          description:
-            'Statement drops columns or constraints which may break existing functionality.',
-          level: 'WARNING',
-          statement,
-        });
-        if (riskLevel !== 'DANGER') {
-          riskLevel = 'WARNING';
+    try {
+      const { stmts } = parseSync(input.sql);
+      for (let i = 0; i < stmts.length; i++) {
+        const stmtWrapper = stmts[i];
+        const statementText = statements[i] || input.sql;
+        const stmt = stmtWrapper.stmt as Record<string, unknown>;
+        const [stmtType, data] = Object.entries(stmt)[0] as [string, Record<string, unknown>];
+
+        if (stmtType === 'DropStmt') {
+          const removeType = String(data.removeType || '');
+          if (
+            removeType === 'OBJECT_TABLE' ||
+            removeType === 'OBJECT_DATABASE' ||
+            removeType === 'OBJECT_SCHEMA'
+          ) {
+            riskFactors.push({
+              code: 'DESTRUCTIVE_DATA_LOSS',
+              description: `Statement drops database object (${removeType}) permanently resulting in potential data loss.`,
+              level: 'DANGER',
+              statement: statementText,
+            });
+            riskLevel = 'DANGER';
+          } else if (removeType === 'OBJECT_COLUMN' || removeType === 'OBJECT_CONSTRAINT') {
+            riskFactors.push({
+              code: 'SCHEMA_BREAKING_CHANGE',
+              description: `Statement drops column/constraint (${removeType}) which may break dependent application logic.`,
+              level: 'WARNING',
+              statement: statementText,
+            });
+            if (riskLevel !== 'DANGER') {
+              riskLevel = 'WARNING';
+            }
+          }
+        } else if (stmtType === 'TruncateStmt') {
+          riskFactors.push({
+            code: 'DESTRUCTIVE_DATA_LOSS',
+            description: 'TRUNCATE statement clears all records from targeted table(s).',
+            level: 'DANGER',
+            statement: statementText,
+          });
+          riskLevel = 'DANGER';
+        } else if (stmtType === 'AlterTableStmt') {
+          const cmds = (data.cmds as Array<Record<string, unknown>>) || [];
+          for (const cmdWrapper of cmds) {
+            const cmd = (cmdWrapper.AlterTableCmd as Record<string, unknown>) || {};
+            const subtype = String(cmd.subtype || '');
+            if (
+              subtype === 'AT_DropColumn' ||
+              subtype === 'AT_DropConstraint' ||
+              subtype === 'AT_AlterColumnType'
+            ) {
+              riskFactors.push({
+                code: 'SCHEMA_BREAKING_CHANGE',
+                description: `ALTER TABLE statement contains destructive command: ${subtype}.`,
+                level: 'WARNING',
+                statement: statementText,
+              });
+              if (riskLevel !== 'DANGER') {
+                riskLevel = 'WARNING';
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      for (const statement of statements) {
+        const upperStmt = statement.toUpperCase();
+        if (
+          upperStmt.includes('DROP TABLE') ||
+          upperStmt.includes('DROP DATABASE') ||
+          upperStmt.includes('TRUNCATE')
+        ) {
+          riskFactors.push({
+            code: 'DESTRUCTIVE_DATA_LOSS',
+            description: 'Statement drops tables or truncates data permanently.',
+            level: 'DANGER',
+            statement,
+          });
+          riskLevel = 'DANGER';
         }
       }
     }

--- a/backend/src/services/database/database-migration.service.ts
+++ b/backend/src/services/database/database-migration.service.ts
@@ -214,7 +214,8 @@ export class DatabaseMigrationService {
       ) {
         riskFactors.push({
           code: 'SCHEMA_BREAKING_CHANGE',
-          description: 'Statement drops columns or constraints which may break existing functionality.',
+          description:
+            'Statement drops columns or constraints which may break existing functionality.',
           level: 'WARNING',
           statement,
         });
@@ -259,4 +260,3 @@ export class DatabaseMigrationService {
     };
   }
 }
-

--- a/backend/src/services/database/database-migration.service.ts
+++ b/backend/src/services/database/database-migration.service.ts
@@ -4,6 +4,10 @@ import {
   type CreateMigrationResponse,
   type DatabaseMigrationsResponse,
   type Migration,
+  type DryRunMigrationRequest,
+  type DryRunMigrationResponse,
+  type MigrationRiskFactor,
+  type MigrationRiskLevel,
 } from '@insforge/shared-schemas';
 import { AppError, isPgErrorLike } from '@/utils/errors.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
@@ -146,4 +150,113 @@ export class DatabaseMigrationService {
       client.release();
     }
   }
+
+  async dryRunMigration(input: DryRunMigrationRequest): Promise<DryRunMigrationResponse> {
+    const statements = parseSQLStatements(input.sql);
+    if (statements.length === 0) {
+      return {
+        valid: false,
+        statementCount: 0,
+        statements: [],
+        riskLevel: 'DANGER',
+        riskFactors: [
+          {
+            code: 'EMPTY_SQL',
+            description: 'Migration SQL must contain at least one statement.',
+            level: 'DANGER',
+          },
+        ],
+        error: 'Migration SQL must contain at least one statement.',
+      };
+    }
+
+    await initSqlParser();
+
+    const guardError = checkSqlExecutionGuards(input.sql);
+    if (guardError) {
+      return {
+        valid: false,
+        statementCount: statements.length,
+        statements,
+        riskLevel: 'DANGER',
+        riskFactors: [
+          {
+            code: 'GUARD_VIOLATION',
+            description: guardError,
+            level: 'DANGER',
+          },
+        ],
+        error: guardError,
+      };
+    }
+
+    const riskFactors: MigrationRiskFactor[] = [];
+    let riskLevel: MigrationRiskLevel = 'SAFE';
+
+    for (const statement of statements) {
+      const upperStmt = statement.toUpperCase();
+      if (
+        upperStmt.includes('DROP TABLE') ||
+        upperStmt.includes('DROP DATABASE') ||
+        upperStmt.includes('TRUNCATE')
+      ) {
+        riskFactors.push({
+          code: 'DESTRUCTIVE_DATA_LOSS',
+          description: 'Statement drops tables or truncates data permanently.',
+          level: 'DANGER',
+          statement,
+        });
+        riskLevel = 'DANGER';
+      } else if (
+        upperStmt.includes('DROP COLUMN') ||
+        upperStmt.includes('DROP CONSTRAINT') ||
+        (upperStmt.includes('ALTER TABLE') && upperStmt.includes('DROP'))
+      ) {
+        riskFactors.push({
+          code: 'SCHEMA_BREAKING_CHANGE',
+          description: 'Statement drops columns or constraints which may break existing functionality.',
+          level: 'WARNING',
+          statement,
+        });
+        if (riskLevel !== 'DANGER') {
+          riskLevel = 'WARNING';
+        }
+      }
+    }
+
+    const client = await this.dbManager.getPool().connect();
+    let valid = true;
+    let executionError: string | undefined = undefined;
+
+    try {
+      await client.query('BEGIN');
+      await client.query('SET LOCAL search_path TO public');
+      await withAdminContext(client, () => client.query(input.sql), true);
+    } catch (error) {
+      valid = false;
+      executionError = error instanceof Error ? error.message : String(error);
+    } finally {
+      await Promise.resolve(client.query('ROLLBACK')).catch(() => {});
+      client.release();
+    }
+
+    if (!valid) {
+      riskLevel = 'DANGER';
+      riskFactors.push({
+        code: 'SYNTAX_OR_EXECUTION_ERROR',
+        description: executionError || 'Failed to execute SQL dry-run.',
+        level: 'DANGER',
+      });
+    }
+
+    return {
+      valid,
+      statementCount: statements.length,
+      statements,
+      riskLevel,
+      riskFactors,
+      error: executionError,
+    };
+  }
 }
+

--- a/backend/src/services/telemetry/agent-telemetry.service.ts
+++ b/backend/src/services/telemetry/agent-telemetry.service.ts
@@ -13,6 +13,7 @@ interface ToolCallRecord {
   errorMessage?: string;
   metadata?: Record<string, unknown>;
   timestamp: string;
+  projectId: string;
 }
 
 export class AgentTelemetryService {
@@ -29,9 +30,10 @@ export class AgentTelemetryService {
     return AgentTelemetryService.instance;
   }
 
-  recordToolCall(input: RecordAgentToolCallRequest): ToolCallRecord {
+  recordToolCall(input: RecordAgentToolCallRequest, projectId = 'default'): ToolCallRecord {
     const record: ToolCallRecord = {
       ...input,
+      projectId,
       timestamp: new Date().toISOString(),
     };
 
@@ -44,8 +46,10 @@ export class AgentTelemetryService {
     return record;
   }
 
-  getSessionMetrics(sessionId: string): AgentSessionMetrics | null {
-    const sessionRecords = this.records.filter((r) => r.sessionId === sessionId);
+  getSessionMetrics(sessionId: string, projectId = 'default'): AgentSessionMetrics | null {
+    const sessionRecords = this.records.filter(
+      (r) => r.sessionId === sessionId && r.projectId === projectId
+    );
 
     if (sessionRecords.length === 0) {
       return null;
@@ -71,14 +75,15 @@ export class AgentTelemetryService {
     };
   }
 
-  getSystemAgentStats(): AgentTelemetryStatsResponse {
+  getSystemAgentStats(projectId = 'default'): AgentTelemetryStatsResponse {
+    const projectRecords = this.records.filter((r) => r.projectId === projectId);
     const sessionsMap = new Map<string, ToolCallRecord[]>();
     const toolCounts = new Map<string, number>();
 
     let totalDurationMs = 0;
     let totalSuccessCount = 0;
 
-    for (const record of this.records) {
+    for (const record of projectRecords) {
       totalDurationMs += record.durationMs;
       if (record.status === 'success') {
         totalSuccessCount++;
@@ -117,7 +122,7 @@ export class AgentTelemetryService {
       .sort((a, b) => b.count - a.count)
       .slice(0, 10);
 
-    const totalRecords = this.records.length;
+    const totalRecords = projectRecords.length;
 
     return {
       activeSessionsCount: sessionsMap.size,

--- a/backend/src/services/telemetry/agent-telemetry.service.ts
+++ b/backend/src/services/telemetry/agent-telemetry.service.ts
@@ -1,0 +1,135 @@
+import {
+  AgentSessionMetrics,
+  AgentTelemetryStatsResponse,
+  RecordAgentToolCallRequest,
+} from '@insforge/shared-schemas';
+
+interface ToolCallRecord {
+  sessionId: string;
+  agentId?: string;
+  toolName: string;
+  durationMs: number;
+  status: 'success' | 'error';
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+  timestamp: string;
+}
+
+export class AgentTelemetryService {
+  private static instance: AgentTelemetryService;
+  private records: ToolCallRecord[] = [];
+  private readonly maxRecords = 5000;
+
+  private constructor() {}
+
+  public static getInstance(): AgentTelemetryService {
+    if (!AgentTelemetryService.instance) {
+      AgentTelemetryService.instance = new AgentTelemetryService();
+    }
+    return AgentTelemetryService.instance;
+  }
+
+  recordToolCall(input: RecordAgentToolCallRequest): ToolCallRecord {
+    const record: ToolCallRecord = {
+      ...input,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.records.unshift(record);
+
+    if (this.records.length > this.maxRecords) {
+      this.records.pop();
+    }
+
+    return record;
+  }
+
+  getSessionMetrics(sessionId: string): AgentSessionMetrics | null {
+    const sessionRecords = this.records.filter((r) => r.sessionId === sessionId);
+
+    if (sessionRecords.length === 0) {
+      return null;
+    }
+
+    const totalToolCalls = sessionRecords.length;
+    const successfulToolCalls = sessionRecords.filter((r) => r.status === 'success').length;
+    const failedToolCalls = totalToolCalls - successfulToolCalls;
+    const totalDurationMs = sessionRecords.reduce((sum, r) => sum + r.durationMs, 0);
+    const avgDurationMs = totalDurationMs / totalToolCalls;
+    const lastActiveAt = sessionRecords[0].timestamp;
+    const agentId = sessionRecords.find((r) => Boolean(r.agentId))?.agentId;
+
+    return {
+      sessionId,
+      agentId,
+      totalToolCalls,
+      successfulToolCalls,
+      failedToolCalls,
+      avgDurationMs,
+      totalDurationMs,
+      lastActiveAt,
+    };
+  }
+
+  getSystemAgentStats(): AgentTelemetryStatsResponse {
+    const sessionsMap = new Map<string, ToolCallRecord[]>();
+    const toolCounts = new Map<string, number>();
+
+    let totalDurationMs = 0;
+    let totalSuccessCount = 0;
+
+    for (const record of this.records) {
+      totalDurationMs += record.durationMs;
+      if (record.status === 'success') {
+        totalSuccessCount++;
+      }
+
+      toolCounts.set(record.toolName, (toolCounts.get(record.toolName) || 0) + 1);
+
+      if (!sessionsMap.has(record.sessionId)) {
+        sessionsMap.set(record.sessionId, []);
+      }
+      sessionsMap.get(record.sessionId)?.push(record);
+    }
+
+    const sessions: AgentSessionMetrics[] = [];
+    for (const [sessionId, recs] of sessionsMap.entries()) {
+      const totalToolCalls = recs.length;
+      const successfulToolCalls = recs.filter((r) => r.status === 'success').length;
+      const failedToolCalls = totalToolCalls - successfulToolCalls;
+      const sumDuration = recs.reduce((sum, r) => sum + r.durationMs, 0);
+      const agentId = recs.find((r) => Boolean(r.agentId))?.agentId;
+
+      sessions.push({
+        sessionId,
+        agentId,
+        totalToolCalls,
+        successfulToolCalls,
+        failedToolCalls,
+        avgDurationMs: sumDuration / totalToolCalls,
+        totalDurationMs: sumDuration,
+        lastActiveAt: recs[0].timestamp,
+      });
+    }
+
+    const topToolsUsed = Array.from(toolCounts.entries())
+      .map(([toolName, count]) => ({ toolName, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    const totalRecords = this.records.length;
+
+    return {
+      activeSessionsCount: sessionsMap.size,
+      totalToolCallsRecorded: totalRecords,
+      overallSuccessRate: totalRecords > 0 ? (totalSuccessCount / totalRecords) * 100 : 100,
+      averageToolLatencyMs: totalRecords > 0 ? totalDurationMs / totalRecords : 0,
+      topToolsUsed,
+      sessions,
+    };
+  }
+
+  clearRecords(): void {
+    this.records = [];
+  }
+}

--- a/backend/tests/unit/agent-telemetry.test.ts
+++ b/backend/tests/unit/agent-telemetry.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AgentTelemetryService } from '../../src/services/telemetry/agent-telemetry.service.js';
+
+describe('AgentTelemetryService', () => {
+  let service: AgentTelemetryService;
+
+  beforeEach(() => {
+    service = AgentTelemetryService.getInstance();
+    service.clearRecords();
+  });
+
+  it('records agent tool calls accurately', () => {
+    const record = service.recordToolCall({
+      sessionId: 'session-123',
+      agentId: 'agent-alpha',
+      toolName: 'execute_sql',
+      durationMs: 150,
+      status: 'success',
+    });
+
+    expect(record.sessionId).toBe('session-123');
+    expect(record.status).toBe('success');
+
+    const session = service.getSessionMetrics('session-123');
+    expect(session).not.toBeNull();
+    expect(session?.totalToolCalls).toBe(1);
+    expect(session?.successfulToolCalls).toBe(1);
+    expect(session?.avgDurationMs).toBe(150);
+  });
+
+  it('aggregates system-wide telemetry statistics across multiple sessions', () => {
+    service.recordToolCall({
+      sessionId: 'session-1',
+      toolName: 'create_table',
+      durationMs: 200,
+      status: 'success',
+    });
+
+    service.recordToolCall({
+      sessionId: 'session-1',
+      toolName: 'deploy_function',
+      durationMs: 400,
+      status: 'error',
+      errorMessage: 'Build failed',
+    });
+
+    service.recordToolCall({
+      sessionId: 'session-2',
+      toolName: 'create_table',
+      durationMs: 100,
+      status: 'success',
+    });
+
+    const stats = service.getSystemAgentStats();
+
+    expect(stats.activeSessionsCount).toBe(2);
+    expect(stats.totalToolCallsRecorded).toBe(3);
+    expect(stats.overallSuccessRate).toBeCloseTo(66.66, 1);
+    expect(stats.averageToolLatencyMs).toBe(233.33333333333334);
+    expect(stats.topToolsUsed[0].toolName).toBe('create_table');
+    expect(stats.topToolsUsed[0].count).toBe(2);
+  });
+
+  it('returns null for unknown session metrics', () => {
+    const metrics = service.getSessionMetrics('non-existent');
+    expect(metrics).toBeNull();
+  });
+});

--- a/backend/tests/unit/agent-telemetry.test.ts
+++ b/backend/tests/unit/agent-telemetry.test.ts
@@ -9,60 +9,67 @@ describe('AgentTelemetryService', () => {
     service.clearRecords();
   });
 
-  it('records agent tool calls accurately', () => {
-    const record = service.recordToolCall({
-      sessionId: 'session-123',
-      agentId: 'agent-alpha',
-      toolName: 'execute_sql',
-      durationMs: 150,
-      status: 'success',
-    });
+  it('records agent tool calls accurately for a specific project scope', () => {
+    const record = service.recordToolCall(
+      {
+        sessionId: 'session-123',
+        agentId: 'agent-alpha',
+        toolName: 'execute_sql',
+        durationMs: 150,
+        status: 'success',
+      },
+      'proj-alpha'
+    );
 
     expect(record.sessionId).toBe('session-123');
     expect(record.status).toBe('success');
 
-    const session = service.getSessionMetrics('session-123');
+    const session = service.getSessionMetrics('session-123', 'proj-alpha');
     expect(session).not.toBeNull();
     expect(session?.totalToolCalls).toBe(1);
     expect(session?.successfulToolCalls).toBe(1);
     expect(session?.avgDurationMs).toBe(150);
   });
 
-  it('aggregates system-wide telemetry statistics across multiple sessions', () => {
-    service.recordToolCall({
-      sessionId: 'session-1',
-      toolName: 'create_table',
-      durationMs: 200,
-      status: 'success',
-    });
+  it('isolates session telemetry between different project scopes', () => {
+    service.recordToolCall(
+      {
+        sessionId: 'shared-session-id',
+        toolName: 'create_table',
+        durationMs: 100,
+        status: 'success',
+      },
+      'proj-1'
+    );
 
-    service.recordToolCall({
-      sessionId: 'session-1',
-      toolName: 'deploy_function',
-      durationMs: 400,
-      status: 'error',
-      errorMessage: 'Build failed',
-    });
+    service.recordToolCall(
+      {
+        sessionId: 'shared-session-id',
+        toolName: 'deploy_function',
+        durationMs: 300,
+        status: 'error',
+      },
+      'proj-2'
+    );
 
-    service.recordToolCall({
-      sessionId: 'session-2',
-      toolName: 'create_table',
-      durationMs: 100,
-      status: 'success',
-    });
+    const proj1Session = service.getSessionMetrics('shared-session-id', 'proj-1');
+    const proj2Session = service.getSessionMetrics('shared-session-id', 'proj-2');
 
-    const stats = service.getSystemAgentStats();
+    expect(proj1Session?.totalToolCalls).toBe(1);
+    expect(proj1Session?.successfulToolCalls).toBe(1);
 
-    expect(stats.activeSessionsCount).toBe(2);
-    expect(stats.totalToolCallsRecorded).toBe(3);
-    expect(stats.overallSuccessRate).toBeCloseTo(66.66, 1);
-    expect(stats.averageToolLatencyMs).toBe(233.33333333333334);
-    expect(stats.topToolsUsed[0].toolName).toBe('create_table');
-    expect(stats.topToolsUsed[0].count).toBe(2);
+    expect(proj2Session?.totalToolCalls).toBe(1);
+    expect(proj2Session?.failedToolCalls).toBe(1);
+
+    const proj1Stats = service.getSystemAgentStats('proj-1');
+    const proj2Stats = service.getSystemAgentStats('proj-2');
+
+    expect(proj1Stats.totalToolCallsRecorded).toBe(1);
+    expect(proj2Stats.totalToolCallsRecorded).toBe(1);
   });
 
   it('returns null for unknown session metrics', () => {
-    const metrics = service.getSessionMetrics('non-existent');
+    const metrics = service.getSessionMetrics('non-existent', 'proj-1');
     expect(metrics).toBeNull();
   });
 });

--- a/backend/tests/unit/database-migration-dry-run.test.ts
+++ b/backend/tests/unit/database-migration-dry-run.test.ts
@@ -74,11 +74,12 @@ describe('DatabaseMigrationService Dry-Run', () => {
   });
 
   it('handles execution errors and flags them as DANGER', async () => {
-    const queryMock = vi
-      .fn()
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({})
-      .mockRejectedValueOnce(new Error('syntax error at or near INVALID'));
+    const queryMock = vi.fn().mockImplementation((queryText: string) => {
+      if (typeof queryText === 'string' && queryText.includes('INVALID SQL STATEMENT')) {
+        return Promise.reject(new Error('syntax error at or near INVALID'));
+      }
+      return Promise.resolve({});
+    });
 
     connectMock.mockResolvedValue({
       query: queryMock,
@@ -93,5 +94,6 @@ describe('DatabaseMigrationService Dry-Run', () => {
     expect(result.valid).toBe(false);
     expect(result.riskLevel).toBe('DANGER');
     expect(result.error).toContain('syntax error');
+    expect(queryMock).toHaveBeenCalledWith('INVALID SQL STATEMENT');
   });
 });

--- a/backend/tests/unit/database-migration-dry-run.test.ts
+++ b/backend/tests/unit/database-migration-dry-run.test.ts
@@ -1,20 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  connectMock,
-  parseSQLStatementsMock,
-  initSqlParserMock,
-  checkSqlExecutionGuardsMock,
-} = vi.hoisted(() => ({
-  connectMock: vi.fn(),
-  parseSQLStatementsMock: vi.fn((sql: string) => [sql]),
-  initSqlParserMock: vi.fn(async () => {}),
-  checkSqlExecutionGuardsMock: vi.fn((query: string) =>
-    query.includes('RESET ROLE')
-      ? 'Changing SQL execution role or session authorization is not allowed.'
-      : null
-  ),
-}));
+const { connectMock, parseSQLStatementsMock, initSqlParserMock, checkSqlExecutionGuardsMock } =
+  vi.hoisted(() => ({
+    connectMock: vi.fn(),
+    parseSQLStatementsMock: vi.fn((sql: string) => [sql]),
+    initSqlParserMock: vi.fn(async () => {}),
+    checkSqlExecutionGuardsMock: vi.fn((query: string) =>
+      query.includes('RESET ROLE')
+        ? 'Changing SQL execution role or session authorization is not allowed.'
+        : null
+    ),
+  }));
 
 vi.mock('../../src/infra/database/database.manager', () => ({
   DatabaseManager: {

--- a/backend/tests/unit/database-migration-dry-run.test.ts
+++ b/backend/tests/unit/database-migration-dry-run.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  connectMock,
+  parseSQLStatementsMock,
+  initSqlParserMock,
+  checkSqlExecutionGuardsMock,
+} = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  parseSQLStatementsMock: vi.fn((sql: string) => [sql]),
+  initSqlParserMock: vi.fn(async () => {}),
+  checkSqlExecutionGuardsMock: vi.fn((query: string) =>
+    query.includes('RESET ROLE')
+      ? 'Changing SQL execution role or session authorization is not allowed.'
+      : null
+  ),
+}));
+
+vi.mock('../../src/infra/database/database.manager', () => ({
+  DatabaseManager: {
+    getInstance: vi.fn(() => ({
+      getPool: vi.fn(() => ({
+        connect: connectMock,
+      })),
+    })),
+    clearColumnTypeCache: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/utils/sql-parser', () => ({
+  parseSQLStatements: parseSQLStatementsMock,
+  analyzeQuery: vi.fn(() => []),
+  initSqlParser: initSqlParserMock,
+  checkSqlExecutionGuards: checkSqlExecutionGuardsMock,
+}));
+
+import { DatabaseMigrationService } from '../../src/services/database/database-migration.service.js';
+
+describe('DatabaseMigrationService Dry-Run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('evaluates safe DDL statements in a dry-run', async () => {
+    const queryMock = vi.fn().mockResolvedValue({});
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: vi.fn(),
+    });
+
+    const service = DatabaseMigrationService.getInstance();
+    const result = await service.dryRunMigration({
+      sql: 'CREATE TABLE public.test_items (id uuid PRIMARY KEY)',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.riskLevel).toBe('SAFE');
+    expect(result.statementCount).toBe(1);
+    expect(result.riskFactors).toHaveLength(0);
+  });
+
+  it('detects destructive DANGER statements in a dry-run', async () => {
+    const queryMock = vi.fn().mockResolvedValue({});
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: vi.fn(),
+    });
+
+    const service = DatabaseMigrationService.getInstance();
+    const result = await service.dryRunMigration({
+      sql: 'DROP TABLE public.legacy_users',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.riskLevel).toBe('DANGER');
+    expect(result.riskFactors).toHaveLength(1);
+    expect(result.riskFactors[0].code).toBe('DESTRUCTIVE_DATA_LOSS');
+  });
+
+  it('handles execution errors and flags them as DANGER', async () => {
+    const queryMock = vi
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('syntax error at or near INVALID'));
+
+    connectMock.mockResolvedValue({
+      query: queryMock,
+      release: vi.fn(),
+    });
+
+    const service = DatabaseMigrationService.getInstance();
+    const result = await service.dryRunMigration({
+      sql: 'INVALID SQL STATEMENT',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.riskLevel).toBe('DANGER');
+    expect(result.error).toContain('syntax error');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5490,8 +5490,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -5505,8 +5504,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.0",
@@ -5520,8 +5518,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -5535,8 +5532,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -5550,8 +5546,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -5565,8 +5560,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -5580,8 +5574,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -5595,8 +5588,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -5610,8 +5602,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -5625,8 +5616,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -5640,8 +5630,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -5655,8 +5644,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -5670,8 +5658,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -5685,8 +5672,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -5700,8 +5686,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -5715,8 +5700,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -5730,8 +5714,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -5745,8 +5728,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -5760,8 +5742,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -5775,8 +5756,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -5790,8 +5770,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -5805,8 +5784,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -5820,8 +5798,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -5835,8 +5812,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -5850,8 +5826,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",

--- a/packages/shared-schemas/src/agent-telemetry-api.schema.ts
+++ b/packages/shared-schemas/src/agent-telemetry-api.schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const recordAgentToolCallSchema = z.object({
+  sessionId: z.string().min(1, 'Session ID is required'),
+  agentId: z.string().optional(),
+  toolName: z.string().min(1, 'Tool name is required'),
+  durationMs: z.number().min(0, 'Duration must be non-negative'),
+  status: z.enum(['success', 'error']),
+  errorMessage: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const agentSessionMetricsSchema = z.object({
+  sessionId: z.string(),
+  agentId: z.string().optional(),
+  totalToolCalls: z.number(),
+  successfulToolCalls: z.number(),
+  failedToolCalls: z.number(),
+  avgDurationMs: z.number(),
+  totalDurationMs: z.number(),
+  lastActiveAt: z.string(),
+});
+
+export const agentTelemetryStatsResponseSchema = z.object({
+  activeSessionsCount: z.number(),
+  totalToolCallsRecorded: z.number(),
+  overallSuccessRate: z.number(),
+  averageToolLatencyMs: z.number(),
+  topToolsUsed: z.array(
+    z.object({
+      toolName: z.string(),
+      count: z.number(),
+    })
+  ),
+  sessions: z.array(agentSessionMetricsSchema),
+});
+
+export type RecordAgentToolCallRequest = z.infer<typeof recordAgentToolCallSchema>;
+export type AgentSessionMetrics = z.infer<typeof agentSessionMetricsSchema>;
+export type AgentTelemetryStatsResponse = z.infer<typeof agentTelemetryStatsResponseSchema>;

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -368,6 +368,29 @@ export const createMigrationResponseSchema = migrationSchema.extend({
   message: z.string(),
 });
 
+export const dryRunMigrationRequestSchema = z.object({
+  sql: z.string().trim().min(1, 'Migration SQL is required'),
+});
+
+export const migrationRiskLevelSchema = z.enum(['SAFE', 'WARNING', 'DANGER']);
+
+export const migrationRiskFactorSchema = z.object({
+  code: z.string(),
+  description: z.string(),
+  level: migrationRiskLevelSchema,
+  statement: z.string().optional(),
+});
+
+export const dryRunMigrationResponseSchema = z.object({
+  valid: z.boolean(),
+  statementCount: z.number(),
+  statements: z.array(z.string()),
+  riskLevel: migrationRiskLevelSchema,
+  riskFactors: z.array(migrationRiskFactorSchema),
+  error: z.string().optional(),
+});
+
+
 export type CreateTableRequest = z.infer<typeof createTableRequestSchema>;
 export type CreateTableResponse = z.infer<typeof createTableResponseSchema>;
 export type GetTableSchemaResponse = z.infer<typeof getTableSchemaResponseSchema>;
@@ -406,6 +429,11 @@ export type AdminTableRecordsListResponse = z.infer<typeof adminTableRecordsList
 export type AdminTableRecordsDeleteResponse = z.infer<typeof adminTableRecordsDeleteResponseSchema>;
 export type CreateMigrationRequest = z.infer<typeof createMigrationRequestSchema>;
 export type CreateMigrationResponse = z.infer<typeof createMigrationResponseSchema>;
+export type DryRunMigrationRequest = z.infer<typeof dryRunMigrationRequestSchema>;
+export type MigrationRiskLevel = z.infer<typeof migrationRiskLevelSchema>;
+export type MigrationRiskFactor = z.infer<typeof migrationRiskFactorSchema>;
+export type DryRunMigrationResponse = z.infer<typeof dryRunMigrationResponseSchema>;
+
 
 // Database Metadata Response Schemas
 export const databaseFunctionsResponseSchema = z.object({

--- a/packages/shared-schemas/src/database-api.schema.ts
+++ b/packages/shared-schemas/src/database-api.schema.ts
@@ -390,7 +390,6 @@ export const dryRunMigrationResponseSchema = z.object({
   error: z.string().optional(),
 });
 
-
 export type CreateTableRequest = z.infer<typeof createTableRequestSchema>;
 export type CreateTableResponse = z.infer<typeof createTableResponseSchema>;
 export type GetTableSchemaResponse = z.infer<typeof getTableSchemaResponseSchema>;
@@ -433,7 +432,6 @@ export type DryRunMigrationRequest = z.infer<typeof dryRunMigrationRequestSchema
 export type MigrationRiskLevel = z.infer<typeof migrationRiskLevelSchema>;
 export type MigrationRiskFactor = z.infer<typeof migrationRiskFactorSchema>;
 export type DryRunMigrationResponse = z.infer<typeof dryRunMigrationResponseSchema>;
-
 
 // Database Metadata Response Schemas
 export const databaseFunctionsResponseSchema = z.object({

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -32,4 +32,3 @@ export * from './posthog-api.schema.js';
 export * from './memory-api.schema.js';
 export * from './agent-telemetry-api.schema.js';
 export * from './error-codes.schema.js';
-

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -30,4 +30,6 @@ export * from './compute-services-api.schema.js';
 export * from './posthog.schema.js';
 export * from './posthog-api.schema.js';
 export * from './memory-api.schema.js';
+export * from './agent-telemetry-api.schema.js';
 export * from './error-codes.schema.js';
+


### PR DESCRIPTION
Closes #1817 
## Summary
This PR introduces two major backend capabilities to enhance AI coding agent experience and platform observability:

1. **Database Migration Dry-Run & Pre-Flight Inspector**:
   - Adds `POST /api/database/migrations/dry-run` endpoint.
   - Runs SQL statements in an isolated PostgreSQL transaction rollback block (`BEGIN` -> `ROLLBACK`) to validate SQL execution and syntax without mutating state.
   - AST risk analysis categorizes DDL impact (`SAFE`, `WARNING`, `DANGER`), warning against destructive table/column drops or truncations.

2. **Agentic Execution Telemetry & Observability**:
   - Adds `AgentTelemetryService` and REST endpoints (`/api/analytics/agent-telemetry/events`, `/api/analytics/agent-telemetry/stats`, `/api/analytics/agent-telemetry/session/:id`).
   - Enables tracking of agent tool call latencies, success/error rates, session activity, and top tools used.

## Validation & Testing
- Monorepo typecheck passed: `npx turbo run typecheck` (8/8 tasks succeeded).
- Unit tests written and passing: `npx vitest run tests/unit/database-migration-dry-run.test.ts tests/unit/agent-telemetry.test.ts` (6/6 tests passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostgreSQL migration dry‑run inspector with AST‑based risk analysis and a multi‑tenant in‑memory agent telemetry service. Admins can safely validate SQL (rate‑limited), and teams can track per‑project tool usage and performance.

- **New Features**
  - Migration dry‑run (admin only): POST `/api/database/migrations/dry-run`
    - Executes in `BEGIN/ROLLBACK`; blocks unsafe session changes; flags `DROP`/`TRUNCATE`, schema/table/column/constraint drops, and `ALTER COLUMN TYPE`.
    - Returns `valid`, `statements`, `statementCount`, `riskLevel` (`SAFE`/`WARNING`/`DANGER`), `riskFactors`, `error`; rate‑limited to 30 requests per 15 minutes (429 on exceed).
  - Agent telemetry (auth required):
    - POST `/api/analytics/agent-telemetry/events`, GET `/api/analytics/agent-telemetry/stats`, GET `/api/analytics/agent-telemetry/session/:id`.
    - Scoped per project/user; provides active sessions, success rate, average latency, and top tools; in‑memory store capped at 5k records.
  - Schemas in `@insforge/shared-schemas`: `recordAgentToolCallSchema`, `agentSessionMetricsSchema`, `agentTelemetryStatsResponseSchema`, `dryRunMigrationRequestSchema`, `dryRunMigrationResponseSchema`, `migrationRiskLevelSchema`, `migrationRiskFactorSchema`.

<sup>Written for commit 6af2112c3e3e9264856932430a3efdc6b28b58d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add database migration dry-run endpoint and in-memory agent telemetry service
> - Adds `POST /database/migrations/dry-run`, an admin-only, rate-limited endpoint (30 req/15 min) that parses SQL, evaluates risk factors via AST analysis (detecting DROP, TRUNCATE, ALTER TABLE), executes transactionally and rolls back, and returns a structured `DryRunMigrationResponse` with validity, risk level, and risk factors.
> - Adds `AgentTelemetryService`, an in-memory singleton (max 5000 records) that records agent tool-call events scoped by project and exposes session metrics and system-wide stats via three new authenticated analytics routes.
> - Adds Zod schemas and TypeScript types for both features in `shared-schemas` ([database-api.schema.ts](https://github.com/InsForge/InsForge/pull/1816/files#diff-b36b10da732a6923ba4ff08476bd3df82a78720ab4015b38906da55567b904ff) and [agent-telemetry-api.schema.ts](https://github.com/InsForge/InsForge/pull/1816/files#diff-73888772cc0113b1c2138787ae152d3abb6a6fdf5554279c66ab126019d0b9f2)).
> - Risk: Agent telemetry data is stored only in memory and is lost on process restart; no persistence layer is used.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6af2112.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent telemetry tracking with per-session and system-wide stats (success rate, latency, top tools).
  * Added authenticated endpoints to record agent tool-call events and retrieve telemetry, including per-session metrics.
  * Added an admin-only database migration **dry-run** endpoint that validates SQL and returns structured risk results, rate-limited to prevent abuse.
* **Tests**
  * Added unit tests covering telemetry aggregation and migration dry-run risk/invalid execution outcomes.
* **Documentation**
  * Extended shared API schemas for agent telemetry and migration dry-run validation/response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->