### PR TITLE
ci: build postgres-all and deno-runtime from this repo

### DIFF
--- a/.github/workflows/build-deno-image.yml
+++ b/.github/workflows/build-deno-image.yml
@@ -1,0 +1,81 @@
+name: Build and Push Deno Runtime Image
+
+# `deno-runtime` bakes in functions/server.ts — the runtime host for edge
+# functions. User function code is NOT in the image: server.ts reads it out of
+# Postgres at request time, which is why the image-only compose file needs no
+# functions/ bind mount.
+#
+# Tag-triggered so a `v*` release produces this image at the same tag as
+# `postgres-all` and `insforge-oss`. See build-postgres-all-image.yml.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'deploy/Dockerfile.deno'
+      - 'functions/**'
+      - '.github/workflows/build-deno-image.yml'
+  workflow_dispatch:
+    inputs:
+      test_tag:
+        description: 'Tag to publish (e.g., v2.3.0 or v2.3.0-test)'
+        required: false
+        default: 'v0.1.1-test'
+
+env:
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_NAME: deno-runtime
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # COPY-only on top of denoland/deno:alpine — emulated arm64 is cheap.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Extract metadata for GHCR
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+
+      # Context is the repo root: Dockerfile.deno COPYs the functions/ directory.
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./deploy/Dockerfile.deno
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=deno-runtime
+          cache-to: type=gha,mode=max,scope=deno-runtime

--- a/.github/workflows/build-postgres-all-image.yml
+++ b/.github/workflows/build-postgres-all-image.yml
@@ -1,0 +1,83 @@
+name: Build and Push Postgres-All Image
+
+# `postgres-all` is the base insforge-db Postgres image with this repo's
+# init SQL and postgresql.conf baked in, so the image-only compose file needs
+# no bind mounts. Built here (not in insforge-db) because the init scripts it
+# layers on live in this repo and must match the backend's migrations.
+#
+# Tag-triggered so a `v*` release produces `postgres-all`, `deno-runtime`, and
+# `insforge-oss` at the SAME tag — one tag names a combination CI built
+# together, which is what `insforge local start` resolves against.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'deploy/Dockerfile.postgres'
+      - 'deploy/docker-init/db/**'
+      - '.github/workflows/build-postgres-all-image.yml'
+  workflow_dispatch:
+    inputs:
+      test_tag:
+        description: 'Tag to publish (e.g., v2.3.0 or v2.3.0-test)'
+        required: false
+        default: 'v0.1.1-test'
+
+env:
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_NAME: postgres-all
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # The build is COPY-only on top of a prebuilt base, so emulated arm64
+      # costs almost nothing — no need for a native runner per architecture.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Extract metadata for GHCR
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.GHCR_REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+
+      # Context is the repo root: Dockerfile.postgres COPYs from deploy/docker-init/db/.
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./deploy/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=postgres-all
+          cache-to: type=gha,mode=max,scope=postgres-all

--- a/deploy/Dockerfile.deno
+++ b/deploy/Dockerfile.deno
@@ -1,10 +1,27 @@
 FROM denoland/deno:alpine-2.0.6
 
-# Create non-root user
-RUN addgroup -S deno && adduser -S deno -G deno
+# The base image already ships a non-root `deno` user (uid/gid 1000), so we run
+# as it directly. Creating one here fails the build with "group 'deno' in use".
 
-WORKDIR /app/functions
+# Pre-create DENO_DIR owned by the non-root user. The compose files mount a
+# named volume here; Docker seeds a fresh named volume from the image's
+# directory, ownership included, so this is what lets the `deno` user write
+# its module cache. Without it the first run fails with EACCES on /deno-dir.
+RUN mkdir -p /deno-dir && chown deno:deno /deno-dir
+ENV DENO_DIR=/deno-dir
+
+# WORKDIR is /app, not /app/functions: the compose files set working_dir: /app
+# and the run command's paths (functions/server.ts, ./functions/worker-template.js)
+# are relative to it. Keeping them in sync avoids a module-not-found on boot.
+WORKDIR /app
 
 COPY --chown=deno:deno functions /app/functions
 
 USER deno
+
+EXPOSE 7133
+
+# Mirrors the dev compose's command without --watch. `deno cache` warms the
+# module cache into the mounted DENO_DIR volume on first boot; later starts
+# find it already populated and skip the download.
+CMD ["sh", "-c", "deno cache functions/server.ts && exec deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --unstable-worker-options functions/server.ts"]


### PR DESCRIPTION
`deploy/docker-compose/docker-compose.yml` and `docker-compose.dokploy.yml` both reference `ghcr.io/insforge/postgres-all` and `ghcr.io/insforge/deno-runtime`, but **nothing in any repo builds them**. I grepped `insforge-infra`, `insforge-cloud`, `insforge-cloud-backend`, `insforge-db`, and `insta-oss` — no build target. `insforge-db` builds only the *base* `postgres` image. Both published images were created **2026-05-28**.

They have since drifted from this repo.

## Evidence

**`postgres-all:latest` is missing everything added to `postgresql.conf` since May.** Queried against the running published image:

```
shared_preload_libraries = pg_cron,http,pgcrypto,vector,pg_net     ← no insforge_pg_utils
insforge.internal_schemas    → ERROR: unrecognized configuration parameter
insforge.policy_grant_role   → ERROR: unrecognized configuration parameter
insforge.policy_grant_tables → ERROR: unrecognized configuration parameter
```

`insforge.internal_schemas` is what `system.is_exposed_schema` (migration 056) reads to build PostgREST's schema allowlist. `insforge_pg_utils` is the preload hook for scoped managed-table RLS policy administration — it can only be loaded via `shared_preload_libraries`, so it is simply absent from every self-hosted instance running this image.

The init SQL still matches (`01-init.sql`, `02-jwt.sql` are byte-identical), but the image also carries a **`03-logs.sql` that does not exist in `deploy/docker-init/db/`** — so it was built from a tree that isn't this one.

**`deno-runtime:latest` runs as root.** `Config.User` is empty, despite 36e72de9f *"fix: run deno container as non-root user (security hardening)"* being in the repo. Its `CMD` also appears in no file here.

## What this adds

Two multi-arch, tag-triggered workflows mirroring `build-image.yml`, so a `v*` release produces all three InsForge images at one tag — which is what makes a single version string name a combination CI actually built together. QEMU rather than a runner per architecture, since both builds are COPY-only on top of a prebuilt base.

## `deploy/Dockerfile.deno` fixes

Three, and they're the strongest evidence the published image came from elsewhere — as committed the file can neither build nor boot:

1. `addgroup -S deno` **fails the build**: `denoland/deno:alpine-2.0.6` already ships a `deno` user at uid/gid 1000.
2. **No `CMD`**, and neither image-based compose file passes a `command:` — the container exits immediately.
3. `DENO_DIR` wasn't pre-created and owned, so the non-root user couldn't write its module cache into the mounted volume. Docker seeds a fresh named volume from the image's directory including ownership, so this has to be fixed in the image.

Verified the fixed image builds, boots as non-root, writes its cache into a mounted named volume, and serves `/health`.

## Note for whoever has been publishing these by hand

Please confirm what `03-logs.sql` is and whether it's still needed — a CI build from this repo won't include it. If it's obsolete (superseded by a migration), nothing to do. If it's live, it needs to come back into `deploy/docker-init/db/`.

Split out of InsForge/InsForge#1868, which is scoped to what `insforge local start` needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflows to build `postgres-all` and `deno-runtime` Docker images from this repo
> - Adds two GitHub Actions workflows ([build-postgres-all-image.yml](https://github.com/InsForge/InsForge/pull/1869/files#diff-4de9f28c68ff7b54bcdadf2ea4b1ae6187fe6b225de0d010b3857d5b6769ef93) and [build-deno-image.yml](https://github.com/InsForge/InsForge/pull/1869/files#diff-c0c34d0cbd3bdc8464785979e3c28406cdb145a4720bf1e33acb7b7053db0a6c)) that build and push multi-arch (`linux/amd64`, `linux/arm64`) images to GHCR on tag pushes matching `v*`.
> - PRs trigger a build-only run (no push); `workflow_dispatch` supports an optional `test_tag` for ad-hoc publishes; `latest` is only tagged for non-prerelease versions.
> - Updates [deploy/Dockerfile.deno](https://github.com/InsForge/InsForge/pull/1869/files#diff-6c4e97eee15b7de3d2fe0fd94e64cbeebae9a76b99f21259121f2ff2016efa51) to set a default `CMD` that caches and runs `functions/server.ts`, changes `WORKDIR` to `/app`, writes the Deno module cache to `/deno-dir`, and exposes port `7133`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddaad25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI to build and publish `postgres-all` and `deno-runtime` from this repo on tag releases, keeping these images in lockstep with `insforge-oss`. Also fixes `deploy/Dockerfile.deno` so the container runs as non-root and starts reliably.

- **New Features**
  - Add `.github/workflows/build-postgres-all-image.yml` and `.github/workflows/build-deno-image.yml`.
  - Multi-arch builds (`linux/amd64`, `linux/arm64`) via QEMU; tag-triggered on `v*` and supports a `workflow_dispatch` test tag.
  - Publish to `ghcr.io/insforge/postgres-all` and `ghcr.io/insforge/deno-runtime` with unified tags (and `latest` on clean `v*`).

- **Bug Fixes**
  - Use existing `deno` user and pre-create `DENO_DIR` with proper ownership for cache writes to a mounted volume.
  - Set `WORKDIR /app`, expose port 7133, and add a `CMD` that caches deps then runs `functions/server.ts`.

<sup>Written for commit ddaad2563625a3c9167894d17cac99f29a5c3467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

