### PR TITLE
fix(auth): accept cloud project authorization tokens

### DIFF
--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -4,6 +4,7 @@ import { AppError } from '@/utils/errors.js';
 import { ERROR_CODES, type RoleSchema } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 import { SecretService } from '@/services/secrets/secret.service.js';
+import jwt from 'jsonwebtoken';
 
 export type UserContext = {
   /**
@@ -126,7 +127,19 @@ export async function verifyAdmin(req: AuthRequest, res: Response, next: NextFun
       );
     }
 
-    // For admin, we use JWT tokens
+    // The unverified type claim is used only to choose the verifier. A Cloud
+    // project authorization candidate must never fall back to local JWT
+    // verification if Cloud verification fails.
+    const decoded = jwt.decode(token);
+    const tokenType = decoded && typeof decoded === 'object' ? decoded.type : undefined;
+    if (tokenType === 'project_authorization') {
+      const { projectId, userId } = await tokenManager.verifyCloudProjectAuthorization(token);
+      req.projectId = projectId;
+      req.authenticated = true;
+      setRequestUser(req, { sub: `cloud:${userId}`, role: 'project_admin' });
+      return next();
+    }
+
     const payload = tokenManager.verifyToken(token);
 
     if (payload.role !== 'project_admin') {

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -29,6 +29,11 @@ export interface RefreshTokenWithCsrf {
   csrfToken: string;
 }
 
+export interface CloudProjectAuthorization {
+  projectId: string;
+  userId: string;
+}
+
 /**
  * Create JWKS instance with caching and timeout configuration
  * The instance will automatically cache keys and handle refetching
@@ -352,6 +357,32 @@ export class TokenManager {
         NEXT_ACTIONS.CHECK_TOKEN
       );
     }
+  }
+
+  /**
+   * Verify a cloud-signed project authorization token.
+   *
+   * This is the shared authority boundary for credentials that grant project
+   * admin access. Claims are inspected only after Cloud signature and project
+   * binding verification succeeds.
+   */
+  async verifyCloudProjectAuthorization(token: string): Promise<CloudProjectAuthorization> {
+    const { projectId, payload } = await this.verifyCloudToken(token);
+
+    if (
+      payload.type !== 'project_authorization' ||
+      typeof payload.userId !== 'string' ||
+      payload.userId.trim().length === 0
+    ) {
+      throw new AppError(
+        'Invalid cloud project authorization token',
+        401,
+        ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+        NEXT_ACTIONS.CHECK_TOKEN
+      );
+    }
+
+    return { projectId, userId: payload.userId };
   }
 
   /**

--- a/backend/src/infra/security/token.manager.ts
+++ b/backend/src/infra/security/token.manager.ts
@@ -367,6 +367,14 @@ export class TokenManager {
    * binding verification succeeds.
    */
   async verifyCloudProjectAuthorization(token: string): Promise<CloudProjectAuthorization> {
+    if (!appConfig.cloud.projectId) {
+      throw new AppError(
+        'PROJECT_ID not found in environment variables',
+        500,
+        ERROR_CODES.INTERNAL_ERROR
+      );
+    }
+
     const { projectId, payload } = await this.verifyCloudToken(token);
 
     if (

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -841,8 +841,8 @@ export class AuthService {
    * Admin login with authorization token (validates JWT from external issuer)
    */
   async adminLoginWithAuthorizationCode(code: string): Promise<CreateAdminSessionResponse> {
-    const { payload } = await this.tokenManager.verifyCloudToken(code);
-    const sub = `cloud:${payload.userId}`;
+    const { userId } = await this.tokenManager.verifyCloudProjectAuthorization(code);
+    const sub = `cloud:${userId}`;
     const accessToken = this.tokenManager.generateAccessToken({
       sub,
       role: 'project_admin',

--- a/backend/tests/unit/admin-login.test.ts
+++ b/backend/tests/unit/admin-login.test.ts
@@ -12,6 +12,7 @@ const { mockPool, mockTokenManager, mockOAuthProvider } = vi.hoisted(() => ({
   },
   mockTokenManager: {
     generateAccessToken: vi.fn().mockReturnValue('test-access-token'),
+    verifyCloudProjectAuthorization: vi.fn(),
   },
   mockOAuthProvider: {
     getInstance: () => ({}),
@@ -151,6 +152,25 @@ describe('AuthService.adminLogin', () => {
     expect(mockTokenManager.generateAccessToken).toHaveBeenCalledWith({
       sub: 'local:admin@test.com',
       role: 'project_admin',
+    });
+  });
+
+  it('exchanges a verified Cloud project authorization for an attributed admin session', async () => {
+    mockTokenManager.verifyCloudProjectAuthorization.mockResolvedValue({
+      projectId: 'project_123',
+      userId: 'user_123',
+    });
+
+    const result = await authService.adminLoginWithAuthorizationCode('cloud-token');
+
+    expect(mockTokenManager.verifyCloudProjectAuthorization).toHaveBeenCalledWith('cloud-token');
+    expect(mockTokenManager.generateAccessToken).toHaveBeenCalledWith({
+      sub: 'cloud:user_123',
+      role: 'project_admin',
+    });
+    expect(result).toEqual({
+      admin: { sub: 'cloud:user_123' },
+      accessToken: 'test-access-token',
     });
   });
 

--- a/backend/tests/unit/cloud-token.test.ts
+++ b/backend/tests/unit/cloud-token.test.ts
@@ -1,6 +1,7 @@
 import { TokenManager } from '../../src/infra/security/token.manager';
 import { jwtVerify } from 'jose';
 import { AppError } from '../../src/utils/errors';
+import { appConfig } from '../../src/infra/config/app.config';
 import { ERROR_CODES } from '@insforge/shared-schemas';
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 
@@ -19,7 +20,7 @@ vi.mock('../../src/utils/logger', () => ({
 vi.mock('../../src/infra/config/app.config', () => {
   const c = {
     cloud: {
-      projectId: 'project_123',
+      projectId: 'project_123' as string | undefined,
       apiHost: 'https://mock-api.dev',
     },
     app: {
@@ -38,6 +39,7 @@ describe('TokenManager.verifyCloudToken', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    appConfig.cloud.projectId = 'project_123';
     process.env = {
       ...oldEnv,
       PROJECT_ID: 'project_123',
@@ -83,6 +85,18 @@ describe('TokenManager.verifyCloudToken', () => {
   });
 
   describe('verifyCloudProjectAuthorization', () => {
+    it('fails closed before Cloud verification when the local project ID is missing', async () => {
+      appConfig.cloud.projectId = undefined;
+
+      await expect(
+        tokenManager.verifyCloudProjectAuthorization('valid-token')
+      ).rejects.toMatchObject({
+        statusCode: 500,
+        code: ERROR_CODES.INTERNAL_ERROR,
+      });
+      expect(jwtVerify).not.toHaveBeenCalled();
+    });
+
     it('returns a typed project and user identity for a valid token', async () => {
       (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
         payload: {
@@ -96,6 +110,7 @@ describe('TokenManager.verifyCloudToken', () => {
         projectId: 'project_123',
         userId: 'user_123',
       });
+      expect(jwtVerify).toHaveBeenCalledOnce();
     });
 
     it.each([undefined, '', '   ', 123, {}])('rejects malformed userId %j', async (userId) => {
@@ -143,6 +158,7 @@ describe('TokenManager.verifyCloudToken', () => {
         statusCode: 403,
         code: ERROR_CODES.AUTH_UNAUTHORIZED,
       });
+      expect(jwtVerify).toHaveBeenCalledOnce();
     });
 
     it.each(['JWT expired', 'signature verification failed'])(

--- a/backend/tests/unit/cloud-token.test.ts
+++ b/backend/tests/unit/cloud-token.test.ts
@@ -53,12 +53,16 @@ describe('TokenManager.verifyCloudToken', () => {
 
   it('returns payload and projectId if valid', async () => {
     (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      payload: { projectId: 'project_123', user: 'testUser' },
+      payload: {
+        projectId: 'project_123',
+        userId: 'test-user',
+        type: 'project_authorization',
+      },
     });
 
     const result = await tokenManager.verifyCloudToken('valid-token');
     expect(result.projectId).toBe('project_123');
-    expect(result.payload.user).toBe('testUser');
+    expect(result.payload.userId).toBe('test-user');
   });
 
   it('throws AppError if project ID mismatch or missing', async () => {
@@ -76,5 +80,83 @@ describe('TokenManager.verifyCloudToken', () => {
       statusCode: 401,
       code: ERROR_CODES.AUTH_INVALID_CREDENTIALS,
     });
+  });
+
+  describe('verifyCloudProjectAuthorization', () => {
+    it('returns a typed project and user identity for a valid token', async () => {
+      (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        payload: {
+          projectId: 'project_123',
+          userId: 'user_123',
+          type: 'project_authorization',
+        },
+      });
+
+      await expect(tokenManager.verifyCloudProjectAuthorization('valid-token')).resolves.toEqual({
+        projectId: 'project_123',
+        userId: 'user_123',
+      });
+    });
+
+    it.each([undefined, '', '   ', 123, {}])('rejects malformed userId %j', async (userId) => {
+      (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        payload: {
+          projectId: 'project_123',
+          userId,
+          type: 'project_authorization',
+        },
+      });
+
+      await expect(
+        tokenManager.verifyCloudProjectAuthorization('invalid-token')
+      ).rejects.toMatchObject({
+        statusCode: 401,
+        code: ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+      });
+    });
+
+    it.each([undefined, 'access', 'project-admin'])('rejects token type %j', async (type) => {
+      (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        payload: { projectId: 'project_123', userId: 'user_123', type },
+      });
+
+      await expect(
+        tokenManager.verifyCloudProjectAuthorization('invalid-token')
+      ).rejects.toMatchObject({
+        statusCode: 401,
+        code: ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+      });
+    });
+
+    it('rejects a token bound to another project', async () => {
+      (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        payload: {
+          projectId: 'project_456',
+          userId: 'user_123',
+          type: 'project_authorization',
+        },
+      });
+
+      await expect(
+        tokenManager.verifyCloudProjectAuthorization('wrong-project')
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        code: ERROR_CODES.AUTH_UNAUTHORIZED,
+      });
+    });
+
+    it.each(['JWT expired', 'signature verification failed'])(
+      'rejects Cloud verification failure: %s',
+      async (message) => {
+        (jwtVerify as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error(message));
+
+        await expect(
+          tokenManager.verifyCloudProjectAuthorization('invalid-token')
+        ).rejects.toMatchObject({
+          statusCode: 401,
+          code: ERROR_CODES.AUTH_INVALID_CREDENTIALS,
+        });
+      }
+    );
   });
 });

--- a/backend/tests/unit/verify-admin.test.ts
+++ b/backend/tests/unit/verify-admin.test.ts
@@ -1,0 +1,129 @@
+import type { NextFunction, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+import { AppError } from '../../src/utils/errors.js';
+
+const { mockTokenManager, mockSecretService } = vi.hoisted(() => ({
+  mockTokenManager: {
+    verifyToken: vi.fn(),
+    verifyCloudProjectAuthorization: vi.fn(),
+  },
+  mockSecretService: {
+    verifyApiKey: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/infra/security/token.manager.js', () => ({
+  TokenManager: { getInstance: () => mockTokenManager },
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: { getInstance: () => mockSecretService },
+}));
+
+import { type AuthRequest, verifyAdmin } from '../../src/api/middlewares/auth.js';
+
+function bearerToken(payload: Record<string, unknown>): string {
+  return jwt.sign(payload, 'dispatch-only-test-secret');
+}
+
+function requestWithBearer(token: string): AuthRequest {
+  return { headers: { authorization: `Bearer ${token}` } } as AuthRequest;
+}
+
+async function authenticate(req: AuthRequest) {
+  const next = vi.fn() as unknown as NextFunction;
+  await verifyAdmin(req, {} as Response, next);
+  return next;
+}
+
+describe('verifyAdmin', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('accepts a valid Cloud project authorization with audit-compatible context', async () => {
+    const token = bearerToken({ type: 'project_authorization' });
+    mockTokenManager.verifyCloudProjectAuthorization.mockResolvedValue({
+      projectId: 'project_123',
+      userId: 'user_123',
+    });
+    const req = requestWithBearer(token);
+
+    const next = await authenticate(req);
+
+    expect(mockTokenManager.verifyCloudProjectAuthorization).toHaveBeenCalledWith(token);
+    expect(mockTokenManager.verifyToken).not.toHaveBeenCalled();
+    expect(req).toMatchObject({
+      projectId: 'project_123',
+      authenticated: true,
+      user: { id: 'cloud:user_123', role: 'project_admin' },
+    });
+    expect(req.hasApiKey).toBeUndefined();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('fails closed without local fallback for a non-Cloud token claiming the Cloud type', async () => {
+    const token = bearerToken({
+      type: 'project_authorization',
+      role: 'project_admin',
+      sub: 'local:attacker',
+    });
+    mockTokenManager.verifyCloudProjectAuthorization.mockRejectedValue(
+      new AppError('Invalid Cloud signature', 401, ERROR_CODES.AUTH_INVALID_CREDENTIALS)
+    );
+
+    const next = await authenticate(requestWithBearer(token));
+
+    expect(mockTokenManager.verifyCloudProjectAuthorization).toHaveBeenCalledWith(token);
+    expect(mockTokenManager.verifyToken).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 401, code: ERROR_CODES.AUTH_INVALID_CREDENTIALS })
+    );
+  });
+
+  it('preserves locally issued project-admin JWT authentication', async () => {
+    const token = bearerToken({ role: 'project_admin', sub: 'local:admin' });
+    mockTokenManager.verifyToken.mockReturnValue({
+      sub: 'local:admin',
+      role: 'project_admin',
+    });
+    const req = requestWithBearer(token);
+
+    const next = await authenticate(req);
+
+    expect(mockTokenManager.verifyToken).toHaveBeenCalledWith(token);
+    expect(mockTokenManager.verifyCloudProjectAuthorization).not.toHaveBeenCalled();
+    expect(req.user).toEqual({ id: 'local:admin', email: undefined, role: 'project_admin' });
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('preserves rejection of locally issued non-admin JWTs', async () => {
+    const token = bearerToken({ role: 'authenticated', sub: 'user_123' });
+    mockTokenManager.verifyToken.mockReturnValue({
+      sub: 'user_123',
+      role: 'authenticated',
+    });
+
+    const next = await authenticate(requestWithBearer(token));
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 403, code: ERROR_CODES.AUTH_UNAUTHORIZED })
+    );
+  });
+
+  it('preserves ik_ API-key authentication', async () => {
+    mockSecretService.verifyApiKey.mockResolvedValue(true);
+    const req = requestWithBearer('ik_project_admin_key');
+
+    const next = await authenticate(req);
+
+    expect(mockSecretService.verifyApiKey).toHaveBeenCalledWith('ik_project_admin_key');
+    expect(mockTokenManager.verifyToken).not.toHaveBeenCalled();
+    expect(mockTokenManager.verifyCloudProjectAuthorization).not.toHaveBeenCalled();
+    expect(req.authenticated).toBe(true);
+    expect(req.hasApiKey).toBe(true);
+    expect(next).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
## Summary

This PR allows Cloud-signed, short-lived `project_authorization` tokens to authenticate directly through `verifyAdmin`, so first-party services no longer need to hold a long-lived project admin API key.

The new verifier validates the token against the Cloud JWKS, checks the project binding and required claims, and attributes the request to `cloud:<userId>`. Tokens identified as Cloud project authorization credentials do not fall back to local JWT verification if validation fails.

The existing API-key and local project-admin JWT flows remain unchanged. The same verifier is also reused by the existing admin authorization-code exchange flow.

Closes #1818

## How did you test this change?

Added coverage for valid and invalid Cloud project authorization tokens, project mismatches, missing claims, fail-closed dispatch, request context population, local admin JWTs, existing API-key authentication used by MCP callers, and the admin authorization-code exchange flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Cloud-signed, short-lived `project_authorization` tokens for admin auth to remove the need for long-lived project admin API keys. Tokens are verified with Cloud JWKS, must match the configured project, and requests are attributed to `cloud:<userId>`.

- **New Features**
  - Added Cloud `project_authorization` token support in `verifyAdmin` with project binding and user attribution.
  - Require a configured project ID; tokens for another project or when local project ID is missing are rejected. Fail-closed: if a token claims `project_authorization`, no fallback to local JWT on Cloud verification failure.
  - Reused the verifier for the admin authorization-code exchange; existing API-key and local admin JWT flows remain unchanged.

<sup>Written for commit 20ca5e3c8931961d6e0dd714363bb33f40c72626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for cloud project authorization tokens during administrator sign-in.
  - Cloud-authorized sessions now identify the associated project and cloud user.
  - Added validation for token type, user identity, project association, and signature.

- **Bug Fixes**
  - Prevented forged cloud-style tokens from bypassing authorization checks.
  - Preserved support for existing administrator JWT and API-key authentication.

- **Tests**
  - Added coverage for successful authentication and invalid or mismatched authorization tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept cloud project authorization tokens in `verifyAdmin` middleware
> - Adds `TokenManager.verifyCloudProjectAuthorization` in [token.manager.ts](https://github.com/InsForge/InsForge/pull/1826/files#diff-daa39ea0a1dd3e8a98038182b1fdb8228fedb70964ee988ffd338295598297bb), which verifies Cloud signature and project binding, then validates `type === 'project_authorization'` and a non-empty `userId` before returning `{ projectId, userId }`.
> - Updates [auth.ts](https://github.com/InsForge/InsForge/pull/1826/files#diff-2afb4fc21a1a8233ad815ccefde24bcb98ee866f4c10919c6b807626c167ae3a) `verifyAdmin` to decode the bearer token, and if `type` is `'project_authorization'`, calls `verifyCloudProjectAuthorization`, sets `req.projectId`, and attaches a `{ sub: 'cloud:<userId>', role: 'project_admin' }` user without falling back to local verification.
> - Updates `AuthService.adminLoginWithAuthorizationCode` in [auth.service.ts](https://github.com/InsForge/InsForge/pull/1826/files#diff-efb526d1eb72363a928158c9f2b98bf73e757c5610a4e10e00ed067d3075738c) to use `verifyCloudProjectAuthorization` instead of `verifyCloudToken`.
> - Risk: if a token claims `type: 'project_authorization'` but Cloud verification fails, the middleware returns an error immediately with no local JWT fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20ca5e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->