### PR TITLE
fix(schedules): return 404 instead of 500 when deleting a missing schedule

### DIFF
--- a/backend/src/services/schedules/schedule.service.ts
+++ b/backend/src/services/schedules/schedule.service.ts
@@ -386,6 +386,14 @@ export class ScheduleService {
 
   async deleteSchedule(id: string) {
     try {
+      // delete_job reports a missing row the same way it reports a genuine
+      // failure (success = false), so check first and surface the 404 that
+      // GET and PATCH on this id already return.
+      const existingSchedule = await this.getScheduleById(id);
+      if (!existingSchedule) {
+        throw new AppError('Schedule not found', 404, ERROR_CODES.SCHEDULE_NOT_FOUND);
+      }
+
       const sql = 'SELECT * FROM schedules.delete_job($1::UUID)';
       const result = await this.getPool().query(sql, [id]);
       const deleteResult = (result.rows && result.rows[0]) as

--- a/backend/tests/unit/schedule.service.delete-not-found.test.ts
+++ b/backend/tests/unit/schedule.service.delete-not-found.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+const queryMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => ({ query: queryMock }),
+    }),
+  },
+}));
+
+vi.mock('@/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({}),
+  },
+}));
+
+import { ScheduleService } from '@/services/schedules/schedule.service.js';
+import { AppError } from '@/utils/errors.js';
+
+describe('ScheduleService.deleteSchedule on a missing schedule', () => {
+  const missingId = '00000000-0000-4000-8000-000000000000';
+
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('reports 404 SCHEDULE_NOT_FOUND rather than a 500 database error', async () => {
+    // schedules.delete_job() returns (success=false, message='Job not found')
+    // for an id that is not in schedules.jobs (migration 021).
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('delete_job')) {
+        return Promise.resolve({ rows: [{ success: false, message: 'Job not found' }] });
+      }
+      // getScheduleById lookup finds nothing
+      return Promise.resolve({ rows: [] });
+    });
+
+    const service = ScheduleService.getInstance();
+    const error = await service.deleteSchedule(missingId).then(
+      () => null,
+      (e: unknown) => e
+    );
+
+    expect(error).toBeInstanceOf(AppError);
+    expect((error as AppError).statusCode).toBe(404);
+    expect((error as AppError).code).toBe('SCHEDULE_NOT_FOUND');
+  });
+
+  it('still deletes an existing schedule', async () => {
+    queryMock.mockImplementation((sql: string) => {
+      if (sql.includes('delete_job')) {
+        return Promise.resolve({
+          rows: [{ success: true, message: 'Cron job deleted successfully' }],
+        });
+      }
+      return Promise.resolve({
+        rows: [
+          {
+            id: missingId,
+            name: 'nightly',
+            cronSchedule: '0 0 * * *',
+            functionUrl: 'https://example.com/hook',
+            httpMethod: 'POST',
+            isActive: true,
+          },
+        ],
+      });
+    });
+
+    const service = ScheduleService.getInstance();
+    await expect(service.deleteSchedule(missingId)).resolves.toBeTruthy();
+  });
+});

--- a/openapi/schedules.yaml
+++ b/openapi/schedules.yaml
@@ -365,6 +365,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
         '500':
           description: Internal server error
           content:


### PR DESCRIPTION
## What

`DELETE /api/schedules/{id}` returns **500 DATABASE_INTERNAL_ERROR** when the schedule does not exist. It should return 404, which is what `GET` and `PATCH` on the same id already do.

## Why it happens

`schedules.delete_job()` reports a missing row exactly like a real failure, by returning `success = false`:

```sql
-- backend/src/infra/database/migrations/021_create-schedules-schema.sql:419
IF NOT FOUND THEN
  RETURN QUERY SELECT FALSE, 'Job not found';
```

and `deleteSchedule` mapped every false result to a 500:

```ts
// backend/src/services/schedules/schedule.service.ts
if (!deleteResult || !deleteResult.success) {
  throw new AppError(deleteResult?.message || 'Database operation failed', 500, ERROR_CODES.DATABASE_INTERNAL_ERROR);
}
```

So a client deleting an id that was already removed, or retrying a delete, gets a server error rather than "this is gone". It also means a genuine database failure and an ordinary missing row are indistinguishable to the caller.

## Change

- Look the schedule up first and throw `404 SCHEDULE_NOT_FOUND`, mirroring what `updateSchedule` already does a few lines above. Real `delete_job` failures still surface as 500.
- Document the 404 on `DELETE /api/schedules/{id}` in `openapi/schedules.yaml`. The spec listed 404 for `GET` and `PATCH` on this id but not for `DELETE`, matching the old behaviour.
- Add a regression test covering the missing-schedule case and the normal delete.

## Verification

The new test fails on current main and passes with the change:

```
# before
Tests  1 failed | 1 passed     - Expected 404  + Received 500
# after
Tests  2 passed (2)
```

Gates on this branch:

```
npx tsc --noEmit                      # clean
npx vitest run tests/unit             # 2082 passed | 21 skipped, 0 failed
npx turbo run lint --filter=insforge-backend   # 1 successful
npx @apidevtools/swagger-cli validate openapi/schedules.yaml   # valid
```

## Note on process

This is a drive-by fix without an assigned issue, per the note in CONTRIBUTING that unassigned PRs are still reviewed. I am currently at the 3 open assigned issue limit, so I did not claim one for this. Happy to open an issue and claim it instead if you would prefer that.

---
Freshman dev here, still learning this codebase. I used Claude Code to help investigate and draft this, and I verified the behaviour myself with the failing test before changing anything. Please push back on anything off and I will fix it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
DELETE `/api/schedules/{id}` now returns 404 `SCHEDULE_NOT_FOUND` when the schedule is missing, instead of 500 `DATABASE_INTERNAL_ERROR`. This aligns DELETE with GET/PATCH and cleanly separates “not found” from real database failures.

- **Bug Fixes**
  - Look up the schedule before delete; throw 404 if absent.
  - Keep genuine `delete_job` failures as 500.
  - Document 404 for DELETE in `openapi/schedules.yaml`.
  - Add unit tests for missing and successful delete cases.

<sup>Written for commit cce6f268107d239b6fd18c1a278be4bb0aa5b5d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ScheduleService.deleteSchedule` to return 404 when schedule is not found
> Previously, deleting a non-existent schedule would fall through to `delete_job` and return a generic 500 error. Now, `deleteSchedule` checks for the schedule's existence first and throws a 404 `AppError` with code `SCHEDULE_NOT_FOUND` if it is missing. The OpenAPI spec in [schedules.yaml](https://github.com/InsForge/InsForge/pull/1831/files#diff-d398743a6092ba39085f8d1dde701ec2913544864e222f815ac6a7b177d68483) is updated to document the 404 response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cce6f26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a schedule that does not exist now returns a clear 404 “Schedule not found” error.
  - Existing schedules continue to be deleted successfully.

- **Documentation**
  - Updated the API documentation to include the 404 response for schedule deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->