### PR TITLE
fix(dashboard): prevent orphaned promise in useConfirm on concurrent calls

### DIFF
--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -18,11 +18,7 @@ export function useConfirm() {
   const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
   const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
-    // A dialog is already pending: return the existing promise instead of
-    // orphaning its resolver (which would leave the first promise hanging).
-    if (pendingPromiseRef.current) {
-      return pendingPromiseRef.current;
-    }
+    resolveRef.current?.(false);
 
     setOptions(confirmOptions);
     setIsOpen(true);

--- a/packages/dashboard/src/lib/hooks/useConfirm.ts
+++ b/packages/dashboard/src/lib/hooks/useConfirm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 interface ConfirmOptions {
   title: string;
@@ -14,26 +14,35 @@ export function useConfirm() {
     title: '',
     description: '',
   });
-  const [resolvePromise, setResolvePromise] = useState<((value: boolean) => void) | null>(null);
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+  const pendingPromiseRef = useRef<Promise<boolean> | null>(null);
 
   const confirm = (confirmOptions: ConfirmOptions): Promise<boolean> => {
+    // A dialog is already pending: return the existing promise instead of
+    // orphaning its resolver (which would leave the first promise hanging).
+    if (pendingPromiseRef.current) {
+      return pendingPromiseRef.current;
+    }
+
     setOptions(confirmOptions);
     setIsOpen(true);
 
-    return new Promise<boolean>((resolve) => {
-      setResolvePromise(() => resolve);
+    const promise = new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
     });
+    pendingPromiseRef.current = promise;
+    return promise;
   };
 
-  const handleConfirm = () => {
-    resolvePromise?.(true);
+  const settle = (value: boolean) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    pendingPromiseRef.current = null;
     setIsOpen(false);
   };
 
-  const handleCancel = () => {
-    resolvePromise?.(false);
-    setIsOpen(false);
-  };
+  const handleConfirm = () => settle(true);
+  const handleCancel = () => settle(false);
 
   return {
     confirm,


### PR DESCRIPTION
Closes #1733

## Problem

`useConfirm` (`packages/dashboard/src/lib/hooks/useConfirm.ts`) stored the promise resolver in `useState`. Calling `confirm()` a second time before the current dialog was dismissed overwrote the stored resolver, orphaning the first promise so it **never resolved** — a permanent hang.

Impact:
- Memory leak from unresolved promises
- UI actions awaiting the first `confirm()` result (delete flows, etc.) never proceed
- Silent failure — no error thrown, the promise just hangs

A secondary stale-closure issue also existed: `handleConfirm`/`handleCancel` read the resolver from render scope rather than a ref, risking calling a stale resolver.

14 components across the dashboard use this hook, including table, function, backup, secret, env var, bucket/file, project, and OAuth config deletion flows.

## Fix

- Move the resolver from `useState` to a `useRef` — avoids stale closures and unnecessary re-renders.
- Add a `pendingPromiseRef` guard: if `confirm()` is called while a dialog is already pending, return the existing promise instead of overwriting the resolver.
- Consolidate `handleConfirm`/`handleCancel` into a single `settle()` that reads the resolver from the ref, resolves it, then clears both refs and closes the dialog.

## Testing

- `tsc --noEmit` passes cleanly for the dashboard package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned promises in `useConfirm` on concurrent calls. Prevents hanging delete flows by cancelling any in-flight confirmation before starting a new one and storing the resolver in a ref.

- **Bug Fixes**
  - Store resolver in a ref to avoid stale closures and re-renders.
  - If `confirm()` is called again, resolve the existing pending confirmation as cancelled before opening a new dialog to prevent orphaned promises.
  - Consolidate confirm/cancel into a single `settle(value)` that resolves, clears refs, and closes the dialog.

<sup>Written for commit 530428e853ce06cb86c6cf3db993e40a12abcdf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix orphaned promise in `useConfirm` when called concurrently
> The `useConfirm` hook previously leaked unresolved promises if `confirm()` was called while a prior confirmation was still pending. The fix replaces the stateful resolver with a `useRef`-based approach and introduces a `settle()` helper that resolves the promise, clears refs, and closes the dialog in one place. Any pending confirmation is now resolved with `false` before a new dialog opens.
> - Behavioral Change: concurrent calls to `confirm()` now auto-reject the previous promise with `false` rather than leaving it unresolved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 530428e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated confirmation prompts so starting a new request safely cancels the previous pending request.
  - Improved confirmation and cancellation handling to consistently complete pending actions and close the dialog.
  - Prevented confirmation requests from remaining unresolved when multiple prompts are triggered in succession.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->