### PR TITLE
feat(telemetry): report which features a self-hosted instance uses

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -43,7 +43,11 @@ import { servicesRouter } from '@/api/routes/compute/services.routes.js';
 import { analyticsRouter } from '@/api/routes/analytics/index.routes.js';
 import { webscraperRouter } from '@/api/routes/webscraper/index.routes.js';
 import { appConfig } from '@/infra/config/app.config.js';
-import { TelemetryService } from '@/services/telemetry/telemetry.service.js';
+import {
+  TelemetryService,
+  isTelemetryRuntimeDisabled,
+} from '@/services/telemetry/telemetry.service.js';
+import { FeatureUsageCollector } from '@/services/telemetry/feature-usage.collector.js';
 import { TokenManager } from '@/infra/security/token.manager.js';
 import { DatabaseBackupService } from '@/services/database/database-backup.service.js';
 const __filename = fileURLToPath(import.meta.url);
@@ -156,6 +160,19 @@ export async function createApp() {
 
     next();
   });
+
+  // Count feature usage for anonymous telemetry. Registered before every route
+  // so the /api routers, the S3 protocol gateway, and direct edge-function
+  // invocations are all covered, and before any router rewrites req.url for
+  // its mount path. Skipped entirely when telemetry is off, so no counters
+  // accumulate that nothing will ever drain.
+  if (!isTelemetryRuntimeDisabled()) {
+    const featureUsage = FeatureUsageCollector.getInstance();
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      featureUsage.track(req, res);
+      next();
+    });
+  }
 
   // Mount webhooks with raw body parser BEFORE JSON middleware
   // This ensures signature verification uses the original bytes
@@ -404,7 +421,7 @@ async function cleanup() {
   }
 
   try {
-    TelemetryService.getInstance().stop();
+    await TelemetryService.getInstance().shutdown();
   } catch (error) {
     logger.error('Error closing TelemetryService', {
       error: error instanceof Error ? error.message : String(error),

--- a/backend/src/services/telemetry/feature-usage.collector.ts
+++ b/backend/src/services/telemetry/feature-usage.collector.ts
@@ -51,17 +51,21 @@ const API_FEATURES = new Set([
 const READ_METHODS = new Set(['GET', 'HEAD']);
 
 /**
- * Statuses meaning the caller never reached the feature.
+ * The status meaning the caller was turned away before reaching the feature.
  *
- * Excluding these keeps two kinds of noise out: an unauthenticated probe
- * against /api/database would otherwise mark the database used, and a dashboard
- * tab whose 15-minute access token has expired fires a rejected read before it
+ * Excluding it keeps two kinds of noise out: an unauthenticated probe against
+ * /api/database would otherwise mark the database used, and a dashboard tab
+ * whose 15-minute access token has expired fires a rejected read before it
  * refreshes and retries, which would defeat the dashboard-read exclusion below.
  *
- * Other failures still count. A validation error or a missing record means the
- * app did reach the feature and used it.
+ * Deliberately only 401. A 403 usually means the request did reach the feature
+ * and was denied by policy — an RLS denial (SQLSTATE 42501 maps to 403),
+ * storage permission checks, or signups being disabled. Those exercised the
+ * feature, and excluding them would systematically undercount exactly the
+ * projects that configure RLS properly. Every other failure counts too: a
+ * validation error or a missing record still means the app reached the feature.
  */
-const REJECTED_STATUSES = new Set([401, 403]);
+const UNAUTHENTICATED_STATUS = 401;
 
 const S3_GATEWAY_PREFIX = '/storage/v1/s3';
 const FUNCTION_INVOKE_PREFIX = '/functions/';
@@ -116,7 +120,7 @@ export function resolveFeature(pathname: string): string | null {
  */
 /** Whether the response says the caller was turned away at the door. */
 export function isRejected(statusCode: number): boolean {
-  return REJECTED_STATUSES.has(statusCode);
+  return statusCode === UNAUTHENTICATED_STATUS;
 }
 
 export function isDashboardRead(req: Request): boolean {

--- a/backend/src/services/telemetry/feature-usage.collector.ts
+++ b/backend/src/services/telemetry/feature-usage.collector.ts
@@ -12,6 +12,7 @@
 
 import type { Request, Response } from 'express';
 import type { AuthRequest } from '@/api/middlewares/auth.js';
+import logger from '@/utils/logger.js';
 
 export type FeatureUsageSnapshot = {
   featuresUsed: string[];
@@ -48,6 +49,19 @@ const API_FEATURES = new Set([
 ]);
 
 const READ_METHODS = new Set(['GET', 'HEAD']);
+
+/**
+ * Statuses meaning the caller never reached the feature.
+ *
+ * Excluding these keeps two kinds of noise out: an unauthenticated probe
+ * against /api/database would otherwise mark the database used, and a dashboard
+ * tab whose 15-minute access token has expired fires a rejected read before it
+ * refreshes and retries, which would defeat the dashboard-read exclusion below.
+ *
+ * Other failures still count. A validation error or a missing record means the
+ * app did reach the feature and used it.
+ */
+const REJECTED_STATUSES = new Set([401, 403]);
 
 const S3_GATEWAY_PREFIX = '/storage/v1/s3';
 const FUNCTION_INVOKE_PREFIX = '/functions/';
@@ -100,6 +114,11 @@ export function resolveFeature(pathname: string): string | null {
  * is using the database — and every non-dashboard request counts regardless of
  * which credential it carried.
  */
+/** Whether the response says the caller was turned away at the door. */
+export function isRejected(statusCode: number): boolean {
+  return REJECTED_STATUSES.has(statusCode);
+}
+
 export function isDashboardRead(req: Request): boolean {
   if (!READ_METHODS.has(req.method.toUpperCase())) {
     return false;
@@ -142,32 +161,48 @@ export class FeatureUsageCollector {
     }
 
     res.once('finish', () => {
-      if (!isDashboardRead(req)) {
-        this.used.add(feature);
+      // This listener runs outside the middleware stack, where Express cannot
+      // catch a throw — an escaped error would reach the process, not the
+      // request. Usage tracking must never be able to take the server down.
+      try {
+        if (!isRejected(res.statusCode) && !isDashboardRead(req)) {
+          this.used.add(feature);
+        }
+      } catch (error) {
+        logger.warn('InsForge feature usage tracking skipped', {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     });
   }
 
-  /** Returns the features used since the last drain and starts a new window. */
-  public drain(): FeatureUsageSnapshot {
-    const now = Date.now();
-    const snapshot = this.snapshot(now);
-
-    this.used = new Set();
-    this.windowStartedAt = now;
-
-    return snapshot;
-  }
-
-  public reset(): void {
-    this.used = new Set();
-    this.windowStartedAt = Date.now();
-  }
-
-  private snapshot(now: number): FeatureUsageSnapshot {
+  /**
+   * Returns the features used so far without clearing them.
+   *
+   * Reading and clearing are separate so a heartbeat that never arrives cannot
+   * take the window with it: the caller clears only after delivery is
+   * confirmed, via commit().
+   */
+  public snapshot(): FeatureUsageSnapshot {
     return {
       featuresUsed: Array.from(this.used).sort(),
-      windowMs: Math.max(0, now - this.windowStartedAt),
+      windowMs: Math.max(0, Date.now() - this.windowStartedAt),
     };
+  }
+
+  /**
+   * Clears a snapshot that was successfully reported and starts a new window.
+   *
+   * Only the reported features are removed, so anything recorded while the
+   * request was in flight survives. A feature used during that brief overlap
+   * is dropped from the next window, which is harmless: the payload is a set,
+   * and continued use re-records it immediately.
+   */
+  public commit(reported: FeatureUsageSnapshot): void {
+    for (const feature of reported.featuresUsed) {
+      this.used.delete(feature);
+    }
+
+    this.windowStartedAt = Date.now();
   }
 }

--- a/backend/src/services/telemetry/feature-usage.collector.ts
+++ b/backend/src/services/telemetry/feature-usage.collector.ts
@@ -1,0 +1,173 @@
+/**
+ * Records which product features an installation touched, so anonymous
+ * telemetry can report the features actually in use rather than only the ones
+ * an admin configured.
+ *
+ * Only the set of features is kept — no request counts, no paths, no payloads,
+ * no identities, no timings. Reads issued by a dashboard session are ignored,
+ * since a tab left open would otherwise mark half the product as used.
+ *
+ * The set is drained onto each telemetry heartbeat.
+ */
+
+import type { Request, Response } from 'express';
+import type { AuthRequest } from '@/api/middlewares/auth.js';
+
+export type FeatureUsageSnapshot = {
+  featuresUsed: string[];
+  windowMs: number;
+};
+
+/**
+ * Allowlist of countable features, mirroring the routers mounted under /api.
+ * An allowlist (rather than "first path segment wins") keeps the property
+ * space bounded no matter what an unknown client requests.
+ */
+const API_FEATURES = new Set([
+  'advisor',
+  'ai',
+  'analytics',
+  'auth',
+  'compute',
+  'database',
+  'deployments',
+  'docs',
+  'email',
+  'functions',
+  'logs',
+  'memory',
+  'metadata',
+  'payments',
+  'realtime',
+  'schedules',
+  'secrets',
+  'storage',
+  'usage',
+  'webhooks',
+  'webscraper',
+]);
+
+const READ_METHODS = new Set(['GET', 'HEAD']);
+
+const S3_GATEWAY_PREFIX = '/storage/v1/s3';
+const FUNCTION_INVOKE_PREFIX = '/functions/';
+/**
+ * Dashboard sign-in, token refresh and logout. These fire for as long as a
+ * dashboard tab is open, so counting them would mark auth as used on every
+ * project, including ones where nobody has ever signed up.
+ */
+const ADMIN_AUTH_PREFIX = '/api/auth/admin';
+
+/**
+ * Maps a request path to the feature it exercises, or null when the request
+ * is not feature traffic (dashboard assets, health checks, JWKS, admin auth).
+ *
+ * The S3 protocol gateway and direct edge-function invocations are counted
+ * toward storage and functions: both bypass the /api router, and both are the
+ * surfaces a finished app actually calls, so ignoring them would make the two
+ * features look unused precisely where they are used most.
+ */
+export function resolveFeature(pathname: string): string | null {
+  if (pathname === S3_GATEWAY_PREFIX || pathname.startsWith(`${S3_GATEWAY_PREFIX}/`)) {
+    return 'storage';
+  }
+
+  if (
+    pathname.startsWith(FUNCTION_INVOKE_PREFIX) &&
+    pathname.length > FUNCTION_INVOKE_PREFIX.length
+  ) {
+    return 'functions';
+  }
+
+  if (!pathname.startsWith('/api/')) {
+    return null;
+  }
+
+  if (pathname === ADMIN_AUTH_PREFIX || pathname.startsWith(`${ADMIN_AUTH_PREFIX}/`)) {
+    return null;
+  }
+
+  const segment = pathname.slice('/api/'.length).split('/')[0];
+  return API_FEATURES.has(segment) ? segment : null;
+}
+
+/**
+ * Whether the request is a dashboard read: someone looking at the project
+ * rather than the project being used.
+ *
+ * A `project_admin` JWT is only ever issued by an admin sign-in, so it marks a
+ * dashboard session. Writes from that session still count — creating a table
+ * is using the database — and every non-dashboard request counts regardless of
+ * which credential it carried.
+ */
+export function isDashboardRead(req: Request): boolean {
+  if (!READ_METHODS.has(req.method.toUpperCase())) {
+    return false;
+  }
+
+  return (req as AuthRequest).user?.role === 'project_admin';
+}
+
+export class FeatureUsageCollector {
+  private static instance: FeatureUsageCollector | undefined;
+
+  private used = new Set<string>();
+
+  private windowStartedAt = Date.now();
+
+  public static getInstance(): FeatureUsageCollector {
+    if (!FeatureUsageCollector.instance) {
+      FeatureUsageCollector.instance = new FeatureUsageCollector();
+    }
+    return FeatureUsageCollector.instance;
+  }
+
+  public record(feature: string): void {
+    this.used.add(feature);
+  }
+
+  /**
+   * Marks the feature a request exercises as used.
+   *
+   * The feature is resolved up front, before any router rewrites req.url for
+   * its mount path, while the dashboard check waits for 'finish', by which
+   * point the auth middleware has resolved the caller. Features already marked
+   * this window are skipped outright: there is nothing left to learn about
+   * them, so the common case attaches no listener at all.
+   */
+  public track(req: Request, res: Response): void {
+    const feature = resolveFeature(req.path);
+    if (!feature || this.used.has(feature)) {
+      return;
+    }
+
+    res.once('finish', () => {
+      if (!isDashboardRead(req)) {
+        this.used.add(feature);
+      }
+    });
+  }
+
+  /** Returns the features used since the last drain and starts a new window. */
+  public drain(): FeatureUsageSnapshot {
+    const now = Date.now();
+    const snapshot = this.snapshot(now);
+
+    this.used = new Set();
+    this.windowStartedAt = now;
+
+    return snapshot;
+  }
+
+  public reset(): void {
+    this.used = new Set();
+    this.windowStartedAt = Date.now();
+  }
+
+  private snapshot(now: number): FeatureUsageSnapshot {
+    return {
+      featuresUsed: Array.from(this.used).sort(),
+      windowMs: Math.max(0, now - this.windowStartedAt),
+    };
+  }
+}

--- a/backend/src/services/telemetry/telemetry.service.ts
+++ b/backend/src/services/telemetry/telemetry.service.ts
@@ -6,7 +6,7 @@ import fetch from 'node-fetch';
 import { appConfig } from '@/infra/config/app.config.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import logger from '@/utils/logger.js';
-import { FeatureUsageCollector } from './feature-usage.collector.js';
+import { FeatureUsageCollector, type FeatureUsageSnapshot } from './feature-usage.collector.js';
 import packageJson from '../../../../package.json';
 
 export type TelemetryEventName = 'instance_started' | 'heartbeat';
@@ -164,7 +164,11 @@ export class TelemetryService {
     }
 
     try {
-      const event = this.buildEvent(eventName, this.getOrCreateInstallationId());
+      // Snapshot without clearing: the window is only released once the
+      // heartbeat carrying it has actually been accepted, so a timeout, a
+      // network blip, or a process exit mid-request cannot swallow it.
+      const usage = eventName === 'heartbeat' ? this.featureUsage.snapshot() : undefined;
+      const event = this.buildEvent(eventName, this.getOrCreateInstallationId(), usage);
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
       timeout.unref?.();
@@ -180,7 +184,11 @@ export class TelemetryService {
           signal: controller.signal,
         });
 
-        if (!response.ok) {
+        if (response.ok) {
+          if (usage) {
+            this.featureUsage.commit(usage);
+          }
+        } else {
           logger.warn('InsForge telemetry request failed', {
             status: response.status,
             statusText: response.statusText,
@@ -244,11 +252,11 @@ export class TelemetryService {
     }
   }
 
-  private buildEvent(eventName: TelemetryEventName, installationId: string): PostHogTelemetryEvent {
-    // Draining resets the window, so it must happen only for events that
-    // actually carry the feature list.
-    const usage = eventName === 'heartbeat' ? this.featureUsage.drain() : undefined;
-
+  private buildEvent(
+    eventName: TelemetryEventName,
+    installationId: string,
+    usage?: FeatureUsageSnapshot
+  ): PostHogTelemetryEvent {
     return {
       api_key: this.config.posthogApiKey,
       event: POSTHOG_EVENT_NAMES[eventName],

--- a/backend/src/services/telemetry/telemetry.service.ts
+++ b/backend/src/services/telemetry/telemetry.service.ts
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import { appConfig } from '@/infra/config/app.config.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import logger from '@/utils/logger.js';
+import { FeatureUsageCollector } from './feature-usage.collector.js';
 import packageJson from '../../../../package.json';
 
 export type TelemetryEventName = 'instance_started' | 'heartbeat';
@@ -45,6 +46,11 @@ interface PostHogTelemetryEvent {
       compute_configured: boolean;
       openrouter_configured: boolean;
     };
+    // Features touched since the previous heartbeat. Present on heartbeat
+    // events only: an instance_started event is emitted before any traffic
+    // exists.
+    features_used?: string[];
+    features_used_window_ms?: number;
   };
 }
 
@@ -86,7 +92,7 @@ function detectRuntimeEnvironment(): TelemetryRuntimeEnvironment {
   return 'unknown';
 }
 
-function isTelemetryRuntimeDisabled(): boolean {
+export function isTelemetryRuntimeDisabled(): boolean {
   return appConfig.telemetry.disabled || isCloudEnvironment();
 }
 
@@ -108,7 +114,8 @@ export class TelemetryService {
 
   public constructor(
     private readonly config: TelemetryConfig = defaultTelemetryConfig(),
-    private readonly fetchImpl: FetchFunction = fetch
+    private readonly fetchImpl: FetchFunction = fetch,
+    private readonly featureUsage: FeatureUsageCollector = FeatureUsageCollector.getInstance()
   ) {}
 
   public static getInstance(): TelemetryService {
@@ -138,6 +145,17 @@ export class TelemetryService {
 
     clearInterval(this.heartbeatTimer);
     this.heartbeatTimer = undefined;
+  }
+
+  /**
+   * Stops the heartbeat and reports the features used since the last one.
+   * Without this, an instance that runs for less than the heartbeat interval —
+   * the short-lived and trial deployments most worth measuring — would report
+   * no feature usage at all.
+   */
+  public async shutdown(): Promise<void> {
+    this.stop();
+    await this.sendEvent('heartbeat');
   }
 
   public async sendEvent(eventName: TelemetryEventName): Promise<void> {
@@ -227,6 +245,10 @@ export class TelemetryService {
   }
 
   private buildEvent(eventName: TelemetryEventName, installationId: string): PostHogTelemetryEvent {
+    // Draining resets the window, so it must happen only for events that
+    // actually carry the feature list.
+    const usage = eventName === 'heartbeat' ? this.featureUsage.drain() : undefined;
+
     return {
       api_key: this.config.posthogApiKey,
       event: POSTHOG_EVENT_NAMES[eventName],
@@ -258,6 +280,12 @@ export class TelemetryService {
           compute_configured: Boolean(appConfig.fly.apiToken && appConfig.fly.org),
           openrouter_configured: Boolean(appConfig.ai.openrouterApiKey),
         },
+        ...(usage
+          ? {
+              features_used: usage.featuresUsed,
+              features_used_window_ms: usage.windowMs,
+            }
+          : {}),
       },
     };
   }

--- a/backend/tests/unit/feature-usage.collector.test.ts
+++ b/backend/tests/unit/feature-usage.collector.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'events';
+import { describe, expect, it } from 'vitest';
+import type { Request, Response } from 'express';
+import {
+  FeatureUsageCollector,
+  isDashboardRead,
+  resolveFeature,
+} from '../../src/services/telemetry/feature-usage.collector';
+
+function makeRequest(method: string, path: string, extra: Record<string, unknown> = {}): Request {
+  return { method, path, headers: {}, ...extra } as unknown as Request;
+}
+
+const DASHBOARD = { user: { id: 'admin-1', role: 'project_admin' } };
+
+describe('resolveFeature', () => {
+  it('maps API routes to their feature', () => {
+    expect(resolveFeature('/api/database/records/posts')).toBe('database');
+    expect(resolveFeature('/api/auth/sessions')).toBe('auth');
+    expect(resolveFeature('/api/compute/services')).toBe('compute');
+  });
+
+  it('counts the S3 gateway as storage', () => {
+    expect(resolveFeature('/storage/v1/s3/my-bucket/key.png')).toBe('storage');
+    expect(resolveFeature('/storage/v1/s3')).toBe('storage');
+  });
+
+  it('counts direct edge function invocations as functions', () => {
+    expect(resolveFeature('/functions/send-email')).toBe('functions');
+  });
+
+  it('excludes dashboard sign-in, refresh and logout', () => {
+    expect(resolveFeature('/api/auth/admin/sessions')).toBeNull();
+    expect(resolveFeature('/api/auth/admin/sessions/exchange')).toBeNull();
+    expect(resolveFeature('/api/auth/admin/refresh')).toBeNull();
+    expect(resolveFeature('/api/auth/admin/logout')).toBeNull();
+  });
+
+  it('ignores traffic that is not feature usage', () => {
+    expect(resolveFeature('/api/health')).toBeNull();
+    expect(resolveFeature('/.well-known/jwks.json')).toBeNull();
+    expect(resolveFeature('/functions/')).toBeNull();
+    expect(resolveFeature('/assets/index-a1b2c3.js')).toBeNull();
+    expect(resolveFeature('/')).toBeNull();
+  });
+
+  it('ignores unknown API segments so the property space stays bounded', () => {
+    expect(resolveFeature('/api/not-a-feature/x')).toBeNull();
+  });
+});
+
+describe('isDashboardRead', () => {
+  it('is true only for reads from a dashboard session', () => {
+    expect(isDashboardRead(makeRequest('GET', '/api/database/tables', DASHBOARD))).toBe(true);
+    expect(isDashboardRead(makeRequest('HEAD', '/api/metadata', DASHBOARD))).toBe(true);
+  });
+
+  it('is false for dashboard writes', () => {
+    expect(isDashboardRead(makeRequest('POST', '/api/database/tables', DASHBOARD))).toBe(false);
+    expect(isDashboardRead(makeRequest('DELETE', '/api/storage/buckets/media', DASHBOARD))).toBe(
+      false
+    );
+  });
+
+  it('is false for every non-dashboard caller, whatever the credential', () => {
+    expect(isDashboardRead(makeRequest('GET', '/api/database/records/posts'))).toBe(false);
+    expect(
+      isDashboardRead(makeRequest('GET', '/api/database/records/posts', { hasApiKey: true }))
+    ).toBe(false);
+    expect(
+      isDashboardRead(
+        makeRequest('GET', '/api/database/records/posts', { user: { role: 'authenticated' } })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('FeatureUsageCollector', () => {
+  // The middleware sees the request before auth runs; the caller is only
+  // resolved onto it by the time the response finishes.
+  function track(collector: FeatureUsageCollector, req: Request): void {
+    const res = new EventEmitter() as unknown as Response;
+    collector.track(req, res);
+    res.emit('finish');
+  }
+
+  it('records the set of features used, once each, and resets on drain', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('GET', '/api/database/records/posts'));
+    track(collector, makeRequest('POST', '/api/database/records/posts'));
+    track(collector, makeRequest('GET', '/functions/send-email'));
+    track(collector, makeRequest('PUT', '/storage/v1/s3/media/logo.png'));
+
+    const first = collector.drain();
+    expect(first.featuresUsed).toEqual(['database', 'functions', 'storage']);
+    expect(first.windowMs).toEqual(expect.any(Number));
+
+    const second = collector.drain();
+    expect(second.featuresUsed).toEqual([]);
+  });
+
+  it('ignores dashboard reads but keeps dashboard writes', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('GET', '/api/metadata', DASHBOARD));
+    track(collector, makeRequest('GET', '/api/logs', DASHBOARD));
+    track(collector, makeRequest('GET', '/api/database/tables', DASHBOARD));
+    track(collector, makeRequest('POST', '/api/database/tables', DASHBOARD));
+
+    expect(collector.drain().featuresUsed).toEqual(['database']);
+  });
+
+  it('records app reads on the same paths a dashboard read would be ignored on', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('GET', '/api/database/records/posts'));
+
+    expect(collector.drain().featuresUsed).toEqual(['database']);
+  });
+
+  it('ignores admin auth and non-feature paths', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('POST', '/api/auth/admin/sessions'));
+    track(collector, makeRequest('POST', '/api/auth/admin/refresh'));
+    track(collector, makeRequest('GET', '/api/health'));
+    track(collector, makeRequest('GET', '/assets/index-a1b2c3.js'));
+
+    expect(collector.drain().featuresUsed).toEqual([]);
+  });
+});

--- a/backend/tests/unit/feature-usage.collector.test.ts
+++ b/backend/tests/unit/feature-usage.collector.test.ts
@@ -76,15 +76,22 @@ describe('isDashboardRead', () => {
 });
 
 describe('FeatureUsageCollector', () => {
-  // The middleware sees the request before auth runs; the caller is only
-  // resolved onto it by the time the response finishes.
-  function track(collector: FeatureUsageCollector, req: Request): void {
+  // The middleware sees the request before auth runs; the caller and the
+  // status are only resolved onto it by the time the response finishes.
+  function track(collector: FeatureUsageCollector, req: Request, statusCode = 200): void {
     const res = new EventEmitter() as unknown as Response;
     collector.track(req, res);
+    (res as { statusCode: number }).statusCode = statusCode;
     res.emit('finish');
   }
 
-  it('records the set of features used, once each, and resets on drain', () => {
+  function drain(collector: FeatureUsageCollector): string[] {
+    const snapshot = collector.snapshot();
+    collector.commit(snapshot);
+    return snapshot.featuresUsed;
+  }
+
+  it('records the set of features used, once each', () => {
     const collector = new FeatureUsageCollector();
 
     track(collector, makeRequest('GET', '/api/database/records/posts'));
@@ -92,12 +99,12 @@ describe('FeatureUsageCollector', () => {
     track(collector, makeRequest('GET', '/functions/send-email'));
     track(collector, makeRequest('PUT', '/storage/v1/s3/media/logo.png'));
 
-    const first = collector.drain();
+    const first = collector.snapshot();
     expect(first.featuresUsed).toEqual(['database', 'functions', 'storage']);
     expect(first.windowMs).toEqual(expect.any(Number));
 
-    const second = collector.drain();
-    expect(second.featuresUsed).toEqual([]);
+    collector.commit(first);
+    expect(collector.snapshot().featuresUsed).toEqual([]);
   });
 
   it('ignores dashboard reads but keeps dashboard writes', () => {
@@ -108,7 +115,7 @@ describe('FeatureUsageCollector', () => {
     track(collector, makeRequest('GET', '/api/database/tables', DASHBOARD));
     track(collector, makeRequest('POST', '/api/database/tables', DASHBOARD));
 
-    expect(collector.drain().featuresUsed).toEqual(['database']);
+    expect(drain(collector)).toEqual(['database']);
   });
 
   it('records app reads on the same paths a dashboard read would be ignored on', () => {
@@ -116,7 +123,29 @@ describe('FeatureUsageCollector', () => {
 
     track(collector, makeRequest('GET', '/api/database/records/posts'));
 
-    expect(collector.drain().featuresUsed).toEqual(['database']);
+    expect(drain(collector)).toEqual(['database']);
+  });
+
+  it('ignores requests rejected before they reached the feature', () => {
+    const collector = new FeatureUsageCollector();
+
+    // An unauthenticated probe against a data endpoint.
+    track(collector, makeRequest('GET', '/api/database/records/posts'), 401);
+    track(collector, makeRequest('POST', '/api/storage/buckets/media/objects'), 403);
+    // A dashboard read whose 15-minute token expired: auth rejects it before
+    // req.user is populated, so the dashboard rule alone would not catch it.
+    track(collector, makeRequest('GET', '/api/metadata'), 401);
+
+    expect(drain(collector)).toEqual([]);
+  });
+
+  it('still records failures that did reach the feature', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('POST', '/api/database/records/posts'), 400);
+    track(collector, makeRequest('GET', '/api/storage/buckets/media/objects/gone.png'), 404);
+
+    expect(drain(collector)).toEqual(['database', 'storage']);
   });
 
   it('ignores admin auth and non-feature paths', () => {
@@ -127,6 +156,46 @@ describe('FeatureUsageCollector', () => {
     track(collector, makeRequest('GET', '/api/health'));
     track(collector, makeRequest('GET', '/assets/index-a1b2c3.js'));
 
-    expect(collector.drain().featuresUsed).toEqual([]);
+    expect(drain(collector)).toEqual([]);
+  });
+
+  it('keeps the window when a snapshot is never committed', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('POST', '/api/database/records/posts'));
+    const abandoned = collector.snapshot();
+    expect(abandoned.featuresUsed).toEqual(['database']);
+
+    // The heartbeat carrying it never arrived, so the feature is still pending.
+    track(collector, makeRequest('POST', '/functions/send-email'));
+    expect(collector.snapshot().featuresUsed).toEqual(['database', 'functions']);
+  });
+
+  it('commits only what was reported, keeping anything recorded since', () => {
+    const collector = new FeatureUsageCollector();
+
+    track(collector, makeRequest('POST', '/api/database/records/posts'));
+    const reported = collector.snapshot();
+
+    track(collector, makeRequest('POST', '/functions/send-email'));
+    collector.commit(reported);
+
+    expect(collector.snapshot().featuresUsed).toEqual(['functions']);
+  });
+
+  it('never lets a tracking failure escape into the request lifecycle', () => {
+    const collector = new FeatureUsageCollector();
+    const res = new EventEmitter() as unknown as Response;
+    const req = makeRequest('GET', '/api/database/records/posts');
+    Object.defineProperty(req, 'user', {
+      get() {
+        throw new Error('auth context exploded');
+      },
+    });
+
+    collector.track(req, res);
+
+    expect(() => res.emit('finish')).not.toThrow();
+    expect(collector.snapshot().featuresUsed).toEqual([]);
   });
 });

--- a/backend/tests/unit/feature-usage.collector.test.ts
+++ b/backend/tests/unit/feature-usage.collector.test.ts
@@ -131,7 +131,6 @@ describe('FeatureUsageCollector', () => {
 
     // An unauthenticated probe against a data endpoint.
     track(collector, makeRequest('GET', '/api/database/records/posts'), 401);
-    track(collector, makeRequest('POST', '/api/storage/buckets/media/objects'), 403);
     // A dashboard read whose 15-minute token expired: auth rejects it before
     // req.user is populated, so the dashboard rule alone would not catch it.
     track(collector, makeRequest('GET', '/api/metadata'), 401);
@@ -146,6 +145,19 @@ describe('FeatureUsageCollector', () => {
     track(collector, makeRequest('GET', '/api/storage/buckets/media/objects/gone.png'), 404);
 
     expect(drain(collector)).toEqual(['database', 'storage']);
+  });
+
+  it('records policy denials, which reached the feature and exercised it', () => {
+    const collector = new FeatureUsageCollector();
+
+    // An RLS denial: SQLSTATE 42501 surfaces as 403. Excluding these would
+    // undercount precisely the projects that configure RLS.
+    track(collector, makeRequest('GET', '/api/database/records/posts'), 403);
+    track(collector, makeRequest('PUT', '/api/storage/buckets/media/objects/logo.png'), 403);
+    // Signups disabled: the app reached auth and auth answered.
+    track(collector, makeRequest('POST', '/api/auth/users'), 403);
+
+    expect(drain(collector)).toEqual(['auth', 'database', 'storage']);
   });
 
   it('ignores admin auth and non-feature paths', () => {

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -168,6 +168,41 @@ describe('TelemetryService', () => {
     expect(second.features_used).toEqual([]);
   });
 
+  it('keeps the feature window when the heartbeat is rejected', async () => {
+    const config = makeConfig();
+    const fetchMock = makeFetchMock(500);
+    const featureUsage = new FeatureUsageCollector();
+    const service = new TelemetryService(config, fetchMock, featureUsage);
+
+    featureUsage.record('database');
+    await service.sendEvent('heartbeat');
+
+    // Rejected, so the window is retained rather than lost.
+    expect(featureUsage.snapshot().featuresUsed).toEqual(['database']);
+
+    const retryFetch = makeFetchMock();
+    await new TelemetryService(config, retryFetch, featureUsage).sendEvent('heartbeat');
+
+    // The next heartbeat carries it, and only then is it released.
+    expect((getPostedBody(retryFetch).properties as Record<string, unknown>).features_used).toEqual([
+      'database',
+    ]);
+    expect(featureUsage.snapshot().featuresUsed).toEqual([]);
+  });
+
+  it('keeps the feature window when the heartbeat request throws', async () => {
+    const config = makeConfig();
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network unreachable');
+    }) as unknown as FetchFunction;
+    const featureUsage = new FeatureUsageCollector();
+
+    featureUsage.record('storage');
+    await new TelemetryService(config, fetchMock, featureUsage).sendEvent('heartbeat');
+
+    expect(featureUsage.snapshot().featuresUsed).toEqual(['storage']);
+  });
+
   it('flushes remaining feature usage on shutdown so short-lived instances still report', async () => {
     const config = makeConfig();
     const fetchMock = makeFetchMock();

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -3,7 +3,12 @@ import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Response } from 'node-fetch';
-import { TelemetryConfig, TelemetryService } from '../../src/services/telemetry/telemetry.service';
+import {
+  TelemetryConfig,
+  TelemetryService,
+  isTelemetryRuntimeDisabled,
+} from '../../src/services/telemetry/telemetry.service';
+import { FeatureUsageCollector } from '../../src/services/telemetry/feature-usage.collector';
 import logger from '../../src/utils/logger';
 
 type FetchFunction = ConstructorParameters<typeof TelemetryService>[1];
@@ -115,6 +120,67 @@ describe('TelemetryService', () => {
     expect(installationId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );
+  });
+
+  it('is disabled on cloud, so no collection or reporting happens there', () => {
+    delete process.env.INSFORGE_TELEMETRY_DISABLED;
+    expect(isTelemetryRuntimeDisabled()).toBe(false);
+
+    // Cloud is identified by the AWS instance profile. This gates both halves:
+    // server.ts skips registering the usage middleware, and the service never
+    // starts a heartbeat or writes an installation id.
+    process.env.AWS_INSTANCE_PROFILE_NAME = 'insforge-cloud-profile';
+    expect(isTelemetryRuntimeDisabled()).toBe(true);
+  });
+
+  it('reports the features used on heartbeats', async () => {
+    const config = makeConfig();
+    const fetchMock = makeFetchMock();
+    const featureUsage = new FeatureUsageCollector();
+    featureUsage.record('storage');
+    featureUsage.record('database');
+    featureUsage.record('database');
+
+    await new TelemetryService(config, fetchMock, featureUsage).sendEvent('heartbeat');
+
+    const properties = getPostedBody(fetchMock).properties as Record<string, unknown>;
+    expect(properties.features_used).toEqual(['database', 'storage']);
+    expect(properties.features_used_window_ms).toEqual(expect.any(Number));
+  });
+
+  it('drains the feature list per heartbeat and omits it from instance_started', async () => {
+    const config = makeConfig();
+    const fetchMock = makeFetchMock();
+    const featureUsage = new FeatureUsageCollector();
+    const service = new TelemetryService(config, fetchMock, featureUsage);
+
+    featureUsage.record('auth');
+    await service.sendEvent('instance_started');
+    await service.sendEvent('heartbeat');
+    await service.sendEvent('heartbeat');
+
+    const started = getPostedBody(fetchMock, 0).properties as Record<string, unknown>;
+    const first = getPostedBody(fetchMock, 1).properties as Record<string, unknown>;
+    const second = getPostedBody(fetchMock, 2).properties as Record<string, unknown>;
+
+    expect(started.features_used).toBeUndefined();
+    expect(first.features_used).toEqual(['auth']);
+    expect(second.features_used).toEqual([]);
+  });
+
+  it('flushes remaining feature usage on shutdown so short-lived instances still report', async () => {
+    const config = makeConfig();
+    const fetchMock = makeFetchMock();
+    const featureUsage = new FeatureUsageCollector();
+    const service = new TelemetryService(config, fetchMock, featureUsage);
+
+    featureUsage.record('functions');
+    await service.shutdown();
+
+    const properties = getPostedBody(fetchMock).properties as Record<string, unknown>;
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(properties.telemetry_event_name).toBe('heartbeat');
+    expect(properties.features_used).toEqual(['functions']);
   });
 
   it('reuses an installation id published by another process during the atomic create', async () => {
@@ -388,6 +454,8 @@ describe('TelemetryService', () => {
           compute_configured: expect.any(Boolean),
           openrouter_configured: expect.any(Boolean),
         },
+        features_used: expect.any(Array),
+        features_used_window_ms: expect.any(Number),
       },
     });
     expect(JSON.stringify(body)).not.toContain('JWT_SECRET');

--- a/backend/tests/unit/telemetry.service.test.ts
+++ b/backend/tests/unit/telemetry.service.test.ts
@@ -148,7 +148,7 @@ describe('TelemetryService', () => {
     expect(properties.features_used_window_ms).toEqual(expect.any(Number));
   });
 
-  it('drains the feature list per heartbeat and omits it from instance_started', async () => {
+  it('clears the feature list after each delivered heartbeat and omits it from instance_started', async () => {
     const config = makeConfig();
     const fetchMock = makeFetchMock();
     const featureUsage = new FeatureUsageCollector();
@@ -184,9 +184,9 @@ describe('TelemetryService', () => {
     await new TelemetryService(config, retryFetch, featureUsage).sendEvent('heartbeat');
 
     // The next heartbeat carries it, and only then is it released.
-    expect((getPostedBody(retryFetch).properties as Record<string, unknown>).features_used).toEqual([
-      'database',
-    ]);
+    expect((getPostedBody(retryFetch).properties as Record<string, unknown>).features_used).toEqual(
+      ['database']
+    );
     expect(featureUsage.snapshot().featuresUsed).toEqual([]);
   });
 

--- a/docs/deployment/telemetry.mdx
+++ b/docs/deployment/telemetry.mdx
@@ -25,6 +25,9 @@ Each event contains:
 - Operating system, CPU architecture, Node.js version, runtime environment, and whether the process appears to be running in CI
 - Storage backend category: local filesystem, S3, or S3-compatible
 - Boolean flags for whether optional features are configured: site deployments, functions, compute, and OpenRouter
+- On heartbeat events only, the list of features touched since the previous heartbeat, such as `["auth", "database", "storage"]`. This is a yes or no per feature. InsForge does not send request counts, request volumes, paths, request contents, or anything about who made the request. Reads issued from an open dashboard tab, and dashboard sign-in traffic, are not treated as usage.
+
+A final heartbeat is sent when the backend shuts down, so deployments that run for less than 24 hours still report their usage.
 
 ## What InsForge never sends
 

--- a/docs/deployment/telemetry.mdx
+++ b/docs/deployment/telemetry.mdx
@@ -25,7 +25,7 @@ Each event contains:
 - Operating system, CPU architecture, Node.js version, runtime environment, and whether the process appears to be running in CI
 - Storage backend category: local filesystem, S3, or S3-compatible
 - Boolean flags for whether optional features are configured: site deployments, functions, compute, and OpenRouter
-- On heartbeat events only, the list of features touched since the previous heartbeat, such as `["auth", "database", "storage"]`. This is a yes or no per feature. InsForge does not send request counts, request volumes, paths, request contents, or anything about who made the request. Reads issued from an open dashboard tab, and dashboard sign-in traffic, are not treated as usage.
+- On heartbeat events only, the list of features touched since the previous heartbeat, such as `["auth", "database", "storage"]`. This is a yes or no per feature. InsForge does not send request counts, request volumes, paths, request contents, or anything about who made the request. Reads issued from an open dashboard tab, dashboard sign-in traffic, and unauthenticated requests are not treated as usage.
 
 A final heartbeat is sent when the backend shuts down, so deployments that run for less than 24 hours still report their usage.
 


### PR DESCRIPTION
## What

Self-host telemetry previously reported only whether optional services were *configured* — four booleans read from env vars. That tells us an admin pasted an API key, not that anyone uses the feature.

Heartbeats now carry the set of features touched since the previous heartbeat:

```json
"features_used": ["auth", "database", "storage"],
"features_used_window_ms": 86400123
```

## Deliberately not collected

This is a yes/no per feature, not a count. No request volumes, no paths, no payloads, no methods, and nothing about who made the request. The docs' existing "what InsForge never sends" list is unchanged and still accurate.

## What counts as usage

Everything except reads from a dashboard session. A `project_admin` JWT is only ever issued by an admin sign-in, so it identifies a dashboard tab; without that exclusion a tab left open would mark half the product as used. Dashboard **writes** still count — creating a table is using the database.

Also excluded: `/api/auth/admin/*` (dashboard sign-in, refresh, logout — otherwise `auth` would be true on every instance anyone ever logged into), health checks, JWKS, and static assets.

The S3 protocol gateway (`/storage/v1/s3`) and direct edge-function invocations (`/functions/:slug`) are counted toward `storage` and `functions`. Both bypass the `/api` router, and both are the surfaces a finished app actually calls, so ignoring them would make those two features look unused precisely where they are used most.

Features come from an allowlist mirroring the mounted routers, so an unknown path cannot invent a property key.

## Cloud

Unchanged, and gated twice: `isTelemetryRuntimeDisabled()` (which includes `isCloudEnvironment()`) means the usage middleware is never registered, and the telemetry service never starts a heartbeat or writes an installation id. Pinned by a test.

## Also

Shutdown now sends a final heartbeat, so instances that run for less than the 24h interval still report — otherwise the short-lived and trial deployments most worth measuring would report nothing.

## Testing

- New `feature-usage.collector.test.ts` covers path resolution, the dashboard-read rule, and the drain lifecycle.
- `telemetry.service.test.ts` extended for the payload, per-heartbeat drain, shutdown flush, and the cloud gate.
- Full backend unit suite matches the clean-tree baseline (two pre-existing unrelated failures: `lru-cache-resolution`, `s3-gateway-multipart`).
- E2E dispatched on this branch before opening: [run 30674400643](https://github.com/InsForge/InsForge/actions/runs/30674400643) — success.

One note: several load-sensitive rate-limiter tests (`write-endpoint-limiter`, `compute-logs-limiter`, `records-auth`) each flaked once across repeated local full-suite runs and passed in isolation. They build their own bare `express()` apps and never call `createApp()`, so this middleware is not in their request path; adding a test file shifts vitest worker scheduling, which is the likely cause. Worth an eye in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-hosted telemetry now reports which product features are actually used, not just configured. Heartbeats include a yes/no list of features seen since the last heartbeat to improve adoption insights without collecting request details.

- **New Features**
  - Added `FeatureUsageCollector` middleware to track feature usage; ignores dashboard reads and `/api/auth/admin/*`, counts `/storage/v1/s3` and direct `/functions/:slug`.
  - Heartbeats include `features_used` and `features_used_window_ms`; usage is released only after a heartbeat is accepted, and omitted from `instance_started`.
  - Send a final heartbeat on shutdown so short-lived instances still report.
  - Cloud unchanged and gated; middleware is not registered and telemetry doesn’t start when `isTelemetryRuntimeDisabled()` is true.
  - Docs updated with the new fields and existing privacy guarantees.

- **Bug Fixes**
  - Ignore 401 responses so unauthenticated probes or expired dashboard tokens don’t mark usage; 403 policy denials (e.g., RLS, storage perms, disabled signups) now count.
  - Separate `snapshot()` and `commit()` to avoid losing a usage window on timeouts or failures.
  - Contain errors in the response `finish` listener to avoid impacting request handling.

<sup>Written for commit c18345ddbf0cbcef487f031fc7785a41f7cda7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report feature usage in self-hosted instance telemetry heartbeats
> - Adds `FeatureUsageCollector`, a singleton that tracks a de-duplicated set of features used per heartbeat window by observing incoming requests via a new middleware in [server.ts](https://github.com/InsForge/InsForge/pull/1829/files#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aa).
> - Request paths are mapped to a bounded allowlist of feature names (e.g. `storage`, `functions`, auth, etc.); dashboard reads and admin auth traffic are excluded.
> - `TelemetryService` heartbeat events now include `features_used` and `features_used_window_ms` fields; a final heartbeat is flushed on shutdown via a new `shutdown()` method.
> - No counts, paths, payloads, or user identities are sent — only which feature categories were touched since the last heartbeat.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1829 opened
>
> - Renamed test case and reformatted assertion in `TelemetryService` test suite [c007239]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9adf31.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry heartbeats now report product features used between intervals.
  * Usage data is deduplicated and excludes dashboard reads, authentication traffic, request details, and unsuccessful requests.
  * A final heartbeat is sent when the backend shuts down, preserving recent usage information.

* **Documentation**
  * Updated telemetry documentation to describe feature usage reporting and shutdown behavior.

* **Tests**
  * Added coverage for feature tracking, filtering, heartbeat reporting, error handling, and shutdown flushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->