### PR TITLE
fix(dashboard): correct false-positive limited flag on CSV export

### DIFF
--- a/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
+++ b/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiClientMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  withAccessToken: vi.fn(() => ({ Authorization: 'Bearer token' })),
+}));
+
+const dataExportMock = vi.hoisted(() => ({
+  convertToCSV: vi.fn(),
+  getExportFilename: vi.fn((name: string) => `${name}.csv`),
+}));
+
+vi.mock('#lib/api/client', () => ({
+  apiClient: apiClientMock,
+}));
+
+vi.mock('#lib/utils/data-export', () => dataExportMock);
+
+import { recordService } from '#features/database/services/record.service';
+
+function makeRecords(count: number, startId: number) {
+  return Array.from({ length: count }, (_, i) => ({ id: startId + i }));
+}
+
+describe('recordService.exportTableAsCSV', () => {
+  beforeEach(() => {
+    apiClientMock.request.mockReset();
+    dataExportMock.convertToCSV.mockReset();
+  });
+
+  it('is not marked limited when the table has exactly MAX_EXPORT_ROWS rows', async () => {
+    // 10,000 rows fetched in pages of 500 (20 full pages, evenly divides the
+    // cap) with pagination.total reporting the true, non-truncated count.
+    let offset = 0;
+    apiClientMock.request.mockImplementation(() => {
+      const remaining = 10_000 - offset;
+      const pageSize = Math.min(500, remaining);
+      const data = pageSize > 0 ? makeRecords(pageSize, offset) : [];
+      offset += pageSize;
+      return Promise.resolve({ data, pagination: { offset, limit: 500, total: 10_000 } });
+    });
+
+    const result = await recordService.exportTableAsCSV('users', 'public');
+
+    expect(result.limited).toBe(false);
+    expect(dataExportMock.convertToCSV).toHaveBeenCalledTimes(1);
+    expect(dataExportMock.convertToCSV.mock.calls[0][0]).toHaveLength(10_000);
+  });
+
+  it('is marked limited when the table has more than MAX_EXPORT_ROWS rows, even on a page-aligned boundary', async () => {
+    // 10,500 rows: page size (500) divides the cap (10,000) evenly, so every
+    // fetched page is "full" right up to the cap. A page-size-based check
+    // would miss the truncation here; pagination.total should catch it.
+    let offset = 0;
+    apiClientMock.request.mockImplementation(() => {
+      const data = makeRecords(500, offset);
+      offset += 500;
+      return Promise.resolve({ data, pagination: { offset, limit: 500, total: 10_500 } });
+    });
+
+    const result = await recordService.exportTableAsCSV('users', 'public');
+
+    expect(result.limited).toBe(true);
+    expect(dataExportMock.convertToCSV.mock.calls[0][0]).toHaveLength(10_000);
+  });
+});

--- a/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
+++ b/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
@@ -22,6 +22,13 @@ function makeRecords(count: number, startId: number) {
   return Array.from({ length: count }, (_, i) => ({ id: startId + i }));
 }
 
+// Derive the requested offset from the actual URL passed to apiClient.request,
+// rather than trusting a closure counter, so the mock reflects real request behavior.
+function offsetFromRequestUrl(url: string): number {
+  const query = url.split('?')[1] ?? '';
+  return Number(new URLSearchParams(query).get('offset') ?? '0');
+}
+
 describe('recordService.exportTableAsCSV', () => {
   beforeEach(() => {
     apiClientMock.request.mockReset();
@@ -31,13 +38,15 @@ describe('recordService.exportTableAsCSV', () => {
   it('is not marked limited when the table has exactly MAX_EXPORT_ROWS rows', async () => {
     // 10,000 rows fetched in pages of 500 (20 full pages, evenly divides the
     // cap) with pagination.total reporting the true, non-truncated count.
-    let offset = 0;
-    apiClientMock.request.mockImplementation(() => {
+    apiClientMock.request.mockImplementation((url: string) => {
+      const offset = offsetFromRequestUrl(url);
       const remaining = 10_000 - offset;
       const pageSize = Math.min(500, remaining);
       const data = pageSize > 0 ? makeRecords(pageSize, offset) : [];
-      offset += pageSize;
-      return Promise.resolve({ data, pagination: { offset, limit: 500, total: 10_000 } });
+      return Promise.resolve({
+        data,
+        pagination: { offset: offset + pageSize, limit: 500, total: 10_000 },
+      });
     });
 
     const result = await recordService.exportTableAsCSV('users', 'public');
@@ -45,22 +54,34 @@ describe('recordService.exportTableAsCSV', () => {
     expect(result.limited).toBe(false);
     expect(dataExportMock.convertToCSV).toHaveBeenCalledTimes(1);
     expect(dataExportMock.convertToCSV.mock.calls[0][0]).toHaveLength(10_000);
+
+    const requestedOffsets = apiClientMock.request.mock.calls.map(([url]) =>
+      offsetFromRequestUrl(url as string)
+    );
+    expect(requestedOffsets).toEqual(Array.from({ length: 20 }, (_, i) => i * 500));
   });
 
   it('is marked limited when the table has more than MAX_EXPORT_ROWS rows, even on a page-aligned boundary', async () => {
     // 10,500 rows: page size (500) divides the cap (10,000) evenly, so every
     // fetched page is "full" right up to the cap. A page-size-based check
     // would miss the truncation here; pagination.total should catch it.
-    let offset = 0;
-    apiClientMock.request.mockImplementation(() => {
+    apiClientMock.request.mockImplementation((url: string) => {
+      const offset = offsetFromRequestUrl(url);
       const data = makeRecords(500, offset);
-      offset += 500;
-      return Promise.resolve({ data, pagination: { offset, limit: 500, total: 10_500 } });
+      return Promise.resolve({
+        data,
+        pagination: { offset: offset + 500, limit: 500, total: 10_500 },
+      });
     });
 
     const result = await recordService.exportTableAsCSV('users', 'public');
 
     expect(result.limited).toBe(true);
     expect(dataExportMock.convertToCSV.mock.calls[0][0]).toHaveLength(10_000);
+
+    const requestedOffsets = apiClientMock.request.mock.calls.map(([url]) =>
+      offsetFromRequestUrl(url as string)
+    );
+    expect(requestedOffsets).toEqual(Array.from({ length: 20 }, (_, i) => i * 500));
   });
 });

--- a/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
+++ b/packages/dashboard/src/features/database/services/__tests__/record.service.test.ts
@@ -84,4 +84,22 @@ describe('recordService.exportTableAsCSV', () => {
     );
     expect(requestedOffsets).toEqual(Array.from({ length: 20 }, (_, i) => i * 500));
   });
+
+  it('conservatively flags limited when hitting the cap without pagination.total', async () => {
+    // If the backend response is ever missing an exact total, we can't tell
+    // whether the export was actually truncated. Fail safe: assume it was,
+    // so the user isn't silently handed a partial export with no warning.
+    apiClientMock.request.mockImplementation((url: string) => {
+      const offset = offsetFromRequestUrl(url);
+      const data = makeRecords(500, offset);
+      return Promise.resolve({ data, pagination: { offset: offset + 500, limit: 500 } });
+    });
+
+    const result = await recordService.exportTableAsCSV('users', 'public');
+
+    expect(result.limited).toBe(true);
+    expect(dataExportMock.convertToCSV.mock.calls[0][0]).toHaveLength(10_000);
+    // Still stops fetching once the cap is reached, even without a total to compare against.
+    expect(apiClientMock.request).toHaveBeenCalledTimes(20);
+  });
 });

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -290,7 +290,12 @@ export class RecordService {
     let isLimited = false;
 
     while (allRecords.length < MAX_EXPORT_ROWS) {
-      const { records } = await this.getTableRecords(tableName, schemaName, limit, offset);
+      const { records, pagination } = await this.getTableRecords(
+        tableName,
+        schemaName,
+        limit,
+        offset
+      );
 
       if (records.length === 0) {
         break;
@@ -300,9 +305,20 @@ export class RecordService {
       const remaining = MAX_EXPORT_ROWS - allRecords.length;
       allRecords.push(...records.slice(0, remaining));
 
-      // Check if we've hit the limit or exhausted records
-      if (allRecords.length >= MAX_EXPORT_ROWS) {
-        isLimited = true;
+      // The API returns an exact total count (Prefer: count=exact), so use it
+      // directly rather than inferring truncation from page sizes. Inferring
+      // from `records.length` alone is wrong whenever the true row count is
+      // an exact multiple of the page size or lands exactly on MAX_EXPORT_ROWS:
+      // in both cases every fetched page is "full" even though nothing (or
+      // everything) was actually cut off.
+      if (typeof pagination?.total === 'number') {
+        isLimited = pagination.total > MAX_EXPORT_ROWS;
+        if (allRecords.length >= MAX_EXPORT_ROWS || allRecords.length >= pagination.total) {
+          break;
+        }
+      } else if (allRecords.length >= MAX_EXPORT_ROWS) {
+        // Fallback if the backend ever omits pagination.total: we can't tell
+        // whether the exact cap was a coincidence, so don't claim truncation.
         break;
       }
 

--- a/packages/dashboard/src/features/database/services/record.service.ts
+++ b/packages/dashboard/src/features/database/services/record.service.ts
@@ -318,7 +318,10 @@ export class RecordService {
         }
       } else if (allRecords.length >= MAX_EXPORT_ROWS) {
         // Fallback if the backend ever omits pagination.total: we can't tell
-        // whether the exact cap was a coincidence, so don't claim truncation.
+        // whether the exact cap was a coincidence, so assume the conservative
+        // (pre-fix) behavior and flag as limited rather than risk silently
+        // truncating an export with no warning shown to the user.
+        isLimited = true;
         break;
       }
 


### PR DESCRIPTION
Fixes a false-positive in the "Export limited to 10,000 rows" warning shown after exporting a table to CSV.

## Bug

`exportTableAsCSV` (`packages/dashboard/src/features/database/services/record.service.ts`) decides whether the export was truncated purely from `allRecords.length` hitting `MAX_EXPORT_ROWS` (10,000), regardless of whether the table actually has more rows than that:

- **Exact-cap case**: a table with exactly 10,000 rows gets `isLimited = true` even though every row was exported. Users see "Your table contains more data" for a complete export.
- **Page-aligned overflow case**: since the page size (500) evenly divides the cap, a table with e.g. 10,500 rows fills every fetched page right up to 10,000. The old page-fill heuristic could not distinguish "exactly 10,000 rows" from "more than 10,000, page-aligned"; both looked identical from page-size alone.

## Fix

The backend already returns an exact row count via `Prefer: count=exact` (`pagination.total`). Use that directly to decide `isLimited` instead of inferring it from page fill state:

```ts
if (typeof pagination?.total === 'number') {
  isLimited = pagination.total > MAX_EXPORT_ROWS;
  ...
}
```

Falls back to the old page-size heuristic if `pagination.total` is ever missing, conservatively flagging as limited when the cap is hit so behavior degrades safely rather than silently truncating with no warning.

## Tests

Added `packages/dashboard/src/features/database/services/__tests__/record.service.test.ts` covering three cases:
- exactly `MAX_EXPORT_ROWS` rows: `limited: false`
- more than `MAX_EXPORT_ROWS` rows on a page-aligned boundary: `limited: true`
- `pagination.total` absent while hitting the cap: `limited: true` (conservative fallback)

## Verification
- `npx vitest run` (dashboard package): 53 files / 215 tests passed
- `npx tsc --noEmit` (dashboard package): clean
- `npx eslint` on changed files: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the false “Export limited to 10,000 rows” warning on CSV exports by using the backend’s exact row count to determine truncation. Tables with exactly 10,000 rows no longer show the warning; truly over-limit tables still do.

- **Bug Fixes**
  - Use `pagination.total` (exact count) to set `limited`; remove page-fill inference.
  - Add a conservative fallback when the total is missing: stop at the cap and set `limited: true` to avoid silent truncation.
  - Tests cover exact-cap, over-cap, and missing-total cases, and assert real pagination offsets (0…9500) and early stop at the cap.

<sup>Written for commit 24bc51e0238a825403adc48d021b2cc5865fb495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix false-positive `limited` flag in `RecordService.exportTableAsCSV` CSV export
> Previously, `exportTableAsCSV` set `isLimited` whenever `allRecords.length >= MAX_EXPORT_ROWS` (10,000), which incorrectly flagged exports as truncated when the true record count exactly equaled the cap or was a page-size multiple of it.
>
> - When `pagination.total` is available, `isLimited` is now set to `pagination.total > MAX_EXPORT_ROWS` and fetching stops once either the cap or the exact total is reached.
> - When `pagination.total` is absent and the cap is hit, `isLimited` conservatively falls back to `true`.
> - Adds a Vitest suite in [record.service.test.ts](https://github.com/InsForge/InsForge/pull/1885/files#diff-d7425cdf6c00bf6baa78e969ec0dbaf4d26056593a4c7eaf6c340fa8a62e6fe8) covering exact-cap, over-cap, and no-total scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24bc51e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV table exports to accurately indicate when results are truncated.
  * Prevented false “limited” indicators when exports contain exactly the maximum allowed rows or align with page boundaries.
  * Improved handling when total record counts are unavailable.

* **Tests**
  * Added coverage for export limits, pagination boundaries, and exact row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Closes #1886
