### PR TITLE
feat(compute): self-hosted Docker driver for custom containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -378,6 +378,49 @@ FLY_API_TOKEN=
 FLY_ORG=
 COMPUTE_DOMAIN=
 
+# ─── Custom Compute: Docker provider (self-host, opt-in) ───────────────────────
+# Runs your containers on THIS host instead of Fly.io. Enabled by mounting the
+# Docker socket into the InsForge container — see the commented lines in
+# docker-compose.prod.yml. The driver registers itself when the socket is
+# reachable, so nothing runs containers on your host unless you grant that.
+#
+# Security: the provider builds every container spec itself and never forwards
+# caller-supplied options, so a leaked InsForge API key cannot ask for a
+# privileged container or a host bind mount. The socket itself is still
+# root-equivalent on the host, so treat mounting it as the decision it is.
+#
+# Known limitation: there are no persistent volumes yet (the Fly path has none
+# either). Container state survives restarts and host reboots, but changing the
+# image, env vars, or port recreates the container and discards anything written
+# inside it. Use the project's Postgres or Storage for data you need to keep.
+
+# Which provider new services go to: fly | cloud | docker | off. Leave empty to
+# auto-detect. Not a restriction — providers coexist, and each service is managed
+# by the one that created it.
+COMPUTE_PROVIDER=
+
+# Ingress for services that do not choose their own:
+#   none (default) — internal network only; no host port, no URL
+#   port           — published on a host port
+#   host           — reachable at a hostname via your own gateway
+COMPUTE_DEFAULT_INGRESS=none
+
+# Host address used to build URLs for `port` ingress. Left empty, no URL is
+# advertised — better than handing out one that does not resolve.
+COMPUTE_PUBLIC_HOST=
+
+# Bind address for published ports. Loopback by default: Docker's own default
+# publishes on 0.0.0.0 AND [::], i.e. the whole internet on a reachable host.
+COMPUTE_BIND_ADDRESS=127.0.0.1
+
+# Path to the Docker socket, if it is not in the usual place.
+DOCKER_SOCKET_PATH=/var/run/docker.sock
+
+# Set true to keep compute containers off this project's network. Off by default:
+# sitting next to the database and storage is the point, and `postgres:5432`
+# resolves from inside a compute container exactly as it does for edge functions.
+COMPUTE_ISOLATE_NETWORK=
+
 # Cloud-mode compute (provisioned automatically when PROJECT_ID + CLOUD_API_HOST
 # are set by insforge-cloud). Self-host users with FLY_API_TOKEN always take
 # priority and do not need to set PROJECT_ID.

--- a/.env.example
+++ b/.env.example
@@ -413,8 +413,18 @@ COMPUTE_PUBLIC_HOST=
 # publishes on 0.0.0.0 AND [::], i.e. the whole internet on a reachable host.
 COMPUTE_BIND_ADDRESS=127.0.0.1
 
-# Path to the Docker socket, if it is not in the usual place.
+# Path to the Docker socket, if it is not in the usual place — rootless Docker
+# ($XDG_RUNTIME_DIR/docker.sock) or Podman (/run/podman/podman.sock). The compose
+# files mount it at this same path inside the container, so one value covers both
+# sides. Only read when the socket mount is uncommented.
 DOCKER_SOCKET_PATH=/var/run/docker.sock
+
+# Host group that owns the socket, required by `group_add` when the mount is
+# enabled — the socket is mode 660 root:docker, so without a matching group the
+# backend gets EACCES. Host-specific (993 on Amazon Linux 2023, commonly 999 on
+# Debian/Ubuntu):
+#   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+DOCKER_GID=
 
 # Set true to keep compute containers off this project's network. Off by default:
 # sitting next to the database and storage is the point, and `postgres:5432`

--- a/.env.example
+++ b/.env.example
@@ -422,14 +422,20 @@ DOCKER_SOCKET_PATH=/var/run/docker.sock
 # Host group that owns the socket, required by `group_add` when the mount is
 # enabled — the socket is mode 660 root:docker, so without a matching group the
 # backend gets EACCES. Host-specific (993 on Amazon Linux 2023, commonly 999 on
-# Debian/Ubuntu):
-#   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+# Debian/Ubuntu), so fill in the value your host reports:
+#   getent group docker | cut -d: -f3
 DOCKER_GID=
 
 # Ceiling on an uploaded source-build context (default 64mb). The whole tarball is
 # buffered in memory before the build starts, and only one upload is accepted at a
 # time, so this is the memory the build path can cost — lower it on a small host.
 COMPUTE_BUILD_MAX_CONTEXT=
+
+# Seconds a build upload may send nothing before it is treated as stalled and cut
+# loose (default 30). Builds run one at a time, so a connection that stops making
+# progress would otherwise block every other deploy. The timer resets on each chunk,
+# so this bounds silence, not total upload time — a slow but active link is fine.
+COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT=
 
 # Set true to keep compute containers off this project's network. Off by default:
 # sitting next to the database and storage is the point, and `postgres:5432`

--- a/.env.example
+++ b/.env.example
@@ -426,6 +426,11 @@ DOCKER_SOCKET_PATH=/var/run/docker.sock
 #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
 DOCKER_GID=
 
+# Ceiling on an uploaded source-build context (default 64mb). The whole tarball is
+# buffered in memory before the build starts, and only one upload is accepted at a
+# time, so this is the memory the build path can cost — lower it on a small host.
+COMPUTE_BUILD_MAX_CONTEXT=
+
 # Set true to keep compute containers off this project's network. Off by default:
 # sitting next to the database and storage is the point, and `postgres:5432`
 # resolves from inside a compute container exactly as it does for edge functions.

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -196,8 +196,12 @@ type BuildRequest = AuthRequest & { releaseBuildSlot?: () => void; buildStarted?
  * No bytes for this long means the client has stalled rather than being slow.
  * Resets on every chunk, so a legitimately slow upload is never penalised — only a
  * connection that stops making progress while holding the only build slot.
+ * Configurable for the same reason the size ceiling is: the operator knows their
+ * network, and a hard-coded value is either too tight for someone or too loose.
  */
-const UPLOAD_IDLE_TIMEOUT_MS = 30_000;
+function uploadIdleTimeoutMs(): number {
+  return appConfig.docker.buildUploadIdleTimeoutMs;
+}
 
 /**
  * Admit one build at a time, deciding *before* `express.raw` buffers a body.
@@ -261,10 +265,11 @@ function oneBuildAtATime(req: BuildRequest, res: Response, next: NextFunction) {
     idle = setTimeout(() => {
       logger.warn('Compute build upload stalled; releasing the build slot', {
         serviceId: req.params.id,
+        idleMs: uploadIdleTimeoutMs(),
       });
       release();
       req.destroy();
-    }, UPLOAD_IDLE_TIMEOUT_MS);
+    }, uploadIdleTimeoutMs());
   };
   armIdleTimer();
   req.on('data', armIdleTimer);

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -1,4 +1,5 @@
-import { Router, Response, NextFunction } from 'express';
+import express, { Router, Response, NextFunction } from 'express';
+import { appConfig } from '@/infra/config/app.config.js';
 import { verifyAdmin, AuthRequest } from '@/api/middlewares/auth.js';
 import { computeWriteLimiter, computeLogsRateLimiter } from '@/api/middlewares/rate-limiters.js';
 import { ComputeServicesService } from '@/services/compute/services.service.js';
@@ -150,6 +151,67 @@ router.post(
 
       const tokenResult = await svc.issueDeployTokenForService(req.params.id);
       successResponse(res, tokenResult);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// Build an uploaded context and deploy the result.
+//
+// The body is the build context tarball itself, which is what Docker's build
+// endpoint natively consumes — so the context streams through without an
+// intermediate copy. Pair with POST /deploy, which reserves the name first.
+//
+// A note for whoever builds the tarball: archive it with `tar --no-xattrs` (or
+// COPYFILE_DISABLE=1) on macOS. Extended attributes the Linux daemon cannot apply
+// make it reject the whole context; the error is recognised and explained, but not
+// producing them is simpler.
+router.post(
+  '/:id/build',
+  verifyAdmin,
+  computeWriteLimiter,
+  express.raw({ type: 'application/x-tar', limit: appConfig.server.maxJsonBodySize }),
+  async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const svc = ComputeServicesService.getInstance();
+      const existing = await svc.getService(req.params.id);
+
+      if (existing.projectId !== getProjectId(req)) {
+        throw new AppError('Service not found', 404, ERROR_CODES.COMPUTE_SERVICE_NOT_FOUND);
+      }
+
+      if (!Buffer.isBuffer(req.body) || req.body.length === 0) {
+        throw new AppError(
+          'Build context must be a non-empty tar archive sent as application/x-tar.',
+          400,
+          ERROR_CODES.INVALID_INPUT
+        );
+      }
+
+      const dockerfile =
+        typeof req.query.dockerfile === 'string' ? req.query.dockerfile : undefined;
+      const result = await svc.buildAndDeploy(req.params.id, req.body, { dockerfile });
+
+      successResponse(res, {
+        service: result.service,
+        imageTag: result.imageTag,
+        logs: result.logs,
+      });
+
+      bestEffortAudit({
+        actor: req.hasApiKey ? 'api-key' : req.user?.id,
+        action: 'BUILD_COMPUTE_SERVICE',
+        module: 'COMPUTE',
+        details: {
+          serviceId: req.params.id,
+          serviceName: existing.name,
+          imageTag: result.imageTag,
+          contextBytes: req.body.length,
+        },
+        ip_address: req.ip,
+      });
+      bestEffortBroadcast();
     } catch (error) {
       next(error);
     }

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -189,18 +189,40 @@ function parseDockerfileParam(raw: unknown): string | undefined {
   return raw;
 }
 
+/** Set by the gate below so the handler can hand the slot back when it is done. */
+type BuildRequest = AuthRequest & { releaseBuildSlot?: () => void; buildStarted?: boolean };
+
 /**
- * Reject a second concurrent upload *before* `express.raw` buffers its body.
- *
- * The driver already caps concurrent builds at one and throws when busy, but by
- * then express holds the entire tarball in memory, so N simultaneous uploads cost
- * N contexts regardless of the cap. On the hosts this feature targets — a t4g.nano
- * has ~418MB usable — that is the difference between a clear 429 and an OOM.
- * Turning the door away keeps resident context bounded to one.
+ * No bytes for this long means the client has stalled rather than being slow.
+ * Resets on every chunk, so a legitimately slow upload is never penalised — only a
+ * connection that stops making progress while holding the only build slot.
  */
-let buildUploadInFlight = false;
-function oneBuildUploadAtATime(req: AuthRequest, res: Response, next: NextFunction) {
-  if (buildUploadInFlight) {
+const UPLOAD_IDLE_TIMEOUT_MS = 30_000;
+
+/**
+ * Admit one build at a time, deciding *before* `express.raw` buffers a body.
+ *
+ * The driver already caps concurrent builds at one, but it only finds out once
+ * express holds the entire tarball in memory, so N simultaneous uploads cost N
+ * contexts regardless of the cap. On the hosts this targets — a t4g.nano has
+ * ~418MB usable — that is the difference between a clear 429 and an OOM.
+ *
+ * The slot is held across the build, not just the upload, because an upload that
+ * cannot be built is worth rejecting at the door rather than buffering and then
+ * failing. That makes releasing it the delicate part, with two distinct cases:
+ *
+ *   - aborted before the handler took over — nothing is building, so the socket
+ *     closing must release it, or the endpoint wedges permanently;
+ *   - aborted after the handler took over — the build carries on regardless of the
+ *     client, so the socket closing must *not* release it, or a disconnect lets a
+ *     second context in alongside the running build.
+ *
+ * Hence `buildStarted`: the handler claims ownership and releases in its own
+ * `finally`, and until it does, the close handler owns the release.
+ */
+let buildSlotTaken = false;
+function oneBuildAtATime(req: BuildRequest, res: Response, next: NextFunction) {
+  if (buildSlotTaken) {
     // Discard the incoming tarball instead of buffering it — that is the whole
     // point of rejecting here. It still has to be drained: a response sent while
     // the request body sits unread stalls the connection until the client gives
@@ -208,20 +230,84 @@ function oneBuildUploadAtATime(req: AuthRequest, res: Response, next: NextFuncti
     req.resume();
     next(
       new AppError(
-        'Another build is already uploading. Retry when it finishes.',
+        'Another build is already in progress. Retry when it finishes.',
         429,
         ERROR_CODES.TOO_MANY_REQUESTS
       )
     );
     return;
   }
-  buildUploadInFlight = true;
-  // `close` fires for a completed response and for a client that hung up
-  // mid-upload, which `finish` would miss.
+
+  buildSlotTaken = true;
+  let idle: NodeJS.Timeout | undefined;
+  let released = false;
+  const release = () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    if (idle) {
+      clearTimeout(idle);
+    }
+    buildSlotTaken = false;
+  };
+  req.releaseBuildSlot = release;
+
+  // Bound how long a client can sit on the slot without sending anything.
+  const armIdleTimer = () => {
+    if (idle) {
+      clearTimeout(idle);
+    }
+    idle = setTimeout(() => {
+      logger.warn('Compute build upload stalled; releasing the build slot', {
+        serviceId: req.params.id,
+      });
+      release();
+      req.destroy();
+    }, UPLOAD_IDLE_TIMEOUT_MS);
+  };
+  armIdleTimer();
+  req.on('data', armIdleTimer);
+  req.once('end', () => {
+    if (idle) {
+      clearTimeout(idle);
+      idle = undefined;
+    }
+  });
+
   res.once('close', () => {
-    buildUploadInFlight = false;
+    // Only ours to release while no build has started — see the note above.
+    if (!req.buildStarted) {
+      release();
+    }
   });
   next();
+}
+
+/**
+ * `express.raw` rejects an over-limit body with `entity.too.large`, which the shared
+ * error middleware does not recognise — it would surface as a 500, telling an
+ * operator who set the limit that the server broke. Translate it where the limit is
+ * known so the message can name it.
+ */
+const rawTarBody = express.raw({
+  type: 'application/x-tar',
+  limit: appConfig.docker.buildMaxContextSize,
+});
+function parseTarBody(req: AuthRequest, res: Response, next: NextFunction) {
+  rawTarBody(req, res, (err?: unknown) => {
+    if (err && (err as { type?: string }).type === 'entity.too.large') {
+      next(
+        new AppError(
+          `Build context is larger than the ${appConfig.docker.buildMaxContextSize} limit. Shrink it with a .dockerignore, or raise COMPUTE_BUILD_MAX_CONTEXT.`,
+          413,
+          ERROR_CODES.INVALID_INPUT
+        )
+      );
+      return;
+    }
+    next(err);
+  });
 }
 
 // Build an uploaded context and deploy the result.
@@ -238,9 +324,13 @@ router.post(
   '/:id/build',
   verifyAdmin,
   computeWriteLimiter,
-  oneBuildUploadAtATime,
-  express.raw({ type: 'application/x-tar', limit: appConfig.docker.buildMaxContextSize }),
-  async (req: AuthRequest, res: Response, next: NextFunction) => {
+  oneBuildAtATime,
+  parseTarBody,
+  async (req: BuildRequest, res: Response, next: NextFunction) => {
+    // Take ownership of the build slot: from here the build outlives the client,
+    // so a disconnect must not hand the slot to someone else.
+    req.buildStarted = true;
+    const releaseBuildSlot = req.releaseBuildSlot ?? (() => {});
     try {
       const svc = ComputeServicesService.getInstance();
       const existing = await svc.getService(req.params.id);
@@ -281,6 +371,8 @@ router.post(
       bestEffortBroadcast();
     } catch (error) {
       next(error);
+    } finally {
+      releaseBuildSlot();
     }
   }
 );

--- a/backend/src/api/routes/compute/services.routes.ts
+++ b/backend/src/api/routes/compute/services.routes.ts
@@ -157,11 +157,78 @@ router.post(
   }
 );
 
+/**
+ * `dockerfile` names a path *inside* the uploaded context. The daemon resolves it
+ * against the context root and rejects an escape on its own, but its error is
+ * opaque — reject the obvious shapes here so the developer gets something to act
+ * on instead of a build failure from the bottom of the stack.
+ */
+function parseDockerfileParam(raw: unknown): string | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const reject = (why: string): never => {
+    throw new AppError(
+      `Invalid \`dockerfile\`: ${why}. It must be a path relative to the root of the uploaded context, e.g. "docker/Dockerfile".`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  };
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return reject('expected a single non-empty string');
+  }
+  if (raw.length > 255) {
+    return reject('longer than 255 characters');
+  }
+  if (raw.startsWith('/') || /^[A-Za-z]:/.test(raw)) {
+    return reject('absolute paths are not allowed');
+  }
+  if (raw.split(/[\\/]/).includes('..')) {
+    return reject('`..` cannot be used to leave the context');
+  }
+  return raw;
+}
+
+/**
+ * Reject a second concurrent upload *before* `express.raw` buffers its body.
+ *
+ * The driver already caps concurrent builds at one and throws when busy, but by
+ * then express holds the entire tarball in memory, so N simultaneous uploads cost
+ * N contexts regardless of the cap. On the hosts this feature targets — a t4g.nano
+ * has ~418MB usable — that is the difference between a clear 429 and an OOM.
+ * Turning the door away keeps resident context bounded to one.
+ */
+let buildUploadInFlight = false;
+function oneBuildUploadAtATime(req: AuthRequest, res: Response, next: NextFunction) {
+  if (buildUploadInFlight) {
+    // Discard the incoming tarball instead of buffering it — that is the whole
+    // point of rejecting here. It still has to be drained: a response sent while
+    // the request body sits unread stalls the connection until the client gives
+    // up, which turns a fast 429 into a hang.
+    req.resume();
+    next(
+      new AppError(
+        'Another build is already uploading. Retry when it finishes.',
+        429,
+        ERROR_CODES.TOO_MANY_REQUESTS
+      )
+    );
+    return;
+  }
+  buildUploadInFlight = true;
+  // `close` fires for a completed response and for a client that hung up
+  // mid-upload, which `finish` would miss.
+  res.once('close', () => {
+    buildUploadInFlight = false;
+  });
+  next();
+}
+
 // Build an uploaded context and deploy the result.
 //
 // The body is the build context tarball itself, which is what Docker's build
-// endpoint natively consumes — so the context streams through without an
-// intermediate copy. Pair with POST /deploy, which reserves the name first.
+// endpoint natively consumes, so it is forwarded as-is. Pair with POST /deploy,
+// which reserves the name first.
 //
 // A note for whoever builds the tarball: archive it with `tar --no-xattrs` (or
 // COPYFILE_DISABLE=1) on macOS. Extended attributes the Linux daemon cannot apply
@@ -171,7 +238,8 @@ router.post(
   '/:id/build',
   verifyAdmin,
   computeWriteLimiter,
-  express.raw({ type: 'application/x-tar', limit: appConfig.server.maxJsonBodySize }),
+  oneBuildUploadAtATime,
+  express.raw({ type: 'application/x-tar', limit: appConfig.docker.buildMaxContextSize }),
   async (req: AuthRequest, res: Response, next: NextFunction) => {
     try {
       const svc = ComputeServicesService.getInstance();
@@ -189,8 +257,7 @@ router.post(
         );
       }
 
-      const dockerfile =
-        typeof req.query.dockerfile === 'string' ? req.query.dockerfile : undefined;
+      const dockerfile = parseDockerfileParam(req.query.dockerfile);
       const result = await svc.buildAndDeploy(req.params.id, req.body, { dockerfile });
 
       successResponse(res, {

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -47,6 +47,14 @@ export interface AppConfig {
     org: string;
     domain: string;
   };
+  docker: {
+    socketPath: string;
+    publicHost: string;
+    domain: string;
+    defaultIngress: string;
+    bindAddress: string;
+    isolateNetwork: boolean;
+  };
   server: {
     maxJsonBodySize: string;
     maxUrlencodedBodySize: string;
@@ -173,6 +181,28 @@ export function loadConfig(): AppConfig {
       apiToken: process.env.FLY_API_TOKEN || '',
       org: process.env.FLY_ORG || '',
       domain: process.env.COMPUTE_DOMAIN || '',
+    },
+    docker: {
+      // Presence of a reachable socket is how an operator opts in: they mount it
+      // into the InsForge container, and the driver registers itself.
+      socketPath: process.env.DOCKER_SOCKET_PATH || '/var/run/docker.sock',
+      // Host address published-port URLs are built from. Left empty we return a
+      // null endpoint rather than guessing the host's public IP and handing out
+      // a URL that does not resolve.
+      publicHost: process.env.COMPUTE_PUBLIC_HOST || '',
+      // Wildcard domain for `host` ingress, shared with the Fly path.
+      domain: process.env.COMPUTE_DOMAIN || '',
+      // Ingress default for containers this driver creates. `none` publishes no
+      // host port at all, which is right for the majority of compute (queue
+      // workers, processors, inference loops) that takes no inbound traffic.
+      defaultIngress: process.env.COMPUTE_DEFAULT_INGRESS || 'none',
+      // Bind address for published ports. Defaults to loopback: a container
+      // reachable from the whole internet should be a deliberate choice, and
+      // Docker's own default (0.0.0.0, plus [::]) is not.
+      bindAddress: process.env.COMPUTE_BIND_ADDRESS || '127.0.0.1',
+      // Skip attaching containers to the project's own compose network. Off by
+      // default — proximity to the database and storage is the point.
+      isolateNetwork: process.env.COMPUTE_ISOLATE_NETWORK === 'true',
     },
     server: {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -54,6 +54,7 @@ export interface AppConfig {
     defaultIngress: string;
     bindAddress: string;
     isolateNetwork: boolean;
+    buildMaxContextSize: string;
   };
   server: {
     maxJsonBodySize: string;
@@ -203,6 +204,12 @@ export function loadConfig(): AppConfig {
       // Skip attaching containers to the project's own compose network. Off by
       // default — proximity to the database and storage is the point.
       isolateNetwork: process.env.COMPUTE_ISOLATE_NETWORK === 'true',
+      // Ceiling on an uploaded build context. Deliberately *not* the JSON body
+      // limit it used to borrow: express buffers the whole tarball in memory
+      // before any handler runs, and a t4g.nano has ~418MB usable, so a 100MB
+      // ceiling is a self-inflicted OOM. A source context is normally single-digit
+      // megabytes; 64MB is generous for one that vendors dependencies.
+      buildMaxContextSize: process.env.COMPUTE_BUILD_MAX_CONTEXT || '64mb',
     },
     server: {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -136,6 +136,9 @@ function parseEnvBool(val: string | undefined): boolean {
 
 const AWS_MAX_SINGLE_PUT_BYTES = 5 * 1024 * 1024 * 1024;
 
+/** Largest delay `setTimeout` honours; anything above it is silently treated as 1ms. */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 function parseEnvBytes(val: string | undefined, fallback: number): number {
   if (!val) return fallback;
   if (!/^\d+$/.test(val)) return fallback;
@@ -218,8 +221,15 @@ export function loadConfig(): AppConfig {
       // progress while holding the slot blocks every other deploy. The timer resets
       // on each chunk, so this bounds silence, not total upload time — a slow but
       // active link is never cut.
-      buildUploadIdleTimeoutMs:
+      //
+      // Clamped to the 32-bit signed max because `setTimeout` silently drops a
+      // larger delay to 1ms: without this, an operator asking for a very lenient
+      // timeout would get the harshest possible behaviour and see every upload
+      // aborted instantly.
+      buildUploadIdleTimeoutMs: Math.min(
         parseEnvInt(process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT, 30) * 1000,
+        MAX_TIMEOUT_MS
+      ),
     },
     server: {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',

--- a/backend/src/infra/config/app.config.ts
+++ b/backend/src/infra/config/app.config.ts
@@ -55,6 +55,7 @@ export interface AppConfig {
     bindAddress: string;
     isolateNetwork: boolean;
     buildMaxContextSize: string;
+    buildUploadIdleTimeoutMs: number;
   };
   server: {
     maxJsonBodySize: string;
@@ -202,14 +203,23 @@ export function loadConfig(): AppConfig {
       // Docker's own default (0.0.0.0, plus [::]) is not.
       bindAddress: process.env.COMPUTE_BIND_ADDRESS || '127.0.0.1',
       // Skip attaching containers to the project's own compose network. Off by
-      // default — proximity to the database and storage is the point.
-      isolateNetwork: process.env.COMPUTE_ISOLATE_NETWORK === 'true',
+      // default — proximity to the database and storage is the point. Uses the
+      // shared parser so `1`/`yes`/`on` work too: a knob that silently ignores
+      // `COMPUTE_ISOLATE_NETWORK=1` fails in the unsafe direction.
+      isolateNetwork: parseEnvBool(process.env.COMPUTE_ISOLATE_NETWORK),
       // Ceiling on an uploaded build context. Deliberately *not* the JSON body
       // limit it used to borrow: express buffers the whole tarball in memory
       // before any handler runs, and a t4g.nano has ~418MB usable, so a 100MB
       // ceiling is a self-inflicted OOM. A source context is normally single-digit
       // megabytes; 64MB is generous for one that vendors dependencies.
       buildMaxContextSize: process.env.COMPUTE_BUILD_MAX_CONTEXT || '64mb',
+      // How long an upload may send nothing before it is treated as stalled and
+      // cut loose. Only builds one at a time, so a connection that stops making
+      // progress while holding the slot blocks every other deploy. The timer resets
+      // on each chunk, so this bounds silence, not total upload time — a slow but
+      // active link is never cut.
+      buildUploadIdleTimeoutMs:
+        parseEnvInt(process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT, 30) * 1000,
     },
     server: {
       maxJsonBodySize: process.env.MAX_JSON_BODY_SIZE || '100mb',

--- a/backend/src/infra/database/migrations/064_compute-services-multi-driver.sql
+++ b/backend/src/infra/database/migrations/064_compute-services-multi-driver.sql
@@ -50,12 +50,21 @@ END $$;
 -- was created by the Fly or cloud-proxied Fly path, since that was the only
 -- option. Cloud mode is Fly behind a control plane and shares the same app and
 -- machine identifiers, so one value covers both.
+--
+-- Split from the column add for the same reason as `ingress` below: on a rerun
+-- against an existing nullable column, `ADD COLUMN IF NOT EXISTS ... NOT NULL
+-- DEFAULT` applies neither the backfill nor the constraint.
 ALTER TABLE compute.services
-  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'fly';
+  ADD COLUMN IF NOT EXISTS provider TEXT;
 
--- Drop the default once the backfill is done. New rows must state their driver
--- explicitly — a Docker row silently defaulting to 'fly' is exactly the
--- corruption the column exists to prevent.
+UPDATE compute.services SET provider = 'fly' WHERE provider IS NULL;
+
+ALTER TABLE compute.services ALTER COLUMN provider SET NOT NULL;
+
+-- No default: new rows must state their driver explicitly — a Docker row
+-- silently defaulting to 'fly' is exactly the corruption the column exists to
+-- prevent. Dropping it covers a rerun over an earlier revision of this file,
+-- which created the column with `DEFAULT 'fly'`.
 ALTER TABLE compute.services ALTER COLUMN provider DROP DEFAULT;
 
 ALTER TABLE compute.services DROP CONSTRAINT IF EXISTS compute_services_provider_check;

--- a/backend/src/infra/database/migrations/064_compute-services-multi-driver.sql
+++ b/backend/src/infra/database/migrations/064_compute-services-multi-driver.sql
@@ -1,0 +1,97 @@
+-- Let compute.services be backed by more than one driver.
+--
+-- Until now the only option was Fly (directly, or cloud-proxied Fly), and the
+-- table said so: the identifier columns were named after Fly's concepts, and
+-- nothing recorded which driver owned a row. Adding a Docker driver that runs
+-- containers on the operator's own host needs three changes:
+--
+--   1. fly_app_id     -> provider_app_id
+--   2. fly_machine_id -> provider_instance_id
+--   3. new `provider` and `ingress` columns
+--
+-- `provider` is the load-bearing one. Drivers coexist — a service is managed by
+-- whichever driver created it — so without this column an operator who enables
+-- Docker leaves Fly-backed rows that the reconcile sweep would try to heal
+-- against the wrong daemon: at best a confusing 404, at worst marking a live,
+-- billing machine as stopped with nothing left to reconcile it.
+--
+-- `ingress` records how a service is reachable, per service rather than per
+-- deployment. Most compute takes no inbound traffic at all (queue workers,
+-- background processors, inference loops, scrapers — the cases the compute docs
+-- lead with), while an API or websocket server on the same deployment does. One
+-- deployment-wide switch forces both into the same shape, and the safe global
+-- default leaves the second case unreachable.
+--
+-- The API keeps serving `flyAppId` / `flyMachineId` as read-only aliases for one
+-- minor version so the CLI, dashboard, and MCP server can migrate without a
+-- lockstep release. See compute-services.schema.ts.
+
+-- Renames are guarded on the old column still existing rather than run bare, so
+-- re-running against a partially-migrated database is a no-op instead of an error.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'compute' AND table_name = 'services' AND column_name = 'fly_app_id'
+  ) THEN
+    ALTER TABLE compute.services RENAME COLUMN fly_app_id TO provider_app_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'compute' AND table_name = 'services' AND column_name = 'fly_machine_id'
+  ) THEN
+    ALTER TABLE compute.services RENAME COLUMN fly_machine_id TO provider_instance_id;
+  END IF;
+END $$;
+
+-- ── provider ────────────────────────────────────────────────────────────────
+-- Backfill existing rows as 'fly': every row that exists before this migration
+-- was created by the Fly or cloud-proxied Fly path, since that was the only
+-- option. Cloud mode is Fly behind a control plane and shares the same app and
+-- machine identifiers, so one value covers both.
+ALTER TABLE compute.services
+  ADD COLUMN IF NOT EXISTS provider TEXT NOT NULL DEFAULT 'fly';
+
+-- Drop the default once the backfill is done. New rows must state their driver
+-- explicitly — a Docker row silently defaulting to 'fly' is exactly the
+-- corruption the column exists to prevent.
+ALTER TABLE compute.services ALTER COLUMN provider DROP DEFAULT;
+
+ALTER TABLE compute.services DROP CONSTRAINT IF EXISTS compute_services_provider_check;
+ALTER TABLE compute.services
+  ADD CONSTRAINT compute_services_provider_check CHECK (provider IN ('fly', 'docker'));
+
+-- Reconcile scans by driver, so it should not sequential-scan the table.
+CREATE INDEX IF NOT EXISTS idx_compute_services_provider ON compute.services(provider);
+
+-- ── ingress ─────────────────────────────────────────────────────────────────
+--   'none' — reachable only on the project's internal network. No host port is
+--            published and no URL is advertised.
+--   'port' — published on a host port.
+--   'host' — reachable at a hostname, routed by the operator's gateway.
+--
+-- Existing rows are all Fly-backed, and Fly allocates public IPs and a `.fly.dev`
+-- hostname when the app is created — so every one of them is already reachable at
+-- a hostname. Backfilling them to 'host' records what is true rather than
+-- imposing a new default on services that are already running.
+--
+-- Split from the column add for the same reason as migrations 047 and 058:
+-- `ADD COLUMN IF NOT EXISTS ... NOT NULL DEFAULT` does not apply the constraints
+-- when the column already exists, only when it creates it.
+ALTER TABLE compute.services
+  ADD COLUMN IF NOT EXISTS ingress TEXT;
+
+UPDATE compute.services SET ingress = 'host' WHERE ingress IS NULL;
+
+ALTER TABLE compute.services ALTER COLUMN ingress SET NOT NULL;
+
+-- New rows state their own ingress. This default is only a safety net for a
+-- caller that predates the column; the service layer resolves it from the
+-- driver's capabilities, which is why it is not 'host' — a driver that can offer
+-- a private-only container should not publish one by accident.
+ALTER TABLE compute.services ALTER COLUMN ingress SET DEFAULT 'none';
+
+ALTER TABLE compute.services DROP CONSTRAINT IF EXISTS compute_services_ingress_check;
+ALTER TABLE compute.services
+  ADD CONSTRAINT compute_services_ingress_check CHECK (ingress IN ('none', 'port', 'host'));

--- a/backend/src/providers/compute/cloud.provider.ts
+++ b/backend/src/providers/compute/cloud.provider.ts
@@ -5,7 +5,11 @@ import { ERROR_CODES } from '@insforge/shared-schemas';
 import {
   MachineGoneError,
   translateMachineGone,
+  flyNetworkName,
+  flyAppNameFor,
+  flyEndpointUrl,
   type ComputeProvider,
+  type ComputeCapabilities,
   type LaunchMachineParams,
   type UpdateMachineParams,
   type MachineSummary,
@@ -31,6 +35,31 @@ export class CloudComputeProvider implements ComputeProvider {
       !!appConfig.app?.jwtSecret
     );
   }
+
+  // Cloud mode is Fly behind a control plane and shares Fly's app/machine
+  // identifiers, so rows it creates are recorded as 'fly'.
+  readonly name = 'fly' as const;
+
+  // Cloud-managed mode runs on Fly, so the machine-level capabilities match
+  // FlyProvider's. The one difference is deploy-token issuance: the cloud holds
+  // an org-wide token and must narrow it to one app before it leaves the
+  // backend, which is exactly what makes source mode work without the user
+  // holding any Fly credentials.
+  readonly capabilities: ComputeCapabilities = {
+    scaleToZero: true,
+    regions: true,
+    // Every Fly app gets public IPs and a `.fly.dev` hostname at create time, so
+    // there is no private-only or bare-port option to offer.
+    ingressModes: ['host'],
+    sourceBuild: 'flyctl',
+    deployTokenIssuance: true,
+  };
+
+  // Identical naming and URL rules to the Fly path — cloud mode is Fly behind a
+  // control plane, so both call the shared helpers rather than one borrowing
+  // from the other (which would drag fly.provider's imports in here).
+  resolveAppName = flyAppNameFor;
+  endpointUrl = flyEndpointUrl;
 
   private signToken(): string {
     if (!this.isConfigured()) {
@@ -89,16 +118,13 @@ export class CloudComputeProvider implements ComputeProvider {
     return text ? (JSON.parse(text) as T) : undefined;
   }
 
-  async createApp(params: { name: string; network?: string; org: string }) {
-    // Forward `network` only if the caller passed one. We keep it short
-    // (services.service.ts uses APP_KEY, ~8 chars) so Fly's network-name
+  async createApp(params: { name: string }) {
+    // `network` is kept short (APP_KEY, ~8 chars) so Fly's network-name
     // validator accepts it. Live e2e on prod (project 2163e1eb-…) showed
     // the previous long `${projectId}-network` (~44 chars) 422'd as
-    // "Name not a valid network name".
-    const body: Record<string, unknown> = { name: params.name };
-    if (params.network !== undefined) {
-      body.network = params.network;
-    }
+    // "Name not a valid network name". Derived here rather than passed in so
+    // the payload stays byte-identical to what the service used to send.
+    const body: Record<string, unknown> = { name: params.name, network: flyNetworkName() };
     const result = await this.call<{ appId: string; serviceId?: string }>('POST', '/apps', body);
     return { appId: result?.appId ?? params.name };
   }
@@ -158,10 +184,12 @@ export class CloudComputeProvider implements ComputeProvider {
     );
   }
 
-  async updateMachine(params: UpdateMachineParams): Promise<void> {
+  // Fly updates a machine in place, so the instance identity never changes.
+  async updateMachine(params: UpdateMachineParams): Promise<{ machineId?: string }> {
     await this.machineScoped(params.appId, params.machineId, () =>
       this.call('PATCH', `/machines/${encodeURIComponent(params.machineId)}`, params)
     );
+    return {};
   }
 
   async stopMachine(appId: string, machineId: string): Promise<void> {

--- a/backend/src/providers/compute/compute.provider.ts
+++ b/backend/src/providers/compute/compute.provider.ts
@@ -125,7 +125,14 @@ export class MachineGoneError extends Error {
  */
 export function flyNetworkName(): string {
   if (!process.env.APP_KEY) {
-    throw new Error('APP_KEY environment variable is required for compute network isolation');
+    // Typed, matching what the service layer threw before this moved: a plain
+    // Error surfaces as a generic 500 with no next action, which is a worse
+    // answer than the one an operator missing APP_KEY used to get.
+    throw new AppError(
+      'APP_KEY environment variable is required for compute network isolation',
+      500,
+      ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
+    );
   }
   return `n-${process.env.APP_KEY}`;
 }

--- a/backend/src/providers/compute/compute.provider.ts
+++ b/backend/src/providers/compute/compute.provider.ts
@@ -1,3 +1,8 @@
+import { createHash } from 'crypto';
+import { appConfig } from '@/infra/config/app.config.js';
+import { AppError } from '@/utils/errors.js';
+import { ERROR_CODES } from '@insforge/shared-schemas';
+
 export interface LaunchMachineParams {
   appId: string;
   /**
@@ -10,6 +15,12 @@ export interface LaunchMachineParams {
   memory: number;
   envVars: Record<string, string>;
   region: string;
+  /**
+   * Requested ingress. Omitted, the provider applies its own default (the first
+   * entry of `capabilities.ingressModes`). A provider that cannot deliver the
+   * requested mode applies the closest one it can.
+   */
+  ingress?: 'none' | 'port' | 'host';
   /**
    * Edge protocol. `'http'` (default) terminates TLS at the Fly anycast edge
    * and proxies HTTP/1.1+HTTP/2 to the container. `'tcp'` exposes the container's
@@ -37,6 +48,12 @@ export interface UpdateMachineParams {
   cpu: string;
   memory: number;
   envVars: Record<string, string>;
+  /**
+   * Requested ingress. Omitted, the provider applies its own default (the first
+   * entry of `capabilities.ingressModes`). A provider that cannot deliver the
+   * requested mode applies the closest one it can.
+   */
+  ingress?: 'none' | 'port' | 'host';
   /**
    * Edge protocol — same semantics as LaunchMachineParams.protocol. Omit
    * for back-compat HTTP behavior.
@@ -93,6 +110,66 @@ export class MachineGoneError extends Error {
   }
 }
 
+/**
+ * 6PN network name for a project's Fly apps, shared by the Fly and cloud
+ * providers so the wire payload stays byte-identical between them.
+ *
+ * Fly's rule: letters, numbers, and dashes, and it must start with a letter.
+ * The old `${projectId}-network` failed for the ~63% of projects whose UUID
+ * begins with a hex digit, and a bare APP_KEY still failed for the ~30% of keys
+ * that are digit-leading. The static `n-` prefix guarantees a letter-leading
+ * name for every project while APP_KEY preserves per-project isolation.
+ *
+ * Lives here rather than in the service layer because it is a provider-specific
+ * naming rule — Docker has no equivalent concept.
+ */
+export function flyNetworkName(): string {
+  if (!process.env.APP_KEY) {
+    throw new Error('APP_KEY environment variable is required for compute network isolation');
+  }
+  return `n-${process.env.APP_KEY}`;
+}
+
+/**
+ * Fly app name for a service. Names are globally unique and capped at 63 chars,
+ * so a long service name is truncated with a short hash of the full name
+ * appended — otherwise two services sharing a prefix would collide.
+ *
+ * Lives in the shared module rather than on FlyProvider because the cloud
+ * provider needs the identical rule (cloud mode *is* Fly behind a control
+ * plane). Having it call into FlyProvider instead would drag that module's
+ * transitive imports into every consumer.
+ */
+export function flyAppNameFor(params: { name: string; projectId: string }): string {
+  const suffix = `-${params.projectId}`;
+  const maxBase = 60 - suffix.length;
+  // Need at least 8 chars for a truncated name: 1 letter + dash + 6-char hash
+  if (maxBase < 8) {
+    throw new AppError(
+      `projectId is too long to produce a valid Fly app name (max ~51 chars, got ${params.projectId.length})`,
+      400,
+      ERROR_CODES.INVALID_INPUT
+    );
+  }
+  if (params.name.length <= maxBase) {
+    return params.name + suffix;
+  }
+  const hash = createHash('sha256').update(params.name).digest('hex').slice(0, 6);
+  const truncated = params.name.slice(0, maxBase - 7); // 6 chars hash + 1 dash
+  return `${truncated}-${hash}${suffix}`;
+}
+
+/**
+ * Public URL for a Fly app. Defaults to Fly's own `.fly.dev` hostname, which
+ * Fly routes automatically for every app. Operators owning a wildcard domain
+ * pointed at Fly can override with COMPUTE_DOMAIN; otherwise we return a URL
+ * that actually resolves rather than a vanity domain nobody controls.
+ */
+export function flyEndpointUrl(appId: string): string {
+  const domain = appConfig.fly.domain || 'fly.dev';
+  return `https://${appId}.${domain}`;
+}
+
 // Shared translation wrapper for machine-scoped provider calls. Each provider
 // supplies its own `isGone` predicate (they see different error shapes), but
 // the translate-and-rethrow contract lives in one place so fly-mode and
@@ -113,12 +190,107 @@ export async function translateMachineGone<T>(
   }
 }
 
+/**
+ * What a provider can actually do. The service layer used to hardcode Fly's
+ * answers to all of these — region changes being impossible in place, machines
+ * being able to scale to zero, source builds going through flyctl — which made
+ * a second driver impossible to add without lying somewhere. Providers now
+ * declare their own, and the service/route/CLI layers gate on the declaration
+ * instead of assuming.
+ */
+export interface ComputeCapabilities {
+  /** Instances can be stopped when idle and cold-started on the next request. */
+  scaleToZero: boolean;
+  /** Instances are placed in named geographic regions. */
+  regions: boolean;
+  /**
+   * Ingress modes the driver can actually deliver.
+   *
+   *   'none' — reachable only on the project's internal network.
+   *   'port' — published on a host port.
+   *   'host' — reachable at a hostname.
+   *
+   * Fly allocates public IPs and a `.fly.dev` hostname for every app, so it can
+   * only offer 'host'; asking it for 'none' is not something it can honour. A
+   * single-host driver can offer all three. The first entry is the driver's
+   * default when a caller does not choose.
+   */
+  ingressModes: ('none' | 'port' | 'host')[];
+  /**
+   * How a caller gets from source to a running image.
+   *   'none'           — image-mode only; the caller supplies a built image.
+   *   'flyctl'         — the CLI shells out to flyctl for a remote build.
+   *   'context-upload' — the caller uploads a build context and we build it.
+   */
+  sourceBuild: 'none' | 'flyctl' | 'context-upload';
+  /**
+   * Whether POST /:id/deploy-token can mint a scoped build credential. Only
+   * cloud-managed mode can: it holds an org-wide token that must be narrowed
+   * before it leaves the backend. A self-hoster already owns their credentials,
+   * so there is nothing to narrow — and the CLI must branch on this rather than
+   * calling the endpoint unconditionally (which is the current self-host bug).
+   */
+  deployTokenIssuance: boolean;
+}
+
 export interface ComputeProvider {
   isConfigured(): boolean;
-  createApp(params: { name: string; network: string; org: string }): Promise<{ appId: string }>;
+  /**
+   * Driver name persisted in `compute.services.provider`. Declared rather than
+   * inferred with `instanceof` — provider identity has to survive being mocked,
+   * and an `instanceof` against a mocked class throws outright.
+   *
+   * Cloud-managed mode reports 'fly': it *is* Fly behind a control plane and
+   * shares Fly's app/machine identifiers, so a row created in one mode stays
+   * manageable in the other.
+   */
+  readonly name: 'fly' | 'docker';
+  readonly capabilities: ComputeCapabilities;
+  /**
+   * Provider-native name for the app/namespace backing a service. Fly needs a
+   * globally-unique, length-capped app name; Docker only needs a locally-unique
+   * container name. Deriving it is the provider's business, not the service's.
+   */
+  resolveAppName(params: { name: string; projectId: string }): string;
+  /**
+   * Public URL for a deployed app, or null when the provider cannot know one
+   * (Docker with no ingress configured). Fly always has a `.fly.dev` hostname;
+   * Docker may have nothing to advertise, and returning null is more honest
+   * than emitting a URL that does not resolve.
+   */
+  endpointUrl(appId: string): string | null;
+  createApp(params: { name: string }): Promise<{ appId: string }>;
   destroyApp(appId: string): Promise<void>;
-  launchMachine(params: LaunchMachineParams): Promise<{ machineId: string }>;
-  updateMachine(params: UpdateMachineParams): Promise<void>;
+  /**
+   * Create and start an instance.
+   *
+   * `endpointUrl` is the provider's chance to report a URL it could only know
+   * after launching — Docker lets the daemon assign an ephemeral host port, so
+   * the address does not exist until the container does. `undefined` means the
+   * provider has no post-launch opinion and the caller should use the synchronous
+   * `endpointUrl(appId)`; an explicit `null` means "resolved, and there is
+   * genuinely nothing to advertise".
+   */
+  launchMachine(
+    params: LaunchMachineParams
+  ): Promise<{ machineId: string; endpointUrl?: string | null }>;
+  /**
+   * Bring the instance to the requested state.
+   *
+   * Returns a `machineId` when satisfying the request required replacing the
+   * instance, so the caller can persist the new identity. Fly updates a machine
+   * in place and returns nothing; Docker cannot change a running container's
+   * image, ports, or env at all and has to recreate — reporting that here is
+   * what keeps the stored instance id from pointing at a container that no
+   * longer exists.
+   *
+   * `endpointUrl` follows the same rules as on launchMachine, and matters for the
+   * same reason: a replacement instance gets a *new* ephemeral host port, so the
+   * previously stored URL would point at one that has been freed.
+   */
+  updateMachine(
+    params: UpdateMachineParams
+  ): Promise<{ machineId?: string; endpointUrl?: string | null }>;
   stopMachine(appId: string, machineId: string): Promise<void>;
   startMachine(appId: string, machineId: string): Promise<void>;
   destroyMachine(appId: string, machineId: string): Promise<void>;

--- a/backend/src/providers/compute/docker.client.ts
+++ b/backend/src/providers/compute/docker.client.ts
@@ -1,0 +1,376 @@
+import http from 'node:http';
+import { appConfig } from '@/infra/config/app.config.js';
+
+/**
+ * Minimal Docker Engine API client over the unix socket.
+ *
+ * Deliberately dependency-free: node's `http` supports `socketPath` directly, and
+ * the surface we need is a handful of endpoints. Adding a Docker SDK would pull a
+ * large transitive tree in to save very little.
+ *
+ * The API is called unversioned (`/containers/...` rather than `/v1.43/...`) so
+ * the daemon applies its own default version. Verified against Engine 25.0.16 and
+ * 29.3.1.
+ */
+
+export class DockerHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'DockerHttpError';
+  }
+}
+
+export interface DockerRawResponse {
+  status: number;
+  body: Buffer;
+}
+
+/**
+ * Docker settings with defaults applied.
+ *
+ * Optional-chained because config objects are routinely partial — test mocks
+ * stub only the slice under test, and a deployment upgraded mid-release can read
+ * a config built before this section existed. Reaching straight for
+ * `appConfig.docker.socketPath` turns either case into an unrelated TypeError
+ * deep inside provider selection; CloudComputeProvider already guards its own
+ * slice the same way.
+ */
+export function dockerConfig(): {
+  socketPath: string;
+  publicHost: string;
+  domain: string;
+  defaultIngress: string;
+  bindAddress: string;
+  isolateNetwork: boolean;
+} {
+  const c = appConfig.docker;
+  return {
+    socketPath: c?.socketPath || '/var/run/docker.sock',
+    publicHost: c?.publicHost || '',
+    domain: c?.domain || '',
+    defaultIngress: c?.defaultIngress || 'none',
+    bindAddress: c?.bindAddress || '127.0.0.1',
+    isolateNetwork: c?.isolateNetwork ?? false,
+  };
+}
+
+function socketPath(): string {
+  return dockerConfig().socketPath;
+}
+
+/**
+ * Issue one request and buffer the whole response.
+ *
+ * Returns raw bytes rather than parsed JSON because the logs endpoint returns a
+ * binary framed stream, not JSON — see demuxDockerStream.
+ */
+export function dockerRequestRaw(
+  method: string,
+  path: string,
+  options: {
+    body?: unknown;
+    /** Pre-encoded body (a build context tarball), sent as-is. */
+    rawBody?: Buffer;
+    contentType?: string;
+    timeoutMs?: number;
+  } = {}
+): Promise<DockerRawResponse> {
+  const payload =
+    options.rawBody ??
+    (options.body === undefined ? null : Buffer.from(JSON.stringify(options.body)));
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        socketPath: socketPath(),
+        path,
+        method,
+        headers: payload
+          ? {
+              'Content-Type': options.contentType ?? 'application/json',
+              'Content-Length': payload.length,
+            }
+          : {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks) }));
+        res.on('error', reject);
+      }
+    );
+
+    // Time-box every call. The daemon is local so anything slow is a stall, and
+    // the logs endpoint is polled live — a hung request must not pile up.
+    req.setTimeout(options.timeoutMs ?? 30_000, () => {
+      req.destroy(new Error(`Docker API request timed out: ${method} ${path}`));
+    });
+    req.on('error', reject);
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+/** Same, but parses JSON and throws DockerHttpError on non-2xx. */
+export async function dockerRequest<T>(
+  method: string,
+  path: string,
+  options: { body?: unknown; timeoutMs?: number } = {}
+): Promise<T | undefined> {
+  const res = await dockerRequestRaw(method, path, options);
+  const text = res.body.toString('utf8');
+
+  if (res.status < 200 || res.status >= 300) {
+    // Docker error bodies are `{"message":"..."}`; fall back to the raw text.
+    let message = text;
+    try {
+      const parsed = JSON.parse(text) as { message?: string };
+      message = parsed.message ?? text;
+    } catch {
+      /* not JSON — use the raw body */
+    }
+    throw new DockerHttpError(res.status, `Docker API error (${res.status}): ${message}`);
+  }
+
+  return text ? (JSON.parse(text) as T) : undefined;
+}
+
+/**
+ * Outcome of a `POST /build`.
+ *
+ * `failed` is not derived from the HTTP status: a build that fails still returns
+ * **200**, with the error appended to the response body as plain JSON. Measured
+ * against Engine 29.3.1 using a Dockerfile containing `RUN exit 7`:
+ *
+ *   {"error":"process \"/bin/sh -c exit 7\" did not complete successfully: exit code: 7",
+ *    "errorDetail":{"message":"…"}}
+ *
+ * An implementation that trusts the status code proceeds to start a container
+ * from a tag that was never produced.
+ */
+export interface DockerBuildResult {
+  ok: boolean;
+  error: string | null;
+  /** Human-readable progress, when the builder produces any. See parseBuildStream. */
+  logs: string[];
+}
+
+/**
+ * Parse the newline-delimited JSON stream that `POST /build` returns.
+ *
+ * The two builders report progress in completely different shapes, both measured:
+ *
+ *   classic (`version=1`) → {"stream":"Step 1/3 : FROM alpine"}  — readable
+ *   BuildKit (`version=2`) → {"id":"moby.buildkit.trace","aux":"<base64 protobuf>"}
+ *
+ * We build with the classic builder (see dockerBuild for why), so the readable form
+ * is what actually arrives. The BuildKit branch is kept because it costs three lines
+ * and means a future switch back — once the session or buildx path exists — degrades
+ * to coarse progress instead of reporting an empty log: `aux` frames are counted, not
+ * decoded, since rendering them would require protobuf and the
+ * `moby.buildkit.v1.StatusResponse` schema.
+ *
+ * Failure detection is builder-independent: the error arrives as plain JSON at the
+ * tail either way, which is why it needs none of the above.
+ */
+export function parseBuildStream(body: string): DockerBuildResult {
+  const logs: string[] = [];
+  let error: string | null = null;
+  let auxFrames = 0;
+
+  for (const line of body.split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+    let frame: {
+      stream?: string;
+      error?: string;
+      errorDetail?: { message?: string };
+      aux?: string;
+    };
+    try {
+      frame = JSON.parse(line) as typeof frame;
+    } catch {
+      // A partial trailing line on a truncated stream — not worth failing over.
+      continue;
+    }
+    if (frame.error || frame.errorDetail?.message) {
+      error = frame.errorDetail?.message ?? frame.error ?? 'Build failed';
+      continue;
+    }
+    if (typeof frame.stream === 'string') {
+      const text = frame.stream.replace(/\n$/, '');
+      if (text.trim()) {
+        logs.push(text);
+      }
+      continue;
+    }
+    if (frame.aux) {
+      auxFrames++;
+    }
+  }
+
+  if (!logs.length && auxFrames) {
+    logs.push(`(BuildKit reported ${auxFrames} progress frames; per-step detail not decoded)`);
+  }
+
+  return { ok: error === null, error, logs };
+}
+
+/**
+ * Stream a build context tarball to the daemon and build it.
+ *
+ * The body is a tar archive, which is the endpoint's native input — so a caller
+ * that already has a tar can pipe straight through with no intermediate storage.
+ *
+ * A note for whoever produces that tar on macOS: files there carry a
+ * `com.apple.provenance` extended attribute, and when bsdtar embeds it the Linux
+ * daemon rejects the whole context with `lsetxattr /Dockerfile: xattr
+ * "com.apple.provenance": operation not supported`.
+ *
+ * Observed once against Engine 29.3.1 and not reproducible on demand — whether
+ * bsdtar writes the attribute into the archive varies, so this is a real failure
+ * with an environment-dependent trigger rather than something every Mac hits.
+ * Producing the tar with `--no-xattrs` (or `COPYFILE_DISABLE=1`) costs nothing and
+ * removes the possibility; buildFromContext also recognises the error and says so.
+ */
+export async function dockerBuild(params: {
+  context: Buffer;
+  tag: string;
+  dockerfile?: string;
+  buildArgs?: Record<string, string>;
+  timeoutMs?: number;
+}): Promise<DockerBuildResult> {
+  const query = new URLSearchParams({
+    t: params.tag,
+    dockerfile: params.dockerfile ?? 'Dockerfile',
+    // **Classic builder, not BuildKit.** An earlier round chose BuildKit
+    // (`version=2`) on the strength of its caching, having checked only its
+    // progress format and error reporting. That comparison missed the thing that
+    // decides it: measured on a fresh host with the base image absent,
+    //
+    //   version=2 → {"error":"nginx:alpine: no active sessions"}
+    //   version=1 → builds, having pulled the base image itself
+    //
+    // BuildKit resolves `FROM` through the gRPC session that `docker build`
+    // establishes over `/session`; a plain POST has no session, so it cannot pull
+    // base images at all. It only appeared to work earlier because the test host
+    // already had them cached — the same blind spot that hid the missing
+    // container-create pull.
+    //
+    // The classic builder also happens to emit readable
+    // `{"stream":"Step 1/3 : FROM alpine"}` progress, so switching improves build
+    // logs rather than costing them.
+    //
+    // The cost is real: Docker has signalled the classic builder for removal. The
+    // durable fixes are to implement the BuildKit session, or to shell out to
+    // `docker buildx` and parse its output. Both are more than v1 needs, and both
+    // are recorded as follow-ups rather than guessed at now.
+    version: '1',
+    // Remove intermediate containers so a long-lived host does not accumulate them.
+    rm: '1',
+  });
+  if (params.buildArgs && Object.keys(params.buildArgs).length) {
+    query.set('buildargs', JSON.stringify(params.buildArgs));
+  }
+
+  const res = await dockerRequestRaw('POST', `/build?${query.toString()}`, {
+    rawBody: params.context,
+    contentType: 'application/x-tar',
+    // Builds are minutes, not seconds — the default request timeout would kill
+    // any real one.
+    timeoutMs: params.timeoutMs ?? 15 * 60_000,
+  });
+
+  const body = res.body.toString('utf8');
+  if (res.status < 200 || res.status >= 300) {
+    // A pre-stream rejection (bad context, unknown parameter) does use the status.
+    return {
+      ok: false,
+      error: `Docker build rejected (${res.status}): ${body.slice(0, 500)}`,
+      logs: [],
+    };
+  }
+  return parseBuildStream(body);
+}
+
+/**
+ * Split a Docker multiplexed stream into its frame payloads.
+ *
+ * For a container created without a TTY, `GET /containers/{id}/logs` returns
+ * frames rather than plain text. Measured against Engine 29.3.1:
+ *
+ *   0100 0000 0000 0026  32303236 2d30382d ...
+ *   ^^                   ^^^^^^^^^^^^^^^^^ payload ("<RFC3339Nano> line\n")
+ *   |  \_ 3 bytes zero   \_ 4-byte big-endian payload length (0x26 = 38)
+ *   \_ stream type: 1 = stdout, 2 = stderr
+ *
+ * Skipping this step yields lines prefixed with `^A^@^@^@^@^@^@&`, which is the
+ * single most likely way this code silently produces garbage.
+ *
+ * Truncated trailing frames are ignored rather than throwing: the response is a
+ * snapshot of a live stream and may end mid-frame.
+ */
+export function demuxDockerStream(buf: Buffer): { stream: 'stdout' | 'stderr'; text: string }[] {
+  const out: { stream: 'stdout' | 'stderr'; text: string }[] = [];
+  let offset = 0;
+
+  while (offset + 8 <= buf.length) {
+    const type = buf[offset];
+    const length = buf.readUInt32BE(offset + 4);
+    const start = offset + 8;
+    const end = start + length;
+    if (end > buf.length) {
+      break;
+    }
+    out.push({
+      stream: type === 2 ? 'stderr' : 'stdout',
+      text: buf.subarray(start, end).toString('utf8'),
+    });
+    offset = end;
+  }
+
+  return out;
+}
+
+/**
+ * Parse Docker's `timestamps=1` RFC3339Nano prefix.
+ *
+ * Both precisions are needed and for different reasons. `ms` populates the
+ * response shape (epoch milliseconds, matching the Fly provider). `nanos` is the
+ * forward cursor: the `since` query parameter only accepts **integer seconds**,
+ * so second granularity cannot be the dedup key — 50 lines inside one second
+ * would be re-fetched on every poll, and dropping by second would discard the
+ * genuinely new ones. See DockerProvider.getLogs.
+ */
+export function parseLogLine(text: string): { ms: number; nanos: bigint; message: string } | null {
+  const space = text.indexOf(' ');
+  if (space === -1) {
+    return null;
+  }
+  const ts = text.slice(0, space);
+  const message = text.slice(space + 1).replace(/\n$/, '');
+
+  const ms = Date.parse(ts);
+  if (Number.isNaN(ms)) {
+    return null;
+  }
+
+  // Recover full nanosecond precision, which Date.parse truncates to ms.
+  const dot = ts.indexOf('.');
+  let nanos: bigint;
+  if (dot === -1) {
+    nanos = BigInt(Math.trunc(ms / 1000)) * 1_000_000_000n;
+  } else {
+    const secs = BigInt(Math.trunc(Date.parse(`${ts.slice(0, dot)}Z`) / 1000));
+    const frac = ts.slice(dot + 1).replace(/[^0-9]/g, '');
+    nanos = secs * 1_000_000_000n + BigInt(frac.padEnd(9, '0').slice(0, 9));
+  }
+
+  return { ms, nanos, message };
+}

--- a/backend/src/providers/compute/docker.provider.ts
+++ b/backend/src/providers/compute/docker.provider.ts
@@ -53,6 +53,11 @@ type ContainerInspect = {
 
 export type DockerIngress = 'none' | 'port' | 'host';
 
+/** Service names are DNS-safe, but a filter built by concatenation should not assume it. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * True when this backend belongs to a cloud-managed project.
  *
@@ -498,15 +503,26 @@ export class DockerProvider implements ComputeProvider {
     const filters = encodeURIComponent(
       JSON.stringify({
         label: [`${LABEL_MANAGED}=true`, `${LABEL_PROJECT}=${this.projectKey()}`],
-        name: [appId],
+        // Anchored. Docker treats a name filter as an unanchored regex over the
+        // container's names, so a bare `api` would also match `api-v2` — and since a
+        // container name carries a leading slash, the anchors have to allow for it.
+        // The service label below is the exact-match check; the name filter only
+        // narrows the scan.
+        name: [`^/?${escapeRegExp(appId)}$`],
       })
     );
     const list =
-      (await dockerRequest<{ Id: string; State: string }[]>(
+      (await dockerRequest<{ Id: string; State: string; Names?: string[] }[]>(
         'GET',
         `/containers/json?all=true&filters=${filters}`
       )) ?? [];
-    return list.map((c) => ({ id: c.Id, state: this.mapState(c.State), region: 'local' }));
+    return (
+      list
+        // Belt and braces: the filter is the daemon's job, but a mismatch here would
+        // report someone else's container as this service's instance.
+        .filter((c) => (c.Names ?? []).some((n) => n.replace(/^\//, '') === appId))
+        .map((c) => ({ id: c.Id, state: this.mapState(c.State), region: 'local' }))
+    );
   }
 
   async getMachineStatus(appId: string, machineId: string): Promise<{ state: string }> {

--- a/backend/src/providers/compute/docker.provider.ts
+++ b/backend/src/providers/compute/docker.provider.ts
@@ -1,0 +1,925 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { cpuTierToCores } from '@insforge/shared-schemas';
+import { appConfig } from '@/infra/config/app.config.js';
+import { isCloudEnvironment } from '@/utils/environment.js';
+import logger from '@/utils/logger.js';
+import {
+  MachineGoneError,
+  translateMachineGone,
+  type ComputeProvider,
+  type ComputeCapabilities,
+  type ComputeEvent,
+  type ComputeLogLine,
+  type ComputeLogsResult,
+  type LaunchMachineParams,
+  type MachineSummary,
+  type UpdateMachineParams,
+} from './compute.provider.js';
+import {
+  DockerHttpError,
+  dockerBuild,
+  demuxDockerStream,
+  dockerConfig,
+  dockerRequest,
+  dockerRequestRaw,
+  parseLogLine,
+} from './docker.client.js';
+
+/** Labels every managed container carries. Scoping reads and writes to these is
+ * not defensive politeness — it is the difference between stopping a service and
+ * stopping Postgres. Measured on a real host: from inside a container with the
+ * socket mounted, an unfiltered `docker ps` lists the whole stack, including the
+ * backend itself. */
+const LABEL_MANAGED = 'insforge.managed';
+const LABEL_PROJECT = 'insforge.project';
+const LABEL_SERVICE = 'insforge.service';
+// Hash of the immutable part of the spec, so an update can tell an in-place
+// resize from a change that requires recreating the container.
+const LABEL_SPEC = 'insforge.spec';
+
+type ContainerInspect = {
+  Id: string;
+  Name: string;
+  State: { Status: string; ExitCode: number; Running: boolean };
+  Config: { Image: string; Labels?: Record<string, string> };
+  HostConfig?: { NanoCpus?: number; Memory?: number };
+  NetworkSettings: {
+    Ports?: Record<string, { HostIp: string; HostPort: string }[] | null>;
+    Networks?: Record<string, unknown>;
+  };
+};
+
+export type DockerIngress = 'none' | 'port' | 'host';
+
+/**
+ * True when this backend belongs to a cloud-managed project.
+ *
+ * Both signals are checked because they answer slightly different questions and
+ * either one being true is disqualifying: `isCloudEnvironment()` asks "am I
+ * running on InsForge Cloud infrastructure", while a configured cloud compute
+ * pair asks "is this project's control plane elsewhere". A guard that protects
+ * tenant isolation should fail closed on either.
+ */
+function isCloudManaged(): boolean {
+  const projectId = appConfig.cloud?.projectId;
+  const cloudProject = !!projectId && projectId !== 'local' && !!appConfig.cloud?.apiHost;
+  return isCloudEnvironment() || cloudProject;
+}
+
+export class DockerProvider implements ComputeProvider {
+  private static instance: DockerProvider;
+
+  static getInstance(): DockerProvider {
+    if (!DockerProvider.instance) {
+      DockerProvider.instance = new DockerProvider();
+    }
+    return DockerProvider.instance;
+  }
+
+  readonly name = 'docker' as const;
+
+  /**
+   * Docker has no scale-to-zero equivalent (waking a stopped container on an
+   * inbound request needs a proxy in front, which is Phase 4), and one daemon is
+   * one place — so `regions` is false and the service normalizes the field.
+   *
+   * Note there is deliberately no `privileged` capability: this driver never
+   * emits a privileged HostConfig at all. It constructs the container spec itself
+   * from a fixed set of fields and never forwards a caller-supplied HostConfig,
+   * which is what makes a leaked API key unable to obtain host control through
+   * container creation — there is no field in which `Privileged` or `Binds` could
+   * be smuggled, so there is nothing to declare.
+   */
+  readonly capabilities: ComputeCapabilities = {
+    scaleToZero: false,
+    regions: false,
+    // All three are available on one host. `none` leads because most compute
+    // takes no inbound traffic at all.
+    ingressModes: ['none', 'port', 'host'],
+    sourceBuild: 'context-upload',
+    deployTokenIssuance: false,
+  };
+
+  private ownNetwork: string | null | undefined;
+
+  /**
+   * Presence of a reachable socket is the operator's opt-in: they add the mount
+   * to their compose file, and the driver appears. Kept synchronous to match the
+   * interface — real reachability is proven by preflight().
+   *
+   * **Self-host only, enforced here rather than assumed.** This driver's entire
+   * safety argument is that the operator and the developer deploying containers
+   * are the same principal — whoever runs the box could already SSH into it. On a
+   * cloud-managed project that is false: the operator is InsForge and the
+   * developer is a customer, so letting a customer create containers on the host
+   * is a tenant escape, and even an unprivileged container consumes shared
+   * capacity and can reach the internal network.
+   *
+   * Cloud does not mount the socket today, so this would be unreachable in
+   * practice — but "unreachable because nobody mounted it" is a deployment
+   * accident away from being wrong, and the failure would be silent. Fail closed
+   * on either cloud signal instead.
+   */
+  isConfigured(): boolean {
+    if (isCloudManaged()) {
+      return false;
+    }
+    return existsSync(dockerConfig().socketPath);
+  }
+
+  /**
+   * Prove the socket actually answers, and report what we are talking to.
+   *
+   * Called at startup so a misconfigured mount fails with something actionable
+   * instead of 500-ing on the operator's first deploy. Also surfaces the
+   * platform facts that decide whether this host is supported at all (rootless
+   * mode, OS type).
+   */
+  async preflight(): Promise<{ version: string; os: string; rootless: boolean }> {
+    const version = await dockerRequest<{ Version: string; Os: string }>('GET', '/version');
+    const info = await dockerRequest<{ SecurityOptions?: string[] }>('GET', '/info');
+    if (!version?.Version) {
+      throw new Error('Docker /version returned no version');
+    }
+    const rootless = (info?.SecurityOptions ?? []).some((o) => o.includes('rootless'));
+    return { version: version.Version, os: version.Os ?? 'unknown', rootless };
+  }
+
+  // ---------------------------------------------------------------- naming ---
+
+  /**
+   * Container name. Namespaced by APP_KEY because one host commonly runs several
+   * InsForge projects (the docs describe exactly that), and two projects both
+   * deploying a service called `api` would otherwise collide on one daemon.
+   */
+  resolveAppName(params: { name: string; projectId: string }): string {
+    return `insforge-${this.projectKey()}-${params.name}`;
+  }
+
+  /**
+   * Always null: ingress is per-service, and this synchronous signature has no
+   * way to know which mode a given service asked for. launchMachine and
+   * updateMachine return the authoritative URL, which the service persists.
+   */
+  endpointUrl(_appId: string): string | null {
+    return null;
+  }
+
+  private projectKey(): string {
+    return process.env.APP_KEY || 'local';
+  }
+
+  /**
+   * Ingress for one call: the service's own choice, else the operator's
+   * deployment-wide default, else private-only.
+   */
+  private ingressFor(requested?: string): DockerIngress {
+    const v = requested ?? dockerConfig().defaultIngress;
+    return v === 'port' || v === 'host' ? v : 'none';
+  }
+
+  // ------------------------------------------------------------ app-scoped ---
+
+  /**
+   * No-op beyond ensuring the project network exists. Docker has no "app"
+   * grouping above the container, so the app id is the container name and the
+   * container itself is created by launchMachine.
+   */
+  async createApp(_params: { name: string }): Promise<{ appId: string }> {
+    await this.resolveNetwork();
+    return { appId: _params.name };
+  }
+
+  /**
+   * Nothing to destroy: the container is removed by destroyMachine, and the
+   * network is shared with the rest of the project's stack so it must outlive
+   * any one service.
+   */
+  async destroyApp(_appId: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  // -------------------------------------------------------------- networking ---
+
+  /**
+   * The project's own compose network, discovered by inspecting our own
+   * container.
+   *
+   * Compose namespaces networks per project (`myproj_insforge-network`), so the
+   * name cannot be guessed. Docker sets the container hostname to the short
+   * container id by default, which gives us a handle on ourselves.
+   *
+   * Attaching by default is deliberate: the product promise is that containers
+   * sit next to the project's database and storage, and forcing them out to the
+   * public URL costs a TLS handshake plus a round trip and depends on the
+   * operator's firewall allowing it — measured on EC2, a closed security group
+   * turns that path into a silent hang rather than an error.
+   */
+  private async resolveNetwork(): Promise<string | null> {
+    if (this.ownNetwork !== undefined) {
+      return this.ownNetwork;
+    }
+    if (dockerConfig().isolateNetwork) {
+      this.ownNetwork = null;
+      return null;
+    }
+    try {
+      const self = await dockerRequest<ContainerInspect>(
+        'GET',
+        `/containers/${encodeURIComponent(hostname())}/json`
+      );
+      const names = Object.keys(self?.NetworkSettings?.Networks ?? {}).filter(
+        (n) => !['bridge', 'host', 'none'].includes(n)
+      );
+      this.ownNetwork = names[0] ?? null;
+      if (!this.ownNetwork) {
+        logger.warn(
+          'Docker compute: could not identify the project network; containers will use the default bridge ' +
+            'and will not resolve `postgres`/`postgrest` by name.'
+        );
+      }
+    } catch (error) {
+      // Not fatal — the backend may not be running in a container at all (local
+      // dev against a host daemon). Containers land on the default bridge.
+      this.ownNetwork = null;
+      logger.warn('Docker compute: own-container inspect failed; using the default bridge', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return this.ownNetwork;
+  }
+
+  // ---------------------------------------------------------------- ownership ---
+
+  /**
+   * Verify a container is ours before touching it.
+   *
+   * Every machine-scoped call addresses a container by id, and a stale or wrong
+   * id could name Postgres or a co-tenant project's container. Docker offers no
+   * way to scope a call by label, so the check has to be explicit — one inspect
+   * per operation against a local socket, which is cheap next to the cost of
+   * being wrong.
+   */
+  private async assertOwned(containerId: string): Promise<ContainerInspect> {
+    const c = await dockerRequest<ContainerInspect>(
+      'GET',
+      `/containers/${encodeURIComponent(containerId)}/json`
+    );
+    if (!c) {
+      throw new DockerHttpError(404, `Container ${containerId} not found`);
+    }
+    const labels = c.Config?.Labels ?? {};
+    if (labels[LABEL_MANAGED] !== 'true' || labels[LABEL_PROJECT] !== this.projectKey()) {
+      // Deliberately reported as gone rather than forbidden: from this project's
+      // point of view the container it is asking about does not exist, and
+      // saying "that belongs to someone else" would confirm what is running on
+      // the host.
+      throw new MachineGoneError(c.Name ?? containerId, containerId);
+    }
+    return c;
+  }
+
+  private machineScoped<T>(appId: string, containerId: string, fn: () => Promise<T>): Promise<T> {
+    return translateMachineGone(
+      appId,
+      containerId,
+      (err) => err instanceof DockerHttpError && err.status === 404,
+      fn
+    );
+  }
+
+  // ------------------------------------------------------------- lifecycle ---
+
+  async launchMachine(
+    params: LaunchMachineParams
+  ): Promise<{ machineId: string; endpointUrl: string | null }> {
+    // Must precede create — see ensureImage.
+    await this.ensureImage(params.image, params.appId);
+
+    const network = await this.resolveNetwork();
+    const ingress = this.ingressFor(params.ingress);
+
+    const exposed = `${params.port}/tcp`;
+    const body: Record<string, unknown> = {
+      Image: params.image,
+      Labels: {
+        [LABEL_MANAGED]: 'true',
+        [LABEL_PROJECT]: this.projectKey(),
+        [LABEL_SERVICE]: params.appId,
+        [LABEL_SPEC]: this.specHash(params),
+      },
+      Env: Object.entries(params.envVars ?? {}).map(([k, v]) => `${k}=${v}`),
+      ExposedPorts: { [exposed]: {} },
+      HostConfig: {
+        // Survives a host reboot. Measured: a container with this policy was
+        // running again seconds after a real EC2 reboot; one without stayed
+        // exited.
+        RestartPolicy: { Name: 'unless-stopped' },
+        NanoCpus: Math.round(cpuTierToCores(params.cpu) * 1e9),
+        Memory: params.memory * 1024 * 1024,
+        // Empty HostPort lets the daemon assign an ephemeral one, which avoids
+        // an allocation race with anything else on the host. Read back from
+        // inspect below.
+        //
+        // Note the bind address: Docker's own default publishes on 0.0.0.0 *and*
+        // [::] (measured), i.e. the whole internet on a reachable host. We
+        // default to loopback so exposure is a deliberate choice.
+        PortBindings:
+          ingress === 'none'
+            ? {}
+            : { [exposed]: [{ HostIp: dockerConfig().bindAddress, HostPort: '' }] },
+      },
+    };
+    if (network) {
+      body.NetworkingConfig = { EndpointsConfig: { [network]: {} } };
+    }
+
+    const created = await dockerRequest<{ Id: string; Warnings?: string[] }>(
+      'POST',
+      `/containers/create?name=${encodeURIComponent(params.appId)}`,
+      { body }
+    );
+    if (!created?.Id) {
+      throw new Error(`Docker container create returned no id for ${params.appId}`);
+    }
+    if (created.Warnings?.length) {
+      logger.warn('Docker container created with warnings', {
+        name: params.appId,
+        warnings: created.Warnings,
+      });
+    }
+
+    try {
+      await dockerRequest('POST', `/containers/${created.Id}/start`);
+    } catch (error) {
+      // A container that will not start is worse than no container: it would sit
+      // in the table looking deployable. Remove it and surface the real reason.
+      await dockerRequest('DELETE', `/containers/${created.Id}?force=true`).catch(() => undefined);
+      throw error;
+    }
+
+    // Resolved here rather than by the caller: under `port` ingress the daemon
+    // assigns an ephemeral host port, so the address does not exist until now.
+    return {
+      machineId: created.Id,
+      endpointUrl: await this.resolvePublishedUrl(created.Id, params.port, ingress),
+    };
+  }
+
+  /**
+   * Bring the container to the requested state.
+   *
+   * Docker can change CPU and memory on a running container, but **not** its
+   * image, ports, or environment. Applying only the in-place fields and ignoring
+   * the rest would make `compute deploy --image newer:tag` report success while
+   * the old image keeps running and the database records the new one — silent,
+   * and the worst possible failure for a deploy command. So anything outside
+   * cpu/memory forces a recreate.
+   *
+   * Which case applies is decided by comparing a hash of the immutable part of
+   * the spec, stored on the container as a label. Comparing fields directly is
+   * unreliable for env: `Config.Env` also carries the image's own defaults, and
+   * a *removed* variable is invisible when you only check that the requested
+   * ones are present. The hash covers removals exactly.
+   */
+  async updateMachine(
+    params: UpdateMachineParams
+  ): Promise<{ machineId?: string; endpointUrl?: string | null }> {
+    return this.machineScoped(params.appId, params.machineId, async () => {
+      const current = await this.assertOwned(params.machineId);
+      const desired = this.specHash(params);
+
+      if (current.Config?.Labels?.[LABEL_SPEC] === desired) {
+        await dockerRequest('POST', `/containers/${encodeURIComponent(params.machineId)}/update`, {
+          body: {
+            NanoCpus: Math.round(cpuTierToCores(params.cpu) * 1e9),
+            Memory: params.memory * 1024 * 1024,
+          },
+        });
+        return {};
+      }
+
+      // Recreate under the same name. Stop and remove first because the name is
+      // taken; if creating the replacement then fails, the row is left pointing
+      // at a removed container, which the existing MachineGoneError healing turns
+      // into a clean relaunch on the next request.
+      const name = (current.Name ?? '').replace(/^\//, '') || params.appId;
+      await dockerRequest('POST', `/containers/${encodeURIComponent(params.machineId)}/stop`).catch(
+        () => undefined
+      );
+      await dockerRequest(
+        'DELETE',
+        `/containers/${encodeURIComponent(params.machineId)}?force=true`
+      );
+
+      const launched = await this.launchMachine({
+        appId: name,
+        image: params.image,
+        port: params.port,
+        cpu: params.cpu,
+        memory: params.memory,
+        envVars: params.envVars,
+        region: 'local',
+        ingress: params.ingress,
+        protocol: params.protocol,
+        scaleToZero: params.scaleToZero,
+      });
+      logger.info('Docker compute: recreated container to apply a spec change', {
+        name,
+        previous: params.machineId.slice(0, 12),
+        replacement: launched.machineId.slice(0, 12),
+      });
+      // The replacement's published port is newly assigned, so the URL has to
+      // travel with the new id.
+      return { machineId: launched.machineId, endpointUrl: launched.endpointUrl };
+    });
+  }
+
+  /**
+   * Hash of the parts of a container spec that cannot be changed in place.
+   *
+   * cpu and memory are deliberately excluded — they are updatable, so including
+   * them would force a pointless recreate on a resize.
+   */
+  private specHash(params: {
+    image: string;
+    port: number;
+    envVars?: Record<string, string>;
+    ingress?: string;
+  }): string {
+    const env = Object.entries(params.envVars ?? {})
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([k, v]) => `${k}=${v}`);
+    return createHash('sha256')
+      .update(
+        JSON.stringify({
+          image: params.image,
+          port: params.port,
+          env,
+          ingress: this.ingressFor(params.ingress),
+        })
+      )
+      .digest('hex')
+      .slice(0, 16);
+  }
+
+  async stopMachine(appId: string, machineId: string): Promise<void> {
+    await this.machineScoped(appId, machineId, async () => {
+      await this.assertOwned(machineId);
+      await dockerRequest('POST', `/containers/${encodeURIComponent(machineId)}/stop`);
+    });
+  }
+
+  async startMachine(appId: string, machineId: string): Promise<void> {
+    await this.machineScoped(appId, machineId, async () => {
+      await this.assertOwned(machineId);
+      await dockerRequest('POST', `/containers/${encodeURIComponent(machineId)}/start`);
+    });
+  }
+
+  async destroyMachine(appId: string, machineId: string): Promise<void> {
+    await this.machineScoped(appId, machineId, async () => {
+      await this.assertOwned(machineId);
+      // force=true so a running container goes in one call, mirroring the Fly
+      // provider (which needs it to avoid a 412).
+      await dockerRequest('DELETE', `/containers/${encodeURIComponent(machineId)}?force=true`);
+    });
+  }
+
+  async listMachines(appId: string): Promise<MachineSummary[]> {
+    const filters = encodeURIComponent(
+      JSON.stringify({
+        label: [`${LABEL_MANAGED}=true`, `${LABEL_PROJECT}=${this.projectKey()}`],
+        name: [appId],
+      })
+    );
+    const list =
+      (await dockerRequest<{ Id: string; State: string }[]>(
+        'GET',
+        `/containers/json?all=true&filters=${filters}`
+      )) ?? [];
+    return list.map((c) => ({ id: c.Id, state: this.mapState(c.State), region: 'local' }));
+  }
+
+  async getMachineStatus(appId: string, machineId: string): Promise<{ state: string }> {
+    const c = await this.machineScoped(appId, machineId, () => this.assertOwned(machineId));
+    return { state: this.mapState(c.State.Status) };
+  }
+
+  /**
+   * Docker's container states, mapped onto the existing service enum.
+   *
+   * `exited` maps to `stopped`, never `failed`, regardless of exit code. Measured
+   * across a real host reboot: containers that shut down cleanly reported
+   * `Exited (0)` while ones the host killed reported `Exited (137)` (SIGKILL).
+   * Treating a non-zero exit as failure would therefore mark a chunk of services
+   * failed after every reboot. Genuine crash detail belongs in events and logs,
+   * which report it accurately.
+   */
+  private mapState(status: string): string {
+    switch (status) {
+      case 'running':
+      case 'restarting':
+        return 'running';
+      case 'created':
+        return 'creating';
+      case 'removing':
+        return 'destroying';
+      case 'dead':
+        return 'failed';
+      case 'paused':
+      case 'exited':
+      default:
+        return 'stopped';
+    }
+  }
+
+  async waitForState(
+    appId: string,
+    machineId: string,
+    targetStates: string[],
+    timeoutMs = 30_000
+  ): Promise<string> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const { state } = await this.getMachineStatus(appId, machineId);
+        if (targetStates.includes(state)) {
+          return state;
+        }
+      } catch (error) {
+        // Definitive gone — polling will not bring it back.
+        if (error instanceof MachineGoneError) {
+          throw error;
+        }
+        logger.warn('Transient error polling container state, retrying', { appId, machineId });
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error(
+      `Container did not reach state [${targetStates.join(',')}] within ${timeoutMs}ms`
+    );
+  }
+
+  /**
+   * Pull the image unless the daemon already has it.
+   *
+   * `POST /containers/create` does **not** pull. `docker run` makes it look as if it
+   * does by catching the 404 and pulling first, but the API leaves that to the
+   * caller — so on a host that has never seen the image, create fails with
+   * `No such image: <ref>`. That is the state of every fresh self-hosted box on its
+   * first deploy, and it survived several rounds of testing because the test scripts
+   * pulled the image themselves beforehand.
+   *
+   * `/images/create` behaves like `/build`: newline-delimited JSON, and failure is
+   * reported **inside the body with HTTP 200**, so the status code alone is not
+   * enough here either.
+   *
+   * Lives on the provider rather than in the client because deciding *when* to pull
+   * and what to log is policy; the client stays transport. (It also keeps the call
+   * mockable — a client function calling its own sibling export bypasses module
+   * mocks.)
+   *
+   * Private registries need credentials in `X-Registry-Auth`, which is not wired up:
+   * pulls are anonymous, so a private image fails with the registry's own error
+   * rather than a confusing local one.
+   */
+  private async ensureImage(ref: string, serviceName: string): Promise<void> {
+    // Cheap existence check first — re-pulling on every launch would add seconds to
+    // each deploy and hammer the registry.
+    const probe = await dockerRequestRaw('GET', `/images/${encodeURIComponent(ref)}/json`);
+    if (probe.status >= 200 && probe.status < 300) {
+      return;
+    }
+
+    const res = await dockerRequestRaw(
+      'POST',
+      `/images/create?fromImage=${encodeURIComponent(ref)}`,
+      {
+        // A multi-hundred-megabyte pull over a slow link is minutes, not seconds; the
+        // default request timeout would abort a legitimate first deploy.
+        timeoutMs: 10 * 60_000,
+      }
+    );
+    const body = res.body.toString('utf8');
+    if (res.status < 200 || res.status >= 300) {
+      throw new DockerHttpError(
+        res.status,
+        `Docker image pull failed (${res.status}): ${body.slice(0, 500)}`
+      );
+    }
+    for (const line of body.split('\n')) {
+      if (!line.trim()) {
+        continue;
+      }
+      type PullFrame = { error?: string; errorDetail?: { message?: string } };
+      let frame: PullFrame;
+      try {
+        frame = JSON.parse(line) as PullFrame;
+      } catch {
+        continue; // partial trailing line
+      }
+      const err = frame.errorDetail?.message ?? frame.error;
+      if (err) {
+        throw new Error(`Docker image pull failed: ${err}`);
+      }
+    }
+    logger.info('Docker compute: pulled an image the host did not have', {
+      image: ref,
+      service: serviceName,
+    });
+  }
+
+  // ------------------------------------------------------------ source build ---
+
+  /**
+   * Build an image from an uploaded context and return the tag to deploy.
+   *
+   * Concurrency is capped because a build saturates CPU and disk: two arriving at
+   * once on a small VPS is the difference between a slow deploy and an OOM. The
+   * limit is a simple in-process gate, which is sufficient because a self-hosted
+   * deployment is a single backend process.
+   */
+  async buildFromContext(params: {
+    serviceName: string;
+    context: Buffer;
+    dockerfile?: string;
+    buildArgs?: Record<string, string>;
+  }): Promise<{ imageTag: string; logs: string[] }> {
+    if (DockerProvider.activeBuilds >= DockerProvider.MAX_CONCURRENT_BUILDS) {
+      throw new Error(
+        `Too many builds already running (${DockerProvider.MAX_CONCURRENT_BUILDS}). Retry when one finishes.`
+      );
+    }
+
+    // Tag carries a digest of the uploaded context, which makes it unique per
+    // deploy and gives prune a stable ordering. Note it is NOT content-addressed
+    // by *source*: tar embeds mtimes, so re-tarring identical files yields
+    // different bytes and therefore a different tag. That is fine — BuildKit's
+    // layer cache is what makes an unchanged rebuild fast, and distinct tags keep
+    // consecutive deploys distinguishable.
+    const digest = createHash('sha256').update(params.context).digest('hex').slice(0, 12);
+    const imageTag = `insforge-${this.projectKey()}/${params.serviceName}:${digest}`;
+
+    DockerProvider.activeBuilds++;
+    try {
+      const result = await dockerBuild({
+        context: params.context,
+        tag: imageTag,
+        dockerfile: params.dockerfile,
+        buildArgs: params.buildArgs,
+      });
+      if (!result.ok) {
+        // Surface the builder's own message: "no such file", "exit code 1" and
+        // friends are what the developer needs, not a generic failure.
+        const message = result.error ?? 'Build failed';
+        if (/xattr|lsetxattr/i.test(message)) {
+          // Baffling on its own — the context was tarred with extended attributes
+          // the Linux daemon cannot apply. Name the fix instead of leaving the
+          // developer to search for it.
+          throw new Error(
+            `${message}\n\nThe build context was archived with extended attributes that the daemon ` +
+              'cannot apply (common when tarring on macOS). Re-create the archive with `tar --no-xattrs` ' +
+              'or set COPYFILE_DISABLE=1.'
+          );
+        }
+        throw new Error(message);
+      }
+      logger.info('Docker compute: built an image from source', {
+        service: params.serviceName,
+        imageTag,
+      });
+      return { imageTag, logs: result.logs };
+    } finally {
+      DockerProvider.activeBuilds--;
+    }
+  }
+
+  private static activeBuilds = 0;
+  /**
+   * One build at a time. Raising this trades deploy latency for the risk of
+   * exhausting a small host — the median self-hosted box is a 2GB VPS.
+   */
+  private static readonly MAX_CONCURRENT_BUILDS = 1;
+
+  /**
+   * Delete images we built for a service beyond the newest `keep`.
+   *
+   * Every source deploy produces a new image, and nothing else reclaims them. This
+   * is the boring maintenance that turns into "the disk filled up" on someone's
+   * VPS six months from now, so it runs after each successful build rather than
+   * waiting for a retention policy nobody configures.
+   *
+   * Only images tagged by this project for this service are considered, and any
+   * still referenced by a container is skipped — Docker refuses those anyway, and
+   * a rollback to the previous tag should keep working.
+   */
+  async pruneServiceImages(serviceName: string, keep = 2): Promise<{ removed: number }> {
+    const prefix = `insforge-${this.projectKey()}/${serviceName}:`;
+    const images =
+      (await dockerRequest<{ Id: string; RepoTags: string[] | null; Created: number }[]>(
+        'GET',
+        '/images/json'
+      )) ?? [];
+
+    const ours = images
+      .filter((i) => (i.RepoTags ?? []).some((t) => t.startsWith(prefix)))
+      .sort((a, b) => b.Created - a.Created);
+
+    let removed = 0;
+    for (const image of ours.slice(keep)) {
+      const tag = (image.RepoTags ?? []).find((t) => t.startsWith(prefix));
+      if (!tag) {
+        continue;
+      }
+      try {
+        await dockerRequest('DELETE', `/images/${encodeURIComponent(tag)}`);
+        removed++;
+      } catch (error) {
+        // In use by a container, or already gone. Neither is worth failing a
+        // deploy over.
+        logger.info('Docker compute: kept an image that could not be removed', {
+          tag,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (removed) {
+      logger.info('Docker compute: pruned old service images', { serviceName, removed });
+    }
+    return { removed };
+  }
+
+  // ------------------------------------------------------------------ reads ---
+
+  /**
+   * Container lifecycle events, the counterpart to Fly's machine events.
+   *
+   * `until` is mandatory in practice: without it Docker's /events endpoint
+   * streams and the request never completes.
+   */
+  async getEvents(
+    appId: string,
+    machineId: string,
+    options?: { limit?: number }
+  ): Promise<ComputeEvent[]> {
+    await this.machineScoped(appId, machineId, () => this.assertOwned(machineId));
+
+    const until = Math.floor(Date.now() / 1000);
+    const since = until - 24 * 60 * 60;
+    const filters = encodeURIComponent(
+      JSON.stringify({ container: [machineId], type: ['container'] })
+    );
+    const res = await dockerRequestRaw(
+      'GET',
+      `/events?since=${since}&until=${until}&filters=${filters}`
+    );
+
+    // /events emits newline-delimited JSON objects, not a JSON array.
+    const events: ComputeEvent[] = [];
+    for (const line of res.body.toString('utf8').split('\n')) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const e = JSON.parse(line) as { Action?: string; Type?: string; time?: number };
+        events.push({
+          timestamp: (e.time ?? 0) * 1000,
+          message: `[${e.Type ?? 'container'}] ${e.Action ?? 'unknown'}`,
+        });
+      } catch {
+        /* skip an unparseable line rather than lose the whole response */
+      }
+    }
+
+    const limit = options?.limit ?? 100;
+    return events.slice(-limit);
+  }
+
+  /**
+   * Container stdout/stderr.
+   *
+   * Two measured constraints shape this, and both are easy to get wrong:
+   *
+   *  1. The response is a multiplexed binary stream, not text — see
+   *     demuxDockerStream.
+   *  2. `since` accepts **integer seconds only** (RFC3339Nano is rejected with a
+   *     `strconv.ParseInt` error) and is **inclusive**. So the cursor is
+   *     two-part: `nextToken` carries a nanosecond watermark, the request floors
+   *     it to seconds, and lines at or before the watermark are dropped. Using
+   *     seconds as the dedup key instead would discard genuinely new lines that
+   *     happen to share a second with the previous batch.
+   */
+  async getLogs(
+    appId: string,
+    machineId: string,
+    options?: { limit?: number; nextToken?: string }
+  ): Promise<ComputeLogsResult> {
+    await this.machineScoped(appId, machineId, () => this.assertOwned(machineId));
+
+    const limit = options?.limit ?? 100;
+    const watermark = options?.nextToken ? this.parseWatermark(options.nextToken) : null;
+
+    const params = new URLSearchParams({
+      stdout: '1',
+      stderr: '1',
+      timestamps: '1',
+      tail: String(limit),
+    });
+    if (watermark !== null) {
+      // Floor to whole seconds — the only precision the parameter accepts.
+      params.set('since', String(watermark / 1_000_000_000n));
+    }
+
+    const res = await dockerRequestRaw(
+      'GET',
+      `/containers/${encodeURIComponent(machineId)}/logs?${params.toString()}`,
+      { timeoutMs: 15_000 }
+    );
+    if (res.status < 200 || res.status >= 300) {
+      throw new DockerHttpError(
+        res.status,
+        `Docker logs error (${res.status}): ${res.body.toString('utf8')}`
+      );
+    }
+
+    const lines: ComputeLogLine[] = [];
+    let highest = watermark;
+    for (const frame of demuxDockerStream(res.body)) {
+      for (const raw of frame.text.split('\n')) {
+        if (!raw.trim()) {
+          continue;
+        }
+        const parsed = parseLogLine(raw);
+        if (!parsed) {
+          continue;
+        }
+        // Inclusive `since` re-delivers everything in the boundary second.
+        if (watermark !== null && parsed.nanos <= watermark) {
+          continue;
+        }
+        lines.push({ timestamp: parsed.ms, message: parsed.message });
+        if (highest === null || parsed.nanos > highest) {
+          highest = parsed.nanos;
+        }
+      }
+    }
+
+    const bounded = lines.length > limit ? lines.slice(-limit) : lines;
+    return { lines: bounded, nextToken: highest === null ? null : highest.toString() };
+  }
+
+  private parseWatermark(token: string): bigint | null {
+    try {
+      return BigInt(token);
+    } catch {
+      // A cursor we cannot read is treated as absent — better to re-deliver a
+      // window than to fail the request.
+      return null;
+    }
+  }
+
+  /**
+   * Host port the daemon assigned, for building the endpoint URL after launch.
+   * Returns null under `none` ingress, where nothing is published.
+   */
+  async resolvePublishedUrl(
+    machineId: string,
+    containerPort: number,
+    requestedIngress?: string
+  ): Promise<string | null> {
+    const ingress = this.ingressFor(requestedIngress);
+    if (ingress === 'none') {
+      return null;
+    }
+    if (ingress === 'host' && dockerConfig().domain) {
+      // Hostname routing does not depend on the published port at all — the
+      // operator's gateway maps the name onto the container.
+      const c = await dockerRequest<ContainerInspect>(
+        'GET',
+        `/containers/${encodeURIComponent(machineId)}/json`
+      );
+      const svc = c?.Config?.Labels?.[LABEL_SERVICE];
+      return svc ? `https://${svc}.${dockerConfig().domain}` : null;
+    }
+    const c = await dockerRequest<ContainerInspect>(
+      'GET',
+      `/containers/${encodeURIComponent(machineId)}/json`
+    );
+    const binding = c?.NetworkSettings?.Ports?.[`${containerPort}/tcp`]?.[0];
+    if (!binding?.HostPort) {
+      return null;
+    }
+    const host = dockerConfig().publicHost;
+    if (!host) {
+      logger.warn(
+        'Docker compute: port ingress is enabled but COMPUTE_PUBLIC_HOST is unset, so no endpoint URL ' +
+          `can be advertised. The container is published on port ${binding.HostPort}.`
+      );
+      return null;
+    }
+    return `http://${host}:${binding.HostPort}`;
+  }
+}

--- a/backend/src/providers/compute/docker.provider.ts
+++ b/backend/src/providers/compute/docker.provider.ts
@@ -243,10 +243,16 @@ export class DockerProvider implements ComputeProvider {
     } catch (error) {
       // Not fatal — the backend may not be running in a container at all (local
       // dev against a host daemon). Containers land on the default bridge.
-      this.ownNetwork = null;
+      //
+      // Deliberately not cached. A daemon blip during the first launch would
+      // otherwise pin `null` for the rest of the process lifetime and detach
+      // every later container from the project network — the one failure mode
+      // this lookup exists to prevent. Retrying costs one inspect per launch,
+      // which is also the steady state when we genuinely aren't containerized.
       logger.warn('Docker compute: own-container inspect failed; using the default bridge', {
         error: error instanceof Error ? error.message : String(error),
       });
+      return null;
     }
     return this.ownNetwork;
   }
@@ -826,11 +832,22 @@ export class DockerProvider implements ComputeProvider {
       stdout: '1',
       stderr: '1',
       timestamps: '1',
-      tail: String(limit),
     });
-    if (watermark !== null) {
+    if (watermark === null) {
+      // First page: no cursor to be consistent with, so ask for the newest
+      // `limit` lines instead of the whole retained history.
+      params.set('tail', String(limit));
+    } else {
       // Floor to whole seconds — the only precision the parameter accepts.
       params.set('since', String(watermark / 1_000_000_000n));
+      // No `tail` when resuming. `tail` keeps the *newest* N, so pairing it with
+      // `since` drops the middle of a backlog: 500 lines since the cursor with
+      // tail=100 returns the newest 100 and the cursor then advances past the
+      // other 400, which no later request can reach. Taking everything since the
+      // cursor and returning the oldest `limit` (below) makes the next page
+      // resume exactly where this one stopped, so a paging caller sees them all.
+      // The response is then only as large as what the container logged since
+      // the last poll.
     }
 
     const res = await dockerRequestRaw(
@@ -845,8 +862,7 @@ export class DockerProvider implements ComputeProvider {
       );
     }
 
-    const lines: ComputeLogLine[] = [];
-    let highest = watermark;
+    const entries: { line: ComputeLogLine; nanos: bigint }[] = [];
     for (const frame of demuxDockerStream(res.body)) {
       for (const raw of frame.text.split('\n')) {
         if (!raw.trim()) {
@@ -860,15 +876,27 @@ export class DockerProvider implements ComputeProvider {
         if (watermark !== null && parsed.nanos <= watermark) {
           continue;
         }
-        lines.push({ timestamp: parsed.ms, message: parsed.message });
-        if (highest === null || parsed.nanos > highest) {
-          highest = parsed.nanos;
-        }
+        entries.push({
+          line: { timestamp: parsed.ms, message: parsed.message },
+          nanos: parsed.nanos,
+        });
       }
     }
 
-    const bounded = lines.length > limit ? lines.slice(-limit) : lines;
-    return { lines: bounded, nextToken: highest === null ? null : highest.toString() };
+    // Docker emits oldest-first, so trimming the tail keeps the oldest `limit`
+    // and leaves the remainder for the next page. The cursor is taken from what
+    // is actually returned — never from a line that got trimmed.
+    const page = entries.length > limit ? entries.slice(0, limit) : entries;
+    let highest = watermark;
+    for (const entry of page) {
+      if (highest === null || entry.nanos > highest) {
+        highest = entry.nanos;
+      }
+    }
+    return {
+      lines: page.map((entry) => entry.line),
+      nextToken: highest === null ? null : highest.toString(),
+    };
   }
 
   private parseWatermark(token: string): bigint | null {

--- a/backend/src/providers/compute/fly.provider.ts
+++ b/backend/src/providers/compute/fly.provider.ts
@@ -3,7 +3,11 @@ import logger from '@/utils/logger.js';
 import {
   MachineGoneError,
   translateMachineGone,
+  flyNetworkName,
+  flyAppNameFor,
+  flyEndpointUrl,
   type ComputeProvider,
+  type ComputeCapabilities,
   type ComputeLogsResult,
 } from './compute.provider.js';
 
@@ -64,6 +68,25 @@ export class FlyProvider implements ComputeProvider {
     return FlyProvider.instance;
   }
 
+  readonly name = 'fly' as const;
+
+  // Fly machines cannot move between regions in place, so a region change
+  // requires destroy + recreate. `deployTokenIssuance` is false here: a
+  // self-hoster owns their own Fly credentials, so there is nothing for the
+  // backend to narrow — the CLI should use the operator's flyctl auth directly.
+  readonly capabilities: ComputeCapabilities = {
+    scaleToZero: true,
+    regions: true,
+    // Every Fly app gets public IPs and a `.fly.dev` hostname at create time, so
+    // there is no private-only or bare-port option to offer.
+    ingressModes: ['host'],
+    sourceBuild: 'flyctl',
+    deployTokenIssuance: false,
+  };
+
+  resolveAppName = flyAppNameFor;
+  endpointUrl = flyEndpointUrl;
+
   // Self-hosters enable compute by setting FLY_API_TOKEN AND FLY_ORG. Both
   // are required: org alone has nothing to authenticate, token alone doesn't
   // know which org to create apps in.
@@ -108,17 +131,15 @@ export class FlyProvider implements ComputeProvider {
     return result;
   }
 
-  async createApp(params: {
-    name: string;
-    network: string;
-    org: string;
-  }): Promise<{ appId: string }> {
+  // Org and network are provider concerns derived from config, not something
+  // the service layer should thread through.
+  async createApp(params: { name: string }): Promise<{ appId: string }> {
     await this.request('/apps', {
       method: 'POST',
       body: JSON.stringify({
         app_name: params.name,
-        org_slug: params.org,
-        network: params.network,
+        org_slug: appConfig.fly.org,
+        network: flyNetworkName(),
       }),
     });
     await this.allocatePublicIps(params.name);
@@ -340,7 +361,7 @@ export class FlyProvider implements ComputeProvider {
     envVars: Record<string, string>;
     protocol?: 'http' | 'tcp';
     scaleToZero?: boolean;
-  }): Promise<void> {
+  }): Promise<{ machineId?: string }> {
     const guest = this.mapCpuTier(params.cpu, params.memory);
     await this.machineScoped(params.appId, params.machineId, () =>
       this.request(`/apps/${params.appId}/machines/${params.machineId}`, {
@@ -361,6 +382,8 @@ export class FlyProvider implements ComputeProvider {
         }),
       })
     );
+    // Fly updates the machine in place — same id, new config.
+    return {};
   }
 
   async stopMachine(appId: string, machineId: string): Promise<void> {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -52,6 +52,7 @@ import {
 import { FeatureUsageCollector } from '@/services/telemetry/feature-usage.collector.js';
 import { TokenManager } from '@/infra/security/token.manager.js';
 import { DatabaseBackupService } from '@/services/database/database-backup.service.js';
+import { ComputeServicesService } from '@/services/compute/services.service.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -373,6 +374,21 @@ async function initializeServer() {
         error: err instanceof Error ? err.message : String(err),
       });
     });
+
+    // Probe each compute driver and heal rows that drifted while we were down
+    // (a container removed out-of-band, a `docker system prune`, a reclaimed
+    // machine). Non-blocking and non-fatal: compute is optional, and it must not
+    // hold up serving. Constructing the service throws when no driver is
+    // configured at all, which is the normal case, so that is caught too.
+    void (async () => {
+      try {
+        await ComputeServicesService.getInstance().runStartupTasks();
+      } catch (err) {
+        logger.info('Compute startup tasks skipped', {
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
 
     TelemetryService.getInstance().start();
 

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -1,22 +1,29 @@
 import { Pool } from 'pg';
-import { createHash } from 'crypto';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import { EncryptionManager } from '@/infra/security/encryption.manager.js';
 import { FlyProvider } from '@/providers/compute/fly.provider.js';
 import { CloudComputeProvider } from '@/providers/compute/cloud.provider.js';
+import { DockerProvider } from '@/providers/compute/docker.provider.js';
+import { dockerConfig } from '@/providers/compute/docker.client.js';
 import {
   MachineGoneError,
   type ComputeProvider,
+  type ComputeCapabilities,
   type ComputeLogsResult,
 } from '@/providers/compute/compute.provider.js';
 import { appConfig } from '@/infra/config/app.config.js';
+import { isCloudEnvironment } from '@/utils/environment.js';
 import { AppError } from '@/utils/errors.js';
 import logger from '@/utils/logger.js';
 import {
   ERROR_CODES,
   errorCodeSchema,
+  cpuTierToCores,
   type ErrorCode,
   type ServiceSchema,
+  type ComputeProviderName,
+  type IngressMode,
+  type ComputeMetadataSchema,
 } from '@insforge/shared-schemas';
 import { NEXT_ACTIONS } from '../../utils/next-actions.js';
 
@@ -37,6 +44,10 @@ export interface CreateServiceInput {
   memory: number;
   region: string;
   envVars?: Record<string, string>;
+  /**
+   * Requested ingress. Omitted, the active driver's default applies.
+   */
+  ingress?: IngressMode;
   /**
    * Edge protocol — `'http'` (default) for HTTP/HTTPS edge handlers,
    * `'tcp'` for raw TCP (Redis, Postgres wire protocol, etc.). Optional;
@@ -68,6 +79,8 @@ export interface UpdateServiceInput {
    * GET path doesn't return env values, so the merge has to happen here).
    */
   envVarsPatch?: { set?: Record<string, string>; unset?: string[] };
+  /** Ingress — same semantics as CreateServiceInput.ingress. */
+  ingress?: IngressMode;
   /** Edge protocol — same semantics as CreateServiceInput.protocol. */
   protocol?: 'http' | 'tcp';
   /** Scale-to-zero — same semantics as CreateServiceInput.scaleToZero. */
@@ -92,8 +105,10 @@ export interface DeletedServiceSnapshot {
   region: string;
   protocol: 'http' | 'tcp';
   scaleToZero: boolean;
-  flyAppId: string | null;
-  flyMachineId: string | null;
+  ingress: string;
+  provider: string;
+  providerAppId: string | null;
+  providerInstanceId: string | null;
   endpointUrl: string | null;
   envVarsEncrypted: string | null;
   createdAt: string;
@@ -117,8 +132,13 @@ interface ServiceRow {
   // going forward. mapRowToSchema normalizes undefined to true for rows read
   // from a pre-migration DB.
   scale_to_zero: boolean;
-  fly_app_id: string | null;
-  fly_machine_id: string | null;
+  // Added by migration 064, backfilled to 'host' for the Fly rows that predate it.
+  ingress: string;
+  // Renamed from fly_app_id / fly_machine_id by migration 064. `provider`
+  // records which driver created the row and is backfilled to 'fly'.
+  provider: string;
+  provider_app_id: string | null;
+  provider_instance_id: string | null;
   status: string;
   endpoint_url: string | null;
   env_vars_encrypted: string | null;
@@ -142,60 +162,23 @@ function mapRowToSchema(row: ServiceRow): ServiceSchema {
     // schema doesn't break the response.
     protocol: (row.protocol ?? 'http') as ServiceSchema['protocol'],
     scaleToZero: row.scale_to_zero ?? true,
-    flyAppId: row.fly_app_id,
-    flyMachineId: row.fly_machine_id,
+    cpus: cpuTierToCores(row.cpu),
+    // 'host' rather than the column default for a row read from a pre-064 DB:
+    // every such row is Fly-backed and therefore already on a public hostname.
+    ingress: (row.ingress ?? 'host') as ServiceSchema['ingress'],
+    // Defense-in-depth for a row read from a pre-064 database, same reasoning as
+    // `protocol` above: 'fly' was the only possibility before the column existed.
+    provider: (row.provider ?? 'fly') as ServiceSchema['provider'],
+    providerAppId: row.provider_app_id,
+    providerInstanceId: row.provider_instance_id,
+    // Deprecated aliases — see serviceSchema. Dropped after one minor version.
+    flyAppId: row.provider_app_id,
+    flyMachineId: row.provider_instance_id,
     status: row.status as ServiceSchema['status'],
     endpointUrl: row.endpoint_url,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
-}
-
-function makeFlyAppName(name: string, projectId: string): string {
-  const suffix = `-${projectId}`;
-  const maxBase = 60 - suffix.length;
-  // Need at least 8 chars for truncated name: 1 letter + dash + 6-char hash
-  if (maxBase < 8) {
-    throw new AppError(
-      `projectId is too long to produce a valid Fly app name (max ~51 chars, got ${projectId.length})`,
-      400,
-      ERROR_CODES.INVALID_INPUT
-    );
-  }
-  if (name.length <= maxBase) {
-    return name + suffix;
-  }
-  // When truncating, append a short hash of the full name to avoid collisions
-  const hash = createHash('sha256').update(name).digest('hex').slice(0, 6);
-  const truncated = name.slice(0, maxBase - 7); // 6 chars hash + 1 dash
-  return `${truncated}-${hash}${suffix}`;
-}
-
-// Network name is sent on Fly POST /apps. Fly's documented rule: "Network
-// names can have letters, numbers, and dashes, but must start with a letter."
-// The old `${projectId}-network` failed for the ~63% of projects whose UUID
-// begins with a hex digit; using bare APP_KEY still failed for the ~30% of
-// keys generateAppKey() produces digit-leading. The static `n-` prefix
-// guarantees a letter-leading name for every project, and APP_KEY's
-// per-project uniqueness still preserves 6PN isolation.
-function makeNetwork(): string {
-  if (!process.env.APP_KEY) {
-    throw new AppError(
-      'APP_KEY environment variable is required for compute network isolation',
-      500,
-      ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
-    );
-  }
-  return `n-${process.env.APP_KEY}`;
-}
-
-// Default to Fly's own .fly.dev hostname (which Fly routes automatically for
-// every app). Operators owning a custom domain can set COMPUTE_DOMAIN; otherwise
-// we return a URL that actually resolves instead of a vanity domain the operator
-// doesn't control.
-function makeEndpointUrl(flyAppName: string): string {
-  const domain = appConfig.fly.domain || 'fly.dev';
-  return `https://${flyAppName}.${domain}`;
 }
 
 // Cloud-mode providers wrap the cloud's structured error body verbatim into
@@ -246,42 +229,233 @@ function rewrapCloudError(error: unknown, defaultMessage: string): AppError {
   );
 }
 
-export function selectComputeProvider(): ComputeProvider {
-  // Self-host takes precedence: if FLY_API_TOKEN is set, the user has their own
-  // Fly account and wants direct control. Otherwise fall through to cloud-proxy
-  // (PROJECT_ID + CLOUD_API_HOST + JWT_SECRET all present).
+/**
+ * Driver name for the `provider` column. Read off the provider rather than
+ * derived with `instanceof`, which throws when the class has been mocked.
+ * Falls back to 'fly' for a provider predating the field — that was the only
+ * possibility before a second driver existed.
+ */
+export function providerName(provider: ComputeProvider): ComputeProviderName {
+  return provider.name ?? 'fly';
+}
+
+/**
+ * Every configured driver, keyed by the name persisted in
+ * `compute.services.provider`, plus which one new services go to.
+ *
+ * Drivers coexist. A service is managed by the driver that created it — read off
+ * its `provider` column — regardless of which one is the default. That matters
+ * for the obvious migration: an operator with Fly services who enables Docker
+ * keeps the Fly ones running and manageable while new work lands locally,
+ * instead of having to destroy and redeploy everything.
+ */
+/**
+ * Region recorded for providers that have no notion of geography. One daemon is one
+ * place, so anything else would be fiction.
+ */
+export const LOCAL_REGION = 'local';
+
+export interface ComputeRegistry {
+  providers: Map<ComputeProviderName, ComputeProvider>;
+  defaultProvider: ComputeProviderName;
+}
+
+/**
+ * Build the registry from the environment.
+ *
+ * `COMPUTE_PROVIDER` selects the **default for new services** (and `off` disables
+ * compute entirely). It is deliberately not a restriction: naming a default must
+ * not strand rows belonging to another driver.
+ *
+ * Note that `fly` and `cloud` are two credential paths to the *same* driver
+ * identity — cloud mode is Fly behind a control plane, managing the same Fly
+ * apps and machines. Registering both would put two credential paths on one set
+ * of resources, so they are mutually exclusive; the Map key enforces that
+ * structurally rather than by convention.
+ */
+export function buildComputeRegistry(): ComputeRegistry {
+  const requested = (process.env.COMPUTE_PROVIDER || '').trim().toLowerCase();
+
+  if (requested === 'off') {
+    throw new AppError(
+      'Compute services are disabled (COMPUTE_PROVIDER=off).',
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+      'Unset COMPUTE_PROVIDER or set it to a provider name, then restart the container.'
+    );
+  }
+  const known = ['', 'auto', 'fly', 'cloud', 'docker'];
+  if (!known.includes(requested)) {
+    throw new AppError(
+      `Unknown COMPUTE_PROVIDER "${requested}". Expected one of: fly, cloud, docker, off.`,
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED
+    );
+  }
+
+  const providers = new Map<ComputeProviderName, ComputeProvider>();
   const fly = FlyProvider.getInstance();
-  if (fly.isConfigured()) {
-    if (!appConfig.fly.org) {
-      // FLY_ORG used to default to "insforge" — our internal org. Operators
-      // who copied .env.example verbatim got opaque "unauthorized" errors
-      // from Fly. Warn loudly at provider selection time instead.
-      logger.warn(
-        'Compute self-host: FLY_ORG is empty. Set FLY_ORG to your Fly org slug ' +
-          '(`fly orgs list`); compute requests will otherwise fail with auth errors from Fly.'
+  const cloud = CloudComputeProvider.getInstance();
+
+  // An explicitly requested driver must actually be usable — failing loudly at
+  // startup beats 500-ing on the first deploy.
+  if (requested === 'fly' && !fly.isConfigured()) {
+    throw new AppError(
+      'COMPUTE_PROVIDER=fly but FLY_API_TOKEN and/or FLY_ORG are not set.',
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+      'Set both FLY_API_TOKEN and FLY_ORG, then restart the container.'
+    );
+  }
+  if (requested === 'cloud' && !cloud.isConfigured()) {
+    throw new AppError(
+      'COMPUTE_PROVIDER=cloud but PROJECT_ID, CLOUD_API_HOST, or JWT_SECRET is missing.',
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED
+    );
+  }
+
+  // Resolve the single Fly-identity driver. Explicit request wins; otherwise
+  // self-host Fly takes precedence over cloud-proxied mode, unchanged from the
+  // pre-registry behaviour (the operator has their own account and wants direct
+  // control).
+  if (requested === 'cloud') {
+    providers.set('fly', cloud);
+  } else if (fly.isConfigured()) {
+    warnIfFlyOrgMissing();
+    providers.set('fly', fly);
+  } else if (cloud.isConfigured()) {
+    providers.set('fly', cloud);
+  }
+
+  // Docker registers itself when the socket is present — mounting it into the
+  // InsForge container *is* the operator's opt-in. Nobody discovers their host is
+  // running arbitrary containers because a default flipped.
+  //
+  // Registration is gated on isConfigured() alone, never on having been
+  // requested: registering an unreachable driver because it was named would make
+  // every subsequent call fail obscurely, which is the opposite of the
+  // fail-loudly-at-startup behaviour the explicit checks exist for.
+  const docker = DockerProvider.getInstance();
+  if (docker.isConfigured()) {
+    providers.set('docker', docker);
+  } else if (requested === 'docker') {
+    // Two very different reasons the driver is unavailable, and conflating them
+    // would send an operator chasing a socket mount that is not the problem.
+    // DockerProvider.isConfigured() fails closed on cloud-managed projects
+    // regardless of whether a socket exists — see the comment there for why
+    // running customer containers on shared infrastructure is a tenant escape.
+    if (cloud.isConfigured() || isCloudEnvironment()) {
+      throw new AppError(
+        'The Docker compute driver is self-host only and cannot run on a cloud-managed project.',
+        400,
+        ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+        'Unset COMPUTE_PROVIDER to use the managed compute provider.'
       );
     }
-    return fly;
+    throw new AppError(
+      `COMPUTE_PROVIDER=docker but no Docker socket at ${dockerConfig().socketPath}.`,
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+      'Mount the Docker socket into the InsForge container (or set DOCKER_SOCKET_PATH), then restart.'
+    );
   }
 
-  const cloud = CloudComputeProvider.getInstance();
-  if (cloud.isConfigured()) {
-    return cloud;
+  if (providers.size === 0) {
+    throw new AppError(
+      'Compute services not configured.',
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+      'Set FLY_API_TOKEN and FLY_ORG in your .env, then restart the container. ' +
+        'See https://docs.insforge.dev/core-concepts/compute/overview for setup details.'
+    );
   }
 
-  throw new AppError(
-    'Compute services not configured.',
-    503,
-    ERROR_CODES.COMPUTE_NOT_CONFIGURED,
-    'Set FLY_API_TOKEN and FLY_ORG in your .env, then restart the container. ' +
-      'See https://docs.insforge.dev/core-concepts/compute/architecture for setup details.'
-  );
+  // Default: honour an explicit request, else prefer the Fly identity when it is
+  // configured so existing installs keep sending new services where they always
+  // did. A newly-enabled Docker driver becoming the silent default for every
+  // subsequent deploy would be a surprising change of behaviour.
+  const requestedKey: ComputeProviderName | null =
+    requested === 'docker' ? 'docker' : requested === 'fly' || requested === 'cloud' ? 'fly' : null;
+  if (requestedKey && !providers.has(requestedKey)) {
+    throw new AppError(
+      `COMPUTE_PROVIDER=${requested} is not configured on this deployment.`,
+      503,
+      ERROR_CODES.COMPUTE_NOT_CONFIGURED
+    );
+  }
+  const defaultProvider: ComputeProviderName =
+    requestedKey ?? (providers.has('fly') ? 'fly' : [...providers.keys()][0]);
+
+  if (providers.size > 1) {
+    logger.info('Compute providers registered', {
+      providers: [...providers.keys()],
+      defaultProvider,
+    });
+  }
+
+  return { providers, defaultProvider };
+}
+
+/**
+ * Compute slice for admin `/api/metadata`.
+ *
+ * Returns `undefined` when no provider is configured, which is what makes the
+ * slice absent and gives callers the coarse "compute is unavailable here" signal
+ * without first issuing a request that would 503.
+ *
+ * Deliberately a free function rather than a method: `ComputeServicesService`
+ * builds the registry in its constructor and therefore throws when nothing is
+ * configured, and metadata aggregation must not be able to fail because an
+ * optional feature is off. Nothing here touches the database either, so this is
+ * the cheapest of the slices the aggregate awaits.
+ */
+export function getComputeMetadata(): ComputeMetadataSchema | undefined {
+  let registry: ComputeRegistry;
+  try {
+    registry = buildComputeRegistry();
+  } catch {
+    // Not configured, disabled, or misconfigured. All three mean the same thing
+    // to a caller deciding whether to offer compute at all.
+    return undefined;
+  }
+
+  const providers: Record<string, ComputeCapabilities> = {};
+  for (const [name, provider] of registry.providers) {
+    providers[name] = provider.capabilities;
+  }
+  return { defaultProvider: registry.defaultProvider, providers };
+}
+
+/**
+ * The driver new services go to. Kept as a named export because it is the
+ * meaningful "which provider is active" question for callers that do not have a
+ * specific service in hand.
+ */
+export function selectComputeProvider(): ComputeProvider {
+  const registry = buildComputeRegistry();
+  // Non-null is an invariant of buildComputeRegistry: it throws when no driver
+  // is configured, and defaultProvider is either a key it verified with
+  // `providers.has()` or one taken straight out of `providers.keys()`.
+  return registry.providers.get(registry.defaultProvider)!;
+}
+
+function warnIfFlyOrgMissing(): void {
+  if (!appConfig.fly.org) {
+    // FLY_ORG used to default to "insforge" — our internal org. Operators who
+    // copied .env.example verbatim got opaque "unauthorized" errors from Fly.
+    // Warn loudly at provider selection time instead.
+    logger.warn(
+      'Compute self-host: FLY_ORG is empty. Set FLY_ORG to your Fly org slug ' +
+        '(`fly orgs list`); compute requests will otherwise fail with auth errors from Fly.'
+    );
+  }
 }
 
 export class ComputeServicesService {
   private static instance: ComputeServicesService;
   private pool: Pool | null = null;
-  private readonly compute: ComputeProvider = selectComputeProvider();
+  private readonly registry: ComputeRegistry = buildComputeRegistry();
 
   private constructor() {}
 
@@ -299,8 +473,250 @@ export class ComputeServicesService {
     return this.pool;
   }
 
+  /** Driver for new services. */
   private getCompute(): ComputeProvider {
-    return this.compute;
+    return this.registry.providers.get(this.registry.defaultProvider)!;
+  }
+
+  /**
+   * Coerce inputs a driver cannot honour into what it will actually do.
+   *
+   * The CLI defaults `--region iad` and the API defaults `scaleToZero: true`,
+   * both of which are Fly-shaped. Persisting them against a single-host,
+   * always-on driver would have the API and dashboard report a region the
+   * container is not in and an idle behaviour it does not have — a stored lie is
+   * worse than a rejected request, because nothing later contradicts it.
+   *
+   * Coerced rather than rejected so an existing CLI keeps working unchanged; the
+   * substitution is logged once per call so it is visible rather than silent.
+   */
+  private normalizeForDriver<
+    T extends { region?: string; scaleToZero?: boolean; ingress?: IngressMode },
+  >(
+    driver: ComputeProvider,
+    input: T,
+    context: {
+      serviceName?: string;
+      /**
+       * On create, an omitted field means "apply the default", so an unsupported
+       * default has to be resolved here. On update it means "leave this alone",
+       * and filling it in would turn a metadata-only PATCH into a deploy change.
+       */
+      resolveDefaults: boolean;
+    }
+  ): T {
+    const out = { ...input };
+    const modes = driver.capabilities.ingressModes;
+    if (out.ingress !== undefined && !modes.includes(out.ingress)) {
+      // Coerced rather than rejected, same reasoning as region below: a driver
+      // that only does public hostnames (Fly) should not fail an otherwise valid
+      // deploy that asked for `none`, but it must not record a mode it is not
+      // delivering either.
+      logger.info('Compute: driver cannot deliver the requested ingress; using its default', {
+        driver: driver.name,
+        requested: out.ingress,
+        applied: modes[0],
+        ...context,
+      });
+      out.ingress = modes[0];
+    }
+    if (!driver.capabilities.regions && out.region !== undefined && out.region !== LOCAL_REGION) {
+      logger.info('Compute: driver has no regions; recording region as local', {
+        driver: driver.name,
+        requested: out.region,
+        ...context,
+      });
+      out.region = LOCAL_REGION;
+    }
+    // `!== false` rather than `=== true` on purpose. The API default for this
+    // field is `true`, so a caller that simply omits it would otherwise have
+    // `true` stored against a driver that cannot do it — which is how the first
+    // end-to-end run produced a row claiming scale-to-zero on Docker. Coercing
+    // only an *explicit* true misses the far more common default path.
+    const impliedScaleToZero = out.scaleToZero ?? (context.resolveDefaults ? true : undefined);
+    if (!driver.capabilities.scaleToZero && impliedScaleToZero === true) {
+      // The API default for this field is `true`, so on create a caller that simply
+      // omits it would otherwise have `true` stored against a driver that cannot do
+      // it — which is exactly what the first end-to-end run produced. Coercing only
+      // an *explicit* true misses the far more common default path.
+      logger.info('Compute: driver cannot scale to zero; recording the service as always-on', {
+        driver: driver.name,
+        explicit: out.scaleToZero === true,
+        ...context,
+      });
+      out.scaleToZero = false;
+    }
+    return out;
+  }
+
+  /**
+   * Driver that owns an existing service, from its `provider` column.
+   *
+   * Routing by row is what lets drivers coexist: a Fly service stays manageable
+   * after an operator enables Docker, instead of having to be destroyed and
+   * redeployed. Acting on it with the wrong driver would issue container calls
+   * against what are actually Fly machine ids — at best a confusing 404, at
+   * worst healing a live, billing machine into a `stopped` row nothing will
+   * reconcile.
+   */
+  private providerFor(provider: string): ComputeProvider {
+    const driver = this.registry.providers.get(provider as ComputeProviderName);
+    if (!driver) {
+      throw new AppError(
+        `This service is backed by the "${provider}" compute driver, which is not configured on this deployment.`,
+        503,
+        ERROR_CODES.COMPUTE_NOT_CONFIGURED,
+        provider === 'docker'
+          ? 'Mount the Docker socket into the InsForge container and restart it.'
+          : 'Set FLY_API_TOKEN and FLY_ORG (or the cloud PROJECT_ID/CLOUD_API_HOST pair), then restart.'
+      );
+    }
+    return driver;
+  }
+
+  private providerForService(svc: ServiceSchema): ComputeProvider {
+    return this.providerFor(svc.provider);
+  }
+
+  /**
+   * Startup work: prove each driver answers, then heal rows that drifted while
+   * the backend was down.
+   *
+   * Non-fatal by design. Compute is optional, so a Docker daemon that is not
+   * running must not stop the rest of the backend from serving — the errors are
+   * logged prominently and individual compute calls fail with the real reason.
+   */
+  async runStartupTasks(): Promise<void> {
+    for (const [name, driver] of this.registry.providers) {
+      const probe = driver as ComputeProvider & {
+        preflight?: () => Promise<{ version: string; os: string; rootless: boolean }>;
+      };
+      if (typeof probe.preflight !== 'function') {
+        continue;
+      }
+      try {
+        const info = await probe.preflight();
+        logger.info(`Compute provider "${name}" ready`, info);
+        if (info.rootless) {
+          // Rootless changes port-binding and networking behaviour enough that a
+          // support report should say so up front.
+          logger.warn(
+            `Compute provider "${name}" is talking to a rootless daemon: published ports below 1024 ` +
+              'are unavailable and container networking differs from the rootful default.'
+          );
+        }
+      } catch (error) {
+        logger.error(
+          `Compute provider "${name}" is registered but did not answer. Compute requests will fail ` +
+            'until it does.',
+          { error: error instanceof Error ? error.message : String(error) }
+        );
+      }
+    }
+
+    await this.reconcile();
+  }
+
+  /**
+   * Compare stored instances against reality and fix what drifted.
+   *
+   * The per-request healing only fires when someone happens to touch a service.
+   * Drift that accumulates while the backend is down — a container removed
+   * out-of-band, a `docker system prune`, a provider reclaiming an idle machine —
+   * otherwise leaves the dashboard showing a ghost `running` service indefinitely.
+   *
+   * Only steady-state rows are corrected. A row left in `creating`/`deploying`/
+   * `destroying` by a crash mid-operation is reported but not touched: deciding
+   * what a half-finished create should become means guessing whether
+   * provider-side resources exist, and guessing wrong destroys someone's service.
+   */
+  async reconcile(): Promise<{
+    checked: number;
+    healed: number;
+    corrected: number;
+    skipped: number;
+  }> {
+    const stats = { checked: 0, healed: 0, corrected: 0, skipped: 0 };
+
+    let rows: ServiceRow[];
+    try {
+      const result = await this.getPool().query<ServiceRow>(
+        `SELECT * FROM compute.services WHERE provider_instance_id IS NOT NULL`
+      );
+      rows = result.rows;
+    } catch (error) {
+      logger.error('Compute reconcile: could not read services', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return stats;
+    }
+
+    for (const row of rows) {
+      const provider = row.provider ?? 'fly';
+      const driver = this.registry.providers.get(provider as ComputeProviderName);
+      if (!driver) {
+        stats.skipped++;
+        continue;
+      }
+      // Both ids are needed to address an instance. The query filters on the
+      // instance id, but a row carrying one without an app id is malformed rather
+      // than merely undeployed — report it instead of crashing the sweep.
+      const appId = row.provider_app_id;
+      const instanceId = row.provider_instance_id;
+      if (!appId || !instanceId) {
+        logger.warn('Compute reconcile: service has an instance id but no app id', {
+          id: row.id,
+          name: row.name,
+        });
+        stats.skipped++;
+        continue;
+      }
+      if (row.status !== 'running' && row.status !== 'stopped') {
+        logger.warn('Compute reconcile: leaving a service in a transient state alone', {
+          id: row.id,
+          name: row.name,
+          status: row.status,
+        });
+        stats.skipped++;
+        continue;
+      }
+
+      stats.checked++;
+      try {
+        const { state } = await driver.getMachineStatus(appId, instanceId);
+        if (state !== row.status) {
+          await this.getPool().query(`UPDATE compute.services SET status = $1 WHERE id = $2`, [
+            state,
+            row.id,
+          ]);
+          stats.corrected++;
+          logger.info('Compute reconcile: corrected a stale status', {
+            id: row.id,
+            name: row.name,
+            was: row.status,
+            now: state,
+          });
+        }
+      } catch (error) {
+        if (error instanceof MachineGoneError) {
+          await this.healMachineGone(row.id, instanceId);
+          stats.healed++;
+          continue;
+        }
+        // Transient (daemon restarting, network blip). Leave the row as-is —
+        // the next request or the next boot will try again.
+        logger.warn('Compute reconcile: could not check a service, leaving it unchanged', {
+          id: row.id,
+          name: row.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (rows.length) {
+      logger.info('Compute reconcile complete', stats);
+    }
+    return stats;
   }
 
   async listServices(projectId: string): Promise<ServiceSchema[]> {
@@ -331,28 +747,135 @@ export class ComputeServicesService {
   async issueDeployTokenForService(
     serviceId: string
   ): Promise<{ token: string; expirySeconds: number }> {
-    const fly = this.getCompute();
-    if (!(fly instanceof CloudComputeProvider)) {
+    // Resolve the service first: the token has to be minted by the driver that
+    // owns this service, not by whichever driver happens to be the default.
+    const service = await this.getService(serviceId);
+    const driver = this.providerForService(service);
+
+    // Capability-gated rather than an instanceof check, so the CLI can ask
+    // GET /api/compute/capabilities up front instead of discovering this by
+    // calling and getting a 400 (which is the current self-host source-mode bug:
+    // it aborts *after* prepareForDeploy has already created the app). The
+    // structural check on issueDeployToken is what actually narrows the type —
+    // instanceof against a mocked class throws.
+    const issuer = driver as ComputeProvider & Partial<CloudComputeProvider>;
+    if (
+      !driver.capabilities?.deployTokenIssuance ||
+      typeof issuer.issueDeployToken !== 'function'
+    ) {
       throw new AppError(
         'Deploy-token issuance is only supported in cloud-managed mode. ' +
-          'Self-hosters with FLY_API_TOKEN set already have a token and do not need this endpoint.',
+          'Self-hosters with FLY_API_TOKEN set already have a token and do not need this endpoint — ' +
+          'let flyctl use your own credentials instead.',
         400,
         ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
       );
     }
-    const service = await this.getService(serviceId);
-    if (!service.flyAppId) {
+    if (!service.providerAppId) {
       throw new AppError(
         `Service ${serviceId} has no Fly app yet — call /api/compute/services/deploy first to create the app.`,
         400,
         ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED
       );
     }
-    return fly.issueDeployToken(service.flyAppId);
+    return issuer.issueDeployToken(service.providerAppId);
   }
 
-  async createService(input: CreateServiceInput): Promise<ServiceSchema> {
+  /**
+   * Build an image from an uploaded context and deploy it to an existing service.
+   *
+   * The second half of source mode for a driver that builds locally. The first
+   * half is prepareForDeploy, which reserves the name and creates the
+   * provider-side app — the same two-step shape the Fly path uses, except the
+   * build happens here instead of on the caller's machine.
+   *
+   * Deploying goes through updateService rather than launching directly, so the
+   * recreate-vs-in-place decision and the instance-id/endpoint bookkeeping are the
+   * ones already tested rather than a second copy.
+   */
+  async buildAndDeploy(
+    serviceId: string,
+    context: Buffer,
+    options?: { dockerfile?: string; buildArgs?: Record<string, string> }
+  ): Promise<{ service: ServiceSchema; imageTag: string; logs: string[] }> {
+    const existing = await this.getService(serviceId);
+    const driver = this.providerForService(existing);
+
+    if (driver.capabilities.sourceBuild !== 'context-upload') {
+      throw new AppError(
+        `The "${driver.name}" compute driver does not build uploaded contexts.`,
+        400,
+        ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED,
+        driver.capabilities.sourceBuild === 'flyctl'
+          ? 'This driver builds through flyctl on your machine; use the CLI source-deploy flow instead.'
+          : 'Deploy a pre-built image with PATCH /api/compute/services/:id and an imageUrl.'
+      );
+    }
+
+    const builder = driver as ComputeProvider & {
+      buildFromContext?: (p: {
+        serviceName: string;
+        context: Buffer;
+        dockerfile?: string;
+        buildArgs?: Record<string, string>;
+      }) => Promise<{ imageTag: string; logs: string[] }>;
+      pruneServiceImages?: (serviceName: string, keep?: number) => Promise<{ removed: number }>;
+    };
+    if (typeof builder.buildFromContext !== 'function') {
+      throw new AppError(
+        `The "${driver.name}" driver declares context builds but does not implement them.`,
+        500,
+        ERROR_CODES.COMPUTE_SERVICE_DEPLOY_FAILED
+      );
+    }
+
+    let built: { imageTag: string; logs: string[] };
+    try {
+      built = await builder.buildFromContext({
+        serviceName: existing.name,
+        context,
+        dockerfile: options?.dockerfile,
+        buildArgs: options?.buildArgs,
+      });
+    } catch (error) {
+      // A build failure leaves the service exactly as it was — the previous image
+      // keeps running. Surface the builder's message so the developer can act.
+      await this.getPool()
+        .query(
+          `UPDATE compute.services SET status = 'failed' WHERE id = $1 AND status = 'deploying'`,
+          [serviceId]
+        )
+        .catch(() => undefined);
+      throw new AppError(
+        error instanceof Error ? error.message : 'Build failed',
+        400,
+        ERROR_CODES.COMPUTE_SERVICE_DEPLOY_FAILED
+      );
+    }
+
+    const service = await this.updateService(serviceId, { imageUrl: built.imageTag });
+
+    // Reclaim superseded images now rather than deferring to a retention policy
+    // nobody configures: every source deploy makes another one, and nothing else
+    // removes them.
+    if (typeof builder.pruneServiceImages === 'function') {
+      await builder.pruneServiceImages(existing.name).catch((error: unknown) => {
+        logger.warn('Compute: image prune failed after a successful deploy', {
+          serviceId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+
+    return { service, imageTag: built.imageTag, logs: built.logs };
+  }
+
+  async createService(rawInput: CreateServiceInput): Promise<ServiceSchema> {
     const fly = this.getCompute();
+    const input = this.normalizeForDriver(fly, rawInput, {
+      serviceName: rawInput.name,
+      resolveDefaults: true,
+    });
 
     if (!fly.isConfigured()) {
       throw new AppError(
@@ -378,8 +901,8 @@ export class ComputeServicesService {
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, env_vars_encrypted, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'creating')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, ingress, env_vars_encrypted, provider, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'creating')
          RETURNING *`,
         [
           input.projectId,
@@ -391,7 +914,14 @@ export class ComputeServicesService {
           input.region,
           input.protocol ?? 'http',
           input.scaleToZero ?? true,
+          // Resolved from the driver when the caller did not choose: a
+          // single-host driver defaults to private-only, Fly to its hostname.
+          input.ingress ?? fly.capabilities.ingressModes[0],
           envVarsEncrypted,
+          // Migration 064 drops the column default, so every insert states the
+          // driver explicitly — a row that lies about its provider is exactly
+          // what reconcile must never see.
+          providerName(fly),
         ]
       );
     } catch (error: unknown) {
@@ -407,60 +937,63 @@ export class ComputeServicesService {
 
     const row: ServiceRow = insertResult.rows[0];
     const serviceId = row.id;
-    const flyAppName = makeFlyAppName(input.name, input.projectId);
-    const network = makeNetwork();
-    const endpointUrl = makeEndpointUrl(flyAppName);
+    const appName = fly.resolveAppName({ name: input.name, projectId: input.projectId });
 
-    let flyMachineId: string | undefined;
+    let launchedInstanceId: string | undefined;
     try {
-      await fly.createApp({
-        name: flyAppName,
-        network,
-        org: appConfig.fly.org,
-      });
+      await fly.createApp({ name: appName });
 
-      const { machineId } = await fly.launchMachine({
-        appId: flyAppName,
+      const launched = await fly.launchMachine({
+        appId: appName,
         image: input.imageUrl,
         port: input.port,
         cpu: input.cpu,
         memory: input.memory,
         envVars: input.envVars ?? {},
         region: input.region,
+        ingress: input.ingress ?? fly.capabilities.ingressModes[0],
         protocol: input.protocol,
         scaleToZero: input.scaleToZero,
       });
-      flyMachineId = machineId;
+      const machineId = launched.machineId;
+      launchedInstanceId = machineId;
+
+      // Prefer the URL the provider resolved after launching: under a driver that
+      // publishes on an ephemeral host port, the address does not exist until the
+      // instance does. `undefined` means the provider has no post-launch opinion,
+      // so fall back to the name-derived one.
+      const endpointUrl =
+        launched.endpointUrl !== undefined ? launched.endpointUrl : fly.endpointUrl(appName);
 
       const updateResult = await this.getPool().query(
         `UPDATE compute.services
-         SET fly_app_id = $1, fly_machine_id = $2, endpoint_url = $3, status = $4
+         SET provider_app_id = $1, provider_instance_id = $2, endpoint_url = $3, status = $4
          WHERE id = $5
          RETURNING *`,
-        [flyAppName, machineId, endpointUrl, 'running', serviceId]
+        [appName, machineId, endpointUrl, 'running', serviceId]
       );
 
-      logger.info('Compute service deployed', { serviceId, flyAppName, machineId });
+      logger.info('Compute service deployed', { serviceId, appName, machineId });
       return mapRowToSchema(updateResult.rows[0]);
     } catch (error) {
       logger.error('Failed to deploy compute service', { serviceId, error });
 
       // Clean up orphaned Fly resources (machine + app) to avoid leaked infrastructure
-      if (flyMachineId) {
+      if (launchedInstanceId) {
         try {
-          await fly.destroyMachine(flyAppName, flyMachineId);
+          await fly.destroyMachine(appName, launchedInstanceId);
         } catch (destroyError) {
           logger.error('Failed to clean up orphaned Fly machine', {
-            flyAppName,
-            flyMachineId,
+            appName,
+            launchedInstanceId,
             error: destroyError,
           });
         }
       }
       try {
-        await fly.destroyApp(flyAppName);
+        await fly.destroyApp(appName);
       } catch (destroyError) {
-        logger.error('Failed to clean up orphaned Fly app', { flyAppName, error: destroyError });
+        logger.error('Failed to clean up orphaned Fly app', { appName, error: destroyError });
       }
 
       // Mark as failed
@@ -473,8 +1006,12 @@ export class ComputeServicesService {
     }
   }
 
-  async prepareForDeploy(input: CreateServiceInput): Promise<ServiceSchema> {
+  async prepareForDeploy(rawInput: CreateServiceInput): Promise<ServiceSchema> {
     const fly = this.getCompute();
+    const input = this.normalizeForDriver(fly, rawInput, {
+      serviceName: rawInput.name,
+      resolveDefaults: true,
+    });
 
     if (!fly.isConfigured()) {
       throw new AppError(
@@ -485,20 +1022,34 @@ export class ComputeServicesService {
       );
     }
 
+    // This is the source-mode entry point: it reserves the name and creates the
+    // provider-side app, then waits for the caller to build and push an image
+    // before a PATCH launches the instance. On a driver that cannot build from
+    // source at all, letting it succeed would leave a row stuck in `deploying`
+    // with nothing able to advance it — the same shape as the self-host Fly bug
+    // this whole effort exists to avoid repeating.
+    if (fly.capabilities.sourceBuild === 'none') {
+      throw new AppError(
+        `The "${fly.name}" compute driver cannot build from source.`,
+        400,
+        ERROR_CODES.COMPUTE_SERVICE_NOT_CONFIGURED,
+        'Deploy a pre-built image instead: POST /api/compute/services with an imageUrl.'
+      );
+    }
+
     const envVarsEncrypted = input.envVars
       ? EncryptionManager.encrypt(JSON.stringify(input.envVars))
       : null;
 
-    const flyAppName = makeFlyAppName(input.name, input.projectId);
-    const network = makeNetwork();
-    const endpointUrl = makeEndpointUrl(flyAppName);
+    const appName = fly.resolveAppName({ name: input.name, projectId: input.projectId });
+    const endpointUrl = fly.endpointUrl(appName);
 
     // Insert row — check for duplicate name before calling Fly APIs
     let insertResult;
     try {
       insertResult = await this.getPool().query(
-        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, env_vars_encrypted, fly_app_id, endpoint_url, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'deploying')
+        `INSERT INTO compute.services (project_id, name, image_url, port, cpu, memory, region, protocol, scale_to_zero, ingress, env_vars_encrypted, provider, provider_app_id, endpoint_url, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, 'deploying')
          RETURNING *`,
         [
           input.projectId,
@@ -510,8 +1061,10 @@ export class ComputeServicesService {
           input.region,
           input.protocol ?? 'http',
           input.scaleToZero ?? true,
+          input.ingress ?? fly.capabilities.ingressModes[0],
           envVarsEncrypted,
-          flyAppName,
+          providerName(fly),
+          appName,
           endpointUrl,
         ]
       );
@@ -528,7 +1081,7 @@ export class ComputeServicesService {
 
     // Create Fly app (no machine — flyctl deploy will create it)
     try {
-      await fly.createApp({ name: flyAppName, network, org: appConfig.fly.org });
+      await fly.createApp({ name: appName });
     } catch (error) {
       // App might already exist from a previous deploy attempt — ignore "already exists"
       const msg = error instanceof Error ? error.message : '';
@@ -544,10 +1097,10 @@ export class ComputeServicesService {
         // and deployService cleanup. Best-effort: log and swallow on Fly
         // errors so the original error still propagates.
         try {
-          await fly.destroyApp(flyAppName);
+          await fly.destroyApp(appName);
         } catch (destroyError) {
           logger.error('Failed to clean up orphaned Fly app after prepareForDeploy failure', {
-            flyAppName,
+            appName,
             error: destroyError,
           });
         }
@@ -558,12 +1111,19 @@ export class ComputeServicesService {
       }
     }
 
-    logger.info('Compute service prepared for deploy', { flyAppName });
+    logger.info('Compute service prepared for deploy', { appName });
     return mapRowToSchema(insertResult.rows[0]);
   }
 
   async updateService(id: string, data: UpdateServiceInput): Promise<ServiceSchema> {
     const existing = await this.getService(id);
+    // Every provider call below targets an existing row, so it goes to the
+    // driver that created it — not the default.
+    const driver = this.providerForService(existing);
+    data = this.normalizeForDriver(driver, data, {
+      serviceName: existing.name,
+      resolveDefaults: false,
+    });
 
     // Mutual exclusion is also enforced by the zod schema at the route layer,
     // but defensively re-check here so service-level callers (cron, tests) get
@@ -617,11 +1177,16 @@ export class ComputeServicesService {
       values.push(data.memory);
     }
     if (data.region !== undefined) {
-      // Region change on a deployed machine is meaningless: Fly machines
-      // can't be moved between regions in-place. Persisting it would let
-      // the API/UI report a region the machine isn't actually running in.
-      // Force the user to delete + redeploy.
-      if (data.region !== existing.region && existing.flyAppId && existing.flyMachineId) {
+      // No provider can move a deployed instance between regions in place, so
+      // persisting a new value would have the API and dashboard report a region
+      // the instance is not running in. Gated on `regions` rather than a separate
+      // `regionChangeInPlace` capability: a driver with no regions has already had
+      // this field normalized to `local`, so the comparison below never fires for
+      // it, and a driver that gains in-place migration can relax this then —
+      // inventing the field before any driver answers differently just moved the
+      // hardcoded rule somewhere less obvious.
+      const deployed = existing.providerAppId && existing.providerInstanceId;
+      if (data.region !== existing.region && deployed && driver.capabilities.regions) {
         throw new AppError(
           `Cannot change region for a deployed service. Delete and redeploy in region "${data.region}" instead.`,
           400,
@@ -643,6 +1208,10 @@ export class ComputeServicesService {
       updates.push(`scale_to_zero = $${paramIdx++}`);
       values.push(data.scaleToZero);
     }
+    if (data.ingress !== undefined) {
+      updates.push(`ingress = $${paramIdx++}`);
+      values.push(data.ingress);
+    }
 
     if (updates.length === 0) {
       return existing;
@@ -653,6 +1222,8 @@ export class ComputeServicesService {
     // `protocol` is a deploy field — switching http<->tcp swaps the Fly edge
     // handlers entirely, so it has to propagate to Fly to take effect.
     // `scaleToZero` likewise lives in the Fly service block (autostop config).
+    // `ingress` belongs here: changing it changes whether a host port is
+    // published at all, which no driver can do to a running instance.
     const deployFields = [
       'imageUrl',
       'port',
@@ -661,6 +1232,7 @@ export class ComputeServicesService {
       'envVars',
       'protocol',
       'scaleToZero',
+      'ingress',
     ] as const;
     const hasDeployChange = deployFields.some((f) => data[f] !== undefined);
 
@@ -668,7 +1240,7 @@ export class ComputeServicesService {
     // for redeploy, launchMachine for first-deploy). Hoist the SELECT so we
     // only hit the DB once.
     let mergedEnvVars: Record<string, string> | undefined;
-    if (hasDeployChange && existing.flyAppId) {
+    if (hasDeployChange && existing.providerAppId) {
       const existingRow = await this.getPool().query(
         `SELECT env_vars_encrypted FROM compute.services WHERE id = $1`,
         [id]
@@ -679,33 +1251,54 @@ export class ComputeServicesService {
     }
 
     // Path A first-launch sets this so the final UPDATE can apply an
-    // optimistic lock (`AND fly_machine_id IS NULL`) and self-heal if a
+    // optimistic lock (`AND provider_instance_id IS NULL`) and self-heal if a
     // concurrent request also launched a machine.
     let justLaunchedMachineId: string | undefined;
 
-    if (hasDeployChange && existing.flyAppId && existing.flyMachineId) {
+    if (hasDeployChange && existing.providerAppId && existing.providerInstanceId) {
       // NOTE: Region changes are persisted in the DB but Fly machine region cannot
       // be changed in-place via updateMachine — a region change requires redeployment
       // (destroy + recreate). The region field is stored for the next deploy.
       try {
-        await this.getCompute().updateMachine({
-          appId: existing.flyAppId,
-          machineId: existing.flyMachineId,
+        const updated = await driver.updateMachine({
+          appId: existing.providerAppId,
+          machineId: existing.providerInstanceId,
           image: data.imageUrl ?? existing.imageUrl,
           port: data.port ?? existing.port,
           cpu: data.cpu ?? existing.cpu,
           memory: data.memory ?? existing.memory,
           envVars: mergedEnvVars ?? {},
+          ingress: data.ingress ?? existing.ingress,
           protocol: data.protocol ?? existing.protocol,
           scaleToZero: data.scaleToZero ?? existing.scaleToZero,
         });
-        logger.info('Compute service machine updated', { id });
+        // A driver that cannot change image/ports/env in place replaces the
+        // instance instead (Docker), so the stored id has to follow — otherwise
+        // it points at a container that no longer exists and every later call
+        // heals the row and reports "redeploy" forever.
+        if (updated?.machineId && updated.machineId !== existing.providerInstanceId) {
+          updates.push(`provider_instance_id = $${paramIdx++}`);
+          values.push(updated.machineId);
+          // A replacement gets a newly-assigned published port, so the stored URL
+          // would otherwise point at one that has been freed.
+          if (updated.endpointUrl !== undefined) {
+            updates.push(`endpoint_url = $${paramIdx++}`);
+            values.push(updated.endpointUrl);
+          }
+          logger.info('Compute service instance replaced to apply the update', {
+            id,
+            previous: existing.providerInstanceId,
+            replacement: updated.machineId,
+          });
+        } else {
+          logger.info('Compute service machine updated', { id });
+        }
       } catch (error) {
         // The machine this PATCH targeted no longer exists. Heal the row
-        // (fly_machine_id → NULL) so the caller's retry takes the
+        // (provider_instance_id → NULL) so the caller's retry takes the
         // first-launch path above and provisions a fresh machine.
         if (error instanceof MachineGoneError) {
-          throw await this.machineGone(id, existing.flyMachineId);
+          throw await this.machineGone(id, existing.providerInstanceId);
         }
         logger.error('Failed to update machine on Fly', { id, error });
         throw rewrapCloudError(error, 'Compute service operation failed');
@@ -721,31 +1314,39 @@ export class ComputeServicesService {
         // placeholder, launch PATCH always carries an explicit imageUrl)
         // never take this arm with a non-launchable image.
         (hasDeployChange && existing.status === 'stopped' ? existing.imageUrl : null)) &&
-      existing.flyAppId &&
-      !existing.flyMachineId
+      existing.providerAppId &&
+      !existing.providerInstanceId
     ) {
       // Path A: no machine exists for the app — first deploy (CLI built+
       // pushed and passes imageUrl explicitly) or recovery relaunch (above).
       try {
-        const { machineId } = await this.getCompute().launchMachine({
-          appId: existing.flyAppId,
+        const launched = await driver.launchMachine({
+          appId: existing.providerAppId,
           image: (data.imageUrl ?? existing.imageUrl) as string,
           port: data.port ?? existing.port,
           cpu: data.cpu ?? existing.cpu,
           memory: data.memory ?? existing.memory,
           envVars: mergedEnvVars ?? {},
           region: data.region ?? existing.region,
+          ingress: data.ingress ?? existing.ingress,
           protocol: data.protocol ?? existing.protocol,
           scaleToZero: data.scaleToZero ?? existing.scaleToZero,
         });
+        const machineId = launched.machineId;
         justLaunchedMachineId = machineId;
         // Persist machine id + flip status alongside the field updates below.
-        updates.push(`fly_machine_id = $${paramIdx++}`);
+        updates.push(`provider_instance_id = $${paramIdx++}`);
         values.push(machineId);
         updates.push(`status = $${paramIdx++}`);
         values.push('running');
         updates.push(`endpoint_url = $${paramIdx++}`);
-        values.push(makeEndpointUrl(existing.flyAppId));
+        // Same precedence as createService: a post-launch URL from the provider
+        // wins, since an ephemeral published port is only knowable now.
+        values.push(
+          launched.endpointUrl !== undefined
+            ? launched.endpointUrl
+            : driver.endpointUrl(existing.providerAppId)
+        );
         logger.info('Compute service machine launched (Path A)', { id, machineId });
       } catch (error) {
         logger.error('Failed to launch machine on Fly (Path A)', { id, error });
@@ -754,13 +1355,13 @@ export class ComputeServicesService {
     }
 
     // Fly accepted the update (or no Fly update was needed) — now commit to DB.
-    // For a first-launch, append `AND fly_machine_id IS NULL` so a concurrent
+    // For a first-launch, append `AND provider_instance_id IS NULL` so a concurrent
     // PATCH (CLI retry, double-click) that also raced to launchMachine loses
     // the DB write. The loser then destroys the orphan machine it just made.
     values.push(id);
     const whereClause =
       justLaunchedMachineId !== undefined
-        ? `WHERE id = $${paramIdx} AND fly_machine_id IS NULL`
+        ? `WHERE id = $${paramIdx} AND provider_instance_id IS NULL`
         : `WHERE id = $${paramIdx}`;
     const result = await this.getPool().query(
       `UPDATE compute.services SET ${updates.join(', ')} ${whereClause} RETURNING *`,
@@ -768,13 +1369,13 @@ export class ComputeServicesService {
     );
 
     if (!result.rows.length) {
-      if (justLaunchedMachineId !== undefined && existing.flyAppId) {
-        // Lost a launch race: another request already wrote fly_machine_id.
+      if (justLaunchedMachineId !== undefined && existing.providerAppId) {
+        // Lost a launch race: another request already wrote provider_instance_id.
         // Destroy the machine we just created so it doesn't keep billing.
         // Best-effort — even if the destroy itself fails, returning the
         // current row is still correct (the winning machine is healthy).
         try {
-          await this.getCompute().destroyMachine(existing.flyAppId, justLaunchedMachineId);
+          await driver.destroyMachine(existing.providerAppId, justLaunchedMachineId);
           logger.info('Cleaned up orphan machine from launch race', {
             id,
             orphanMachineId: justLaunchedMachineId,
@@ -818,6 +1419,24 @@ export class ComputeServicesService {
     }
     const row = result.rows[0];
 
+    // Delete tolerates an unavailable driver where the other operations refuse.
+    // Blocking it would trap the operator with a row they can never remove — for
+    // instance after decommissioning the Fly account behind existing services.
+    // We skip the remote cleanup we cannot perform and say loudly what was left
+    // behind; the audit snapshot records providerAppId/providerInstanceId, so the
+    // orphaned resources are recoverable by hand.
+    const rowProvider = row.provider ?? 'fly';
+    const driver = this.registry.providers.get(rowProvider as ComputeProviderName);
+    if (!driver) {
+      logger.warn('Deleting a compute service whose driver is not configured; skipping cleanup', {
+        id,
+        rowProvider,
+        configuredDrivers: [...this.registry.providers.keys()],
+        orphanedAppId: row.provider_app_id,
+        orphanedInstanceId: row.provider_instance_id,
+      });
+    }
+
     // Mark as destroying first so it's visible in the UI
     await this.getPool().query(`UPDATE compute.services SET status = 'destroying' WHERE id = $1`, [
       id,
@@ -825,9 +1444,9 @@ export class ComputeServicesService {
 
     // Fly cleanup — abort delete if cleanup fails to preserve the reference
     // Treat 404 as success (resource already destroyed)
-    if (row.fly_machine_id && row.fly_app_id) {
+    if (driver && row.provider_instance_id && row.provider_app_id) {
       try {
-        await this.getCompute().destroyMachine(row.fly_app_id, row.fly_machine_id);
+        await driver.destroyMachine(row.provider_app_id, row.provider_instance_id);
       } catch (error) {
         if (!isAlreadyGone(error)) {
           logger.error('Failed to destroy Fly machine during delete', { id, error });
@@ -845,9 +1464,9 @@ export class ComputeServicesService {
       }
     }
 
-    if (row.fly_app_id) {
+    if (driver && row.provider_app_id) {
       try {
-        await this.getCompute().destroyApp(row.fly_app_id);
+        await driver.destroyApp(row.provider_app_id);
       } catch (error) {
         if (!isAlreadyGone(error)) {
           logger.error('Failed to destroy Fly app during delete', { id, error });
@@ -879,8 +1498,10 @@ export class ComputeServicesService {
       region: row.region,
       protocol: (row.protocol ?? 'http') as 'http' | 'tcp',
       scaleToZero: row.scale_to_zero ?? true,
-      flyAppId: row.fly_app_id,
-      flyMachineId: row.fly_machine_id,
+      ingress: row.ingress ?? 'host',
+      provider: rowProvider,
+      providerAppId: row.provider_app_id,
+      providerInstanceId: row.provider_instance_id,
       endpointUrl: row.endpoint_url,
       envVarsEncrypted: row.env_vars_encrypted,
       createdAt: row.created_at,
@@ -891,14 +1512,14 @@ export class ComputeServicesService {
   // still points at it — the machine was reclaimed or deleted out-of-band.
   // Heal the row: clear the dead machine pointer and mark the service
   // stopped, so the dashboard stops showing a ghost "running" service and
-  // the next deploy takes the first-launch path (fly_machine_id IS NULL →
-  // launchMachine provisions a fresh machine). Guarded by fly_machine_id so
+  // the next deploy takes the first-launch path (provider_instance_id IS NULL →
+  // launchMachine provisions a fresh machine). Guarded by provider_instance_id so
   // a concurrent redeploy's fresh machine id is never clobbered.
   private async healMachineGone(id: string, machineId: string): Promise<void> {
     await this.getPool().query(
       `UPDATE compute.services
-          SET status = 'stopped', fly_machine_id = NULL
-        WHERE id = $1 AND fly_machine_id = $2`,
+          SET status = 'stopped', provider_instance_id = NULL
+        WHERE id = $1 AND provider_instance_id = $2`,
       [id, machineId]
     );
     logger.warn('Compute machine gone on provider; healed stale service row', {
@@ -926,8 +1547,15 @@ export class ComputeServicesService {
   // list`, so COMPUTE_SERVICE_NOT_FOUND here sends callers chasing the wrong
   // problem (and every post-heal request would contradict the redeploy
   // guidance the healing request just returned).
-  private requireMachine(svc: ServiceSchema): { flyAppId: string; flyMachineId: string } {
-    if (svc.flyAppId && !svc.flyMachineId) {
+  private requireMachine(svc: ServiceSchema): {
+    appId: string;
+    instanceId: string;
+    driver: ComputeProvider;
+  } {
+    // Chokepoint for stop/start/events/logs — all four route through here, so
+    // resolving the owning driver once covers them.
+    const driver = this.providerForService(svc);
+    if (svc.providerAppId && !svc.providerInstanceId) {
       throw new AppError(
         'No machine exists for this service',
         404,
@@ -935,7 +1563,7 @@ export class ComputeServicesService {
         NEXT_ACTIONS.REDEPLOY_COMPUTE_SERVICE
       );
     }
-    if (!svc.flyAppId || !svc.flyMachineId) {
+    if (!svc.providerAppId || !svc.providerInstanceId) {
       throw new AppError(
         'Service not found',
         404,
@@ -943,21 +1571,21 @@ export class ComputeServicesService {
         NEXT_ACTIONS.CHECK_COMPUTE_SERVICE_EXISTS
       );
     }
-    return { flyAppId: svc.flyAppId, flyMachineId: svc.flyMachineId };
+    return { appId: svc.providerAppId, instanceId: svc.providerInstanceId, driver };
   }
 
   async stopService(id: string): Promise<ServiceSchema> {
     const svc = await this.getService(id);
-    const { flyAppId, flyMachineId } = this.requireMachine(svc);
+    const { appId, instanceId, driver } = this.requireMachine(svc);
 
     try {
-      await this.getCompute().stopMachine(flyAppId, flyMachineId);
+      await driver.stopMachine(appId, instanceId);
     } catch (error) {
       // Stopping a machine that no longer exists: the desired state is
       // already true. Heal the row and fall through to the status update —
       // "Stop" on a ghost service succeeds instead of erroring.
       if (error instanceof MachineGoneError) {
-        await this.healMachineGone(id, flyMachineId);
+        await this.healMachineGone(id, instanceId);
       } else {
         logger.error('Failed to stop compute service', { id, error });
         throw new AppError(
@@ -988,15 +1616,15 @@ export class ComputeServicesService {
 
   async startService(id: string): Promise<ServiceSchema> {
     const svc = await this.getService(id);
-    const { flyAppId, flyMachineId } = this.requireMachine(svc);
+    const { appId, instanceId, driver } = this.requireMachine(svc);
 
     try {
-      await this.getCompute().startMachine(flyAppId, flyMachineId);
+      await driver.startMachine(appId, instanceId);
     } catch (error) {
       // Can't start a machine that no longer exists — heal the row and tell
       // the caller to redeploy (which provisions a fresh machine).
       if (error instanceof MachineGoneError) {
-        throw await this.machineGone(id, flyMachineId);
+        throw await this.machineGone(id, instanceId);
       }
       logger.error('Failed to start compute service', { id, error });
       throw new AppError(
@@ -1029,13 +1657,13 @@ export class ComputeServicesService {
     options?: { limit?: number }
   ): Promise<{ timestamp: number; message: string }[]> {
     const svc = await this.getService(id);
-    const { flyAppId, flyMachineId } = this.requireMachine(svc);
+    const { appId, instanceId, driver } = this.requireMachine(svc);
 
     try {
-      return await this.getCompute().getEvents(flyAppId, flyMachineId, options);
+      return await driver.getEvents(appId, instanceId, options);
     } catch (error) {
       if (error instanceof MachineGoneError) {
-        throw await this.machineGone(id, flyMachineId);
+        throw await this.machineGone(id, instanceId);
       }
       throw error;
     }
@@ -1051,13 +1679,13 @@ export class ComputeServicesService {
     options?: { limit?: number; nextToken?: string }
   ): Promise<ComputeLogsResult> {
     const svc = await this.getService(id);
-    const { flyAppId, flyMachineId } = this.requireMachine(svc);
+    const { appId, instanceId, driver } = this.requireMachine(svc);
 
     try {
-      return await this.getCompute().getLogs(flyAppId, flyMachineId, options);
+      return await driver.getLogs(appId, instanceId, options);
     } catch (error) {
       if (error instanceof MachineGoneError) {
-        throw await this.machineGone(id, flyMachineId);
+        throw await this.machineGone(id, instanceId);
       }
       throw error;
     }

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -685,10 +685,15 @@ export class ComputeServicesService {
       try {
         const { state } = await driver.getMachineStatus(appId, instanceId);
         if (state !== row.status) {
-          await this.getPool().query(`UPDATE compute.services SET status = $1 WHERE id = $2`, [
-            state,
-            row.id,
-          ]);
+          // Scoped to the instance this observation was made against, the same way
+          // healMachineGone is. The sweep runs alongside live requests, so a
+          // concurrent deploy can replace the instance between the snapshot and
+          // this write; without the guard, a stale `stopped` reading about the old
+          // container would overwrite the `running` the deploy just committed.
+          await this.getPool().query(
+            `UPDATE compute.services SET status = $1 WHERE id = $2 AND provider_instance_id = $3`,
+            [state, row.id, instanceId]
+          );
           stats.corrected++;
           logger.info('Compute reconcile: corrected a stale status', {
             id: row.id,
@@ -866,21 +871,29 @@ export class ComputeServicesService {
       );
     }
 
-    const service = await this.updateService(serviceId, { imageUrl: built.imageTag });
-
-    // Reclaim superseded images now rather than deferring to a retention policy
-    // nobody configures: every source deploy makes another one, and nothing else
-    // removes them.
-    if (typeof builder.pruneServiceImages === 'function') {
-      await builder.pruneServiceImages(existing.name).catch((error: unknown) => {
-        logger.warn('Compute: image prune failed after a successful deploy', {
-          serviceId,
-          error: error instanceof Error ? error.message : String(error),
+    try {
+      const service = await this.updateService(serviceId, { imageUrl: built.imageTag });
+      return { service, imageTag: built.imageTag, logs: built.logs };
+    } finally {
+      // Reclaim superseded images rather than deferring to a retention policy
+      // nobody configures: every source deploy makes another one, and nothing else
+      // removes them.
+      //
+      // In a `finally` because the build already wrote an image to disk by the time
+      // the deploy runs — if the deploy throws, that image is otherwise orphaned
+      // until some later deploy happens to succeed, so repeated failures pile up
+      // without bound. Docker refuses to delete the image a container is still
+      // using (409, logged and skipped), so pruning here cannot pull the running
+      // image out from under a failed deploy.
+      if (typeof builder.pruneServiceImages === 'function') {
+        await builder.pruneServiceImages(existing.name).catch((error: unknown) => {
+          logger.warn('Compute: image prune failed after a deploy', {
+            serviceId,
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+      }
     }
-
-    return { service, imageTag: built.imageTag, logs: built.logs };
   }
 
   async createService(rawInput: CreateServiceInput): Promise<ServiceSchema> {
@@ -1285,6 +1298,17 @@ export class ComputeServicesService {
           protocol: data.protocol ?? existing.protocol,
           scaleToZero: data.scaleToZero ?? existing.scaleToZero,
         });
+        // Any URL the driver reports is authoritative, replacement or not. Kept
+        // outside the id check below because the contract does not tie the two:
+        // a driver that re-publishes a port on the same instance (an `ingress`
+        // change from `none` to `port`, say) returns a fresh URL with no new id,
+        // and nesting this under the id check would drop it. Omitting the field
+        // still means "unchanged" — both current drivers omit it on an in-place
+        // update, where the published port cannot have moved.
+        if (updated?.endpointUrl !== undefined) {
+          updates.push(`endpoint_url = $${paramIdx++}`);
+          values.push(updated.endpointUrl);
+        }
         // A driver that cannot change image/ports/env in place replaces the
         // instance instead (Docker), so the stored id has to follow — otherwise
         // it points at a container that no longer exists and every later call
@@ -1292,12 +1316,6 @@ export class ComputeServicesService {
         if (updated?.machineId && updated.machineId !== existing.providerInstanceId) {
           updates.push(`provider_instance_id = $${paramIdx++}`);
           values.push(updated.machineId);
-          // A replacement gets a newly-assigned published port, so the stored URL
-          // would otherwise point at one that has been freed.
-          if (updated.endpointUrl !== undefined) {
-            updates.push(`endpoint_url = $${paramIdx++}`);
-            values.push(updated.endpointUrl);
-          }
           // The replacement is launched running, so the row has to follow: a
           // service the caller had stopped and then redeployed would otherwise
           // keep reporting 'stopped' while its container runs. Unconditional

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -699,8 +699,21 @@ export class ComputeServicesService {
         }
       } catch (error) {
         if (error instanceof MachineGoneError) {
-          await this.healMachineGone(row.id, instanceId);
-          stats.healed++;
+          // Guarded: this is the one write inside the catch, and letting it throw
+          // would escape the loop and abandon every row still unchecked. A sweep
+          // that heals nine of ten rows beats one that stops at the first bad
+          // write — the next boot retries this row anyway.
+          try {
+            await this.healMachineGone(row.id, instanceId);
+            stats.healed++;
+          } catch (healError) {
+            logger.error('Compute reconcile: could not heal a vanished machine', {
+              id: row.id,
+              name: row.name,
+              error: healError instanceof Error ? healError.message : String(healError),
+            });
+            stats.skipped++;
+          }
           continue;
         }
         // Transient (daemon restarting, network blip). Leave the row as-is —
@@ -1285,6 +1298,13 @@ export class ComputeServicesService {
             updates.push(`endpoint_url = $${paramIdx++}`);
             values.push(updated.endpointUrl);
           }
+          // The replacement is launched running, so the row has to follow: a
+          // service the caller had stopped and then redeployed would otherwise
+          // keep reporting 'stopped' while its container runs. Unconditional
+          // because Path A owns the only other status write and cannot co-occur
+          // with this branch (it requires no instance).
+          updates.push(`status = $${paramIdx++}`);
+          values.push('running');
           logger.info('Compute service instance replaced to apply the update', {
             id,
             previous: existing.providerInstanceId,

--- a/backend/src/services/compute/services.service.ts
+++ b/backend/src/services/compute/services.service.ts
@@ -690,17 +690,29 @@ export class ComputeServicesService {
           // concurrent deploy can replace the instance between the snapshot and
           // this write; without the guard, a stale `stopped` reading about the old
           // container would overwrite the `running` the deploy just committed.
-          await this.getPool().query(
+          const corrected = await this.getPool().query(
             `UPDATE compute.services SET status = $1 WHERE id = $2 AND provider_instance_id = $3`,
             [state, row.id, instanceId]
           );
-          stats.corrected++;
-          logger.info('Compute reconcile: corrected a stale status', {
-            id: row.id,
-            name: row.name,
-            was: row.status,
-            now: state,
-          });
+          // Zero rows means the guard did its job, which is a skip rather than a
+          // correction — counting it either way would report work that never
+          // happened and hide how often the race actually fires.
+          if (corrected.rowCount === 0) {
+            stats.skipped++;
+            logger.info('Compute reconcile: skipped a stale reading, the row moved on', {
+              id: row.id,
+              name: row.name,
+              observedInstance: instanceId,
+            });
+          } else {
+            stats.corrected++;
+            logger.info('Compute reconcile: corrected a stale status', {
+              id: row.id,
+              name: row.name,
+              was: row.status,
+              now: state,
+            });
+          }
         }
       } catch (error) {
         if (error instanceof MachineGoneError) {

--- a/backend/src/services/metadata/metadata.service.ts
+++ b/backend/src/services/metadata/metadata.service.ts
@@ -196,6 +196,23 @@ export class MetadataService {
       lines.push('');
     }
 
+    // Compute (absent when no driver is configured, which is the common case)
+    if (metadata.compute) {
+      lines.push('## Compute');
+      lines.push(`- **Default provider**: ${codeSpan(metadata.compute.defaultProvider)}`);
+      for (const [name, caps] of Object.entries(metadata.compute.providers)) {
+        // The capabilities exist so a client stops offering what the provider cannot
+        // do, so spell out the answer rather than dumping the object.
+        lines.push(
+          `- ${codeSpan(name)}: regions ${caps.regions ? 'yes' : 'no'}, ` +
+            `scale-to-zero ${caps.scaleToZero ? 'yes' : 'no'}, ` +
+            `ingress ${caps.ingressModes.map(codeSpan).join('/')}, ` +
+            `source build ${codeSpan(caps.sourceBuild)}`
+        );
+      }
+      lines.push('');
+    }
+
     return lines.join('\n');
   }
 }

--- a/backend/src/services/metadata/metadata.service.ts
+++ b/backend/src/services/metadata/metadata.service.ts
@@ -7,6 +7,7 @@ import { AuthService } from '@/services/auth/auth.service.js';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { FunctionService } from '@/services/functions/function.service.js';
 import { RealtimeChannelService } from '@/services/realtime/realtime-channel.service.js';
+import { getComputeMetadata } from '@/services/compute/services.service.js';
 import { DeploymentService } from '@/services/deployments/deployment.service.js';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
 import type { AppMetadataSchema } from '@insforge/shared-schemas';
@@ -40,6 +41,10 @@ export class MetadataService {
       deploymentService.getConfigMetadata(),
     ]);
 
+    // Synchronous and database-free (it reads the in-memory driver registry), so
+    // it stays out of the Promise.all above.
+    const compute = getComputeMetadata();
+
     const version = process.env.npm_package_version || '1.0.0';
 
     return {
@@ -54,6 +59,9 @@ export class MetadataService {
       // probe depends on this presence/absence signal to gate
       // [deployments] TOML sections.
       ...(deployments ? { deployments } : {}),
+      // Absent when no compute provider is configured — same presence/absence
+      // capability signal as the deployments slice above.
+      ...(compute ? { compute } : {}),
       version,
     };
   }

--- a/backend/tests/unit/app.config.test.ts
+++ b/backend/tests/unit/app.config.test.ts
@@ -743,3 +743,55 @@ describe('loadConfig() structural integrity', () => {
     expect(c.deployments.maxDeploymentFileBytes).not.toBeNaN();
   });
 });
+
+// ---------------------------------------------------------------------------
+// docker (self-hosted compute driver)
+// ---------------------------------------------------------------------------
+describe('docker compute config', () => {
+  it('defaults the upload idle timeout to 30 seconds', () => {
+    delete process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT;
+    expect(loadConfig().docker.buildUploadIdleTimeoutMs).toBe(30_000);
+  });
+
+  it('reads the idle timeout in seconds', () => {
+    process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = '90';
+    expect(loadConfig().docker.buildUploadIdleTimeoutMs).toBe(90_000);
+  });
+
+  // setTimeout silently treats any delay past the 32-bit signed max as 1ms, so an
+  // unclamped value inverts the setting: asking for a very lenient timeout would
+  // abort every upload immediately.
+  it('clamps an oversized idle timeout instead of inverting it', () => {
+    process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = '3000000';
+    const ms = loadConfig().docker.buildUploadIdleTimeoutMs;
+    expect(ms).toBe(2_147_483_647);
+    expect(ms).toBeLessThanOrEqual(2_147_483_647);
+  });
+
+  it.each(['0', '-5', 'abc', ''])('falls back to the default for %o', (v) => {
+    process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = v;
+    expect(loadConfig().docker.buildUploadIdleTimeoutMs).toBe(30_000);
+  });
+
+  // A knob that silently ignores `=1` fails in the unsafe direction: the operator
+  // believes containers are off the project network when they are on it.
+  it.each([
+    ['true', true],
+    ['1', true],
+    ['yes', true],
+    ['on', true],
+    ['TRUE', true],
+    ['false', false],
+    ['0', false],
+    ['', false],
+  ])('parses COMPUTE_ISOLATE_NETWORK=%o as %s', (v, expected) => {
+    process.env.COMPUTE_ISOLATE_NETWORK = v;
+    expect(loadConfig().docker.isolateNetwork).toBe(expected);
+  });
+
+  it('defaults the build context ceiling to 64mb, not the JSON body limit', () => {
+    delete process.env.COMPUTE_BUILD_MAX_CONTEXT;
+    process.env.MAX_JSON_BODY_SIZE = '100mb';
+    expect(loadConfig().docker.buildMaxContextSize).toBe('64mb');
+  });
+});

--- a/backend/tests/unit/compute/cloud-provider.test.ts
+++ b/backend/tests/unit/compute/cloud-provider.test.ts
@@ -22,6 +22,8 @@ describe('CloudComputeProvider', () => {
   let fetchMock: FetchMock;
 
   beforeEach(() => {
+    // createApp derives the 6PN network name from APP_KEY.
+    process.env.APP_KEY = 'd9byq46t';
     fetchMock = vi.fn() as unknown as FetchMock;
     global.fetch = fetchMock as unknown as typeof fetch;
   });
@@ -33,11 +35,7 @@ describe('CloudComputeProvider', () => {
     } as Response);
 
     const provider = CloudComputeProvider.getInstance();
-    const result = await provider.createApp({
-      name: 'test',
-      network: 'test',
-      org: 'unused-in-cloud-mode',
-    });
+    const result = await provider.createApp({ name: 'test' });
 
     const call = fetchMock.mock.calls[0];
     expect(call[0]).toBe('https://cloud.test/projects/v1/proj-1/compute/apps');
@@ -48,52 +46,29 @@ describe('CloudComputeProvider', () => {
   });
 
   // Regression: live e2e on prod (project 2163e1eb-...) showed Fly 422
-  // "Validation failed: Name not a valid network name" because the caller
-  // (services.service.ts) used to pass `${projectId}-network` (~44 chars)
-  // which exceeded Fly's network-name validator on stricter orgs. The
-  // service now uses APP_KEY (~8 chars) — these tests pin the wire format.
-  it('createApp forwards network when caller passes a (short) value', async () => {
+  // "Validation failed: Name not a valid network name" because the caller used
+  // to pass `${projectId}-network` (~44 chars), which exceeded Fly's
+  // network-name validator on stricter orgs. The network name is now derived
+  // inside the provider from APP_KEY (~8 chars) rather than passed in — this
+  // pins the wire format so it stays byte-identical to what the service sent.
+  it('createApp derives the network name from APP_KEY', async () => {
     fetchMock.mockResolvedValue({
       ok: true,
       text: async () => JSON.stringify({ appId: 'ifc-proj-test' }),
     } as Response);
 
     const provider = CloudComputeProvider.getInstance();
-    await provider.createApp({
-      name: 'test',
-      network: 'd9byq46t',
-      org: 'unused-in-cloud-mode',
-    });
+    await provider.createApp({ name: 'test' });
 
     const call = fetchMock.mock.calls[0];
     const sentBody = JSON.parse((call[1] as RequestInit).body as string);
-    expect(sentBody).toEqual({ name: 'test', network: 'd9byq46t' });
-  });
-
-  it('createApp omits network field when caller does not pass one', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: async () => JSON.stringify({ appId: 'ifc-proj-test' }),
-    } as Response);
-
-    const provider = CloudComputeProvider.getInstance();
-    await provider.createApp({
-      name: 'test',
-      org: 'unused-in-cloud-mode',
-    });
-
-    const call = fetchMock.mock.calls[0];
-    const sentBody = JSON.parse((call[1] as RequestInit).body as string);
-    expect(sentBody).toEqual({ name: 'test' });
-    expect('network' in sentBody).toBe(false);
+    expect(sentBody).toEqual({ name: 'test', network: 'n-d9byq46t' });
   });
 
   it('throws COMPUTE_CLOUD_UNAVAILABLE on network error', async () => {
     fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
     const provider = CloudComputeProvider.getInstance();
-    await expect(provider.createApp({ name: 't', network: 't', org: 'o' })).rejects.toThrow(
-      /COMPUTE_CLOUD_UNAVAILABLE/
-    );
+    await expect(provider.createApp({ name: 't' })).rejects.toThrow(/COMPUTE_CLOUD_UNAVAILABLE/);
   });
 
   it('throws AppError when cloud returns non-2xx with body', async () => {
@@ -107,7 +82,7 @@ describe('CloudComputeProvider', () => {
         }),
     } as Response);
     const provider = CloudComputeProvider.getInstance();
-    await expect(provider.createApp({ name: 't', network: 't', org: 'o' })).rejects.toThrow(
+    await expect(provider.createApp({ name: 't' })).rejects.toThrow(
       new RegExp(`limit reached|${ERROR_CODES.COMPUTE_QUOTA_EXCEEDED}`)
     );
   });
@@ -178,7 +153,7 @@ describe('CloudComputeProvider', () => {
     const abortError = new DOMException('The operation was aborted', 'AbortError');
     fetchMock.mockRejectedValue(abortError);
     const provider = CloudComputeProvider.getInstance();
-    await expect(provider.createApp({ name: 't', network: 't', org: 'o' })).rejects.toMatchObject({
+    await expect(provider.createApp({ name: 't' })).rejects.toMatchObject({
       code: 'COMPUTE_CLOUD_UNAVAILABLE',
     });
   });
@@ -198,7 +173,7 @@ describe('CloudComputeProvider', () => {
       }
     );
 
-    await expect(provider.createApp({ name: 't', network: 't', org: 'o' })).rejects.toThrow(
+    await expect(provider.createApp({ name: 't' })).rejects.toThrow(
       /COMPUTE_NOT_CONFIGURED|not configured/
     );
   });

--- a/backend/tests/unit/compute/compute-build-route.test.ts
+++ b/backend/tests/unit/compute/compute-build-route.test.ts
@@ -185,6 +185,84 @@ describe('POST /api/compute/services/:id/build', () => {
     );
   });
 
+  // An over-limit context is the client's problem, and the operator who set the
+  // limit is the one who needs to hear about it. The shared error middleware does
+  // not know `entity.too.large`, so without translation this is a bare 500.
+  it('answers an over-limit context with 413 and names the knob', async () => {
+    // `express.raw` captures the limit when the module loads, and resetting the
+    // module registry re-reads config from the environment — so the knob has to be
+    // set there, not on the already-built config object.
+    const original = process.env.COMPUTE_BUILD_MAX_CONTEXT;
+    process.env.COMPUTE_BUILD_MAX_CONTEXT = '1kb';
+    vi.resetModules();
+    try {
+      const app = await createApp();
+      const res = await request(app)
+        .post('/api/compute/services/svc-1/build')
+        .set('Content-Type', 'application/x-tar')
+        .send(Buffer.alloc(4096, 1));
+
+      expect(res.status).toBe(413);
+      expect(res.body.message).toMatch(/COMPUTE_BUILD_MAX_CONTEXT/);
+      expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+    } finally {
+      if (original === undefined) {
+        delete process.env.COMPUTE_BUILD_MAX_CONTEXT;
+      } else {
+        process.env.COMPUTE_BUILD_MAX_CONTEXT = original;
+      }
+      vi.resetModules();
+    }
+  });
+
+  // The build outlives the client, so a disconnect must not hand the slot to the
+  // next caller while the daemon is still working — that is how a second full
+  // context gets in alongside the first.
+  it('keeps the slot while a build runs even if the client disconnects', async () => {
+    let releaseBuild: () => void = () => {};
+    computeServiceMock.buildAndDeploy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseBuild = () => resolve({ service: { id: 'svc-1' }, imageTag: 'tag', logs: [] });
+        })
+    );
+
+    const app = await createApp();
+    const abortable = request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    const inFlight = abortable.then(
+      (r) => r,
+      () => undefined // aborting rejects the client promise; the server keeps going
+    );
+
+    for (let i = 0; i < 200 && computeServiceMock.buildAndDeploy.mock.calls.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(computeServiceMock.buildAndDeploy).toHaveBeenCalledTimes(1);
+
+    abortable.abort();
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Slot still held: the build did not stop just because the client left.
+    const during = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    expect(during.status).toBe(429);
+
+    releaseBuild();
+    await inFlight;
+    computeServiceMock.buildAndDeploy.mockResolvedValue({
+      service: { id: 'svc-1' },
+      imageTag: 'tag',
+      logs: [],
+    });
+    const after = await retryUntilNot429(app);
+    expect(after.status).toBe(200);
+  });
+
   // The point of the door: express buffers the whole tarball before any handler
   // runs, so a second upload has to be turned away *before* that, not after the
   // driver's own concurrency cap throws.
@@ -220,8 +298,6 @@ describe('POST /api/compute/services/:id/build', () => {
     expect(computeServiceMock.buildAndDeploy).toHaveBeenCalledTimes(1);
     releaseBuild();
     await first;
-    // `res.on('close')` fires a tick after the response is delivered.
-    await new Promise((r) => setTimeout(r, 20));
 
     // Back to an implementation that settles — the blocking one above would hang
     // the next request in the handler and hide whether the gate reopened.
@@ -231,11 +307,29 @@ describe('POST /api/compute/services/:id/build', () => {
       logs: [],
     });
 
-    // The door reopens once the first response closes.
-    const third = await request(app)
-      .post('/api/compute/services/svc-1/build')
-      .set('Content-Type', 'application/x-tar')
-      .send(TAR);
+    // The slot is handed back in the handler's `finally`, which runs on its own
+    // tick. Poll for the reopen instead of sleeping a guessed interval: a fixed
+    // sleep that loses the race reports a spurious 429 and flakes under load.
+    const third = await retryUntilNot429(app);
     expect(third.status).toBe(200);
   });
 });
+
+/**
+ * Re-issue the request until the build slot is free, bounded so a genuinely stuck
+ * gate still fails the test rather than hanging it.
+ */
+async function retryUntilNot429(app: express.Express) {
+  let last;
+  for (let i = 0; i < 100; i++) {
+    last = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    if (last.status !== 429) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return last!;
+}

--- a/backend/tests/unit/compute/compute-build-route.test.ts
+++ b/backend/tests/unit/compute/compute-build-route.test.ts
@@ -1,3 +1,6 @@
+import { createServer } from 'node:http';
+import { request as httpRequest } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import express, { type ErrorRequestHandler } from 'express';
 import request from 'supertest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -312,6 +315,110 @@ describe('POST /api/compute/services/:id/build', () => {
     // sleep that loses the race reports a spurious 429 and flakes under load.
     const third = await retryUntilNot429(app);
     expect(third.status).toBe(200);
+  });
+
+  // The two slot-lifecycle branches that decide whether builds block forever or
+  // overlap. Neither is reachable through supertest, which always sends a complete
+  // body — they need a socket we can stall or drop mid-upload, so these drive a real
+  // listener with `http.request` and a `Content-Length` we deliberately underfill.
+  describe('build slot lifecycle under a misbehaving client', () => {
+    /** Start the app on an ephemeral port. */
+    async function listen(app: express.Express) {
+      const server = createServer(app);
+      await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+      const { port } = server.address() as AddressInfo;
+      return { server, port, close: () => new Promise<void>((r) => server.close(() => r())) };
+    }
+
+    /**
+     * Open a build request that announces more body than it sends, so the server sits
+     * inside `express.raw` waiting for the rest.
+     */
+    function openPartialUpload(port: number) {
+      const req = httpRequest({
+        host: '127.0.0.1',
+        port,
+        method: 'POST',
+        path: '/api/compute/services/svc-1/build',
+        headers: {
+          'content-type': 'application/x-tar',
+          'content-length': String(TAR.length * 2),
+          'x-api-key': 'test',
+        },
+      });
+      // Both tests kill this socket on purpose; without a listener the ECONNRESET
+      // surfaces as an unhandled error and fails the run even though the
+      // assertions pass.
+      req.on('error', () => {});
+      req.write(TAR); // half of what we promised
+      return req;
+    }
+
+    it('frees the slot when the client vanishes before the handler runs', async () => {
+      const app = await createApp();
+      const { port, close } = await listen(app);
+      try {
+        const partial = openPartialUpload(port);
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Held: the upload is parked inside express.raw, so nothing else gets in.
+        const blocked = await request(app)
+          .post('/api/compute/services/svc-1/build')
+          .set('Content-Type', 'application/x-tar')
+          .send(TAR);
+        expect(blocked.status).toBe(429);
+        expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+
+        // The client disappears without ever reaching the handler. `res.close` is the
+        // only thing that can hand the slot back here.
+        partial.destroy();
+
+        const after = await retryUntilNot429(app);
+        expect(after.status).toBe(200);
+      } finally {
+        await close();
+      }
+    });
+
+    it('cuts a stalled upload loose after the configured idle timeout', async () => {
+      const original = process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT;
+      // Seconds, so this is the smallest value the knob expresses.
+      process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = '1';
+      vi.resetModules();
+      try {
+        const app = await createApp();
+        const { port, close } = await listen(app);
+        try {
+          const stalled = openPartialUpload(port);
+          const died = new Promise<string>((resolve) => {
+            stalled.on('error', () => resolve('socket dropped'));
+            stalled.on('response', () => resolve('got a response'));
+          });
+          await new Promise((r) => setTimeout(r, 50));
+
+          // Held while the upload looks alive.
+          const blocked = await request(app)
+            .post('/api/compute/services/svc-1/build')
+            .set('Content-Type', 'application/x-tar')
+            .send(TAR);
+          expect(blocked.status).toBe(429);
+
+          // Send nothing further: the watchdog should destroy the request and release.
+          expect(await died).toBe('socket dropped');
+          const after = await retryUntilNot429(app);
+          expect(after.status).toBe(200);
+        } finally {
+          await close();
+        }
+      } finally {
+        if (original === undefined) {
+          delete process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT;
+        } else {
+          process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = original;
+        }
+        vi.resetModules();
+      }
+    }, 15_000);
   });
 });
 

--- a/backend/tests/unit/compute/compute-build-route.test.ts
+++ b/backend/tests/unit/compute/compute-build-route.test.ts
@@ -359,15 +359,22 @@ describe('POST /api/compute/services/:id/build', () => {
       const { port, close } = await listen(app);
       try {
         const partial = openPartialUpload(port);
-        await new Promise((r) => setTimeout(r, 50));
 
         // Held: the upload is parked inside express.raw, so nothing else gets in.
+        // Polled rather than slept on — a fixed wait that loses the race reads as a
+        // spurious 200 on a loaded worker.
+        await waitUntilSlotHeld(app);
+
+        // Counted as a delta rather than "never called": a probe that raced ahead of
+        // the partial upload legitimately takes the slot and builds once, and that
+        // says nothing about whether a *rejected* upload reaches the service.
+        const callsBefore = computeServiceMock.buildAndDeploy.mock.calls.length;
         const blocked = await request(app)
           .post('/api/compute/services/svc-1/build')
           .set('Content-Type', 'application/x-tar')
           .send(TAR);
         expect(blocked.status).toBe(429);
-        expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+        expect(computeServiceMock.buildAndDeploy.mock.calls.length).toBe(callsBefore);
 
         // The client disappears without ever reaching the handler. `res.close` is the
         // only thing that can hand the slot back here.
@@ -382,8 +389,10 @@ describe('POST /api/compute/services/:id/build', () => {
 
     it('cuts a stalled upload loose after the configured idle timeout', async () => {
       const original = process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT;
-      // Seconds, so this is the smallest value the knob expresses.
-      process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = '1';
+      // Seconds. Two rather than one so there is room to observe the slot held
+      // before the watchdog fires — at one, a slow worker can reach the probe after
+      // the release and see 200 for the right reason at the wrong time.
+      process.env.COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT = '2';
       vi.resetModules();
       try {
         const app = await createApp();
@@ -394,13 +403,8 @@ describe('POST /api/compute/services/:id/build', () => {
             stalled.on('error', () => resolve('socket dropped'));
             stalled.on('response', () => resolve('got a response'));
           });
-          await new Promise((r) => setTimeout(r, 50));
-
           // Held while the upload looks alive.
-          const blocked = await request(app)
-            .post('/api/compute/services/svc-1/build')
-            .set('Content-Type', 'application/x-tar')
-            .send(TAR);
+          const blocked = await waitUntilSlotHeld(app);
           expect(blocked.status).toBe(429);
 
           // Send nothing further: the watchdog should destroy the request and release.
@@ -437,6 +441,26 @@ async function retryUntilNot429(app: express.Express) {
       return last;
     }
     await new Promise((r) => setTimeout(r, 10));
+  }
+  return last!;
+}
+
+/**
+ * Poll until a probe is actually turned away, i.e. the slot is observably held.
+ * Returns that 429 response so the caller can assert on it. Bounded, so a gate that
+ * never closes fails the test with a real status instead of hanging.
+ */
+async function waitUntilSlotHeld(app: express.Express) {
+  let last;
+  for (let i = 0; i < 200; i++) {
+    last = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    if (last.status === 429) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 5));
   }
   return last!;
 }

--- a/backend/tests/unit/compute/compute-build-route.test.ts
+++ b/backend/tests/unit/compute/compute-build-route.test.ts
@@ -1,0 +1,241 @@
+import express, { type ErrorRequestHandler } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Behavioural coverage for POST /:id/build at the HTTP boundary. The service-level
+// tests cover what happens once a context is in hand; everything interesting here
+// happens before that — the raw-tar body parse, the tenant check, the `dockerfile`
+// parameter, and the concurrency door that keeps a second upload from being
+// buffered at all.
+
+const computeServiceMock = vi.hoisted(() => ({
+  getService: vi.fn(),
+  buildAndDeploy: vi.fn(),
+}));
+const auditMock = vi.hoisted(() => ({ log: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('@/api/middlewares/auth.js', () => ({
+  verifyAdmin: (req: Record<string, unknown>, _res: unknown, next: () => void) => {
+    req.user = { id: 'admin-1' };
+    req.hasApiKey = false;
+    next();
+  },
+}));
+
+// The real limiter carries per-instance state across tests in the same file.
+vi.mock('@/api/middlewares/rate-limiters.js', () => ({
+  computeWriteLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+  computeLogsRateLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('@/services/compute/services.service.js', () => ({
+  ComputeServicesService: { getInstance: () => computeServiceMock },
+}));
+
+vi.mock('@/services/logs/audit.service.js', () => ({
+  AuditService: { getInstance: () => auditMock },
+}));
+
+vi.mock('@/services/dashboard/dashboard-event.service.js', () => ({
+  dashboardEventService: { publishDataUpdate: vi.fn() },
+}));
+
+const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  void _next;
+  const status =
+    error instanceof Error && 'statusCode' in error && typeof error.statusCode === 'number'
+      ? error.statusCode
+      : 500;
+  res.status(status).json({
+    message: error instanceof Error ? error.message : 'Error',
+    error: (error as { code?: string })?.code,
+  });
+};
+
+async function createApp() {
+  const { servicesRouter: router } = await import('@/api/routes/compute/services.routes.js');
+  const app = express();
+  app.use('/api/compute/services', router);
+  app.use(errorHandler);
+  return app;
+}
+
+const TAR = Buffer.alloc(2048, 1);
+
+describe('POST /api/compute/services/:id/build', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PROJECT_ID = 'proj-1';
+    computeServiceMock.getService.mockResolvedValue({
+      id: 'svc-1',
+      projectId: 'proj-1',
+      name: 'api',
+    });
+    computeServiceMock.buildAndDeploy.mockResolvedValue({
+      service: { id: 'svc-1', name: 'api' },
+      imageTag: 'insforge-x/api:abc',
+      logs: ['Step 1/2'],
+    });
+  });
+
+  it('accepts an application/x-tar body and returns the built tag', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+
+    expect(res.status).toBe(200);
+    const [, context, options] = computeServiceMock.buildAndDeploy.mock.calls[0];
+    expect(Buffer.isBuffer(context)).toBe(true);
+    expect(context.length).toBe(TAR.length);
+    expect(options).toEqual({ dockerfile: undefined });
+  });
+
+  // Anything that is not the declared type never reaches express.raw, so the body
+  // arrives unparsed rather than as a Buffer. That has to be a 400, not a crash.
+  it('rejects a body sent with the wrong content type', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/json')
+      .send('{}');
+
+    expect(res.status).toBe(400);
+    expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty context', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(Buffer.alloc(0));
+
+    expect(res.status).toBe(400);
+    expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+  });
+
+  // A service belonging to someone else must be indistinguishable from one that
+  // does not exist.
+  it('404s a service from another project without building', async () => {
+    computeServiceMock.getService.mockResolvedValue({
+      id: 'svc-1',
+      projectId: 'other-project',
+      name: 'api',
+    });
+    const app = await createApp();
+    const res = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+
+    expect(res.status).toBe(404);
+    expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+  });
+
+  it('passes a build failure through with the builder message', async () => {
+    computeServiceMock.buildAndDeploy.mockRejectedValue(
+      Object.assign(new Error('process "/bin/sh -c exit 7" did not complete successfully'), {
+        statusCode: 400,
+      })
+    );
+    const app = await createApp();
+    const res = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/exit 7/);
+  });
+
+  describe('the `dockerfile` parameter', () => {
+    it.each([
+      ['/etc/passwd', 'absolute'],
+      ['../../etc/passwd', 'parent traversal'],
+      ['nested/../../out', 'traversal after a valid segment'],
+      ['C:\\Windows\\System32', 'windows absolute'],
+      ['x'.repeat(256), 'over-long'],
+      ['', 'empty'],
+    ])('rejects %s (%s) with a 400 before building', async (value) => {
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/compute/services/svc-1/build?dockerfile=${encodeURIComponent(value)}`)
+        .set('Content-Type', 'application/x-tar')
+        .send(TAR);
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/dockerfile/i);
+      expect(computeServiceMock.buildAndDeploy).not.toHaveBeenCalled();
+    });
+
+    it.each(['Dockerfile', 'docker/Dockerfile.prod', './Dockerfile'])(
+      'forwards the legitimate path %s',
+      async (value) => {
+        const app = await createApp();
+        const res = await request(app)
+          .post(`/api/compute/services/svc-1/build?dockerfile=${encodeURIComponent(value)}`)
+          .set('Content-Type', 'application/x-tar')
+          .send(TAR);
+
+        expect(res.status).toBe(200);
+        expect(computeServiceMock.buildAndDeploy.mock.calls[0][2]).toEqual({ dockerfile: value });
+      }
+    );
+  });
+
+  // The point of the door: express buffers the whole tarball before any handler
+  // runs, so a second upload has to be turned away *before* that, not after the
+  // driver's own concurrency cap throws.
+  it('rejects a concurrent upload with 429 rather than buffering it', async () => {
+    let releaseBuild: () => void = () => {};
+    computeServiceMock.buildAndDeploy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseBuild = () => resolve({ service: { id: 'svc-1' }, imageTag: 'tag', logs: [] });
+        })
+    );
+
+    const app = await createApp();
+    // `.then()` is what actually dispatches a supertest request; holding the Test
+    // object alone would never enter the handler.
+    const first = request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR)
+      .then((r) => r);
+
+    // Wait until the first request is inside the handler, i.e. past express.raw.
+    for (let i = 0; i < 200 && computeServiceMock.buildAndDeploy.mock.calls.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(computeServiceMock.buildAndDeploy).toHaveBeenCalledTimes(1);
+    const second = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    expect(second.status).toBe(429);
+    // Still one call: the rejected upload never reached the service.
+    expect(computeServiceMock.buildAndDeploy).toHaveBeenCalledTimes(1);
+    releaseBuild();
+    await first;
+    // `res.on('close')` fires a tick after the response is delivered.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Back to an implementation that settles — the blocking one above would hang
+    // the next request in the handler and hide whether the gate reopened.
+    computeServiceMock.buildAndDeploy.mockResolvedValue({
+      service: { id: 'svc-1' },
+      imageTag: 'tag',
+      logs: [],
+    });
+
+    // The door reopens once the first response closes.
+    const third = await request(app)
+      .post('/api/compute/services/svc-1/build')
+      .set('Content-Type', 'application/x-tar')
+      .send(TAR);
+    expect(third.status).toBe(200);
+  });
+});

--- a/backend/tests/unit/compute/docker-client.test.ts
+++ b/backend/tests/unit/compute/docker-client.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/infra/config/app.config.js', () => {
+  const c = { docker: { socketPath: '/nonexistent/test.sock' } };
+  return { config: c, appConfig: c };
+});
+
+import {
+  demuxDockerStream,
+  parseLogLine,
+  parseBuildStream,
+  dockerConfig,
+} from '@/providers/compute/docker.client.js';
+
+/**
+ * Builds a Docker multiplexed frame: 1-byte stream type, 3 zero bytes, then a
+ * 4-byte big-endian payload length. Byte layout verified against Engine 29.3.1 —
+ * a real stdout frame started `0100 0000 0000 0026` for a 38-byte payload.
+ */
+function frame(text: string, stream: 1 | 2 = 1): Buffer {
+  const payload = Buffer.from(text, 'utf8');
+  const header = Buffer.alloc(8);
+  header[0] = stream;
+  header.writeUInt32BE(payload.length, 4);
+  return Buffer.concat([header, payload]);
+}
+
+describe('demuxDockerStream', () => {
+  it('strips the 8-byte header that would otherwise prefix every line', () => {
+    const buf = frame('2026-08-06T22:51:32.781160549Z line-1\n');
+    const out = demuxDockerStream(buf);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].stream).toBe('stdout');
+    expect(out[0].text).toBe('2026-08-06T22:51:32.781160549Z line-1\n');
+    // The failure mode this guards against: leaking header bytes into the text.
+    // Written as an escape rather than a literal control character so an editor
+    // or formatter cannot silently eat it and make the assertion vacuous.
+    expect(out[0].text).not.toContain('\x01');
+    expect(out[0].text.charCodeAt(0)).toBe('2'.charCodeAt(0));
+  });
+
+  it('reads consecutive frames and distinguishes stdout from stderr', () => {
+    const buf = Buffer.concat([frame('one\n', 1), frame('two\n', 2), frame('three\n', 1)]);
+    expect(demuxDockerStream(buf).map((f) => [f.stream, f.text.trim()])).toEqual([
+      ['stdout', 'one'],
+      ['stderr', 'two'],
+      ['stdout', 'three'],
+    ]);
+  });
+
+  // The response is a snapshot of a live stream, so it can end mid-frame.
+  // Dropping the partial tail beats throwing away the whole batch.
+  it('ignores a truncated trailing frame', () => {
+    const buf = Buffer.concat([frame('complete\n'), frame('cut off here\n').subarray(0, 11)]);
+    const out = demuxDockerStream(buf);
+    expect(out).toHaveLength(1);
+    expect(out[0].text.trim()).toBe('complete');
+  });
+
+  it('returns nothing for an empty body', () => {
+    expect(demuxDockerStream(Buffer.alloc(0))).toEqual([]);
+  });
+});
+
+describe('parseLogLine', () => {
+  it('splits the RFC3339Nano prefix from the message', () => {
+    const parsed = parseLogLine('2026-08-06T22:51:32.781160549Z hello world');
+    expect(parsed?.message).toBe('hello world');
+    expect(parsed?.ms).toBe(Date.parse('2026-08-06T22:51:32.781Z'));
+  });
+
+  // Full nanosecond precision is what makes the forward cursor correct: `since`
+  // only accepts integer seconds, so ms-truncated timestamps would collapse
+  // distinct lines inside one millisecond and re-deliver or drop them.
+  it('preserves nanoseconds that Date.parse would truncate', () => {
+    const a = parseLogLine('2026-08-06T22:51:32.781160549Z first');
+    const b = parseLogLine('2026-08-06T22:51:32.781160550Z second');
+    expect(a!.nanos).toBe(1786056692781160549n);
+    expect(b!.nanos - a!.nanos).toBe(1n);
+    // Both round to the same millisecond — hence the separate nanos field.
+    expect(a!.ms).toBe(b!.ms);
+  });
+
+  it('handles a timestamp with no fractional part', () => {
+    const parsed = parseLogLine('2026-08-06T22:51:32Z plain');
+    expect(parsed?.nanos).toBe(1786056692000000000n);
+    expect(parsed?.message).toBe('plain');
+  });
+
+  it('keeps spaces inside the message and strips only the trailing newline', () => {
+    expect(parseLogLine('2026-08-06T22:51:32.000000000Z a b  c\n')?.message).toBe('a b  c');
+  });
+
+  it('returns null for a line with no timestamp rather than fabricating one', () => {
+    expect(parseLogLine('no-timestamp-here')).toBeNull();
+    expect(parseLogLine('')).toBeNull();
+  });
+});
+
+describe('parseBuildStream', () => {
+  // The failure mode that matters: a failed build still returns HTTP 200, with the
+  // error appended to the body. Trusting the status code means starting a
+  // container from a tag that was never produced.
+  it('reports failure from the stream body, not the status code', () => {
+    const body = [
+      '{"stream":"Step 1/2 : FROM alpine"}',
+      '{"stream":"Step 2/2 : RUN exit 7"}',
+      '{"error":"process \\"/bin/sh -c exit 7\\" did not complete successfully: exit code: 7",' +
+        '"errorDetail":{"message":"process \\"/bin/sh -c exit 7\\" did not complete successfully: exit code: 7"}}',
+    ].join('\n');
+
+    const result = parseBuildStream(body);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('exit code: 7');
+  });
+
+  it('collects readable progress from the classic builder', () => {
+    const body = [
+      '{"stream":"Step 1/3 : FROM alpine"}',
+      '{"stream":"\\n"}',
+      '{"stream":" ---\\u003e 28bd5fe8b56d\\n"}',
+      '{"stream":"Successfully built abc123\\n"}',
+    ].join('\n');
+
+    const result = parseBuildStream(body);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.logs).toContain('Step 1/3 : FROM alpine');
+    expect(result.logs).toContain('Successfully built abc123');
+    // Blank frames are dropped rather than padding the log with empty lines.
+    expect(result.logs.every((l) => l.trim().length > 0)).toBe(true);
+  });
+
+  // BuildKit's progress is base64 protobuf, which we deliberately do not decode.
+  // Counting the frames keeps the response honest without the dependency.
+  it('summarises BuildKit aux frames instead of decoding them', () => {
+    const body = [
+      '{"id":"moby.buildkit.trace","aux":"Cm8KR3NoYTI1Njo5NWUx"}',
+      '{"id":"moby.buildkit.trace","aux":"Cn0KR3NoYTI1Njo5NWUx"}',
+    ].join('\n');
+
+    const result = parseBuildStream(body);
+    expect(result.ok).toBe(true);
+    expect(result.logs).toHaveLength(1);
+    expect(result.logs[0]).toContain('2 progress frames');
+  });
+
+  it('succeeds on an empty stream rather than inventing a failure', () => {
+    expect(parseBuildStream('')).toEqual({ ok: true, error: null, logs: [] });
+  });
+
+  it('ignores a truncated trailing line', () => {
+    const body = '{"stream":"Step 1/1 : FROM alpine"}\n{"stream":"partial';
+    const result = parseBuildStream(body);
+    expect(result.ok).toBe(true);
+    expect(result.logs).toEqual(['Step 1/1 : FROM alpine']);
+  });
+});
+
+describe('dockerConfig', () => {
+  // Config objects are routinely partial (test mocks stub one slice), and
+  // reaching straight for appConfig.docker.socketPath turned that into an
+  // unrelated TypeError inside provider selection.
+  it('applies documented defaults for fields the config omits', () => {
+    const c = dockerConfig();
+    expect(c.socketPath).toBe('/nonexistent/test.sock');
+    expect(c.defaultIngress).toBe('none');
+    expect(c.bindAddress).toBe('127.0.0.1');
+    expect(c.isolateNetwork).toBe(false);
+    expect(c.publicHost).toBe('');
+  });
+});

--- a/backend/tests/unit/compute/docker-provider.test.ts
+++ b/backend/tests/unit/compute/docker-provider.test.ts
@@ -1,0 +1,616 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/infra/config/app.config.js', () => {
+  const c = {
+    docker: {
+      socketPath: '/nonexistent/test.sock',
+      publicHost: '',
+      domain: '',
+      defaultIngress: 'none',
+      bindAddress: '127.0.0.1',
+      // Skip own-container network discovery: it inspects the host daemon, which
+      // has nothing to do with the behaviour under test here.
+      isolateNetwork: true,
+    },
+  };
+  return { config: c, appConfig: c };
+});
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// vi.mock factories are hoisted above const initialization, so the spies have to
+// be created inside the factory and pulled back out via vi.hoisted.
+const { mockRequest, mockRequestRaw } = vi.hoisted(() => ({
+  mockRequest: vi.fn(),
+  mockRequestRaw: vi.fn(),
+}));
+
+vi.mock('@/providers/compute/docker.client.js', async () => {
+  // Keep the real demux/parse/config helpers — only the socket calls are faked.
+  const actual = await vi.importActual<typeof import('@/providers/compute/docker.client.js')>(
+    '@/providers/compute/docker.client.js'
+  );
+  return {
+    ...actual,
+    dockerRequest: mockRequest,
+    dockerRequestRaw: mockRequestRaw,
+  };
+});
+
+import { DockerProvider } from '@/providers/compute/docker.provider.js';
+import { MachineGoneError } from '@/providers/compute/compute.provider.js';
+
+/** An inspect payload that passes the ownership check. */
+function ownedContainer(overrides: Record<string, unknown> = {}) {
+  return {
+    Id: 'container-abc',
+    Name: '/insforge-testkey1-api',
+    State: { Status: 'running', ExitCode: 0, Running: true },
+    Config: {
+      Image: 'nginx:alpine',
+      Labels: {
+        'insforge.managed': 'true',
+        'insforge.project': 'testkey1',
+        'insforge.service': 'insforge-testkey1-api',
+      },
+    },
+    NetworkSettings: { Ports: {} },
+    ...overrides,
+  };
+}
+
+/**
+ * Queue the image-existence probe that launchMachine performs before create.
+ * A 2xx means "already on this host", so no pull is attempted.
+ */
+function imageAlreadyPresent() {
+  mockRequestRaw.mockResolvedValueOnce({ status: 200, body: Buffer.from('{}') });
+}
+
+function frame(text: string): Buffer {
+  const payload = Buffer.from(text, 'utf8');
+  const header = Buffer.alloc(8);
+  header[0] = 1;
+  header.writeUInt32BE(payload.length, 4);
+  return Buffer.concat([header, payload]);
+}
+
+describe('DockerProvider', () => {
+  let provider: DockerProvider;
+  const oldAppKey = process.env.APP_KEY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APP_KEY = 'testkey1';
+    provider = DockerProvider.getInstance();
+  });
+
+  afterEach(() => {
+    if (oldAppKey === undefined) {
+      delete process.env.APP_KEY;
+    } else {
+      process.env.APP_KEY = oldAppKey;
+    }
+  });
+
+  describe('capabilities', () => {
+    it('declares no scale-to-zero and no regions, but all three ingress modes', () => {
+      expect(provider.capabilities).toEqual({
+        scaleToZero: false,
+        regions: false,
+        ingressModes: ['none', 'port', 'host'],
+        sourceBuild: 'context-upload',
+        deployTokenIssuance: false,
+      });
+      expect(provider.name).toBe('docker');
+    });
+  });
+
+  describe('resolveAppName', () => {
+    // One host commonly runs several InsForge projects, so two of them deploying
+    // a service called `api` must not collide on the same daemon.
+    it('namespaces the container name by APP_KEY', () => {
+      expect(provider.resolveAppName({ name: 'api', projectId: 'proj-1' })).toBe(
+        'insforge-testkey1-api'
+      );
+      process.env.APP_KEY = 'otherkey';
+      expect(provider.resolveAppName({ name: 'api', projectId: 'proj-2' })).toBe(
+        'insforge-otherkey-api'
+      );
+    });
+  });
+
+  describe('launchMachine', () => {
+    it('builds a spec with ownership labels, restart policy, and resource limits', async () => {
+      imageAlreadyPresent();
+      mockRequest.mockResolvedValueOnce({ Id: 'container-new' }).mockResolvedValueOnce(undefined);
+
+      const result = await provider.launchMachine({
+        appId: 'insforge-testkey1-api',
+        image: 'nginx:alpine',
+        port: 8080,
+        cpu: 'shared-2x',
+        memory: 512,
+        envVars: { FOO: 'bar' },
+        region: 'local',
+      });
+
+      expect(result).toEqual({ machineId: 'container-new', endpointUrl: null });
+
+      const [, path, opts] = mockRequest.mock.calls[0];
+      expect(path).toBe('/containers/create?name=insforge-testkey1-api');
+      const body = opts.body;
+
+      expect(body.Labels).toMatchObject({
+        'insforge.managed': 'true',
+        'insforge.project': 'testkey1',
+        'insforge.service': 'insforge-testkey1-api',
+      });
+      // Spec hash is stamped so a later update can tell an in-place resize from a
+      // change that needs the container recreated.
+      expect(body.Labels['insforge.spec']).toMatch(/^[0-9a-f]{16}$/);
+      expect(body.Env).toEqual(['FOO=bar']);
+      // Survives a host reboot — measured as the difference between a container
+      // coming back and staying exited.
+      expect(body.HostConfig.RestartPolicy).toEqual({ Name: 'unless-stopped' });
+      expect(body.HostConfig.NanoCpus).toBe(2e9);
+      expect(body.HostConfig.Memory).toBe(512 * 1024 * 1024);
+
+      // Then started.
+      expect(mockRequest.mock.calls[1][1]).toBe('/containers/container-new/start');
+    });
+
+    // The security property: there is no field through which a caller could
+    // smuggle Privileged, Binds, or host networking, because the spec is
+    // constructed here rather than forwarded.
+    it('never emits privileged, bind-mount, or host-network settings', async () => {
+      imageAlreadyPresent();
+      mockRequest.mockResolvedValueOnce({ Id: 'c1' }).mockResolvedValueOnce(undefined);
+      await provider.launchMachine({
+        appId: 'insforge-testkey1-api',
+        image: 'nginx:alpine',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'local',
+      });
+      const host = mockRequest.mock.calls[0][2].body.HostConfig;
+      expect(host.Privileged).toBeUndefined();
+      expect(host.Binds).toBeUndefined();
+      expect(host.NetworkMode).toBeUndefined();
+      expect(host.PidMode).toBeUndefined();
+      expect(host.CapAdd).toBeUndefined();
+      expect(host.Devices).toBeUndefined();
+    });
+
+    // Most compute takes no inbound traffic at all (workers, processors,
+    // inference loops), so publishing a host port for every container is wrong.
+    it('publishes no host port under the default `none` ingress', async () => {
+      imageAlreadyPresent();
+      mockRequest.mockResolvedValueOnce({ Id: 'c1' }).mockResolvedValueOnce(undefined);
+      await provider.launchMachine({
+        appId: 'insforge-testkey1-api',
+        image: 'nginx:alpine',
+        port: 8080,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'local',
+      });
+      expect(mockRequest.mock.calls[0][2].body.HostConfig.PortBindings).toEqual({});
+    });
+
+    // The bug this covers: `containers/create` does not pull, so on a host that has
+    // never seen the image it fails with `No such image`. Every earlier test — unit
+    // and live — pre-pulled the image, which is not what a fresh deploy does.
+    it('pulls the image when the host does not have it', async () => {
+      mockRequestRaw
+        .mockResolvedValueOnce({ status: 404, body: Buffer.from('{"message":"No such image"}') })
+        .mockResolvedValueOnce({
+          status: 200,
+          body: Buffer.from(
+            '{"status":"Pulling from library/nginx"}\n{"status":"Download complete"}'
+          ),
+        });
+      mockRequest.mockResolvedValueOnce({ Id: 'c-pulled' }).mockResolvedValueOnce(undefined);
+
+      const result = await provider.launchMachine({
+        appId: 'insforge-testkey1-api',
+        image: 'nginx:alpine',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'local',
+      });
+
+      expect(result.machineId).toBe('c-pulled');
+      const [probe, pull] = mockRequestRaw.mock.calls;
+      expect(probe[1]).toBe('/images/nginx%3Aalpine/json');
+      expect(pull[0]).toBe('POST');
+      expect(pull[1]).toBe('/images/create?fromImage=nginx%3Aalpine');
+      // The pull must happen before create, or create sees no image.
+      expect(mockRequest.mock.calls[0][1]).toContain('/containers/create');
+    });
+
+    it('does not pull when the image is already present', async () => {
+      imageAlreadyPresent();
+      mockRequest.mockResolvedValueOnce({ Id: 'c1' }).mockResolvedValueOnce(undefined);
+      await provider.launchMachine({
+        appId: 'insforge-testkey1-api',
+        image: 'nginx:alpine',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        envVars: {},
+        region: 'local',
+      });
+      // Probe only — re-pulling on every launch would add seconds to each deploy.
+      expect(mockRequestRaw.mock.calls).toHaveLength(1);
+    });
+
+    // /images/create reports failure inside the body with HTTP 200, exactly like
+    // /build — so a bad image reference must not look like a successful pull.
+    it('surfaces a pull failure reported inside a 200 response', async () => {
+      mockRequestRaw
+        .mockResolvedValueOnce({ status: 404, body: Buffer.from('{}') })
+        .mockResolvedValueOnce({
+          status: 200,
+          body: Buffer.from(
+            '{"status":"Pulling"}\n{"errorDetail":{"message":"manifest for nope:bad not found"},"error":"manifest unknown"}'
+          ),
+        });
+
+      await expect(
+        provider.launchMachine({
+          appId: 'insforge-testkey1-api',
+          image: 'nope:bad',
+          port: 80,
+          cpu: 'shared-1x',
+          memory: 256,
+          envVars: {},
+          region: 'local',
+        })
+      ).rejects.toThrow(/manifest for nope:bad not found/);
+
+      // Nothing was created from an image that never arrived.
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+
+    it('removes the container when it is created but will not start', async () => {
+      imageAlreadyPresent();
+      mockRequest
+        .mockResolvedValueOnce({ Id: 'c-doomed' })
+        .mockRejectedValueOnce(new Error('no such image'))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(
+        provider.launchMachine({
+          appId: 'insforge-testkey1-api',
+          image: 'bad:image',
+          port: 80,
+          cpu: 'shared-1x',
+          memory: 256,
+          envVars: {},
+          region: 'local',
+        })
+      ).rejects.toThrow('no such image');
+
+      // A container that cannot start must not linger looking deployable.
+      expect(mockRequest.mock.calls[2]).toEqual(['DELETE', '/containers/c-doomed?force=true']);
+    });
+  });
+
+  describe('updateMachine', () => {
+    const baseSpec = {
+      appId: 'insforge-testkey1-api',
+      image: 'nginx:alpine',
+      port: 8080,
+      cpu: 'shared-1x',
+      memory: 256,
+      envVars: { FOO: 'bar' },
+    };
+
+    /** Launch once to learn the spec hash the provider stamps for a given spec. */
+    async function hashFor(spec: typeof baseSpec) {
+      mockRequest.mockReset();
+      mockRequestRaw.mockReset();
+      imageAlreadyPresent();
+      mockRequest.mockResolvedValueOnce({ Id: 'x' }).mockResolvedValueOnce(undefined);
+      await provider.launchMachine({ ...spec, region: 'local' });
+      const labels = mockRequest.mock.calls[0][2].body.Labels as Record<string, string>;
+      mockRequest.mockReset();
+      return labels['insforge.spec'];
+    }
+
+    it('resizes cpu/memory in place when the immutable spec is unchanged', async () => {
+      const spec = await hashFor(baseSpec);
+      mockRequest
+        .mockResolvedValueOnce(
+          ownedContainer({
+            Config: {
+              Image: 'nginx:alpine',
+              Labels: {
+                'insforge.managed': 'true',
+                'insforge.project': 'testkey1',
+                'insforge.spec': spec,
+              },
+            },
+          })
+        )
+        .mockResolvedValueOnce(undefined);
+
+      // Same image/port/env, bigger box.
+      const result = await provider.updateMachine({
+        ...baseSpec,
+        machineId: 'container-abc',
+        cpu: 'shared-4x',
+        memory: 1024,
+      });
+
+      expect(result).toEqual({});
+      expect(mockRequest.mock.calls[1][1]).toBe('/containers/container-abc/update');
+      expect(mockRequest.mock.calls[1][2].body).toEqual({
+        NanoCpus: 4e9,
+        Memory: 1024 * 1024 * 1024,
+      });
+    });
+
+    // The bug this guards: Docker cannot swap a running container's image, so
+    // applying only cpu/memory would report success while the old image keeps
+    // serving and the database records the new one.
+    it('recreates the container when the image changes, and reports the new id', async () => {
+      const oldSpec = await hashFor(baseSpec);
+      mockRequest
+        .mockResolvedValueOnce(
+          ownedContainer({
+            Name: '/insforge-testkey1-api',
+            Config: {
+              Image: 'nginx:alpine',
+              Labels: {
+                'insforge.managed': 'true',
+                'insforge.project': 'testkey1',
+                'insforge.spec': oldSpec,
+              },
+            },
+          })
+        )
+        .mockResolvedValueOnce(undefined) // stop
+        .mockResolvedValueOnce(undefined) // remove
+        .mockResolvedValueOnce({ Id: 'container-new' }) // create
+        .mockResolvedValueOnce(undefined); // start
+      imageAlreadyPresent();
+
+      const result = await provider.updateMachine({
+        ...baseSpec,
+        machineId: 'container-abc',
+        image: 'nginx:1.27-alpine',
+      });
+
+      expect(result).toEqual({ machineId: 'container-new', endpointUrl: null });
+      const paths = mockRequest.mock.calls.map((c) => `${c[0]} ${c[1]}`);
+      expect(paths).toEqual([
+        'GET /containers/container-abc/json',
+        'POST /containers/container-abc/stop',
+        'DELETE /containers/container-abc?force=true',
+        'POST /containers/create?name=insforge-testkey1-api',
+        'POST /containers/container-new/start',
+      ]);
+      // Replacement runs the requested image, under the original name.
+      expect(mockRequest.mock.calls[3][2].body.Image).toBe('nginx:1.27-alpine');
+    });
+
+    // Removing an env var is invisible if you only check that the requested ones
+    // are present, which is why the decision is hash-based.
+    it('recreates when an env var is removed', async () => {
+      const twoVars = await hashFor({ ...baseSpec, envVars: { FOO: 'bar', BAZ: 'qux' } });
+      mockRequest
+        .mockResolvedValueOnce(
+          ownedContainer({
+            Config: {
+              Image: 'nginx:alpine',
+              Labels: {
+                'insforge.managed': 'true',
+                'insforge.project': 'testkey1',
+                'insforge.spec': twoVars,
+              },
+            },
+          })
+        )
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ Id: 'container-new' })
+        .mockResolvedValueOnce(undefined);
+      imageAlreadyPresent();
+
+      const result = await provider.updateMachine({
+        ...baseSpec,
+        machineId: 'container-abc',
+        envVars: { FOO: 'bar' }, // BAZ dropped
+      });
+      expect(result).toEqual({ machineId: 'container-new', endpointUrl: null });
+    });
+
+    it('is insensitive to env var ordering', async () => {
+      const spec = await hashFor({ ...baseSpec, envVars: { A: '1', B: '2' } });
+      mockRequest
+        .mockResolvedValueOnce(
+          ownedContainer({
+            Config: {
+              Image: 'nginx:alpine',
+              Labels: {
+                'insforge.managed': 'true',
+                'insforge.project': 'testkey1',
+                'insforge.spec': spec,
+              },
+            },
+          })
+        )
+        .mockResolvedValueOnce(undefined);
+
+      const result = await provider.updateMachine({
+        ...baseSpec,
+        machineId: 'container-abc',
+        envVars: { B: '2', A: '1' },
+      });
+      // Same set, different order — must not churn the container.
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('ownership scoping', () => {
+    // Measured on a real host: from inside a container with the socket mounted,
+    // an unfiltered listing includes Postgres and the backend itself. Acting on
+    // an id without checking labels is how a stop takes out the database.
+    it('refuses to act on a container that is not ours', async () => {
+      mockRequest.mockResolvedValueOnce({
+        Id: 'postgres-container',
+        Name: '/insforge_postgres_1',
+        State: { Status: 'running', ExitCode: 0, Running: true },
+        Config: { Image: 'postgres:15', Labels: { 'com.docker.compose.service': 'postgres' } },
+        NetworkSettings: {},
+      });
+
+      await expect(provider.stopMachine('whatever', 'postgres-container')).rejects.toThrow(
+        MachineGoneError
+      );
+      // Crucially, the stop itself was never issued.
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses a container belonging to another project on the same host', async () => {
+      mockRequest.mockResolvedValueOnce(
+        ownedContainer({
+          Config: {
+            Image: 'nginx',
+            Labels: { 'insforge.managed': 'true', 'insforge.project': 'someoneelse' },
+          },
+        })
+      );
+      await expect(provider.destroyMachine('app', 'container-abc')).rejects.toThrow(
+        MachineGoneError
+      );
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('acts on a container that carries our labels', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer()).mockResolvedValueOnce(undefined);
+      await provider.stopMachine('insforge-testkey1-api', 'container-abc');
+      expect(mockRequest.mock.calls[1][1]).toBe('/containers/container-abc/stop');
+    });
+  });
+
+  describe('state mapping', () => {
+    // Measured across a real host reboot: cleanly-stopped containers reported
+    // `Exited (0)` while host-killed ones reported `Exited (137)` (SIGKILL).
+    // Mapping a non-zero exit to `failed` would mark a chunk of services failed
+    // after every reboot.
+    it('maps exited to stopped regardless of exit code, including SIGKILL', async () => {
+      for (const exitCode of [0, 1, 137]) {
+        mockRequest.mockResolvedValueOnce(
+          ownedContainer({ State: { Status: 'exited', ExitCode: exitCode, Running: false } })
+        );
+        const { state } = await provider.getMachineStatus('app', 'container-abc');
+        expect(state).toBe('stopped');
+      }
+    });
+
+    it('maps the remaining Docker states onto the service enum', async () => {
+      const cases: [string, string][] = [
+        ['running', 'running'],
+        ['restarting', 'running'],
+        ['created', 'creating'],
+        ['removing', 'destroying'],
+        ['dead', 'failed'],
+        ['paused', 'stopped'],
+      ];
+      for (const [docker, expected] of cases) {
+        mockRequest.mockResolvedValueOnce(
+          ownedContainer({ State: { Status: docker, ExitCode: 0, Running: false } })
+        );
+        const { state } = await provider.getMachineStatus('app', 'container-abc');
+        expect(state, `docker "${docker}"`).toBe(expected);
+      }
+    });
+  });
+
+  describe('getLogs', () => {
+    it('demuxes frames and returns a nanosecond watermark as the cursor', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({
+        status: 200,
+        body: Buffer.concat([
+          frame('2026-08-06T22:51:32.781160549Z line-1\n'),
+          frame('2026-08-06T22:51:33.785353049Z line-2\n'),
+        ]),
+      });
+
+      const result = await provider.getLogs('app', 'container-abc');
+
+      expect(result.lines).toEqual([
+        { timestamp: Date.parse('2026-08-06T22:51:32.781Z'), message: 'line-1' },
+        { timestamp: Date.parse('2026-08-06T22:51:33.785Z'), message: 'line-2' },
+      ]);
+      // Cursor carries full nanosecond precision, not the millisecond timestamp.
+      expect(result.nextToken).toBe('1786056693785353049');
+    });
+
+    // `since` accepts integer seconds only and is inclusive, so the boundary
+    // second is always re-delivered. Dedup therefore has to happen against the
+    // nanosecond watermark — filtering by second would drop genuinely new lines
+    // that share a second with the previous batch.
+    it('floors the cursor to seconds on the wire but dedupes by nanosecond', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({
+        status: 200,
+        body: Buffer.concat([
+          frame('2026-08-06T22:51:33.100000000Z already-seen\n'),
+          frame('2026-08-06T22:51:33.200000000Z also-seen\n'),
+          frame('2026-08-06T22:51:33.300000000Z brand-new\n'),
+        ]),
+      });
+
+      const result = await provider.getLogs('app', 'container-abc', {
+        nextToken: '1786056693200000000', // the .2 line
+      });
+
+      // Same second as the watermark, but later — must survive.
+      expect(result.lines.map((l) => l.message)).toEqual(['brand-new']);
+      expect(result.nextToken).toBe('1786056693300000000');
+
+      const url = mockRequestRaw.mock.calls[0][1] as string;
+      expect(url).toContain('since=1786056693');
+      expect(url).toContain('timestamps=1');
+    });
+
+    it('treats an unreadable cursor as absent rather than failing the request', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({
+        status: 200,
+        body: frame('2026-08-06T22:51:32.000000000Z hello\n'),
+      });
+      const result = await provider.getLogs('app', 'container-abc', { nextToken: 'garbage' });
+      expect(result.lines.map((l) => l.message)).toEqual(['hello']);
+      expect(mockRequestRaw.mock.calls[0][1]).not.toContain('since=');
+    });
+
+    it('returns a null cursor when there is nothing to page from', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: Buffer.alloc(0) });
+      const result = await provider.getLogs('app', 'container-abc');
+      expect(result).toEqual({ lines: [], nextToken: null });
+    });
+  });
+
+  describe('endpointUrl', () => {
+    // Returning a plausible-looking URL that times out is worse than returning
+    // nothing: measured on EC2, a closed security group makes a published port
+    // hang with no diagnostic.
+    it('is null under `none` ingress, where nothing is published', () => {
+      expect(provider.endpointUrl('insforge-testkey1-api')).toBeNull();
+    });
+  });
+});

--- a/backend/tests/unit/compute/docker-provider.test.ts
+++ b/backend/tests/unit/compute/docker-provider.test.ts
@@ -624,27 +624,77 @@ describe('DockerProvider', () => {
       expect(resumed).not.toContain('tail=');
     });
 
-    it('hands back the oldest `limit` lines and a cursor that reaches the rest', async () => {
-      const backlog = Buffer.concat(
-        Array.from({ length: 5 }, (_, i) => frame(`2026-08-06T22:51:4${i}.000000000Z line-${i}\n`))
-      );
+    /**
+     * Mock what the daemon would actually send for a given request, so the mock
+     * cannot assert a shape the real thing never produces: `tail=N` returns the
+     * *newest* N, and `since` alone returns everything after that second.
+     */
+    function daemonLogs(lines: { nanos: string; message: string }[]) {
+      return (_method: string, url: string) => {
+        const params = new URLSearchParams(url.split('?')[1] ?? '');
+        let out = lines;
+        const since = params.get('since');
+        if (since !== null) {
+          out = out.filter((l) => BigInt(l.nanos) / 1_000_000_000n >= BigInt(since));
+        }
+        const tail = params.get('tail');
+        if (tail !== null) {
+          out = out.slice(-Number(tail));
+        }
+        const iso = (nanos: string) => {
+          const ns = BigInt(nanos);
+          const ms = new Date(Number(ns / 1_000_000n)).toISOString().replace('Z', '');
+          return `${ms.slice(0, 19)}.${String(ns % 1_000_000_000n).padStart(9, '0')}Z`;
+        };
+        return Promise.resolve({
+          status: 200,
+          body: Buffer.concat(out.map((l) => frame(`${iso(l.nanos)} ${l.message}\n`))),
+        });
+      };
+    }
+
+    // One second apart, so every `since` boundary lands on a distinct line.
+    const FIVE_LINES = Array.from({ length: 5 }, (_, i) => ({
+      nanos: String(1786056700000000000n + BigInt(i) * 1_000_000_000n),
+      message: `line-${i}`,
+    }));
+
+    // First page asks for `tail`, so the daemon hands back the newest `limit` —
+    // "most recent logs" is what a caller with no cursor wants.
+    it('returns the newest lines on a first page, per `tail` semantics', async () => {
       mockRequest.mockResolvedValueOnce(ownedContainer());
-      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: backlog });
+      mockRequestRaw.mockImplementationOnce(daemonLogs(FIVE_LINES));
 
       const first = await provider.getLogs('app', 'container-abc', { limit: 2 });
-      // Oldest first, so nothing is skipped — not the newest 2.
-      expect(first.lines.map((l) => l.message)).toEqual(['line-0', 'line-1']);
-      // Cursor is the last line returned, never one that got trimmed.
-      expect(first.nextToken).toBe(String(Date.parse('2026-08-06T22:51:41Z') * 1_000_000));
 
-      // Replay the same backlog: the cursor picks up exactly where page 1 stopped.
-      mockRequest.mockResolvedValueOnce(ownedContainer());
-      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: backlog });
-      const second = await provider.getLogs('app', 'container-abc', {
-        limit: 2,
-        nextToken: first.nextToken as string,
-      });
-      expect(second.lines.map((l) => l.message)).toEqual(['line-2', 'line-3']);
+      expect(first.lines.map((l) => l.message)).toEqual(['line-3', 'line-4']);
+      expect(first.nextToken).toBe(FIVE_LINES[4].nanos);
+    });
+
+    // Resuming sends no `tail`, so the daemon returns the whole backlog and the
+    // trimming happens here. This is the only path where more lines arrive than
+    // were asked for, and the property under test is that paging reaches them all
+    // rather than jumping to the newest.
+    it('pages through a backlog larger than `limit` without skipping lines', async () => {
+      const seen: string[] = [];
+      let token: string | null = null;
+
+      // Start from before the first line so the whole backlog is "new".
+      token = String(BigInt(FIVE_LINES[0].nanos) - 1_000_000_000n);
+      for (let page = 0; page < 3; page++) {
+        mockRequest.mockResolvedValueOnce(ownedContainer());
+        mockRequestRaw.mockImplementationOnce(daemonLogs(FIVE_LINES));
+        const res = await provider.getLogs('app', 'container-abc', {
+          limit: 2,
+          nextToken: token as string,
+        });
+        seen.push(...res.lines.map((l) => l.message));
+        token = res.nextToken;
+      }
+
+      // Every line, in order, once — the failure this guards against is pages of
+      // ['line-3','line-4'] repeating while 0-2 are never delivered.
+      expect(seen).toEqual(['line-0', 'line-1', 'line-2', 'line-3', 'line-4']);
     });
   });
 

--- a/backend/tests/unit/compute/docker-provider.test.ts
+++ b/backend/tests/unit/compute/docker-provider.test.ts
@@ -603,6 +603,96 @@ describe('DockerProvider', () => {
       const result = await provider.getLogs('app', 'container-abc');
       expect(result).toEqual({ lines: [], nextToken: null });
     });
+
+    // `tail` keeps the newest N. Pairing it with `since` would return the newest
+    // N of the backlog and then advance the cursor past everything older, which
+    // no later request could reach — the middle of the backlog would be gone.
+    it('asks for a tail on the first page but not when resuming from a cursor', async () => {
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: Buffer.alloc(0) });
+      await provider.getLogs('app', 'container-abc', { limit: 50 });
+      expect(mockRequestRaw.mock.calls[0][1]).toContain('tail=50');
+
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: Buffer.alloc(0) });
+      await provider.getLogs('app', 'container-abc', {
+        limit: 50,
+        nextToken: '1786056693200000000',
+      });
+      const resumed = mockRequestRaw.mock.calls[1][1] as string;
+      expect(resumed).toContain('since=1786056693');
+      expect(resumed).not.toContain('tail=');
+    });
+
+    it('hands back the oldest `limit` lines and a cursor that reaches the rest', async () => {
+      const backlog = Buffer.concat(
+        Array.from({ length: 5 }, (_, i) => frame(`2026-08-06T22:51:4${i}.000000000Z line-${i}\n`))
+      );
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: backlog });
+
+      const first = await provider.getLogs('app', 'container-abc', { limit: 2 });
+      // Oldest first, so nothing is skipped — not the newest 2.
+      expect(first.lines.map((l) => l.message)).toEqual(['line-0', 'line-1']);
+      // Cursor is the last line returned, never one that got trimmed.
+      expect(first.nextToken).toBe(String(Date.parse('2026-08-06T22:51:41Z') * 1_000_000));
+
+      // Replay the same backlog: the cursor picks up exactly where page 1 stopped.
+      mockRequest.mockResolvedValueOnce(ownedContainer());
+      mockRequestRaw.mockResolvedValueOnce({ status: 200, body: backlog });
+      const second = await provider.getLogs('app', 'container-abc', {
+        limit: 2,
+        nextToken: first.nextToken as string,
+      });
+      expect(second.lines.map((l) => l.message)).toEqual(['line-2', 'line-3']);
+    });
+  });
+
+  describe('project network discovery', () => {
+    // A cached null would detach every later container from the project network
+    // for the rest of the process lifetime, so a failed inspect must not stick.
+    it('retries after a failed self-inspect instead of caching the failure', async () => {
+      const { config } = await import('@/infra/config/app.config.js');
+      const isolated = config.docker.isolateNetwork;
+      config.docker.isolateNetwork = false;
+      try {
+        const fresh = new DockerProvider();
+        const params = {
+          appId: 'insforge-testkey1-api',
+          image: 'nginx:alpine',
+          port: 80,
+          cpu: 'shared-1x',
+          memory: 256,
+          region: 'local',
+        };
+        const createBody = () =>
+          mockRequest.mock.calls.find((c) => String(c[1]).includes('/containers/create'))?.[2]
+            ?.body;
+
+        // First launch: the self-inspect blips, so we fall back to the bridge.
+        imageAlreadyPresent();
+        mockRequest.mockRejectedValueOnce(new Error('daemon restarting'));
+        mockRequest.mockResolvedValueOnce({ Id: 'new-1' });
+        mockRequest.mockResolvedValueOnce(undefined);
+        await fresh.launchMachine(params);
+        expect(createBody()?.NetworkingConfig).toBeUndefined();
+
+        // Second launch: the daemon is back, so the network is found and used.
+        mockRequest.mockClear();
+        imageAlreadyPresent();
+        mockRequest.mockResolvedValueOnce({
+          NetworkSettings: { Networks: { bridge: {}, 'myproj_insforge-network': {} } },
+        });
+        mockRequest.mockResolvedValueOnce({ Id: 'new-2' });
+        mockRequest.mockResolvedValueOnce(undefined);
+        await fresh.launchMachine(params);
+        expect(createBody()?.NetworkingConfig).toEqual({
+          EndpointsConfig: { 'myproj_insforge-network': {} },
+        });
+      } finally {
+        config.docker.isolateNetwork = isolated;
+      }
+    });
   });
 
   describe('endpointUrl', () => {

--- a/backend/tests/unit/compute/docker-provider.test.ts
+++ b/backend/tests/unit/compute/docker-provider.test.ts
@@ -503,6 +503,26 @@ describe('DockerProvider', () => {
     });
   });
 
+  describe('listMachines', () => {
+    // Docker's name filter is an unanchored regex over container names, so a bare
+    // `api` also matches `api-v2`. Reporting a sibling service's container as this
+    // service's instance is the kind of mistake that ends with the wrong container
+    // being stopped.
+    it('anchors the name filter and drops any prefix match that slips through', async () => {
+      mockRequest.mockResolvedValueOnce([
+        { Id: 'right', State: 'running', Names: ['/insforge-testkey1-api'] },
+        { Id: 'wrong', State: 'running', Names: ['/insforge-testkey1-api-v2'] },
+      ]);
+
+      const list = await provider.listMachines('insforge-testkey1-api');
+
+      const url = mockRequest.mock.calls[0][1] as string;
+      const filters = JSON.parse(decodeURIComponent(url.split('filters=')[1]));
+      expect(filters.name).toEqual(['^/?insforge-testkey1-api$']);
+      expect(list.map((m) => m.id)).toEqual(['right']);
+    });
+  });
+
   describe('state mapping', () => {
     // Measured across a real host reboot: cleanly-stopped containers reported
     // `Exited (0)` while host-killed ones reported `Exited (137)` (SIGKILL).

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -559,4 +559,42 @@ describe('FlyProvider machine-gone translation', () => {
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toMatch(/500/);
   });
+
+  describe('flyNetworkName', () => {
+    // The service layer used to own this and threw a typed AppError; moving it to
+    // the shared module must not downgrade a missing APP_KEY into a generic 500
+    // with no next action.
+    it('throws a typed compute error when APP_KEY is missing', async () => {
+      const { flyNetworkName } = await import('@/providers/compute/compute.provider.js');
+      const { AppError } = await import('@/utils/errors.js');
+      const saved = process.env.APP_KEY;
+      delete process.env.APP_KEY;
+      try {
+        expect(() => flyNetworkName()).toThrow(AppError);
+        try {
+          flyNetworkName();
+        } catch (e) {
+          expect((e as InstanceType<typeof AppError>).statusCode).toBe(500);
+          expect((e as InstanceType<typeof AppError>).code).toBe('COMPUTE_SERVICE_NOT_CONFIGURED');
+        }
+      } finally {
+        if (saved === undefined) {
+          delete process.env.APP_KEY;
+        } else {
+          process.env.APP_KEY = saved;
+        }
+      }
+    });
+
+    it('prefixes with `n-` so the name always starts with a letter', async () => {
+      const { flyNetworkName } = await import('@/providers/compute/compute.provider.js');
+      const saved = process.env.APP_KEY;
+      process.env.APP_KEY = '9digitlead';
+      try {
+        expect(flyNetworkName()).toBe('n-9digitlead');
+      } finally {
+        process.env.APP_KEY = saved as string;
+      }
+    });
+  });
 });

--- a/backend/tests/unit/compute/fly-provider.test.ts
+++ b/backend/tests/unit/compute/fly-provider.test.ts
@@ -37,6 +37,8 @@ describe('FlyProvider', () => {
   let provider: FlyProvider;
 
   beforeEach(() => {
+    // createApp derives the 6PN network name from APP_KEY.
+    process.env.APP_KEY = 'testkey1';
     provider = FlyProvider.getInstance();
     vi.restoreAllMocks();
   });
@@ -54,11 +56,7 @@ describe('FlyProvider', () => {
         .mockResolvedValueOnce(graphqlOkResponse());
       vi.stubGlobal('fetch', mockFetch);
 
-      const result = await provider.createApp({
-        name: 'my-app',
-        network: 'default',
-        org: 'test-org',
-      });
+      const result = await provider.createApp({ name: 'my-app' });
 
       expect(mockFetch).toHaveBeenCalledTimes(3);
 
@@ -71,7 +69,8 @@ describe('FlyProvider', () => {
           body: JSON.stringify({
             app_name: 'my-app',
             org_slug: 'test-org',
-            network: 'default',
+            // Derived from APP_KEY by flyNetworkName(), not passed in.
+            network: 'n-testkey1',
           }),
         })
       );
@@ -105,9 +104,9 @@ describe('FlyProvider', () => {
       });
       vi.stubGlobal('fetch', mockFetch);
 
-      await expect(
-        provider.createApp({ name: 'my-app', network: 'default', org: 'test-org' })
-      ).rejects.toThrow('Fly API error (422): app already exists');
+      await expect(provider.createApp({ name: 'my-app' })).rejects.toThrow(
+        'Fly API error (422): app already exists'
+      );
     });
 
     it('throws when GraphQL allocateIpAddress returns errors', async () => {
@@ -120,9 +119,9 @@ describe('FlyProvider', () => {
         });
       vi.stubGlobal('fetch', mockFetch);
 
-      await expect(
-        provider.createApp({ name: 'my-app', network: 'default', org: 'test-org' })
-      ).rejects.toThrow(/Fly GraphQL allocateIpAddress\(shared_v4\) errors/);
+      await expect(provider.createApp({ name: 'my-app' })).rejects.toThrow(
+        /Fly GraphQL allocateIpAddress\(shared_v4\) errors/
+      );
     });
 
     it('throws when GraphQL allocateIpAddress responds non-2xx', async () => {
@@ -136,9 +135,9 @@ describe('FlyProvider', () => {
         });
       vi.stubGlobal('fetch', mockFetch);
 
-      await expect(
-        provider.createApp({ name: 'my-app', network: 'default', org: 'test-org' })
-      ).rejects.toThrow(/Fly GraphQL allocateIpAddress\(shared_v4\) failed \(500\)/);
+      await expect(provider.createApp({ name: 'my-app' })).rejects.toThrow(
+        /Fly GraphQL allocateIpAddress\(shared_v4\) failed \(500\)/
+      );
     });
   });
 

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -337,7 +337,7 @@ describe('ComputeServicesService', () => {
     it('corrects a row that says running when the instance is stopped', async () => {
       mockQuery.mockResolvedValueOnce({ rows: [row()] });
       mockGetMachineStatus.mockResolvedValueOnce({ state: 'stopped' });
-      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const stats = await service.reconcile();
 
@@ -348,6 +348,21 @@ describe('ComputeServicesService', () => {
       // replaced it concurrently is not overwritten by a stale observation.
       expect(sql).toContain('provider_instance_id = $3');
       expect(params).toEqual(['stopped', 'svc-1', 'machine-1']);
+    });
+
+    // The guard firing is the normal outcome of a race, not a correction. Counting
+    // it as one would report work that never happened and hide how often the race
+    // actually fires.
+    it('reports a skip, not a correction, when the guard blocks the write', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row()] });
+      mockGetMachineStatus.mockResolvedValueOnce({ state: 'stopped' });
+      // A concurrent deploy already replaced provider_instance_id, so the guarded
+      // UPDATE matches nothing.
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ checked: 1, corrected: 0, skipped: 1, healed: 0 });
     });
 
     it('leaves a row alone when reality already matches', async () => {
@@ -421,7 +436,7 @@ describe('ComputeServicesService', () => {
         .mockRejectedValueOnce(new MachineGoneError('app-1', 'machine-1'))
         .mockResolvedValueOnce({ state: 'stopped' });
       mockQuery.mockRejectedValueOnce(new Error('deadlock detected')); // the heal
-      mockQuery.mockResolvedValueOnce({ rows: [] }); // svc-2's correction still lands
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // svc-2's correction lands
 
       const stats = await service.reconcile();
 

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/infra/config/app.config.js', () => {
       org: 'test-org',
       domain: 'fly.dev',
     },
+    docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
     cloud: {
       projectId: '',
       apiHost: '',
@@ -61,6 +62,9 @@ const mockDestroyMachine = vi.fn();
 const mockGetEvents = vi.fn();
 const mockGetLogs = vi.fn();
 const mockListMachines = vi.fn();
+// reconcile is the first caller of these two, so they were not mocked before.
+const mockGetMachineStatus = vi.fn();
+const mockWaitForState = vi.fn();
 const mockIsConfigured = vi.fn(() => true);
 
 const mockFlyInstance = {
@@ -74,7 +78,25 @@ const mockFlyInstance = {
   getEvents: mockGetEvents,
   getLogs: mockGetLogs,
   listMachines: mockListMachines,
+  getMachineStatus: mockGetMachineStatus,
+  waitForState: mockWaitForState,
   isConfigured: mockIsConfigured,
+  // Provider-neutral surface (migration 064 / capability descriptor). The real
+  // FlyProvider derives these itself; the mock mirrors its behaviour so the
+  // service's naming and URL calls resolve to the same values the fixtures use.
+  name: 'fly' as const,
+  capabilities: {
+    scaleToZero: true,
+    regions: true,
+    ingressModes: ['host'] as ('none' | 'port' | 'host')[],
+    sourceBuild: 'flyctl' as const,
+    deployTokenIssuance: false,
+  },
+  // Delegates to the real helper (rather than a naive template) so the service
+  // test keeps covering the Fly app-name length guard, which moved here from
+  // the service layer.
+  resolveAppName: (params: { name: string; projectId: string }) => flyAppNameFor(params),
+  endpointUrl: (appId: string) => `https://${appId}.fly.dev`,
 };
 
 vi.mock('@/providers/compute/fly.provider.js', () => ({
@@ -84,7 +106,7 @@ vi.mock('@/providers/compute/fly.provider.js', () => ({
 }));
 
 import { ComputeServicesService } from '@/services/compute/services.service.js';
-import { MachineGoneError } from '@/providers/compute/compute.provider.js';
+import { MachineGoneError, flyAppNameFor } from '@/providers/compute/compute.provider.js';
 
 describe('ComputeServicesService', () => {
   let service: ComputeServicesService;
@@ -104,6 +126,367 @@ describe('ComputeServicesService', () => {
     } else {
       process.env.APP_KEY = oldEnvAppKey;
     }
+  });
+
+  describe('driver routing and capabilities', () => {
+    // Served as the `compute` slice of /api/metadata rather than its own endpoint:
+    // the CLI already capability-probes through metadata slices, and a second
+    // mechanism for "what can this deployment do" would drift from the first.
+    it('reports the compute metadata slice keyed by provider', async () => {
+      const { getComputeMetadata } = await import('@/services/compute/services.service.js');
+      expect(getComputeMetadata()).toEqual({
+        defaultProvider: 'fly',
+        providers: {
+          fly: {
+            scaleToZero: true,
+            regions: true,
+            ingressModes: ['host'],
+            sourceBuild: 'flyctl',
+            deployTokenIssuance: false,
+          },
+        },
+      });
+    });
+
+    // A stored value the driver cannot honour is worse than a rejected request:
+    // nothing later contradicts it, so the API and dashboard keep reporting a
+    // region the container is not in. The CLI defaults `--region iad`, so this
+    // path is hit by every Docker deploy from an unmodified CLI.
+    it('records a capability-less region as local instead of the requested value', async () => {
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, regions: false };
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+      mockCreateApp.mockResolvedValue({ appId: 'a' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'm1' });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly', region: 'local' }] });
+
+      await service.createService({
+        projectId: 'proj-123',
+        name: 'svc',
+        imageUrl: 'nginx',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        region: 'iad',
+      });
+
+      // The INSERT stores `local`, and the launch is told the same thing.
+      expect(mockQuery.mock.calls[0][1]).toContain('local');
+      expect(mockQuery.mock.calls[0][1]).not.toContain('iad');
+      expect(mockLaunchMachine.mock.calls[0][0].region).toBe('local');
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, regions: true };
+    });
+
+    // Found by the first end-to-end run: the API default for scaleToZero is
+    // `true`, so omitting it stored `true` against a driver that cannot do it.
+    // Coercing only an explicit `true` missed the common path.
+    it('records always-on even when the caller omits scaleToZero entirely', async () => {
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: false };
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+      mockCreateApp.mockResolvedValue({ appId: 'a' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'm1' });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+
+      await service.createService({
+        projectId: 'proj-123',
+        name: 'svc',
+        imageUrl: 'nginx',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        region: 'iad',
+        // scaleToZero deliberately not sent
+      });
+
+      // The INSERT must persist false, not the schema default of true.
+      expect(mockQuery.mock.calls[0][1]).toContain(false);
+      expect(mockLaunchMachine.mock.calls[0][0].scaleToZero).toBe(false);
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
+    });
+
+    // On update, an omitted field means "leave it alone". Filling it in would turn
+    // a metadata-only PATCH into a deploy change and call the provider needlessly.
+    it('does not invent a scaleToZero change on an update that omits it', async () => {
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: false };
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 's1',
+            name: 'svc',
+            provider: 'fly',
+            provider_app_id: 'a',
+            provider_instance_id: 'm1',
+            status: 'running',
+            cpu: 'shared-1x',
+            region: 'local',
+            ingress: 'host',
+            scale_to_zero: false,
+          },
+        ],
+      });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+
+      await service.updateService('s1', { region: 'local' });
+
+      // Region-only change: no deploy-affecting field was implied, so the provider
+      // was never asked to update the instance.
+      expect(mockUpdateMachine).not.toHaveBeenCalled();
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
+    });
+
+    it('records a service as always-on when the driver cannot scale to zero', async () => {
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: false };
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+      mockCreateApp.mockResolvedValue({ appId: 'a' });
+      mockLaunchMachine.mockResolvedValue({ machineId: 'm1' });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 's1', provider: 'fly' }] });
+
+      await service.createService({
+        projectId: 'proj-123',
+        name: 'svc',
+        imageUrl: 'nginx',
+        port: 80,
+        cpu: 'shared-1x',
+        memory: 256,
+        region: 'iad',
+        scaleToZero: true,
+      });
+
+      expect(mockLaunchMachine.mock.calls[0][0].scaleToZero).toBe(false);
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
+    });
+
+    // prepareForDeploy reserves a name and creates the provider-side app, then
+    // waits for a build. On a driver with no source-build path, succeeding would
+    // strand the row in `deploying` with nothing able to advance it — the exact
+    // shape of the self-host Fly bug this work exists to stop repeating.
+    it('rejects prepareForDeploy on a driver that cannot build from source', async () => {
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'none' };
+
+      await expect(
+        service.prepareForDeploy({
+          projectId: 'proj-123',
+          name: 'svc',
+          port: 80,
+          cpu: 'shared-1x',
+          memory: 256,
+          region: 'iad',
+        })
+      ).rejects.toThrow(/cannot build from source/);
+
+      // Nothing was written and no provider-side app was created.
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockCreateApp).not.toHaveBeenCalled();
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
+    });
+
+    // Drivers coexist, so a row is routed by its own `provider`. When that
+    // driver isn't configured here we must refuse rather than hand Docker a Fly
+    // machine id (or vice versa) — that would 404 confusingly at best, and at
+    // worst heal a live, billing machine into a `stopped` row.
+    it('refuses machine operations on a row whose driver is not configured', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'svc-docker-1',
+            project_id: 'proj-123',
+            name: 'local-worker',
+            image_url: 'nginx:alpine',
+            port: 8080,
+            cpu: 'shared-1x',
+            memory: 512,
+            region: 'local',
+            provider: 'docker',
+            provider_app_id: 'insforge-local-worker',
+            provider_instance_id: 'container-abc',
+            status: 'running',
+            endpoint_url: null,
+            created_at: 'now',
+            updated_at: 'now',
+          },
+        ],
+      });
+
+      await expect(service.stopService('svc-docker-1')).rejects.toThrow(/"docker".*not configured/);
+      expect(mockStopMachine).not.toHaveBeenCalled();
+    });
+  });
+
+  // Reconcile exists for drift that accumulates while the backend is down, which
+  // is precisely the state no request-path test ever reaches.
+  describe('reconcile', () => {
+    function row(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'svc-1',
+        name: 'worker',
+        provider: 'fly',
+        provider_app_id: 'app-1',
+        provider_instance_id: 'machine-1',
+        status: 'running',
+        cpu: 'shared-1x',
+        ...overrides,
+      };
+    }
+
+    it('corrects a row that says running when the instance is stopped', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row()] });
+      mockGetMachineStatus.mockResolvedValueOnce({ state: 'stopped' });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ checked: 1, corrected: 1, healed: 0 });
+      const [sql, params] = mockQuery.mock.calls[1];
+      expect(sql).toContain('SET status = $1');
+      expect(params).toEqual(['stopped', 'svc-1']);
+    });
+
+    it('leaves a row alone when reality already matches', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row()] });
+      mockGetMachineStatus.mockResolvedValueOnce({ state: 'running' });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ checked: 1, corrected: 0 });
+      expect(mockQuery).toHaveBeenCalledTimes(1); // read only, no write
+    });
+
+    it('heals a row whose instance is gone entirely', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row()] });
+      mockGetMachineStatus.mockRejectedValueOnce(new MachineGoneError('app-1', 'machine-1'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ healed: 1 });
+      // Healing clears the dead pointer so the next deploy relaunches.
+      expect(mockQuery.mock.calls[1][0]).toContain('provider_instance_id = NULL');
+    });
+
+    // Deciding what a half-finished create should become means guessing whether
+    // provider-side resources exist; guessing wrong destroys a service.
+    it('reports but does not touch rows left in a transient state', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [row({ status: 'deploying' }), row({ id: 'svc-2', status: 'destroying' })],
+      });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ skipped: 2, checked: 0, corrected: 0 });
+      expect(mockGetMachineStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips rows belonging to a driver that is not configured', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row({ provider: 'docker' })] });
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ skipped: 1, checked: 0 });
+      expect(mockGetMachineStatus).not.toHaveBeenCalled();
+    });
+
+    // A daemon restarting mid-reconcile must not be mistaken for "instance gone".
+    it('leaves a row unchanged on a transient provider error', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [row()] });
+      mockGetMachineStatus.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ checked: 1, corrected: 0, healed: 0 });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a database read failure without throwing into startup', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('connection terminated'));
+      await expect(service.reconcile()).resolves.toMatchObject({ checked: 0 });
+    });
+  });
+
+  describe('buildAndDeploy', () => {
+    function serviceRow() {
+      return {
+        id: 'svc-b1',
+        project_id: 'proj-123',
+        name: 'api',
+        image_url: 'old:tag',
+        port: 8080,
+        cpu: 'shared-1x',
+        memory: 256,
+        region: 'local',
+        provider: 'fly',
+        provider_app_id: 'app-1',
+        provider_instance_id: 'inst-1',
+        status: 'deploying',
+        ingress: 'host',
+      };
+    }
+
+    // A driver whose source builds run on the caller's machine (flyctl) must not
+    // silently accept a context upload it will never build.
+    it('refuses a context upload on a driver that builds through flyctl', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] });
+
+      await expect(service.buildAndDeploy('svc-b1', Buffer.from('tar-bytes'))).rejects.toThrow(
+        /does not build uploaded contexts/
+      );
+    });
+
+    it('builds, deploys the resulting tag, and prunes superseded images', async () => {
+      mockFlyInstance.capabilities = {
+        ...mockFlyInstance.capabilities,
+        sourceBuild: 'context-upload',
+      };
+      const build = vi
+        .fn()
+        .mockResolvedValue({ imageTag: 'insforge-x/api:abc', logs: ['Step 1/2'] });
+      const prune = vi.fn().mockResolvedValue({ removed: 1 });
+      (mockFlyInstance as Record<string, unknown>).buildFromContext = build;
+      (mockFlyInstance as Record<string, unknown>).pruneServiceImages = prune;
+
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] }); // getService in buildAndDeploy
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] }); // getService in updateService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] });
+      mockUpdateMachine.mockResolvedValue({});
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ...serviceRow(), image_url: 'insforge-x/api:abc' }],
+      });
+
+      const result = await service.buildAndDeploy('svc-b1', Buffer.from('tar-bytes'), {
+        dockerfile: 'Dockerfile.prod',
+      });
+
+      expect(build).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceName: 'api', dockerfile: 'Dockerfile.prod' })
+      );
+      expect(result.imageTag).toBe('insforge-x/api:abc');
+      // Deployment goes through updateService, so the tested recreate/instance-id
+      // bookkeeping applies rather than a second copy of it.
+      expect(mockUpdateMachine.mock.calls[0][0].image).toBe('insforge-x/api:abc');
+      expect(prune).toHaveBeenCalledWith('api');
+
+      delete (mockFlyInstance as Record<string, unknown>).buildFromContext;
+      delete (mockFlyInstance as Record<string, unknown>).pruneServiceImages;
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
+    });
+
+    // A failed build must leave the previous image serving, and must say why.
+    it('surfaces the builder error and does not deploy anything', async () => {
+      mockFlyInstance.capabilities = {
+        ...mockFlyInstance.capabilities,
+        sourceBuild: 'context-upload',
+      };
+      (mockFlyInstance as Record<string, unknown>).buildFromContext = vi
+        .fn()
+        .mockRejectedValue(new Error('process "/bin/sh -c exit 7" did not complete successfully'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] });
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // status -> failed
+
+      await expect(service.buildAndDeploy('svc-b1', Buffer.from('t'))).rejects.toThrow(/exit 7/);
+      expect(mockUpdateMachine).not.toHaveBeenCalled();
+
+      delete (mockFlyInstance as Record<string, unknown>).buildFromContext;
+      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
+    });
   });
 
   describe('createService', () => {
@@ -133,8 +516,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -159,8 +542,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: 'machine-abc',
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: 'machine-abc',
             status: 'running',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -180,11 +563,7 @@ describe('ComputeServicesService', () => {
       expect(insertCall[1]).toContain(input.name);
 
       // Verify Fly calls
-      expect(mockCreateApp).toHaveBeenCalledWith({
-        name: 'my-api-proj-123',
-        network: 'n-testkey1',
-        org: 'test-org',
-      });
+      expect(mockCreateApp).toHaveBeenCalledWith({ name: 'my-api-proj-123' });
       expect(mockLaunchMachine).toHaveBeenCalledWith(
         expect.objectContaining({
           appId: 'my-api-proj-123',
@@ -233,8 +612,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -276,8 +655,8 @@ describe('ComputeServicesService', () => {
             memory: tcpInput.memory,
             region: tcpInput.region,
             protocol: 'tcp',
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -300,8 +679,8 @@ describe('ComputeServicesService', () => {
             memory: tcpInput.memory,
             region: tcpInput.region,
             protocol: 'tcp',
-            fly_app_id: 'my-redis-proj-123',
-            fly_machine_id: 'mach-tcp',
+            provider_app_id: 'my-redis-proj-123',
+            provider_instance_id: 'mach-tcp',
             status: 'running',
             endpoint_url: 'https://my-redis-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -347,8 +726,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -370,8 +749,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: 'mach-default',
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: 'mach-default',
             status: 'running',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -410,8 +789,8 @@ describe('ComputeServicesService', () => {
             region: alwaysOnInput.region,
             protocol: 'http',
             scale_to_zero: false,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -435,8 +814,8 @@ describe('ComputeServicesService', () => {
             region: alwaysOnInput.region,
             protocol: 'http',
             scale_to_zero: false,
-            fly_app_id: 'my-always-on-proj-123',
-            fly_machine_id: 'mach-always-on',
+            provider_app_id: 'my-always-on-proj-123',
+            provider_instance_id: 'mach-always-on',
             status: 'running',
             endpoint_url: 'https://my-always-on-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -480,8 +859,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -503,8 +882,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: 'mach-default-stz',
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: 'mach-default-stz',
             status: 'running',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -545,8 +924,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: null,
-            fly_machine_id: null,
+            provider_app_id: null,
+            provider_instance_id: null,
             status: 'creating',
             endpoint_url: null,
             env_vars_encrypted: null,
@@ -601,8 +980,8 @@ describe('ComputeServicesService', () => {
             cpu: 'shared-1x',
             memory: 256,
             region: 'iad',
-            fly_app_id: 'app-one-proj-123',
-            fly_machine_id: 'machine-1',
+            provider_app_id: 'app-one-proj-123',
+            provider_instance_id: 'machine-1',
             status: 'running',
             endpoint_url: 'https://app-one-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -639,8 +1018,8 @@ describe('ComputeServicesService', () => {
             cpu: 'shared-1x',
             memory: 256,
             region: 'iad',
-            fly_app_id: 'app-gone-proj-123',
-            fly_machine_id: 'machine-gone-1',
+            provider_app_id: 'app-gone-proj-123',
+            provider_instance_id: 'machine-gone-1',
             status: 'stopped',
             endpoint_url: 'https://app-gone-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -683,8 +1062,8 @@ describe('ComputeServicesService', () => {
             cpu: 'shared-1x',
             memory: 256,
             region: 'iad',
-            fly_app_id: 'app-del-proj-123',
-            fly_machine_id: 'machine-del',
+            provider_app_id: 'app-del-proj-123',
+            provider_instance_id: 'machine-del',
             status: 'running',
             endpoint_url: 'https://app-del-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -734,8 +1113,14 @@ describe('ComputeServicesService', () => {
         // Same back-compat fallback: fixture has no scale_to_zero column, so
         // the snapshot surfaces the default (true).
         scaleToZero: true,
-        flyAppId: 'app-del-proj-123',
-        flyMachineId: 'machine-del',
+        // Same back-compat fallback again: the fixture predates migration 064, so
+        // the snapshot surfaces its documented defaults — 'fly' because that was
+        // the only driver, and 'host' because every Fly app is already on a public
+        // hostname.
+        ingress: 'host',
+        provider: 'fly',
+        providerAppId: 'app-del-proj-123',
+        providerInstanceId: 'machine-del',
         endpointUrl: 'https://app-del-proj-123.fly.dev',
         envVarsEncrypted: null,
         createdAt: '2026-01-01T00:00:00Z',
@@ -761,8 +1146,8 @@ describe('ComputeServicesService', () => {
             cpu: 'shared-1x',
             memory: 256,
             region: 'iad',
-            fly_app_id: 'app-env-proj-123',
-            fly_machine_id: 'machine-env',
+            provider_app_id: 'app-env-proj-123',
+            provider_instance_id: 'machine-env',
             status: 'running',
             endpoint_url: 'https://app-env-proj-123.fly.dev',
             env_vars_encrypted: ciphertext,
@@ -796,8 +1181,8 @@ describe('ComputeServicesService', () => {
             cpu: 'shared-1x',
             memory: 256,
             region: 'iad',
-            fly_app_id: 'app-del2-proj-123',
-            fly_machine_id: 'machine-del2',
+            provider_app_id: 'app-del2-proj-123',
+            provider_instance_id: 'machine-del2',
             status: 'running',
             endpoint_url: 'https://app-del2-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -848,8 +1233,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: null,
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: null,
             status: 'deploying',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -871,11 +1256,7 @@ describe('ComputeServicesService', () => {
       expect(insertCall[1]).toContain('my-api-proj-123'); // flyAppId
 
       // Verify Fly app created
-      expect(mockCreateApp).toHaveBeenCalledWith({
-        name: 'my-api-proj-123',
-        network: 'n-testkey1',
-        org: 'test-org',
-      });
+      expect(mockCreateApp).toHaveBeenCalledWith({ name: 'my-api-proj-123' });
 
       // Verify NO machine launched
       expect(mockLaunchMachine).not.toHaveBeenCalled();
@@ -909,8 +1290,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: null,
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: null,
             status: 'deploying',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -942,8 +1323,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: null,
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: null,
             status: 'deploying',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -986,8 +1367,8 @@ describe('ComputeServicesService', () => {
             cpu: input.cpu,
             memory: input.memory,
             region: input.region,
-            fly_app_id: 'my-api-proj-123',
-            fly_machine_id: null,
+            provider_app_id: 'my-api-proj-123',
+            provider_instance_id: null,
             status: 'deploying',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             env_vars_encrypted: null,
@@ -1040,8 +1421,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 256,
       region: 'iad',
-      fly_app_id: 'my-api-proj-123',
-      fly_machine_id: 'machine-1',
+      provider_app_id: 'my-api-proj-123',
+      provider_instance_id: 'machine-1',
       status: 'running',
       endpoint_url: 'https://my-api-proj-123.fly.dev',
       env_vars_encrypted: null,
@@ -1086,8 +1467,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 256,
       region: 'iad',
-      fly_app_id: 'my-api-proj-123',
-      fly_machine_id: 'machine-1',
+      provider_app_id: 'my-api-proj-123',
+      provider_instance_id: 'machine-1',
       status: 'stopped',
       endpoint_url: 'https://my-api-proj-123.fly.dev',
       env_vars_encrypted: null,
@@ -1137,8 +1518,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 256,
       region: 'iad',
-      fly_app_id: 'my-api-proj-123',
-      fly_machine_id: 'machine-ghost',
+      provider_app_id: 'my-api-proj-123',
+      provider_instance_id: 'machine-ghost',
       status: 'running',
       endpoint_url: 'https://my-api-proj-123.fly.dev',
       env_vars_encrypted: null,
@@ -1149,7 +1530,7 @@ describe('ComputeServicesService', () => {
 
     function expectHealQuery() {
       const healCall = mockQuery.mock.calls.find(
-        ([sql]) => typeof sql === 'string' && sql.includes('fly_machine_id = NULL')
+        ([sql]) => typeof sql === 'string' && sql.includes('provider_instance_id = NULL')
       );
       expect(healCall).toBeDefined();
       expect(healCall?.[1]).toEqual(['svc-ghost-1', 'machine-ghost']);
@@ -1196,7 +1577,7 @@ describe('ComputeServicesService', () => {
       mockStopMachine.mockRejectedValue(gone());
       mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // heal UPDATE
       mockQuery.mockResolvedValueOnce({
-        rows: [{ ...serviceRow, fly_machine_id: null, status: 'stopped' }],
+        rows: [{ ...serviceRow, provider_instance_id: null, status: 'stopped' }],
       }); // status UPDATE
 
       const result = await service.stopService('svc-ghost-1');
@@ -1206,7 +1587,7 @@ describe('ComputeServicesService', () => {
     });
 
     it('post-heal requests get COMPUTE_MACHINE_NOT_FOUND + redeploy guidance, not "Service not found"', async () => {
-      const healedRow = { ...serviceRow, fly_machine_id: null, status: 'stopped' };
+      const healedRow = { ...serviceRow, provider_instance_id: null, status: 'stopped' };
       const calls = [
         () => service.getServiceEvents('svc-ghost-1'),
         () => service.getServiceLogs('svc-ghost-1'),
@@ -1223,12 +1604,12 @@ describe('ComputeServicesService', () => {
     });
 
     it('updateService relaunches the stored image when a deploy-field PATCH hits a healed row', async () => {
-      const healedRow = { ...serviceRow, fly_machine_id: null, status: 'stopped' };
+      const healedRow = { ...serviceRow, provider_instance_id: null, status: 'stopped' };
       mockQuery.mockResolvedValueOnce({ rows: [healedRow] }); // getService
       mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
       mockLaunchMachine.mockResolvedValue({ machineId: 'mach-fresh' });
       mockQuery.mockResolvedValueOnce({
-        rows: [{ ...healedRow, fly_machine_id: 'mach-fresh', status: 'running' }],
+        rows: [{ ...healedRow, provider_instance_id: 'mach-fresh', status: 'running' }],
       }); // final UPDATE
 
       const result = await service.updateService('svc-ghost-1', {
@@ -1248,7 +1629,7 @@ describe('ComputeServicesService', () => {
       // prepareForDeploy rows: status deploying, image_url is a placeholder.
       const prepareRow = {
         ...serviceRow,
-        fly_machine_id: null,
+        provider_instance_id: null,
         status: 'deploying',
         image_url: 'dockerfile',
       };
@@ -1268,7 +1649,7 @@ describe('ComputeServicesService', () => {
 
       await expect(service.getServiceEvents('svc-ghost-1')).rejects.toThrow(/500/);
       const healCall = mockQuery.mock.calls.find(
-        ([sql]) => typeof sql === 'string' && sql.includes('fly_machine_id = NULL')
+        ([sql]) => typeof sql === 'string' && sql.includes('provider_instance_id = NULL')
       );
       expect(healCall).toBeUndefined();
     });
@@ -1287,8 +1668,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 512,
       region: 'iad',
-      fly_app_id: 'my-api-proj-123',
-      fly_machine_id: null,
+      provider_app_id: 'my-api-proj-123',
+      provider_instance_id: null,
       status: 'deploying',
       endpoint_url: 'https://my-api-proj-123.fly.dev',
       env_vars_encrypted: null,
@@ -1304,7 +1685,7 @@ describe('ComputeServicesService', () => {
         rows: [
           {
             ...baseRow,
-            fly_machine_id: 'mach-pa-1',
+            provider_instance_id: 'mach-pa-1',
             status: 'running',
             endpoint_url: 'https://my-api-proj-123.fly.dev',
             image_url: 'registry.fly.io/my-api-proj-123:deployment-abc',
@@ -1333,7 +1714,7 @@ describe('ComputeServicesService', () => {
       // The final UPDATE carries the optimistic lock.
       const updateCall = mockQuery.mock.calls[2];
       expect(updateCall[0]).toContain('UPDATE compute.services');
-      expect(updateCall[0]).toContain('fly_machine_id IS NULL');
+      expect(updateCall[0]).toContain('provider_instance_id IS NULL');
       expect(updateCall[1]).toContain('mach-pa-1');
       expect(updateCall[1]).toContain('running');
 
@@ -1377,7 +1758,7 @@ describe('ComputeServicesService', () => {
     it('forwards protocol: tcp to updateMachine on redeploy', async () => {
       const deployedRow = {
         ...baseRow,
-        fly_machine_id: 'mach-existing',
+        provider_instance_id: 'mach-existing',
         status: 'running',
         protocol: 'http',
       };
@@ -1410,7 +1791,7 @@ describe('ComputeServicesService', () => {
     it('preserves existing.protocol when update omits the field', async () => {
       const deployedRow = {
         ...baseRow,
-        fly_machine_id: 'mach-existing',
+        provider_instance_id: 'mach-existing',
         status: 'running',
         protocol: 'tcp',
       };
@@ -1431,7 +1812,7 @@ describe('ComputeServicesService', () => {
     it('forwards scaleToZero: false to updateMachine on redeploy', async () => {
       const deployedRow = {
         ...baseRow,
-        fly_machine_id: 'mach-existing',
+        provider_instance_id: 'mach-existing',
         status: 'running',
         scale_to_zero: true,
       };
@@ -1465,7 +1846,7 @@ describe('ComputeServicesService', () => {
     it('preserves existing scaleToZero: false when update omits the field', async () => {
       const deployedRow = {
         ...baseRow,
-        fly_machine_id: 'mach-existing',
+        provider_instance_id: 'mach-existing',
         status: 'running',
         scale_to_zero: false,
       };
@@ -1482,7 +1863,7 @@ describe('ComputeServicesService', () => {
     });
 
     it('regression: existing machine + imageUrl takes the redeploy path (updateMachine, no launch, no optimistic lock)', async () => {
-      const deployedRow = { ...baseRow, fly_machine_id: 'mach-existing', status: 'running' };
+      const deployedRow = { ...baseRow, provider_instance_id: 'mach-existing', status: 'running' };
       mockQuery.mockResolvedValueOnce({ rows: [deployedRow] }); // getService
       mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
       mockUpdateMachine.mockResolvedValue(undefined);
@@ -1504,7 +1885,7 @@ describe('ComputeServicesService', () => {
       const updateCall = mockQuery.mock.calls[2];
       expect(updateCall[0]).toContain('UPDATE compute.services');
       // No optimistic lock on the redeploy path — only first-launch needs it.
-      expect(updateCall[0]).not.toContain('fly_machine_id IS NULL');
+      expect(updateCall[0]).not.toContain('provider_instance_id IS NULL');
     });
 
     it('race condition: concurrent launch loses DB write, destroys orphan, returns winning state', async () => {
@@ -1516,7 +1897,7 @@ describe('ComputeServicesService', () => {
       mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
       mockDestroyMachine.mockResolvedValue(undefined);
       // Cleanup path: getService returns the winning state.
-      const winningRow = { ...baseRow, fly_machine_id: 'mach-winner', status: 'running' };
+      const winningRow = { ...baseRow, provider_instance_id: 'mach-winner', status: 'running' };
       mockQuery.mockResolvedValueOnce({ rows: [winningRow] }); // final getService
 
       const result = await service.updateService('svc-pa-1', {
@@ -1537,7 +1918,7 @@ describe('ComputeServicesService', () => {
       mockLaunchMachine.mockResolvedValue({ machineId: 'mach-loser' });
       mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // optimistic lock filters us out
       mockDestroyMachine.mockRejectedValue(new Error('Fly transient 503'));
-      const winningRow = { ...baseRow, fly_machine_id: 'mach-winner', status: 'running' };
+      const winningRow = { ...baseRow, provider_instance_id: 'mach-winner', status: 'running' };
       mockQuery.mockResolvedValueOnce({ rows: [winningRow] }); // final getService
 
       const result = await service.updateService('svc-pa-1', {
@@ -1560,8 +1941,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 256,
       region: 'iad',
-      fly_app_id: 'patch-svc-proj-1',
-      fly_machine_id: 'mach-1',
+      provider_app_id: 'patch-svc-proj-1',
+      provider_instance_id: 'mach-1',
       status: 'running',
       endpoint_url: 'https://patch-svc-proj-1.fly.dev',
       env_vars_encrypted: `encrypted:${JSON.stringify({ KEEP: 'k', ROTATE_ME: 'old' })}`,
@@ -1647,8 +2028,8 @@ describe('ComputeServicesService', () => {
       cpu: 'shared-1x',
       memory: 256,
       region: 'iad',
-      fly_app_id: 'my-api-proj-123',
-      fly_machine_id: 'machine-1',
+      provider_app_id: 'my-api-proj-123',
+      provider_instance_id: 'machine-1',
       status: 'running',
       endpoint_url: 'https://my-api-proj-123.fly.dev',
       env_vars_encrypted: null,
@@ -1672,7 +2053,7 @@ describe('ComputeServicesService', () => {
 
     it('throws COMPUTE_SERVICE_NOT_FOUND when the service has no machine yet', async () => {
       mockQuery.mockResolvedValueOnce({
-        rows: [{ ...serviceRow, fly_app_id: null, fly_machine_id: null }],
+        rows: [{ ...serviceRow, provider_app_id: null, provider_instance_id: null }],
       });
 
       await expect(service.getServiceLogs('svc-logs-1')).rejects.toThrow('Service not found');
@@ -1699,6 +2080,7 @@ describe('selectComputeProvider factory', () => {
     vi.doMock('@/infra/config/app.config.js', () => {
       const c = {
         fly: { apiToken: 'tok', org: 'o', enabled: true, domain: 'd' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
         cloud: { projectId: 'local', apiHost: '' },
         app: { jwtSecret: 'x' },
       };
@@ -1716,6 +2098,7 @@ describe('selectComputeProvider factory', () => {
     vi.doMock('@/infra/config/app.config.js', () => {
       const c = {
         fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
         cloud: { projectId: 'p', apiHost: 'https://x' },
         app: { jwtSecret: 'x' },
       };
@@ -1733,6 +2116,7 @@ describe('selectComputeProvider factory', () => {
     vi.doMock('@/infra/config/app.config.js', () => {
       const c = {
         fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
         cloud: { projectId: 'local', apiHost: '' },
         app: { jwtSecret: 'x' },
       };
@@ -1743,5 +2127,158 @@ describe('selectComputeProvider factory', () => {
     });
     const { selectComputeProvider } = await import('@/services/compute/services.service.js');
     expect(() => selectComputeProvider()).toThrow(/COMPUTE_NOT_CONFIGURED|not configured/);
+  });
+});
+
+describe('buildComputeRegistry', () => {
+  const flyConfigured = () => {
+    vi.doMock('@/infra/config/app.config.js', () => {
+      const c = {
+        fly: { apiToken: 'tok', org: 'o', enabled: true, domain: 'd' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
+        cloud: { projectId: 'p', apiHost: 'https://x' },
+        app: { jwtSecret: 'x' },
+      };
+      return { config: c, appConfig: c };
+    });
+  };
+
+  /** Fly credentials present, but NOT a cloud-managed project. */
+  const selfHostedFly = () => {
+    vi.doMock('@/infra/config/app.config.js', () => {
+      const c = {
+        fly: { apiToken: 'tok', org: 'o', enabled: true, domain: 'd' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
+        cloud: { projectId: 'local', apiHost: '' },
+        app: { jwtSecret: 'x' },
+      };
+      return { config: c, appConfig: c };
+    });
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@/providers/compute/fly.provider.js');
+    vi.doUnmock('@/providers/compute/cloud.provider.js');
+    delete process.env.COMPUTE_PROVIDER;
+  });
+
+  afterEach(() => {
+    delete process.env.COMPUTE_PROVIDER;
+  });
+
+  // Self-host Fly and cloud-proxied mode are two credential paths to the same
+  // Fly resources, so registering both would put two sets of credentials on one
+  // set of apps. They share the 'fly' key, which makes that impossible.
+  it('registers fly and cloud under a single key, self-host winning', async () => {
+    flyConfigured();
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    const { FlyProvider } = await import('@/providers/compute/fly.provider.js');
+    const registry = buildComputeRegistry();
+
+    expect([...registry.providers.keys()]).toEqual(['fly']);
+    expect(registry.providers.get('fly')).toBe(FlyProvider.getInstance());
+    expect(registry.defaultProvider).toBe('fly');
+  });
+
+  it('COMPUTE_PROVIDER=cloud selects the cloud credential path for the fly key', async () => {
+    flyConfigured();
+    process.env.COMPUTE_PROVIDER = 'cloud';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    const { CloudComputeProvider } = await import('@/providers/compute/cloud.provider.js');
+    const registry = buildComputeRegistry();
+
+    expect(registry.providers.get('fly')).toBe(CloudComputeProvider.getInstance());
+    expect(registry.defaultProvider).toBe('fly');
+  });
+
+  it('COMPUTE_PROVIDER=off disables compute outright', async () => {
+    flyConfigured();
+    process.env.COMPUTE_PROVIDER = 'off';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect(() => buildComputeRegistry()).toThrow(/disabled/);
+  });
+
+  it('rejects an unknown COMPUTE_PROVIDER rather than silently falling back', async () => {
+    flyConfigured();
+    process.env.COMPUTE_PROVIDER = 'kubernetes';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect(() => buildComputeRegistry()).toThrow(/Unknown COMPUTE_PROVIDER/);
+  });
+
+  // Naming a default that isn't configured is a stated intent we can't honour —
+  // failing at startup beats 500-ing on the operator's first deploy. The message
+  // names the socket path it looked at, since a wrong DOCKER_SOCKET_PATH or a
+  // missing compose mount is the whole failure mode.
+  it('rejects COMPUTE_PROVIDER=docker when no socket is present', async () => {
+    selfHostedFly();
+    process.env.COMPUTE_PROVIDER = 'docker';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect(() => buildComputeRegistry()).toThrow(
+      /no Docker socket at .*insforge-test-docker\.sock/
+    );
+  });
+
+  // The Docker driver's safety argument is that the operator and the developer
+  // deploying containers are the same principal. On a cloud-managed project they
+  // are not — the operator is InsForge and the developer is a customer — so a
+  // customer creating containers on shared infrastructure is a tenant escape.
+  // Fail closed, and say the real reason rather than blaming a missing socket.
+  it('refuses the Docker driver on a cloud-managed project', async () => {
+    flyConfigured(); // cloud projectId + apiHost present
+    process.env.COMPUTE_PROVIDER = 'docker';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect(() => buildComputeRegistry()).toThrow(/self-host only/);
+  });
+
+  it('never registers Docker on a cloud-managed project, socket or not', async () => {
+    flyConfigured();
+    const { DockerProvider } = await import('@/providers/compute/docker.provider.js');
+    // isConfigured is the "can I be used at all" question, so the guard lives
+    // there too — any future caller inherits it, not just the registry.
+    expect(DockerProvider.getInstance().isConfigured()).toBe(false);
+
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect([...buildComputeRegistry().providers.keys()]).toEqual(['fly']);
+  });
+
+  // Presence/absence of the slice is the coarse "is compute available" signal, so
+  // it has to be absent rather than throwing or returning an empty object — a
+  // caller gating a whole feature must not have to first make a request that 503s.
+  it('omits the metadata slice entirely when no provider is configured', async () => {
+    vi.doMock('@/infra/config/app.config.js', () => {
+      const c = {
+        fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
+        cloud: { projectId: 'local', apiHost: '' },
+        app: { jwtSecret: 'x' },
+      };
+      return { config: c, appConfig: c };
+    });
+    const { getComputeMetadata } = await import('@/services/compute/services.service.js');
+    expect(getComputeMetadata()).toBeUndefined();
+  });
+
+  it('omits the slice when compute is explicitly disabled', async () => {
+    selfHostedFly();
+    process.env.COMPUTE_PROVIDER = 'off';
+    const { getComputeMetadata } = await import('@/services/compute/services.service.js');
+    // `off` and `not configured` are the same answer to "should I offer compute".
+    expect(getComputeMetadata()).toBeUndefined();
+  });
+
+  it('COMPUTE_PROVIDER=fly errors when Fly credentials are absent', async () => {
+    vi.doMock('@/infra/config/app.config.js', () => {
+      const c = {
+        fly: { apiToken: '', org: '', enabled: false, domain: '' },
+        docker: { socketPath: '/nonexistent/insforge-test-docker.sock' },
+        cloud: { projectId: 'p', apiHost: 'https://x' },
+        app: { jwtSecret: 'x' },
+      };
+      return { config: c, appConfig: c };
+    });
+    process.env.COMPUTE_PROVIDER = 'fly';
+    const { buildComputeRegistry } = await import('@/services/compute/services.service.js');
+    expect(() => buildComputeRegistry()).toThrow(/FLY_API_TOKEN/);
   });
 });

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -67,6 +67,19 @@ const mockGetMachineStatus = vi.fn();
 const mockWaitForState = vi.fn();
 const mockIsConfigured = vi.fn(() => true);
 
+/**
+ * Canonical Fly capabilities. Tests that need a different shape assign onto
+ * `mockFlyInstance.capabilities`; `beforeEach` restores from this, so a test that
+ * throws mid-body cannot leak its mutation into everything that follows.
+ */
+const FLY_CAPABILITIES = {
+  scaleToZero: true,
+  regions: true,
+  ingressModes: ['host'] as ('none' | 'port' | 'host')[],
+  sourceBuild: 'flyctl' as const,
+  deployTokenIssuance: false,
+};
+
 const mockFlyInstance = {
   createApp: mockCreateApp,
   destroyApp: mockDestroyApp,
@@ -85,13 +98,7 @@ const mockFlyInstance = {
   // FlyProvider derives these itself; the mock mirrors its behaviour so the
   // service's naming and URL calls resolve to the same values the fixtures use.
   name: 'fly' as const,
-  capabilities: {
-    scaleToZero: true,
-    regions: true,
-    ingressModes: ['host'] as ('none' | 'port' | 'host')[],
-    sourceBuild: 'flyctl' as const,
-    deployTokenIssuance: false,
-  },
+  capabilities: { ...FLY_CAPABILITIES },
   // Delegates to the real helper (rather than a naive template) so the service
   // test keeps covering the Fly app-name length guard, which moved here from
   // the service layer.
@@ -118,6 +125,11 @@ describe('ComputeServicesService', () => {
     process.env.APP_KEY = 'testkey1';
     service = ComputeServicesService.getInstance();
     mockIsConfigured.mockReturnValue(true);
+    // The mock provider is a module-scoped singleton, so a capability override
+    // survives the test that made it. Restore here rather than at the end of each
+    // test body, where a failing assertion skips the restore and the leak shows up
+    // as unrelated failures further down the file.
+    mockFlyInstance.capabilities = { ...FLY_CAPABILITIES };
   });
 
   afterEach(() => {
@@ -173,7 +185,6 @@ describe('ComputeServicesService', () => {
       expect(mockQuery.mock.calls[0][1]).toContain('local');
       expect(mockQuery.mock.calls[0][1]).not.toContain('iad');
       expect(mockLaunchMachine.mock.calls[0][0].region).toBe('local');
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, regions: true };
     });
 
     // Found by the first end-to-end run: the API default for scaleToZero is
@@ -200,7 +211,6 @@ describe('ComputeServicesService', () => {
       // The INSERT must persist false, not the schema default of true.
       expect(mockQuery.mock.calls[0][1]).toContain(false);
       expect(mockLaunchMachine.mock.calls[0][0].scaleToZero).toBe(false);
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
     });
 
     // On update, an omitted field means "leave it alone". Filling it in would turn
@@ -230,7 +240,6 @@ describe('ComputeServicesService', () => {
       // Region-only change: no deploy-affecting field was implied, so the provider
       // was never asked to update the instance.
       expect(mockUpdateMachine).not.toHaveBeenCalled();
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
     });
 
     it('records a service as always-on when the driver cannot scale to zero', async () => {
@@ -252,7 +261,6 @@ describe('ComputeServicesService', () => {
       });
 
       expect(mockLaunchMachine.mock.calls[0][0].scaleToZero).toBe(false);
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, scaleToZero: true };
     });
 
     // prepareForDeploy reserves a name and creates the provider-side app, then
@@ -276,7 +284,6 @@ describe('ComputeServicesService', () => {
       // Nothing was written and no provider-side app was created.
       expect(mockQuery).not.toHaveBeenCalled();
       expect(mockCreateApp).not.toHaveBeenCalled();
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
     });
 
     // Drivers coexist, so a row is routed by its own `provider`. When that
@@ -337,7 +344,10 @@ describe('ComputeServicesService', () => {
       expect(stats).toMatchObject({ checked: 1, corrected: 1, healed: 0 });
       const [sql, params] = mockQuery.mock.calls[1];
       expect(sql).toContain('SET status = $1');
-      expect(params).toEqual(['stopped', 'svc-1']);
+      // Scoped to the instance the reading was taken against, so a deploy that
+      // replaced it concurrently is not overwritten by a stale observation.
+      expect(sql).toContain('provider_instance_id = $3');
+      expect(params).toEqual(['stopped', 'svc-1', 'machine-1']);
     });
 
     it('leaves a row alone when reality already matches', async () => {
@@ -416,7 +426,7 @@ describe('ComputeServicesService', () => {
       const stats = await service.reconcile();
 
       expect(stats).toMatchObject({ checked: 2, healed: 0, corrected: 1, skipped: 1 });
-      expect(mockQuery.mock.calls[2][1]).toEqual(['stopped', 'svc-2']);
+      expect(mockQuery.mock.calls[2][1]).toEqual(['stopped', 'svc-2', 'machine-2']);
     });
   });
 
@@ -484,7 +494,6 @@ describe('ComputeServicesService', () => {
 
       delete (mockFlyInstance as Record<string, unknown>).buildFromContext;
       delete (mockFlyInstance as Record<string, unknown>).pruneServiceImages;
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
     });
 
     // A failed build must leave the previous image serving, and must say why.
@@ -504,7 +513,32 @@ describe('ComputeServicesService', () => {
       expect(mockUpdateMachine).not.toHaveBeenCalled();
 
       delete (mockFlyInstance as Record<string, unknown>).buildFromContext;
-      mockFlyInstance.capabilities = { ...mockFlyInstance.capabilities, sourceBuild: 'flyctl' };
+    });
+
+    // The build already wrote an image to disk before the deploy ran, and nothing
+    // else removes service images — so a deploy failure that skipped the prune let
+    // repeated failures pile up without bound.
+    it('still prunes when the build succeeded but the deploy failed', async () => {
+      mockFlyInstance.capabilities = {
+        ...mockFlyInstance.capabilities,
+        sourceBuild: 'context-upload',
+      };
+      const prune = vi.fn().mockResolvedValue({ removed: 1 });
+      (mockFlyInstance as Record<string, unknown>).buildFromContext = vi
+        .fn()
+        .mockResolvedValue({ imageTag: 'insforge-x/api:abc', logs: [] });
+      (mockFlyInstance as Record<string, unknown>).pruneServiceImages = prune;
+
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] }); // getService in buildAndDeploy
+      mockQuery.mockResolvedValueOnce({ rows: [serviceRow()] }); // getService in updateService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] });
+      mockUpdateMachine.mockRejectedValue(new Error('daemon refused to start the container'));
+
+      await expect(service.buildAndDeploy('svc-b1', Buffer.from('t'))).rejects.toThrow();
+      expect(prune).toHaveBeenCalledWith('api');
+
+      delete (mockFlyInstance as Record<string, unknown>).buildFromContext;
+      delete (mockFlyInstance as Record<string, unknown>).pruneServiceImages;
     });
   });
 
@@ -1825,6 +1859,26 @@ describe('ComputeServicesService', () => {
       expect(sql).toContain('status');
       expect(params).toContain('running');
       expect(params).toContain('mach-new');
+    });
+
+    // The provider contract does not tie `endpointUrl` to a replacement: a driver
+    // that re-publishes a port on the same instance (ingress none -> port) reports
+    // a fresh URL with no new id, and nesting the write under the id check dropped
+    // it.
+    it('persists a new endpointUrl even when the instance was not replaced', async () => {
+      const deployedRow = { ...baseRow, provider_instance_id: 'mach-existing', status: 'running' };
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] });
+      mockUpdateMachine.mockResolvedValue({ endpointUrl: 'http://127.0.0.1:32770' });
+      mockQuery.mockResolvedValueOnce({ rows: [deployedRow] });
+
+      await service.updateService('svc-pa-1', { ingress: 'port' });
+
+      const [sql, params] = mockQuery.mock.calls[2];
+      expect(sql).toContain('endpoint_url');
+      expect(params).toContain('http://127.0.0.1:32770');
+      // No replacement happened, so the stored instance id must not be touched.
+      expect(sql).not.toContain('provider_instance_id');
     });
 
     // The mirror image: an in-place update starts nothing, so a stopped service

--- a/backend/tests/unit/compute/services-service.test.ts
+++ b/backend/tests/unit/compute/services-service.test.ts
@@ -399,6 +399,25 @@ describe('ComputeServicesService', () => {
       mockQuery.mockRejectedValueOnce(new Error('connection terminated'));
       await expect(service.reconcile()).resolves.toMatchObject({ checked: 0 });
     });
+
+    // The heal is a write inside the catch block. Letting it throw would escape
+    // the loop and abandon every row after it — nine healthy corrections lost to
+    // one bad write.
+    it('keeps sweeping when a heal write fails', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [row(), row({ id: 'svc-2', name: 'api', provider_instance_id: 'machine-2' })],
+      });
+      mockGetMachineStatus
+        .mockRejectedValueOnce(new MachineGoneError('app-1', 'machine-1'))
+        .mockResolvedValueOnce({ state: 'stopped' });
+      mockQuery.mockRejectedValueOnce(new Error('deadlock detected')); // the heal
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // svc-2's correction still lands
+
+      const stats = await service.reconcile();
+
+      expect(stats).toMatchObject({ checked: 2, healed: 0, corrected: 1, skipped: 1 });
+      expect(mockQuery.mock.calls[2][1]).toEqual(['stopped', 'svc-2']);
+    });
   });
 
   describe('buildAndDeploy', () => {
@@ -1783,6 +1802,49 @@ describe('ComputeServicesService', () => {
       const updateCall = mockQuery.mock.calls[2];
       expect(updateCall[0]).toContain('protocol');
       expect(updateCall[1]).toContain('tcp');
+    });
+
+    // Docker cannot change an image in place, so it replaces the container. The
+    // replacement comes up running, and a row that was 'stopped' (the caller had
+    // stopped the service, then redeployed it) would otherwise keep claiming
+    // 'stopped' while the container runs.
+    it('flips a stopped row to running when the driver replaced the instance', async () => {
+      const stoppedRow = {
+        ...baseRow,
+        provider_instance_id: 'mach-old',
+        status: 'stopped',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [stoppedRow] }); // getService
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] }); // hoisted SELECT
+      mockUpdateMachine.mockResolvedValue({ machineId: 'mach-new', endpointUrl: null });
+      mockQuery.mockResolvedValueOnce({ rows: [{ ...stoppedRow, status: 'running' }] });
+
+      await service.updateService('svc-pa-1', { imageUrl: 'nginx:1.27' });
+
+      const [sql, params] = mockQuery.mock.calls[2];
+      expect(sql).toContain('status');
+      expect(params).toContain('running');
+      expect(params).toContain('mach-new');
+    });
+
+    // The mirror image: an in-place update starts nothing, so a stopped service
+    // that only resizes stays stopped.
+    it('leaves a stopped row stopped when the driver updated in place', async () => {
+      const stoppedRow = {
+        ...baseRow,
+        provider_instance_id: 'mach-existing',
+        status: 'stopped',
+      };
+      mockQuery.mockResolvedValueOnce({ rows: [stoppedRow] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ env_vars_encrypted: null }] });
+      mockUpdateMachine.mockResolvedValue({}); // same instance, resized in place
+      mockQuery.mockResolvedValueOnce({ rows: [stoppedRow] });
+
+      await service.updateService('svc-pa-1', { memory: 1024 });
+
+      const [sql, params] = mockQuery.mock.calls[2];
+      expect(sql).not.toContain('status');
+      expect(params).not.toContain('running');
     });
 
     // Back-compat — if the caller doesn't pass `protocol`, the persisted value

--- a/backend/tests/unit/context-export.test.ts
+++ b/backend/tests/unit/context-export.test.ts
@@ -142,6 +142,39 @@ describe('MetadataService.formatAsMarkdown', () => {
     expect(md).not.toContain('## Realtime');
     // Deployments section omitted for self-hosted
     expect(md).not.toContain('## Deployments');
+    // Compute likewise: absence of the slice is how a client learns compute is off,
+    // so the markdown must not imply otherwise.
+    expect(md).not.toContain('## Compute');
+  });
+
+  // The JSON response gained a compute slice; the markdown export is the same
+  // metadata for a human, so it has to describe what the provider can actually do.
+  it('renders the compute slice with per-provider capabilities', () => {
+    const withCompute: AppMetadataSchema = {
+      ...sampleMetadata,
+      compute: {
+        defaultProvider: 'docker',
+        providers: {
+          docker: {
+            scaleToZero: false,
+            regions: false,
+            ingressModes: ['none', 'port', 'host'],
+            sourceBuild: 'context-upload',
+            deployTokenIssuance: false,
+          },
+        },
+      },
+    };
+
+    const md = metadataService.formatAsMarkdown(withCompute);
+
+    expect(md).toContain('## Compute');
+    expect(md).toContain('docker');
+    // Spelled out rather than dumped, since the point is what a client should stop
+    // offering: no regions, no scale-to-zero.
+    expect(md).toContain('regions no');
+    expect(md).toContain('scale-to-zero no');
+    expect(md).toContain('context-upload');
   });
 
   it('renders database hint when present', () => {

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -129,6 +129,10 @@ services:
       # hostname gets no URL rather than an unroutable guess.
       COMPUTE_DOMAIN: ${COMPUTE_DOMAIN:-}
       COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Ceiling on an uploaded source-build context. Express buffers the whole
+      # tarball before the handler runs, so this is a memory bound, not just a
+      # policy — lower it on a small host.
+      COMPUTE_BUILD_MAX_CONTEXT: ${COMPUTE_BUILD_MAX_CONTEXT:-}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -114,6 +114,16 @@ services:
       DENO_RUNTIME_URL: http://deno:7133
       LOGS_DIR: /insforge-logs
       STORAGE_DIR: /insforge-storage
+      # ─── Custom Compute: Docker provider (opt-in) ──────────────────────────
+      # Enabled by mounting the Docker socket (see volumes below). Note this
+      # platform is UNVERIFIED for compute: its own reconciler may remove
+      # containers it does not recognise, and its reverse proxy expects specific
+      # labels. Treat it as untested until someone runs it.
+      COMPUTE_PROVIDER: ${COMPUTE_PROVIDER:-}
+      COMPUTE_DEFAULT_INGRESS: ${COMPUTE_DEFAULT_INGRESS:-none}
+      COMPUTE_PUBLIC_HOST: ${COMPUTE_PUBLIC_HOST:-}
+      COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set
       # S3_USE_PRESIGNED_URLS=false to proxy object bytes through the backend
@@ -153,6 +163,13 @@ services:
     volumes:
       - storage-data:/insforge-storage
       - insforge-logs:/insforge-logs
+      # Uncomment to enable the Docker compute provider. `group_add` must name the
+      # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
+      # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
+      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      # UNVERIFIED on this platform — see the note in `environment` above.
+      # - /var/run/docker.sock:/var/run/docker.sock
+    # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     security_opt:
       - no-new-privileges:true
 

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -133,6 +133,11 @@ services:
       # tarball before the handler runs, so this is a memory bound, not just a
       # policy — lower it on a small host.
       COMPUTE_BUILD_MAX_CONTEXT: ${COMPUTE_BUILD_MAX_CONTEXT:-}
+      # Seconds an upload may send nothing before it is treated as stalled and
+      # cut loose. Only one build runs at a time, so a connection that stops
+      # making progress would otherwise block every other deploy. Resets on each
+      # chunk, so a slow but active link is never cut.
+      COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT: ${COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT:-}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set
@@ -176,9 +181,9 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
-      # It has to land in .env (or the exported environment) — Compose does
-      # not see a bare assignment made in your shell.
+      #   getent group docker | cut -d: -f3
+      # The value goes on .env's DOCKER_GID line (or the exported environment).
+      # Compose does not see a bare assignment made in your shell.
       # UNVERIFIED on this platform — see the note in `environment` above.
       # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -120,8 +120,14 @@ services:
       # containers it does not recognise, and its reverse proxy expects specific
       # labels. Treat it as untested until someone runs it.
       COMPUTE_PROVIDER: ${COMPUTE_PROVIDER:-}
+      # Socket the driver dials, mounted at the same path below so both sides
+      # agree. Override for rootless Docker or Podman.
+      DOCKER_SOCKET_PATH: ${DOCKER_SOCKET_PATH:-}
       COMPUTE_DEFAULT_INGRESS: ${COMPUTE_DEFAULT_INGRESS:-none}
       COMPUTE_PUBLIC_HOST: ${COMPUTE_PUBLIC_HOST:-}
+      # Base domain for `host` ingress. Unset, a service that asks for a
+      # hostname gets no URL rather than an unroutable guess.
+      COMPUTE_DOMAIN: ${COMPUTE_DOMAIN:-}
       COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
@@ -166,9 +172,11 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+      # It has to land in .env (or the exported environment) — Compose does
+      # not see a bare assignment made in your shell.
       # UNVERIFIED on this platform — see the note in `environment` above.
-      # - /var/run/docker.sock:/var/run/docker.sock
+      # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     security_opt:
       - no-new-privileges:true

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -154,6 +154,11 @@ services:
       # tarball before the handler runs, so this is a memory bound, not just a
       # policy — lower it on a small host.
       - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
+      # Seconds an upload may send nothing before it is treated as stalled and
+      # cut loose. Only one build runs at a time, so a connection that stops
+      # making progress would otherwise block every other deploy. Resets on each
+      # chunk, so a slow but active link is never cut.
+      - COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT=${COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT:-}
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     restart: unless-stopped
     volumes:
@@ -162,9 +167,9 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
-      # It has to land in .env (or the exported environment) — Compose does
-      # not see a bare assignment made in your shell.
+      #   getent group docker | cut -d: -f3
+      # The value goes on .env's DOCKER_GID line (or the exported environment).
+      # Compose does not see a bare assignment made in your shell.
       # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     networks:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -150,6 +150,10 @@ services:
       # hostname gets no URL rather than an unroutable guess.
       - COMPUTE_DOMAIN=${COMPUTE_DOMAIN:-}
       - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Ceiling on an uploaded source-build context. Express buffers the whole
+      # tarball before the handler runs, so this is a memory bound, not just a
+      # policy — lower it on a small host.
+      - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     restart: unless-stopped
     volumes:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -141,8 +141,14 @@ services:
       # Uncommenting the socket mount in `volumes` below is what enables it.
       # See .env.example for what each of these does.
       - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      # Socket the driver dials, mounted at the same path below so both sides
+      # agree. Override for rootless Docker or Podman.
+      - DOCKER_SOCKET_PATH=${DOCKER_SOCKET_PATH:-}
       - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
       - COMPUTE_PUBLIC_HOST=${COMPUTE_PUBLIC_HOST:-}
+      # Base domain for `host` ingress. Unset, a service that asks for a
+      # hostname gets no URL rather than an unroutable guess.
+      - COMPUTE_DOMAIN=${COMPUTE_DOMAIN:-}
       - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     restart: unless-stopped
@@ -152,8 +158,10 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
-      # - /var/run/docker.sock:/var/run/docker.sock
+      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+      # It has to land in .env (or the exported environment) — Compose does
+      # not see a bare assignment made in your shell.
+      # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     networks:
       - insforge-network

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -137,10 +137,24 @@ services:
       # (required when the S3 endpoint is not reachable by browsers).
       - S3_USE_PRESIGNED_URLS=${S3_USE_PRESIGNED_URLS:-}
       - MAX_FILE_SIZE=${MAX_FILE_SIZE:-}
+      # ─── Custom Compute: Docker provider (opt-in) ────────────────────────
+      # Uncommenting the socket mount in `volumes` below is what enables it.
+      # See .env.example for what each of these does.
+      - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
+      - COMPUTE_PUBLIC_HOST=${COMPUTE_PUBLIC_HOST:-}
+      - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     restart: unless-stopped
     volumes:
       - storage-data:/insforge-storage
       - insforge-logs:/insforge-logs
+      # Uncomment to enable the Docker compute provider. `group_add` must name the
+      # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
+      # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
+      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      # - /var/run/docker.sock:/var/run/docker.sock
+    # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     networks:
       - insforge-network
 

--- a/deploy/dokploy/docker-compose.yml
+++ b/deploy/dokploy/docker-compose.yml
@@ -118,6 +118,10 @@ services:
       # hostname gets no URL rather than an unroutable guess.
       COMPUTE_DOMAIN: ${COMPUTE_DOMAIN:-}
       COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Ceiling on an uploaded source-build context. Express buffers the whole
+      # tarball before the handler runs, so this is a memory bound, not just a
+      # policy — lower it on a small host.
+      COMPUTE_BUILD_MAX_CONTEXT: ${COMPUTE_BUILD_MAX_CONTEXT:-}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set

--- a/deploy/dokploy/docker-compose.yml
+++ b/deploy/dokploy/docker-compose.yml
@@ -109,8 +109,14 @@ services:
       # containers it does not recognise, and its reverse proxy expects specific
       # labels. Treat it as untested until someone runs it.
       COMPUTE_PROVIDER: ${COMPUTE_PROVIDER:-}
+      # Socket the driver dials, mounted at the same path below so both sides
+      # agree. Override for rootless Docker or Podman.
+      DOCKER_SOCKET_PATH: ${DOCKER_SOCKET_PATH:-}
       COMPUTE_DEFAULT_INGRESS: ${COMPUTE_DEFAULT_INGRESS:-none}
       COMPUTE_PUBLIC_HOST: ${COMPUTE_PUBLIC_HOST:-}
+      # Base domain for `host` ingress. Unset, a service that asks for a
+      # hostname gets no URL rather than an unroutable guess.
+      COMPUTE_DOMAIN: ${COMPUTE_DOMAIN:-}
       COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
@@ -155,9 +161,11 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+      # It has to land in .env (or the exported environment) — Compose does
+      # not see a bare assignment made in your shell.
       # UNVERIFIED on this platform — see the note in `environment` above.
-      # - /var/run/docker.sock:/var/run/docker.sock
+      # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     security_opt:
       - no-new-privileges:true

--- a/deploy/dokploy/docker-compose.yml
+++ b/deploy/dokploy/docker-compose.yml
@@ -103,6 +103,16 @@ services:
       DENO_RUNTIME_URL: http://deno:7133
       LOGS_DIR: /insforge-logs
       STORAGE_DIR: /insforge-storage
+      # ─── Custom Compute: Docker provider (opt-in) ──────────────────────────
+      # Enabled by mounting the Docker socket (see volumes below). Note this
+      # platform is UNVERIFIED for compute: its own reconciler may remove
+      # containers it does not recognise, and its reverse proxy expects specific
+      # labels. Treat it as untested until someone runs it.
+      COMPUTE_PROVIDER: ${COMPUTE_PROVIDER:-}
+      COMPUTE_DEFAULT_INGRESS: ${COMPUTE_DEFAULT_INGRESS:-none}
+      COMPUTE_PUBLIC_HOST: ${COMPUTE_PUBLIC_HOST:-}
+      COMPUTE_BIND_ADDRESS: ${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set
       # S3_USE_PRESIGNED_URLS=false to proxy object bytes through the backend
@@ -142,6 +152,13 @@ services:
     volumes:
       - storage-data:/insforge-storage
       - insforge-logs:/insforge-logs
+      # Uncomment to enable the Docker compute provider. `group_add` must name the
+      # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
+      # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
+      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      # UNVERIFIED on this platform — see the note in `environment` above.
+      # - /var/run/docker.sock:/var/run/docker.sock
+    # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     security_opt:
       - no-new-privileges:true
 

--- a/deploy/dokploy/docker-compose.yml
+++ b/deploy/dokploy/docker-compose.yml
@@ -122,6 +122,11 @@ services:
       # tarball before the handler runs, so this is a memory bound, not just a
       # policy — lower it on a small host.
       COMPUTE_BUILD_MAX_CONTEXT: ${COMPUTE_BUILD_MAX_CONTEXT:-}
+      # Seconds an upload may send nothing before it is treated as stalled and
+      # cut loose. Only one build runs at a time, so a connection that stops
+      # making progress would otherwise block every other deploy. Resets on each
+      # chunk, so a slow but active link is never cut.
+      COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT: ${COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT:-}
       COMPUTE_ISOLATE_NETWORK: ${COMPUTE_ISOLATE_NETWORK:-}
       # S3-compatible storage (AWS S3, MinIO, RustFS, Wasabi, R2, Tencent COS ...).
       # Leave S3_BUCKET empty to keep local filesystem storage. Set
@@ -165,9 +170,9 @@ services:
       # Uncomment to enable the Docker compute provider. `group_add` must name the
       # host's docker group; the GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu) so it cannot be baked in:
-      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
-      # It has to land in .env (or the exported environment) — Compose does
-      # not see a bare assignment made in your shell.
+      #   getent group docker | cut -d: -f3
+      # The value goes on .env's DOCKER_GID line (or the exported environment).
+      # Compose does not see a bare assignment made in your shell.
       # UNVERIFIED on this platform — see the note in `environment` above.
       # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -174,6 +174,10 @@ services:
       # Bind address for published ports. Loopback by default — reaching a
       # container from the internet should be a deliberate choice.
       - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Ceiling on an uploaded source-build context. Express buffers the whole
+      # tarball before the handler runs, so this is a memory bound, not just a
+      # policy — lower it on a small host.
+      - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
       # Keep compute containers off this project's network. Off by default:
       # proximity to the database and storage is the point.
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -149,9 +149,38 @@ services:
       - INSFORGE_DEPLOYMENT_METHOD=docker-compose
       # Storage directory (for local file storage when S3 is not configured)
       - STORAGE_DIR=/insforge-storage
+      # ─── Custom Compute: Docker provider (opt-in) ──────────────────────────
+      # Mounting the Docker socket below is what enables it: the driver registers
+      # itself when the socket is reachable, so nothing runs containers on your
+      # host unless you deliberately grant this.
+      #
+      # Read the security note in the compute docs first. The driver constructs
+      # every container spec itself and never forwards caller-supplied options, so
+      # a leaked API key cannot request a privileged container — but the socket is
+      # still root-equivalent on the host.
+      - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      # Ingress default for services that do not choose one. `none` publishes no
+      # host port, which is right for workers and processors.
+      - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
+      # Host address used to build URLs for `port` ingress. Unset, no URL is
+      # advertised rather than guessing an address that may not resolve.
+      - COMPUTE_PUBLIC_HOST=${COMPUTE_PUBLIC_HOST:-}
+      # Bind address for published ports. Loopback by default — reaching a
+      # container from the internet should be a deliberate choice.
+      - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Keep compute containers off this project's network. Off by default:
+      # proximity to the database and storage is the point.
+      - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     volumes:
       - storage-data:/insforge-storage
       - shared-logs:/insforge-logs
+      # Uncomment to enable the Docker compute provider. `group_add` is required
+      # because the socket is mode 660 root:docker — without a matching group the
+      # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
+      # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
+      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      # - /var/run/docker.sock:/var/run/docker.sock
+    # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     restart: unless-stopped
     networks:
       - insforge-network

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -159,12 +159,18 @@ services:
       # a leaked API key cannot request a privileged container — but the socket is
       # still root-equivalent on the host.
       - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      # Socket the driver dials, mounted at the same path below so both sides
+      # agree. Override for rootless Docker or Podman.
+      - DOCKER_SOCKET_PATH=${DOCKER_SOCKET_PATH:-}
       # Ingress default for services that do not choose one. `none` publishes no
       # host port, which is right for workers and processors.
       - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
       # Host address used to build URLs for `port` ingress. Unset, no URL is
       # advertised rather than guessing an address that may not resolve.
       - COMPUTE_PUBLIC_HOST=${COMPUTE_PUBLIC_HOST:-}
+      # Base domain for `host` ingress. Unset, a service that asks for a
+      # hostname gets no URL rather than an unroutable guess.
+      - COMPUTE_DOMAIN=${COMPUTE_DOMAIN:-}
       # Bind address for published ports. Loopback by default — reaching a
       # container from the internet should be a deliberate choice.
       - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
@@ -178,8 +184,10 @@ services:
       # because the socket is mode 660 root:docker — without a matching group the
       # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
-      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
-      # - /var/run/docker.sock:/var/run/docker.sock
+      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+      # It has to land in .env (or the exported environment) — Compose does
+      # not see a bare assignment made in your shell.
+      # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     restart: unless-stopped
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -178,6 +178,11 @@ services:
       # tarball before the handler runs, so this is a memory bound, not just a
       # policy — lower it on a small host.
       - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
+      # Seconds an upload may send nothing before it is treated as stalled and
+      # cut loose. Only one build runs at a time, so a connection that stops
+      # making progress would otherwise block every other deploy. Resets on each
+      # chunk, so a slow but active link is never cut.
+      - COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT=${COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT:-}
       # Keep compute containers off this project's network. Off by default:
       # proximity to the database and storage is the point.
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
@@ -188,9 +193,9 @@ services:
       # because the socket is mode 660 root:docker — without a matching group the
       # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
-      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
-      # It has to land in .env (or the exported environment) — Compose does
-      # not see a bare assignment made in your shell.
+      #   getent group docker | cut -d: -f3
+      # The value goes on .env's DOCKER_GID line (or the exported environment).
+      # Compose does not see a bare assignment made in your shell.
       # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,11 @@ services:
       # tarball before the handler runs, so this is a memory bound, not just a
       # policy — lower it on a small host.
       - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
+      # Seconds an upload may send nothing before it is treated as stalled and
+      # cut loose. Only one build runs at a time, so a connection that stops
+      # making progress would otherwise block every other deploy. Resets on each
+      # chunk, so a slow but active link is never cut.
+      - COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT=${COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT:-}
       # Keep compute containers off this project's network. Off by default:
       # proximity to the database and storage is the point.
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
@@ -211,9 +216,9 @@ services:
       # because the socket is mode 660 root:docker — without a matching group the
       # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
-      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
-      # It has to land in .env (or the exported environment) — Compose does
-      # not see a bare assignment made in your shell.
+      #   getent group docker | cut -d: -f3
+      # The value goes on .env's DOCKER_GID line (or the exported environment).
+      # Compose does not see a bare assignment made in your shell.
       # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,10 @@ services:
       # Bind address for published ports. Loopback by default — reaching a
       # container from the internet should be a deliberate choice.
       - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Ceiling on an uploaded source-build context. Express buffers the whole
+      # tarball before the handler runs, so this is a memory bound, not just a
+      # policy — lower it on a small host.
+      - COMPUTE_BUILD_MAX_CONTEXT=${COMPUTE_BUILD_MAX_CONTEXT:-}
       # Keep compute containers off this project's network. Off by default:
       # proximity to the database and storage is the point.
       - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,28 @@ services:
       - INSFORGE_DEPLOYMENT_METHOD=docker-compose
       # Storage directory (for local file storage when S3 is not configured)
       - STORAGE_DIR=/insforge-storage
+      # ─── Custom Compute: Docker provider (opt-in) ──────────────────────────
+      # Mounting the Docker socket below is what enables it: the driver registers
+      # itself when the socket is reachable, so nothing runs containers on your
+      # host unless you deliberately grant this.
+      #
+      # Read the security note in the compute docs first. The driver constructs
+      # every container spec itself and never forwards caller-supplied options, so
+      # a leaked API key cannot request a privileged container — but the socket is
+      # still root-equivalent on the host.
+      - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      # Ingress default for services that do not choose one. `none` publishes no
+      # host port, which is right for workers and processors.
+      - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
+      # Host address used to build URLs for `port` ingress. Unset, no URL is
+      # advertised rather than guessing an address that may not resolve.
+      - COMPUTE_PUBLIC_HOST=${COMPUTE_PUBLIC_HOST:-}
+      # Bind address for published ports. Loopback by default — reaching a
+      # container from the internet should be a deliberate choice.
+      - COMPUTE_BIND_ADDRESS=${COMPUTE_BIND_ADDRESS:-127.0.0.1}
+      # Keep compute containers off this project's network. Off by default:
+      # proximity to the database and storage is the point.
+      - COMPUTE_ISOLATE_NETWORK=${COMPUTE_ISOLATE_NETWORK:-}
     volumes:
       - ./package.json:/app/package.json
       - ./package-lock.json:/app/package-lock.json
@@ -178,6 +200,13 @@ services:
       - ui_node_modules:/app/packages/ui/node_modules
       - shared-logs:/insforge-logs
       - storage-data:/insforge-storage
+      # Uncomment to enable the Docker compute provider. `group_add` is required
+      # because the socket is mode 660 root:docker — without a matching group the
+      # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
+      # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
+      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
+      # - /var/run/docker.sock:/var/run/docker.sock
+    # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'
     restart: unless-stopped
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,9 @@ services:
       # a leaked API key cannot request a privileged container — but the socket is
       # still root-equivalent on the host.
       - COMPUTE_PROVIDER=${COMPUTE_PROVIDER:-}
+      # Socket the driver dials, mounted at the same path below so both sides
+      # agree. Override for rootless Docker or Podman.
+      - DOCKER_SOCKET_PATH=${DOCKER_SOCKET_PATH:-}
       # Ingress default for services that do not choose one. `none` publishes no
       # host port, which is right for workers and processors.
       - COMPUTE_DEFAULT_INGRESS=${COMPUTE_DEFAULT_INGRESS:-none}
@@ -204,8 +207,10 @@ services:
       # because the socket is mode 660 root:docker — without a matching group the
       # backend gets EACCES. The GID is host-specific (993 on Amazon Linux 2023,
       # commonly 999 on Debian/Ubuntu), so it cannot be baked in:
-      #   DOCKER_GID=$(getent group docker | cut -d: -f3)
-      # - /var/run/docker.sock:/var/run/docker.sock
+      #   echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> .env
+      # It has to land in .env (or the exported environment) — Compose does
+      # not see a bare assignment made in your shell.
+      # - ${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:${DOCKER_SOCKET_PATH:-/var/run/docker.sock}
     # group_add: ["${DOCKER_GID:?set DOCKER_GID to your host docker group id}"]
     command: sh -c 'npm install && npx turbo run build --filter=@insforge/shared-schemas --filter=@insforge/ui --filter=@insforge/dashboard && cd backend && npm run migrate:up && cd .. && npx concurrently -n backend,frontend -c cyan,magenta "npm run dev:backend" "npm run dev:frontend"'
     restart: unless-stopped

--- a/openapi/metadata.yaml
+++ b/openapi/metadata.yaml
@@ -111,6 +111,46 @@ paths:
                       customSlug:
                         type: string
                         nullable: true
+                  compute:
+                    type: object
+                    description: >-
+                      Optional; absent when no compute driver is configured, which is
+                      how a client detects that compute is unavailable. Capabilities
+                      are per provider so a client can stop offering what the
+                      configured driver cannot honour.
+                    properties:
+                      defaultProvider:
+                        type: string
+                        enum: [fly, docker]
+                        description: Provider new services are created on.
+                      providers:
+                        type: object
+                        description: Keyed by provider name; only configured providers appear.
+                        additionalProperties:
+                          type: object
+                          properties:
+                            scaleToZero:
+                              type: boolean
+                              description: Whether idle instances can stop and wake on request.
+                            regions:
+                              type: boolean
+                              description: Whether a region can be chosen. False for a single daemon.
+                            ingressModes:
+                              type: array
+                              description: Which ingress modes this provider supports.
+                              items:
+                                type: string
+                                enum: [none, port, host]
+                            sourceBuild:
+                              type: string
+                              enum: [none, flyctl, context-upload]
+                              description: >-
+                                How source builds happen. `flyctl` builds on the
+                                caller's machine; `context-upload` accepts a tarball at
+                                POST /api/compute/services/{id}/build.
+                            deployTokenIssuance:
+                              type: boolean
+                              description: Whether the backend can issue a provider deploy token.
                   version:
                     type: string
               example:
@@ -136,6 +176,15 @@ paths:
                     name: "hello-world"
                     status: "active"
                     description: "Test function"
+                compute:
+                  defaultProvider: "docker"
+                  providers:
+                    docker:
+                      scaleToZero: false
+                      regions: false
+                      ingressModes: ["none", "port", "host"]
+                      sourceBuild: "context-upload"
+                      deployTokenIssuance: false
                 version: "2.0.0"
             text/markdown:
               schema:

--- a/packages/dashboard/src/features/compute/pages/ComputePage.tsx
+++ b/packages/dashboard/src/features/compute/pages/ComputePage.tsx
@@ -284,8 +284,8 @@ export default function ComputePage() {
               </dl>
             </div>
 
-            {currentService.flyMachineId && <ServiceLogs serviceId={currentService.id} />}
-            {currentService.flyMachineId && <ServiceEvents serviceId={currentService.id} />}
+            {currentService.providerInstanceId && <ServiceLogs serviceId={currentService.id} />}
+            {currentService.providerInstanceId && <ServiceEvents serviceId={currentService.id} />}
           </div>
         </div>
 

--- a/packages/shared-schemas/src/compute-services-api.schema.ts
+++ b/packages/shared-schemas/src/compute-services-api.schema.ts
@@ -46,6 +46,7 @@ export const createServiceSchema = z.object({
    * inspection. Optional and back-compat: omitting the field is identical to
    * sending `'http'` at every fallback site downstream.
    */
+  protocol: z.enum(['http', 'tcp']).optional(),
   /**
    * How the service should be reachable. Omitted, the server picks the active
    * driver's default (see ComputeCapabilities.ingressModes) — which for a
@@ -54,7 +55,6 @@ export const createServiceSchema = z.object({
    * substitution rather than failing an otherwise valid deploy.
    */
   ingress: ingressModeEnum.optional(),
-  protocol: z.enum(['http', 'tcp']).optional(),
   /**
    * Scale-to-zero. `true` (default) is the existing behaviour — Fly stops the
    * machine when idle and cold-starts it on the next request. `false` keeps

--- a/packages/shared-schemas/src/compute-services-api.schema.ts
+++ b/packages/shared-schemas/src/compute-services-api.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { serviceSchema, cpuTierEnum } from './compute-services.schema.js';
+import { serviceSchema, cpuTierEnum, ingressModeEnum } from './compute-services.schema.js';
 
 const envVarKeyRegex = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -46,6 +46,14 @@ export const createServiceSchema = z.object({
    * inspection. Optional and back-compat: omitting the field is identical to
    * sending `'http'` at every fallback site downstream.
    */
+  /**
+   * How the service should be reachable. Omitted, the server picks the active
+   * driver's default (see ComputeCapabilities.ingressModes) — which for a
+   * single-host driver is `none`, since most compute takes no inbound traffic.
+   * A driver that cannot honour the requested mode coerces it and logs the
+   * substitution rather than failing an otherwise valid deploy.
+   */
+  ingress: ingressModeEnum.optional(),
   protocol: z.enum(['http', 'tcp']).optional(),
   /**
    * Scale-to-zero. `true` (default) is the existing behaviour — Fly stops the
@@ -112,6 +120,8 @@ export const updateServiceSchema = z
       })
       .optional(),
     region: z.string().optional(),
+    /** Ingress — same semantics as createServiceSchema.ingress. */
+    ingress: ingressModeEnum.optional(),
     /**
      * Edge protocol — same semantics as createServiceSchema.protocol. Optional
      * on update; omitting it leaves the existing service's protocol in place.

--- a/packages/shared-schemas/src/compute-services.schema.ts
+++ b/packages/shared-schemas/src/compute-services.schema.ts
@@ -9,10 +9,29 @@ export const serviceStatusEnum = z.enum([
   'destroying',
 ]);
 
+/**
+ * How a service is reachable.
+ *
+ *   'none' — internal network only; no host port, no advertised URL.
+ *   'port' — published on a host port.
+ *   'host' — reachable at a hostname via the operator's gateway.
+ *
+ * Not every driver can offer every mode — see ComputeCapabilities.ingressModes.
+ */
+export const ingressModeEnum = z.enum(['none', 'port', 'host']);
+
+// Which driver backs a service. Recorded per row so switching COMPUTE_PROVIDER
+// cannot leave the reconcile loop operating on another driver's resources.
+export const computeProviderEnum = z.enum(['fly', 'docker']);
+
 // CPU tier accepts Fly.io's standard `<kind>-<N>x` format (e.g. shared-1x,
 // performance-8x). No hardcoded allow-list — Fly.io is the source of truth
 // for which sizes exist, so adding `performance-32x` (if/when Fly offers it)
 // needs zero schema changes here.
+//
+// This is a *Fly* format and stays the accepted input shape for back-compat,
+// but responses also carry a neutral `cpus` count derived from it so a driver
+// with no notion of shared-vs-performance tiers has something to map onto.
 export const cpuTierRegex = /^(shared|performance)-[1-9]\d*x$/;
 export const cpuTierEnum = z
   .string()
@@ -20,6 +39,16 @@ export const cpuTierEnum = z
     cpuTierRegex,
     'cpu must match `<shared|performance>-<N>x`, e.g. shared-2x or performance-8x'
   );
+
+/**
+ * Parse a Fly CPU tier into a neutral core count. Falls back to 1 for malformed
+ * input rather than throwing — the provider validates the final spec anyway, and
+ * a typo should not crash a response mapper.
+ */
+export function cpuTierToCores(cpu: string): number {
+  const m = /^(?:shared|performance)-([1-9]\d*)x$/.exec(cpu);
+  return m ? parseInt(m[1], 10) : 1;
+}
 
 export const serviceSchema = z.object({
   id: z.string().uuid(),
@@ -38,6 +67,23 @@ export const serviceSchema = z.object({
   // pre-existing rows). true = Fly stops the machine when idle and
   // cold-starts it on the next request (the default); false = always-on.
   scaleToZero: z.boolean(),
+  /** Neutral core count derived from `cpu`. See cpuTierToCores. */
+  cpus: z.number(),
+  /** How this service is reachable. Backfilled to 'host' for Fly rows by 064. */
+  ingress: ingressModeEnum,
+  /** Which driver backs this service. Backfilled to 'fly' by migration 064. */
+  provider: computeProviderEnum,
+  /** Provider-native app/namespace id — a Fly app name, or a Docker name prefix. */
+  providerAppId: z.string().nullable(),
+  /** Provider-native instance id — a Fly machine id, or a Docker container id. */
+  providerInstanceId: z.string().nullable(),
+  /**
+   * @deprecated Read-only aliases for providerAppId / providerInstanceId, kept
+   * for one minor version so the CLI, dashboard, and MCP server can migrate
+   * without a lockstep release. Populated on every response regardless of which
+   * driver backs the row — a Docker container id appears here too, which is why
+   * these are going away.
+   */
   flyAppId: z.string().nullable(),
   flyMachineId: z.string().nullable(),
   status: serviceStatusEnum,
@@ -46,6 +92,18 @@ export const serviceSchema = z.object({
   updatedAt: z.string(),
 });
 
+/** What a driver can do. Mirrors ComputeCapabilities on the backend interface. */
+export const computeCapabilitiesSchema = z.object({
+  scaleToZero: z.boolean(),
+  regions: z.boolean(),
+  ingressModes: z.array(ingressModeEnum),
+  sourceBuild: z.enum(['none', 'flyctl', 'context-upload']),
+  deployTokenIssuance: z.boolean(),
+});
+
 export type ServiceSchema = z.infer<typeof serviceSchema>;
 export type ServiceStatus = z.infer<typeof serviceStatusEnum>;
 export type CpuTier = z.infer<typeof cpuTierEnum>;
+export type ComputeProviderName = z.infer<typeof computeProviderEnum>;
+export type IngressMode = z.infer<typeof ingressModeEnum>;
+export type ComputeCapabilitiesSchema = z.infer<typeof computeCapabilitiesSchema>;

--- a/packages/shared-schemas/src/metadata.schema.ts
+++ b/packages/shared-schemas/src/metadata.schema.ts
@@ -3,6 +3,7 @@ import { storageBucketSchema } from './storage.schema.js';
 import { realtimeChannelSchema } from './realtime.schema.js';
 import { realtimePermissionsResponseSchema } from './realtime-api.schema.js';
 import { authConfigAdminResponseSchema } from './auth-api.schema.js';
+import { computeCapabilitiesSchema, computeProviderEnum } from './compute-services.schema.js';
 
 // Admin metadata for /api/metadata/auth (gated behind verifyAdmin). Identical
 // shape to the canonical admin auth response — public response in
@@ -55,6 +56,32 @@ export const deploymentsMetadataSchema = z.object({
   customSlug: z.string().nullable(),
 });
 
+/**
+ * Compute slice for the admin metadata response.
+ *
+ * Omitted entirely when no compute provider is configured, so presence/absence is
+ * the coarse "is compute available here" signal — the same mechanism the
+ * deployments slice uses, which lets a caller gate a whole feature without first
+ * making a request that would 503.
+ *
+ * When present it carries content rather than just existing, because two things
+ * are not derivable by a caller that already knows the provider enum:
+ *
+ *   - `defaultProvider`, and which providers are active, depend on the operator's
+ *     environment (is a Docker socket mounted, are Fly credentials set).
+ *   - Capabilities are not frozen per provider name. `sourceBuild` for Docker
+ *     changed from 'none' to 'context-upload' when server-side builds landed, and
+ *     `deployTokenIssuance` differs for the *same* provider name — false on
+ *     self-hosted Fly, true on cloud-managed. A caller-side constant table keyed
+ *     by provider cannot express either, and would be silently wrong across a
+ *     version skew, which is routine when an operator's backend and a developer's
+ *     CLI upgrade on different schedules.
+ */
+export const computeMetadataSchema = z.object({
+  defaultProvider: computeProviderEnum,
+  providers: z.record(computeProviderEnum, computeCapabilitiesSchema),
+});
+
 export const appMetaDataSchema = z.object({
   auth: authMetadataSchema,
   database: databaseMetadataSchema,
@@ -62,6 +89,7 @@ export const appMetaDataSchema = z.object({
   functions: z.array(edgeFunctionMetadataSchema),
   realtime: realtimeMetadataSchema.optional(),
   deployments: deploymentsMetadataSchema.optional(),
+  compute: computeMetadataSchema.optional(),
   version: z.string().optional(),
 });
 
@@ -72,6 +100,7 @@ export type StorageMetadataSchema = z.infer<typeof storageMetadataSchema>;
 export type EdgeFunctionMetadataSchema = z.infer<typeof edgeFunctionMetadataSchema>;
 export type RealtimeMetadataSchema = z.infer<typeof realtimeMetadataSchema>;
 export type DeploymentsMetadataSchema = z.infer<typeof deploymentsMetadataSchema>;
+export type ComputeMetadataSchema = z.infer<typeof computeMetadataSchema>;
 export type AppMetadataSchema = z.infer<typeof appMetaDataSchema>;
 
 // Database connection schemas


### PR DESCRIPTION
## Summary

Self-hosted InsForge runs its data locally but has only ever been able to run custom containers on **Fly.io** — the operator's Postgres and storage sit on their box while their compute sits in someone else's account. This adds a **Docker driver behind the compute API that already exists**, so containers run on the operator's own host.

Essence: container CRUD and lifecycle via the host's Docker Engine API. **No new API surface** — the existing routes get a second driver.

### Phase 0 — provider-neutral seam
Fly-specific naming moves out of the service layer into shared helpers. Providers declare a `ComputeCapabilities` descriptor instead of the service hardcoding Fly's answers — that hardcoding is what made a second driver impossible to add without lying somewhere.

**Migration 064** renames `fly_app_id`/`fly_machine_id` → `provider_app_id`/`provider_instance_id` and adds `provider` and `ingress`. Old API field names stay as read-only aliases for one minor version so the CLI/dashboard/MCP can migrate without a lockstep release.

**Drivers coexist.** A service is managed by the driver that created it, routed by its `provider` column. `COMPUTE_DRIVER` picks the default for *new* services rather than restricting the deployment, so an operator with Fly services keeps them manageable while new work lands locally.

### Phase 1 — the driver
Dependency-free client over the unix socket (node's `http` supports `socketPath`; a Docker SDK would pull a large tree to save little).

Three things that are easy to get silently wrong, all measured rather than assumed:
- **Log frames.** Without a TTY the logs endpoint returns 8-byte-headered frames, not text. Undemuxed, every line arrives as `^A^@^@^@^@^@^@&2026-…`.
- **The log cursor is two-part.** `since` takes **integer seconds only** (RFC3339Nano is rejected by `strconv.ParseInt`) and is **inclusive**. So a nanosecond watermark dedupes while the request floors to seconds — using seconds as the dedup key would discard new lines sharing a second with the previous batch.
- **`exited` maps to `stopped`, never `failed`.** A host reboot leaves SIGKILLed containers at exit 137; treating non-zero as failure would mark a chunk of services failed after every boot.

**Label scoping is a safety property, not politeness.** From inside a container with the socket mounted, an unfiltered listing includes Postgres and the backend itself — an unscoped stop takes out the database. Every read and write filters on `insforge.managed` + `insforge.project`, and machine-scoped calls verify ownership before acting.

**Privilege can't come from the request.** The driver builds each container spec itself and never forwards a caller-supplied `HostConfig`, so there is no field through which a leaked API key could ask for `--privileged`, a host bind mount, or host networking.

**Ingress is per-service** and defaults to `none` — most compute (workers, processors, inference loops) takes no inbound traffic, so publishing a port for everything is the wrong default. Published ports bind **loopback** by default; Docker's own default is `0.0.0.0` *and* `[::]`.

Startup runs a preflight probe and a reconcile sweep. Reconcile only corrects steady-state rows; a row left mid-operation by a crash is reported, not guessed at.

### Phase 2 — source build
The uploaded context tarball streams straight to the daemon's build endpoint (its native input, so no intermediate copy). BuildKit is used **without** decoding its protobuf progress frames — affordable because a failed build reports the error as plain JSON in the body, and it returns **HTTP 200** while doing so, so status alone must not be trusted. Superseded images are pruned after each successful deploy.

### Known v1 limitation
**No persistent volumes** (the Fly path has none either, so this is platform-wide rather than a self-host gap). State survives restarts and host reboots but **not a redeploy**, which recreates the container. Use the project's Postgres or Storage for data that must persist.

## How did you test this change?

**Unit: 181 compute tests** (up from 108). Full backend suite 2259 passing; the one failure is pre-existing and unrelated (a migration guard test globs `.claude/worktrees/` copies).

**Against a real Docker daemon** (Engine 29.3.1) — 21 checks covering lifecycle, labels, log demux/cursor, ingress modes, build, and prune. Two security checks included: refusing to act on an unlabelled container, and confirming that container was left running untouched.

**On a real Linux host** (EC2 t4g.small, AL2023, Engine 25.0.16, via SSM; instance and security group destroyed after). Socket-in-container creates *siblings*; `-p 0:80` binds both `0.0.0.0` and `[::]`; the socket is `660 root:docker` with GID **993** on AL2023 so `group_add` is required and the GID can't be baked in; `unless-stopped` survived a real reboot while a no-policy container stayed exited.

**Migration 064 against real Postgres** — rename, backfill, idempotent re-apply, and the constraints they claim (no-default `provider` rejects a bare insert; invalid `ingress` rejected; pre-existing Fly rows backfill to `host`, which is truthful since every Fly app is already on a hostname).

**End-to-end through the HTTP API**, isolated stack (own project name, ports, volumes; prod target, socket mounted):
- Migrations applied by the real `migrate:up`; driver registered at startup
- `POST /api/compute/services` created a real container; labels correct
- Container attached to the project's compose network, and reached `postgres:5432` and `postgrest:3000` **by name** — the proximity promise
- `ingress: port` → served 200 on loopback only; `ingress: none` → no published port, no URL
- Source build: prepare → upload tar → build → launch → served the content the Dockerfile produced
- Logs: 0 frame-header bytes leaked; cursor re-poll returned 0 duplicates
- Image update recreated the container onto the new image (`nginx:alpine` → `nginx:1.27-alpine`, new container id)
- Reconcile: removed a container out-of-band, restarted the backend, row healed `running` → `stopped` with the dead pointer cleared
- Delete removed both row and container. Stack torn down, no leftovers.

**Compose files** validated both as shipped (commented) and with the socket instructions uncommented — the latter caught a broken-YAML `group_add` placement that would have made the guidance fail for anyone following it.

### Found only by end-to-end testing
- **`scaleToZero` stored a lie.** The API default is `true`, and normalization only coerced an *explicit* `true` — so omitting the field (the common case) stored `true` against a driver that can't do it. Fixed, with create-time default resolution kept separate from update-time coercion so a metadata-only PATCH doesn't become a deploy change.
- **`group_add` with the docker GID is Linux-only.** Docker Desktop exposes the socket as `660 root:root`, where the only group granting access is 0. The instruction is right for the documented target; the Docker Desktop difference needs a doc note.

## Not in this PR (deliberate, agreed)
Docs, the CLI/MCP changes, and dashboard capability-gating are held until the backend settles, to avoid writing them twice. The practical consequence: **the CLI does not yet call `POST /:id/build`**, so source build is API-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hosted Docker compute driver so custom containers run on the operator’s host with per‑service ingress and source builds. Docker is opt‑in via a mounted socket and can be the default via `COMPUTE_PROVIDER`. Run migration 064.

- **New Features**
  - Provider‑agnostic compute with per‑service `provider` and `ingress`; IDs renamed to `provider_app_id`/`provider_instance_id`; capability discovery via `GET /api/compute/services/capabilities`; startup preflight and reconcile.
  - Docker driver: full lifecycle with scoped labels, safe spec (no `HostConfig` passthrough), correct log demux/cursor, and ingress modes `none` (default), `port` (loopback), `host` (configured host/domain).
  - Source builds: `POST /api/compute/services/:id/build` streams a context tar; superseded images pruned after deploy.
  - Config: enable by mounting `DOCKER_SOCKET_PATH`; new envs `COMPUTE_DEFAULT_INGRESS`, `COMPUTE_PUBLIC_HOST`, `COMPUTE_DOMAIN`, `COMPUTE_BIND_ADDRESS`, `COMPUTE_ISOLATE_NETWORK`, `COMPUTE_BUILD_MAX_CONTEXT`, `COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT`; compose files updated; dashboard now uses `providerInstanceId` for logs/events.
  - Admin metadata: `/api/metadata` now includes compute provider capabilities for gating UI features; OpenAPI `metadata.yaml` and markdown export updated to describe the compute slice.

- **Bug Fixes**
  - Build uploads: gate now releases on socket close and in handler `finally`; adds idle watchdog via `COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT` (clamped to max `setTimeout`); over‑limit bodies return 413; prevents buffering concurrent contexts; default `COMPUTE_BUILD_MAX_CONTEXT` is 64mb; tests poll for slot acquisition instead of fixed sleeps.
  - Logs pagination: `tail` only on first page; resume uses `since`; returns oldest‑first to avoid dropped lines.
  - Docker network discovery retries after failures instead of caching null.
  - Reconcile: continues on heal errors; status correction scoped by `provider_instance_id` and counted only on `rowCount > 0`; `endpointUrl` persisted even on in‑place publish; recreate persists new status.
  - Migration 064: split add/backfill/constrain for `provider` and `ingress` so NOT NULL and backfill apply idempotently.
  - Build route: validates `dockerfile`, enforces size limit, and adds idle timeout; tests cover size limit, concurrency, disconnects, idle aborts, and first‑page vs paged log semantics.
  - Docker provider: container listing anchors name filters to exact matches to avoid cross‑service collisions.
  - Config/docs: `COMPUTE_ISOLATE_NETWORK` now uses standard truthy parsing; `DOCKER_GID` guidance corrected in compose/env; OpenAPI/markdown now document compute capabilities; protocol/ingress docblocks ordered correctly.
  - Fly path: restores typed `AppError` for missing `APP_KEY` (`COMPUTE_SERVICE_NOT_CONFIGURED`) when deriving the network name.

<sup>Written for commit 8cde62142ee34c50be5a84bd8a260447416911be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-hosted Docker compute driver for running services on a local Docker daemon
> - Introduces `DockerProvider` as a new `ComputeProvider` implementation that builds images from uploaded tar contexts and manages container lifecycle (create, start, stop, update, delete) via the Docker Unix socket.
> - Adds a `POST /:id/build` API endpoint that accepts an `application/x-tar` build context, triggers `buildAndDeploy`, and returns `{ service, imageTag, logs }`.
> - Refactors the compute layer from a single Fly-centric driver to a `ComputeRegistry` supporting multiple coexisting providers; per-service operations are now routed to the driver that created the service.
> - DB migration [064](https://github.com/InsForge/InsForge/pull/1892/files#diff-2aa8ba391e4bed59538b75445872728b6e2bf5c16012e019e744d3a7614472b6) renames `fly_app_id`/`fly_machine_id` to `provider_app_id`/`provider_instance_id` and adds `provider` and `ingress` columns, backfilling existing rows with `provider='fly'` and `ingress='host'`.
> - Extends `serviceSchema` with `cpus`, `ingress`, `provider`, `providerAppId`, and `providerInstanceId`; `flyAppId`/`flyMachineId` are retained as deprecated aliases.
> - Risk: migration renames columns and adds NOT NULL constraints — services created before migration will have `provider='fly'` and `ingress='host'` backfilled, and any code reading `fly_app_id`/`fly_machine_id` directly will break.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1892 opened
>
> - Changed database migration for `compute.services.provider` column to use three-step process with backfill [40f6cc8]
> - Fixed `DockerProvider.getLogs` method to prevent dropping backlog entries during pagination [40f6cc8]
> - Added error handling to `ComputeServicesService.reconcile` sweep to continue processing on heal failures [40f6cc8]
> - Fixed `ComputeServicesService.updateService` method to set status to 'running' when replacement instance is created [40f6cc8]
> - Fixed `DockerProvider.getOwnNetwork` method to retry network discovery instead of caching null [40f6cc8]
> - Added `DOCKER_SOCKET_PATH`, `COMPUTE_DOMAIN`, and `DOCKER_GID` environment variables to compose files [40f6cc8]
> - Added unit tests for Docker provider log pagination and network discovery behavior [40f6cc8]
> - Added unit tests for service reconciliation error handling and update status behavior [40f6cc8]
> - Added concurrency control and input validation to build upload endpoint [233654b]
> - Configured build context size limit across application and deployment environments [233654b]
> - Fixed database consistency issues in service reconciliation and updates [233654b]
> - Moved image pruning to finally block in build and deploy workflow [233654b]
> - Added unit test coverage for build route, docker provider log paging, and services service behavior [233654b]
> - Replaced single-boolean concurrency gate with semaphore-based build slot system in `oneBuildAtATime` middleware and `/:id/build` route handler [0ff6b1d]
> - Introduced `parseTarBody` middleware to intercept entity size limit errors for `application/x-tar` requests [0ff6b1d]
> - Added differentiation between skipped and corrected reconciliation operations in `ComputeServicesService.reconcile` method [0ff6b1d]
> - Added configurable `COMPUTE_BUILD_UPLOAD_IDLE_TIMEOUT` environment variable to all Docker Compose deployment configurations [b46edcc]
> - Implemented configurable upload idle timeout in backend configuration and build upload route [b46edcc]
> - Added unit tests for build slot lifecycle under client misbehavior scenarios [b46edcc]
> - Introduced `MAX_TIMEOUT_MS` constant set to 2,147,483,647 and capped `docker.buildUploadIdleTimeoutMs` in `loadConfig()` to this maximum value using `Math.min()`, preventing timeout values from exceeding the largest delay `setTimeout` honors [b9964fd]
> - Replaced fixed sleep delays in POST `/api/compute/services/:id/build` test suite with a `waitUntilSlotHeld()` polling helper that repeatedly posts build requests until a 429 response is returned [b9964fd]
> - Fixed container name matching in Docker provider to use exact matches instead of prefix matches [e27b99b]
> - Added Compute section to metadata markdown output displaying provider capabilities [e27b99b]
> - Removed duplicate `protocol` field definition in create service schema [e27b99b]
> - Changed `flyNetworkName` utility to throw typed error when APP_KEY is missing [8cde621]
> - Added test suite for `flyNetworkName` utility function [8cde621]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57e722b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in self-hosted Docker compute alongside cloud compute.
  - Services now support configurable ingress modes, CPU sizing, networking, endpoints, logs, events, and lifecycle controls.
  - Added source builds from uploaded project contexts.
  - Compute provider capabilities and configuration are available through application metadata.
  - Dashboard logs and events support deployments across providers.

- **Improvements**
  - Deployments route through their configured provider.
  - Startup reconciliation detects and repairs compute resource drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->