### PR TITLE
docs(openapi): add usage API specification

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -330,6 +330,10 @@
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/logs.yaml"
               },
               {
+                "group": "Usage",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/usage.yaml"
+              },
+              {
                 "group": "Metadata",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/metadata.yaml"
               },
@@ -637,6 +641,10 @@
               {
                 "group": "Logs",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/logs.yaml"
+              },
+              {
+                "group": "用量",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/usage.yaml"
               },
               {
                 "group": "Metadata",
@@ -948,6 +956,10 @@
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/logs.yaml"
               },
               {
+                "group": "用量",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/usage.yaml"
+              },
+              {
                 "group": "Metadata",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/metadata.yaml"
               },
@@ -1255,6 +1267,10 @@
               {
                 "group": "Logs",
                 "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/logs.yaml"
+              },
+              {
+                "group": "Uso",
+                "openapi": "https://raw.githubusercontent.com/InsForge/InsForge/main/openapi/usage.yaml"
               },
               {
                 "group": "Metadata",

--- a/openapi/usage.yaml
+++ b/openapi/usage.yaml
@@ -203,7 +203,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: AUTH_UNAUTHORIZED
-                message: Forbidden
+                message: Project ID mismatch
                 statusCode: 403
         '500':
           description: Failed to get usage stats

--- a/openapi/usage.yaml
+++ b/openapi/usage.yaml
@@ -145,7 +145,7 @@ paths:
       tags:
         - Usage
       security:
-        - bearerAuth: []
+        - cloudBackendAuth: []
       parameters:
         - name: start_date
           in: query
@@ -215,6 +215,11 @@ components:
       type: apiKey
       in: header
       name: x-api-key
+    cloudBackendAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Bearer token issued by InsForge Cloud and verified by the backend cloud token verifier.
   schemas:
     RecordMcpUsageRequest:
       type: object

--- a/openapi/usage.yaml
+++ b/openapi/usage.yaml
@@ -136,7 +136,12 @@ paths:
   /api/usage/stats:
     get:
       summary: Get usage statistics
-      description: Returns usage counters for the requested date range. Both `start_date` and `end_date` are required.
+      description: >
+          Returns usage statistics for the supplied date range. The
+          `mcp_usage_count` field is filtered by `start_date` and `end_date`,
+          while `database_size_bytes`, `storage_size_bytes`, and `user_count`
+          reflect the current system state. Both `start_date` and `end_date`
+          are required.
       tags:
         - Usage
       security:

--- a/openapi/usage.yaml
+++ b/openapi/usage.yaml
@@ -1,0 +1,287 @@
+openapi: 3.0.3
+info:
+  title: Insforge Usage API
+  version: 1.0.0
+  description: MCP usage tracking and usage statistics for the backend usage module.
+
+tags:
+  - name: Usage
+    description: Record MCP tool usage and fetch usage summaries.
+
+paths:
+  /api/usage/mcp:
+    post:
+      summary: Record MCP tool usage
+      description: Records an MCP tool invocation in `system.mcp_usage`. The `success` flag defaults to `true` when omitted.
+      tags:
+        - Usage
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordMcpUsageRequest'
+            example:
+              tool_name: generate_report
+              success: true
+      responses:
+        '200':
+          description: MCP usage recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordMcpUsageResponse'
+              example:
+                success: true
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: INVALID_INPUT
+                message: tool_name is required
+                statusCode: 400
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: AUTH_INVALID_API_KEY
+                message: Invalid API key
+                statusCode: 401
+        '500':
+          description: Failed to record MCP usage
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: INTERNAL_ERROR
+                message: Failed to record MCP usage
+                statusCode: 500
+
+    get:
+      summary: List MCP usage records
+      description: Returns recent MCP usage rows filtered by `success`.
+      tags:
+        - Usage
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 5
+          description: Maximum number of usage records to return.
+        - name: success
+          in: query
+          schema:
+            type: boolean
+            default: true
+          description: Filter records by success state.
+      responses:
+        '200':
+          description: MCP usage records
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/McpUsageListResponse'
+              example:
+                records:
+                  - tool_name: generate_report
+                    success: true
+                    created_at: '2026-08-04T04:30:00.000Z'
+                  - tool_name: sync_docs
+                    success: true
+                    created_at: '2026-08-04T03:15:00.000Z'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: AUTH_INVALID_CREDENTIALS
+                message: No admin token provided
+                statusCode: 401
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: AUTH_UNAUTHORIZED
+                message: Admin access required
+                statusCode: 403
+        '500':
+          description: Failed to get MCP usage
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: INTERNAL_ERROR
+                message: Failed to get MCP usage
+                statusCode: 500
+
+  /api/usage/stats:
+    get:
+      summary: Get usage statistics
+      description: Returns usage counters for the requested date range. Both `start_date` and `end_date` are required.
+      tags:
+        - Usage
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: start_date
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+          description: Start date, inclusive.
+          example: '2026-07-01'
+        - name: end_date
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+          description: End date, exclusive.
+          example: '2026-08-01'
+      responses:
+        '200':
+          description: Usage statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageStats'
+              example:
+                mcp_usage_count: 128
+                database_size_bytes: 2147483648
+                storage_size_bytes: 1073741824
+                user_count: 42
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: INVALID_INPUT
+                message: start_date and end_date are required
+                statusCode: 400
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: AUTH_INVALID_CREDENTIALS
+                message: No authorization token provided
+                statusCode: 401
+        '500':
+          description: Failed to get usage stats
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: INTERNAL_ERROR
+                message: Failed to get usage stats
+                statusCode: 500
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    RecordMcpUsageRequest:
+      type: object
+      required:
+        - tool_name
+      properties:
+        tool_name:
+          type: string
+          description: MCP tool name to record.
+        success:
+          type: boolean
+          default: true
+          description: Whether the tool invocation succeeded.
+    RecordMcpUsageResponse:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          example: true
+    McpUsageRecord:
+      type: object
+      required:
+        - tool_name
+        - success
+        - created_at
+      properties:
+        tool_name:
+          type: string
+        success:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+    McpUsageListResponse:
+      type: object
+      required:
+        - records
+      properties:
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/McpUsageRecord'
+    UsageStats:
+      type: object
+      required:
+        - mcp_usage_count
+        - database_size_bytes
+        - storage_size_bytes
+        - user_count
+      properties:
+        mcp_usage_count:
+          type: integer
+        database_size_bytes:
+          type: integer
+        storage_size_bytes:
+          type: integer
+        user_count:
+          type: integer
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+        message:
+          type: string
+        statusCode:
+          type: integer
+        nextActions:
+          type: string

--- a/openapi/usage.yaml
+++ b/openapi/usage.yaml
@@ -137,11 +137,11 @@ paths:
     get:
       summary: Get usage statistics
       description: >
-          Returns usage statistics for the supplied date range. The
-          `mcp_usage_count` field is filtered by `start_date` and `end_date`,
-          while `database_size_bytes`, `storage_size_bytes`, and `user_count`
-          reflect the current system state. Both `start_date` and `end_date`
-          are required.
+        Returns usage statistics for the supplied date range. The
+        `mcp_usage_count` field counts successful MCP usage records and is
+        filtered by `start_date` and `end_date`, while `database_size_bytes`,
+        `storage_size_bytes`, and `user_count` reflect the current system
+        state. Both `start_date` and `end_date` are required.
       tags:
         - Usage
       security:
@@ -195,6 +195,16 @@ paths:
                 error: AUTH_INVALID_CREDENTIALS
                 message: No authorization token provided
                 statusCode: 401
+        '403':
+          description: Forbidden - the cloud backend token is valid but not authorized for the configured project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: AUTH_UNAUTHORIZED
+                message: Forbidden
+                statusCode: 403
         '500':
           description: Failed to get usage stats
           content:


### PR DESCRIPTION
## Summary

This PR adds an OpenAPI specification for the Usage module as part of #1856.

### Changes

- Added `openapi/usage.yaml`
- Documented:
  - `POST /api/usage/mcp`
  - `GET /api/usage/mcp`
  - `GET /api/usage/stats`
- Added reusable schemas for usage requests and responses
- Registered the Usage specification in `docs/docs.json`

### Validation

- ✅ OpenAPI specification validates with:

```bash
npx @apidevtools/swagger-cli validate openapi/usage.yaml
```

### Notes

The specification was written by inspecting the route handlers and `UsageService` implementation to ensure request/response bodies, status codes, and authentication match the current implementation.

Closes #1856 (Usage module)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAPI spec for the Usage module and registers it in the docs. Documents MCP usage record/list and stats with required date range and InsForge Cloud bearer auth per #1856.

- **New Features**
  - Added `openapi/usage.yaml` with `POST /api/usage/mcp`, `GET /api/usage/mcp`, and `GET /api/usage/stats`; stats require `start_date` (inclusive) and `end_date` (exclusive), with real-time fields noted.
  - Defined shared schemas, errors, and security: `apiKey` (record), `bearerAuth`/`apiKey` (list), and `cloudBackendAuth` (stats, InsForge Cloud JWT); aligned 401/403 cloud authorization examples (missing token, project mismatch).
  - Registered the spec in `docs/docs.json` across locales (Usage/用量/Uso).

<sup>Written for commit a5f9579a54a9305d55b38a7936b02e2b10adb9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Usage API documentation.
  * Documented endpoints for recording MCP usage, listing usage records, and viewing date-range statistics.
  * Added authentication guidance, examples, schemas, and error details.
  * Added Usage API references to English, Simplified Chinese, Traditional Chinese, and Spanish documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenAPI specification for the Insforge Usage API
> Adds [openapi/usage.yaml](https://github.com/InsForge/InsForge/pull/1859/files#diff-334a7d1e5fa9876878191efae874787edf22f47bd830fd81cd0dbb0c0318bf9d) defining three endpoints: `POST /api/usage/mcp` to record MCP tool usage (API key auth), `GET /api/usage/mcp` to list MCP usage records (bearer + API key auth), and `GET /api/usage/stats` to fetch usage statistics for a date range (JWT bearer auth). Also registers the spec in [docs/docs.json](https://github.com/InsForge/InsForge/pull/1859/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9) under English, Chinese, and Spanish locale groups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5f9579.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->