### PR TITLE
fix(dashboard): stabilize lazy route loading

### DIFF
--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -5,16 +5,30 @@ import { LoadingState } from '@insforge/ui';
 import { ErrorState } from '#components';
 import { RequireAuth } from './RequireAuth';
 import AppLayout from '#layout/AppLayout';
+import AILayout from '#features/ai/components/AILayout';
+import AnalyticsLayout from '#features/analytics/components/AnalyticsLayout';
+import WebscraperLayout from '#features/webscraper/components/WebscraperLayout';
+import AuthenticationLayout from '#features/auth/components/AuthenticationLayout';
+import DashboardLayout from '#features/dashboard/components/DashboardLayout';
+import DatabaseLayout from '#features/database/components/DatabaseLayout';
+import SQLEditorLayout from '#features/database/components/SQLEditorLayout';
+import DeploymentsLayout from '#features/deployments/components/DeploymentsLayout';
+import FunctionsLayout from '#features/functions/components/FunctionsLayout';
+import LogsLayout from '#features/logs/components/LogsLayout';
+import PaymentsLayout from '#features/payments/components/PaymentsLayout';
+import RealtimeLayout from '#features/realtime/components/RealtimeLayout';
+import StorageLayout from '#features/storage/components/StorageLayout';
+import VisualizerLayout from '#features/visualizer/components/VisualizerLayout';
 import { getFeatureFlag, trackEvent } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 
-// Lazy-loaded so heavy feature libs load on demand, not in the initial bundle.
-const AILayout = lazy(() => import('#features/ai/components/AILayout'));
+// Leaf pages stay lazy so their feature dependencies load on demand. Layouts
+// remain eager as stable routing chrome, which lets React start loading the
+// matched page without a layout -> page waterfall.
 const AIOverviewPage = lazy(() => import('#features/ai/pages/AIOverviewPage'));
 const AIUsagePage = lazy(() => import('#features/ai/pages/AIUsagePage'));
 const AIQuickStartPage = lazy(() => import('#features/ai/pages/AIQuickStartPage'));
 const AIModelsPage = lazy(() => import('#features/ai/pages/AIModelsPage'));
-const AnalyticsLayout = lazy(() => import('#features/analytics/components/AnalyticsLayout'));
 const TrafficPage = lazy(() =>
   import('#features/analytics/pages/TrafficPage').then((m) => ({ default: m.TrafficPage }))
 );
@@ -26,7 +40,6 @@ const SessionReplayPage = lazy(() =>
     default: m.SessionReplayPage,
   }))
 );
-const WebscraperLayout = lazy(() => import('#features/webscraper/components/WebscraperLayout'));
 const WebscraperActorsPage = lazy(() =>
   import('#features/webscraper/pages/WebscraperActorsPage').then((m) => ({
     default: m.WebscraperActorsPage,
@@ -42,17 +55,13 @@ const WebscraperDatasetPage = lazy(() =>
     default: m.WebscraperDatasetPage,
   }))
 );
-const AuthenticationLayout = lazy(() => import('#features/auth/components/AuthenticationLayout'));
 const AuthMethodsPage = lazy(() => import('#features/auth/pages/AuthMethodsPage'));
 const EmailPage = lazy(() => import('#features/auth/pages/EmailPage'));
 const UsersPage = lazy(() => import('#features/auth/pages/UsersPage'));
 const ComputePage = lazy(() => import('#features/compute/pages/ComputePage'));
-const DashboardLayout = lazy(() => import('#features/dashboard/components/DashboardLayout'));
 const DashboardPage = lazy(() => import('#features/dashboard/pages/DashboardPage'));
 const DTestDashboardPage = lazy(() => import('#features/dashboard/pages/DTestDashboardPage'));
 const DTestInstallPage = lazy(() => import('#features/dashboard/pages/DTestInstallPage'));
-const DatabaseLayout = lazy(() => import('#features/database/components/DatabaseLayout'));
-const SQLEditorLayout = lazy(() => import('#features/database/components/SQLEditorLayout'));
 const BackupsPage = lazy(() => import('#features/database/pages/BackupsPage'));
 const DatabaseFunctionsPage = lazy(() => import('#features/database/pages/FunctionsPage'));
 const IndexesPage = lazy(() => import('#features/database/pages/IndexesPage'));
@@ -62,7 +71,6 @@ const SQLEditorPage = lazy(() => import('#features/database/pages/SQLEditorPage'
 const TablesPage = lazy(() => import('#features/database/pages/TablesPage'));
 const TemplatesPage = lazy(() => import('#features/database/pages/TemplatesPage'));
 const TriggersPage = lazy(() => import('#features/database/pages/TriggersPage'));
-const DeploymentsLayout = lazy(() => import('#features/deployments/components/DeploymentsLayout'));
 const DeploymentDomainsPage = lazy(
   () => import('#features/deployments/pages/DeploymentDomainsPage')
 );
@@ -73,31 +81,25 @@ const DeploymentLogsPage = lazy(() => import('#features/deployments/pages/Deploy
 const DeploymentOverviewPage = lazy(
   () => import('#features/deployments/pages/DeploymentOverviewPage')
 );
-const FunctionsLayout = lazy(() => import('#features/functions/components/FunctionsLayout'));
 const FunctionsPage = lazy(() => import('#features/functions/pages/FunctionsPage'));
 const SchedulesPage = lazy(() => import('#features/functions/pages/SchedulesPage'));
 const SecretsPage = lazy(() => import('#features/functions/pages/SecretsPage'));
 const CloudLoginPage = lazy(() => import('#features/login/pages/CloudLoginPage'));
 const LoginPage = lazy(() => import('#features/login/pages/LoginPage'));
-const LogsLayout = lazy(() => import('#features/logs/components/LogsLayout'));
 const AuditsPage = lazy(() => import('#features/logs/pages/AuditsPage'));
 const FunctionLogsPage = lazy(() => import('#features/logs/pages/FunctionLogsPage'));
 const LogsPage = lazy(() => import('#features/logs/pages/LogsPage'));
 const MCPLogsPage = lazy(() => import('#features/logs/pages/MCPLogsPage'));
-const PaymentsLayout = lazy(() => import('#features/payments/components/PaymentsLayout'));
 const CatalogPage = lazy(() => import('#features/payments/pages/CatalogPage'));
 const CustomersPage = lazy(() => import('#features/payments/pages/CustomersPage'));
 const SubscriptionsPage = lazy(() => import('#features/payments/pages/SubscriptionsPage'));
 const TransactionsPage = lazy(() => import('#features/payments/pages/TransactionsPage'));
-const RealtimeLayout = lazy(() => import('#features/realtime/components/RealtimeLayout'));
 const RealtimeChannelsPage = lazy(() => import('#features/realtime/pages/RealtimeChannelsPage'));
 const RealtimeMessagesPage = lazy(() => import('#features/realtime/pages/RealtimeMessagesPage'));
 const RealtimePermissionsPage = lazy(
   () => import('#features/realtime/pages/RealtimePermissionsPage')
 );
-const StorageLayout = lazy(() => import('#features/storage/components/StorageLayout'));
 const BucketsPage = lazy(() => import('#features/storage/pages/BucketsPage'));
-const VisualizerLayout = lazy(() => import('#features/visualizer/components/VisualizerLayout'));
 const VisualizerPage = lazy(() => import('#features/visualizer/pages/VisualizerPage'));
 
 interface ChunkErrorBoundaryProps {
@@ -297,19 +299,31 @@ function AuthenticatedRoutes() {
 
 export function AppRoutes() {
   return (
-    <RouteBoundary>
-      <Routes>
-        <Route path="/dashboard/login" element={<LoginPage />} />
-        <Route path="/cloud/login" element={<CloudLoginPage />} />
-        <Route
-          path="/*"
-          element={
-            <RequireAuth>
-              <AuthenticatedRoutes />
-            </RequireAuth>
-          }
-        />
-      </Routes>
-    </RouteBoundary>
+    <Routes>
+      <Route
+        path="/dashboard/login"
+        element={
+          <RouteBoundary>
+            <LoginPage />
+          </RouteBoundary>
+        }
+      />
+      <Route
+        path="/cloud/login"
+        element={
+          <RouteBoundary>
+            <CloudLoginPage />
+          </RouteBoundary>
+        }
+      />
+      <Route
+        path="/*"
+        element={
+          <RequireAuth>
+            <AuthenticatedRoutes />
+          </RequireAuth>
+        }
+      />
+    </Routes>
   );
 }

--- a/packages/dashboard/src/router/__tests__/AppRoutes.test.tsx
+++ b/packages/dashboard/src/router/__tests__/AppRoutes.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 // The router pulls in every feature layout in the app. Only the three this file
@@ -10,9 +10,26 @@ import { MemoryRouter } from 'react-router-dom';
 vi.mock('#router/RequireAuth', () => ({
   RequireAuth: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
-vi.mock('#layout/AppLayout', () => ({
-  default: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
+vi.mock('#layout/AppLayout', async () => {
+  const { useState } = await import('react');
+  const { Link } = await import('react-router-dom');
+
+  return {
+    default: ({ children }: { children: ReactNode }) => {
+      const [layoutState, setLayoutState] = useState(0);
+
+      return (
+        <>
+          <button onClick={() => setLayoutState((value) => value + 1)}>
+            LAYOUT_STATE_{layoutState}
+          </button>
+          <Link to="/dashboard/analytics/traffic">GO_TO_ANALYTICS</Link>
+          {children}
+        </>
+      );
+    },
+  };
+});
 vi.mock('#features/webscraper/components/WebscraperLayout', () => ({
   default: () => <div>WEBSCRAPER_LAYOUT</div>,
 }));
@@ -82,5 +99,17 @@ describe('AppRoutes host-mode gating', () => {
     renderAt('/dashboard/analytics/traffic');
 
     expect(await screen.findByText('ANALYTICS_LAYOUT')).toBeInTheDocument();
+  });
+
+  it('preserves AppLayout state while navigating between authenticated routes', async () => {
+    renderAt('/dashboard/webscraper/actors');
+    expect(await screen.findByText('WEBSCRAPER_LAYOUT')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'LAYOUT_STATE_0' }));
+    expect(screen.getByRole('button', { name: 'LAYOUT_STATE_1' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: 'GO_TO_ANALYTICS' }));
+    expect(await screen.findByText('ANALYTICS_LAYOUT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'LAYOUT_STATE_1' })).toBeInTheDocument();
   });
 });

--- a/packages/dashboard/tests/ui/fixtures/api.ts
+++ b/packages/dashboard/tests/ui/fixtures/api.ts
@@ -57,6 +57,17 @@ export async function mockLoggedOutApi(page: Page) {
 export async function mockSelfHostingDashboardApi(page: Page) {
   let isLoggedIn = false;
 
+  // Keep the authenticated event stream from falling through to the absent
+  // backend. A 401 here clears the dashboard session and makes navigation
+  // smoke tests race back to the login page.
+  await page.route('**/api/dashboard/events', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: ': dashboard-ui-smoke\n\n',
+    })
+  );
+
   await page.route('**/api/auth/admin/sessions/current', (route) => {
     if (!isLoggedIn) {
       return fulfillLoggedOutSession(route);
@@ -84,9 +95,26 @@ export async function mockSelfHostingDashboardApi(page: Page) {
     });
   });
 
+  await page.route('**/api/auth/config', (route) =>
+    fulfillJson(route, 200, selfHostingMetadata.auth)
+  );
+
+  await page.route('**/api/auth/oauth/custom/configs', (route) =>
+    fulfillJson(route, 200, {
+      data: [],
+      count: 0,
+    })
+  );
+
   await page.route('**/api/metadata/api-key', (route) =>
     fulfillJson(route, 200, {
       apiKey: 'ik_test_dashboard_ui_smoke_key',
+    })
+  );
+
+  await page.route('**/api/metadata/anon-key', (route) =>
+    fulfillJson(route, 200, {
+      anonKey: 'anon_test_dashboard_ui_smoke_key',
     })
   );
 


### PR DESCRIPTION
## Summary

- keep feature layouts eager and lazy-load leaf pages to avoid nested layout-to-page chunk waterfalls
- remove the pathname-keyed boundary around the whole authenticated tree so AppLayout state survives navigation
- keep loading and chunk-error handling local to lazy login and authenticated route content
- add regression coverage for layout state preservation and complete the UI smoke-test mocks

## Loading impact

- heavy page-only dependencies remain on demand
- feature layout code moves into the initial graph, increasing the frontend entry from 676.62 kB / 209.51 kB gzip to 759.34 kB / 226.41 kB gzip
- this trades about 16.9 kB of entry gzip, or about 52.5 kB across the complete initial preload graph, for one fewer sequential network round trip when entering a nested feature route
- no new product UI is introduced; users may only see the existing route loading fallback while a leaf-page chunk loads, with AppLayout and the sidebar staying mounted

## Regression fixed

The previous outer keyed Suspense remounted AppLayout on every pathname change, resetting local sidebar or dialog state and re-running layout effects.

## Validation

- Turbo typecheck: 8/8
- Turbo lint: 5/5
- Turbo build: 5/5
- dashboard Vitest: 213/213
- dashboard Playwright UI: 3/3
- [test image run](https://github.com/InsForge/InsForge/actions/runs/30962294809)
- [deterministic fixture E2E](https://github.com/InsForge/agent-e2e/actions/runs/30962389641)

## Notes

- no agent-e2e fixture changes were needed because this does not change deployed API or backend behavior
- base branch: dashboard-route-splitting-intermediate-1796


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes dashboard lazy route loading by eager-loading feature layouts and keeping leaf pages lazy. This preserves `AppLayout` state across navigation and removes layout-to-page chunk waterfalls.

- **Bug Fixes**
  - Preserve `AppLayout` state by removing the pathname-keyed boundary; `RouteBoundary` now wraps only login routes.
  - Keep loading and chunk errors local to lazy leaf pages; the authenticated shell stays mounted.
  - Add tests for layout state across navigation and complete UI smoke-test mocks (stub SSE stream and auth/metadata endpoints).

- **Performance**
  - Eager-load feature layouts; keep pages lazy to avoid layout → page waterfalls.
  - One fewer network round trip when entering nested feature routes.
  - Entry size from 676.62 kB / 209.51 kB gzip to 759.34 kB / 226.41 kB gzip (~16.9 kB gzip; ~52.5 kB across preload); heavy page-only deps remain on demand.

<sup>Written for commit 6abeefe07e8650445f5544625c552851627b36f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize lazy route loading by eagerly importing layout components in the dashboard router
> - Converts feature layout components (e.g. `AILayout`, `DatabaseLayout`, `SQLEditorLayout`, etc.) from `React.lazy` dynamic imports to static eager imports in [AppRoutes.tsx](https://github.com/InsForge/InsForge/pull/1864/files#diff-c22275f3f786ab893302862c0831269fc75644a99b6fbf59e3292d44e76e1433), so Suspense boundaries no longer wrap these layouts.
> - Moves `RouteBoundary` from wrapping the entire `<Routes>` tree to wrapping only the `/dashboard/login` and `/cloud/login` routes, leaving the authenticated `/*` subtree without this error boundary at the routing layer.
> - Adds a test asserting that `AppLayout` does not remount (state persists) when navigating between authenticated routes.
> - Stubs additional endpoints (`**/api/dashboard/events`, auth config, anon key) in UI test fixtures to prevent SSE-triggered logouts during smoke tests.
> - Behavioral Change: errors thrown inside authenticated routes are no longer caught by the top-level `RouteBoundary`; error handling for those routes must be handled further down the tree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6abeefe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->