### PR TITLE
ci: publish release images to Docker Hub

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -211,15 +211,16 @@ jobs:
       contents: read
 
     steps:
+      # SHA-pinned: this step is the only place DOCKERHUB_TOKEN is exposed.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   GHCR_REGISTRY: ghcr.io
+  DOCKERHUB_REGISTRY: docker.io
+  DOCKERHUB_NAMESPACE: insforge
   IMAGE_NAME: insforge-oss
 
 jobs:
@@ -200,3 +202,41 @@ jobs:
           if [[ "${TAG_LATEST}" == "true" ]]; then
             crane copy ${GHCR_IMAGE}:${VERSION} ${ECR_IMAGE}:latest
           fi
+
+  push-to-dockerhub:
+    needs: merge-manifests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    permissions:
+      contents: read
+
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987  # v0.5
+
+      - name: Copy multi-arch image to Docker Hub
+        env:
+          VERSION: ${{ github.ref_name }}
+          GHCR_IMAGE_RAW: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_NAMESPACE }}/${{ env.IMAGE_NAME }}
+        run: |
+          # Convert GHCR image name to lowercase (Docker requires lowercase)
+          GHCR_IMAGE=$(echo "${GHCR_IMAGE_RAW}" | tr '[:upper:]' '[:lower:]')
+          # Copy multi-arch image from GHCR to Docker Hub (preserves all platforms)
+          crane copy ${GHCR_IMAGE}:${VERSION} ${DOCKERHUB_IMAGE}:${VERSION}
+          # The job's `if` gate already restricts this to clean release tags
+          crane copy ${GHCR_IMAGE}:${VERSION} ${DOCKERHUB_IMAGE}:latest


### PR DESCRIPTION
## What

Adds a `push-to-dockerhub` job to `build-image.yml` so release images land on Docker Hub automatically.

`insforge/insforge-oss` on Docker Hub has been kept up by manual pushes and drifted — `latest` still points at **v2.1.9** (2026-05-28), while the repo is at 2.2.9. Everything from v2.2.0 onward never made it there.

## How

- Runs in parallel with `push-to-ecr` (both `needs: merge-manifests`), so it adds no wall-clock to a release.
- No rebuild: `crane copy` moves the already-built multi-arch manifest out of GHCR, so Docker Hub gets identical amd64/arm64 digests.
- Same gate as ECR — `push` events on `v*` tags with no `-` suffix. Pre-release and `workflow_dispatch` test tags never reach the public registry.
- Auth via `docker/login-action`, which writes `~/.docker/config.json`; crane reads creds from there, the same mechanism the ECR job already relies on. Both login steps in this job are SHA-pinned to `dbcb813823bdd20940b903addbd779551569679f` (v4.6.0) because `DOCKERHUB_TOKEN` is a new public-registry write credential whose only exposure point is here.

Because the `if` already guarantees a clean release tag, `VERSION` is just `github.ref_name` and `latest` is pushed unconditionally — no need for ECR's `TAG_LATEST` indirection.

## Before merging

Two repo secrets are required, or the job fails at login:

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN` — Docker Hub PAT with Read/Write on `insforge/insforge-oss`

## Note on backfill

This only fires on new tags, so v2.2.0–v2.2.9 won't be filled in retroactively; the next release tag moves `latest` straight to that version. Backfilling an old one is a one-off `crane copy` from GHCR if we want the history present.

## E2E gate

Test tag `v2.3.0-dockerhub`.

- Build and Push Docker Image (this branch) — [run 31028680419](https://github.com/InsForge/InsForge/actions/runs/31028680419) — success. `push-to-ecr` and `push-to-dockerhub` both skipped, confirming a `workflow_dispatch` test tag cannot reach the public registry.
- Deterministic Fixture E2E — [run 31028867363](https://github.com/InsForge/agent-e2e/actions/runs/31028867363) — success.

No `agent-e2e` fixture changes: this diff is CI config, with no API contract or runtime behavior to assert against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically publish release images to Docker Hub via a new `push-to-dockerhub` job, keeping Docker Hub in sync with GHCR/ECR without extra build time. Adds SHA-pinned logins to protect the new Docker Hub token.

- **New Features**
  - Add `push-to-dockerhub` job running in parallel after `merge-manifests`.
  - Use `crane` to copy the multi-arch image from GHCR to Docker Hub, tagging `${VERSION}` and `latest` with identical digests.
  - Gate on clean `v*` tags (no hyphen); auth via SHA-pinned `docker/login-action`.

- **Migration**
  - Add repo secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (PAT with read/write on `insforge/insforge-oss`).
  - Backfill for past releases is not automatic; run a one-off `crane copy` from GHCR if needed.

<sup>Written for commit 58dc574f387bac584dcb93cce2c005e9b416d499. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release container images are now published to Docker Hub.
  * Images are available under both their version tag and the `latest` tag.
  * Multi-architecture releases are supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish release images to Docker Hub on versioned tag push
> Adds a `push-to-dockerhub` job to [build-image.yml](.github/workflows/build-image.yml) that runs after `merge-manifests` completes. On push events for clean release tags (v-prefixed, no hyphen), it copies the multi-arch image from GHCR to Docker Hub (`docker.io/insforge`) using `crane`, tagging both the version and `latest`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90cf11a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

