### PR TITLE
docs: disable PostHog session recording on docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1354,7 +1354,7 @@
   "integrations": {
     "posthog": {
       "apiKey": "phc_ueV1ii62wdBTkH7E70ugyeqHIHu8dFDdjs0qq3TZhJz",
-      "sessionRecording": true
+      "sessionRecording": false
     }
   }
 }


### PR DESCRIPTION
Follow-up to #1861: sets `sessionRecording: false` for the docs PostHog integration. Pageview/event analytics keep flowing; session replays are disabled — they add rrweb client overhead without much value on a public docs site, and this also removes the need to authorize the docs domain for recordings in PostHog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcFYkLqoAuXW2fPbNm11V9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled PostHog session recording on the docs site to cut rrweb client overhead; pageview and event analytics remain enabled.
Also removes the need to authorize the docs domain for recordings.

<sup>Written for commit cb7df81335f825914c8763f046c427dd47cadec8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

