### PR TITLE
fix(dashboard): update UI when PostHog feature flags finish loading

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/dtest/ClientDetailPage.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/ClientDetailPage.tsx
@@ -21,7 +21,7 @@ import {
   useDatabasePassword,
 } from '#lib/hooks/useMetadata';
 import { getBackendUrl } from '#lib/utils/utils';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS } from '#lib/analytics/constants';
 
 interface ClientDetailPageProps {
@@ -36,7 +36,7 @@ export function ClientDetailPage({ clientId, onBack }: ClientDetailPageProps) {
     ? t(CLIENT_LABEL_I18N_KEYS[clientId] as string, { defaultValue: entry.label })
     : entry.label;
   const declaredTabs = entry.tabs ?? DEFAULT_AGENT_TABS;
-  const mcpVsCliVariant = getFeatureFlag(FEATURE_FLAGS.MCP_VS_CLI);
+  const mcpVsCliVariant = useFeatureFlag(FEATURE_FLAGS.MCP_VS_CLI);
   const variantAllowed: ReadonlyArray<AgentTab> =
     mcpVsCliVariant === 'mcp' ? ['mcp'] : mcpVsCliVariant === 'cli' ? ['cli'] : declaredTabs;
   const filteredTabs = declaredTabs.filter((t) => variantAllowed.includes(t));

--- a/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectTip.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/DTestConnectTip.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { X } from 'lucide-react';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { useProjectId } from '#lib/hooks/useMetadata';
 import { useDashboardHost, useDashboardProject } from '#lib/config/DashboardHostContext';
@@ -31,7 +31,7 @@ function writeConnectTipDismissed(key: string): void {
 // AppHeader) because cloud-hosting hides our AppHeader via showNavbar=false.
 export function DTestConnectTip() {
   const { t } = useTranslation('chrome');
-  const dashboardVariant = getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
   const { pathname } = useLocation();
   const isOnInstallPage = pathname === '/dashboard/install';
   // Prefer the host-injected project id (synchronous) so the dismissal state

--- a/packages/dashboard/src/features/dashboard/components/dtest/InstallInsForgePage.tsx
+++ b/packages/dashboard/src/features/dashboard/components/dtest/InstallInsForgePage.tsx
@@ -10,7 +10,7 @@ import {
   DIRECT_CONNECT_IDS,
   type ClientId,
 } from './clientRegistry';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS } from '#lib/analytics/constants';
 
 interface InstallInsForgePageProps {
@@ -20,7 +20,7 @@ interface InstallInsForgePageProps {
 
 export function InstallInsForgePage({ onSelectClient, onDismiss }: InstallInsForgePageProps) {
   const { t } = useTranslation('chrome');
-  const mcpVsCliVariant = getFeatureFlag(FEATURE_FLAGS.MCP_VS_CLI);
+  const mcpVsCliVariant = useFeatureFlag(FEATURE_FLAGS.MCP_VS_CLI);
   const gridEntries = CODING_AGENT_GRID_IDS.map((id) => CLIENT_ENTRIES[id]).filter((entry) => {
     const tabs = entry.tabs ?? DEFAULT_AGENT_TABS;
     if (mcpVsCliVariant === 'mcp') {

--- a/packages/dashboard/src/features/login/pages/CloudLoginPage.tsx
+++ b/packages/dashboard/src/features/login/pages/CloudLoginPage.tsx
@@ -5,7 +5,7 @@ import { Lock } from 'lucide-react';
 import { Button } from '@insforge/ui';
 import { useDashboardHost, useDashboardProject } from '#lib/config/DashboardHostContext';
 import { useAuth } from '#lib/contexts/AuthContext';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { useMcpUsage } from '#features/logs/hooks/useMcpUsage';
 
@@ -18,8 +18,8 @@ export default function CloudLoginPage() {
   const { hasCompletedOnboarding, isLoading: isMcpUsageLoading } = useMcpUsage();
   const hasRequestedAuthRef = useRef(false);
   const isCloudHosting = host.mode === 'cloud-hosting';
-  const isDTest =
-    getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT) === FEATURE_FLAG_VARIANTS.D_TEST;
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;
   const isBranch = project?.isBranch === true;
 
   useEffect(() => {

--- a/packages/dashboard/src/layout/AppHeader.tsx
+++ b/packages/dashboard/src/layout/AppHeader.tsx
@@ -14,7 +14,7 @@ import { useTheme } from '#lib/contexts/ThemeContext';
 import { useAuth } from '#lib/contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
 import { useOpenConnectDialog } from './ConnectDialogContext';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { githubService } from '#features/dashboard/services/github.service';
 
@@ -29,7 +29,7 @@ export default function AppHeader() {
   const { resolvedTheme } = useTheme();
   const { logout } = useAuth();
   const openConnectDialog = useOpenConnectDialog();
-  const dashboardVariant = getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;

--- a/packages/dashboard/src/layout/AppLayout.tsx
+++ b/packages/dashboard/src/layout/AppLayout.tsx
@@ -8,7 +8,7 @@ import { ConnectDialog } from '#features/dashboard/components/connect';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
 import { cn } from '@insforge/ui';
 import { ConnectDialogProvider } from './ConnectDialogContext';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { DTestConnectTip } from '#features/dashboard/components/dtest/DTestConnectTip';
 
@@ -21,6 +21,7 @@ interface ConnectOverlayBridgeProps {
 
 function ConnectOverlayBridge({ hostMode, onOpenDialog }: ConnectOverlayBridgeProps) {
   const navigate = useNavigate();
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
 
   useEffect(() => {
     if (hostMode !== 'cloud-hosting') {
@@ -42,7 +43,7 @@ function ConnectOverlayBridge({ hostMode, onOpenDialog }: ConnectOverlayBridgePr
         return;
       }
 
-      if (getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT) === FEATURE_FLAG_VARIANTS.D_TEST) {
+      if (dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST) {
         void navigate('/dashboard/install');
       } else {
         onOpenDialog();
@@ -51,7 +52,7 @@ function ConnectOverlayBridge({ hostMode, onOpenDialog }: ConnectOverlayBridgePr
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [hostMode, navigate, onOpenDialog]);
+  }, [hostMode, navigate, onOpenDialog, dashboardVariant]);
 
   return null;
 }

--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -16,7 +16,7 @@ import { isInsForgeCloudProject } from '#lib/utils/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@insforge/ui';
 import { ProjectSettingsMenuDialog } from '#features/dashboard/components';
 import { LanguageSelect } from '#components';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 import { useTranslation } from 'react-i18next';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
@@ -34,8 +34,8 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
   const host = useDashboardHost();
   const { t } = useTranslation('chrome');
   const { mode: hostMode, onOpenWhatsNew } = host;
-  const isDTest =
-    getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT) === FEATURE_FLAG_VARIANTS.D_TEST;
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;
   const isDTestCloud = isDTest && host.mode === 'cloud-hosting';
 
   // Cloud-only addition: Deployments inserted after AI.

--- a/packages/dashboard/src/lib/analytics/__tests__/posthog.test.tsx
+++ b/packages/dashboard/src/lib/analytics/__tests__/posthog.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import posthog from 'posthog-js';
+import { useFeatureFlag, getFeatureFlag } from '#lib/analytics/posthog';
+
+vi.mock('posthog-js', () => {
+  let flagCallback: (() => void) | null = null;
+  let currentFlags: Record<string, string | boolean> = {};
+
+  return {
+    default: {
+      init: vi.fn(),
+      getFeatureFlag: vi.fn((key: string) => currentFlags[key]),
+      onFeatureFlags: vi.fn((cb: () => void) => {
+        flagCallback = cb;
+        return () => {
+          flagCallback = null;
+        };
+      }),
+      __triggerFeatureFlagsLoaded: (newFlags: Record<string, string | boolean>) => {
+        currentFlags = { ...currentFlags, ...newFlags };
+        if (flagCallback) {
+          flagCallback();
+        }
+      },
+      __reset: () => {
+        flagCallback = null;
+        currentFlags = {};
+      },
+    },
+  };
+});
+
+describe('useFeatureFlag', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+    // @ts-expect-error test mock helper
+    posthog.__reset();
+    vi.clearAllMocks();
+  });
+
+  it('updates state and re-renders when PostHog finishes loading feature flags', () => {
+    const FLAG_NAME = 'dashboard-v4-experiment';
+
+    // 1. Initial render before PostHog loads flags -> returns undefined
+    const { result } = renderHook(() => useFeatureFlag(FLAG_NAME));
+    expect(result.current).toBeUndefined();
+
+    // 2. Simulate PostHog finishing loading feature flags via network call (/decide)
+    act(() => {
+      // @ts-expect-error test mock helper
+      posthog.__triggerFeatureFlagsLoaded({ [FLAG_NAME]: 'd_test' });
+    });
+
+    // 3. Hook updates state and re-renders with 'd_test'
+    expect(result.current).toBe('d_test');
+  });
+
+  it('unsubscribes from PostHog feature flag callback on unmount', () => {
+    const FLAG_NAME = 'dashboard-v4-experiment';
+    const { unmount } = renderHook(() => useFeatureFlag(FLAG_NAME));
+
+    expect(posthog.onFeatureFlags).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/packages/dashboard/src/lib/analytics/posthog.tsx
+++ b/packages/dashboard/src/lib/analytics/posthog.tsx
@@ -1,11 +1,12 @@
+import { useState, useEffect } from 'react';
 import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react';
 
-const POSTHOG_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY || '';
+const getPostHogKey = (): string => import.meta.env.VITE_PUBLIC_POSTHOG_KEY || '';
 
-if (POSTHOG_KEY) {
+if (getPostHogKey()) {
   try {
-    posthog.init(POSTHOG_KEY, {
+    posthog.init(getPostHogKey(), {
       api_host: 'https://us.i.posthog.com',
       capture_exceptions: true,
       debug: import.meta.env.DEV,
@@ -19,7 +20,7 @@ if (POSTHOG_KEY) {
 }
 
 export const PostHogAnalyticsProvider = ({ children }: { children: React.ReactNode }) => {
-  if (POSTHOG_KEY) {
+  if (getPostHogKey()) {
     return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
   }
   return <>{children}</>;
@@ -29,7 +30,7 @@ export const identifyUser = (
   userId: string,
   properties?: Record<string, unknown>
 ): Promise<void> => {
-  if (!POSTHOG_KEY) {
+  if (!getPostHogKey()) {
     return Promise.resolve();
   }
 
@@ -65,22 +66,49 @@ export const identifyUser = (
 };
 
 export const getCurrentDistinctId = (): string | undefined => {
-  if (!POSTHOG_KEY) {
+  if (!getPostHogKey()) {
     return undefined;
   }
   return posthog.get_distinct_id();
 };
 
 export const trackEvent = (eventName: string, properties?: Record<string, unknown>) => {
-  if (!POSTHOG_KEY) {
+  if (!getPostHogKey()) {
     return;
   }
   posthog.capture(eventName, properties);
 };
 
 export const getFeatureFlag = (featureFlag: string): string | boolean | undefined => {
-  if (!POSTHOG_KEY) {
+  if (!getPostHogKey()) {
     return undefined;
   }
   return posthog.getFeatureFlag(featureFlag);
 };
+
+export const useFeatureFlag = (featureFlag: string): string | boolean | undefined => {
+  const [flagValue, setFlagValue] = useState<string | boolean | undefined>(() =>
+    getFeatureFlag(featureFlag)
+  );
+
+  useEffect(() => {
+    if (!getPostHogKey()) {
+      return;
+    }
+
+    setFlagValue(getFeatureFlag(featureFlag));
+
+    const unsubscribe = posthog.onFeatureFlags(() => {
+      setFlagValue(getFeatureFlag(featureFlag));
+    });
+
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [featureFlag]);
+
+  return flagValue;
+};
+

--- a/packages/dashboard/src/router/AppRoutes.tsx
+++ b/packages/dashboard/src/router/AppRoutes.tsx
@@ -63,11 +63,11 @@ import BucketsPage from '#features/storage/pages/BucketsPage';
 import VisualizerLayout from '#features/visualizer/components/VisualizerLayout';
 import VisualizerPage from '#features/visualizer/pages/VisualizerPage';
 import AppLayout from '#layout/AppLayout';
-import { getFeatureFlag } from '#lib/analytics/posthog';
+import { useFeatureFlag } from '#lib/analytics/posthog';
 import { FEATURE_FLAGS, FEATURE_FLAG_VARIANTS } from '#lib/analytics/constants';
 
 function AuthenticatedRoutes() {
-  const dashboardVariant = getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
+  const dashboardVariant = useFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT);
   const isDTest = dashboardVariant === FEATURE_FLAG_VARIANTS.D_TEST;
   const DashboardHomePage = isDTest ? DTestDashboardPage : DashboardPage;
 


### PR DESCRIPTION
**What changed**
Components reading feature flags directly via \getFeatureFlag(...)\ were not updating when PostHog finished loading feature flags asynchronously.

**Root cause**
\getFeatureFlag\ was a plain non-reactive getter returning \posthog.getFeatureFlag(key)\. When PostHog initialized and finished fetching \/decide\ or feature flags asynchronously in the background, PostHog fired \onFeatureFlags\ listeners, but React components had no reactive subscription to re-render. Consequently, \isDTest\ and other flag variants remained stuck on \undefined\ (or initial state) until an unrelated state change forced a re-render.

**Fix**
- Introduced a reactive \useFeatureFlag(featureFlag: string)\ hook in \posthog.tsx\ that subscribes to \posthog.onFeatureFlags(...)\ and updates component state when flags load/change.
- Updated \AppRoutes\, \AppSidebar\, \AppHeader\, \AppLayout\, \CloudLoginPage\, \DTestConnectTip\, \ClientDetailPage\, and \InstallInsForgePage\ to use \useFeatureFlag\.
- Added unit tests in \posthog.test.tsx\ verifying that \useFeatureFlag\ initial render returns \undefined\ and updates reactively when PostHog flags finish loading.

Closes #1881

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make feature-flag reads reactive so the UI updates when PostHog finishes loading flags. Fixes DTest routing and MCP vs CLI UI staying undefined. Closes #1881.

- **Bug Fixes**
  - Added `useFeatureFlag(featureFlag)` hook that subscribes to `posthog.onFeatureFlags` and updates state when flags load/change.
  - Replaced `getFeatureFlag` in `AppRoutes`, `AppSidebar`, `AppHeader`, `AppLayout`, `CloudLoginPage`, `DTestConnectTip`, `ClientDetailPage`, and `InstallInsForgePage`.
  - Added unit tests for the hook using mocked `posthog-js` to verify initial undefined, reactive updates, and unsubscribe on unmount.
  - Hardened PostHog setup by centralizing key access via `getPostHogKey()` across helpers.

<sup>Written for commit e1a0bc5d2fdf251e9eca05a926035728de900f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dashboard UI to react to PostHog feature flags after they finish loading
> - Introduces a new `useFeatureFlag` hook in [`posthog.tsx`](https://github.com/InsForge/InsForge/pull/1888/files#diff-58eca1014f0bbab046404c0df838c40c273859866b7c8996678b4460f7fe2a75) that subscribes to `posthog.onFeatureFlags` and triggers re-renders when flag values resolve or change, replacing the one-shot `getFeatureFlag` accessor.
> - Updates components across the dashboard (tabs, sidebar, header, login page, routing) to use `useFeatureFlag` so flag-gated UI reflects the current flag state rather than a snapshot taken at initial render.
> - Behavioral Change: Components now re-render whenever PostHog flags load or change at runtime; previously they were fixed to whatever value was available synchronously at mount.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1a0bc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature-flag changes now update dashboard content and navigation reactively without requiring a refresh.
  * Dashboard experiment routing responds automatically when flag values load or change.
* **Bug Fixes**
  * Improved routing for D-test experiences, including navigation to the installation page.
  * Added safer handling when feature flags are temporarily unavailable.
* **Tests**
  * Added coverage for feature-flag loading, updates, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->