### PR TITLE
fix(deploy): bump the stale insforge-oss pin to latest

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - insforge-network
 
   insforge:
-    image: ghcr.io/insforge/insforge-oss:v1.5.0
+    image: ghcr.io/insforge/insforge-oss:latest
 
     working_dir: /app
     depends_on:


### PR DESCRIPTION
One line.

```diff
   insforge:
-    image: ghcr.io/insforge/insforge-oss:v1.5.0
+    image: ghcr.io/insforge/insforge-oss:latest
```

## Why it was stale

`v1.5.0` was written on **2026-02-02** in `2225d6359` ("add one-click deployment to README.md") and the line was never touched again. Since then:

- **36 releases**
- **48 migrations**
- the file itself edited **17 times** — telemetry, payments, S3 backends, healthcheck fixes — without the tag ever moving

Nothing automated reads this file, which is why it went unnoticed: CI and E2E use the root `docker-compose.yml`, which builds from source. So anyone installing via the documented download-and-run path has been getting a February backend.

The other two images here were already on `:latest` and never rotted. Only the pinned one did — so it goes to `:latest` too, rather than to a new version that would rot the same way.

## Who this affects

**Affected** — self-hosters following the download-and-run path: README quickstart, [deploy/docker-deploy.md](deploy/docker-deploy.md) (the "Deploy on Docker" button), and the `docs/zh` / `docs/zh-Hant` deployment guides.

**Not affected:**
- **Cloud** — resolves versions through `INSFORGE_OSS_VER` written onto the instance (`deployment.service.ts`), with its own compose template. Nothing to do with this file.
- **CI / E2E** — root `docker-compose.yml`, built from source.
- **Build-from-source users** — `docker-compose.prod.yml`.
- **Existing running deployments** — unchanged until they re-download the compose file.

## One thing for the release notes

An existing `v1.5.0` deployment that re-downloads the compose file will actually pull a new image (different tag), so boot-time `migrate:up` applies the pending migrations in order. That's the supported path — `node-pg-migrate` with the `system.migrations` tracking table — but it isn't reversible: the old image can't read the new schema afterwards. Worth a "pg_dump first" line wherever upgrades get announced.

## Split out of this PR

- Docs (quickstart leading with `insforge local start`) → #1870
- `postgres-all` / `deno-runtime` CI and the `Dockerfile.deno` fixes → #1869
- The CLI itself → [CLI#222](https://github.com/InsForge/CLI/pull/222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)