### PR TITLE
docs(storage): document S3 proxy mode upload and download strategies

### DIFF
--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -1370,8 +1370,8 @@ components:
           enum: [presigned, direct]
           description: |
             Download method:
-            - `direct`: Direct access using either an object URL (public S3) or a backend proxy endpoint (local storage or S3 proxy mode)
-            - `presigned`: Secure URL with signature and expiration (private S3 with presigned URLs enabled)
+            - `direct`: Direct backend endpoint for local storage or S3 proxy mode (`S3_USE_PRESIGNED_URLS=false`)
+            - `presigned`: Signed download URL returned when `S3_USE_PRESIGNED_URLS=true` for both public and private S3 buckets. Bucket visibility only affects the URL expiration period.
           example: direct
         url:
           type: string

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -516,7 +516,9 @@ paths:
     post:
       summary: Get Upload Strategy (Direct or Presigned URL)
       description: |
-        Returns upload strategy based on storage backend (S3 returns presigned URLs, local returns direct upload endpoints).
+        Returns the upload strategy for the requested object.
+        Local storage always returns direct upload endpoints. S3 storage may return either `presigned` or `direct` strategies depending on the `S3_USE_PRESIGNED_URLS` configuration.
+        Clients must determine the upload flow from the returned response, using the method field, rather than assuming behavior based on the configured storage backend. 
 
         The filename is used verbatim as the object key. Uploading to an existing key replaces the current object in place. To upload with a server-generated unique key instead, use `POST /api/storage/buckets/{bucketName}/objects`. End-user creates and replacements are gated by the `storage.objects` row-level-security policies.
       tags:
@@ -577,6 +579,13 @@ paths:
                     confirmRequired: true
                     confirmUrl: /api/storage/buckets/avatars/objects/profile-photo.jpg/confirm-upload
                     expiresAt: "2025-09-05T01:00:00Z"
+                s3Proxy:
+                  summary: S3 Backend (Proxy Mode)
+                  value:
+                    method: direct
+                    uploadUrl: /api/storage/buckets/avatars/objects/profile-photo.jpg
+                    key: profile-photo.jpg
+                    confirmRequired: false
                 local:
                   summary: Local Storage Response
                   value:
@@ -851,10 +860,14 @@ paths:
     get:
       summary: Get Download Strategy (Direct or Presigned URL)
       description: |
-        Returns download strategy based on storage backend and bucket visibility.
-        - S3 with public bucket: Direct URLs (no presigning, better performance)
-        - S3 with private bucket: Presigned URLs with expiration
-        - Local storage: Always direct endpoints
+        Returns the download strategy based on the storage backend, bucket visibility, and the `S3_USE_PRESIGNED_URLS` configuration.
+
+        - S3 with public bucket: Direct object URLs
+        - S3 with private bucket and presigned URLs enabled: Presigned URLs with expiration
+        - S3 proxy mode (`S3_USE_PRESIGNED_URLS=false`): Direct backend download endpoint
+        - Local storage: Direct backend download endpoint
+
+        Clients must determine the download flow from the returned `method` field.
 
         Expiry (when presigned) is auto-calculated server-side from bucket
         visibility; no request body is accepted.
@@ -1315,7 +1328,7 @@ components:
         method:
           type: string
           enum: [presigned, direct]
-          description: Upload method - presigned for S3, direct for local storage
+          description: Upload method. `presigned` is returned when S3 presigned URLs are enabled; `direct` is returned for local storage and S3 proxy mode.
           example: presigned
         uploadUrl:
           type: string
@@ -1335,11 +1348,11 @@ components:
           example: profile-photo.jpg
         confirmRequired:
           type: boolean
-          description: Whether upload confirmation is required
+          description: Whether the upload must be confirmed after completion. When `false`, clients must not call the confirm upload endpoint.
           example: true
         confirmUrl:
           type: string
-          description: URL to confirm the upload (if confirmRequired is true)
+          description: Upload confirmation endpoint. Present only when `confirmRequired` is `true`.
           example: /api/storage/buckets/avatars/objects/profile.jpg/confirm-upload
         expiresAt:
           type: string
@@ -1358,8 +1371,8 @@ components:
           enum: [presigned, direct]
           description: |
             Download method:
-            - `direct`: Direct URL access (S3 public buckets or local storage)
-            - `presigned`: Secure URL with signature and expiration (S3 private buckets)
+            - `direct`: Direct access using either an object URL (public S3) or a backend proxy endpoint (local storage or S3 proxy mode)
+            - `presigned`: Secure URL with signature and expiration (private S3 with presigned URLs enabled)
           example: direct
         url:
           type: string

--- a/openapi/storage.yaml
+++ b/openapi/storage.yaml
@@ -862,10 +862,9 @@ paths:
       description: |
         Returns the download strategy based on the storage backend, bucket visibility, and the `S3_USE_PRESIGNED_URLS` configuration.
 
-        - S3 with public bucket: Direct object URLs
-        - S3 with private bucket and presigned URLs enabled: Presigned URLs with expiration
-        - S3 proxy mode (`S3_USE_PRESIGNED_URLS=false`): Direct backend download endpoint
-        - Local storage: Direct backend download endpoint
+        - S3 with `S3_USE_PRESIGNED_URLS=true`: Returns `method: presigned` for both public and private buckets. Bucket visibility only affects the URL expiration period.
+        - S3 with `S3_USE_PRESIGNED_URLS=false` (proxy mode): Returns `method: direct` using the backend download endpoint.
+        - Local storage: Returns `method: direct` using the backend download endpoint.
 
         Clients must determine the download flow from the returned `method` field.
 
@@ -904,7 +903,7 @@ paths:
                 s3-public:
                   summary: S3 Public Bucket Response
                   value:
-                    method: direct
+                    method: presigned
                     url: https://s3-bucket.s3.us-east-2.amazonaws.com/app-key/public-assets/logo.png
                 s3-private:
                   summary: S3 Private Bucket Response


### PR DESCRIPTION
Closes #1823

## Summary

Updates the storage OpenAPI specification to reflect the current behavior when `S3_USE_PRESIGNED_URLS=false`.

## Changes

- Clarify that upload strategy depends on both the storage backend and `S3_USE_PRESIGNED_URLS`.
- Document that clients should determine upload and download behavior from the returned `method` field rather than assuming behavior based on the storage backend.
- Document S3 proxy-mode download behavior.
- Add an S3 proxy-mode upload strategy example (`method: direct`, `confirmRequired: false`).
- Clarify the `confirmRequired` / `confirmUrl` contract.

## Validation

- [x] `npx @apidevtools/swagger-cli validate openapi/storage.yaml`

This is a documentation-only change; no runtime behavior has been modified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the storage OpenAPI spec to document S3 proxy mode (`S3_USE_PRESIGNED_URLS=false`) and instruct clients to use the returned `method` for upload and download. Adds an S3 proxy upload example, clarifies `confirmRequired`/`confirmUrl`, aligns download behavior and examples (public S3 is `presigned`), and updates the `DownloadStrategy` schema to match runtime.

<sup>Written for commit 93bced8e16f37798909c879fdcae88ac1de0e37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document S3 proxy mode upload and download strategies in storage API spec
> Updates [openapi/storage.yaml](https://github.com/InsForge/InsForge/pull/1827/files#diff-d577afade0093479dfede991f2189a906ea0708dedfcc15581212dfdfd832551) to clarify how clients should interpret the `method` field returned by the upload and download strategy endpoints.
>
> - Upload strategy description now explains that `method: direct` is returned for both local storage and S3 proxy mode, while `method: presigned` is returned when `S3_USE_PRESIGNED_URLS` is enabled. Adds a new example for S3 proxy mode.
> - Download strategy description is rewritten to define behavior in terms of `S3_USE_PRESIGNED_URLS`, covering proxy mode, public/private buckets, and local storage. Fixes the S3 public bucket example to use `method: presigned` instead of `direct`.
> - Schema field descriptions for `UploadStrategy` and `DownloadStrategy` are refined to match the documented behavior, including a clarification that `confirmUrl` is only present when `confirmRequired` is true.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93bced8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Clarified configurable S3 proxy and direct upload/download strategies.
* Added an example response for proxy-based uploads.
* Documented how clients select the appropriate upload method from the response.
* Updated public S3 download examples to use presigned URLs.
* Clarified proxy behavior, upload confirmation requirements, and endpoint availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->