### PR TITLE
fix(auth): rate limit public self-serve registration

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -196,6 +196,50 @@ export const sendEmailOTPLimiter = [
 export const verifyOTPLimiter = [verifyOTPRateLimiter];
 
 /**
+ * Per-IP rate limiter for public self-serve registration (POST /api/auth/users).
+ *
+ * Every other public write path here is already bounded (OTP send/verify, functions,
+ * deployments, compute, storage); registration is brought in line with them.
+ *
+ * `skipSuccessfulRequests` is deliberately FALSE, unlike the OTP-verify limiter above.
+ * There, a success means a legitimate user finished a flow and shouldn't spend budget.
+ * On registration a success is what consumes the resource being bounded, since it writes
+ * a user row, so successes are counted too.
+ *
+ * The ceiling is per IP and deliberately generous — end users of a busy app can share an
+ * egress IP (office NAT, carrier CGNAT), and throttling a customer's real signups is the
+ * more costly failure. Override with REGISTRATION_RATE_LIMIT_MAX where a deployment
+ * needs a different shape.
+ */
+const REGISTRATION_LIMIT_MAX = parseInt(process.env.REGISTRATION_RATE_LIMIT_MAX ?? '', 10) || 20;
+
+export const registrationRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: REGISTRATION_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many registration attempts from this IP. Please try again in 15 minutes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+  // Count successes AND failures — see above.
+  skipSuccessfulRequests: false,
+  skipFailedRequests: false,
+  // Admin-initiated creation is not self-serve signup: the dashboard adding a user and
+  // server-side API-key calls (bulk import, seeding) must not be throttled. Mirrors the
+  // route's own `adminCreatingUser` check, so the two cannot drift apart silently.
+  skip: (req: Request) => {
+    const authReq = req as Request & { hasApiKey?: boolean; user?: { role?: string } };
+    return authReq.hasApiKey === true || authReq.user?.role === 'project_admin';
+  },
+});
+
+/**
  * Per-IP rate limiters for "write" endpoints that ultimately drive an external
  * provider call.
  *

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -16,6 +16,7 @@ import {
   sendEmailOTPLimiter,
   verifyOTPLimiter,
   verifyOTPRateLimiter,
+  registrationRateLimiter,
 } from '@/api/middlewares/rate-limiters.js';
 import {
   REFRESH_TOKEN_COOKIE_NAME,
@@ -347,81 +348,86 @@ router.put('/config', verifyAdmin, async (req: AuthRequest, res: Response, next:
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
 // When called with a valid admin token (e.g. dashboard adding a user), we do NOT set session
 // cookie or return csrf/refresh tokens, so the admin's session is not overwritten.
-router.post('/users', verifyUser, async (req: AuthRequest, res: Response, next: NextFunction) => {
-  try {
-    const clientType = parseClientType(req.query.client_type);
-    // verifyUser has already authenticated the caller by credential shape.
-    // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
-    const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
+router.post(
+  '/users',
+  verifyUser,
+  registrationRateLimiter,
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const clientType = parseClientType(req.query.client_type);
+      // verifyUser has already authenticated the caller by credential shape.
+      // API keys set req.hasApiKey; project_admin JWTs set req.user.role.
+      const adminCreatingUser = req.hasApiKey === true || req.user?.role === 'project_admin';
 
-    const validationResult = createUserRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
-    }
-
-    if (!adminCreatingUser) {
-      const { disableSignup } = await authConfigService.getAuthConfig();
-      if (disableSignup) {
+      const validationResult = createUserRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
         throw new AppError(
-          'User signups are disabled for this project.',
-          403,
-          ERROR_CODES.AUTH_SIGNUP_DISABLED
+          validationResult.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
         );
       }
-    }
 
-    const {
-      email,
-      password,
-      name,
-      redirectTo,
-      autoConfirm: bodyAutoConfirm,
-    } = validationResult.data;
-    const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
-    const result: CreateUserResponse = await authService.register(
-      email,
-      password,
-      name,
-      redirectTo,
-      { isAdminCreation: adminCreatingUser, autoConfirm }
-    );
-
-    // Set refresh token based on client type (skip when admin is adding a user)
-    if (result.accessToken && result.user && !adminCreatingUser) {
-      const tokenManager = TokenManager.getInstance();
-      if (clientType === 'web') {
-        // Web clients: use httpOnly cookie + CSRF token
-        const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-          result.user.id,
-          'user'
-        );
-        setRefreshTokenCookie(res, refreshToken);
-        result.csrfToken = csrfToken;
-      } else {
-        const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
-        // Non-web clients (mobile, desktop, server): return refresh token in response body.
-        // Server clients cannot rely on browser cookies, so they follow the native-app flow.
-        result.refreshToken = refreshToken;
+      if (!adminCreatingUser) {
+        const { disableSignup } = await authConfigService.getAuthConfig();
+        if (disableSignup) {
+          throw new AppError(
+            'User signups are disabled for this project.',
+            403,
+            ERROR_CODES.AUTH_SIGNUP_DISABLED
+          );
+        }
       }
+
+      const {
+        email,
+        password,
+        name,
+        redirectTo,
+        autoConfirm: bodyAutoConfirm,
+      } = validationResult.data;
+      const autoConfirm = adminCreatingUser ? bodyAutoConfirm : false;
+      const result: CreateUserResponse = await authService.register(
+        email,
+        password,
+        name,
+        redirectTo,
+        { isAdminCreation: adminCreatingUser, autoConfirm }
+      );
+
+      // Set refresh token based on client type (skip when admin is adding a user)
+      if (result.accessToken && result.user && !adminCreatingUser) {
+        const tokenManager = TokenManager.getInstance();
+        if (clientType === 'web') {
+          // Web clients: use httpOnly cookie + CSRF token
+          const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+            result.user.id,
+            'user'
+          );
+          setRefreshTokenCookie(res, refreshToken);
+          result.csrfToken = csrfToken;
+        } else {
+          const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
+          // Non-web clients (mobile, desktop, server): return refresh token in response body.
+          // Server clients cannot rely on browser cookies, so they follow the native-app flow.
+          result.refreshToken = refreshToken;
+        }
+      }
+
+      const socket = SocketManager.getInstance();
+      socket.broadcastToRoom(
+        'role:project_admin',
+        ServerEvents.DATA_UPDATE,
+        { resource: DataUpdateResourceType.USERS },
+        'system'
+      );
+
+      successResponse(res, result);
+    } catch (error) {
+      next(error);
     }
-
-    const socket = SocketManager.getInstance();
-    socket.broadcastToRoom(
-      'role:project_admin',
-      ServerEvents.DATA_UPDATE,
-      { resource: DataUpdateResourceType.USERS },
-      'system'
-    );
-
-    successResponse(res, result);
-  } catch (error) {
-    next(error);
   }
-});
+);
 
 // POST /api/auth/sessions - Create a new session with a password or email OTP
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'

--- a/backend/tests/unit/auth-create-user-route.test.ts
+++ b/backend/tests/unit/auth-create-user-route.test.ts
@@ -69,6 +69,8 @@ const NEW_USER = {
   accessToken: 'test-access-token',
 };
 
+let callRouteCounter = 1;
+
 function callRoute(
   router: Router,
   overrides: { headers?: Record<string, string>; body?: Record<string, unknown> }
@@ -82,8 +84,14 @@ function callRoute(
       headers: overrides.headers ?? {},
       query: {},
       body: overrides.body ?? {},
+      // registrationRateLimiter keys on the client IP, so every call gets its OWN ip.
+      // Sharing one would make these tests share a rate-limit bucket: harmless today at
+      // 20/15min, but the suite would start failing on whichever test happened to be
+      // ~21st, with a 429 that has nothing to do with what it asserts.
+      ip: `10.0.0.${callRouteCounter++ % 255}`,
     };
 
+    const headers = new Map<string, unknown>();
     const res: Partial<Response> = {
       status: vi.fn((c: number) => {
         statusCode = c;
@@ -91,6 +99,14 @@ function callRoute(
       }),
       json: vi.fn((d: unknown) => resolve({ statusCode, body: d })),
       cookie: vi.fn(() => res),
+      // `standardHeaders: true` on the registration limiter writes RateLimit-* headers.
+      // These are no-ops here, but their absence made the limiter throw inside a promise
+      // that never settled, so every test on this route timed out rather than failing.
+      setHeader: vi.fn((name: string, value: unknown) => {
+        headers.set(name, value);
+        return res as Response;
+      }),
+      getHeader: vi.fn((name: string) => headers.get(name)),
     };
 
     router(

--- a/backend/tests/unit/auth-email-otp-route.test.ts
+++ b/backend/tests/unit/auth-email-otp-route.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/api/middlewares/rate-limiters.js', () => ({
     mocks.verifyOTPRequest(req.body);
     next();
   },
+  registrationRateLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
 vi.mock('@/infra/security/token.manager.js', () => ({

--- a/backend/tests/unit/registration-limiter.test.ts
+++ b/backend/tests/unit/registration-limiter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express, { type RequestHandler, type Request, type Response } from 'express';
+import request from 'supertest';
+import { registrationRateLimiter } from '@/api/middlewares/rate-limiters.js';
+
+// express-rate-limit keeps in-memory state per limiter instance; reset the
+// bucket between tests. supertest's default remote address is the key below.
+const DEFAULT_KEY = '::ffff:127.0.0.1';
+const BUDGET = 20; // keep in sync with registrationRateLimiter `max`
+
+function resetLimiter(limiter: RequestHandler): void {
+  (limiter as unknown as { resetKey: (k: string) => void }).resetKey(DEFAULT_KEY);
+}
+
+/**
+ * Models POST /api/auth/users: `verifyUser` runs FIRST and sets the credential
+ * shape, then the limiter reads it. `as` mirrors what verifyUser would attach —
+ * undefined for an anon_ key (self-serve signup), hasApiKey/project_admin for an
+ * admin-initiated create.
+ */
+function buildApp(as?: { hasApiKey?: boolean; role?: string }) {
+  const app = express();
+  app.post(
+    '/users',
+    (req: Request, _res: Response, next) => {
+      const authReq = req as Request & { hasApiKey?: boolean; user?: { role?: string } };
+      if (as?.hasApiKey) authReq.hasApiKey = true;
+      if (as?.role) authReq.user = { role: as.role };
+      next();
+    },
+    registrationRateLimiter,
+    // A registration that SUCCEEDS. This matters: the limiter must charge for
+    // successes, so the stub must not return an error.
+    (_req, res) => {
+      res.status(201).json({ ok: true });
+    }
+  );
+  return app;
+}
+
+describe('registrationRateLimiter (POST /api/auth/users)', () => {
+  beforeEach(() => {
+    resetLimiter(registrationRateLimiter);
+  });
+
+  it(`allows ${BUDGET} self-serve registrations in the window from one IP`, async () => {
+    const app = buildApp();
+    for (let i = 0; i < BUDGET; i++) {
+      await request(app).post('/users').send({}).expect(201);
+    }
+  });
+
+  it(`rejects registration #${BUDGET + 1} with 429, not 500`, async () => {
+    const app = buildApp();
+    for (let i = 0; i < BUDGET; i++) {
+      await request(app).post('/users').send({}).expect(201);
+    }
+    const r = await request(app).post('/users').send({});
+    // The limiter surfaces the refusal via next(new AppError(..., 429)). If that
+    // ever gets swallowed into a generic 500 the endpoint is still blocked but
+    // blames us and drops Retry-After, so assert the status explicitly.
+    expect(r.status).toBe(429);
+  });
+
+  // GUARD: this is the test that fails if someone sets skipSuccessfulRequests:true.
+  // Every request above returned 201, so the budget can only have been consumed by
+  // successes. Registration differs from the OTP-verify limiter above precisely
+  // here: an accepted call is the one that costs something (it writes a user row),
+  // so a setting that skipped successes would make this limiter ineffective for the
+  // case it exists to cover while still appearing on the route.
+  it('charges for SUCCESSFUL registrations, not just failed ones', async () => {
+    const app = buildApp();
+    for (let i = 0; i < BUDGET; i++) {
+      await request(app).post('/users').send({}).expect(201);
+    }
+    const r = await request(app).post('/users').send({});
+    expect(r.status).toBe(429);
+  });
+
+  it('exposes RateLimit-* headers and no legacy X-RateLimit-*', async () => {
+    const app = buildApp();
+    const r = await request(app).post('/users').send({}).expect(201);
+    expect(r.headers['ratelimit-limit']).toBe(String(BUDGET));
+    expect(r.headers['x-ratelimit-limit']).toBeUndefined();
+  });
+
+  describe('admin-initiated creation is exempt', () => {
+    it('does not throttle an API-key caller past the budget', async () => {
+      const app = buildApp({ hasApiKey: true });
+      for (let i = 0; i < BUDGET + 5; i++) {
+        await request(app).post('/users').send({}).expect(201);
+      }
+    });
+
+    it('does not throttle a project_admin caller past the budget', async () => {
+      const app = buildApp({ role: 'project_admin' });
+      for (let i = 0; i < BUDGET + 5; i++) {
+        await request(app).post('/users').send({}).expect(201);
+      }
+    });
+
+    // NEGATIVE CONTROL for the two above: `skip` must stop the request being
+    // COUNTED, not merely stop it being refused. Without this, an implementation
+    // that counted admin calls and only skipped the refusal would pass both tests
+    // while silently burning a customer's signup budget from the dashboard.
+    it('admin calls do not consume the self-serve budget', async () => {
+      const adminApp = buildApp({ hasApiKey: true });
+      for (let i = 0; i < BUDGET + 5; i++) {
+        await request(adminApp).post('/users').send({}).expect(201);
+      }
+      // Same limiter instance, same IP — a self-serve caller must still have its
+      // full allowance.
+      const selfServeApp = buildApp();
+      for (let i = 0; i < BUDGET; i++) {
+        await request(selfServeApp).post('/users').send({}).expect(201);
+      }
+      const r = await request(selfServeApp).post('/users').send({});
+      expect(r.status).toBe(429);
+    });
+  });
+});


### PR DESCRIPTION
`rate-limiters.ts` is applied to every other public write path in this backend — OTP send/verify, functions, deployments, compute and storage writes. `POST /api/auth/users` was missed. This adds it, so registration is consistent with the rest.

## What this does

- Per-IP limiter, **20 per 15 minutes**, `REGISTRATION_RATE_LIMIT_MAX` to override.
- Placed **after `verifyUser`** so it can distinguish self-serve signup from admin-initiated creation, and **skips the latter** — the dashboard adding a user and server-side API-key calls (bulk import, seeding) must not be throttled. The `skip` predicate mirrors the route's own `adminCreatingUser` check so the two can't drift apart silently.
- The ceiling is deliberately generous rather than tight: end users of a busy app share egress IPs (office NAT, carrier CGNAT), and throttling a customer's real signups is a worse failure than a slow attacker.

## The one judgement call worth reviewing

**`skipSuccessfulRequests` is `false` here, unlike the OTP-verify limiter above it.** That difference is deliberate:

- On OTP verify, a success means a legitimate user finished a flow, and spending their budget on it would penalise normal use.
- On registration, a success is what consumes the resource being bounded — it writes a user row. Counting only failures would make the limiter's behaviour differ sharply from what its presence on the route implies.

## Test-harness fixes this forced

Both would otherwise surface later as unrelated-looking flakes, so they're called out rather than buried:

- `auth-create-user-route.test.ts` drives the router with a hand-rolled fake `res` that had no `setHeader`. With `standardHeaders: true` the limiter threw inside a promise that never settled, so **every test on this route timed out rather than failing** — a 30s hang with no useful message. The fake now implements `setHeader`/`getHeader`.
- The same file now uses a **distinct IP per call**. Sharing one meant the cases shared a rate-limit bucket: harmless at 11 tests, but whoever pushed it past 20 would get a 429 on whichever test happened to land 21st, unrelated to what it asserts.
- `auth-email-otp-route.test.ts` mocks the rate-limiters module and needed the new export.

## Verification

`npm run typecheck` clean, `eslint` clean, `prettier --check` clean on all four files. Full backend unit suite: **1941 passed, 21 skipped, 0 failed**.

Not covered here: an end-to-end test that drives real HTTP at the route and asserts a 429 on the N+1th call. Asserting the limiter is *present in the route config* would prove only that a literal was written, not that Express enforces it. That test is coming separately from our QA side and is the assertion that actually pins this behaviour.

## Note on process

Filed as a PR without a linked issue by internal decision. Per `CONTRIBUTING.md` that means a `needs-issue` / `needs-assignment` label is expected — the label is not a request to go open an issue.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rate limit public self-serve registration at 20 requests per IP per 15 minutes
> - Adds `registrationRateLimiter` middleware in [`rate-limiters.ts`](https://github.com/InsForge/InsForge/pull/1819/files#diff-480baae8624beaf0acd251f42ee5b1770f4ce53f5b14346ed6f91efe75227d21) using a 15-minute window, defaulting to 20 attempts per IP (configurable via `REGISTRATION_RATE_LIMIT_MAX`).
> - Applies the limiter to `POST /api/auth/users` in [`auth/index.routes.ts`](https://github.com/InsForge/InsForge/pull/1819/files#diff-02e5766444cbf08dddf5fdd3cb633546685cfd90633155f33680e6d8aa72d1fd); both successful and failed attempts count against the budget.
> - API-key callers and `project_admin` users are exempt from the limit.
> - Returns a 429 `AppError` with `TOO_MANY_REQUESTS` error code when the limit is exceeded and emits standard `RateLimit-*` headers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5815158.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->