### PR TITLE
feat(ai): add an Embeddings mode to the AI Quick Start

### DIFF
--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockFetch } = vi.hoisted(() => ({
   mockFetch: vi.fn(),
@@ -12,6 +12,13 @@ describe('AIModelService', () => {
   beforeEach(() => {
     mockFetch.mockReset();
     _resetCacheForTesting();
+  });
+
+  // Guarded here rather than at the end of an individual test: if an assertion
+  // throws before the restore, fake timers would leak into every later test in
+  // the same worker.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('fetches the public OpenRouter catalog with all output modalities and caches it', async () => {
@@ -110,6 +117,66 @@ describe('AIModelService', () => {
         outputPriceLabel: undefined,
       },
     ]);
+  });
+
+  it('includes embedding-only models with correct pricing', async () => {
+    // Advance time past the 1-hour cache TTL so the stale cache from prior tests is bypassed
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(61 * 60 * 1000);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'openai/text-embedding-3-small',
+              created: 1767225600,
+              architecture: {
+                input_modalities: ['text'],
+                output_modalities: ['embeddings'],
+              },
+              pricing: {
+                prompt: '0.00000002',
+                completion: '0',
+              },
+            },
+            {
+              id: 'google/gemini-embedding-2-preview',
+              created: 1777248000,
+              architecture: {
+                input_modalities: ['text', 'image', 'file', 'audio', 'video'],
+                output_modalities: ['embeddings'],
+              },
+              pricing: {
+                prompt: '0.0000002',
+                completion: '0',
+              },
+            },
+          ],
+        }),
+    });
+
+    const models = await AIModelService.getModels();
+
+    // Both embedding models should be included (not filtered out)
+    expect(models).toHaveLength(2);
+
+    // Embedding-only model: input has text so inputPrice is set, output is embeddings so no outputPrice
+    const smallModel = models.find((m) => m.id === 'openai/text-embedding-3-small');
+    expect(smallModel).toBeDefined();
+    expect(smallModel!.inputModality).toEqual(['text']);
+    expect(smallModel!.outputModality).toEqual(['embeddings']);
+    expect(smallModel!.inputPrice).toBeGreaterThanOrEqual(0);
+    expect(smallModel!.outputPrice).toBeUndefined();
+    expect(smallModel!.outputPriceLabel).toBeUndefined();
+
+    // Multimodal embedding model: input has text (among others) so inputPrice is set
+    const geminiModel = models.find((m) => m.id === 'google/gemini-embedding-2-preview');
+    expect(geminiModel).toBeDefined();
+    expect(geminiModel!.inputModality).toContain('text');
+    expect(geminiModel!.outputModality).toEqual(['embeddings']);
+    expect(geminiModel!.inputPrice).toBeGreaterThanOrEqual(0);
   });
 
   it('clears in-flight state after a failed fetch so a later call retries', async () => {

--- a/backend/tests/unit/ai-model.service.test.ts
+++ b/backend/tests/unit/ai-model.service.test.ts
@@ -14,9 +14,9 @@ describe('AIModelService', () => {
     _resetCacheForTesting();
   });
 
-  // Guarded here rather than at the end of an individual test: if an assertion
-  // throws before the restore, fake timers would leak into every later test in
-  // the same worker.
+  // Suite-level safety net: a test that reaches for fake timers and throws
+  // mid-assertion would otherwise leak them into every later test in the same
+  // worker.
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -120,10 +120,6 @@ describe('AIModelService', () => {
   });
 
   it('includes embedding-only models with correct pricing', async () => {
-    // Advance time past the 1-hour cache TTL so the stale cache from prior tests is bypassed
-    vi.useFakeTimers();
-    vi.advanceTimersByTime(61 * 60 * 1000);
-
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
@@ -163,20 +159,20 @@ describe('AIModelService', () => {
     expect(models).toHaveLength(2);
 
     // Embedding-only model: input has text so inputPrice is set, output is embeddings so no outputPrice
-    const smallModel = models.find((m) => m.id === 'openai/text-embedding-3-small');
+    const smallModel = models.find((model) => model.id === 'openai/text-embedding-3-small');
     expect(smallModel).toBeDefined();
     expect(smallModel!.inputModality).toEqual(['text']);
     expect(smallModel!.outputModality).toEqual(['embeddings']);
-    expect(smallModel!.inputPrice).toBeGreaterThanOrEqual(0);
+    expect(smallModel!.inputPrice).toBeGreaterThan(0);
     expect(smallModel!.outputPrice).toBeUndefined();
     expect(smallModel!.outputPriceLabel).toBeUndefined();
 
     // Multimodal embedding model: input has text (among others) so inputPrice is set
-    const geminiModel = models.find((m) => m.id === 'google/gemini-embedding-2-preview');
+    const geminiModel = models.find((model) => model.id === 'google/gemini-embedding-2-preview');
     expect(geminiModel).toBeDefined();
     expect(geminiModel!.inputModality).toContain('text');
     expect(geminiModel!.outputModality).toEqual(['embeddings']);
-    expect(geminiModel!.inputPrice).toBeGreaterThanOrEqual(0);
+    expect(geminiModel!.inputPrice).toBeGreaterThan(0);
   });
 
   it('clears in-flight state after a failed fetch so a later call retries', async () => {

--- a/packages/dashboard/src/features/ai/__tests__/constants.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/constants.test.ts
@@ -10,10 +10,10 @@ import {
 
 describe('AI Quick Start constants', () => {
   it('includes embeddings in QUICK_START_MODES', () => {
-    const modeValues = QUICK_START_MODES.map((m) => m.value);
+    const modeValues = QUICK_START_MODES.map((mode) => mode.value);
     expect(modeValues).toContain('embeddings');
 
-    const embeddingsMode = QUICK_START_MODES.find((m) => m.value === 'embeddings');
+    const embeddingsMode = QUICK_START_MODES.find((mode) => mode.value === 'embeddings');
     expect(embeddingsMode?.label).toBe('Embeddings');
   });
 

--- a/packages/dashboard/src/features/ai/__tests__/constants.test.ts
+++ b/packages/dashboard/src/features/ai/__tests__/constants.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  QUICK_START_MODES,
+  PROMPT_CARD_COPY,
+  QUICK_START_COPY,
+  getQuickStartScript,
+  getQuickStartPrompt,
+  type QuickStartMode,
+} from '#features/ai/constants';
+
+describe('AI Quick Start constants', () => {
+  it('includes embeddings in QUICK_START_MODES', () => {
+    const modeValues = QUICK_START_MODES.map((m) => m.value);
+    expect(modeValues).toContain('embeddings');
+
+    const embeddingsMode = QUICK_START_MODES.find((m) => m.value === 'embeddings');
+    expect(embeddingsMode?.label).toBe('Embeddings');
+  });
+
+  it('has PROMPT_CARD_COPY for embeddings', () => {
+    expect(PROMPT_CARD_COPY.embeddings).toBeDefined();
+    expect(PROMPT_CARD_COPY.embeddings).toContain('embeddings');
+  });
+
+  it('has QUICK_START_COPY for embeddings with expected fields', () => {
+    const copy = QUICK_START_COPY.embeddings;
+    expect(copy).toBeDefined();
+    expect(copy.projectName).toBe('ai-embeddings-demo');
+    expect(copy.model).toContain('embedding');
+    expect(copy.installCommand).toContain('openai');
+  });
+
+  it('getQuickStartScript generates embeddings.create code for embeddings mode', () => {
+    const script = getQuickStartScript('embeddings', 'openai/text-embedding-3-small');
+    expect(script).toContain('openai.embeddings.create');
+    expect(script).toContain('openai/text-embedding-3-small');
+    expect(script).not.toContain('chat.completions');
+  });
+
+  it('getQuickStartScript generates chat.completions code for text mode', () => {
+    const script = getQuickStartScript('text', 'openai/gpt-5.5');
+    expect(script).toContain('chat.completions.create');
+    expect(script).not.toContain('embeddings.create');
+  });
+
+  it('getQuickStartPrompt names the same SDK instance as the generated script', () => {
+    const prompt = getQuickStartPrompt('embeddings');
+    expect(prompt).toContain('embedding');
+    expect(prompt).toContain('openai.embeddings.create');
+    expect(prompt).toContain('OPENROUTER_API_KEY');
+    // The generated script instantiates the SDK as `openai`, so the prompt must
+    // not tell the agent to call `client.embeddings.create()`.
+    expect(prompt).not.toContain('client.embeddings.create');
+  });
+
+  it('all modes have consistent QUICK_START_COPY entries', () => {
+    const modes: QuickStartMode[] = ['text', 'image', 'video', 'embeddings'];
+    for (const mode of modes) {
+      const copy = QUICK_START_COPY[mode];
+      expect(copy.projectName).toBeTruthy();
+      expect(copy.description).toBeTruthy();
+      expect(copy.model).toBeTruthy();
+      expect(copy.installCommand).toBeTruthy();
+    }
+  });
+});

--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -3,7 +3,7 @@ import ClaudeIcon from '#assets/logos/claude_code.svg?react';
 import GeminiIcon from '#assets/logos/gemini.svg?react';
 
 export type CodeTab = 'sdk' | 'python' | 'http';
-export type QuickStartMode = 'text' | 'image' | 'video';
+export type QuickStartMode = 'text' | 'image' | 'video' | 'embeddings';
 export type ModelModalityFilter = string;
 
 export function getOverviewCodeSnippets(modelId: string): Record<CodeTab, string> {
@@ -82,19 +82,22 @@ export const MODEL_MODALITY_FILTERS: { id: ModelModalityFilter; label: string }[
   { id: 'image', label: 'Image' },
   { id: 'audio', label: 'Audio' },
   { id: 'video', label: 'Video' },
-  { id: 'embeddings', label: 'Embed' },
+  { id: 'embeddings', label: 'Embeddings' },
 ];
 
 export const QUICK_START_MODES: { value: QuickStartMode; label: string }[] = [
   { value: 'text', label: 'Text Generation' },
   { value: 'image', label: 'Image Generation' },
   { value: 'video', label: 'Video Generation' },
+  { value: 'embeddings', label: 'Embeddings' },
 ];
 
 export const PROMPT_CARD_COPY: Record<QuickStartMode, string> = {
   text: 'Copy this prompt for your agent to generate text through the OpenRouter model gateway.',
   image: 'Copy this prompt for your agent to generate images through the OpenRouter model gateway.',
   video: 'Copy this prompt for your agent to generate videos through the OpenRouter model gateway.',
+  embeddings:
+    'Copy this prompt for your agent to generate text embeddings through the OpenRouter model gateway.',
 };
 
 export const QUICK_START_COPY: Record<
@@ -118,6 +121,12 @@ export const QUICK_START_COPY: Record<
     description: 'Submit an asynchronous video generation job and poll until it completes.',
     model: 'google/veo-3.1',
     installCommand: 'npm install dotenv\nnpm install --save-dev @types/node tsx typescript',
+  },
+  embeddings: {
+    projectName: 'ai-embeddings-demo',
+    description: 'Generate text embeddings through OpenRouter with the OpenAI SDK.',
+    model: 'openai/text-embedding-3-small',
+    installCommand: 'npm install openai dotenv\nnpm install --save-dev @types/node tsx typescript',
   },
 };
 
@@ -175,6 +184,25 @@ while (result.status !== 'completed' && result.status !== 'failed') {
 console.log(result);`;
   }
 
+  if (mode === 'embeddings') {
+    return `import OpenAI from 'openai';
+import 'dotenv/config';
+
+const openai = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+});
+
+const response = await openai.embeddings.create({
+  model: '${model}',
+  input: 'The quick brown fox jumps over the lazy dog.',
+});
+
+console.log('Dimensions:', response.data[0].embedding.length);
+console.log('First 5 values:', response.data[0].embedding.slice(0, 5));
+console.log('Usage:', response.usage);`;
+  }
+
   return `import OpenAI from 'openai';
 import 'dotenv/config';
 
@@ -200,6 +228,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
     image: 'an image generation feature that sends a user prompt and renders the returned image',
     video:
       'a video generation feature that submits a prompt, polls the job status, and renders the completed video',
+    embeddings:
+      'a text embedding feature that converts user input into vector embeddings for semantic search or similarity comparison',
   };
   const apiCopy: Record<QuickStartMode, string> = {
     text: 'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1.',
@@ -207,6 +237,8 @@ export function getQuickStartPrompt(mode: QuickStartMode) {
       "Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1 and request modalities ['image', 'text'].",
     video:
       'Use fetch with the OpenRouter video endpoint at https://openrouter.ai/api/v1/videos; do not install or use the OpenAI SDK for video.',
+    embeddings:
+      'Use the OpenAI SDK with baseURL set to https://openrouter.ai/api/v1. Call openai.embeddings.create() — not chat.completions.create().',
   };
 
   return [

--- a/packages/dashboard/src/lib/i18n/locales/en.json
+++ b/packages/dashboard/src/lib/i18n/locales/en.json
@@ -589,7 +589,7 @@
         "image": "Image",
         "audio": "Audio",
         "video": "Video",
-        "embeddings": "Embed"
+        "embeddings": "Embeddings"
       },
       "columns": {
         "model": "Model",
@@ -679,7 +679,8 @@
       "step2Description": {
         "text": "Create a chat completion through OpenRouter with the OpenAI SDK.",
         "image": "Generate an image with an OpenRouter model that supports image output.",
-        "video": "Submit an asynchronous video generation job and poll until it completes."
+        "video": "Submit an asynchronous video generation job and poll until it completes.",
+        "embeddings": "Generate text embeddings through OpenRouter with the OpenAI SDK."
       },
       "step3Title": "Set Up Your API Key",
       "step3Description": "Add your OpenRouter API key to a .env.local file.",
@@ -688,12 +689,14 @@
       "modes": {
         "text": "Text Generation",
         "image": "Image Generation",
-        "video": "Video Generation"
+        "video": "Video Generation",
+        "embeddings": "Embeddings"
       },
       "promptCard": {
         "text": "Copy this prompt for your agent to generate text through the OpenRouter model gateway.",
         "image": "Copy this prompt for your agent to generate images through the OpenRouter model gateway.",
-        "video": "Copy this prompt for your agent to generate videos through the OpenRouter model gateway."
+        "video": "Copy this prompt for your agent to generate videos through the OpenRouter model gateway.",
+        "embeddings": "Copy this prompt for your agent to generate text embeddings through the OpenRouter model gateway."
       }
     }
   },

--- a/packages/dashboard/src/lib/i18n/locales/es.json
+++ b/packages/dashboard/src/lib/i18n/locales/es.json
@@ -683,7 +683,8 @@
       "step2Description": {
         "text": "Crea una respuesta de chat a través de OpenRouter con el SDK de OpenAI.",
         "image": "Genera una imagen con un modelo de OpenRouter que admita salida de imágenes.",
-        "video": "Envía un trabajo asíncrono de generación de video y consúltalo hasta que termine."
+        "video": "Envía un trabajo asíncrono de generación de video y consúltalo hasta que termine.",
+        "embeddings": "Genera embeddings de texto a través de OpenRouter con el SDK de OpenAI."
       },
       "step3Title": "Configura tu clave de API",
       "step3Description": "Agrega tu clave de API de OpenRouter a un archivo .env.local.",
@@ -692,12 +693,14 @@
       "modes": {
         "text": "Generación de texto",
         "image": "Generación de imágenes",
-        "video": "Generación de video"
+        "video": "Generación de video",
+        "embeddings": "Embeddings"
       },
       "promptCard": {
         "text": "Copia este prompt para que tu agente genere texto a través del gateway de modelos de OpenRouter.",
         "image": "Copia este prompt para que tu agente genere imágenes a través del gateway de modelos de OpenRouter.",
-        "video": "Copia este prompt para que tu agente genere videos a través del gateway de modelos de OpenRouter."
+        "video": "Copia este prompt para que tu agente genere videos a través del gateway de modelos de OpenRouter.",
+        "embeddings": "Copia este prompt para que tu agente genere embeddings de texto a través del gateway de modelos de OpenRouter."
       }
     }
   },

--- a/packages/dashboard/src/lib/i18n/locales/zh-CN.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-CN.json
@@ -664,7 +664,8 @@
       "step2Description": {
         "text": "使用 OpenAI SDK 通过 OpenRouter 创建聊天补全。",
         "image": "使用支持图像输出的 OpenRouter 模型生成图像。",
-        "video": "提交异步视频生成任务并轮询直至完成。"
+        "video": "提交异步视频生成任务并轮询直至完成。",
+        "embeddings": "使用 OpenAI SDK 通过 OpenRouter 生成文本嵌入。"
       },
       "step3Title": "设置 API 密钥",
       "step3Description": "将你的 OpenRouter API 密钥添加到 .env.local 文件。",
@@ -673,12 +674,14 @@
       "modes": {
         "text": "文本生成",
         "image": "图像生成",
-        "video": "视频生成"
+        "video": "视频生成",
+        "embeddings": "嵌入生成"
       },
       "promptCard": {
         "text": "复制此提示词，让你的智能体通过 OpenRouter 模型网关生成文本。",
         "image": "复制此提示词，让你的智能体通过 OpenRouter 模型网关生成图像。",
-        "video": "复制此提示词，让你的智能体通过 OpenRouter 模型网关生成视频。"
+        "video": "复制此提示词，让你的智能体通过 OpenRouter 模型网关生成视频。",
+        "embeddings": "复制此提示词，让你的智能体通过 OpenRouter 模型网关生成文本嵌入。"
       }
     }
   },

--- a/packages/dashboard/src/lib/i18n/locales/zh-TW.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-TW.json
@@ -664,7 +664,8 @@
       "step2Description": {
         "text": "使用 OpenAI SDK 透過 OpenRouter 建立聊天補全。",
         "image": "使用支援圖片輸出的 OpenRouter 模型產生圖片。",
-        "video": "提交非同步影片產生工作並輪詢直到完成。"
+        "video": "提交非同步影片產生工作並輪詢直到完成。",
+        "embeddings": "使用 OpenAI SDK 透過 OpenRouter 產生文字嵌入。"
       },
       "step3Title": "設定 API 金鑰",
       "step3Description": "將你的 OpenRouter API 金鑰加入 .env.local 檔案。",
@@ -673,12 +674,14 @@
       "modes": {
         "text": "文字生成",
         "image": "圖片生成",
-        "video": "影片生成"
+        "video": "影片生成",
+        "embeddings": "嵌入生成"
       },
       "promptCard": {
         "text": "複製此提示詞，讓你的代理透過 OpenRouter 模型閘道生成文字。",
         "image": "複製此提示詞，讓你的代理透過 OpenRouter 模型閘道產生圖片。",
-        "video": "複製此提示詞，讓你的代理透過 OpenRouter 模型閘道產生影片。"
+        "video": "複製此提示詞，讓你的代理透過 OpenRouter 模型閘道產生影片。",
+        "embeddings": "複製此提示詞，讓你的代理透過 OpenRouter 模型閘道產生文字嵌入。"
       }
     }
   },


### PR DESCRIPTION
Closes #1147

## Summary

The Model Gateway proxies embedding models, but the Quick Start only advertises Text, Image, and Video; so the one page that teaches you (and your agent) what the gateway can do never mentions embeddings. This adds the fourth tab.

Supersedes #1285 and #1314. Both stalled after review and now conflict with `main`; this carries @Fermionic-Lyu's feedback on each forward. Credit to @kgarg2468 and @abhigyan1102, the constants and the backend test here follow #1314's shape.

**Scope.** Per the review on #1285: *"we just need an additional tab in the quick start page and that's pretty much it"*, the change is confined to `constants.ts`. No page components, no `OverviewStartKind`, no `OVERVIEW_QUICK_START_MODELS`. `AIQuickStartPage` already maps over `QUICK_START_MODES`, so the tab renders without touching it.

<!-- Briefly describe what this PR does -->

**Review notes from #1314, applied:**

- Fake timers were only restored at the end of the test, now an `afterEach(() => vi.useRealTimers())` guard on the `AIModelService` suite, so a throwing assertion can't leak them into later tests.
- `getQuickStartPrompt()` said `client.embeddings.create()` while the generated script names the instance `openai`, aligned to `openai.embeddings.create()`, with a test asserting the prompt and script agree.
- The modality filter still read `Embed` — renamed to `Embeddings` in `MODEL_MODALITY_FILTERS` and in `en.json`. `es` and both Chinese locales already read `Embeddings`/`嵌入`, so English was the only one out of step.

**Snippet target.** The generated snippet calls OpenRouter's `/embeddings` directly with the provisioned key, matching the other three modes, since `docs/sdks/rest/ai.mdx` marks the `/api/ai/*` proxy routes deprecated.

**Locale.** Neither predecessor added locale entries, so the new tab would have rendered in English beside three translated ones. Added `ai.quickStart.modes`, `.step2Description`, and `.promptCard` for `en`, `es`, `zh-CN`, and `zh-TW`.

**One open question.** The second line of the original report is that an agent can't seed pgvector without an external embedding model. A Quick Start tab doesn't address that, and `docs/core-concepts/database/pgvector.mdx` already covers the flow end to end, so I've left it out rather than widen the diff. Happy to add a pointer from the Embeddings tab to that guide if you want it here; otherwise it's probably its own docs issue.

<!-- Describe how you tested this PR -->

Dashboard unit tests: 7 new cases covering the mode, the snippet shape, and the prompt/script alignment:

```
npx vitest run src/features/ai/__tests__/constants.test.ts
# 7 passed
```

Locale parity across all four locales:

```
npx vitest run src/lib/i18n/__tests__/localeParity.test.ts
# 6 passed
```

Backend — embedding-only models survive catalogue mapping with correct pricing (input priced, no output price):

```
npx vitest run tests/unit/ai-model.service.test.ts
# 5 passed
```

Types and formatting:

```
npx tsc -p tsconfig.build.json --noEmit   # clean
npx prettier --check <changed files>      # clean
```

Also ran the dashboard locally (`docker compose up -d`) and confirmed the Embeddings tab renders alongside Text/Image/Video on the Quick Start page, and that the Models page `Embeddings` filter lists the embedding models.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Embeddings mode to the AI Quick Start so users can generate vector embeddings through the Model Gateway. Closes #1147.

- **New Features**
  - Adds an Embeddings tab alongside Text/Image/Video in Quick Start.
  - Generates SDK code using `openai.embeddings.create()` with baseURL `https://openrouter.ai/api/v1`.
  - Adds mode-specific copy, prompts, and project details.
  - Adds locale strings for `en`, `es`, `zh-CN`, and `zh-TW`.

- **Bug Fixes**
  - Ensures embedding-only models are included with correct input-only pricing; tightens assertions and restores real timers after each `AIModelService` test.
  - Aligns prompt and snippet to use `openai.embeddings.create()` (not `client.embeddings.create()`).
  - Renames the modality filter label from "Embed" to "Embeddings" in English.

<sup>Written for commit 60d9271c3b7a7ddfdddc67871e6679269d632fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Embeddings mode to the AI Quick Start
> - Adds `'embeddings'` as a new `QuickStartMode` in [constants.ts](https://github.com/InsForge/InsForge/pull/1889/files#diff-6e0469653322f877c0f2586d4f45b993a0786400fa047f4c64360e5fb7c6a68b), with its own prompt card copy, quick start metadata, and a `getQuickStartScript` branch that generates `openai.embeddings.create` example code.
> - Updates the `MODEL_MODALITY_FILTERS` label from `'Embed'` to `'Embeddings'` in the UI and i18n strings across English, Spanish, Simplified Chinese, and Traditional Chinese locales.
> - Adds a backend unit test verifying that embedding-only models are included with correct pricing (inputPrice present, outputPrice undefined), using fake timers to bypass the 1-hour cache TTL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f706e28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added embeddings as a supported AI quick-start option.
  - Added guidance, prompt cards, demo configuration, and SDK examples for generating vector embeddings.
  - Added embedding modality labels and descriptions in English, Spanish, Simplified Chinese, and Traditional Chinese.

- **Tests**
  - Added coverage for embedding quick-start content, scripts, modes, and required translations.
  - Added validation for embedding model availability, mappings, and pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->