### PR TITLE
fix(db): reassign root-owned public objects to project_admin

### DIFF
--- a/backend/src/infra/database/migrations/063_reassign-root-owned-public-objects.sql
+++ b/backend/src/infra/database/migrations/063_reassign-root-owned-public-objects.sql
@@ -1,0 +1,132 @@
+-- Migration: 063 - Reassign root-owned public objects to project_admin, durably
+--
+-- Migration 046 transferred existing public objects to project_admin as a
+-- one-time sweep, but root execution paths that remained after it — the
+-- unrestricted raw SQL endpoint (used by `insforge create` template init and
+-- `db query --unrestricted`) and superuser restores — keep creating public
+-- objects owned by the superuser. Custom migrations and restricted raw SQL
+-- run as project_admin, so any later ALTER on those objects fails with
+-- "must be owner of table <name>".
+--
+-- This migration wraps the 046 sweep in a reusable function and runs it once
+-- to repair databases broken since 046. The backend calls the same function
+-- after every unrestricted DDL statement so ownership can no longer drift.
+
+CREATE OR REPLACE FUNCTION system.reassign_public_objects_to_project_admin()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  object_record record;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'project_admin') THEN
+    RETURN;
+  END IF;
+
+  FOR object_record IN
+    SELECT
+      CASE c.relkind
+        WHEN 'r' THEN 'TABLE'
+        WHEN 'p' THEN 'TABLE'
+        WHEN 'v' THEN 'VIEW'
+        WHEN 'm' THEN 'MATERIALIZED VIEW'
+        WHEN 'S' THEN 'SEQUENCE'
+        WHEN 'f' THEN 'FOREIGN TABLE'
+      END AS object_type,
+      n.nspname AS schema_name,
+      c.relname AS object_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+      AND pg_get_userbyid(c.relowner) <> 'project_admin'
+      -- Table-owned and identity sequences inherit ownership from ALTER TABLE.
+      -- PostgreSQL rejects changing them directly while linked to a table.
+      AND NOT (
+        c.relkind = 'S'
+        AND EXISTS (
+          SELECT 1
+          FROM pg_depend d
+          WHERE d.objid = c.oid
+            AND d.deptype IN ('a', 'i')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        WHERE d.objid = c.oid
+          AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format(
+      'ALTER %s %I.%I OWNER TO project_admin',
+      object_record.object_type,
+      object_record.schema_name,
+      object_record.object_name
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT
+      CASE p.prokind
+        WHEN 'p' THEN 'PROCEDURE'
+        WHEN 'a' THEN 'AGGREGATE'
+        ELSE 'FUNCTION'
+      END AS object_type,
+      n.nspname AS schema_name,
+      p.proname AS object_name,
+      pg_get_function_identity_arguments(p.oid) AS arguments
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND pg_get_userbyid(p.proowner) <> 'project_admin'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        WHERE d.objid = p.oid
+          AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format(
+      'ALTER %s %I.%I(%s) OWNER TO project_admin',
+      object_record.object_type,
+      object_record.schema_name,
+      object_record.object_name,
+      object_record.arguments
+    );
+  END LOOP;
+
+  FOR object_record IN
+    SELECT
+      n.nspname AS schema_name,
+      t.typname AS object_name
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    LEFT JOIN pg_class type_class ON type_class.oid = t.typrelid
+    WHERE n.nspname = 'public'
+      AND t.typtype IN ('c', 'd', 'e', 'm', 'r')
+      AND pg_get_userbyid(t.typowner) <> 'project_admin'
+      -- Relation row types inherit ownership from ALTER TABLE/VIEW above.
+      -- User-created composite types are backed by relkind = 'c' and are safe.
+      AND (t.typrelid = 0 OR type_class.relkind = 'c')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        WHERE d.objid = t.oid
+          AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format(
+      'ALTER TYPE %I.%I OWNER TO project_admin',
+      object_record.schema_name,
+      object_record.object_name
+    );
+  END LOOP;
+END;
+$$;
+
+-- SECURITY INVOKER (the default): only the superuser can actually reassign
+-- ownership, so revoking PUBLIC just keeps the callable surface tidy.
+REVOKE EXECUTE ON FUNCTION system.reassign_public_objects_to_project_admin() FROM PUBLIC;
+
+SELECT system.reassign_public_objects_to_project_admin();

--- a/backend/src/services/database/database-advance.service.ts
+++ b/backend/src/services/database/database-advance.service.ts
@@ -111,6 +111,19 @@ export class DatabaseAdvanceService {
 
       // Refresh schema cache if it was a DDL operation
       if (/CREATE|ALTER|DROP/i.test(sanitizedQuery)) {
+        if (asRoot) {
+          // Root-created public objects stay owned by the superuser, which
+          // breaks later project_admin DDL (custom migrations, restricted raw
+          // SQL) with "must be owner of ..." errors. Reassign before anyone
+          // can hit that. Best-effort: the user's DDL already succeeded.
+          await client
+            .query('SELECT system.reassign_public_objects_to_project_admin()')
+            .catch((error: unknown) => {
+              logger.warn('Failed to reassign public object ownership after unrestricted DDL', {
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+        }
         await client.query(`NOTIFY pgrst, 'reload schema';`);
         // Metadata is now updated on-demand
       }

--- a/backend/tests/unit/reassign-root-owned-public-objects-migration.test.ts
+++ b/backend/tests/unit/reassign-root-owned-public-objects-migration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationDir = path.resolve(currentDir, '../../src/infra/database/migrations');
+const migrationFile = '063_reassign-root-owned-public-objects.sql';
+const migrationPath = path.resolve(migrationDir, migrationFile);
+
+const servicePath = path.resolve(
+  currentDir,
+  '../../src/services/database/database-advance.service.ts'
+);
+
+function readMigration(): string {
+  return fs.readFileSync(migrationPath, 'utf8');
+}
+
+describe('reassign root-owned public objects migration', () => {
+  it('migration file exists and runs after the one-time 046 transfer', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+
+    const migrations = fs
+      .readdirSync(migrationDir)
+      .filter((file) => file.endsWith('.sql'))
+      .sort();
+
+    const migrationIndex = migrations.indexOf(migrationFile);
+    const predecessorIndex = migrations.indexOf('046_transfer-public-object-ownership.sql');
+
+    expect(predecessorIndex).not.toBe(-1);
+    expect(migrationIndex).not.toBe(-1);
+    expect(migrationIndex).toBeGreaterThan(predecessorIndex);
+  });
+
+  it('defines the reusable sweep function and invokes it once', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(
+      /CREATE OR REPLACE FUNCTION system\.reassign_public_objects_to_project_admin\(\)/
+    );
+    expect(sql).toMatch(/SELECT system\.reassign_public_objects_to_project_admin\(\);/);
+  });
+
+  it('is a no-op when project_admin does not exist', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(
+      /IF NOT EXISTS \(SELECT 1 FROM pg_roles WHERE rolname = 'project_admin'\) THEN\s+RETURN;/
+    );
+  });
+
+  it('keeps the 046 guards: skips table-owned sequences and relation row types', () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(
+      /AND NOT\s*\(\s*c\.relkind\s*=\s*'S'\s+AND EXISTS\s*\(\s*SELECT 1\s+FROM pg_depend d\s+WHERE d\.objid = c\.oid\s+AND d\.deptype IN \('a', 'i'\)\s*\)\s*\)/
+    );
+    expect(sql).toMatch(/AND \(t\.typrelid = 0 OR type_class\.relkind = 'c'\)/);
+  });
+
+  it('never touches extension-owned objects', () => {
+    const sql = readMigration();
+
+    const extensionGuards = sql.match(/d\.deptype = 'e'/g) ?? [];
+    expect(extensionGuards.length).toBe(3);
+  });
+
+  it('backend reassigns ownership after unrestricted DDL', () => {
+    const service = fs.readFileSync(servicePath, 'utf8');
+
+    expect(service).toMatch(
+      /if \(asRoot\) \{[\s\S]*?system\.reassign_public_objects_to_project_admin\(\)/
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Customer feedback `470623e7-5b61-4874-9c96-b8aedf745447`: `db migrations up` cannot ALTER an existing `public.reports` table — **`must be owner of table reports`**. A second customer hit the same class on 2026-08-02 (asked us to transfer `public.provision_merchant_workspace` from `postgres` to `project_admin`).

## Root cause

Two execution paths create objects with different owners:

| Path | Role | Owner of created objects |
|---|---|---|
| `POST /api/database/advance/rawsql/unrestricted` (CLI `db query --unrestricted`, **`insforge create` template `db_init.sql`** — `runRawSql(sql, true)` in CLI `create.ts`) | superuser (`asRoot`) | `postgres` |
| `POST /api/database/migrations` (`db migrations up`), restricted rawsql | `SET ROLE project_admin` | `project_admin` |

Postgres requires table ownership for ALTER, so any table created via the root path can never be modified by a custom migration. Migration 046 swept ownership once, but every unrestricted DDL statement since then re-creates the drift — templates initialize their schema through exactly that path, so this bites anyone who scaffolds with a template (or whose agent follows the CLI's own `--unrestricted` hint) and later writes a migration.

Minimal repro (mirrors the backend's exact SQL):
```sql
-- as superuser (unrestricted path)
CREATE TABLE public.reports(id serial primary key);
-- migration path
BEGIN; SET LOCAL ROLE project_admin;
ALTER TABLE public.reports ADD COLUMN status text;  -- ERROR: must be owner of table reports
```

## Fix

- **Migration 063**: wraps the vetted 046 sweep in a reusable function `system.reassign_public_objects_to_project_admin()` and runs it once — repairs every drifted database at its next backend update (including this customer's).
- **`database-advance.service.ts`**: after any unrestricted DDL, call the sweep (best-effort, logged on failure) before the PostgREST schema reload — root-created public objects are handed to `project_admin` immediately, so the drift can no longer recur.

Same guards as 046: extension-owned objects, table-owned/identity sequences, and relation row types are skipped.

## Verification

- Live Postgres 16 run of `063`: superuser-created table / standalone sequence / function / composite type all transfer to `project_admin`; `pgcrypto` extension objects untouched; second run is a no-op; `SET ROLE project_admin; ALTER TABLE public.reports ...` succeeds after the sweep.
- `tests/unit/reassign-root-owned-public-objects-migration.test.ts` (new) + existing 046 test, advance/migration service tests: pass. `tsc --noEmit`: clean.

## Support unblock (until this ships)

For an affected project, run once via the dashboard SQL editor / unrestricted path — the 046 DO-block, or targeted:
```sql
ALTER TABLE public.reports OWNER TO project_admin;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb31ysqY3osuUqBXGEqKLY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reassigns superuser-owned objects in the public schema to `project_admin` to fix “must be owner of …” errors during `db migrations up`. Adds a reusable sweep and runs it after unrestricted DDL to prevent future ownership drift.

- **Bug Fixes**
  - Added migration 063 that defines `system.reassign_public_objects_to_project_admin()` and runs it once to repair existing drift; skips extension-owned objects and table-owned/identity sequences; idempotent.
  - After unrestricted DDL, the backend now calls the sweep before the PostgREST schema reload so root-created objects are immediately transferred to `project_admin`.
  - Added a unit test to check migration content/order and the backend hook.

<sup>Written for commit 64b1c8198663ac9aa2ca27a62e59d1d4f6343fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reassign root-owned public schema objects to `project_admin` after DDL
> - Adds migration [063_reassign-root-owned-public-objects.sql](https://github.com/InsForge/InsForge/pull/1860/files#diff-39851ababa13472c7e5a1793cbedf37ed45fc043c22fa6ae918a190cf0753602) that defines `system.reassign_public_objects_to_project_admin()`, a plpgsql function that transfers ownership of tables, views, sequences, functions, and types in the public schema to `project_admin`, skipping extension-owned and table-owned objects.
> - The migration runs the function once on apply; `EXECUTE` privilege is revoked from `PUBLIC`.
> - [database-advance.service.ts](https://github.com/InsForge/InsForge/pull/1860/files#diff-8c5ec353b1320498356d927a119d27831c87d4c5da2ae0cb804039e6598f951d) now calls the function after any DDL executed as root, with failures caught and logged as warnings without interrupting the original operation.
> - Risk: the best-effort reassignment silently swallows errors, so ownership may remain with root if the function fails post-DDL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64b1c81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->