### PR TITLE
fix(deploy): set DENO_RUNTIME_URL so edge functions work

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
+      # Deno Runtime URL for serverless functions
+      - DENO_RUNTIME_URL=http://deno:7133
       # LLM Model API keys
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       # Stripe Payments Configuration


### PR DESCRIPTION
```diff
       - POSTGREST_BASE_URL=http://postgrest:3000
+      # Deno Runtime URL for serverless functions
+      - DENO_RUNTIME_URL=http://deno:7133
       # LLM Model API keys
```

## The bug

This compose file starts a `deno` container but never tells the backend where it is. `DENO_RUNTIME_URL` is set in `docker-compose.yml`, `docker-compose.prod.yml` and `docker-compose.dokploy.yml` — only this file omits it. The backend then falls back to its default of `http://localhost:7133` ([app.config.ts:243](backend/src/infra/config/app.config.ts:243)), which inside the `insforge` container is the container itself, where nothing listens.

So for anyone self-hosting via the documented download-and-run path, edge functions have never worked:

```
$ insforge functions deploy hello
✓ Function "hello" creation success.

$ insforge functions invoke hello
{ "error": "request to http://localhost:7133/hello failed, reason: " }
Error: HTTP 502
```

Deploy reports success — the code lands in Postgres — and every invoke 502s. The `deno` container runs the whole time, just unreachable.

## Verification

On this stack, from a clean `docker compose up -d`:

```
$ docker exec durlfix-insforge-1 printenv DENO_RUNTIME_URL
http://deno:7133

$ docker exec durlfix-insforge-1 wget -qO- http://deno:7133/health
{"status":"ok","runtime":"deno","version":"2.0.6",...}
```

The full deploy → invoke chain was verified separately against the same variable value (via `insforge local start`, which sets it identically): `functions invoke` returns the function's own JSON instead of 502.

## Scope

One line, one file. Found while building `insforge local start` ([CLI#222](https://github.com/InsForge/CLI/pull/222)), which hit the same 502 because it drives this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `DENO_RUNTIME_URL` in the Docker Compose stack so the backend reaches the `deno` runtime, fixing 502s when invoking edge functions in self-hosted Docker setups.

- **Bug Fixes**
  - Added `DENO_RUNTIME_URL=http://deno:7133` to `deploy/docker-compose/docker-compose.yml` to prevent fallback to `http://localhost:7133` inside the container.

<sup>Written for commit 9a73a04e083dee075c3573d177f2a64728d2a602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

