### PR TITLE
ci: SHA-pin tj-actions/changed-files in lint-and-format

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
         with:
           files: |
             **/*.{ts,tsx,js,jsx,mjs,cjs}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get changed files for Prettier
         id: changed-files-prettier
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
 
       - name: Check Prettier formatting on changed files
         if: steps.changed-files-prettier.outputs.any_changed == 'true'


### PR DESCRIPTION
## Summary

This PR SHA-pins both uses of `tj-actions/changed-files` in
`.github/workflows/lint-and-format.yml` to the commit currently referenced by
`v45`, while retaining the tag as a comment for readability.

This preserves existing behavior while following the repository's established
practice of pinning third-party GitHub Actions by commit SHA.

Closes #1867

## Changes

- SHA-pin both `tj-actions/changed-files` uses to:
  `48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c`
- Retain `# v45` comments for readability.
- No functional changes to the workflow.

## Testing

- Verified `v45` currently resolves to
  `48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c`.
- Workflow behavior is otherwise unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SHA-pins both uses of `tj-actions/changed-files` in `.github/workflows/lint-and-format.yml` to the commit currently referenced by `v45`, keeping the tag as a comment for clarity. No functional changes to the workflow.

<sup>Written for commit ff8ec062db65cd303d8bfd2b2fe77baff1af9c71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `tj-actions/changed-files` to a commit SHA in lint-and-format workflow
> Replaces the `v45` tag reference with the pinned commit SHA `48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c` (annotated `# v45`) in both the 'Get changed files' and 'Get changed files for Prettier' steps of [lint-and-format.yml](.github/workflows/lint-and-format.yml). SHA-pinning prevents supply chain attacks where a mutable tag could be silently updated to point to malicious code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff8ec06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability by pinning file-change detection steps to a specific version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->