### PR TITLE
perf(database): bound the data browser's row counts instead of running COUNT(*) per page load

### DIFF
--- a/backend/src/api/routes/database/admin.routes.ts
+++ b/backend/src/api/routes/database/admin.routes.ts
@@ -99,7 +99,9 @@ router.get(
         filterValue,
       });
 
-      paginatedResponse(res, response.records, response.total, offset);
+      paginatedResponse(res, response.records, response.total, offset, {
+        isEstimate: response.isEstimate,
+      });
     } catch (error) {
       next(error);
     }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -89,7 +89,9 @@ export async function createApp() {
     cors({
       origin: true, // Allow all origins (matches Better Auth's trustedOrigins: ['*'])
       credentials: true, // Allow cookies/credentials
-      exposedHeaders: ['Content-Range', 'Preference-Applied'],
+      // Without X-Total-Is-Estimate here, a cross-origin dashboard cannot read it and
+      // renders every approximate total as an exact count.
+      exposedHeaders: ['Content-Range', 'Preference-Applied', 'X-Total-Is-Estimate'],
     })
   );
   app.use(cookieParser()); // Parse cookies for refresh token handling

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -3,9 +3,10 @@ import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { ERROR_CODES, type AdminTableRecordPrimaryKey } from '@insforge/shared-schemas';
 import type { PoolClient } from 'pg';
 import type { DatabaseRecord } from '@/types/database.js';
-import { TEXT_LIKE_DATA_TYPES } from '@/utils/constants.js';
+import { ADMIN_RECORD_STATEMENT_TIMEOUT, TEXT_LIKE_DATA_TYPES } from '@/utils/constants.js';
 import { escapeSqlLikePattern, validateTableName } from '@/utils/validations.js';
 import { quoteIdentifier, quoteQualifiedName } from './helpers.js';
+import { estimateOrExactCount } from './record-count.js';
 import { withAdminContext } from './user-context.service.js';
 
 interface SortClause {
@@ -45,18 +46,27 @@ export class AdminRecordService {
     schemaName: string,
     tableName: string,
     options: ListTableRecordsOptions
-  ): Promise<{ records: DatabaseRecord[]; total: number }> {
+  ): Promise<{ records: DatabaseRecord[]; total: number; isEstimate: boolean }> {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
+      // Transaction-scoped: a pathological read (deep OFFSET, unindexable search on a
+      // huge table) fails with a clear error instead of holding this connection until
+      // the browser gives up. Only this read path is bounded -- mutations keep the
+      // server default.
+      await client.query(`SET LOCAL statement_timeout = '${ADMIN_RECORD_STATEMENT_TIMEOUT}'`);
+
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);
       const { whereSql, params } = this.buildWhereClause(metadata, options);
       const qualifiedTableName = quoteQualifiedName(schemaName, tableName);
       const orderBySql = this.buildOrderByClause(metadata, options.sort);
 
-      const countResult = await client.query<{
-        total: string;
-      }>(`SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}${whereSql}`, params);
+      const { total, isEstimate } = await estimateOrExactCount(
+        client,
+        qualifiedTableName,
+        whereSql,
+        params
+      );
 
       const dataParams = [...params, options.limit, options.offset];
       const limitPlaceholder = `$${params.length + 1}`;
@@ -68,7 +78,8 @@ export class AdminRecordService {
 
       return {
         records: recordsResult.rows,
-        total: Number(countResult.rows[0]?.total ?? 0),
+        total,
+        isEstimate,
       };
     });
   }

--- a/backend/src/services/database/admin-record.service.ts
+++ b/backend/src/services/database/admin-record.service.ts
@@ -50,10 +50,8 @@ export class AdminRecordService {
     validateTableName(tableName);
 
     return this.withAdminTransaction(async (client) => {
-      // Transaction-scoped: a pathological read (deep OFFSET, unindexable search on a
-      // huge table) fails with a clear error instead of holding this connection until
-      // the browser gives up. Only this read path is bounded -- mutations keep the
-      // server default.
+      // Transaction-scoped, so a deep OFFSET or unindexable search fails fast instead of
+      // holding this connection. Only this read path is bounded; mutations are untouched.
       await client.query(`SET LOCAL statement_timeout = '${ADMIN_RECORD_STATEMENT_TIMEOUT}'`);
 
       const metadata = await this.getTableColumnMetadata(schemaName, tableName, client);

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -425,9 +425,8 @@ export class DatabaseTableService {
       const uniqueColumns = uniqueColumnsResult.rows;
       const uniqueSet = new Set(uniqueColumns.map((u: { column_name: string }) => u.column_name));
 
-      // Row count: exact on small tables, planner estimate on large ones. An exact
-      // COUNT(*) here is a full scan paid on every table-open, on top of the one the
-      // record listing already runs -- see estimateOrExactCount.
+      // An exact COUNT(*) here is a full scan paid on every table-open, on top of the
+      // one the record listing already runs. estimateOrExactCount bounds both.
       let row_count = 0;
       let row_count_is_estimate = false;
       try {

--- a/backend/src/services/database/database-table.service.ts
+++ b/backend/src/services/database/database-table.service.ts
@@ -23,6 +23,7 @@ import {
   FOREIGN_KEY_INTROSPECTION_QUERY,
   groupForeignKeyRows,
 } from './helpers.js';
+import { estimateOrExactCount } from './record-count.js';
 import { withAdminContext } from './user-context.service.js';
 
 const reservedColumns = {
@@ -424,13 +425,20 @@ export class DatabaseTableService {
       const uniqueColumns = uniqueColumnsResult.rows;
       const uniqueSet = new Set(uniqueColumns.map((u: { column_name: string }) => u.column_name));
 
-      // Get exact row count using standard COUNT(*)
+      // Row count: exact on small tables, planner estimate on large ones. An exact
+      // COUNT(*) here is a full scan paid on every table-open, on top of the one the
+      // record listing already runs -- see estimateOrExactCount.
       let row_count = 0;
+      let row_count_is_estimate = false;
       try {
-        const countResult = await client.query(
-          `SELECT COUNT(*) as row_count FROM ${quoteQualifiedName(schemaName, table)}`
+        const counted = await estimateOrExactCount(
+          client,
+          quoteQualifiedName(schemaName, table),
+          '',
+          []
         );
-        row_count = Number(countResult.rows[0]?.row_count || 0);
+        row_count = counted.total;
+        row_count_is_estimate = counted.isEstimate;
       } catch {
         row_count = 0;
       }
@@ -452,6 +460,7 @@ export class DatabaseTableService {
         }),
         foreignKeys,
         recordCount: row_count,
+        recordCountIsEstimate: row_count_is_estimate,
       };
     } finally {
       client.release();

--- a/backend/src/services/database/record-count.ts
+++ b/backend/src/services/database/record-count.ts
@@ -3,60 +3,38 @@ import { APPROX_COUNT_THRESHOLD, FILTERED_COUNT_CAP } from '@/utils/constants.js
 
 export interface CountResult {
   total: number;
-  /**
-   * True when `total` is not an exact row count: either the planner's `reltuples`
-   * statistic, or a filtered count that stopped at {@link FILTERED_COUNT_CAP}
-   * (i.e. "at least this many"). Clients render these as "~N" / "N+".
-   */
+  /** True when `total` is a planner estimate or a capped lower bound, not an exact count. */
   isEstimate: boolean;
 }
 
+/** How an unfiltered table should be counted, given the planner's `reltuples`. */
+export type UnfilteredCountStrategy =
+  | { kind: 'estimate'; total: number }
+  | { kind: 'exact' }
+  | { kind: 'capped' };
+
 /**
- * Decides how an *unfiltered* table should be counted, given the planner's
- * `reltuples` statistic.
- *
- * `reltuples` is -1 on a never-analyzed table (PostgreSQL 14+) and 0 on older
- * versions, where 0 is also what a genuinely empty table reports. Both are
- * treated as "unknown" and fall through to the exact count — which is free on an
- * empty table and correct on an un-analyzed one, so the ambiguity costs nothing.
- *
- * Split out from the query so the branching is unit-testable without a database.
+ * `reltuples` is -1 on a never-analyzed table (PG14+) and 0 on older versions, where 0
+ * is also what an empty table reports -- both mean "size unknown", so the scan is capped.
  */
-export function decideUnfilteredCount(reltuples: number | null): CountResult | null {
+export function decideUnfilteredCount(reltuples: number | null): UnfilteredCountStrategy {
   if (reltuples === null || !Number.isFinite(reltuples) || reltuples <= 0) {
-    return null; // unknown or empty -> caller runs the exact count
+    return { kind: 'capped' };
   }
-
   if (reltuples <= APPROX_COUNT_THRESHOLD) {
-    return null; // small enough that an exact count is cheap and worth the precision
+    return { kind: 'exact' };
   }
+  return { kind: 'estimate', total: Math.round(reltuples) };
+}
 
-  return { total: Math.round(reltuples), isEstimate: true };
+/** Interprets a capped count that scanned at most `cap + 1` rows. */
+export function decideCappedCount(observed: number, cap: number): CountResult {
+  return observed > cap ? { total: cap, isEstimate: true } : { total: observed, isEstimate: false };
 }
 
 /**
- * Interprets the result of the capped filtered count. `observed` is the number of
- * matching rows seen while scanning at most `FILTERED_COUNT_CAP + 1` of them.
- */
-export function decideFilteredCount(observed: number): CountResult {
-  if (observed > FILTERED_COUNT_CAP) {
-    return { total: FILTERED_COUNT_CAP, isEstimate: true };
-  }
-  return { total: observed, isEstimate: false };
-}
-
-/**
- * Counts rows without the unbounded `COUNT(*)` full scan that the dashboard's data
- * browser used to pay on every page load and every keystroke of search.
- *
- * - Unfiltered, large table: one O(1) `pg_class` catalog lookup instead of an O(N) scan.
- * - Unfiltered, small/unknown table: exact `COUNT(*)` (cheap, and precise).
- * - Filtered: exact, but stops after {@link FILTERED_COUNT_CAP} matches. This bounds the
- *   common "search matches lots of rows" case. A search matching *few* rows still scans
- *   the table — only an index can fix that, so the statement timeout is the backstop.
- *
- * `qualifiedTableName` must already be quoted via `quoteQualifiedName`; `whereSql` is
- * either empty or a leading-space ` WHERE ...` fragment whose placeholders bind `params`.
+ * Counts rows without the unbounded `COUNT(*)` the data browser used to run on every
+ * page load. No branch here can scan more than `cap + 1` rows or read a planner stat.
  */
 export async function estimateOrExactCount(
   client: PoolClient,
@@ -71,24 +49,45 @@ export async function estimateOrExactCount(
     );
 
     const raw = estimateResult.rows[0]?.reltuples;
-    const decided = decideUnfilteredCount(raw === null || raw === undefined ? null : Number(raw));
-    if (decided) {
-      return decided;
+    const strategy = decideUnfilteredCount(raw === null || raw === undefined ? null : Number(raw));
+
+    if (strategy.kind === 'estimate') {
+      return { total: strategy.total, isEstimate: true };
     }
 
-    const exact = await client.query<{ total: string }>(
-      `SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}`
+    // Known-small tables are counted exactly (cheap, and precision is worth more);
+    // unknown-size tables are capped, so a never-analyzed huge table can't be scanned.
+    if (strategy.kind === 'exact') {
+      const exact = await client.query<{ total: string }>(
+        `SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}`
+      );
+      return { total: Number(exact.rows[0]?.total ?? 0), isEstimate: false };
+    }
+
+    return decideCappedCount(
+      await countUpTo(client, qualifiedTableName, '', [], APPROX_COUNT_THRESHOLD),
+      APPROX_COUNT_THRESHOLD
     );
-    return { total: Number(exact.rows[0]?.total ?? 0), isEstimate: false };
   }
 
-  // Filtered: `reltuples` says nothing about a WHERE clause, so count for real but
-  // stop one row past the cap — that single extra row is what distinguishes
-  // "exactly CAP" from "CAP or more".
-  const capped = await client.query<{ observed: string }>(
-    `SELECT COUNT(*)::text AS observed FROM (SELECT 1 FROM ${qualifiedTableName}${whereSql} LIMIT ${FILTERED_COUNT_CAP + 1}) AS capped`,
+  // `reltuples` says nothing about a WHERE, so filtered sets are counted for real but
+  // stop one row past the cap -- that extra row distinguishes "exactly cap" from "more".
+  return decideCappedCount(
+    await countUpTo(client, qualifiedTableName, whereSql, params, FILTERED_COUNT_CAP),
+    FILTERED_COUNT_CAP
+  );
+}
+
+async function countUpTo(
+  client: PoolClient,
+  qualifiedTableName: string,
+  whereSql: string,
+  params: unknown[],
+  cap: number
+): Promise<number> {
+  const result = await client.query<{ observed: string }>(
+    `SELECT COUNT(*)::text AS observed FROM (SELECT 1 FROM ${qualifiedTableName}${whereSql} LIMIT ${cap + 1}) AS capped`,
     params
   );
-
-  return decideFilteredCount(Number(capped.rows[0]?.observed ?? 0));
+  return Number(result.rows[0]?.observed ?? 0);
 }

--- a/backend/src/services/database/record-count.ts
+++ b/backend/src/services/database/record-count.ts
@@ -1,0 +1,94 @@
+import type { PoolClient } from 'pg';
+import { APPROX_COUNT_THRESHOLD, FILTERED_COUNT_CAP } from '@/utils/constants.js';
+
+export interface CountResult {
+  total: number;
+  /**
+   * True when `total` is not an exact row count: either the planner's `reltuples`
+   * statistic, or a filtered count that stopped at {@link FILTERED_COUNT_CAP}
+   * (i.e. "at least this many"). Clients render these as "~N" / "N+".
+   */
+  isEstimate: boolean;
+}
+
+/**
+ * Decides how an *unfiltered* table should be counted, given the planner's
+ * `reltuples` statistic.
+ *
+ * `reltuples` is -1 on a never-analyzed table (PostgreSQL 14+) and 0 on older
+ * versions, where 0 is also what a genuinely empty table reports. Both are
+ * treated as "unknown" and fall through to the exact count — which is free on an
+ * empty table and correct on an un-analyzed one, so the ambiguity costs nothing.
+ *
+ * Split out from the query so the branching is unit-testable without a database.
+ */
+export function decideUnfilteredCount(reltuples: number | null): CountResult | null {
+  if (reltuples === null || !Number.isFinite(reltuples) || reltuples <= 0) {
+    return null; // unknown or empty -> caller runs the exact count
+  }
+
+  if (reltuples <= APPROX_COUNT_THRESHOLD) {
+    return null; // small enough that an exact count is cheap and worth the precision
+  }
+
+  return { total: Math.round(reltuples), isEstimate: true };
+}
+
+/**
+ * Interprets the result of the capped filtered count. `observed` is the number of
+ * matching rows seen while scanning at most `FILTERED_COUNT_CAP + 1` of them.
+ */
+export function decideFilteredCount(observed: number): CountResult {
+  if (observed > FILTERED_COUNT_CAP) {
+    return { total: FILTERED_COUNT_CAP, isEstimate: true };
+  }
+  return { total: observed, isEstimate: false };
+}
+
+/**
+ * Counts rows without the unbounded `COUNT(*)` full scan that the dashboard's data
+ * browser used to pay on every page load and every keystroke of search.
+ *
+ * - Unfiltered, large table: one O(1) `pg_class` catalog lookup instead of an O(N) scan.
+ * - Unfiltered, small/unknown table: exact `COUNT(*)` (cheap, and precise).
+ * - Filtered: exact, but stops after {@link FILTERED_COUNT_CAP} matches. This bounds the
+ *   common "search matches lots of rows" case. A search matching *few* rows still scans
+ *   the table — only an index can fix that, so the statement timeout is the backstop.
+ *
+ * `qualifiedTableName` must already be quoted via `quoteQualifiedName`; `whereSql` is
+ * either empty or a leading-space ` WHERE ...` fragment whose placeholders bind `params`.
+ */
+export async function estimateOrExactCount(
+  client: PoolClient,
+  qualifiedTableName: string,
+  whereSql: string,
+  params: unknown[]
+): Promise<CountResult> {
+  if (whereSql === '') {
+    const estimateResult = await client.query<{ reltuples: string | null }>(
+      `SELECT reltuples::bigint::text AS reltuples FROM pg_class WHERE oid = to_regclass($1)`,
+      [qualifiedTableName]
+    );
+
+    const raw = estimateResult.rows[0]?.reltuples;
+    const decided = decideUnfilteredCount(raw === null || raw === undefined ? null : Number(raw));
+    if (decided) {
+      return decided;
+    }
+
+    const exact = await client.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM ${qualifiedTableName}`
+    );
+    return { total: Number(exact.rows[0]?.total ?? 0), isEstimate: false };
+  }
+
+  // Filtered: `reltuples` says nothing about a WHERE clause, so count for real but
+  // stop one row past the cap — that single extra row is what distinguishes
+  // "exactly CAP" from "CAP or more".
+  const capped = await client.query<{ observed: string }>(
+    `SELECT COUNT(*)::text AS observed FROM (SELECT 1 FROM ${qualifiedTableName}${whereSql} LIMIT ${FILTERED_COUNT_CAP + 1}) AS capped`,
+    params
+  );
+
+  return decideFilteredCount(Number(capped.rows[0]?.observed ?? 0));
+}

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,2 +1,41 @@
 /** PostgreSQL data types that should preserve empty strings instead of stripping them. */
 export const TEXT_LIKE_DATA_TYPES = new Set(['text', 'character varying', 'character', 'citext']);
+
+/**
+ * Row-count estimate above which an unfiltered table is counted with the planner's
+ * `pg_class.reltuples` statistic instead of an exact `COUNT(*)`. Below it, the exact
+ * count is cheap enough to be worth its precision.
+ */
+export const APPROX_COUNT_THRESHOLD = 50_000;
+
+/**
+ * Upper bound for counting a *filtered* result set. `reltuples` says nothing about a
+ * WHERE clause, so filtered counts stay exact but stop early: once this many matching
+ * rows are seen the total is reported as an estimate ("10,000+") rather than scanning on.
+ */
+export const FILTERED_COUNT_CAP = 10_000;
+
+const DEFAULT_ADMIN_RECORD_STATEMENT_TIMEOUT = '15s';
+
+/**
+ * `statement_timeout` values are interpolated into `SET LOCAL` (PostgreSQL cannot bind a
+ * parameter there), so the configured value must be safe by construction rather than by
+ * quoting. Accepts a bare integer (milliseconds) or an integer with a time unit.
+ */
+export function isValidStatementTimeout(value: string): boolean {
+  return /^\d+\s*(ms|s|min|h|d)?$/.test(value.trim());
+}
+
+/**
+ * Transaction-scoped `statement_timeout` for the dashboard's admin record reads. A
+ * pathological scan (deep OFFSET, unindexable search) fails with a clear error instead
+ * of holding a connection until the client gives up. An unparseable override falls back
+ * to the default rather than injecting the raw string into SQL.
+ */
+export const ADMIN_RECORD_STATEMENT_TIMEOUT = (() => {
+  const configured = process.env.ADMIN_RECORD_STATEMENT_TIMEOUT?.trim();
+  if (configured && isValidStatementTimeout(configured)) {
+    return configured;
+  }
+  return DEFAULT_ADMIN_RECORD_STATEMENT_TIMEOUT;
+})();

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -2,35 +2,27 @@
 export const TEXT_LIKE_DATA_TYPES = new Set(['text', 'character varying', 'character', 'citext']);
 
 /**
- * Row-count estimate above which an unfiltered table is counted with the planner's
- * `pg_class.reltuples` statistic instead of an exact `COUNT(*)`. Below it, the exact
- * count is cheap enough to be worth its precision.
+ * Above this many rows an unfiltered table is counted from the planner's
+ * `pg_class.reltuples`; below it an exact `COUNT(*)` is cheap enough to be worth it.
  */
 export const APPROX_COUNT_THRESHOLD = 50_000;
 
-/**
- * Upper bound for counting a *filtered* result set. `reltuples` says nothing about a
- * WHERE clause, so filtered counts stay exact but stop early: once this many matching
- * rows are seen the total is reported as an estimate ("10,000+") rather than scanning on.
- */
+/** Upper bound for counting a filtered result set; past it the total reads "10,000+". */
 export const FILTERED_COUNT_CAP = 10_000;
 
 const DEFAULT_ADMIN_RECORD_STATEMENT_TIMEOUT = '15s';
 
 /**
- * `statement_timeout` values are interpolated into `SET LOCAL` (PostgreSQL cannot bind a
- * parameter there), so the configured value must be safe by construction rather than by
- * quoting. Accepts a bare integer (milliseconds) or an integer with a time unit.
+ * `SET LOCAL` cannot bind a parameter, so the value is interpolated and must be safe by
+ * construction. Accepts a bare integer (ms) or an integer with a time unit.
  */
 export function isValidStatementTimeout(value: string): boolean {
   return /^\d+\s*(ms|s|min|h|d)?$/.test(value.trim());
 }
 
 /**
- * Transaction-scoped `statement_timeout` for the dashboard's admin record reads. A
- * pathological scan (deep OFFSET, unindexable search) fails with a clear error instead
- * of holding a connection until the client gives up. An unparseable override falls back
- * to the default rather than injecting the raw string into SQL.
+ * Bounds the dashboard's admin record reads, so a pathological scan fails with a clear
+ * error instead of holding a connection. An invalid override falls back to the default.
  */
 export const ADMIN_RECORD_STATEMENT_TIMEOUT = (() => {
   const configured = process.env.ADMIN_RECORD_STATEMENT_TIMEOUT?.trim();

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -42,21 +42,40 @@ export function errorResponse(
 }
 
 // Pagination response helper - returns data with PostgREST-style pagination headers
-export function paginatedResponse<T>(res: Response, data: T[], total: number, offset: number) {
+export function paginatedResponse<T>(
+  res: Response,
+  data: T[],
+  total: number,
+  offset: number,
+  options: { isEstimate?: boolean } = {}
+) {
+  // An estimated total can undershoot the rows actually returned (the planner's
+  // `reltuples` is approximate, and a capped filtered count reports a lower bound).
+  // Never advertise a total smaller than what this page already proves exists, or the
+  // range would contradict itself (e.g. "60000-50000/50001").
+  const effectiveTotal = Math.max(total, offset + data.length);
+
   // Calculate the range for Content-Range header
   const start = offset;
-  const end = Math.min(offset + data.length - 1, total - 1);
+  const end = Math.min(offset + data.length - 1, effectiveTotal - 1);
 
   // Set PostgREST-style pagination headers
   // Format: "Content-Range: start-end/total"
   // Example: "Content-Range: 0-9/200" for first 10 items out of 200
-  res.setHeader('Content-Range', `${start}-${end}/${total}`);
+  res.setHeader('Content-Range', `${start}-${end}/${effectiveTotal}`);
+
+  // `total` may be a planner estimate or a capped "at least N" (see estimateOrExactCount).
+  // Content-Range stays numeric so existing clients keep working; this side-channel lets
+  // the dashboard render it as "~N" / "N+" instead of implying precision it doesn't have.
+  if (options.isEstimate) {
+    res.setHeader('X-Total-Is-Estimate', 'true');
+  }
 
   // Also set Prefer header to indicate preference was applied
-  res.setHeader('Preference-Applied', 'count=exact');
+  res.setHeader('Preference-Applied', options.isEstimate ? 'count=planned' : 'count=exact');
 
   // Use 206 Partial Content when not returning all results, 200 when returning everything
-  const statusCode = data.length < total ? 206 : 200;
+  const statusCode = data.length < effectiveTotal ? 206 : 200;
 
   return res.status(statusCode).json(data);
 }

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -49,11 +49,9 @@ export function paginatedResponse<T>(
   offset: number,
   options: { isEstimate?: boolean } = {}
 ) {
-  // An estimated total can undershoot the rows actually returned (the planner's
-  // `reltuples` is approximate, and a capped filtered count reports a lower bound).
-  // Never advertise a total smaller than what this page already proves exists, or the
-  // range would contradict itself (e.g. "60000-50000/50001").
-  const effectiveTotal = Math.max(total, offset + data.length);
+  // An estimate can undershoot the rows returned ("60000-50000/50001"). Only returned rows
+  // are evidence, so an empty page keeps `total` instead of inventing one from its offset.
+  const effectiveTotal = data.length > 0 ? Math.max(total, offset + data.length) : total;
 
   // Calculate the range for Content-Range header
   const start = offset;
@@ -64,9 +62,8 @@ export function paginatedResponse<T>(
   // Example: "Content-Range: 0-9/200" for first 10 items out of 200
   res.setHeader('Content-Range', `${start}-${end}/${effectiveTotal}`);
 
-  // `total` may be a planner estimate or a capped "at least N" (see estimateOrExactCount).
   // Content-Range stays numeric so existing clients keep working; this side-channel lets
-  // the dashboard render it as "~N" / "N+" instead of implying precision it doesn't have.
+  // the dashboard mark the total approximate instead of implying precision.
   if (options.isEstimate) {
     res.setHeader('X-Total-Is-Estimate', 'true');
   }

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -94,9 +94,9 @@ describe('AdminRecordService', () => {
     // O(N) in table size. The filtered count must stay bounded by a LIMIT.
     const countCall = sqlCalls.find((sql) => sql.includes('AS observed'));
     expect(countCall).toMatch(/LIMIT \d+\) AS capped/);
-    expect(sqlCalls.some((sql) => /COUNT\(\*\)::text AS total FROM "auth"\."users"/.test(sql))).toBe(
-      false
-    );
+    expect(
+      sqlCalls.some((sql) => /COUNT\(\*\)::text AS total FROM "auth"\."users"/.test(sql))
+    ).toBe(false);
 
     // The read is bounded in time as well as in rows, so a pathological scan fails
     // fast instead of holding the connection until the browser gives up.

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -40,8 +40,7 @@ describe('AdminRecordService', () => {
           ],
         };
       }
-      // A search is a filtered count, which is counted exactly but capped (see
-      // estimateOrExactCount) rather than with an unbounded COUNT(*).
+      // A search is a filtered count: exact, but capped rather than unbounded.
       if (sql.includes('AS observed')) {
         return { rows: [{ observed: '2' }] };
       }
@@ -89,17 +88,15 @@ describe('AdminRecordService', () => {
       false
     );
 
-    // Regression (#1797): the data browser used to run an unbounded `COUNT(*)` over the
-    // whole filtered set on every page load and every keystroke of search, making it
-    // O(N) in table size. The filtered count must stay bounded by a LIMIT.
+    // Regression (#1797): this count used to be an unbounded COUNT(*) over the whole
+    // filtered set, run on every page load and every keystroke of search.
     const countCall = sqlCalls.find((sql) => sql.includes('AS observed'));
     expect(countCall).toMatch(/LIMIT \d+\) AS capped/);
     expect(
       sqlCalls.some((sql) => /COUNT\(\*\)::text AS total FROM "auth"\."users"/.test(sql))
     ).toBe(false);
 
-    // The read is bounded in time as well as in rows, so a pathological scan fails
-    // fast instead of holding the connection until the browser gives up.
+    // Bounded in time as well as rows, so a pathological scan fails fast.
     expect(sqlCalls.some((sql) => sql.startsWith('SET LOCAL statement_timeout'))).toBe(true);
   });
 

--- a/backend/tests/unit/admin-record.service.test.ts
+++ b/backend/tests/unit/admin-record.service.test.ts
@@ -40,8 +40,10 @@ describe('AdminRecordService', () => {
           ],
         };
       }
-      if (sql.includes('COUNT(*)::text AS total')) {
-        return { rows: [{ total: '2' }] };
+      // A search is a filtered count, which is counted exactly but capped (see
+      // estimateOrExactCount) rather than with an unbounded COUNT(*).
+      if (sql.includes('AS observed')) {
+        return { rows: [{ observed: '2' }] };
       }
       if (sql.includes('SELECT * FROM "auth"."users"')) {
         return {
@@ -64,6 +66,8 @@ describe('AdminRecordService', () => {
 
     expect(result.total).toBe(2);
     expect(result.records).toHaveLength(2);
+    // Under the cap, the count is exact and must not be flagged as approximate.
+    expect(result.isEstimate).toBe(false);
 
     const sqlCalls = clientQueryMock.mock.calls.map(([sql]) => sql as string);
     const beginIndex = sqlCalls.indexOf('BEGIN');
@@ -84,6 +88,19 @@ describe('AdminRecordService', () => {
     expect(sqlCalls.some((sql) => sql.includes('information_schema.table_constraints'))).toBe(
       false
     );
+
+    // Regression (#1797): the data browser used to run an unbounded `COUNT(*)` over the
+    // whole filtered set on every page load and every keystroke of search, making it
+    // O(N) in table size. The filtered count must stay bounded by a LIMIT.
+    const countCall = sqlCalls.find((sql) => sql.includes('AS observed'));
+    expect(countCall).toMatch(/LIMIT \d+\) AS capped/);
+    expect(sqlCalls.some((sql) => /COUNT\(\*\)::text AS total FROM "auth"\."users"/.test(sql))).toBe(
+      false
+    );
+
+    // The read is bounded in time as well as in rows, so a pathological scan fails
+    // fast instead of holding the connection until the browser gives up.
+    expect(sqlCalls.some((sql) => sql.startsWith('SET LOCAL statement_timeout'))).toBe(true);
   });
 
   it('delegates protected-schema writes to project_admin privileges', async () => {

--- a/backend/tests/unit/database-schema-routes.test.ts
+++ b/backend/tests/unit/database-schema-routes.test.ts
@@ -24,8 +24,7 @@ describe('database schema route wiring', () => {
   it('mounts a separate admin database router for dashboard-only record access', () => {
     expect(indexRoutesSource).toContain("router.use('/admin', databaseAdminRouter);");
     expect(adminRoutesSource).toMatch(/router\.get\(\s*'\/tables\/:tableName\/records'/);
-    // Matched loosely so formatting (and the trailing options argument that carries
-    // the estimated-count flag) can change without failing the wiring assertion.
+    // Matched loosely so formatting can change without failing the wiring assertion.
     expect(adminRoutesSource).toMatch(
       /paginatedResponse\(\s*res,\s*response\.records,\s*response\.total,\s*offset\b/s
     );

--- a/backend/tests/unit/database-schema-routes.test.ts
+++ b/backend/tests/unit/database-schema-routes.test.ts
@@ -24,8 +24,10 @@ describe('database schema route wiring', () => {
   it('mounts a separate admin database router for dashboard-only record access', () => {
     expect(indexRoutesSource).toContain("router.use('/admin', databaseAdminRouter);");
     expect(adminRoutesSource).toMatch(/router\.get\(\s*'\/tables\/:tableName\/records'/);
-    expect(adminRoutesSource).toContain(
-      'paginatedResponse(res, response.records, response.total, offset);'
+    // Matched loosely so formatting (and the trailing options argument that carries
+    // the estimated-count flag) can change without failing the wiring assertion.
+    expect(adminRoutesSource).toMatch(
+      /paginatedResponse\(\s*res,\s*response\.records,\s*response\.total,\s*offset\b/s
     );
     expect(adminRoutesSource).not.toContain('PostgrestProxyService');
   });

--- a/backend/tests/unit/record-count.test.ts
+++ b/backend/tests/unit/record-count.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { decideUnfilteredCount, decideFilteredCount } from '../../src/services/database/record-count';
+import { APPROX_COUNT_THRESHOLD, FILTERED_COUNT_CAP } from '../../src/utils/constants';
+
+/**
+ * The dashboard's data browser used to run an unbounded `COUNT(*)` on every page load
+ * and every keystroke of search, making it O(N) in table size. These tests pin the
+ * decision logic that replaces it: exact counts stay exact where they're cheap, and
+ * only large/filtered result sets fall back to an approximation.
+ */
+describe('decideUnfilteredCount', () => {
+  it('falls back to an exact count when the table has never been analyzed', () => {
+    // PostgreSQL 14+ reports -1 for a table with no statistics yet.
+    expect(decideUnfilteredCount(-1)).toBeNull();
+  });
+
+  it('falls back to an exact count when reltuples is unavailable', () => {
+    expect(decideUnfilteredCount(null)).toBeNull();
+  });
+
+  it('falls back to an exact count when reltuples is zero', () => {
+    // Ambiguous: a genuinely empty table, or an un-analyzed one on older PostgreSQL.
+    // Counting an empty table is free, so the ambiguity costs nothing.
+    expect(decideUnfilteredCount(0)).toBeNull();
+  });
+
+  it('keeps the exact count for small tables', () => {
+    expect(decideUnfilteredCount(1_000)).toBeNull();
+    expect(decideUnfilteredCount(APPROX_COUNT_THRESHOLD)).toBeNull();
+  });
+
+  it('uses the planner estimate once the table is large enough', () => {
+    const result = decideUnfilteredCount(APPROX_COUNT_THRESHOLD + 1);
+
+    expect(result).toEqual({ total: APPROX_COUNT_THRESHOLD + 1, isEstimate: true });
+  });
+
+  it('rounds a fractional reltuples to a whole number of rows', () => {
+    expect(decideUnfilteredCount(5_000_000.7)).toEqual({ total: 5_000_001, isEstimate: true });
+  });
+
+  it('ignores a non-finite reltuples rather than reporting NaN as a total', () => {
+    expect(decideUnfilteredCount(Number.NaN)).toBeNull();
+    expect(decideUnfilteredCount(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe('decideFilteredCount', () => {
+  it('reports an exact total when the result set fits under the cap', () => {
+    expect(decideFilteredCount(0)).toEqual({ total: 0, isEstimate: false });
+    expect(decideFilteredCount(42)).toEqual({ total: 42, isEstimate: false });
+  });
+
+  it('treats exactly the cap as an exact total', () => {
+    // The query scans CAP + 1 rows, so seeing exactly CAP proves there are no more.
+    expect(decideFilteredCount(FILTERED_COUNT_CAP)).toEqual({
+      total: FILTERED_COUNT_CAP,
+      isEstimate: false,
+    });
+  });
+
+  it('reports a lower bound once the scan passes the cap', () => {
+    expect(decideFilteredCount(FILTERED_COUNT_CAP + 1)).toEqual({
+      total: FILTERED_COUNT_CAP,
+      isEstimate: true,
+    });
+  });
+});

--- a/backend/tests/unit/record-count.test.ts
+++ b/backend/tests/unit/record-count.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { decideUnfilteredCount, decideFilteredCount } from '../../src/services/database/record-count';
+import {
+  decideUnfilteredCount,
+  decideFilteredCount,
+} from '../../src/services/database/record-count';
 import { APPROX_COUNT_THRESHOLD, FILTERED_COUNT_CAP } from '../../src/utils/constants';
 
 /**

--- a/backend/tests/unit/record-count.test.ts
+++ b/backend/tests/unit/record-count.test.ts
@@ -1,69 +1,64 @@
 import { describe, expect, it } from 'vitest';
-import {
-  decideUnfilteredCount,
-  decideFilteredCount,
-} from '../../src/services/database/record-count';
+import { decideUnfilteredCount, decideCappedCount } from '../../src/services/database/record-count';
 import { APPROX_COUNT_THRESHOLD, FILTERED_COUNT_CAP } from '../../src/utils/constants';
 
 /**
- * The dashboard's data browser used to run an unbounded `COUNT(*)` on every page load
- * and every keystroke of search, making it O(N) in table size. These tests pin the
- * decision logic that replaces it: exact counts stay exact where they're cheap, and
- * only large/filtered result sets fall back to an approximation.
+ * The data browser used to run an unbounded COUNT(*) on every page load and every
+ * keystroke of search. These pin the strategy that replaces it (#1797).
  */
 describe('decideUnfilteredCount', () => {
-  it('falls back to an exact count when the table has never been analyzed', () => {
-    // PostgreSQL 14+ reports -1 for a table with no statistics yet.
-    expect(decideUnfilteredCount(-1)).toBeNull();
+  it('caps the scan when the table has never been analyzed', () => {
+    // PostgreSQL 14+ reports -1 when a table has no statistics yet.
+    expect(decideUnfilteredCount(-1)).toEqual({ kind: 'capped' });
   });
 
-  it('falls back to an exact count when reltuples is unavailable', () => {
-    expect(decideUnfilteredCount(null)).toBeNull();
+  it('caps the scan when reltuples is unavailable', () => {
+    expect(decideUnfilteredCount(null)).toEqual({ kind: 'capped' });
   });
 
-  it('falls back to an exact count when reltuples is zero', () => {
-    // Ambiguous: a genuinely empty table, or an un-analyzed one on older PostgreSQL.
-    // Counting an empty table is free, so the ambiguity costs nothing.
-    expect(decideUnfilteredCount(0)).toBeNull();
+  it('caps the scan when reltuples is zero', () => {
+    // Ambiguous: an empty table, or an un-analyzed one on older PostgreSQL.
+    expect(decideUnfilteredCount(0)).toEqual({ kind: 'capped' });
   });
 
-  it('keeps the exact count for small tables', () => {
-    expect(decideUnfilteredCount(1_000)).toBeNull();
-    expect(decideUnfilteredCount(APPROX_COUNT_THRESHOLD)).toBeNull();
+  it('counts small tables exactly', () => {
+    expect(decideUnfilteredCount(1_000)).toEqual({ kind: 'exact' });
+    expect(decideUnfilteredCount(APPROX_COUNT_THRESHOLD)).toEqual({ kind: 'exact' });
   });
 
   it('uses the planner estimate once the table is large enough', () => {
-    const result = decideUnfilteredCount(APPROX_COUNT_THRESHOLD + 1);
-
-    expect(result).toEqual({ total: APPROX_COUNT_THRESHOLD + 1, isEstimate: true });
+    expect(decideUnfilteredCount(APPROX_COUNT_THRESHOLD + 1)).toEqual({
+      kind: 'estimate',
+      total: APPROX_COUNT_THRESHOLD + 1,
+    });
   });
 
   it('rounds a fractional reltuples to a whole number of rows', () => {
-    expect(decideUnfilteredCount(5_000_000.7)).toEqual({ total: 5_000_001, isEstimate: true });
+    expect(decideUnfilteredCount(5_000_000.7)).toEqual({ kind: 'estimate', total: 5_000_001 });
   });
 
-  it('ignores a non-finite reltuples rather than reporting NaN as a total', () => {
-    expect(decideUnfilteredCount(Number.NaN)).toBeNull();
-    expect(decideUnfilteredCount(Number.POSITIVE_INFINITY)).toBeNull();
+  it('never reports NaN as a total', () => {
+    expect(decideUnfilteredCount(Number.NaN)).toEqual({ kind: 'capped' });
+    expect(decideUnfilteredCount(Number.POSITIVE_INFINITY)).toEqual({ kind: 'capped' });
   });
 });
 
-describe('decideFilteredCount', () => {
+describe('decideCappedCount', () => {
   it('reports an exact total when the result set fits under the cap', () => {
-    expect(decideFilteredCount(0)).toEqual({ total: 0, isEstimate: false });
-    expect(decideFilteredCount(42)).toEqual({ total: 42, isEstimate: false });
+    expect(decideCappedCount(0, FILTERED_COUNT_CAP)).toEqual({ total: 0, isEstimate: false });
+    expect(decideCappedCount(42, FILTERED_COUNT_CAP)).toEqual({ total: 42, isEstimate: false });
   });
 
   it('treats exactly the cap as an exact total', () => {
-    // The query scans CAP + 1 rows, so seeing exactly CAP proves there are no more.
-    expect(decideFilteredCount(FILTERED_COUNT_CAP)).toEqual({
+    // The query scans cap + 1 rows, so seeing exactly cap proves there are no more.
+    expect(decideCappedCount(FILTERED_COUNT_CAP, FILTERED_COUNT_CAP)).toEqual({
       total: FILTERED_COUNT_CAP,
       isEstimate: false,
     });
   });
 
   it('reports a lower bound once the scan passes the cap', () => {
-    expect(decideFilteredCount(FILTERED_COUNT_CAP + 1)).toEqual({
+    expect(decideCappedCount(FILTERED_COUNT_CAP + 1, FILTERED_COUNT_CAP)).toEqual({
       total: FILTERED_COUNT_CAP,
       isEstimate: true,
     });

--- a/backend/tests/unit/response.test.ts
+++ b/backend/tests/unit/response.test.ts
@@ -55,4 +55,35 @@ describe('Response Utilities', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
   });
+
+  it('paginatedResponse marks approximate totals without changing Content-Range', () => {
+    paginatedResponse(res as Response, [1, 2], 5_000_000, 0, { isEstimate: true });
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', '0-1/5000000');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Total-Is-Estimate', 'true');
+    expect(res.setHeader).toHaveBeenCalledWith('Preference-Applied', 'count=planned');
+  });
+
+  it('paginatedResponse omits the estimate header for exact counts', () => {
+    paginatedResponse(res as Response, [1, 2], 10, 0);
+
+    const headers = (res.setHeader as ReturnType<typeof vi.fn>).mock.calls.map(([name]) => name);
+    expect(headers).not.toContain('X-Total-Is-Estimate');
+  });
+
+  // An undershooting estimate would otherwise emit a range like "60000-50000/50001".
+  it('paginatedResponse never advertises a total below the rows it returned', () => {
+    paginatedResponse(res as Response, [1, 2, 3], 50, 100, { isEstimate: true });
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', '100-102/103');
+  });
+
+  // Regression: an empty page past the end must not invent a total from its own
+  // offset (this reported "50-49/50" and a 206).
+  it('paginatedResponse keeps the reported total when the page is empty', () => {
+    paginatedResponse(res as Response, [], 0, 50);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', '50--1/0');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
 });

--- a/packages/dashboard/src/components/PaginationControls.tsx
+++ b/packages/dashboard/src/components/PaginationControls.tsx
@@ -7,11 +7,7 @@ export interface PaginationControlsProps {
   totalPages?: number;
   onPageChange?: (page: number) => void;
   totalRecords?: number;
-  /**
-   * Marks `totalRecords` as approximate. Large tables are counted from the query
-   * planner's statistics rather than an unbounded COUNT(*), so the figure is shown
-   * as "~N" instead of implying a precision it doesn't have.
-   */
+  /** Marks `totalRecords` as approximate, shown as "~N" rather than implying precision. */
   totalRecordsIsEstimate?: boolean;
   pageSize?: number;
   pageSizeOptions?: number[];

--- a/packages/dashboard/src/components/PaginationControls.tsx
+++ b/packages/dashboard/src/components/PaginationControls.tsx
@@ -7,6 +7,12 @@ export interface PaginationControlsProps {
   totalPages?: number;
   onPageChange?: (page: number) => void;
   totalRecords?: number;
+  /**
+   * Marks `totalRecords` as approximate. Large tables are counted from the query
+   * planner's statistics rather than an unbounded COUNT(*), so the figure is shown
+   * as "~N" instead of implying a precision it doesn't have.
+   */
+  totalRecordsIsEstimate?: boolean;
   pageSize?: number;
   pageSizeOptions?: number[];
   recordLabel?: string;
@@ -19,6 +25,7 @@ export function PaginationControls({
   totalPages = 1,
   onPageChange,
   totalRecords = 0,
+  totalRecordsIsEstimate = false,
   pageSize = 50,
   pageSizeOptions,
   recordLabel,
@@ -31,6 +38,10 @@ export function PaginationControls({
   const startRecord = totalRecords === 0 ? 0 : (normalizedCurrentPage - 1) * pageSize + 1;
   const endRecord =
     totalRecords === 0 ? 0 : Math.min(normalizedCurrentPage * pageSize, totalRecords);
+  const totalDisplay =
+    totalRecordsIsEstimate && totalRecords > 0
+      ? `~${totalRecords.toLocaleString()}`
+      : totalRecords.toLocaleString();
 
   return (
     <Pagination
@@ -46,7 +57,7 @@ export function PaginationControls({
       summaryText={t('common.paginationSummary', {
         start: startRecord,
         end: endRecord,
-        total: totalRecords,
+        total: totalDisplay,
         label,
         defaultValue: 'Showing {{start}} to {{end}} of {{total}} {{label}}',
       })}

--- a/packages/dashboard/src/components/datagrid/DataGrid.tsx
+++ b/packages/dashboard/src/components/datagrid/DataGrid.tsx
@@ -39,6 +39,8 @@ export interface DataGridProps<TRow extends DataGridRowType = DataGridRow> {
   pageSize?: number;
   pageSizeOptions?: number[];
   totalRecords?: number;
+  /** Renders `totalRecords` as approximate ("~N") — see PaginationControls. */
+  totalRecordsIsEstimate?: boolean;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
   emptyState?: React.ReactNode;
@@ -84,6 +86,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
   pageSize,
   pageSizeOptions,
   totalRecords,
+  totalRecordsIsEstimate,
   onPageChange,
   onPageSizeChange,
   emptyState,
@@ -372,6 +375,7 @@ export default function DataGrid<TRow extends DataGridRowType = DataGridRow>({
           totalPages={totalPages}
           onPageChange={onPageChange}
           totalRecords={totalRecords}
+          totalRecordsIsEstimate={totalRecordsIsEstimate}
           pageSize={pageSize}
           pageSizeOptions={pageSizeOptions}
           recordLabel={paginationRecordLabel}

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -309,6 +309,32 @@ export default function TablesPage() {
     !!selectedTable && !!schemaData
   );
 
+  // Totals are approximate for large or capped counts. The marker has to describe the
+  // number actually shown, so it is read off whichever count wins the max below.
+  const recordTotals = (() => {
+    const listTotal = recordsData?.pagination?.total ?? 0;
+    const listIsEstimate = recordsData?.pagination?.isEstimate ?? false;
+
+    if (searchQuery.trim()) {
+      return {
+        total: recordsData?.pagination?.total ?? recordsData?.records.length ?? 0,
+        isEstimate: listIsEstimate,
+      };
+    }
+
+    const schemaTotal = schemaData?.recordCount ?? 0;
+    const schemaIsEstimate = schemaData?.recordCountIsEstimate ?? false;
+
+    if (listTotal === schemaTotal) {
+      // Equal totals: stay conservative and mark it approximate if either source is.
+      return { total: schemaTotal, isEstimate: listIsEstimate || schemaIsEstimate };
+    }
+
+    return listTotal > schemaTotal
+      ? { total: listTotal, isEstimate: listIsEstimate }
+      : { total: schemaTotal, isEstimate: schemaIsEstimate };
+  })();
+
   // Combine schema and records data
   const tableData =
     selectedTable && schemaData && recordsData
@@ -316,14 +342,8 @@ export default function TablesPage() {
           name: selectedTable,
           schema: schemaData,
           records: recordsData.records,
-          totalRecords: searchQuery.trim()
-            ? (recordsData.pagination?.total ?? recordsData.records.length)
-            : Math.max(schemaData.recordCount ?? 0, recordsData.pagination?.total ?? 0),
-          // Large or filtered counts come back approximate (planner estimate, or a
-          // capped "at least N") so the browser never pays an unbounded COUNT(*).
-          totalRecordsIsEstimate: searchQuery.trim()
-            ? (recordsData.pagination?.isEstimate ?? false)
-            : (schemaData.recordCountIsEstimate ?? recordsData.pagination?.isEstimate ?? false),
+          totalRecords: recordTotals.total,
+          totalRecordsIsEstimate: recordTotals.isEstimate,
         }
       : null;
 

--- a/packages/dashboard/src/features/database/pages/TablesPage.tsx
+++ b/packages/dashboard/src/features/database/pages/TablesPage.tsx
@@ -319,6 +319,11 @@ export default function TablesPage() {
           totalRecords: searchQuery.trim()
             ? (recordsData.pagination?.total ?? recordsData.records.length)
             : Math.max(schemaData.recordCount ?? 0, recordsData.pagination?.total ?? 0),
+          // Large or filtered counts come back approximate (planner estimate, or a
+          // capped "at least N") so the browser never pays an unbounded COUNT(*).
+          totalRecordsIsEstimate: searchQuery.trim()
+            ? (recordsData.pagination?.isEstimate ?? false)
+            : (schemaData.recordCountIsEstimate ?? recordsData.pagination?.isEstimate ?? false),
         }
       : null;
 
@@ -767,6 +772,7 @@ export default function TablesPage() {
                   pageSize={pageSize}
                   pageSizeOptions={pageSizeOptions}
                   totalRecords={tableData?.totalRecords || 0}
+                  totalRecordsIsEstimate={tableData?.totalRecordsIsEstimate ?? false}
                   paginationRecordLabel={t('database.recordsRecordLabel', {
                     defaultValue: 'records',
                   })}

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -6,7 +6,7 @@ import { convertToCSV, getExportFilename } from '#lib/utils/data-export';
 
 interface AdminRecordListResponse {
   data: { [key: string]: ConvertedValue }[];
-  pagination: { offset: number; limit: number; total: number };
+  pagination: { offset: number; limit: number; total: number; isEstimate?: boolean };
 }
 
 export class RecordService {

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -134,6 +134,10 @@ export class ApiClient {
 
       const contentRange = response.headers.get('content-range');
       if (contentRange && Array.isArray(responseData)) {
+        // The server counts large or filtered result sets approximately rather than
+        // running an unbounded COUNT(*); this flag tells the UI to render the total as
+        // "~N" / "N+" instead of implying an exact figure.
+        const isEstimate = response.headers.get('x-total-is-estimate') === 'true';
         const match = contentRange.match(/(\d+)-(\d+)\/(\d+|\*)/);
         if (match) {
           const start = parseInt(match[1]);
@@ -141,12 +145,12 @@ export class ApiClient {
           const total = match[3] === '*' ? responseData.length : parseInt(match[3]);
           return {
             data: responseData,
-            pagination: { offset: start, limit: end - start + 1, total },
+            pagination: { offset: start, limit: end - start + 1, total, isEstimate },
           };
         }
         return {
           data: responseData,
-          pagination: { offset: 0, limit: 0, total: 0 },
+          pagination: { offset: 0, limit: 0, total: 0, isEstimate },
         };
       }
 

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -134,9 +134,8 @@ export class ApiClient {
 
       const contentRange = response.headers.get('content-range');
       if (contentRange && Array.isArray(responseData)) {
-        // The server counts large or filtered result sets approximately rather than
-        // running an unbounded COUNT(*); this flag tells the UI to render the total as
-        // "~N" / "N+" instead of implying an exact figure.
+        // Large or filtered result sets are counted approximately rather than with an
+        // unbounded COUNT(*); this tells the UI not to present the total as exact.
         const isEstimate = response.headers.get('x-total-is-estimate') === 'true';
         const match = contentRange.match(/(\d+)-(\d+)\/(\d+|\*)/);
         if (match) {

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -80,6 +80,10 @@ export const tableSchema = z.object({
   // Foreign keys are table-level, one entry per constraint.
   foreignKeys: z.array(foreignKeySchema).optional(),
   recordCount: z.number().optional(),
+  // True when `recordCount` is the planner's estimate rather than an exact count.
+  // Large tables are counted from `pg_class.reltuples` to avoid a full scan on every
+  // table-open, so consumers should present the number as approximate.
+  recordCountIsEstimate: z.boolean().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),
 });

--- a/packages/shared-schemas/src/database.schema.ts
+++ b/packages/shared-schemas/src/database.schema.ts
@@ -80,9 +80,8 @@ export const tableSchema = z.object({
   // Foreign keys are table-level, one entry per constraint.
   foreignKeys: z.array(foreignKeySchema).optional(),
   recordCount: z.number().optional(),
-  // True when `recordCount` is the planner's estimate rather than an exact count.
-  // Large tables are counted from `pg_class.reltuples` to avoid a full scan on every
-  // table-open, so consumers should present the number as approximate.
+  // True when `recordCount` is approximate: large tables are counted from the planner's
+  // statistics to avoid a full scan on every table-open.
   recordCountIsEstimate: z.boolean().optional(),
   createdAt: z.string().optional(),
   updatedAt: z.string().optional(),


### PR DESCRIPTION
Part of #1797. First of three staged PRs — this one is backward-compatible and does not change the pagination UX.

## Problem

Opening a table in the dashboard data browser ran **two** separate unbounded `COUNT(*)` queries, both O(N) in table size:

1. `AdminRecordService.listRecords` — counted on every page load and every keystroke of search.
2. `DatabaseTableService.getTableSchema` — counted again for `recordCount`, which the dashboard fetches alongside the record list.

Postgres caches no row count, so each of these is a full scan. On large tables the data browser degrades linearly and eventually times out — precisely on the tables where inspecting data matters most.

## Change

Adds `estimateOrExactCount` (`backend/src/services/database/record-count.ts`), used by both call sites:

- **Unfiltered:** reads the planner's `pg_class.reltuples` statistic — an O(1) catalog lookup instead of an O(N) scan. Tables under `APPROX_COUNT_THRESHOLD` (50k) keep an exact count, since counting them is cheap and precision is worth more. Never-analyzed tables (`reltuples = -1`, or `0` on older Postgres) fall back to an exact count.
- **Filtered/search:** `reltuples` says nothing about a `WHERE`, so the count stays exact but stops at `FILTERED_COUNT_CAP + 1` (10,001) rows — enough to distinguish "exactly 10,000" from "10,000 or more".
- Adds a transaction-scoped `SET LOCAL statement_timeout` (default 15s, `ADMIN_RECORD_STATEMENT_TIMEOUT`) on the admin read path, so a pathological scan fails with a clear error rather than holding a connection until the browser gives up. Mutations are untouched.

## Why this is backward-compatible

`total` never travelled in the response body — the body is a bare array and the total rides in the `Content-Range` header. That stays numeric. A new `X-Total-Is-Estimate` header is the only addition; the dashboard reads it and renders the total as `~4,300,192` instead of implying precision it doesn't have.

## Tradeoffs (deliberate)

- Filtered counts cap at 10,000, so **search results can no longer be paged past the 10,000th row** — users refine the query instead. This is the cost of not scanning the whole table.
- A search matching *few or zero* rows is **not** faster: the `LIMIT` can't short-circuit when there's nothing to find, so it still scans. Only indexing fixes that — see Stage 2. The statement timeout is the backstop until then.
- `~N` doesn't currently distinguish a planner estimate from a capped "at least N". Happy to split the flag into a kind if reviewers prefer.

## Remaining work (separate PRs)

- **Stage 2 — search:** `col ILIKE '%term%'` across every text column is unindexable, so low-match searches remain full scans. Fixed by `pg_trgm` GIN indexes or by restricting search to indexed columns. Independent of this PR and of Stage 3; needs a policy call on whether indexes are opt-in, since auto-creating them on user tables adds write and disk cost.
- **Stage 3 — keyset pagination:** `OFFSET` is still scan-and-discard, so deep pages stay slow. Fixing it means cursor pagination, which is incompatible with a precise total and numbered pages — a deliberate UX change that builds on the approximate-total plumbing introduced here. Worth a maintainer decision before it's written.

## Testing

- New `backend/tests/unit/record-count.test.ts` covers the count-strategy branches (never-analyzed, empty, small, large, fractional/non-finite `reltuples`, and the filtered cap boundary).
- `admin-record.service.test.ts` now asserts the filtered count is `LIMIT`-bound and that the unbounded `COUNT(*)` is gone — regression cover for this issue.
- Full backend unit suite: 2189 passed, 0 failed. Dashboard and shared-schemas typecheck clean; lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the data browser’s row counts to avoid unbounded COUNT(*) on every load and search, improving responsiveness while keeping pagination payloads unchanged. Old behavior: exact totals from full scans; new behavior: planner estimates for large unfiltered tables and capped counts for filtered queries; side effects: some totals are approximate and deep search paging stops at 10,000 rows. Part of #1797.

- Unfiltered counts: tables over 50k rows use `pg_class.reltuples`; small tables stay exact; never-analyzed tables cap the scan. `getTableSchema` now uses the same path and sets `recordCountIsEstimate`.
- Filtered counts: scan up to 10,001 rows and report “10,000+” when capped; users cannot page past 10,000 matching rows.
- Headers and CORS: keep `Content-Range` numeric; never advertise a total below rows returned; empty pages keep the reported total and return 200. Add `X-Total-Is-Estimate: true` and set `Preference-Applied: count=planned` when approximate; expose `X-Total-Is-Estimate` in CORS.
- UI and API: carry `pagination.isEstimate` through the client; dashboard pagination renders “~N” and reconciles schema vs list totals conservatively.
- Resilience: apply `SET LOCAL statement_timeout` to admin reads (default 15s via `ADMIN_RECORD_STATEMENT_TIMEOUT`).

<sup>Written for commit a14ffe16b6c0d83e21f72f0d9b4acce4f619f2f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace unbounded `COUNT(*)` with bounded estimate counts in the data browser
> - Adds [`estimateOrExactCount`](https://github.com/InsForge/InsForge/pull/1849/files#diff-046ccb1ce311a072941a87da20d60a155015dfc8298459c3eaee21f1b1e63199): for unfiltered tables above a threshold, uses the planner's `reltuples` estimate; for filtered queries, runs a capped `COUNT(*)` via a subselect limited to `FILTERED_COUNT_CAP+1` rows.
> - Applies a transaction-local `statement_timeout` (configurable via `ADMIN_RECORD_STATEMENT_TIMEOUT`) to all admin record reads.
> - Propagates an `isEstimate` flag through the API response headers (`X-Total-Is-Estimate`, `Preference-Applied`) and surfaces it in the dashboard as a `~N` prefix on pagination totals.
> - Behavioral Change: `Content-Range` totals are now sometimes approximate; clients relying on exact row counts from this endpoint will see planner estimates for large unfiltered tables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef9d1d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database table and record listings now support faster total-count handling for large datasets.
  * Approximate totals are clearly marked with a `~` in pagination controls.
  * Pagination metadata identifies whether totals are estimated or exact.

* **Bug Fixes**
  * Pagination remains accurate and consistent when estimated totals are used.
  * Filtered counts are capped to prevent excessive processing.
  * Long-running record-count operations are limited to improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->