### PR TITLE
docs: lead the self-host quickstart with `insforge local start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,24 +112,51 @@ If you find InsForge useful or interesting, a GitHub Star ⭐️ would be greatl
 
 <a href="https://insforge.dev" target="_blank" rel="noopener noreferrer"><img src="https://img.shields.io/badge/insforge.dev-181818?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMjQwIiBoZWlnaHQ9IjI0MCIgdmlld0JveD0iMCAwIDI0MCAyNDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTI2LjExODQgMTAxLjZDMjMuMjkzOSA5OC43ODMzIDIzLjI5MzkgOTQuMjE2NiAyNi4xMTg0IDkxLjRMOTcuNzE2NyAyMEwyMDAgMjBMNzcuMjYgMTQyLjRDNzQuNDM1NSAxNDUuMjE3IDY5Ljg1NjIgMTQ1LjIxNyA2Ny4wMzE3IDE0Mi40TDI2LjExODQgMTAxLjZaIiBmaWxsPSJ3aGl0ZSIvPjxwYXRoIGQ9Ik0xNTUuMjUxIDc3LjM3NUwyMDAgMTIyVjIyNEwxMDQuMTA5IDEyOC4zNzVMMTU1LjI1MSA3Ny4zNzVaIiBmaWxsPSJ3aGl0ZSIvPjwvc3ZnPgo=&logoColor=white" alt="InsForge.dev"></a>
 
-### Self-hosted: Docker Compose
+### Self-hosted: one command
 
 Prerequisites: [Docker](https://www.docker.com/) + [Node.js](https://nodejs.org/)
 
-#### 1. Setup
+#### 1. Start
 
-You can run InsForge locally using Docker Compose. This will start a local InsForge instance on your machine.
+```bash
+npx -y @insforge/cli@latest local start
+```
+
+Run it in your app directory. It pulls the published images, waits for the
+backend to be healthy, links the directory, and writes `.env.local` with your
+API URL and anon key — no clone, no `.env` to fill in, no account required.
+
+```bash
+npx -y @insforge/cli@latest local status   # ports, keys, container health
+npx -y @insforge/cli@latest local stop     # stop (data is kept)
+```
+
+Every other CLI command then targets the local instance: `insforge db query`,
+`insforge storage upload`, `insforge functions deploy`, and so on.
+
+<details>
+<summary>Or drive Docker Compose yourself</summary>
 
 [![Deploy on Docker][docker-btn]][docker-deploy]
 
-Or run from source:
+No checkout needed — every service pulls a published image:
+
 ```bash
-# Run with Docker
+curl -O https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/docker-compose/docker-compose.yml
+curl -o .env https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/docker-compose/.env.example
+docker compose up -d
+```
+
+To build from source instead:
+
+```bash
 git clone https://github.com/InsForge/InsForge.git
 cd InsForge
 cp .env.example .env
 docker compose -f docker-compose.prod.yml up
 ```
+
+</details>
 
 #### 2. Connect InsForge MCP
 
@@ -149,6 +176,10 @@ I'm using InsForge as my backend platform, call InsForge MCP's fetch-docs tool t
 ```
 
 #### 4. Running Multiple Projects
+
+`insforge local start` already isolates per directory — each app folder gets its
+own containers, database, and volumes, so running it in two projects needs no
+setup. The rest of this section is for driving Compose by hand.
 
 You can run multiple InsForge projects on the same host by using different ports and project names.
 

--- a/deploy/docker-deploy.md
+++ b/deploy/docker-deploy.md
@@ -4,6 +4,21 @@
 
 - Docker and Docker Compose installed on your machine
 
+## The short way: let the CLI do it
+
+For local development, the CLI drives this same compose file for you — it
+generates the secrets, picks the keys, waits for health, links the directory,
+and writes `.env.local`:
+
+```bash
+npx -y @insforge/cli@latest local start
+```
+
+Each directory gets its own isolated instance. Use `local status` to see ports
+and keys, and `local stop` to shut down without losing data. The rest of this
+guide covers running Compose yourself — for servers, CI, or any case where you
+want direct control.
+
 ## Setup InsForge
 
 ### Step 1: Download the Docker Compose file


### PR DESCRIPTION
Splits the documentation half out of #1868 so that PR can be reviewed as the one-line fix it is.

Replaces "clone the repo, copy `.env.example`, `docker compose up`" as the first thing a self-hoster sees:

```bash
npx -y @insforge/cli@latest local start
```

Raw Compose stays documented, collapsed behind a `<details>` block, for servers and CI. The multi-project section also notes that `local start` isolates per directory on its own, so the manual per-project port and project-name setup below it is only needed when driving Compose by hand.

`prettier --check` clean.

## ⚠️ Merge order

**Do not merge before [CLI#222](https://github.com/InsForge/CLI/pull/222) is merged *and* published to npm.** Until then the README documents a command that doesn't exist, and `npx -y @insforge/cli@latest local start` fails with an unknown-command error.

#1868 (the `insforge-oss:v1.5.0` → `:latest` fix) has no such constraint and can go in independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `npx -y @insforge/cli@latest local start` the primary self-host quickstart so users can spin up InsForge with one command. Keep raw Docker Compose behind a collapsed details block and note that `local start` isolates per directory; mirror this guidance in `deploy/docker-deploy.md`.

- **Dependencies**
  - Requires `@insforge/cli` with `local start` (CLI#222) published to npm. Do not merge until released.

<sup>Written for commit 28c98f2beb35f9af532ab59df3da945166207f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lead self-host quickstart with `insforge local start` one-command setup
> Updates [README.md](https://github.com/InsForge/InsForge/pull/1870/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [deploy/docker-deploy.md](https://github.com/InsForge/InsForge/pull/1870/files#diff-5ed00744d268f99e135ac7e6d7d5463e42c2cfcfebd8029341b6607eee4e8b4b) to present `npx -y @insforge/cli@latest local start` as the primary self-hosting path, replacing the previous Docker Compose instructions as the lead.
>
> - The CLI command pulls images, waits for backend health, links the working directory, and writes `.env.local` with the API URL and anon key
> - Adds `local status` and `local stop` commands, and notes that per-directory isolation (containers, database, volumes) applies
> - Manual Docker Compose steps are moved into a collapsible details section in the README and a secondary section in the deploy guide
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28c98f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->