### PR TITLE
docs: publish the deployments and dashboard API references

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -336,6 +336,14 @@
               {
                 "group": "Health",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/health.yaml"
+              },
+              {
+                "group": "Deployments",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/deployments.yaml"
+              },
+              {
+                "group": "Dashboard",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/dashboard.yaml"
               }
             ]
           }
@@ -637,6 +645,14 @@
               {
                 "group": "Health",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/health.yaml"
+              },
+              {
+                "group": "Deployments",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/deployments.yaml"
+              },
+              {
+                "group": "Dashboard",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/dashboard.yaml"
               }
             ]
           }
@@ -938,6 +954,14 @@
               {
                 "group": "Health",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/health.yaml"
+              },
+              {
+                "group": "Deployments",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/deployments.yaml"
+              },
+              {
+                "group": "Dashboard",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/dashboard.yaml"
               }
             ]
           }
@@ -1239,6 +1263,14 @@
               {
                 "group": "Health",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/health.yaml"
+              },
+              {
+                "group": "Deployments",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/deployments.yaml"
+              },
+              {
+                "group": "Dashboard",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/dashboard.yaml"
               }
             ]
           }


### PR DESCRIPTION
## What

`openapi/deployments.yaml` and `openapi/dashboard.yaml` live in the repo but are never referenced from `docs/docs.json`, so neither is published. Every other spec is registered once per language.

```
specs on disk (16):  ai auth dashboard deployments email functions health logs
                     metadata payments realtime records schedules secrets storage tables
registered (14):     ai auth email functions health logs metadata payments
                     realtime records schedules secrets storage tables
```

Each registered spec appears exactly 4 times, once per language. `deployments.yaml` and `dashboard.yaml` appear 0 times.

That hides 15 documented endpoints, 14 paths in the deployments spec and 1 in the dashboard spec. Confirmed against the live site:

```
https://docs.insforge.dev/api-reference/deployments                    404
https://docs.insforge.dev/api-reference/deployments/list-deployments   404
https://docs.insforge.dev/api-reference/dashboard                      404
```

Both files are valid and current, so this is only a registration gap:

```
npx @apidevtools/swagger-cli validate openapi/deployments.yaml   # valid
npx @apidevtools/swagger-cli validate openapi/dashboard.yaml     # valid
```

## Change

Adds both specs to the `groups` list in each of the four language navigations, using the same entry shape as the existing ones. Eight entries, +32 lines, no deletions and no reformatting of the rest of the file.

On the group names: I left them in English because these navigations already keep `Tables`, `Records` and `Schedules` in English alongside translated ones like `身份认证` and `Autenticación`. I did not want to invent translations. Glad to localise both if you tell me the wording you want.

I also did not guess at placement beyond appending to the same API reference group, since ordering there looks intentional. Say the word if you would rather they sit next to a particular section.

## Verification

All four languages now resolve 16 specs each, including the two new ones:

```
en      specs: 16   has deployments+dashboard: True
zh      specs: 16   has deployments+dashboard: True
zh-Hant specs: 16   has deployments+dashboard: True
es      specs: 16   has deployments+dashboard: True
```

`docs/docs.json` still parses as valid JSON.

## Note on CI

The local preflight flags `npm run test`, but that reproduces identically on an unmodified `main` checkout: 6 failures in `packages/dashboard/src/lib/contexts/__tests__/LocaleContext.test.tsx`, all from jsdom `SecurityError: localStorage is not available for opaque origins` under Node 26 locally, while CI pins Node 20 and the same job passes there. This PR touches one JSON file and no code.

## Note on process

Drive-by fix without an assigned issue, per the note in CONTRIBUTING that unassigned PRs still get reviewed. I am at the 3 open assigned issue limit. Happy to file an issue and claim it instead if you prefer that route.

---
Freshman dev here, still learning this codebase. I used Claude Code to help with this and checked the live docs URLs myself before changing anything. Please push back on anything off and I will fix it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the Deployments and Dashboard API references by registering their OpenAPI specs in all four language navigations. Adds `openapi/deployments.yaml` and `openapi/dashboard.yaml` to `docs/docs.json` (groups labeled in English to match existing entries), exposing 15 endpoints and fixing 404s.

<sup>Written for commit 944b235c4abf1bd2dc033ce0f3ca2de7c64f8888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Deployments and Dashboard API references to the API Reference navigation.
  * Updated English, Simplified Chinese, Traditional Chinese, and Spanish documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->