### PR TITLE
fix: return full type name for unrecognized SQL types

### DIFF
--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -74,7 +74,7 @@ export const convertSqlTypeToColumnType = (sqlType: string): ColumnType | string
     case 'character':
       return ColumnType.STRING;
     default:
-      return sqlType.slice(0, 8);
+      return sqlType;
   }
 };
 

--- a/backend/tests/unit/helpers.test.ts
+++ b/backend/tests/unit/helpers.test.ts
@@ -57,7 +57,10 @@ describe('convertSqlTypeToColumnType', () => {
     });
   });
 
-  it('returns first 8 chars for unknown types', () => {
-    expect(convertSqlTypeToColumnType('customtype')).toBe('customty');
+  it('returns full type name for unknown/extension types', () => {
+    expect(convertSqlTypeToColumnType('customtype')).toBe('customtype');
+    expect(convertSqlTypeToColumnType('geography')).toBe('geography');
+    expect(convertSqlTypeToColumnType('order_status')).toBe('order_status');
+    expect(convertSqlTypeToColumnType('vector')).toBe('vector');
   });
 });


### PR DESCRIPTION
Fixes #1882

`convertSqlTypeToColumnType` truncated unknown/extension type names to 8 characters, mangling USER-DEFINED types such as `geography` (→ `geograph`) and custom enums (→ `order_st`).

## Changes
- `backend/src/utils/utils.ts`: `default` case now returns the full `sqlType` instead of `sqlType.slice(0, 8)`, so extension types (pgvector, PostGIS, custom enums) surface intact in the table-schema API.
- `backend/tests/unit/helpers.test.ts`: updated test to assert full type names for unknown/extension types.

## Verification
- `cd backend && npm test` — 2208 passed
- `cd backend && npm run build` — success

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return full SQL type names for unrecognized/extension types in `convertSqlTypeToColumnType` to stop truncation (e.g., geography, `order_status`, `vector`) and ensure the table-schema API exposes exact types. Updated unit tests to assert full names for these cases.

<sup>Written for commit 7ac94d3fb29efcf9283194328efb782101af2216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `convertSqlTypeToColumnType` to return full type name for unrecognized SQL types
> Previously, unrecognized SQL types were truncated to 8 characters via `.slice(0, 8)`. The default branch in [utils.ts](https://github.com/InsForge/InsForge/pull/1884/files#diff-c5b576a597a1297a9da313313c48636e12029be9cb78607b394b05fe42af601e) now returns the full input string, so types like `geography`, `order_status`, or `vector` are preserved correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ac94d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of cloud-hosted and self-hosted deployments, including partner-managed hosting.
  - The dashboard now displays the appropriate experience based on the detected hosting environment.
  - Added reliable runtime handling for cloud project status.

- **Bug Fixes**
  - Preserved complete names for unknown SQL types, including custom types such as `geography`, `order_status`, and `vector`.
  - Improved handling of invalid or unavailable hosting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->