### PR TITLE
feat(deploy): pin the insforge_pg_utils grant roles explicitly

### DIFF
--- a/deploy/docker-init/db/postgresql.conf
+++ b/deploy/docker-init/db/postgresql.conf
@@ -12,7 +12,10 @@ max_wal_senders = 10
 # Shared preload libraries
 shared_preload_libraries = 'pg_cron,http,pgcrypto,insforge_pg_utils'
 
+# Both default to 'project_admin' inside insforge_pg_utils. Pinned here so the
+# value is visible and can't shift when the extension is rebuilt.
 insforge.policy_grant_role = 'project_admin'
+insforge.extension_grant_role = 'project_admin'
 insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
 
 # InsForge-internal schemas that must never be exposed to the REST data API.

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -159,7 +159,10 @@ spec:
                     max_wal_senders = 10
 
                     shared_preload_libraries = 'pg_cron,http,pgcrypto,insforge_pg_utils'
+                    # Both default to 'project_admin' inside insforge_pg_utils. Pinned here so the
+                    # value is visible and can't shift when the extension is rebuilt.
                     insforge.policy_grant_role = 'project_admin'
+                    insforge.extension_grant_role = 'project_admin'
                     insforge.policy_grant_tables = 'storage.objects,realtime.channels,realtime.messages,payments.stripe_checkout_sessions,payments.stripe_customer_portal_sessions,payments.razorpay_orders,payments.razorpay_subscriptions'
                     insforge.internal_schemas = 'ai,auth,compute,deployments,email,functions,memory,payments,realtime,schedules,storage,system'
                     cron.database_name = 'insforge'


### PR DESCRIPTION
> Stacked on #1872. Base retargets to `main` automatically when that merges.

`insforge.policy_grant_role` and `insforge.extension_grant_role` both already default to `project_admin` inside the extension (`insforge_pg_utils.c:74-84` and `:98-103`), so **behaviour is unchanged**. Pinned explicitly because:

- the default lives in a **compiled `.so`** — invisible to anyone reading this file. Cloud's conf declares `policy_grant_tables` but not `policy_grant_role`, which reads as "the role isn't configured"; I misread it exactly that way while tracing a bug.
- rebuilding the extension could shift permission behaviour with **no diff in any config repo**.

`extension_grant_role` was declared **nowhere** and matters more than it looks: the hook runs `CREATE/DROP EXTENSION` as the bootstrap superuser (`run_as_user(BOOTSTRAP_SUPERUSERID, …)`), a broader grant than the policy one.

Verified on `ghcr.io/insforge/postgres:v15.13.4`: both report `source=configuration file` with value `project_admin`, and the preload list is byte-identical to `origin/main`.

## pg_net dropped from this PR

An earlier revision also added `pg_net` to `shared_preload_libraries`, reasoning that cloud had it and self-hosted didn't. Dropped, because the asymmetry turned out to be meaningless:

Cloud has had `pg_net` preloaded since 2026-01-15 **with `pg_net.database_name` unset**. The worker serves one database and defaults to `postgres`, so `net.http_*` calls from `insforge` queue and are never processed — silently, since `CREATE EXTENSION` succeeds and `net.http_get()` returns a request id. Seven months, zero reports. There is no demand to serve, and preloading costs a permanent background worker per instance.

The cloud side is fixed separately in insforge-standalone#110 so the setting at least matches the preload; whether cloud should drop the preload too is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `insforge.extension_grant_role` explicitly to `project_admin` in PostgreSQL config
> Sets `insforge.extension_grant_role = 'project_admin'` in both [postgresql.conf](https://github.com/InsForge/InsForge/pull/1873/files#diff-febb45fc7d6c62444d3a5fea7ecd2fc96aef47c07cda6cbab104126eb6ce5660) and the [Zeabur template](https://github.com/InsForge/InsForge/pull/1873/files#diff-768619cd3302d77e6df6d9008a03f3775147bcdb0730c6f0726cb97b2c94a77f). This role already defaults to `project_admin` in `insforge_pg_utils`, but is now pinned explicitly for visibility and auditability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 610c472.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->