### PR TITLE
docs: send docs analytics to PostHog

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1350,5 +1350,10 @@
       "github": "https://github.com/InsForge/InsForge",
       "linkedin": "https://linkedin.com/company/insforge"
     }
+  },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_ueV1ii62wdBTkH7E70ugyeqHIHu8dFDdjs0qq3TZhJz"
+    }
   }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1353,7 +1353,8 @@
   },
   "integrations": {
     "posthog": {
-      "apiKey": "phc_ueV1ii62wdBTkH7E70ugyeqHIHu8dFDdjs0qq3TZhJz"
+      "apiKey": "phc_ueV1ii62wdBTkH7E70ugyeqHIHu8dFDdjs0qq3TZhJz",
+      "sessionRecording": true
     }
   }
 }


### PR DESCRIPTION
## What

Adds the [Mintlify PostHog integration](https://mintlify.com/docs/integrations/analytics/posthog) to `docs/docs.json` so the docs site reports page analytics and session recordings to our existing PostHog project.

## Details

- Uses the same public write-only project key (`phc_…`) the dashboard already ships in its client bundle — docs traffic lands in the same PostHog project.
- No `apiHost` set: Mintlify proxies events through its default `ph.mintlify.com` proxy (we're on PostHog US cloud, which is what that proxy targets).
- Session recording is on by default. For recordings to actually arrive, the docs domain (`docs.insforge.dev`) must be added under **Authorized domains for recordings** in PostHog project settings — one-time dashboard step, analytics events flow regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcFYkLqoAuXW2fPbNm11V9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable docs analytics and session recordings by adding the Mintlify `posthog` integration to `docs/docs.json`. Uses our existing PostHog project key via Mintlify’s proxy, with `sessionRecording` explicitly set to `true`.

- **Migration**
  - Add `docs.insforge.dev` to Authorized domains for recordings in PostHog so session replays are saved.

<sup>Written for commit a71c779bce7b8c3ea6cda9a097aa5802d09eb715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PostHog analytics to docs
> Adds a PostHog integration to [docs.json](https://github.com/InsForge/InsForge/pull/1861/files#diff-873ce17c654718debe2fe308a2f2279bde8663686423c51f97fab2dd0722b8d9) by configuring an API key under the `integrations.posthog` object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b6754b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PostHog integration settings to the documentation site.
  * Enabled documentation analytics and session recording through the site configuration.
  * Updated the site configuration to support analytics API credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->