### PR TITLE
feat(auth): add native Apple ID token sign-in

### DIFF
--- a/backend/src/api/middlewares/rate-limiters.ts
+++ b/backend/src/api/middlewares/rate-limiters.ts
@@ -146,6 +146,31 @@ export const verifyOTPRateLimiter = rateLimit({
 });
 
 /**
+ * Per-IP rate limiter for native provider ID-token exchanges.
+ * These unauthenticated requests perform cryptographic token verification and
+ * may fetch provider signing keys, so count both successful and failed calls.
+ *
+ * Limits: 30 attempts per 15 minutes per IP
+ */
+export const idTokenSignInRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (_req: Request, _res: Response, next: NextFunction) => {
+    next(
+      new AppError(
+        'Too many ID token sign-in attempts from this IP. Please try again in 15 minutes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+  },
+  skipSuccessfulRequests: false,
+  skipFailedRequests: false,
+});
+
+/**
  * Per-email cooldown middleware
  * Prevents enumeration attacks by enforcing minimum time between requests for same email
  *

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -53,6 +53,7 @@ import {
   updateAuthConfigRequestSchema,
   upsertSmtpConfigRequestSchema,
   updateEmailTemplateRequestSchema,
+  idTokenSignInRequestSchema,
 } from '@insforge/shared-schemas';
 import { SmtpConfigService } from '@/services/email/smtp-config.service.js';
 import { EmailTemplateService } from '@/services/email/email-template.service.js';
@@ -469,33 +470,33 @@ router.post(
   }
 );
 
-// POST /api/auth/id-token - Sign in with ID token from native SDK (Google One Tap, etc.)
+// POST /api/auth/id-token - Sign in with an ID token from a native provider SDK
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
 router.post('/id-token', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const clientType = parseClientType(req.query.client_type);
 
-    const { provider, token } = req.body;
-
-    // Validate input
-    if (!provider || typeof provider !== 'string') {
-      throw new AppError('Provider is required', 400, ERROR_CODES.INVALID_INPUT);
-    }
-
-    if (provider !== 'google') {
+    const validationResult = idTokenSignInRequestSchema.safeParse(req.body);
+    if (!validationResult.success) {
       throw new AppError(
-        `Provider ${provider} is not supported for ID token sign-in. Supported: google`,
+        validationResult.error.issues
+          .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+          .join(', '),
         400,
         ERROR_CODES.INVALID_INPUT
       );
     }
 
-    if (!token || typeof token !== 'string') {
-      throw new AppError('Token is required', 400, ERROR_CODES.INVALID_INPUT);
-    }
+    const request = validationResult.data;
 
     // Sign in with ID token
-    const result: CreateSessionResponse = await authService.signInWithIdToken(provider, token);
+    const result: CreateSessionResponse =
+      request.provider === 'apple'
+        ? await authService.signInWithIdToken('apple', request.token, {
+            nonce: request.nonce,
+            name: request.name,
+          })
+        : await authService.signInWithIdToken('google', request.token);
 
     // Set refresh token based on client type
     const tokenManager = TokenManager.getInstance();

--- a/backend/src/api/routes/auth/index.routes.ts
+++ b/backend/src/api/routes/auth/index.routes.ts
@@ -13,6 +13,7 @@ import adminRouter from './admin.routes.js';
 import oauthRouter from './oauth.routes.js';
 import customOAuthRouter from './custom-oauth.routes.js';
 import {
+  idTokenSignInRateLimiter,
   sendEmailOTPLimiter,
   verifyOTPLimiter,
   verifyOTPRateLimiter,
@@ -472,54 +473,58 @@ router.post(
 
 // POST /api/auth/id-token - Sign in with an ID token from a native provider SDK
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'
-router.post('/id-token', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const clientType = parseClientType(req.query.client_type);
+router.post(
+  '/id-token',
+  idTokenSignInRateLimiter,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const clientType = parseClientType(req.query.client_type);
 
-    const validationResult = idTokenSignInRequestSchema.safeParse(req.body);
-    if (!validationResult.success) {
-      throw new AppError(
-        validationResult.error.issues
-          .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
-          .join(', '),
-        400,
-        ERROR_CODES.INVALID_INPUT
-      );
+      const validationResult = idTokenSignInRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        throw new AppError(
+          validationResult.error.issues
+            .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+            .join(', '),
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const request = validationResult.data;
+
+      // Sign in with ID token
+      const result: CreateSessionResponse =
+        request.provider === 'apple'
+          ? await authService.signInWithIdToken('apple', request.token, {
+              nonce: request.nonce,
+              name: request.name,
+            })
+          : await authService.signInWithIdToken('google', request.token);
+
+      // Set refresh token based on client type
+      const tokenManager = TokenManager.getInstance();
+      if (clientType === 'web') {
+        // Web clients: use httpOnly cookie + CSRF token
+        const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
+          result.user.id,
+          'user'
+        );
+        setRefreshTokenCookie(res, refreshToken);
+        result.csrfToken = csrfToken;
+      } else {
+        const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
+        // Non-web clients (mobile, desktop, server): return refresh token in response body.
+        // Server clients cannot rely on browser cookies, so they follow the native-app flow.
+        result.refreshToken = refreshToken;
+      }
+
+      successResponse(res, result);
+    } catch (error) {
+      next(error);
     }
-
-    const request = validationResult.data;
-
-    // Sign in with ID token
-    const result: CreateSessionResponse =
-      request.provider === 'apple'
-        ? await authService.signInWithIdToken('apple', request.token, {
-            nonce: request.nonce,
-            name: request.name,
-          })
-        : await authService.signInWithIdToken('google', request.token);
-
-    // Set refresh token based on client type
-    const tokenManager = TokenManager.getInstance();
-    if (clientType === 'web') {
-      // Web clients: use httpOnly cookie + CSRF token
-      const { refreshToken, csrfToken } = tokenManager.generateRefreshTokenWithCsrf(
-        result.user.id,
-        'user'
-      );
-      setRefreshTokenCookie(res, refreshToken);
-      result.csrfToken = csrfToken;
-    } else {
-      const refreshToken = tokenManager.generateRefreshToken(result.user.id, 'user');
-      // Non-web clients (mobile, desktop, server): return refresh token in response body.
-      // Server clients cannot rely on browser cookies, so they follow the native-app flow.
-      result.refreshToken = refreshToken;
-    }
-
-    successResponse(res, result);
-  } catch (error) {
-    next(error);
   }
-});
+);
 
 // POST /api/auth/refresh - Refresh access token
 // Query params: client_type (optional) - 'web' (default), 'mobile', 'desktop', or 'server'

--- a/backend/src/infra/database/migrations/062_add-oauth-native-client-ids.sql
+++ b/backend/src/infra/database/migrations/062_add-oauth-native-client-ids.sql
@@ -1,0 +1,9 @@
+-- Migration 062: Native OAuth client IDs
+--
+-- Browser OAuth commonly uses a web/service client ID while native provider
+-- SDKs issue ID tokens for an app-specific client ID. Keep those trusted
+-- audiences in project-owned OAuth configuration instead of accepting an
+-- audience selected by an unauthenticated sign-in request.
+
+ALTER TABLE auth.oauth_configs
+  ADD COLUMN IF NOT EXISTS native_client_ids TEXT[] NOT NULL DEFAULT '{}';

--- a/backend/src/infra/database/migrations/062_add-oauth-native-client-ids.sql
+++ b/backend/src/infra/database/migrations/062_add-oauth-native-client-ids.sql
@@ -6,4 +6,14 @@
 -- audience selected by an unauthenticated sign-in request.
 
 ALTER TABLE auth.oauth_configs
-  ADD COLUMN IF NOT EXISTS native_client_ids TEXT[] NOT NULL DEFAULT '{}';
+  ADD COLUMN IF NOT EXISTS native_client_ids TEXT[];
+
+UPDATE auth.oauth_configs
+SET native_client_ids = '{}'
+WHERE native_client_ids IS NULL;
+
+ALTER TABLE auth.oauth_configs
+  ALTER COLUMN native_client_ids SET DEFAULT '{}';
+
+ALTER TABLE auth.oauth_configs
+  ALTER COLUMN native_client_ids SET NOT NULL;

--- a/backend/src/providers/oauth/apple.provider.ts
+++ b/backend/src/providers/oauth/apple.provider.ts
@@ -1,9 +1,57 @@
 import axios from 'axios';
+import { createHash } from 'node:crypto';
+import { createRemoteJWKSet, jwtVerify, type JWTVerifyGetKey } from 'jose';
 import logger from '@/utils/logger.js';
 import { getApiBaseUrl } from '@/utils/environment.js';
 import { OAuthConfigService } from '@/services/auth/oauth-config.service.js';
 import type { AppleUserInfo, OAuthUserData } from '@/types/auth.js';
 import { OAuthProvider } from './base.provider.js';
+
+const APPLE_ISSUER = 'https://appleid.apple.com';
+
+export interface AppleIdTokenVerificationOptions {
+  audiences: string[];
+  nonce?: string;
+}
+
+/**
+ * Verify an Apple identity token against an explicit server-owned audience set.
+ * Exported separately so tests can use a generated local JWK set without network access.
+ */
+export async function verifyAppleIdToken(
+  idToken: string,
+  getKey: JWTVerifyGetKey,
+  options: AppleIdTokenVerificationOptions
+): Promise<AppleUserInfo> {
+  const audiences = [...new Set(options.audiences.map((value) => value.trim()).filter(Boolean))];
+  if (!audiences.length) {
+    throw new Error('No Apple ID token audiences are configured');
+  }
+
+  const { payload } = await jwtVerify(idToken, getKey, {
+    algorithms: ['ES256'],
+    issuer: APPLE_ISSUER,
+    audience: audiences,
+  });
+
+  if (typeof payload.sub !== 'string' || !payload.sub.trim()) {
+    throw new Error('Apple ID token is missing the sub claim');
+  }
+
+  if (options.nonce !== undefined) {
+    const expectedNonce = createHash('sha256').update(options.nonce, 'utf8').digest('hex');
+    if (payload.nonce !== expectedNonce) {
+      throw new Error('Apple ID token nonce does not match');
+    }
+  }
+
+  return {
+    sub: payload.sub,
+    email: typeof payload.email === 'string' ? payload.email : '',
+    email_verified: payload.email_verified === 'true' || payload.email_verified === true,
+    is_private_email: payload.is_private_email === 'true' || payload.is_private_email === true,
+  };
+}
 
 /**
  * Apple OAuth Service
@@ -17,9 +65,10 @@ import { OAuthProvider } from './base.provider.js';
  */
 export class AppleOAuthProvider implements OAuthProvider {
   private static instance: AppleOAuthProvider;
+  private readonly appleJwks: JWTVerifyGetKey;
 
   private constructor() {
-    // No initialization needed - jose handles JWKS caching internally
+    this.appleJwks = createRemoteJWKSet(new URL(`${APPLE_ISSUER}/auth/keys`));
   }
 
   public static getInstance(): AppleOAuthProvider {
@@ -204,7 +253,10 @@ export class AppleOAuthProvider implements OAuthProvider {
   /**
    * Verify Apple ID token and extract user info
    */
-  async verifyIdToken(idToken: string): Promise<AppleUserInfo> {
+  async verifyIdToken(
+    idToken: string,
+    options?: { nonce?: string; native?: boolean }
+  ): Promise<AppleUserInfo> {
     const oAuthConfigService = OAuthConfigService.getInstance();
     const config = await oAuthConfigService.getConfigByProvider('apple');
 
@@ -213,23 +265,18 @@ export class AppleOAuthProvider implements OAuthProvider {
     }
 
     try {
-      const { createRemoteJWKSet, jwtVerify } = await import('jose');
-      const JWKS = createRemoteJWKSet(new URL('https://appleid.apple.com/auth/keys'));
+      const audiences = options?.native
+        ? [config.clientId, ...(config.nativeClientIds ?? [])]
+        : [config.clientId];
 
-      const { payload } = await jwtVerify(idToken, JWKS, {
-        issuer: 'https://appleid.apple.com',
-        audience: config.clientId,
+      return await verifyAppleIdToken(idToken, this.appleJwks, {
+        audiences: audiences.filter((value): value is string => Boolean(value)),
+        nonce: options?.nonce,
       });
-
-      return {
-        sub: String(payload.sub),
-        email: (payload.email as string) || '',
-        email_verified: payload.email_verified === 'true' || payload.email_verified === true,
-        is_private_email: payload.is_private_email === 'true' || payload.is_private_email === true,
-      };
     } catch (error) {
-      logger.error('Apple ID token verification failed:', error);
-      throw new Error(`Apple token verification failed: ${error}`);
+      const message = error instanceof Error ? error.message : 'Unknown verification error';
+      logger.error('Apple ID token verification failed', { error: message });
+      throw new Error(`Apple token verification failed: ${message}`);
     }
   }
 

--- a/backend/src/providers/oauth/apple.provider.ts
+++ b/backend/src/providers/oauth/apple.provider.ts
@@ -29,7 +29,7 @@ export async function verifyAppleIdToken(
   }
 
   const { payload } = await jwtVerify(idToken, getKey, {
-    algorithms: ['ES256'],
+    algorithms: ['RS256'],
     issuer: APPLE_ISSUER,
     audience: audiences,
   });

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -912,6 +912,14 @@ export class AuthService {
       return { user, accessToken };
     }
 
+    if (!email) {
+      throw new AppError(
+        'A verified email address is required to create or link an OAuth account.',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+
     // If not found by provider_id, try to find by email in _user table
     const existingUserResult = await pool.query('SELECT * FROM auth.users WHERE email = $1', [
       email,
@@ -1260,10 +1268,13 @@ export class AuthService {
   }
 
   /**
-   * Sign in with ID token from native SDK (Google One Tap, etc.)
-   * Limited to Google for now to unblock customer ask, can extend to other providers later as needed.
+   * Sign in with ID token from a native provider SDK.
    */
-  async signInWithIdToken(provider: 'google', idToken: string): Promise<CreateSessionResponse> {
+  async signInWithIdToken(
+    provider: 'google' | 'apple',
+    idToken: string,
+    options?: { nonce?: string; name?: string }
+  ): Promise<CreateSessionResponse> {
     let userData: OAuthUserData;
 
     switch (provider) {
@@ -1305,9 +1316,50 @@ export class AuthService {
         break;
       }
 
+      case 'apple': {
+        const nonce = options?.nonce?.trim();
+        if (!nonce) {
+          throw new AppError(
+            'Nonce is required for Apple ID token sign-in',
+            400,
+            ERROR_CODES.INVALID_INPUT
+          );
+        }
+
+        let appleUserInfo: AppleUserInfo;
+        try {
+          appleUserInfo = await this.appleOAuthProvider.verifyIdToken(idToken, {
+            nonce,
+            native: true,
+          });
+        } catch (error) {
+          logger.error('Failed to verify Apple ID token', {
+            error: error instanceof Error ? error.message : 'Unknown verification error',
+          });
+          throw new AppError('Failed to verify Apple ID token', 401, ERROR_CODES.AUTH_UNAUTHORIZED);
+        }
+
+        const email =
+          appleUserInfo.email_verified && appleUserInfo.email
+            ? appleUserInfo.email.trim().toLowerCase()
+            : '';
+        const suppliedName = options?.name?.trim();
+        const userName = suppliedName || (email ? email.split('@')[0] : 'Apple User');
+
+        userData = {
+          provider: 'apple',
+          providerId: appleUserInfo.sub,
+          email,
+          userName,
+          avatarUrl: '',
+          identityData: appleUserInfo,
+        };
+        break;
+      }
+
       default:
         throw new AppError(
-          `Provider ${provider} is not supported for ID token sign-in. Supported: google`,
+          `Provider ${provider} is not supported for ID token sign-in. Supported: google, apple`,
           400,
           ERROR_CODES.INVALID_INPUT
         );

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -873,7 +873,8 @@ export class AuthService {
       | FacebookUserInfo
       | XUserInfo
       | AppleUserInfo
-      | Record<string, unknown>
+      | Record<string, unknown>,
+    options?: { requireEmailForNewAccount?: boolean }
   ): Promise<CreateSessionResponse> {
     const pool = this.getPool();
 
@@ -912,7 +913,7 @@ export class AuthService {
       return { user, accessToken };
     }
 
-    if (!email) {
+    if (options?.requireEmailForNewAccount && !email) {
       throw new AppError(
         'A verified email address is required to create or link an OAuth account.',
         400,
@@ -921,9 +922,14 @@ export class AuthService {
     }
 
     // If not found by provider_id, try to find by email in _user table
-    const existingUserResult = await pool.query('SELECT * FROM auth.users WHERE email = $1', [
-      email,
-    ]);
+    const existingUserResult = await pool.query(
+      `SELECT *
+       FROM auth.users
+       WHERE lower(email) = lower($1)
+       ORDER BY created_at ASC
+       LIMIT 1`,
+      [email]
+    );
     const existingUser = existingUserResult.rows[0];
 
     if (existingUser) {
@@ -1317,8 +1323,8 @@ export class AuthService {
       }
 
       case 'apple': {
-        const nonce = options?.nonce?.trim();
-        if (!nonce) {
+        const nonce = options?.nonce;
+        if (!nonce || !nonce.trim()) {
           throw new AppError(
             'Nonce is required for Apple ID token sign-in',
             400,
@@ -1372,7 +1378,8 @@ export class AuthService {
       userData.email,
       userData.userName,
       userData.avatarUrl,
-      userData.identityData
+      userData.identityData,
+      provider === 'apple' ? { requireEmailForNewAccount: true } : undefined
     );
   }
 

--- a/backend/src/services/auth/oauth-config.service.ts
+++ b/backend/src/services/auth/oauth-config.service.ts
@@ -24,6 +24,10 @@ export interface UpdateOAuthConfigInput {
   useSharedKey?: boolean;
 }
 
+function normalizeNativeClientIds(ids?: string[]): string[] {
+  return [...new Set((ids ?? []).map((id) => id.trim()).filter(Boolean))];
+}
+
 export class OAuthConfigService {
   private static instance: OAuthConfigService;
   private pool: Pool | null = null;
@@ -256,7 +260,7 @@ export class OAuthConfigService {
         [
           input.provider.toLowerCase(),
           input.clientId || null,
-          input.nativeClientIds || [],
+          normalizeNativeClientIds(input.nativeClientIds),
           secretId,
           null, // Deprecating redirect_uri
           scopes,
@@ -344,7 +348,7 @@ export class OAuthConfigService {
 
       if (input.nativeClientIds !== undefined) {
         updates.push(`native_client_ids = $${paramCount++}`);
-        values.push(input.nativeClientIds);
+        values.push(normalizeNativeClientIds(input.nativeClientIds));
       }
 
       if (input.redirectUri !== undefined) {

--- a/backend/src/services/auth/oauth-config.service.ts
+++ b/backend/src/services/auth/oauth-config.service.ts
@@ -8,6 +8,7 @@ import { ERROR_CODES, OAuthConfigSchema, OAuthProvidersSchema } from '@insforge/
 export interface CreateOAuthConfigInput {
   provider: OAuthProvidersSchema;
   clientId?: string;
+  nativeClientIds?: string[];
   clientSecret?: string;
   redirectUri?: string;
   scopes?: string[];
@@ -16,6 +17,7 @@ export interface CreateOAuthConfigInput {
 
 export interface UpdateOAuthConfigInput {
   clientId?: string;
+  nativeClientIds?: string[];
   clientSecret?: string;
   redirectUri?: string;
   scopes?: string[];
@@ -56,6 +58,7 @@ export class OAuthConfigService {
           id,
           provider,
           client_id as "clientId",
+          native_client_ids as "nativeClientIds",
           redirect_uri as "redirectUri",
           scopes,
           use_shared_key as "useSharedKey",
@@ -102,6 +105,7 @@ export class OAuthConfigService {
           id,
           provider,
           client_id as "clientId",
+          native_client_ids as "nativeClientIds",
           redirect_uri as "redirectUri",
           scopes,
           use_shared_key as "useSharedKey",
@@ -237,12 +241,13 @@ export class OAuthConfigService {
 
       // Create new OAuth config
       const result = await client.query(
-        `INSERT INTO auth.oauth_configs (provider, client_id, secret_id, redirect_uri, scopes, use_shared_key)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO auth.oauth_configs (provider, client_id, native_client_ids, secret_id, redirect_uri, scopes, use_shared_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
          RETURNING
            id,
            provider,
            client_id as "clientId",
+           native_client_ids as "nativeClientIds",
            redirect_uri as "redirectUri",
            scopes,
            use_shared_key as "useSharedKey",
@@ -251,6 +256,7 @@ export class OAuthConfigService {
         [
           input.provider.toLowerCase(),
           input.clientId || null,
+          input.nativeClientIds || [],
           secretId,
           null, // Deprecating redirect_uri
           scopes,
@@ -336,6 +342,11 @@ export class OAuthConfigService {
         values.push(input.clientId);
       }
 
+      if (input.nativeClientIds !== undefined) {
+        updates.push(`native_client_ids = $${paramCount++}`);
+        values.push(input.nativeClientIds);
+      }
+
       if (input.redirectUri !== undefined) {
         updates.push(`redirect_uri = $${paramCount++}`);
         values.push(input.redirectUri);
@@ -373,6 +384,7 @@ export class OAuthConfigService {
              id,
              provider,
              client_id as "clientId",
+             native_client_ids as "nativeClientIds",
              redirect_uri as "redirectUri",
              scopes,
              use_shared_key as "useSharedKey",

--- a/backend/tests/unit/apple-id-token-verifier.test.ts
+++ b/backend/tests/unit/apple-id-token-verifier.test.ts
@@ -1,0 +1,151 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { SignJWT, createLocalJWKSet, exportJWK, generateKeyPair, type JWK } from 'jose';
+import { verifyAppleIdToken } from '../../src/providers/oauth/apple.provider.js';
+
+const ISSUER = 'https://appleid.apple.com';
+const NATIVE_CLIENT_ID = 'com.example.transcribed';
+const NONCE = 'test-native-nonce';
+const HASHED_NONCE = createHash('sha256').update(NONCE, 'utf8').digest('hex');
+
+describe('verifyAppleIdToken', () => {
+  let privateKey: Awaited<ReturnType<typeof generateKeyPair>>['privateKey'];
+  let jwk: JWK;
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair('ES256');
+    privateKey = keyPair.privateKey;
+    jwk = {
+      ...(await exportJWK(keyPair.publicKey)),
+      kid: 'apple-test-key',
+      alg: 'ES256',
+      use: 'sig',
+    };
+  });
+
+  async function signToken(
+    claims: Record<string, unknown> = {},
+    options: { issuer?: string; audience?: string; expiresIn?: string } = {}
+  ): Promise<string> {
+    return new SignJWT({
+      email: 'relay@privaterelay.appleid.com',
+      email_verified: 'true',
+      is_private_email: 'true',
+      nonce: HASHED_NONCE,
+      ...claims,
+    })
+      .setProtectedHeader({ alg: 'ES256', kid: 'apple-test-key' })
+      .setIssuer(options.issuer ?? ISSUER)
+      .setSubject('apple-subject')
+      .setAudience(options.audience ?? NATIVE_CLIENT_ID)
+      .setIssuedAt()
+      .setExpirationTime(options.expiresIn ?? '5m')
+      .sign(privateKey);
+  }
+
+  function localJwks() {
+    return createLocalJWKSet({ keys: [jwk] });
+  }
+
+  it('verifies Apple claims against a server-owned audience and nonce', async () => {
+    const result = await verifyAppleIdToken(await signToken(), localJwks(), {
+      audiences: [NATIVE_CLIENT_ID],
+      nonce: NONCE,
+    });
+
+    expect(result).toEqual({
+      sub: 'apple-subject',
+      email: 'relay@privaterelay.appleid.com',
+      email_verified: true,
+      is_private_email: true,
+    });
+  });
+
+  it('accepts any audience in the configured server allowlist', async () => {
+    const token = await signToken({}, { audience: 'com.example.second-app' });
+
+    await expect(
+      verifyAppleIdToken(token, localJwks(), {
+        audiences: [NATIVE_CLIENT_ID, 'com.example.second-app'],
+        nonce: NONCE,
+      })
+    ).resolves.toMatchObject({ sub: 'apple-subject' });
+  });
+
+  it('rejects a caller credential with the wrong audience', async () => {
+    await expect(
+      verifyAppleIdToken(await signToken(), localJwks(), {
+        audiences: ['com.example.attacker'],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects a mismatched nonce', async () => {
+    await expect(
+      verifyAppleIdToken(await signToken(), localJwks(), {
+        audiences: [NATIVE_CLIENT_ID],
+        nonce: 'different-nonce',
+      })
+    ).rejects.toThrow('Apple ID token nonce does not match');
+  });
+
+  it('requires Apple to receive the SHA-256 hash rather than the raw nonce', async () => {
+    const token = await signToken({ nonce: NONCE });
+
+    await expect(
+      verifyAppleIdToken(token, localJwks(), {
+        audiences: [NATIVE_CLIENT_ID],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow('Apple ID token nonce does not match');
+  });
+
+  it('rejects the wrong issuer', async () => {
+    const token = await signToken({}, { issuer: 'https://attacker.example' });
+
+    await expect(
+      verifyAppleIdToken(token, localJwks(), {
+        audiences: [NATIVE_CLIENT_ID],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects expired tokens', async () => {
+    const token = await signToken({}, { expiresIn: '-1m' });
+
+    await expect(
+      verifyAppleIdToken(token, localJwks(), {
+        audiences: [NATIVE_CLIENT_ID],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects tokens without a subject', async () => {
+    const token = await new SignJWT({ nonce: HASHED_NONCE })
+      .setProtectedHeader({ alg: 'ES256', kid: 'apple-test-key' })
+      .setIssuer(ISSUER)
+      .setAudience(NATIVE_CLIENT_ID)
+      .setIssuedAt()
+      .setExpirationTime('5m')
+      .sign(privateKey);
+
+    await expect(
+      verifyAppleIdToken(token, localJwks(), {
+        audiences: [NATIVE_CLIENT_ID],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow('Apple ID token is missing the sub claim');
+  });
+
+  it('rejects verification when no trusted audience is configured', async () => {
+    await expect(
+      verifyAppleIdToken(await signToken(), localJwks(), {
+        audiences: [' ', ''],
+        nonce: NONCE,
+      })
+    ).rejects.toThrow('No Apple ID token audiences are configured');
+  });
+});

--- a/backend/tests/unit/apple-id-token-verifier.test.ts
+++ b/backend/tests/unit/apple-id-token-verifier.test.ts
@@ -13,12 +13,12 @@ describe('verifyAppleIdToken', () => {
   let jwk: JWK;
 
   beforeAll(async () => {
-    const keyPair = await generateKeyPair('ES256');
+    const keyPair = await generateKeyPair('RS256');
     privateKey = keyPair.privateKey;
     jwk = {
       ...(await exportJWK(keyPair.publicKey)),
       kid: 'apple-test-key',
-      alg: 'ES256',
+      alg: 'RS256',
       use: 'sig',
     };
   });
@@ -34,7 +34,7 @@ describe('verifyAppleIdToken', () => {
       nonce: HASHED_NONCE,
       ...claims,
     })
-      .setProtectedHeader({ alg: 'ES256', kid: 'apple-test-key' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'apple-test-key' })
       .setIssuer(options.issuer ?? ISSUER)
       .setSubject('apple-subject')
       .setAudience(options.audience ?? NATIVE_CLIENT_ID)
@@ -125,7 +125,7 @@ describe('verifyAppleIdToken', () => {
 
   it('rejects tokens without a subject', async () => {
     const token = await new SignJWT({ nonce: HASHED_NONCE })
-      .setProtectedHeader({ alg: 'ES256', kid: 'apple-test-key' })
+      .setProtectedHeader({ alg: 'RS256', kid: 'apple-test-key' })
       .setIssuer(ISSUER)
       .setAudience(NATIVE_CLIENT_ID)
       .setIssuedAt()

--- a/backend/tests/unit/auth-email-otp-route.test.ts
+++ b/backend/tests/unit/auth-email-otp-route.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/services/auth/auth.service.js', () => ({
 }));
 
 vi.mock('@/api/middlewares/rate-limiters.js', () => ({
+  idTokenSignInRateLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
   sendEmailOTPLimiter: [(_req: Request, _res: Response, next: NextFunction) => next()],
   verifyOTPLimiter: [(_req: Request, _res: Response, next: NextFunction) => next()],
   verifyOTPRateLimiter: (req: Request, _res: Response, next: NextFunction) => {

--- a/backend/tests/unit/auth-id-token-apple.test.ts
+++ b/backend/tests/unit/auth-id-token-apple.test.ts
@@ -155,7 +155,8 @@ describe('AuthService native ID-token sign-in', () => {
       'relay@privaterelay.appleid.com',
       'First Sign In Name',
       '',
-      expect.objectContaining({ sub: 'apple-subject', is_private_email: true })
+      expect.objectContaining({ sub: 'apple-subject', is_private_email: true }),
+      { requireEmailForNewAccount: true }
     );
   });
 
@@ -165,6 +166,24 @@ describe('AuthService native ID-token sign-in', () => {
       code: 'INVALID_INPUT',
     });
     expect(mocks.verifyAppleIdToken).not.toHaveBeenCalled();
+  });
+
+  it('passes the exact raw nonce to Apple verification', async () => {
+    mocks.verifyAppleIdToken.mockResolvedValue({
+      sub: 'apple-subject',
+      email: 'relay@privaterelay.appleid.com',
+      email_verified: true,
+    });
+    vi.spyOn(service, 'findOrCreateThirdPartyUser').mockResolvedValue(session);
+
+    await service.signInWithIdToken('apple', 'apple-token', {
+      nonce: '  native-nonce  ',
+    });
+
+    expect(mocks.verifyAppleIdToken).toHaveBeenCalledWith('apple-token', {
+      nonce: '  native-nonce  ',
+      native: true,
+    });
   });
 
   it('maps Apple verification failures to an authentication error', async () => {
@@ -219,12 +238,56 @@ describe('AuthService native ID-token sign-in', () => {
     mocks.pool.query.mockResolvedValueOnce({ rows: [] });
 
     await expect(
-      service.findOrCreateThirdPartyUser('apple', 'new-apple-subject', '', 'Apple User', '', {
-        sub: 'new-apple-subject',
-        email: '',
-      })
+      service.findOrCreateThirdPartyUser(
+        'apple',
+        'new-apple-subject',
+        '',
+        'Apple User',
+        '',
+        {
+          sub: 'new-apple-subject',
+          email: '',
+        },
+        { requireEmailForNewAccount: true }
+      )
     ).rejects.toThrow('A verified email address is required');
     expect(mocks.pool.query).toHaveBeenCalledOnce();
+  });
+
+  it('links Apple identities to case-variant existing emails', async () => {
+    const existingUserId = '00000000-0000-4000-8000-000000000002';
+    mocks.pool.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: existingUserId, email: 'Relay@Example.com' }],
+      })
+      .mockResolvedValue({ rows: [] });
+    vi.spyOn(service, 'getUserById').mockResolvedValue({
+      id: existingUserId,
+      email: 'Relay@Example.com',
+      email_verified: true,
+      profile: { name: 'Existing User', avatar_url: '' },
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+      auth_metadata: null,
+    });
+
+    await service.findOrCreateThirdPartyUser(
+      'apple',
+      'apple-subject',
+      'relay@example.com',
+      'Apple User',
+      '',
+      { sub: 'apple-subject', email: 'relay@example.com' },
+      { requireEmailForNewAccount: true }
+    );
+
+    expect(mocks.pool.query.mock.calls[1]?.[0]).toContain('lower(email) = lower($1)');
+    expect(mocks.pool.query.mock.calls[1]?.[1]).toEqual(['relay@example.com']);
+    expect(mocks.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO auth.user_providers'),
+      expect.arrayContaining([existingUserId, 'apple', 'apple-subject'])
+    );
   });
 
   it('keeps Google ID-token sign-in behavior unchanged', async () => {
@@ -244,7 +307,8 @@ describe('AuthService native ID-token sign-in', () => {
       'google@example.com',
       'Google User',
       'https://example.com/avatar.png',
-      expect.objectContaining({ sub: 'google-subject' })
+      expect.objectContaining({ sub: 'google-subject' }),
+      undefined
     );
   });
 });

--- a/backend/tests/unit/auth-id-token-apple.test.ts
+++ b/backend/tests/unit/auth-id-token-apple.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  pool: {
+    query: vi.fn(),
+    connect: vi.fn(),
+  },
+  verifyAppleIdToken: vi.fn(),
+  verifyGoogleIdToken: vi.fn(),
+  getAuthConfig: vi.fn(),
+  generateAccessToken: vi.fn().mockReturnValue('access-token'),
+  makeProviderMock: () => ({
+    getInstance: () => ({
+      generateOAuthUrl: vi.fn(),
+      handleCallback: vi.fn(),
+      handleSharedCallback: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: { getInstance: () => ({ getPool: () => mocks.pool }) },
+}));
+
+vi.mock('../../src/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({ generateAccessToken: mocks.generateAccessToken }),
+  },
+}));
+
+vi.mock('../../src/services/auth/oauth-config.service.js', () => ({
+  OAuthConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/auth/custom-oauth-config.service.js', () => ({
+  CustomOAuthConfigService: { getInstance: () => ({ listConfigs: vi.fn() }) },
+}));
+
+vi.mock('../../src/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({
+      getAuthConfig: mocks.getAuthConfig,
+      validateRedirectUrl: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/auth/auth-otp.service.js', () => ({
+  AuthOTPService: { getInstance: () => ({}) },
+  OTPPurpose: {},
+  OTPType: {},
+}));
+
+vi.mock('../../src/services/email/smtp-config.service.js', () => ({
+  SmtpConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/services/email/email.service.js', () => ({
+  EmailService: { getInstance: () => ({}) },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/utils/environment.js', () => ({
+  getApiBaseUrl: () => 'http://localhost:7130',
+}));
+
+vi.mock('../../src/infra/config/app.config.js', () => ({
+  appConfig: {
+    auth: { rootAdminUsername: 'admin@test.com', rootAdminPassword: 'password123' },
+    app: { jwtSecret: 'test-secret' },
+    cloud: { projectId: null },
+  },
+}));
+
+vi.mock('../../src/providers/oauth/google.provider.js', () => ({
+  GoogleOAuthProvider: {
+    getInstance: () => ({ verifyToken: mocks.verifyGoogleIdToken }),
+  },
+}));
+vi.mock('../../src/providers/oauth/github.provider.js', () => ({
+  GitHubOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/discord.provider.js', () => ({
+  DiscordOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/linkedin.provider.js', () => ({
+  LinkedInOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/facebook.provider.js', () => ({
+  FacebookOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/microsoft.provider.js', () => ({
+  MicrosoftOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/x.provider.js', () => ({
+  XOAuthProvider: mocks.makeProviderMock(),
+}));
+vi.mock('../../src/providers/oauth/apple.provider.js', () => ({
+  AppleOAuthProvider: {
+    getInstance: () => ({ verifyIdToken: mocks.verifyAppleIdToken }),
+  },
+}));
+
+import { AuthService } from '../../src/services/auth/auth.service.js';
+
+const session = {
+  user: {
+    id: '00000000-0000-4000-8000-000000000001',
+    email: 'relay@privaterelay.appleid.com',
+    emailVerified: true,
+    providers: ['apple'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    profile: { name: 'Apple User', avatar_url: '' },
+    metadata: null,
+  },
+  accessToken: 'access-token',
+};
+
+describe('AuthService native ID-token sign-in', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.pool.query.mockResolvedValue({ rows: [] });
+    mocks.getAuthConfig.mockResolvedValue({ disableSignup: false });
+    (AuthService as unknown as { instance?: AuthService }).instance = undefined;
+    service = AuthService.getInstance();
+  });
+
+  it('verifies Apple using the native audience set and nonce', async () => {
+    mocks.verifyAppleIdToken.mockResolvedValue({
+      sub: 'apple-subject',
+      email: 'Relay@privaterelay.appleid.com',
+      email_verified: true,
+      is_private_email: true,
+    });
+    const findOrCreate = vi.spyOn(service, 'findOrCreateThirdPartyUser').mockResolvedValue(session);
+
+    await service.signInWithIdToken('apple', 'apple-token', {
+      nonce: 'native-nonce',
+      name: 'First Sign In Name',
+    });
+
+    expect(mocks.verifyAppleIdToken).toHaveBeenCalledWith('apple-token', {
+      nonce: 'native-nonce',
+      native: true,
+    });
+    expect(findOrCreate).toHaveBeenCalledWith(
+      'apple',
+      'apple-subject',
+      'relay@privaterelay.appleid.com',
+      'First Sign In Name',
+      '',
+      expect.objectContaining({ sub: 'apple-subject', is_private_email: true })
+    );
+  });
+
+  it('requires a nonce before invoking Apple verification', async () => {
+    await expect(service.signInWithIdToken('apple', 'apple-token')).rejects.toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_INPUT',
+    });
+    expect(mocks.verifyAppleIdToken).not.toHaveBeenCalled();
+  });
+
+  it('maps Apple verification failures to an authentication error', async () => {
+    mocks.verifyAppleIdToken.mockRejectedValue(new Error('nonce mismatch'));
+
+    await expect(
+      service.signInWithIdToken('apple', 'apple-token', { nonce: 'native-nonce' })
+    ).rejects.toMatchObject({
+      statusCode: 401,
+      code: 'AUTH_UNAUTHORIZED',
+    });
+  });
+
+  it('does not use an unverified Apple email for account linking', async () => {
+    mocks.verifyAppleIdToken.mockResolvedValue({
+      sub: 'apple-subject',
+      email: 'victim@example.com',
+      email_verified: false,
+    });
+    const findOrCreate = vi.spyOn(service, 'findOrCreateThirdPartyUser').mockResolvedValue(session);
+
+    await service.signInWithIdToken('apple', 'apple-token', { nonce: 'native-nonce' });
+
+    expect(findOrCreate.mock.calls[0]?.[2]).toBe('');
+  });
+
+  it('lets an existing Apple subject sign in when profile claims are absent', async () => {
+    mocks.pool.query
+      .mockResolvedValueOnce({
+        rows: [{ user_id: '00000000-0000-4000-8000-000000000001' }],
+      })
+      .mockResolvedValue({ rows: [] });
+    vi.spyOn(service, 'getUserById').mockResolvedValue({
+      id: '00000000-0000-4000-8000-000000000001',
+      email: 'relay@privaterelay.appleid.com',
+      email_verified: true,
+      profile: { name: 'Apple User', avatar_url: '' },
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-01T00:00:00.000Z'),
+      auth_metadata: null,
+    });
+
+    await expect(
+      service.findOrCreateThirdPartyUser('apple', 'apple-subject', '', 'Apple User', '', {
+        sub: 'apple-subject',
+        email: '',
+      })
+    ).resolves.toMatchObject({ accessToken: 'access-token' });
+  });
+
+  it('rejects a new Apple identity without a verified email', async () => {
+    mocks.pool.query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      service.findOrCreateThirdPartyUser('apple', 'new-apple-subject', '', 'Apple User', '', {
+        sub: 'new-apple-subject',
+        email: '',
+      })
+    ).rejects.toThrow('A verified email address is required');
+    expect(mocks.pool.query).toHaveBeenCalledOnce();
+  });
+
+  it('keeps Google ID-token sign-in behavior unchanged', async () => {
+    mocks.verifyGoogleIdToken.mockResolvedValue({
+      sub: 'google-subject',
+      email: 'google@example.com',
+      name: 'Google User',
+      picture: 'https://example.com/avatar.png',
+    });
+    const findOrCreate = vi.spyOn(service, 'findOrCreateThirdPartyUser').mockResolvedValue(session);
+
+    await service.signInWithIdToken('google', 'google-token');
+
+    expect(findOrCreate).toHaveBeenCalledWith(
+      'google',
+      'google-subject',
+      'google@example.com',
+      'Google User',
+      'https://example.com/avatar.png',
+      expect.objectContaining({ sub: 'google-subject' })
+    );
+  });
+});

--- a/backend/tests/unit/auth-id-token-route.test.ts
+++ b/backend/tests/unit/auth-id-token-route.test.ts
@@ -9,6 +9,7 @@ interface AppErrorLike {
 
 const mocks = vi.hoisted(() => ({
   signInWithIdToken: vi.fn(),
+  idTokenRateLimit: vi.fn(),
   generateRefreshToken: vi.fn().mockReturnValue('mobile-refresh-token'),
   generateRefreshTokenWithCsrf: vi.fn(),
 }));
@@ -18,6 +19,16 @@ vi.mock('@/api/middlewares/auth.js', () => ({
   verifyOptionalUser: vi.fn((_req, _res, next: NextFunction) => next()),
   verifyAdmin: vi.fn((_req, _res, next: NextFunction) => next()),
   verifyToken: vi.fn((_req, _res, next: NextFunction) => next()),
+}));
+
+vi.mock('@/api/middlewares/rate-limiters.js', () => ({
+  idTokenSignInRateLimiter: (_req: Request, _res: Response, next: NextFunction) => {
+    mocks.idTokenRateLimit();
+    next();
+  },
+  sendEmailOTPLimiter: [(_req: Request, _res: Response, next: NextFunction) => next()],
+  verifyOTPLimiter: [(_req: Request, _res: Response, next: NextFunction) => next()],
+  verifyOTPRateLimiter: (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
 vi.mock('@/services/auth/auth.service.js', () => ({
@@ -162,6 +173,19 @@ describe('POST /api/auth/id-token', () => {
       nonce: 'native-nonce',
       name: 'First Sign In Name',
     });
+  });
+
+  it('rate limits requests before external token verification', async () => {
+    await callRoute(router, {
+      provider: 'apple',
+      token: 'apple-token',
+      nonce: 'native-nonce',
+    });
+
+    expect(mocks.idTokenRateLimit).toHaveBeenCalledOnce();
+    expect(mocks.idTokenRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signInWithIdToken.mock.invocationCallOrder[0]
+    );
   });
 
   it('rejects Apple requests without a nonce', async () => {

--- a/backend/tests/unit/auth-id-token-route.test.ts
+++ b/backend/tests/unit/auth-id-token-route.test.ts
@@ -1,0 +1,208 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response, Router } from 'express';
+
+interface AppErrorLike {
+  statusCode: number;
+  code: string;
+  message: string;
+}
+
+const mocks = vi.hoisted(() => ({
+  signInWithIdToken: vi.fn(),
+  generateRefreshToken: vi.fn().mockReturnValue('mobile-refresh-token'),
+  generateRefreshTokenWithCsrf: vi.fn(),
+}));
+
+vi.mock('@/api/middlewares/auth.js', () => ({
+  verifyUser: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyOptionalUser: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyAdmin: vi.fn((_req, _res, next: NextFunction) => next()),
+  verifyToken: vi.fn((_req, _res, next: NextFunction) => next()),
+}));
+
+vi.mock('@/services/auth/auth.service.js', () => ({
+  AuthService: {
+    getInstance: () => ({ signInWithIdToken: mocks.signInWithIdToken }),
+  },
+}));
+
+vi.mock('@/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: {
+    getInstance: () => ({ getAuthConfig: vi.fn(), validateRedirectUrl: vi.fn() }),
+  },
+}));
+
+vi.mock('@/services/auth/auth-otp.service.js', () => ({
+  AuthOTPService: { getInstance: () => ({}) },
+  OTPPurpose: {},
+}));
+
+vi.mock('@/services/logs/audit.service.js', () => ({
+  AuditService: { getInstance: () => ({ log: vi.fn() }) },
+}));
+
+vi.mock('@/services/secrets/secret.service.js', () => ({
+  SecretService: { getInstance: () => ({}) },
+}));
+
+vi.mock('@/services/email/smtp-config.service.js', () => ({
+  SmtpConfigService: { getInstance: () => ({}) },
+}));
+
+vi.mock('@/services/email/email-template.service.js', () => ({
+  EmailTemplateService: { getInstance: () => ({}) },
+}));
+
+vi.mock('@/infra/socket/socket.manager.js', () => ({
+  SocketManager: { getInstance: () => ({ broadcastToRoom: vi.fn() }) },
+}));
+
+vi.mock('@/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      generateRefreshToken: mocks.generateRefreshToken,
+      generateRefreshTokenWithCsrf: mocks.generateRefreshTokenWithCsrf,
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const baseSession = {
+  user: {
+    id: '00000000-0000-4000-8000-000000000001',
+    email: 'relay@privaterelay.appleid.com',
+    emailVerified: true,
+    providers: ['apple'],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    profile: { name: 'Apple User', avatar_url: '' },
+    metadata: null,
+  },
+  accessToken: 'access-token',
+};
+
+function callRoute(
+  router: Router,
+  body: Record<string, unknown>,
+  clientType = 'mobile'
+): Promise<{ statusCode: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    let statusCode = 200;
+    const req: Partial<Request> = {
+      url: '/id-token',
+      method: 'POST',
+      headers: {},
+      query: { client_type: clientType },
+      body,
+    };
+    const res: Partial<Response> = {
+      status: vi.fn((code: number) => {
+        statusCode = code;
+        return res;
+      }),
+      json: vi.fn((responseBody: unknown) => resolve({ statusCode, body: responseBody })),
+      cookie: vi.fn(() => res),
+    };
+
+    router(
+      req as Request,
+      res as Response,
+      vi.fn((error?: unknown) => {
+        if (error && typeof error === 'object' && 'statusCode' in error) {
+          const appError = error as AppErrorLike;
+          resolve({
+            statusCode: appError.statusCode,
+            body: {
+              error: appError.code,
+              message: appError.message,
+              statusCode: appError.statusCode,
+            },
+          });
+          return;
+        }
+        reject(error instanceof Error ? error : new Error(`Unexpected next: ${String(error)}`));
+      })
+    );
+  });
+}
+
+describe('POST /api/auth/id-token', () => {
+  let router: Router;
+
+  beforeAll(async () => {
+    router = (await import('../../src/api/routes/auth/index.routes.js')).default;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.generateRefreshToken.mockReturnValue('mobile-refresh-token');
+    mocks.signInWithIdToken.mockResolvedValue({
+      ...baseSession,
+      user: { ...baseSession.user },
+    });
+  });
+
+  it('exchanges a native Apple credential for a mobile session', async () => {
+    const response = await callRoute(router, {
+      provider: 'apple',
+      token: 'apple-token',
+      nonce: 'native-nonce',
+      name: '  First Sign In Name  ',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      accessToken: 'access-token',
+      refreshToken: 'mobile-refresh-token',
+    });
+    expect(mocks.signInWithIdToken).toHaveBeenCalledWith('apple', 'apple-token', {
+      nonce: 'native-nonce',
+      name: 'First Sign In Name',
+    });
+  });
+
+  it('rejects Apple requests without a nonce', async () => {
+    const response = await callRoute(router, {
+      provider: 'apple',
+      token: 'apple-token',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.signInWithIdToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller-selected Apple audience', async () => {
+    const response = await callRoute(router, {
+      provider: 'apple',
+      token: 'apple-token',
+      nonce: 'native-nonce',
+      audience: 'com.attacker.app',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.signInWithIdToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing Google request contract', async () => {
+    const response = await callRoute(router, {
+      provider: 'google',
+      token: 'google-token',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.signInWithIdToken).toHaveBeenCalledWith('google', 'google-token');
+  });
+
+  it('rejects unsupported providers', async () => {
+    const response = await callRoute(router, {
+      provider: 'github',
+      token: 'github-token',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(mocks.signInWithIdToken).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/auth-id-token-schemas.test.ts
+++ b/backend/tests/unit/auth-id-token-schemas.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { idTokenSignInRequestSchema, oAuthConfigSchema } from '@insforge/shared-schemas';
+
+describe('idTokenSignInRequestSchema', () => {
+  it('keeps the existing Google request compatible', () => {
+    expect(
+      idTokenSignInRequestSchema.safeParse({ provider: 'google', token: 'google-token' }).success
+    ).toBe(true);
+  });
+
+  it('accepts an Apple token, nonce, and first-authorization name', () => {
+    const result = idTokenSignInRequestSchema.safeParse({
+      provider: 'apple',
+      token: 'apple-token',
+      nonce: 'native-nonce',
+      name: 'Apple User',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('requires a nonce for Apple requests', () => {
+    expect(
+      idTokenSignInRequestSchema.safeParse({ provider: 'apple', token: 'apple-token' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a caller-selected Apple audience', () => {
+    expect(
+      idTokenSignInRequestSchema.safeParse({
+        provider: 'apple',
+        token: 'apple-token',
+        nonce: 'native-nonce',
+        audience: 'com.attacker.app',
+      }).success
+    ).toBe(false);
+  });
+
+  it('bounds optional first-authorization names', () => {
+    expect(
+      idTokenSignInRequestSchema.safeParse({
+        provider: 'apple',
+        token: 'apple-token',
+        nonce: 'native-nonce',
+        name: 'a'.repeat(101),
+      }).success
+    ).toBe(false);
+  });
+
+  it('validates project-owned native client ID configuration', () => {
+    const result = oAuthConfigSchema.safeParse({
+      id: '00000000-0000-4000-8000-000000000001',
+      provider: 'apple',
+      clientId: 'com.example.web',
+      nativeClientIds: ['com.example.ios'],
+      useSharedKey: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/backend/tests/unit/auth-id-token-schemas.test.ts
+++ b/backend/tests/unit/auth-id-token-schemas.test.ts
@@ -25,6 +25,26 @@ describe('idTokenSignInRequestSchema', () => {
     ).toBe(false);
   });
 
+  it('preserves the exact raw Apple nonce while rejecting whitespace-only values', () => {
+    const result = idTokenSignInRequestSchema.safeParse({
+      provider: 'apple',
+      token: 'apple-token',
+      nonce: '  native-nonce  ',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.nonce).toBe('  native-nonce  ');
+    }
+    expect(
+      idTokenSignInRequestSchema.safeParse({
+        provider: 'apple',
+        token: 'apple-token',
+        nonce: '   ',
+      }).success
+    ).toBe(false);
+  });
+
   it('rejects a caller-selected Apple audience', () => {
     expect(
       idTokenSignInRequestSchema.safeParse({

--- a/backend/tests/unit/disable-new-user-signups.test.ts
+++ b/backend/tests/unit/disable-new-user-signups.test.ts
@@ -257,4 +257,28 @@ describe('AuthService.findOrCreateThirdPartyUser – disableSignup gate', () => 
     expect(result.user.email).toBe('brand-new@test.com');
     expect(mockGetAuthConfig).toHaveBeenCalledOnce();
   });
+
+  it('preserves non-Apple provider behavior when an email is unavailable', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [] }) // user_providers lookup
+      .mockResolvedValueOnce({ rows: [] }); // email lookup
+    mockGetAuthConfig.mockResolvedValueOnce(ENABLED_CONFIG);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(authService as any, 'createThirdPartyUser').mockResolvedValue({
+      user: { id: 'facebook-user', email: '' },
+      accessToken: 'token',
+    });
+
+    const result = await authService.findOrCreateThirdPartyUser(
+      'facebook',
+      'facebook-id-new',
+      '',
+      'Facebook User',
+      '',
+      {}
+    );
+
+    expect(result.user.email).toBe('');
+  });
 });

--- a/backend/tests/unit/oauth-native-client-ids-migration.test.ts
+++ b/backend/tests/unit/oauth-native-client-ids-migration.test.ts
@@ -4,9 +4,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationFile = '062_add-oauth-native-client-ids.sql';
 const migrationPath = path.resolve(
   currentDirectory,
-  '../../src/infra/database/migrations/062_add-oauth-native-client-ids.sql'
+  `../../src/infra/database/migrations/${migrationFile}`
 );
 
 describe('062_add-oauth-native-client-ids migration', () => {
@@ -14,7 +15,27 @@ describe('062_add-oauth-native-client-ids migration', () => {
 
   it('adds the native audience allowlist idempotently', () => {
     expect(sql).toMatch(
-      /ALTER TABLE auth\.oauth_configs\s+ADD COLUMN IF NOT EXISTS native_client_ids TEXT\[\] NOT NULL DEFAULT '\{\}'/i
+      /ALTER TABLE auth\.oauth_configs\s+ADD COLUMN IF NOT EXISTS native_client_ids TEXT\[\]/i
     );
+    expect(sql).toMatch(/UPDATE auth\.oauth_configs\s+SET native_client_ids = '\{\}'/i);
+    expect(sql).toMatch(/ALTER COLUMN native_client_ids SET DEFAULT '\{\}'/i);
+    expect(sql).toMatch(/ALTER COLUMN native_client_ids SET NOT NULL/i);
+  });
+
+  it('runs after migration 061', () => {
+    const migrationDirectory = path.resolve(
+      currentDirectory,
+      '../../src/infra/database/migrations'
+    );
+    const migrations = fs
+      .readdirSync(migrationDirectory)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const index061 = migrations.indexOf('061_add-database-config.sql');
+    const index062 = migrations.indexOf(migrationFile);
+
+    expect(index061).toBeGreaterThanOrEqual(0);
+    expect(index062).toBeGreaterThan(index061);
   });
 });

--- a/backend/tests/unit/oauth-native-client-ids-migration.test.ts
+++ b/backend/tests/unit/oauth-native-client-ids-migration.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  currentDirectory,
+  '../../src/infra/database/migrations/062_add-oauth-native-client-ids.sql'
+);
+
+describe('062_add-oauth-native-client-ids migration', () => {
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+
+  it('adds the native audience allowlist idempotently', () => {
+    expect(sql).toMatch(
+      /ALTER TABLE auth\.oauth_configs\s+ADD COLUMN IF NOT EXISTS native_client_ids TEXT\[\] NOT NULL DEFAULT '\{\}'/i
+    );
+  });
+});

--- a/backend/tests/unit/oauth-native-client-ids.test.ts
+++ b/backend/tests/unit/oauth-native-client-ids.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  pool: {
+    query: vi.fn(),
+    connect: vi.fn(),
+  },
+  client: {
+    query: vi.fn(),
+    release: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: { getInstance: () => ({ getPool: () => mocks.pool }) },
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({
+      createSecret: vi.fn(),
+      updateSecret: vi.fn(),
+      getSecretById: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { OAuthConfigService } from '../../src/services/auth/oauth-config.service.js';
+
+describe('OAuthConfigService native client IDs', () => {
+  let service: OAuthConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.pool.connect.mockResolvedValue(mocks.client);
+    (OAuthConfigService as unknown as { instance?: OAuthConfigService }).instance = undefined;
+    service = OAuthConfigService.getInstance();
+  });
+
+  it('reads native client IDs from project OAuth configuration', async () => {
+    mocks.pool.query.mockResolvedValue({
+      rows: [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          provider: 'apple',
+          clientId: 'com.example.web',
+          nativeClientIds: ['com.example.ios'],
+          useSharedKey: false,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await service.getConfigByProvider('apple');
+
+    expect(result?.nativeClientIds).toEqual(['com.example.ios']);
+    expect(mocks.pool.query.mock.calls[0]?.[0]).toContain('native_client_ids as "nativeClientIds"');
+  });
+
+  it('persists native client IDs when creating an OAuth configuration', async () => {
+    mocks.client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT id FROM auth.oauth_configs')) {
+        return { rows: [] };
+      }
+      if (sql.includes('INSERT INTO auth.oauth_configs')) {
+        return {
+          rows: [
+            {
+              id: '00000000-0000-4000-8000-000000000001',
+              provider: 'apple',
+              nativeClientIds: ['com.example.ios'],
+              useSharedKey: true,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await service.createConfig({
+      provider: 'apple',
+      nativeClientIds: ['com.example.ios'],
+      useSharedKey: true,
+    });
+
+    const insertCall = mocks.client.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO auth.oauth_configs')
+    );
+    expect(insertCall?.[0]).toContain('native_client_ids');
+    expect(insertCall?.[1]?.[2]).toEqual(['com.example.ios']);
+  });
+
+  it('updates native client IDs independently of browser credentials', async () => {
+    mocks.client.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT id, secret_id')) {
+        return {
+          rows: [{ id: '00000000-0000-4000-8000-000000000001', secretId: null }],
+        };
+      }
+      if (sql.includes('UPDATE auth.oauth_configs')) {
+        return {
+          rows: [
+            {
+              id: '00000000-0000-4000-8000-000000000001',
+              provider: 'apple',
+              clientId: 'com.example.web',
+              nativeClientIds: ['com.example.ios', 'com.example.ipados'],
+              useSharedKey: false,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const result = await service.updateConfig('apple', {
+      nativeClientIds: ['com.example.ios', 'com.example.ipados'],
+    });
+
+    const updateCall = mocks.client.query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE auth.oauth_configs')
+    );
+    expect(updateCall?.[0]).toContain('native_client_ids = $1');
+    expect(updateCall?.[1]?.[0]).toEqual(['com.example.ios', 'com.example.ipados']);
+    expect(result.nativeClientIds).toEqual(['com.example.ios', 'com.example.ipados']);
+  });
+});

--- a/backend/tests/unit/oauth-native-client-ids.test.ts
+++ b/backend/tests/unit/oauth-native-client-ids.test.ts
@@ -86,7 +86,7 @@ describe('OAuthConfigService native client IDs', () => {
 
     await service.createConfig({
       provider: 'apple',
-      nativeClientIds: ['com.example.ios'],
+      nativeClientIds: [' com.example.ios ', 'com.example.ios', '', 'com.example.ipados'],
       useSharedKey: true,
     });
 
@@ -94,7 +94,7 @@ describe('OAuthConfigService native client IDs', () => {
       ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO auth.oauth_configs')
     );
     expect(insertCall?.[0]).toContain('native_client_ids');
-    expect(insertCall?.[1]?.[2]).toEqual(['com.example.ios']);
+    expect(insertCall?.[1]?.[2]).toEqual(['com.example.ios', 'com.example.ipados']);
   });
 
   it('updates native client IDs independently of browser credentials', async () => {
@@ -123,7 +123,7 @@ describe('OAuthConfigService native client IDs', () => {
     });
 
     const result = await service.updateConfig('apple', {
-      nativeClientIds: ['com.example.ios', 'com.example.ipados'],
+      nativeClientIds: ['com.example.ios', ' com.example.ipados ', 'com.example.ios', ''],
     });
 
     const updateCall = mocks.client.query.mock.calls.find(

--- a/docs/sdks/rest/auth.mdx
+++ b/docs/sdks/rest/auth.mdx
@@ -722,6 +722,65 @@ curl -X POST "https://your-app.insforge.app/api/auth/email/reset-password" \
 
 ---
 
+## Native ID Token Sign-In
+
+Exchange an ID token from Google or Apple's native AuthenticationServices framework for an
+InsForge session:
+
+```
+POST /api/auth/id-token?client_type=mobile
+```
+
+For native Sign in with Apple, generate a high-entropy raw nonce and attach its lowercase
+SHA-256 hex digest to the `ASAuthorizationAppleIDRequest`. Send the original raw nonce with the
+returned identity token. InsForge hashes it before comparing it with Apple's signed `nonce`
+claim. If Apple returns a name on first authorization, send the display name in the same request;
+later authorizations may omit it.
+
+```bash
+curl -X POST "https://your-app.insforge.app/api/auth/id-token?client_type=mobile" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "apple",
+    "token": "APPLE_IDENTITY_TOKEN",
+    "nonce": "ORIGINAL_RAW_NONCE",
+    "name": "Optional First Sign-In Name"
+  }'
+```
+
+InsForge verifies Apple's signature, issuer, expiry, subject, nonce, and token audience. The
+audience is selected exclusively from the project's Apple OAuth configuration; the sign-in
+request cannot override it. Configure the native App ID (normally the iOS bundle identifier) in
+`nativeClientIds` while retaining `clientId` for the browser/service OAuth client when needed:
+
+```bash
+curl -X PUT "https://your-app.insforge.app/api/auth/oauth/apple/config" \
+  -H "Authorization: Bearer ADMIN_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "nativeClientIds": ["com.example.ios-app"]
+  }'
+```
+
+Apple private-relay addresses are supported. InsForge finds returning accounts by Apple's stable
+subject before inspecting profile claims, so a returning user can sign in when optional profile
+data is absent. Creating or email-linking a new account requires a verified email from the Apple
+identity token; InsForge never creates a fabricated placeholder address.
+
+Google keeps its existing request shape:
+
+```json
+{
+  "provider": "google",
+  "token": "GOOGLE_ID_TOKEN"
+}
+```
+
+For `client_type=mobile`, `desktop`, or `server`, the response includes `accessToken` and
+`refreshToken` in the JSON body. Web clients receive the refresh token in an HTTP-only cookie.
+
+---
+
 ## OAuth Authentication
 
 OAuth authentication now uses the PKCE (Proof Key for Code Exchange) flow for enhanced security. Instead of returning tokens directly in the redirect URL, an authorization code is returned which must be exchanged for tokens.

--- a/docs/sdks/rest/auth.mdx
+++ b/docs/sdks/rest/auth.mdx
@@ -731,6 +731,21 @@ InsForge session:
 POST /api/auth/id-token?client_type=mobile
 ```
 
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `client_type` | `web` \| `mobile` \| `desktop` \| `server` | No | Defaults to `web`. Controls whether the refresh token is set as a cookie or returned in the response body. |
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `provider` | `google` \| `apple` | Yes | Native identity provider that issued the token. |
+| `token` | string | Yes | Raw provider ID token. For Apple, use `identityToken` from `ASAuthorizationAppleIDCredential`. |
+| `nonce` | string | Apple only | Original raw nonce, 1–255 characters. It is hashed without normalization and must match Apple's signed `nonce` claim. |
+| `name` | string | No | Apple first-authorization display name, 1–100 characters. Apple may only provide this value once. |
+
 For native Sign in with Apple, generate a high-entropy raw nonce and attach its lowercase
 SHA-256 hex digest to the `ASAuthorizationAppleIDRequest`. Send the original raw nonce with the
 returned identity token. InsForge hashes it before comparing it with Apple's signed `nonce`
@@ -776,8 +791,39 @@ Google keeps its existing request shape:
 }
 ```
 
-For `client_type=mobile`, `desktop`, or `server`, the response includes `accessToken` and
-`refreshToken` in the JSON body. Web clients receive the refresh token in an HTTP-only cookie.
+### Response
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `user` | object | Authenticated InsForge user, including `id`, `email`, verification state, providers, profile, metadata, and timestamps. |
+| `accessToken` | string | InsForge access token for authenticated API requests. |
+| `refreshToken` | string | Returned for `mobile`, `desktop`, and `server` clients. Omitted for web clients. |
+| `csrfToken` | string | Returned for web clients alongside the HTTP-only refresh-token cookie. |
+
+```json
+{
+  "user": {
+    "id": "00000000-0000-4000-8000-000000000001",
+    "email": "user@example.com",
+    "emailVerified": true,
+    "providers": ["apple"]
+  },
+  "accessToken": "INSFORGE_ACCESS_TOKEN",
+  "refreshToken": "INSFORGE_REFRESH_TOKEN"
+}
+```
+
+### Errors
+
+| Status | Meaning |
+|--------|---------|
+| `400` | Invalid request shape, unsupported provider, missing nonce, or missing verified email for a new Apple identity. |
+| `401` | Provider token is invalid, expired, has an untrusted audience, or fails Apple nonce verification. |
+| `429` | Too many ID-token sign-in attempts from the requesting IP. |
+
+For `client_type=mobile`, `desktop`, or `server`, the response includes `refreshToken` in the
+JSON body. Web clients receive the refresh token in an HTTP-only cookie and a `csrfToken` in the
+response body.
 
 ---
 

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -1359,6 +1359,8 @@ paths:
                   description: Server-trusted native app client IDs used as ID-token audiences
                   items:
                     type: string
+                    minLength: 1
+                    maxLength: 255
                 clientSecret:
                   type: string
                 redirectUri:
@@ -1446,6 +1448,8 @@ paths:
                   description: Server-trusted native app client IDs used as ID-token audiences
                   items:
                     type: string
+                    minLength: 1
+                    maxLength: 255
                 clientSecret:
                   type: string
                 redirectUri:
@@ -2051,39 +2055,13 @@ paths:
           application/json:
             schema:
               oneOf:
-                - type: object
-                  required: [provider, token]
-                  properties:
-                    provider:
-                      type: string
-                      enum: [google]
-                    token:
-                      type: string
-                      minLength: 1
-                      description: Raw Google ID token
-                - type: object
-                  additionalProperties: false
-                  required: [provider, token, nonce]
-                  properties:
-                    provider:
-                      type: string
-                      enum: [apple]
-                    token:
-                      type: string
-                      minLength: 1
-                      description: Raw identityToken from ASAuthorizationAppleIDCredential
-                    nonce:
-                      type: string
-                      minLength: 1
-                      maxLength: 255
-                      description: Original raw nonce whose lowercase SHA-256 hex digest was attached to ASAuthorizationAppleIDRequest
-                    name:
-                      type: string
-                      minLength: 1
-                      maxLength: 100
-                      description: Optional display name returned on first Apple authorization
+                - $ref: '#/components/schemas/GoogleIdTokenSignInRequest'
+                - $ref: '#/components/schemas/AppleIdTokenSignInRequest'
               discriminator:
                 propertyName: provider
+                mapping:
+                  google: '#/components/schemas/GoogleIdTokenSignInRequest'
+                  apple: '#/components/schemas/AppleIdTokenSignInRequest'
       responses:
         '200':
           description: Sign-in successful
@@ -2305,6 +2283,41 @@ components:
       name: x-api-key
 
   schemas:
+    GoogleIdTokenSignInRequest:
+      type: object
+      required: [provider, token]
+      properties:
+        provider:
+          type: string
+          enum: [google]
+        token:
+          type: string
+          minLength: 1
+          description: Raw Google ID token
+
+    AppleIdTokenSignInRequest:
+      type: object
+      additionalProperties: false
+      required: [provider, token, nonce]
+      properties:
+        provider:
+          type: string
+          enum: [apple]
+        token:
+          type: string
+          minLength: 1
+          description: Raw identityToken from ASAuthorizationAppleIDCredential
+        nonce:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: Original raw nonce whose lowercase SHA-256 hex digest was attached to ASAuthorizationAppleIDRequest
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          description: Optional display name returned on first Apple authorization
+
     ProjectAdminResponse:
       type: object
       required:
@@ -2393,6 +2406,8 @@ components:
           description: Server-trusted native app client IDs used as ID-token audiences
           items:
             type: string
+            minLength: 1
+            maxLength: 255
         redirectUri:
           type: string
           nullable: true

--- a/openapi/auth.yaml
+++ b/openapi/auth.yaml
@@ -1353,6 +1353,12 @@ paths:
                   enum: [google, github, discord, linkedin, facebook, instagram, tiktok, apple, x, spotify, microsoft]
                 clientId:
                   type: string
+                nativeClientIds:
+                  type: array
+                  maxItems: 20
+                  description: Server-trusted native app client IDs used as ID-token audiences
+                  items:
+                    type: string
                 clientSecret:
                   type: string
                 redirectUri:
@@ -1434,6 +1440,12 @@ paths:
               properties:
                 clientId:
                   type: string
+                nativeClientIds:
+                  type: array
+                  maxItems: 20
+                  description: Server-trusted native app client IDs used as ID-token audiences
+                  items:
+                    type: string
                 clientSecret:
                   type: string
                 redirectUri:
@@ -2013,10 +2025,13 @@ paths:
 
   /api/auth/id-token:
     post:
-      summary: Sign in with ID token (Google One Tap, native SDKs)
+      summary: Sign in with a native provider ID token
       description: |
-        Authenticate a user using an ID token obtained from a native SDK (e.g., Google One Tap).
-        Currently only the `google` provider is supported.
+        Authenticate a user using an ID token obtained from Google or Apple's native SDK.
+        Apple requests require the original raw nonce whose lowercase SHA-256 hex digest was
+        attached to the native authorization request. Apple token audiences are validated only
+        against the project's configured clientId and nativeClientIds; callers cannot select a
+        trusted audience.
       tags:
         - Client
       parameters:
@@ -2035,18 +2050,40 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - provider
-                - token
-              properties:
-                provider:
-                  type: string
-                  enum: [google]
-                  description: Identity provider that issued the token
-                token:
-                  type: string
-                  description: Raw ID token from the provider SDK
+              oneOf:
+                - type: object
+                  required: [provider, token]
+                  properties:
+                    provider:
+                      type: string
+                      enum: [google]
+                    token:
+                      type: string
+                      minLength: 1
+                      description: Raw Google ID token
+                - type: object
+                  additionalProperties: false
+                  required: [provider, token, nonce]
+                  properties:
+                    provider:
+                      type: string
+                      enum: [apple]
+                    token:
+                      type: string
+                      minLength: 1
+                      description: Raw identityToken from ASAuthorizationAppleIDCredential
+                    nonce:
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                      description: Original raw nonce whose lowercase SHA-256 hex digest was attached to ASAuthorizationAppleIDRequest
+                    name:
+                      type: string
+                      minLength: 1
+                      maxLength: 100
+                      description: Optional display name returned on first Apple authorization
+              discriminator:
+                propertyName: provider
       responses:
         '200':
           description: Sign-in successful
@@ -2350,6 +2387,12 @@ components:
         clientId:
           type: string
           nullable: true
+        nativeClientIds:
+          type: array
+          maxItems: 20
+          description: Server-trusted native app client IDs used as ID-token audiences
+          items:
+            type: string
         redirectUri:
           type: string
           nullable: true

--- a/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
@@ -64,6 +64,7 @@ export function OAuthConfigDialog({
     defaultValues: {
       provider: provider?.id || 'google',
       clientId: '',
+      nativeClientIds: [],
       clientSecret: '',
       useSharedKey: false,
     },
@@ -108,6 +109,7 @@ export function OAuthConfigDialog({
       form.reset({
         provider: provider.id,
         clientId: '',
+        nativeClientIds: [],
         clientSecret: '',
         useSharedKey: isSharedKeysAvailable,
       });
@@ -118,6 +120,7 @@ export function OAuthConfigDialog({
       form.reset({
         provider: provider.id,
         clientId: providerConfig.clientId || '',
+        nativeClientIds: providerConfig.nativeClientIds || [],
         clientSecret: providerConfig.clientSecret || '',
         useSharedKey: providerConfig.useSharedKey || false,
       });
@@ -139,9 +142,10 @@ export function OAuthConfigDialog({
         updateConfig({
           provider: provider.id,
           config: data.useSharedKey
-            ? { useSharedKey: true }
+            ? { useSharedKey: true, nativeClientIds: data.nativeClientIds }
             : {
                 clientId: data.clientId,
+                nativeClientIds: data.nativeClientIds,
                 clientSecret: data.clientSecret,
                 useSharedKey: false,
               },
@@ -151,6 +155,7 @@ export function OAuthConfigDialog({
         createConfig({
           provider: provider.id,
           clientId: data.useSharedKey ? undefined : data.clientId,
+          nativeClientIds: data.nativeClientIds,
           clientSecret: data.useSharedKey ? undefined : clientSecret,
           useSharedKey: data.useSharedKey,
         });
@@ -331,6 +336,43 @@ export function OAuthConfigDialog({
                         defaultValue: 'Enter {{name}} OAuth App Secret',
                       })}
                       className="w-[340px]"
+                    />
+                  </div>
+                </div>
+              )}
+              {provider?.id === 'apple' && (
+                <div className="p-6 border-t border-zinc-200 dark:border-neutral-700">
+                  <div className="flex flex-row items-start justify-between gap-10">
+                    <div className="space-y-1">
+                      <label className="text-sm text-zinc-950 dark:text-white">
+                        {t('auth.nativeClientIds', { defaultValue: 'Native App IDs' })}
+                      </label>
+                      <p className="max-w-52 text-xs text-zinc-500 dark:text-neutral-400">
+                        {t('auth.nativeClientIdsDescription', {
+                          defaultValue:
+                            'Comma-separated bundle IDs trusted for native Apple ID tokens.',
+                        })}
+                      </p>
+                    </div>
+                    <Controller
+                      name="nativeClientIds"
+                      control={form.control}
+                      render={({ field }) => (
+                        <Input
+                          type="text"
+                          value={(field.value ?? []).join(', ')}
+                          onChange={(event) =>
+                            field.onChange(
+                              event.target.value
+                                .split(',')
+                                .map((value) => value.trim())
+                                .filter(Boolean)
+                            )
+                          }
+                          placeholder="com.example.ios-app"
+                          className="w-[340px]"
+                        />
+                      )}
                     />
                   </div>
                 </div>

--- a/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
+++ b/packages/dashboard/src/features/auth/components/OAuthConfigDialog.tsx
@@ -48,6 +48,48 @@ interface OAuthConfigDialogProps {
 
 export type OAuthDialogMode = OAuthConfigDialogProps['mode'];
 
+function NativeClientIdsInput({
+  value,
+  onChange,
+  onBlur,
+  onTextChange,
+}: {
+  value?: string[];
+  onChange: (value: string[]) => void;
+  onBlur: () => void;
+  onTextChange: (value: string) => void;
+}) {
+  const [text, setText] = useState((value ?? []).join(', '));
+
+  useEffect(() => {
+    const nextText = (value ?? []).join(', ');
+    setText(nextText);
+    onTextChange(nextText);
+  }, [onTextChange, value]);
+
+  return (
+    <Input
+      type="text"
+      value={text}
+      onChange={(event) => {
+        setText(event.target.value);
+        onTextChange(event.target.value);
+      }}
+      onBlur={() => {
+        onChange(
+          text
+            .split(',')
+            .map((clientId) => clientId.trim())
+            .filter(Boolean)
+        );
+        onBlur();
+      }}
+      placeholder="com.example.ios-app"
+      className="w-[340px]"
+    />
+  );
+}
+
 export function OAuthConfigDialog({
   provider,
   mode,
@@ -73,6 +115,7 @@ export function OAuthConfigDialog({
   const useSharedKey = form.watch('useSharedKey');
   const clientId = form.watch('clientId');
   const clientSecret = form.watch('clientSecret');
+  const [nativeClientIdsText, setNativeClientIdsText] = useState('');
   const [isClientSecretVisible, setIsClientSecretVisible] = useState(false);
 
   // Our Cloud only support shared keys of these OAuth Providers for now
@@ -133,6 +176,12 @@ export function OAuthConfigDialog({
     }
 
     try {
+      const isNativeOnlyApple =
+        provider.id === 'apple' &&
+        (data.nativeClientIds?.length ?? 0) > 0 &&
+        !data.clientId &&
+        !data.clientSecret;
+
       if (mode === 'edit') {
         if (!providerConfig) {
           return;
@@ -143,12 +192,14 @@ export function OAuthConfigDialog({
           provider: provider.id,
           config: data.useSharedKey
             ? { useSharedKey: true, nativeClientIds: data.nativeClientIds }
-            : {
-                clientId: data.clientId,
-                nativeClientIds: data.nativeClientIds,
-                clientSecret: data.clientSecret,
-                useSharedKey: false,
-              },
+            : isNativeOnlyApple
+              ? { useSharedKey: false, nativeClientIds: data.nativeClientIds }
+              : {
+                  clientId: data.clientId,
+                  nativeClientIds: data.nativeClientIds,
+                  clientSecret: data.clientSecret || undefined,
+                  useSharedKey: false,
+                },
         });
       } else {
         // Create new config
@@ -196,7 +247,15 @@ export function OAuthConfigDialog({
       return false;
     }
 
-    // If NOT using shared keys, require both clientId and clientSecret
+    // Native-only Apple setups require a trusted app audience but no browser credentials.
+    if (
+      provider?.id === 'apple' &&
+      nativeClientIdsText.split(',').some((clientIdValue) => clientIdValue.trim().length > 0)
+    ) {
+      return false;
+    }
+
+    // If NOT using shared keys, require both clientId and clientSecret.
     return !clientId || !clientSecret;
   };
 
@@ -358,19 +417,11 @@ export function OAuthConfigDialog({
                       name="nativeClientIds"
                       control={form.control}
                       render={({ field }) => (
-                        <Input
-                          type="text"
-                          value={(field.value ?? []).join(', ')}
-                          onChange={(event) =>
-                            field.onChange(
-                              event.target.value
-                                .split(',')
-                                .map((value) => value.trim())
-                                .filter(Boolean)
-                            )
-                          }
-                          placeholder="com.example.ios-app"
-                          className="w-[340px]"
+                        <NativeClientIdsInput
+                          value={field.value}
+                          onChange={field.onChange}
+                          onBlur={field.onBlur}
+                          onTextChange={setNativeClientIdsText}
                         />
                       )}
                     />

--- a/packages/dashboard/src/lib/i18n/locales/en.json
+++ b/packages/dashboard/src/lib/i18n/locales/en.json
@@ -970,6 +970,8 @@
     "providerKeyHelp": "Use lowercase letters, numbers, hyphens, and underscores. Add this callback URL to your provider:",
     "discoveryEndpoint": "Discovery endpoint",
     "clientId": "Client ID",
+    "nativeClientIds": "Native App IDs",
+    "nativeClientIdsDescription": "Comma-separated bundle IDs trusted for native Apple ID tokens.",
     "clientSecret": "Client Secret",
     "enterClientSecret": "Enter client secret",
     "createProvider": "Create provider",

--- a/packages/dashboard/src/lib/i18n/locales/es.json
+++ b/packages/dashboard/src/lib/i18n/locales/es.json
@@ -974,6 +974,8 @@
     "providerKeyHelp": "Usa letras minúsculas, números, guiones y guiones bajos. Agrega esta URL de callback a tu proveedor:",
     "discoveryEndpoint": "Endpoint de descubrimiento",
     "clientId": "ID de cliente",
+    "nativeClientIds": "IDs de aplicaciones nativas",
+    "nativeClientIdsDescription": "IDs de paquete separados por comas y autorizados para tokens de ID nativos de Apple.",
     "clientSecret": "Secreto de cliente",
     "enterClientSecret": "Introduce el secreto de cliente",
     "createProvider": "Crear proveedor",

--- a/packages/dashboard/src/lib/i18n/locales/zh-CN.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-CN.json
@@ -950,6 +950,8 @@
     "providerKeyHelp": "只能使用小写字母、数字、连字符和下划线。请将此回调 URL 添加到您的提供商：",
     "discoveryEndpoint": "发现端点",
     "clientId": "客户端 ID",
+    "nativeClientIds": "原生应用 ID",
+    "nativeClientIdsDescription": "以逗号分隔、受信任用于原生 Apple ID 令牌的软件包 ID。",
     "clientSecret": "客户端密钥",
     "enterClientSecret": "输入客户端密钥",
     "createProvider": "创建提供商",

--- a/packages/dashboard/src/lib/i18n/locales/zh-TW.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-TW.json
@@ -950,6 +950,8 @@
     "providerKeyHelp": "只能使用小寫字母、數字、連字號與底線。請將此回呼 URL 加入您的提供者：",
     "discoveryEndpoint": "探索端點",
     "clientId": "用戶端 ID",
+    "nativeClientIds": "原生 App ID",
+    "nativeClientIdsDescription": "以逗號分隔、受信任用於原生 Apple ID 權杖的套件 ID。",
     "clientSecret": "用戶端密鑰",
     "enterClientSecret": "輸入用戶端密鑰",
     "createProvider": "建立提供者",

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -96,7 +96,11 @@ const appleIdTokenSignInRequestSchema = z
   .object({
     provider: z.literal('apple'),
     token: z.string().min(1, 'Token is required'),
-    nonce: z.string().trim().min(1, 'Nonce is required').max(255, 'Nonce is too long'),
+    nonce: z
+      .string()
+      .min(1, 'Nonce is required')
+      .max(255, 'Nonce is too long')
+      .refine((nonce) => nonce.trim().length > 0, 'Nonce is required'),
     name: nameSchema.optional(),
   })
   .strict();

--- a/packages/shared-schemas/src/auth-api.schema.ts
+++ b/packages/shared-schemas/src/auth-api.schema.ts
@@ -84,6 +84,29 @@ export const createSessionRequestSchema = z.preprocess(
 );
 
 /**
+ * POST /api/auth/id-token - Exchange a provider ID token for an InsForge session.
+ * Apple requires the nonce that the client attached to its native authorization request.
+ */
+const googleIdTokenSignInRequestSchema = z.object({
+  provider: z.literal('google'),
+  token: z.string().min(1, 'Token is required'),
+});
+
+const appleIdTokenSignInRequestSchema = z
+  .object({
+    provider: z.literal('apple'),
+    token: z.string().min(1, 'Token is required'),
+    nonce: z.string().trim().min(1, 'Nonce is required').max(255, 'Nonce is too long'),
+    name: nameSchema.optional(),
+  })
+  .strict();
+
+export const idTokenSignInRequestSchema = z.discriminatedUnion('provider', [
+  googleIdTokenSignInRequestSchema,
+  appleIdTokenSignInRequestSchema,
+]);
+
+/**
  * POST /api/auth/email/send-otp - Send a sign-in OTP
  */
 export const sendOTPRequestSchema = z.object({
@@ -553,6 +576,7 @@ type OTPSessionRequest = z.infer<typeof otpSessionRequestSchema>;
 export type CreateSessionRequest =
   | (Omit<PasswordSessionRequest, 'method'> & { method?: 'password' })
   | OTPSessionRequest;
+export type IdTokenSignInRequest = z.infer<typeof idTokenSignInRequestSchema>;
 export type SendOTPRequest = z.infer<typeof sendOTPRequestSchema>;
 export type CreateAdminSessionRequest = z.infer<typeof createAdminSessionRequestSchema>;
 export type RefreshSessionRequest = z.infer<typeof refreshSessionRequestSchema>;

--- a/packages/shared-schemas/src/auth.schema.ts
+++ b/packages/shared-schemas/src/auth.schema.ts
@@ -92,6 +92,10 @@ export const oAuthConfigSchema = z.object({
   id: z.string().uuid(),
   provider: oAuthProvidersSchema,
   clientId: z.string().optional(),
+  nativeClientIds: z
+    .array(z.string().trim().min(1).max(255))
+    .max(20, 'At most 20 native client IDs are allowed')
+    .optional(),
   scopes: z.array(z.string()).optional(),
   redirectUri: z.string().optional(),
   useSharedKey: z.boolean(),


### PR DESCRIPTION
Closes #1821.

## What changed

- extends `POST /api/auth/id-token` with a strict Apple request containing an identity token, raw nonce, and optional first-authorization display name
- verifies Apple RS256 signatures, issuer, expiry, subject, server-owned audiences, and `SHA256(rawNonce)` against Apple's signed nonce claim
- stores trusted native App IDs in project OAuth configuration as `nativeClientIds`, including migration, admin API, and dashboard support
- finds returning Apple users by provider subject before profile claims, supports private-relay email, and rejects new/linking identities without a verified token email instead of fabricating one
- returns the existing mobile access/refresh session shape and preserves Google's current ID-token request contract
- updates shared schemas, OpenAPI, REST documentation, and localized dashboard copy

## Why

Apple OAuth currently requires native iOS apps to open the browser-based OAuth session. This gives apps using `ASAuthorizationController` a server-supported credential-to-InsForge-session exchange while keeping the audience trust boundary in project configuration.

Authorization-code exchange and Apple refresh-token/revocation storage are intentionally left for a focused follow-up; this change does not accept a code that it would ignore.

PR #1302 was useful prior art. This implementation is a fresh current-`main` branch and adds nonce binding, managed project audiences, first-authorization metadata handling, stricter email/linking behavior, dashboard configuration, and current tests/docs.

## Validation

- `npm run test:backend` — 2,016 passed, 21 skipped
- focused native Apple/config suite — 31 passed
- database integration suite — 20 passed
- Docker HTTP E2E suite — 13/13 scripts passed
- `npm run typecheck` — 8/8 tasks
- `npm run lint` — 5/5 tasks
- `npm run format:check`
- `git diff --check`
- clean Docker migration verified `native_client_ids TEXT[] NOT NULL DEFAULT '{}'`
- targeted HTTP checks verified missing nonce `400`, config round trip, and invalid token `401`

Automated Apple verification uses generated RS256 keys; no live Apple credentials or tokens are stored in fixtures.

Live local end-to-end verification also passed on an iOS 18.6 Simulator with a separately signed test App ID and disposable self-hosted InsForge backend:

- `ASAuthorizationAppleIDButton` presented Apple's native `ASAuthorizationController` sheet
- a deliberately wrong raw nonce was rejected with `401` before the correctly bound credential was exchanged
- the valid Apple identity token created/returned the Apple-linked user and returned mobile access + refresh tokens
- refresh succeeded for the same Apple-linked user
- an authenticated `GET /api/auth/sessions/current` request succeeded
- sanitized database verification found exactly one Apple-linked user and preserved first-authorization name data

The standalone harness, credentials, tokens, nonces, full email address, and Apple account details are not part of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native Sign in with Apple to `POST /api/auth/id-token` with nonce binding and server‑owned audience validation, enabling iOS apps to exchange Apple identity tokens for InsForge sessions (closes #1821). Requests are schema‑validated and per‑IP rate‑limited; Google ID‑token flow is unchanged.

- **New Features**
  - Extend `POST /api/auth/id-token` to accept Apple: `{ provider: 'apple', token, nonce, name? }`; verify RS256, issuer, expiry, subject, and audience from project config (`clientId` + `nativeClientIds`), and `SHA256(rawNonce)` vs token `nonce`.
  - Add per‑IP rate limiter for ID‑token exchanges (30/15m) and use `idTokenSignInRequestSchema` (`@insforge/shared-schemas`) for input validation; web returns CSRF + cookie, native/server return `refreshToken` in the body.
  - Add `native_client_ids` migration and expose `nativeClientIds` in admin API and dashboard (new Apple “Native App IDs” input, supports native‑only Apple configs); normalize and dedupe IDs.
  - Improve account linking: find returning Apple users by `sub`, support private‑relay emails, require a verified token email for new/linking, and use case‑insensitive email matching.

- **Migration**
  - Run DB migrations to add `native_client_ids`.
  - Configure Apple `nativeClientIds` (bundle IDs) via admin API or dashboard.
  - iOS: generate a high‑entropy raw nonce, attach its SHA‑256 hex to the native request, then POST identity token + raw nonce to `POST /api/auth/id-token?client_type=mobile`.

<sup>Written for commit 4c10f5c4984ee1cb3cb57dc577ff855a55794c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native Apple ID token sign-in to `POST /api/auth/id-token`
> - Extends `AuthService.signInWithIdToken` to support Apple as a native provider, requiring a `nonce` for verification via `AppleOAuthProvider.verifyIdToken` using `jose` and Apple's remote JWKS.
> - Adds `nativeClientIds` (TEXT[]) to `auth.oauth_configs` via migration [062](https://github.com/InsForge/InsForge/pull/1822/files#diff-7c683a3754928f2ac9361b042e73739658ca3f87c960a58d897e011568ab8b37), allowing Apple tokens from native iOS/macOS app audiences to be validated separately from browser flows.
> - Updates `POST /api/auth/id-token` to use a discriminated union schema (`idTokenSignInRequestSchema`) that enforces nonce for Apple and applies `idTokenSignInRateLimiter` (30 req / 15 min per IP).
> - Adds a `NativeClientIdsInput` UI control to `OAuthConfigDialog` so admins can configure native client IDs per provider, with Apple-only configs (no browser client ID/secret) now valid.
> - `findOrCreateThirdPartyUser` now rejects new Apple accounts without a verified email (`requireEmailForNewAccount`) and performs case-insensitive email matching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c10f5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-discriminated native `id_token` sign-in for Apple and Google.
  * Introduced server-trusted native Apple app client IDs for OAuth config and dashboard “native-only Apple” setup.
  * Added per-IP rate limiting for native `id_token` sign-in.
* **Bug Fixes**
  * Strengthened Apple token validation (issuer/audience/nonce/nonce hashing) and request schema enforcement.
  * Enforced email-required flows for Apple when creating new accounts and made email lookup case-insensitive/deterministic.
  * Improved native client IDs migration/backfill and normalization.
* **Documentation**
  * Expanded REST auth docs and updated OpenAPI contracts for native sign-in and native client IDs.
* **Tests**
  * Expanded unit tests for Apple verification, native sign-in routing, schemas, dashboard inputs, and migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->