### PR TITLE
fix(dashboard): react to PostHog feature flag updates

### DIFF
--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -16,7 +16,7 @@ import { isInsForgeCloudProject } from '#lib/utils/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@insforge/ui';
 import { ProjectSettingsMenuDialog } from '#features/dashboard/components';
 import { LanguageSelect } from '#components';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlagVariant } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { useTranslation } from 'react-i18next';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
@@ -34,8 +34,8 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
   const host = useDashboardHost();
   const { t } = useTranslation('chrome');
   const { mode: hostMode, onOpenWhatsNew } = host;
-  const isDTest =
-    getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT) === FEATURE_FLAG_VARIANTS.D_TEST;
+  const dashboardVariant = useFeatureFlagVariant(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;
   const isDTestCloud = isDTest && host.mode === 'cloud-hosting';
 
   // Cloud-only addition: Deployments inserted after AI.

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -1,5 +1,5 @@
 import posthog from 'posthog-js';
-import { PostHogProvider } from 'posthog-js/react';
+import { PostHogProvider, useFeatureFlagVariantKey } from 'posthog-js/react';
 
 const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY || '';
 
@@ -83,4 +83,8 @@ export const getFeatureFlag = (featureFlag: string): string | boolean | undefine
     return undefined;
   }
   return posthog.getFeatureFlag(featureFlag);
+};
+
+export const useFeatureFlagVariant = (featureFlag: string) => {
+  return useFeatureFlagVariantKey(featureFlag);
 };

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -63,11 +63,11 @@ import BucketsPage from '#features/storage/pages/BucketsPage';
 import VisualizerLayout from '#features/visualizer/components/VisualizerLayout';
 import VisualizerPage from '#features/visualizer/pages/VisualizerPage';
 import AppLayout from '#layout/AppLayout';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlagVariant } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 
 function AuthenticatedRoutes() {
-  const dashboardVariant = getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const dashboardVariant = useFeatureFlagVariant(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
   const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;
   const DashboardHomePage = isDTest ? DTestDashboardPage : DashboardPage;
 


### PR DESCRIPTION
## Summary

Replace synchronous PostHog feature flag reads with the reactive PostHog hook for the `D_TEST` experiment in dashboard routing and sidebar rendering.

Fixes #1881

## Problem

`AppRoutes` and `AppSidebar` currently call `getFeatureFlag()` during render.

Since `getFeatureFlag()` returns a snapshot and does not subscribe to feature flag updates, the dashboard can remain on the default experiment variant if PostHog finishes loading after the initial render.

## Solution

Expose a reactive feature flag hook through the analytics wrapper and use it in:

- `AppRoutes`
- `AppSidebar`

This allows React to re-render automatically when PostHog resolves feature flags.

## Testing

- Verified application builds successfully.
- Verified dashboard updates automatically after feature flags load without requiring a page refresh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the dashboard react to PostHog feature flag updates so the correct experiment variant renders without a refresh. Prevents staying on the default variant when flags load after initial render.

- **Bug Fixes**
  - Expose `useFeatureFlagVariant` via `#lib/analytics/posthog` using `useFeatureFlagVariantKey` from `posthog-js/react`.
  - Replace `getFeatureFlag` with the reactive hook in `AppRoutes` and `AppSidebar`.
  - Automatically switches `DASHBOARD_V4_EXPERIMENT` (`D_TEST`) variant when flags resolve.

<sup>Written for commit 89afbbd7f2407a7663f1f4928221e9625527f0bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PostHog feature flag reactivity in dashboard by replacing `getFeatureFlag` with a React hook
> Adds a `useFeatureFlagVariant` hook in [posthog.tsx](https://github.com/InsForge/InsForge/pull/1880/files#diff-58eca1014f0bbab046404c0df838c40c273859866b7c8996678b4460f7fe2a75) that wraps `useFeatureFlagVariantKey` from `posthog-js/react`. Replaces the static `getFeatureFlag` call with this hook in both [AppSidebar.tsx](https://github.com/InsForge/InsForge/pull/1880/files#diff-7919b594e83f183258ffa1550ae664977d3331f7c0dbe282f9f557055b7695d0) and [AppRoutes.tsx](https://github.com/InsForge/InsForge/pull/1880/files#diff-c22275f3f786ab893302862c0831269fc75644a99b6fbf59e3292d44e76e1433), so the `DASHBOARD_V4_EXPERIMENT` variant is read reactively and components re-render when PostHog updates the flag during a session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89afbbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard experiment variants and D-Test mode now update reactively when feature flag values change.
  * Improved consistency of feature flag behavior across dashboard navigation and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->