### PR TITLE
fix(dashboard): include cron schedule in schedule search

### DIFF
--- a/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
+++ b/packages/dashboard/src/features/functions/pages/SchedulesPage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, CirclePlus } from 'lucide-react';
 import { useSchedules } from '#features/functions/hooks/useSchedules';
+import type { ScheduleSchema } from '@insforge/shared-schemas';
 import {
   Button,
   ConfirmDialog,
@@ -63,30 +64,30 @@ export default function SchedulesPage() {
     setSearchQuery(value);
   }, []);
 
+  const matchesSearch = useCallback(
+    (s: ScheduleSchema) => {
+      if (!searchQuery) {
+        return true;
+      }
+
+      const query = searchQuery.toLowerCase();
+
+      return (
+        s.name.toLowerCase().includes(query) ||
+        s.functionUrl.toLowerCase().includes(query) ||
+        s.cronSchedule.toLowerCase().includes(query)
+      );
+    },
+    [searchQuery]
+  );
+
   const filteredSchedules = useMemo(() => {
-    const filtered = searchQuery
-      ? schedules.filter(
-          (s) =>
-            s.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            s.functionUrl.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            s.functionUrl.toLowerCase().includes(searchQuery.toLowerCase())
-        )
-      : schedules;
+    const filtered = schedules.filter(matchesSearch);
     const offset = (currentPage - 1) * PAGE_SIZE;
     return filtered.slice(offset, offset + PAGE_SIZE);
-  }, [schedules, searchQuery, currentPage]);
+  }, [schedules, matchesSearch, currentPage]);
 
-  const totalPages = Math.ceil(
-    (searchQuery
-      ? schedules.filter(
-          (s) =>
-            s.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            s.functionUrl.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            s.functionUrl.toLowerCase().includes(searchQuery.toLowerCase())
-        )
-      : schedules
-    ).length / PAGE_SIZE
-  );
+  const totalPages = Math.ceil(schedules.filter(matchesSearch).length / PAGE_SIZE);
 
   const handleRefresh = async () => {
     setIsRefreshing(true);


### PR DESCRIPTION
## Summary

Fixes a duplicated predicate in the schedule search.

The search logic checked `functionUrl` twice, preventing users from searching by cron schedule.

## Changes

- Replace duplicated `functionUrl` predicate
- Search `cronSchedule` instead

## Testing

- Reviewed the search logic
- Verified the duplicated predicate was replaced consistently in both filtering and pagination calculations


 Fixes #1832

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schedule search by adding `cronSchedule` matching and centralizing the predicate, so cron queries work and pagination counts are accurate.

<sup>Written for commit e24ee798c3a36721960c352fcd500357b33c7161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule search now matches cron expressions, names, and function URLs.
  * Pagination totals accurately reflect all matching schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix schedule search to include `cronSchedule` in filter predicate
> The search filter in [SchedulesPage.tsx](https://github.com/InsForge/InsForge/pull/1833/files#diff-04957397460ff3b46515fc29a8634abf284c984fd4c42162c61714cc20952d9a) previously checked `functionUrl` twice and omitted `cronSchedule`, causing incorrect results and wrong page counts. Replaces the duplicated inline logic with a single memoized `matchesSearch` predicate that checks `name`, `functionUrl`, and `cronSchedule` (case-insensitive). Behavioral Change: search results and pagination counts will change for any query that matches a cron expression but not the name or URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e24ee79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->