### PR TITLE
fix(deploy): pass the two keys .env.example already documents, and let setup.sh be driven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,15 +111,16 @@ ROOT_ADMIN_PASSWORD=change-this-password
 # Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=
 
-# API Key for authenticated requests
-# Must start with 'ik_' prefix and be at least 32 characters
-# Optional - will be auto-generated if not provided
-ACCESS_API_KEY=ik_your-api-key-here-32-chars-minimum
+# API Key for authenticated requests. Must start with 'ik_'.
+# LEAVE EMPTY unless you have a value to pin: the backend generates one on first
+# boot, and the compose file passes whatever is here straight through — so a
+# placeholder left in place becomes this instance's real superadmin key.
+# deploy/setup.sh generates one for you.
+ACCESS_API_KEY=
 
-# Anon Key for public client requests (safe to embed in frontends)
-# Must start with 'anon_' prefix
-# Optional - will be auto-generated if not provided
-ACCESS_ANON_KEY=anon_your-anon-key-here
+# Anon Key for public client requests (safe to embed in frontends). Starts with
+# 'anon_'. Same rule: empty means the backend generates it.
+ACCESS_ANON_KEY=
 
 # Cloud API Host (Optional)
 # Only needed if using cloud features

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,16 @@ COMPOSE_PROJECT_NAME=insforge
 #   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.minio.yml
 COMPOSE_FILE=docker-compose.yml
 
+# Pin the insforge-oss image to one release instead of tracking latest. The
+# other three images carry their own upstream versions in the compose file, so
+# this names that one image rather than the whole stack.
+# Empty means latest, which is the default this file has always run.
+# INSFORGE_OSS_VERSION=
+
+# Artifact stamp anonymous telemetry reads to tell the deployment paths apart.
+# Leave it alone unless you are wrapping this compose file in something else.
+# INSFORGE_DEPLOYMENT_METHOD=
+
 # -----------------------------------------------------------------------------
 # Server Configuration
 # -----------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,6 @@ COMPOSE_PROJECT_NAME=insforge
 #   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.minio.yml
 COMPOSE_FILE=docker-compose.yml
 
-
 # -----------------------------------------------------------------------------
 # Server Configuration
 # -----------------------------------------------------------------------------
@@ -111,15 +110,11 @@ ROOT_ADMIN_PASSWORD=change-this-password
 # Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=
 
-# API Key for authenticated requests. Must start with 'ik_'.
-# LEAVE EMPTY unless you have a value to pin: the backend generates one on first
-# boot, and the compose file passes whatever is here straight through — so a
-# placeholder left in place becomes this instance's real superadmin key.
-# deploy/setup.sh generates one for you.
+# API key for authenticated requests ('ik_' prefix), and anon key for public
+# clients ('anon_'). Leave empty and the backend generates them on first boot;
+# deploy/setup.sh generates them for you. Whatever is here is used as-is, so do
+# not leave a placeholder — it becomes this instance's real key.
 ACCESS_API_KEY=
-
-# Anon Key for public client requests (safe to embed in frontends). Starts with
-# 'anon_'. Same rule: empty means the backend generates it.
 ACCESS_ANON_KEY=
 
 # Cloud API Host (Optional)

--- a/.env.example
+++ b/.env.example
@@ -23,15 +23,6 @@ COMPOSE_PROJECT_NAME=insforge
 #   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.minio.yml
 COMPOSE_FILE=docker-compose.yml
 
-# Pin the insforge-oss image to one release instead of tracking latest. The
-# other three images carry their own upstream versions in the compose file, so
-# this names that one image rather than the whole stack.
-# Empty means latest, which is the default this file has always run.
-# INSFORGE_OSS_VERSION=
-
-# Artifact stamp anonymous telemetry reads to tell the deployment paths apart.
-# Leave it alone unless you are wrapping this compose file in something else.
-# INSFORGE_DEPLOYMENT_METHOD=
 
 # -----------------------------------------------------------------------------
 # Server Configuration

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Check insforge-dev skill copies are in sync
         run: scripts/sync-skills.sh --check
 
+      - name: Check deploy/setup.sh invariants
+        run: sh scripts/check-setup-sh.sh
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -59,11 +59,7 @@ services:
       - insforge-network
 
   insforge:
-    # The one image on a release train. Postgres, PostgREST and Deno are pinned
-    # to their own upstream versions above and below, which is why this names the
-    # image rather than the stack. Defaults to latest, which is what this file has
-    # always run.
-    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VERSION:-latest}
+    image: ghcr.io/insforge/insforge-oss:latest
 
     working_dir: /app
     depends_on:
@@ -129,9 +125,6 @@ services:
       - APPLE_CLIENT_SECRET=${APPLE_CLIENT_SECRET:-}
       # Logs directory
       - LOGS_DIR=/insforge-logs
-      # Artifact stamp telemetry reads to tell the deployment paths apart. This
-      # file is the docker-compose one; a caller that wraps it says so instead.
-      - INSFORGE_DEPLOYMENT_METHOD=${INSFORGE_DEPLOYMENT_METHOD:-docker-compose}
       # Anonymous telemetry (set INSFORGE_TELEMETRY_DISABLED=1 to opt out)
       - INSFORGE_TELEMETRY_DISABLED=${INSFORGE_TELEMETRY_DISABLED:-}
       # Storage directory (for local file storage when S3 is not configured)

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -59,7 +59,11 @@ services:
       - insforge-network
 
   insforge:
-    image: ghcr.io/insforge/insforge-oss:latest
+    # The one image on a release train. Postgres, PostgREST and Deno are pinned
+    # to their own upstream versions above and below, which is why this names the
+    # image rather than the stack. Defaults to latest, which is what this file has
+    # always run.
+    image: ghcr.io/insforge/insforge-oss:${INSFORGE_OSS_VERSION:-latest}
 
     working_dir: /app
     depends_on:
@@ -89,6 +93,11 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-insforge}
       - POSTGREST_BASE_URL=http://postgrest:3000
+      # The keys the CLI and SDKs authenticate with. Empty here means the backend
+      # generates its own on first boot; set them to drive this instance from a
+      # machine that already knows the values.
+      - ACCESS_API_KEY=${ACCESS_API_KEY:-}
+      - ACCESS_ANON_KEY=${ACCESS_ANON_KEY:-}
       - POSTGREST_MAX_SOCKETS=${POSTGREST_MAX_SOCKETS:-}
       - POSTGREST_MAX_FREE_SOCKETS=${POSTGREST_MAX_FREE_SOCKETS:-}
       - POSTGREST_FREE_SOCKET_TIMEOUT_MS=${POSTGREST_FREE_SOCKET_TIMEOUT_MS:-}
@@ -120,6 +129,9 @@ services:
       - APPLE_CLIENT_SECRET=${APPLE_CLIENT_SECRET:-}
       # Logs directory
       - LOGS_DIR=/insforge-logs
+      # Artifact stamp telemetry reads to tell the deployment paths apart. This
+      # file is the docker-compose one; a caller that wraps it says so instead.
+      - INSFORGE_DEPLOYMENT_METHOD=${INSFORGE_DEPLOYMENT_METHOD:-docker-compose}
       # Anonymous telemetry (set INSFORGE_TELEMETRY_DISABLED=1 to opt out)
       - INSFORGE_TELEMETRY_DISABLED=${INSFORGE_TELEMETRY_DISABLED:-}
       # Storage directory (for local file storage when S3 is not configured)

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -35,6 +35,9 @@ NO_GIT=
 # the same protection the update path relies on.
 checkout_ref() {
   [ -n "$REF" ] || return 0
+  # The HTTPS path already fetched each file at $REF, and there is no repository
+  # here to fetch into.
+  [ -z "${NO_GIT:-}" ] || return 0
   git fetch --depth 1 origin "$REF" ||
     { echo "Could not fetch $REF from origin." >&2; exit 1; }
   git checkout --detach FETCH_HEAD ||
@@ -42,8 +45,13 @@ checkout_ref() {
 }
 
 
-# Every file the image-only stack reads, plus this script so it travels with the
-# checkout. One list, used by both acquisition modes below.
+# Every file the image-only stack reads. One list, used by both acquisition modes
+# below, so they cannot disagree about what the stack needs.
+#
+# This script is not in it. The git path adds it to the sparse patterns so it
+# travels with the checkout for the update procedure; the HTTPS path has no
+# update procedure, its caller already holds the script, and a ref older than
+# this file would 404 on it and fail the whole fetch.
 #
 # functions/examples/ is deliberately absent, where the old directory pattern
 # swept it in: the compose file mounts all of functions/ but the runtime only
@@ -55,7 +63,6 @@ docker-compose.rustfs.yml
 functions/deno.json
 functions/server.ts
 functions/worker-template.js
-deploy/setup.sh
 deploy/docker-compose/docker-compose.yml
 deploy/docker-init/db/db-init.sql
 deploy/docker-init/db/jwt.sql
@@ -68,7 +75,9 @@ if [ -n "${INSFORGE_NO_GIT:-}" ] || ! command -v git >/dev/null 2>&1; then
   # Same guard as the git path below, and it matters more here: curl overwrites
   # tracked files in place without asking, where git at least refuses. A previous
   # self-host install is sparse, so it is not caught.
-  if [ -d "$TARGET/.git" ] &&
+  # -e, not -d: in a linked worktree .git is a file, and this guard read as
+  # "no git here" for exactly the tree it most needs to protect.
+  if [ -e "$TARGET/.git" ] &&
      [ "$(git -C "$TARGET" config --get core.sparseCheckout 2>/dev/null)" != true ]; then
     echo "$TARGET is a git working tree. Fetching into it would overwrite files" >&2
     echo "it tracks, including uncommitted changes." >&2
@@ -140,7 +149,8 @@ checkout_ref
 if [ -z "${NO_GIT:-}" ]; then
   # Leading slash anchors each pattern at the repository root.
   # shellcheck disable=SC2086
-  git sparse-checkout set --no-cone $(for f in $FILES; do printf '/%s ' "$f"; done)
+  git sparse-checkout set --no-cone /deploy/setup.sh \
+    $(for f in $FILES; do printf '/%s ' "$f"; done)
 fi
 
 set_var() {

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -4,19 +4,17 @@
 #   curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/insforge
 #   sh deploy/setup.sh .        # re-apply after `git merge`, see below
 #
-# Safe to re-run: an existing .env is left untouched. Does not start anything —
-# review .env first, since API_BASE_URL has to match the URL browsers will use
-# and Postgres reads .env only at first boot.
+# Safe to re-run: an existing .env is left untouched. Starts nothing — review
+# .env first, since Postgres reads it only at first boot.
 #
 # Environment:
-#   INSFORGE_REF=vX.Y.Z   Stay on one release instead of tracking main.
-#   INSFORGE_NO_GIT=1     Fetch the files over HTTPS instead of cloning. Loses
-#                         the update path below, which needs a checkout.
+#   INSFORGE_REF=vX.Y.Z   A tag, branch or commit instead of main.
+#   INSFORGE_NO_GIT=1     Fetch over HTTPS instead of cloning. No update path.
+#   INSFORGE_REPO=...     Clone source. INSFORGE_RAW=... for the HTTPS host.
 set -e
 
 REPO=${INSFORGE_REPO:-https://github.com/InsForge/InsForge.git}
-# Derived from REPO so pointing at a fork does not silently fetch the official
-# files. INSFORGE_RAW overrides it for a host that is not raw.githubusercontent.
+# Derived from REPO, so a fork does not silently fetch the official files.
 RAW=${INSFORGE_RAW:-$(echo "$REPO" |
   sed -e 's|^git@github\.com:|https://raw.githubusercontent.com/|' \
       -e 's|^https://github\.com/|https://raw.githubusercontent.com/|' \
@@ -45,18 +43,13 @@ checkout_ref() {
 }
 
 
-# Every file the image-only stack reads. One list, used by both acquisition modes
-# below, so they cannot disagree about what the stack needs.
+# Every file the image-only stack reads. Both acquisition modes read this list,
+# so they cannot disagree about what the stack needs.
 #
-# This script is not in it. The git path adds it to the sparse patterns so it
-# travels with the checkout for the update procedure; the HTTPS path has no
-# update procedure, its caller already holds the script, and a ref older than
-# this file would 404 on it and fail the whole fetch.
+# Not this script: the git path adds it to the sparse patterns separately, and on
+# the HTTPS path a ref older than this file would 404 and fail the whole fetch.
 #
-# functions/examples/ is deliberately absent, where the old directory pattern
-# swept it in: the compose file mounts all of functions/ but the runtime only
-# loads server.ts, and demo functions are not something a self-host install
-# needs on disk.
+# functions/examples/ is left out on purpose: the runtime only loads server.ts.
 FILES='.env.example
 docker-compose.minio.yml
 docker-compose.rustfs.yml
@@ -133,19 +126,10 @@ checkout_ref
 # path for it here, and without re-applying, the merge would land the file in git
 # but never in the working tree.
 #
-# --no-cone rather than cone mode: cone always adds every root-level file, which
-# would include the development docker-compose.yml. With COMPOSE_FILE unset for
-# any reason, `docker compose up` would then build from source and start dev
-# servers instead of failing with "no configuration file provided".
-#
-# git's own docs call non-cone mode deprecated, so a future git dropping the
-# flag would break this script rather than silently widening the checkout.
-# There is no cone-mode spelling of "these root files but not those".
-#
-# Built from FILES so the two acquisition modes cannot list different files. That
-# makes the patterns file-level rather than the directory-level ones this used:
-# a release that mounts a new file has to add it here, which is what the note
-# above already says.
+# --no-cone: cone mode always adds every root-level file, including the
+# development docker-compose.yml, and there is no cone-mode way to say "these
+# root files but not those". git calls non-cone deprecated, so a git that drops
+# the flag breaks this script rather than silently widening the checkout.
 if [ -z "${NO_GIT:-}" ]; then
   # Leading slash anchors each pattern at the repository root.
   # shellcheck disable=SC2086

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -18,7 +18,9 @@ REPO=${INSFORGE_REPO:-https://github.com/InsForge/InsForge.git}
 # Derived from REPO so pointing at a fork does not silently fetch the official
 # files. INSFORGE_RAW overrides it for a host that is not raw.githubusercontent.
 RAW=${INSFORGE_RAW:-$(echo "$REPO" |
-  sed -e 's|^https://github.com/|https://raw.githubusercontent.com/|' -e 's|\.git$||')}
+  sed -e 's|^git@github\.com:|https://raw.githubusercontent.com/|' \
+      -e 's|^https://github\.com/|https://raw.githubusercontent.com/|' \
+      -e 's|\.git$||')}
 REF=${INSFORGE_REF:-}
 TARGET=${1:-insforge}
 CLONED=
@@ -38,6 +40,7 @@ checkout_ref() {
   git checkout --detach FETCH_HEAD ||
     { echo "Could not check out $REF. Commit or stash local changes first." >&2; exit 1; }
 }
+
 
 # Every file the image-only stack reads, plus this script so it travels with the
 # checkout. One list, used by both acquisition modes below.
@@ -86,10 +89,8 @@ if [ -n "${NO_GIT:-}" ]; then
   : # already fetched above
 elif [ -e "$TARGET/.git" ]; then
   cd "$TARGET"
-  checkout_ref
 elif [ -z "$1" ] && [ -e .git ] && [ -f deploy/docker-compose/docker-compose.yml ]; then
-  # no target given and we are already inside a checkout
-  checkout_ref
+  : # no target given and we are already inside a checkout
 else
   # --branch takes a tag as well, so one flag covers both refs.
   git clone --depth 1 --filter=blob:none --sparse \
@@ -112,6 +113,10 @@ if [ -z "${NO_GIT:-}" ] && [ -z "$CLONED" ] &&
   echo "  sh deploy/setup.sh ~/insforge" >&2
   exit 1
 fi
+
+# Only now that the guard has accepted this directory: moving HEAD first would
+# leave a development checkout detached at the requested ref and *then* fail.
+checkout_ref
 
 # Every file the image-only stack reads, plus this script so it travels with the
 # checkout. Re-applied on every run, which is why the update procedure calls this
@@ -150,6 +155,10 @@ set_var() {
 # Compose treats an empty value as unset, so `${JWT_SECRET:-dev-secret-...}`
 # would fall back to the placeholder default. An openssl that fails — or is
 # missing — must stop the script rather than hand out a known secret.
+# $3 is an optional prefix the backend expects on that kind of key. It is added
+# here rather than by the caller so a failed openssl cannot leave the prefix
+# behind as the whole value — `ACCESS_API_KEY=ik_` is non-empty, so Compose would
+# pass it through and the backend would seed three characters as its API key.
 gen_secret() {
   value=$(openssl rand -hex "$2") || value=
   if [ -z "$value" ]; then
@@ -160,7 +169,7 @@ gen_secret() {
     echo "Could not generate $1: openssl rand failed. No .env was written." >&2
     exit 1
   fi
-  set_var "$1" "$value"
+  set_var "$1" "${3:-}$value"
 }
 
 COMPOSE_FILE_VALUE=deploy/docker-compose/docker-compose.yml
@@ -224,8 +233,8 @@ gen_secret POSTGRES_PASSWORD 16
 # The keys the CLI and SDKs authenticate with. The backend would generate its own
 # if these were empty, but then only it would know them; generating here means the
 # install has credentials to hand out. Prefixed because the backend expects it.
-set_var ACCESS_API_KEY "ik_$(openssl rand -hex 20)"
-set_var ACCESS_ANON_KEY "anon_$(openssl rand -hex 20)"
+gen_secret ACCESS_API_KEY 20 ik_
+gen_secret ACCESS_ANON_KEY 20 anon_
 
 cat <<DONE
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -62,12 +62,14 @@ deploy/docker-init/db/postgresql.conf'
 # total, against 47MB for the repository tarball, and precise where a tar glob
 # would not be — `*/functions` also matches backend/src/.../functions.
 if [ -n "${INSFORGE_NO_GIT:-}" ] || ! command -v git >/dev/null 2>&1; then
-  # Same guard as the git path below: overwriting a development clone's tracked
-  # files in place is worse here, because curl does it without asking.
+  # Same guard as the git path below, and it matters more here: curl overwrites
+  # tracked files in place without asking, where git at least refuses. A previous
+  # self-host install is sparse, so it is not caught.
   if [ -d "$TARGET/.git" ] &&
      [ "$(git -C "$TARGET" config --get core.sparseCheckout 2>/dev/null)" != true ]; then
-    echo "$TARGET is a full checkout, not a self-hosting one." >&2
-    echo "Pass a different target: sh deploy/setup.sh ~/insforge" >&2
+    echo "$TARGET is a git working tree. Fetching into it would overwrite files" >&2
+    echo "it tracks, including uncommitted changes." >&2
+    echo "Pass a directory of its own: sh deploy/setup.sh ~/insforge" >&2
     exit 1
   fi
   mkdir -p "$TARGET"
@@ -104,8 +106,10 @@ ENV_FILE=.env
 # production compose file.
 if [ -z "${NO_GIT:-}" ] && [ -z "$CLONED" ] &&
    [ "$(git config --get core.sparseCheckout)" != true ]; then
-  echo "$ROOT is a full checkout, not a self-hosting one." >&2
-  echo "Pass a target instead: sh deploy/setup.sh ~/insforge" >&2
+  echo "$ROOT is a git working tree that is not a self-host checkout." >&2
+  echo "Applying a sparse checkout here would empty it of everything outside" >&2
+  echo "this script's file list. Pass a directory of its own instead:" >&2
+  echo "  sh deploy/setup.sh ~/insforge" >&2
   exit 1
 fi
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -9,19 +9,43 @@
 # and Postgres reads .env only at first boot.
 #
 # Environment:
-#   INSFORGE_REF=v2.2.9   Stay on one release instead of tracking main.
+#   INSFORGE_REF=vX.Y.Z   Stay on one release instead of tracking main.
 #   INSFORGE_NO_GIT=1     Fetch the files over HTTPS instead of cloning. Loses
 #                         the update path below, which needs a checkout.
 set -e
 
 REPO=${INSFORGE_REPO:-https://github.com/InsForge/InsForge.git}
-RAW=${INSFORGE_RAW:-https://raw.githubusercontent.com/InsForge/InsForge}
+# Derived from REPO so pointing at a fork does not silently fetch the official
+# files. INSFORGE_RAW overrides it for a host that is not raw.githubusercontent.
+RAW=${INSFORGE_RAW:-$(echo "$REPO" |
+  sed -e 's|^https://github.com/|https://raw.githubusercontent.com/|' -e 's|\.git$||')}
 REF=${INSFORGE_REF:-}
 TARGET=${1:-insforge}
 CLONED=
+# Initialized rather than assigned only inside the branch below: an inherited
+# NO_GIT from the caller's environment would otherwise skip acquisition entirely
+# and run the rest against whatever directory invoked this.
+NO_GIT=
+
+# Move an existing checkout onto INSFORGE_REF. Without this the ref was honoured
+# only by the first clone, so re-running with a different one reported success
+# and changed nothing. git refuses rather than discarding local edits, which is
+# the same protection the update path relies on.
+checkout_ref() {
+  [ -n "$REF" ] || return 0
+  git fetch --depth 1 origin "$REF" ||
+    { echo "Could not fetch $REF from origin." >&2; exit 1; }
+  git checkout --detach FETCH_HEAD ||
+    { echo "Could not check out $REF. Commit or stash local changes first." >&2; exit 1; }
+}
 
 # Every file the image-only stack reads, plus this script so it travels with the
 # checkout. One list, used by both acquisition modes below.
+#
+# functions/examples/ is deliberately absent, where the old directory pattern
+# swept it in: the compose file mounts all of functions/ but the runtime only
+# loads server.ts, and demo functions are not something a self-host install
+# needs on disk.
 FILES='.env.example
 docker-compose.minio.yml
 docker-compose.rustfs.yml
@@ -38,6 +62,14 @@ deploy/docker-init/db/postgresql.conf'
 # total, against 47MB for the repository tarball, and precise where a tar glob
 # would not be — `*/functions` also matches backend/src/.../functions.
 if [ -n "${INSFORGE_NO_GIT:-}" ] || ! command -v git >/dev/null 2>&1; then
+  # Same guard as the git path below: overwriting a development clone's tracked
+  # files in place is worse here, because curl does it without asking.
+  if [ -d "$TARGET/.git" ] &&
+     [ "$(git -C "$TARGET" config --get core.sparseCheckout 2>/dev/null)" != true ]; then
+    echo "$TARGET is a full checkout, not a self-hosting one." >&2
+    echo "Pass a different target: sh deploy/setup.sh ~/insforge" >&2
+    exit 1
+  fi
   mkdir -p "$TARGET"
   cd "$TARGET"
   for f in $FILES; do
@@ -52,8 +84,10 @@ if [ -n "${NO_GIT:-}" ]; then
   : # already fetched above
 elif [ -e "$TARGET/.git" ]; then
   cd "$TARGET"
+  checkout_ref
 elif [ -z "$1" ] && [ -e .git ] && [ -f deploy/docker-compose/docker-compose.yml ]; then
-  : # no target given and we are already inside a checkout
+  # no target given and we are already inside a checkout
+  checkout_ref
 else
   # --branch takes a tag as well, so one flag covers both refs.
   git clone --depth 1 --filter=blob:none --sparse \
@@ -182,6 +216,12 @@ gen_secret ROOT_ADMIN_PASSWORD 12
 # Postgres reads this only when it initializes the cluster, so it has to be
 # settled before the first boot — after that, editing .env changes nothing.
 gen_secret POSTGRES_PASSWORD 16
+
+# The keys the CLI and SDKs authenticate with. The backend would generate its own
+# if these were empty, but then only it would know them; generating here means the
+# install has credentials to hand out. Prefixed because the backend expects it.
+set_var ACCESS_API_KEY "ik_$(openssl rand -hex 20)"
+set_var ACCESS_ANON_KEY "anon_$(openssl rand -hex 20)"
 
 cat <<DONE
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Check out the files a self-hosted InsForge needs, and generate its secrets.
+# Fetch the files a self-hosted InsForge needs, and generate its secrets.
 #
 #   curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/insforge
 #   sh deploy/setup.sh .        # re-apply after `git merge`, see below
@@ -7,18 +7,57 @@
 # Safe to re-run: an existing .env is left untouched. Does not start anything —
 # review .env first, since API_BASE_URL has to match the URL browsers will use
 # and Postgres reads .env only at first boot.
+#
+# Environment:
+#   INSFORGE_REF=v2.2.9   Stay on one release instead of tracking main.
+#   INSFORGE_NO_GIT=1     Fetch the files over HTTPS instead of cloning. Loses
+#                         the update path below, which needs a checkout.
 set -e
 
 REPO=${INSFORGE_REPO:-https://github.com/InsForge/InsForge.git}
+RAW=${INSFORGE_RAW:-https://raw.githubusercontent.com/InsForge/InsForge}
+REF=${INSFORGE_REF:-}
 TARGET=${1:-insforge}
 CLONED=
 
-if [ -e "$TARGET/.git" ]; then
+# Every file the image-only stack reads, plus this script so it travels with the
+# checkout. One list, used by both acquisition modes below.
+FILES='.env.example
+docker-compose.minio.yml
+docker-compose.rustfs.yml
+functions/deno.json
+functions/server.ts
+functions/worker-template.js
+deploy/setup.sh
+deploy/docker-compose/docker-compose.yml
+deploy/docker-init/db/db-init.sql
+deploy/docker-init/db/jwt.sql
+deploy/docker-init/db/postgresql.conf'
+
+# No git, or asked not to use it: fetch each file straight from the ref. 34KB in
+# total, against 47MB for the repository tarball, and precise where a tar glob
+# would not be — `*/functions` also matches backend/src/.../functions.
+if [ -n "${INSFORGE_NO_GIT:-}" ] || ! command -v git >/dev/null 2>&1; then
+  mkdir -p "$TARGET"
+  cd "$TARGET"
+  for f in $FILES; do
+    mkdir -p "$(dirname "$f")"
+    curl -fsSL "$RAW/${REF:-main}/$f" -o "$f" ||
+      { echo "Could not fetch $f at ${REF:-main} from $RAW." >&2; exit 1; }
+  done
+  NO_GIT=1
+fi
+
+if [ -n "${NO_GIT:-}" ]; then
+  : # already fetched above
+elif [ -e "$TARGET/.git" ]; then
   cd "$TARGET"
 elif [ -z "$1" ] && [ -e .git ] && [ -f deploy/docker-compose/docker-compose.yml ]; then
   : # no target given and we are already inside a checkout
 else
-  git clone --depth 1 --filter=blob:none --sparse "$REPO" "$TARGET"
+  # --branch takes a tag as well, so one flag covers both refs.
+  git clone --depth 1 --filter=blob:none --sparse \
+    ${REF:+--branch "$REF"} "$REPO" "$TARGET"
   cd "$TARGET"
   CLONED=1
 fi
@@ -29,7 +68,8 @@ ENV_FILE=.env
 # A full checkout is somebody's development clone: the sparse-checkout below
 # would empty its working tree, and COMPOSE_FILE would repoint its .env at the
 # production compose file.
-if [ -z "$CLONED" ] && [ "$(git config --get core.sparseCheckout)" != true ]; then
+if [ -z "${NO_GIT:-}" ] && [ -z "$CLONED" ] &&
+   [ "$(git config --get core.sparseCheckout)" != true ]; then
   echo "$ROOT is a full checkout, not a self-hosting one." >&2
   echo "Pass a target instead: sh deploy/setup.sh ~/insforge" >&2
   exit 1
@@ -49,13 +89,16 @@ fi
 # git's own docs call non-cone mode deprecated, so a future git dropping the
 # flag would break this script rather than silently widening the checkout.
 # There is no cone-mode spelling of "these root files but not those".
-git sparse-checkout set --no-cone \
-  /.env.example \
-  /docker-compose.minio.yml /docker-compose.rustfs.yml \
-  /functions/ \
-  /deploy/setup.sh \
-  /deploy/docker-compose/docker-compose.yml \
-  /deploy/docker-init/db/
+#
+# Built from FILES so the two acquisition modes cannot list different files. That
+# makes the patterns file-level rather than the directory-level ones this used:
+# a release that mounts a new file has to add it here, which is what the note
+# above already says.
+if [ -z "${NO_GIT:-}" ]; then
+  # Leading slash anchors each pattern at the repository root.
+  # shellcheck disable=SC2086
+  git sparse-checkout set --no-cone $(for f in $FILES; do printf '/%s ' "$f"; done)
+fi
 
 set_var() {
   tmp=$(mktemp)

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -935,19 +935,29 @@ docker compose down
 
 #### 16.2 Pin the Previous Version
 
-Set the version you were running in `.env`, then start again:
+Write an overlay naming the version you were running, next to your `.env`:
+
+```yaml
+# pin.yml
+services:
+  insforge:
+    image: ghcr.io/insforge/insforge-oss:v2.2.9
+```
+
+Append it to `COMPOSE_FILE` in `.env`, then start again:
 
 ```env
-INSFORGE_OSS_VERSION=v2.2.9
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```
 
 ```bash
 docker compose up -d
 ```
 
-Set it in `.env` rather than editing the compose file. `.env` is yours and no update touches it, while a compose file you have edited makes the next `git merge --ff-only` refuse rather than overwrite your change — which is the protection working, but it leaves you unable to update until you revert the edit.
-
-`docker compose images` lists what is running now, and 14.3 records the version before an update so there is something to pin back to.
+An overlay rather than an edit to the compose file: it is a file of your own that
+no update touches, and the same trick pins any image in the stack, not just this
+one. `docker compose images` lists what is running, and 14.3 records the versions
+before an update so there is something to pin back to.
 
 #### 16.3 Restore the Database (If Needed)
 

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -933,25 +933,23 @@ cd ~/insforge
 docker compose down
 ```
 
-#### 16.2 Restore the Previous Docker Compose File
+#### 16.2 Pin the Previous Version
+
+Set the version you were running in `.env`, then start again:
+
+```env
+INSFORGE_OSS_VERSION=v2.2.9
+```
 
 ```bash
-# If you saved the old file
-mv docker-compose.yml.old docker-compose.yml
+docker compose up -d
 ```
 
-#### 16.3 Pin to a Specific Image Version
+Set it in `.env` rather than editing the compose file. `.env` is yours and no update touches it, while a compose file you have edited makes the next `git merge --ff-only` refuse rather than overwrite your change — which is the protection working, but it leaves you unable to update until you revert the edit.
 
-Edit `docker-compose.yml` and replace `latest` tags with the previous version:
+`docker compose images` lists what is running now, and 14.3 records the version before an update so there is something to pin back to.
 
-```yaml
-# Example: pin to a known-good version (replace with your previous tag)
-image: ghcr.io/insforge/insforge-oss:v1.5.0
-```
-
-> Note: the current `deploy/docker-compose` pins `v1.5.0`, and the project is now on the 2.x line. Pin to whatever version you were running before the update.
-
-#### 16.4 Restore the Database (If Needed)
+#### 16.3 Restore the Database (If Needed)
 
 Only restore the database if the update included a database migration that caused issues:
 
@@ -974,7 +972,7 @@ cat backup_YYYYMMDD_HHMMSS.sql | \
 docker compose up -d
 ```
 
-#### 16.5 Restore Environment File (If Changed)
+#### 16.4 Restore Environment File (If Changed)
 
 ```bash
 cp .env.backup_YYYYMMDD .env

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -944,15 +944,21 @@ services:
     image: ghcr.io/insforge/insforge-oss:v2.2.9
 ```
 
-Append it to `COMPOSE_FILE` in `.env`, then start again:
+Append it to whatever `COMPOSE_FILE` already holds in `.env` — keep the entries
+that are there, or a storage overlay you had enabled drops out of the stack:
 
 ```env
+# was: COMPOSE_FILE=deploy/docker-compose/docker-compose.yml
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```
 
 ```bash
 docker compose up -d
 ```
+
+**Remove the `:pin.yml` when you are done.** While it is there, section 15's
+update pulls new images and then keeps running the pinned one — the pin wins over
+`latest`, silently, for as long as the entry stays.
 
 An overlay rather than an edit to the compose file: it is a file of your own that
 no update touches, and the same trick pins any image in the stack, not just this

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -935,35 +935,26 @@ docker compose down
 
 #### 16.2 Pin the Previous Version
 
-Write an overlay naming the version you were running, next to your `.env`:
+1. Write `pin.yml` next to your `.env`, naming the version 14.3 recorded:
 
-```yaml
-# pin.yml
-services:
-  insforge:
-    image: ghcr.io/insforge/insforge-oss:v2.2.9
-```
+   ```yaml
+   services:
+     insforge:
+       image: ghcr.io/insforge/insforge-oss:v2.2.9
+   ```
 
-Append it to whatever `COMPOSE_FILE` already holds in `.env` — keep the entries
-that are there, or a storage overlay you had enabled drops out of the stack:
+2. Append it to `COMPOSE_FILE` in `.env`, keeping the entries already there:
 
-```env
-# was: COMPOSE_FILE=deploy/docker-compose/docker-compose.yml
-COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
-```
+   ```env
+   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
+   ```
 
-```bash
-docker compose up -d
-```
+3. `docker compose up -d`
 
-**Remove the `:pin.yml` when you are done.** While it is there, section 15's
-update pulls new images and then keeps running the pinned one — the pin wins over
-`latest`, silently, for as long as the entry stays.
+4. Remove `:pin.yml` once you are back on a good release.
 
-An overlay rather than an edit to the compose file: it is a file of your own that
-no update touches, and the same trick pins any image in the stack, not just this
-one. `docker compose images` lists what is running, and 14.3 records the versions
-before an update so there is something to pin back to.
+Until you do, section 15's update pulls new images and keeps running the pinned
+one.
 
 #### 16.3 Restore the Database (If Needed)
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -924,25 +924,23 @@ cd ~/insforge
 docker compose down
 ```
 
-#### 16.2 Restaura el archivo de Docker Compose anterior
+#### 16.2 Fija la versión anterior
+
+Escribe en `.env` la versión que ejecutabas antes y arranca de nuevo:
+
+```env
+INSFORGE_OSS_VERSION=v2.2.9
+```
 
 ```bash
-# If you saved the old file
-mv docker-compose.yml.old docker-compose.yml
+docker compose up -d
 ```
 
-#### 16.3 Fija una versión específica de la imagen
+Defínela en `.env` en lugar de editar el archivo compose. `.env` es tuyo y ninguna actualización lo toca, mientras que un archivo compose que hayas editado hace que el siguiente `git merge --ff-only` se niegue en vez de sobrescribir tu cambio — la protección funcionando, pero te deja sin poder actualizar hasta que revi ertas la edición.
 
-Edita `docker-compose.yml` y sustituye las etiquetas `latest` por la versión anterior:
+`docker compose images` muestra qué versión se está ejecutando, y 14.3 registra la versión antes de una actualización para tener algo a lo que volver.
 
-```yaml
-# Example: pin to a known-good version (replace with your previous tag)
-image: ghcr.io/insforge/insforge-oss:v1.5.0
-```
-
-> Nota: el `deploy/docker-compose` actual fija la versión `v1.5.0`, y el proyecto ya está en la línea 2.x. Fija la versión que estuvieras ejecutando antes de la actualización.
-
-#### 16.4 Restaura la base de datos (si es necesario)
+#### 16.3 Restaura la base de datos (si es necesario)
 
 Restaura la base de datos solo si la actualización incluyó una migración de base de datos que causó problemas:
 
@@ -965,7 +963,7 @@ cat backup_YYYYMMDD_HHMMSS.sql | \
 docker compose up -d
 ```
 
-#### 16.5 Restaura el archivo de entorno (si cambió)
+#### 16.4 Restaura el archivo de entorno (si cambió)
 
 ```bash
 cp .env.backup_YYYYMMDD .env

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -935,7 +935,7 @@ services:
     image: ghcr.io/insforge/insforge-oss:v2.2.9
 ```
 
-Añádelo a `COMPOSE_FILE` en `.env` y arranca de nuevo:
+Añádelo a lo que `COMPOSE_FILE` ya contenga en `.env` — conserva las entradas que estén allí, o un overlay de almacenamiento que hubieras activado desaparece del stack:
 
 ```env
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
@@ -944,6 +944,8 @@ COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```bash
 docker compose up -d
 ```
+
+**Quita el `:pin.yml` cuando termines.** Mientras esté ahí, la actualización de la sección 15 descarga imágenes nuevas y sigue ejecutando la fijada: el pin gana sobre `latest`, en silencio, mientras la entrada permanezca.
 
 Un overlay en lugar de editar el archivo compose: es un archivo tuyo que ninguna
 actualización toca, y el mismo recurso fija cualquier imagen del stack, no solo

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -926,31 +926,26 @@ docker compose down
 
 #### 16.2 Fija la versión anterior
 
-Escribe un overlay con la versión que ejecutabas, junto a tu `.env`:
+1. Escribe `pin.yml` junto a tu `.env`, con la versión que registró 14.3:
 
-```yaml
-# pin.yml
-services:
-  insforge:
-    image: ghcr.io/insforge/insforge-oss:v2.2.9
-```
+   ```yaml
+   services:
+     insforge:
+       image: ghcr.io/insforge/insforge-oss:v2.2.9
+   ```
 
-Añádelo a lo que `COMPOSE_FILE` ya contenga en `.env` — conserva las entradas que estén allí, o un overlay de almacenamiento que hubieras activado desaparece del stack:
+2. Añádelo a `COMPOSE_FILE` en `.env`, conservando las entradas que ya estén:
 
-```env
-COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
-```
+   ```env
+   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
+   ```
 
-```bash
-docker compose up -d
-```
+3. `docker compose up -d`
 
-**Quita el `:pin.yml` cuando termines.** Mientras esté ahí, la actualización de la sección 15 descarga imágenes nuevas y sigue ejecutando la fijada: el pin gana sobre `latest`, en silencio, mientras la entrada permanezca.
+4. Quita `:pin.yml` cuando vuelvas a una versión buena.
 
-Un overlay en lugar de editar el archivo compose: es un archivo tuyo que ninguna
-actualización toca, y el mismo recurso fija cualquier imagen del stack, no solo
-esta. `docker compose images` muestra qué se está ejecutando, y 14.3 registra las
-versiones antes de una actualización para tener algo a lo que volver.
+Hasta que lo hagas, la actualización de la sección 15 descarga imágenes nuevas y
+sigue ejecutando la fijada.
 
 #### 16.3 Restaura la base de datos (si es necesario)
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -926,19 +926,29 @@ docker compose down
 
 #### 16.2 Fija la versión anterior
 
-Escribe en `.env` la versión que ejecutabas antes y arranca de nuevo:
+Escribe un overlay con la versión que ejecutabas, junto a tu `.env`:
+
+```yaml
+# pin.yml
+services:
+  insforge:
+    image: ghcr.io/insforge/insforge-oss:v2.2.9
+```
+
+Añádelo a `COMPOSE_FILE` en `.env` y arranca de nuevo:
 
 ```env
-INSFORGE_OSS_VERSION=v2.2.9
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```
 
 ```bash
 docker compose up -d
 ```
 
-Defínela en `.env` en lugar de editar el archivo compose. `.env` es tuyo y ninguna actualización lo toca, mientras que un archivo compose que hayas editado hace que el siguiente `git merge --ff-only` se niegue en vez de sobrescribir tu cambio — la protección funcionando, pero te deja sin poder actualizar hasta que revi ertas la edición.
-
-`docker compose images` muestra qué versión se está ejecutando, y 14.3 registra la versión antes de una actualización para tener algo a lo que volver.
+Un overlay en lugar de editar el archivo compose: es un archivo tuyo que ninguna
+actualización toca, y el mismo recurso fija cualquier imagen del stack, no solo
+esta. `docker compose images` muestra qué se está ejecutando, y 14.3 registra las
+versiones antes de una actualización para tener algo a lo que volver.
 
 #### 16.3 Restaura la base de datos (si es necesario)
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -934,7 +934,7 @@ services:
     image: ghcr.io/insforge/insforge-oss:v2.2.9
 ```
 
-將它附加到 `.env` 中的 `COMPOSE_FILE`，然後重新啟動：
+將它**附加**到 `.env` 中 `COMPOSE_FILE` 既有的內容之後——保留原有項目，否則你啟用過的儲存 overlay 會從 stack 中掉出：
 
 ```env
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
@@ -943,6 +943,8 @@ COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```bash
 docker compose up -d
 ```
+
+**用完請將 `:pin.yml` 移除。** 它留著的期間，第 15 節的更新會拉取新映像，然後繼續執行被固定的那個——pin 會靜默地覆蓋 `latest`。
 
 用 overlay 而不是直接修改 compose 檔案：它是你自己的檔案，任何更新都不會動；而且同樣的方式能固定 stack 中任何一個映像，不限於這一個。`docker compose images` 可以看到目前執行的版本，14.3 會在更新前記錄，這樣才有可回退的目標。
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -923,25 +923,23 @@ cd ~/insforge
 docker compose down
 ```
 
-#### 16.2 還原先前的 Docker Compose 檔案
+#### 16.2 固定回先前的版本
+
+在 `.env` 中寫上你更新前執行的版本，然後重新啟動：
+
+```env
+INSFORGE_OSS_VERSION=v2.2.9
+```
 
 ```bash
-# If you saved the old file
-mv docker-compose.yml.old docker-compose.yml
+docker compose up -d
 ```
 
-#### 16.3 固定至指定的映像檔版本
+要寫在 `.env` 中，不要去修改 compose 檔案。`.env` 屬於你，任何更新都不會動它；而被你修改過的 compose 檔案會讓下一次 `git merge --ff-only` 拒絕合併——那是保護機制在運作，但在你還原修改之前就無法更新了。
 
-編輯 `docker-compose.yml`，將 `latest` 標籤替換為先前的版本：
+`docker compose images` 可以看到目前執行的版本，14.3 會在更新前記錄版本，這樣才有可回退的目標。
 
-```yaml
-# Example: pin to a known-good version (replace with your previous tag)
-image: ghcr.io/insforge/insforge-oss:v1.5.0
-```
-
-> 注意：目前 `deploy/docker-compose` 固定使用 `v1.5.0`，而專案現已進展到 2.x 系列。請固定至你更新前所執行的版本。
-
-#### 16.4 還原資料庫（如有需要）
+#### 16.3 還原資料庫（如有需要）
 
 僅當此次更新包含造成問題的資料庫遷移時，才需要還原資料庫：
 
@@ -964,7 +962,7 @@ cat backup_YYYYMMDD_HHMMSS.sql | \
 docker compose up -d
 ```
 
-#### 16.5 還原環境變數檔案（如有變更）
+#### 16.4 還原環境變數檔案（如有變更）
 
 ```bash
 cp .env.backup_YYYYMMDD .env

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -925,28 +925,25 @@ docker compose down
 
 #### 16.2 固定回先前的版本
 
-在 `.env` 旁邊寫一個 overlay，指明你更新前執行的版本：
+1. 在 `.env` 旁邊寫 `pin.yml`，填 14.3 記錄的版本：
 
-```yaml
-# pin.yml
-services:
-  insforge:
-    image: ghcr.io/insforge/insforge-oss:v2.2.9
-```
+   ```yaml
+   services:
+     insforge:
+       image: ghcr.io/insforge/insforge-oss:v2.2.9
+   ```
 
-將它**附加**到 `.env` 中 `COMPOSE_FILE` 既有的內容之後——保留原有項目，否則你啟用過的儲存 overlay 會從 stack 中掉出：
+2. 附加到 `.env` 中的 `COMPOSE_FILE`，保留既有項目：
 
-```env
-COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
-```
+   ```env
+   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
+   ```
 
-```bash
-docker compose up -d
-```
+3. `docker compose up -d`
 
-**用完請將 `:pin.yml` 移除。** 它留著的期間，第 15 節的更新會拉取新映像，然後繼續執行被固定的那個——pin 會靜默地覆蓋 `latest`。
+4. 回到可用版本後，將 `:pin.yml` 移除。
 
-用 overlay 而不是直接修改 compose 檔案：它是你自己的檔案，任何更新都不會動；而且同樣的方式能固定 stack 中任何一個映像，不限於這一個。`docker compose images` 可以看到目前執行的版本，14.3 會在更新前記錄，這樣才有可回退的目標。
+在移除之前，第 15 節的更新會拉取新映像，但仍然執行被固定的那個。
 
 #### 16.3 還原資料庫（如有需要）
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -925,19 +925,26 @@ docker compose down
 
 #### 16.2 固定回先前的版本
 
-在 `.env` 中寫上你更新前執行的版本，然後重新啟動：
+在 `.env` 旁邊寫一個 overlay，指明你更新前執行的版本：
+
+```yaml
+# pin.yml
+services:
+  insforge:
+    image: ghcr.io/insforge/insforge-oss:v2.2.9
+```
+
+將它附加到 `.env` 中的 `COMPOSE_FILE`，然後重新啟動：
 
 ```env
-INSFORGE_OSS_VERSION=v2.2.9
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```
 
 ```bash
 docker compose up -d
 ```
 
-要寫在 `.env` 中，不要去修改 compose 檔案。`.env` 屬於你，任何更新都不會動它；而被你修改過的 compose 檔案會讓下一次 `git merge --ff-only` 拒絕合併——那是保護機制在運作，但在你還原修改之前就無法更新了。
-
-`docker compose images` 可以看到目前執行的版本，14.3 會在更新前記錄版本，這樣才有可回退的目標。
+用 overlay 而不是直接修改 compose 檔案：它是你自己的檔案，任何更新都不會動；而且同樣的方式能固定 stack 中任何一個映像，不限於這一個。`docker compose images` 可以看到目前執行的版本，14.3 會在更新前記錄，這樣才有可回退的目標。
 
 #### 16.3 還原資料庫（如有需要）
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -924,28 +924,25 @@ docker compose down
 
 #### 16.2 固定回之前的版本
 
-在 `.env` 旁边写一个 overlay，指明你更新前运行的版本：
+1. 在 `.env` 旁边写 `pin.yml`，填 14.3 记录的版本：
 
-```yaml
-# pin.yml
-services:
-  insforge:
-    image: ghcr.io/insforge/insforge-oss:v2.2.9
-```
+   ```yaml
+   services:
+     insforge:
+       image: ghcr.io/insforge/insforge-oss:v2.2.9
+   ```
 
-把它**追加**到 `.env` 中 `COMPOSE_FILE` 已有的内容之后——保留原有条目，否则你启用过的存储 overlay 会从栈里掉出去：
+2. 追加到 `.env` 里的 `COMPOSE_FILE`，保留已有条目：
 
-```env
-COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
-```
+   ```env
+   COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
+   ```
 
-```bash
-docker compose up -d
-```
+3. `docker compose up -d`
 
-**用完记得把 `:pin.yml` 去掉。** 它留在那里的期间，第 15 节的更新会拉到新镜像，然后继续跑被钉住的那个——pin 会静默地压过 `latest`。
+4. 回到可用版本后，把 `:pin.yml` 去掉。
 
-用 overlay 而不是直接改 compose 文件：它是你自己的文件，任何更新都不会碰；而且同样的办法能钉栈里任何一个镜像，不限于这一个。`docker compose images` 能看到当前跑的版本，14.3 会在更新前记录，这样才有可回退的目标。
+在去掉之前，第 15 节的更新会拉到新镜像，但仍然跑被钉住的那个。
 
 #### 16.3 恢复数据库（如有需要）
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -924,19 +924,26 @@ docker compose down
 
 #### 16.2 固定回之前的版本
 
-在 `.env` 里写上你更新前运行的版本，然后重新启动：
+在 `.env` 旁边写一个 overlay，指明你更新前运行的版本：
+
+```yaml
+# pin.yml
+services:
+  insforge:
+    image: ghcr.io/insforge/insforge-oss:v2.2.9
+```
+
+把它追加到 `.env` 里的 `COMPOSE_FILE`，然后重新启动：
 
 ```env
-INSFORGE_OSS_VERSION=v2.2.9
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```
 
 ```bash
 docker compose up -d
 ```
 
-要写在 `.env` 里，不要去改 compose 文件。`.env` 属于你，任何更新都不会碰它；而被你改过的 compose 文件会让下一次 `git merge --ff-only` 拒绝合并——那是保护机制在起作用，但你在撤回改动之前就无法更新了。
-
-`docker compose images` 能看到当前跑的是什么版本，14.3 会在更新前记录版本，这样才有可回退的目标。
+用 overlay 而不是直接改 compose 文件：它是你自己的文件，任何更新都不会碰；而且同样的办法能钉栈里任何一个镜像，不限于这一个。`docker compose images` 能看到当前跑的版本，14.3 会在更新前记录，这样才有可回退的目标。
 
 #### 16.3 恢复数据库（如有需要）
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -922,25 +922,23 @@ cd ~/insforge
 docker compose down
 ```
 
-#### 16.2 恢复之前的 Docker Compose 文件
+#### 16.2 固定回之前的版本
+
+在 `.env` 里写上你更新前运行的版本，然后重新启动：
+
+```env
+INSFORGE_OSS_VERSION=v2.2.9
+```
 
 ```bash
-# If you saved the old file
-mv docker-compose.yml.old docker-compose.yml
+docker compose up -d
 ```
 
-#### 16.3 固定到指定的镜像版本
+要写在 `.env` 里，不要去改 compose 文件。`.env` 属于你，任何更新都不会碰它；而被你改过的 compose 文件会让下一次 `git merge --ff-only` 拒绝合并——那是保护机制在起作用，但你在撤回改动之前就无法更新了。
 
-编辑 `docker-compose.yml`，将 `latest` 标签替换为之前的版本：
+`docker compose images` 能看到当前跑的是什么版本，14.3 会在更新前记录版本，这样才有可回退的目标。
 
-```yaml
-# Example: pin to a known-good version (replace with your previous tag)
-image: ghcr.io/insforge/insforge-oss:v1.5.0
-```
-
-> 注意：目前 `deploy/docker-compose` 固定使用 `v1.5.0`，而项目目前已在 2.x 系列。请固定到你更新之前所运行的版本。
-
-#### 16.4 恢复数据库（如有需要）
+#### 16.3 恢复数据库（如有需要）
 
 只有当此次更新包含导致问题的数据库迁移时，才需要恢复数据库：
 
@@ -963,7 +961,7 @@ cat backup_YYYYMMDD_HHMMSS.sql | \
 docker compose up -d
 ```
 
-#### 16.5 恢复环境变量文件（如有更改）
+#### 16.4 恢复环境变量文件（如有更改）
 
 ```bash
 cp .env.backup_YYYYMMDD .env

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -933,7 +933,7 @@ services:
     image: ghcr.io/insforge/insforge-oss:v2.2.9
 ```
 
-把它追加到 `.env` 里的 `COMPOSE_FILE`，然后重新启动：
+把它**追加**到 `.env` 中 `COMPOSE_FILE` 已有的内容之后——保留原有条目，否则你启用过的存储 overlay 会从栈里掉出去：
 
 ```env
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
@@ -942,6 +942,8 @@ COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
 ```bash
 docker compose up -d
 ```
+
+**用完记得把 `:pin.yml` 去掉。** 它留在那里的期间，第 15 节的更新会拉到新镜像，然后继续跑被钉住的那个——pin 会静默地压过 `latest`。
 
 用 overlay 而不是直接改 compose 文件：它是你自己的文件，任何更新都不会碰；而且同样的办法能钉栈里任何一个镜像，不限于这一个。`docker compose images` 能看到当前跑的版本，14.3 会在更新前记录，这样才有可回退的目标。
 

--- a/scripts/check-setup-sh.sh
+++ b/scripts/check-setup-sh.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env sh
+# Structural checks on deploy/setup.sh.
+#
+# Every rule here exists because the invariant it guards was broken after being
+# established — twice by bypassing a helper written to enforce it, once by
+# inserting a call ahead of the guard meant to run first. Those regressions do
+# not show up in a diff review or a happy-path run, so they are asserted here.
+#
+#   sh scripts/check-setup-sh.sh
+set -e
+
+SCRIPT=deploy/setup.sh
+fails=0
+
+fail() {
+  echo "✗ $1" >&2
+  fails=$((fails + 1))
+}
+
+# ── Secrets ─────────────────────────────────────────────────────────────────
+# gen_secret aborts and removes the half-written .env when openssl fails.
+# set_var does not, and Compose treats a non-empty value as authoritative — so a
+# secret written with set_var can ship as the empty string, or as a bare prefix.
+if grep -nE '^set_var (JWT_SECRET|ENCRYPTION_KEY|ROOT_ADMIN_PASSWORD|POSTGRES_PASSWORD|ACCESS_API_KEY|ACCESS_ANON_KEY)' "$SCRIPT"; then
+  fail "secret written with set_var; use gen_secret so a failed openssl aborts"
+fi
+
+# Same rule stated the other way: nothing may inline a generator into set_var.
+if grep -nE 'set_var [A-Z_]+ ".*\$\(openssl' "$SCRIPT"; then
+  fail "openssl inlined into set_var; the prefix would survive as the value"
+fi
+
+# ── Guard ordering ──────────────────────────────────────────────────────────
+# Anything that writes to the target has to run after the guard that refuses a
+# git working tree, or the guard reports damage it was placed there to prevent.
+guard=$(grep -n 'is a git working tree that is not' "$SCRIPT" | head -1 | cut -d: -f1)
+[ -n "$guard" ] || fail "cannot find the working-tree guard"
+if [ -n "$guard" ]; then
+  for op in '^checkout_ref$' '^ *git sparse-checkout set' '^cp \.env\.example'; do
+    line=$(grep -nE "$op" "$SCRIPT" | head -1 | cut -d: -f1)
+    if [ -n "$line" ] && [ "$line" -lt "$guard" ]; then
+      fail "$op runs at line $line, before the guard at $guard"
+    fi
+  done
+fi
+
+# ── git presence ────────────────────────────────────────────────────────────
+# In a linked worktree .git is a file, so -d reads as "no repository here" for
+# exactly the tree the guard most needs to catch.
+if grep -nE '\[ -d "\$[A-Za-z_]+/\.git" \]' "$SCRIPT"; then
+  fail "-d on a .git path; use -e so a linked worktree is not missed"
+fi
+
+# Every git call has to be skipped in the HTTPS path, where there is no
+# repository to run it against.
+if ! grep -q '\[ -z "${NO_GIT:-}" \] || return 0' "$SCRIPT"; then
+  fail "checkout_ref does not bail out when NO_GIT is set"
+fi
+
+# ── File list ───────────────────────────────────────────────────────────────
+# Both acquisition modes read FILES, so a path in one and not the other means a
+# self-host install differs by how it was fetched.
+if grep -q '^deploy/setup\.sh$' "$SCRIPT"; then
+  fail "deploy/setup.sh is in FILES; refs older than it 404 the whole fetch"
+fi
+
+# Every path FILES names has to exist, or the fetch fails for everyone at once.
+list=$(sed -n "/^FILES='/,/'$/p" "$SCRIPT" | sed -e "s/^FILES='//" -e "s/'$//")
+for f in $list; do
+  [ -e "$f" ] || fail "FILES names $f, which is not in this repository"
+done
+
+# And every file the compose file mounts has to be in FILES, or the stack starts
+# without it.
+# Strip every leading ../ so ../docker-init/db/x and ../../functions both reduce
+# to the repository-relative path FILES uses.
+for mounted in $(grep -oE '^ *- \.\.[./]*[a-z][a-z/.-]*' deploy/docker-compose/docker-compose.yml |
+    sed -e 's|^ *- ||' -e 's|^\(\.\./\)*||' | sort -u); do
+  case $mounted in
+    functions)
+      echo "$list" | grep -q '^functions/' ||
+        fail "compose mounts functions/, absent from FILES" ;;
+    *)
+      echo "$list" | grep -qF "$mounted" ||
+        fail "compose mounts $mounted, absent from FILES" ;;
+  esac
+done
+
+if [ "$fails" -eq 0 ]; then
+  echo "✓ deploy/setup.sh: all structural checks passed"
+else
+  echo "$fails check(s) failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
Three changes, each standing on its own.

## The compose file drops two variables `.env.example` documents

`.env.example` lines 121–129 document `ACCESS_API_KEY` and `ACCESS_ANON_KEY` as settable — *"Optional - will be auto-generated if not provided"* — and the backend seeds from them when present (`secret.service.ts:840`). `deploy/docker-compose/docker-compose.yml` never passed them, so a self-hoster who set them in `.env` saw no effect.

Same inconsistency as section 5.4 telling people to set `AWS_*` variables the file does not pass, which #1887 fixed. This fixes the other half.

Empty defaults, so nothing changes for anyone not setting them: the backend keeps generating its own.

## setup.sh can be driven

**`INSFORGE_REF`** — stay on one ref instead of tracking main. Self-hosting had no way to pin a release at all.

**`INSFORGE_NO_GIT=1`** (or no git on PATH) — fetch the files over HTTPS instead of cloning. 34KB, against 47MB for the repository tarball. I tried the tarball first: `tar` globs cannot portably express "`functions/` at the root but not `backend/src/.../functions/`", and `*/functions` extracted 400KB of unrelated files. This mode loses the update path, which needs a checkout to `git diff` and `merge --ff-only` into.

Both modes read one `FILES` list, so they cannot disagree about what the stack needs. That makes the sparse patterns file-level rather than the directory-level ones they were — a release that mounts a new file adds it to that list, which the comment above it already required.

## Section 16 was not a procedure you could follow

It told the reader to edit `docker-compose.yml` to pin an older image. Two things in it were also no longer true: it claimed `deploy/docker-compose` pins `v1.5.0` (it pins `latest`, with the other three images on their own upstream versions), and it opened by restoring `docker-compose.yml.old`, a file no step in the guide creates.

It uses an overlay now — a file of the operator's own that no update touches, and the same trick pins any image in the stack:

```yaml
# pin.yml
services:
  insforge:
    image: ghcr.io/insforge/insforge-oss:v2.2.9
```

```env
COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
```

## What this PR no longer does

Earlier revisions added `INSFORGE_OSS_VERSION` and `INSFORGE_DEPLOYMENT_METHOD`. Both are gone: an overlay already overrides an image and adds variables the base file never mentions, using `COMPOSE_FILE`, which `.env.example` documents for the storage overlays. The overlay is more capable than the variable it would have replaced, and dropping the telemetry stamp avoids changing what every existing self-host reports.

The version variable's justification was also weaker than I claimed. I said a rollback that edited the compose file would block the next update, since `merge --ff-only` refuses when a tracked file has local changes — it refuses only when upstream also changed that line.

## Verified

Both acquisition modes land the same twelve files in the same layout, and the compose file parses with its relative mounts resolving. On a stack started from the git-free result:

| | |
|---|---|
| `/api/health` | 200 @ 2.2.9 |
| injected `ACCESS_API_KEY` | 200 on `/api/database/tables` |
| overlay pins the image | `insforge-oss:v2.2.9` |
| overlay adds a variable the base file never names | arrives in the container |
| `insforge_pg_utils` | preloaded |
| `CREATE POLICY` as `project_admin` | succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> Three changes, each standing on its own.
>
> ## The compose file drops two variables `.env.example` documents
>
> `.env.example` lines 121–129 document `ACCESS_API_KEY` and `ACCESS_ANON_KEY` as settable — *"Optional - will be auto-generated if not provided"* — and the backend seeds from them when present (`secret.service.ts:840`). `deploy/docker-compose/docker-compose.yml` never passed them, so a self-hoster who set them in `.env` saw no effect.
>
> Same inconsistency as section 5.4 telling people to set `AWS_*` variables the file does not pass, which #1887 fixed. This fixes the other half.
>
> Empty defaults, so nothing changes for anyone not setting them: the backend keeps generating its own.
>
> ## setup.sh can be driven
>
> **`INSFORGE_REF`** — stay on one ref instead of tracking main. Self-hosting had no way to pin a release at all.
>
> **`INSFORGE_NO_GIT=1`** (or no git on PATH) — fetch the files over HTTPS instead of cloning. 34KB, against 47MB for the repository tarball. I tried the tarball first: `tar` globs cannot portably express "`functions/` at the root but not `backend/src/.../functions/`", and `*/functions` extracted 400KB of unrelated files. This mode loses the update path, which needs a checkout to `git diff` and `merge --ff-only` into.
>
> Both modes read one `FILES` list, so they cannot disagree about what the stack needs. That makes the sparse patterns file-level rather than the directory-level ones they were — a release that mounts a new file adds it to that list, which the comment above it already required.
>
> ## Section 16 was not a procedure you could follow
>
> It told the reader to edit `docker-compose.yml` to pin an older image. Two things in it were also no longer true: it claimed `deploy/docker-compose` pins `v1.5.0` (it pins `latest`, with the other three images on their own upstream versions), and it opened by restoring `docker-compose.yml.old`, a file no step in the guide creates.
>
> It uses an overlay now — a file of the operator's own that no update touches, and the same trick pins any image in the stack:
>
> ```yaml
> # pin.yml
> services:
>   insforge:
>     image: ghcr.io/insforge/insforge-oss:v2.2.9
> ```
>
> ```env
> COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:pin.yml
> ```
>
> ## What this PR no longer does
>
> Earlier revisions added `INSFORGE_OSS_VERSION` and `INSFORGE_DEPLOYMENT_METHOD`. Both are gone: an overlay already overrides an image and adds variables the base file never mentions, using `COMPOSE_FILE`, which `.env.example` documents for the storage overlays. The overlay is more capable than the variable it would have replaced, and dropping the telemetry stamp avoids changing what every existing self-host reports.
>
> The version variable's justification was also weaker than I claimed. I said a rollback that edited the compose file would block the next update, since `merge --ff-only` refuses when a tracked file has local changes — it refuses only when upstream also changed that line.
>
> ## Verified
>
> Both acquisition modes land the same twelve files in the same layout, and the compose file parses with its relative mounts resolving. On a stack started from the git-free result:
>
> | | |
> |---|---|
> | `/api/health` | 200 @ 2.2.9 |
> | injected `ACCESS_API_KEY` | 200 on `/api/database/tables` |
> | overlay pins the image | `insforge-oss:v2.2.9` |
> | overlay adds a variable the base file never names | arrives in the container |
> | `insforge_pg_utils` | preloaded |
> | `CREATE POLICY` as `project_admin` | succeeds |
>
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- Macroscope's changelog starts here -->
> #### Changes since #1897 opened
>
> - Changed the `insforge` service in `docker-compose.yml` to use a hardcoded `ghcr.io/insforge/insforge-oss:latest` image instead of the parameterized `${INSFORGE_OSS_VERSION:-latest}` and removed the `INSFORGE_DEPLOYMENT_METHOD` environment variable assignment [c6181a3]
> - Removed the commented guidance and placeholder entries for `INSFORGE_OSS_VERSION` and `INSFORGE_DEPLOYMENT_METHOD` variables from `.env.example` [c6181a3]
> - Updated deployment security documentation across English, Spanish, Simplified Chinese, and Traditional Chinese to replace `INSFORGE_OSS_VERSION` environment variable approach with a `pin.yml` overlay file approach that specifies a fixed image tag and is appended to `COMPOSE_FILE` [c6181a3]
> - Generated `ACCESS_API_KEY` and `ACCESS_ANON_KEY` with required prefixes and random hex payloads in the setup script, and updated the example environment file to use empty assignments with guidance that the setup script generates these values [b18e70d]
> - Added a `checkout_ref` function that fetches and checks out a specified ref when `INSFORGE_REF` is set, and invoked it in existing-checkout and current-directory branches [b18e70d]
> - Derived `RAW` from `REPO` by rewriting the GitHub host and stripping `.git` unless overridden, initialized `NO_GIT` at top scope, and added a guard in the no-git path to abort if the target appears to be a full non-sparse Git checkout [b18e70d]
> - Updated error messages and comments in guard conditions within the `deploy/setup.sh` script [89f3ab6]
> - Modified `gen_secret` function to accept an optional prefix parameter and updated `ACCESS_API_KEY` and `ACCESS_ANON_KEY` generation to use `gen_secret` with required prefixes [5b1e34a]
> - Expanded RAW variable initialization to support SSH-form GitHub remotes by transforming them to HTTPS raw.githubusercontent.com URLs [5b1e34a]
> - Refactored repository checkout flow to invoke `checkout_ref` after the self-hosting guard check [5b1e34a]
> - Added validation script and CI integration to enforce structural invariants on deployment setup [74b1f1d]
> - Modified deployment setup script to separate setup.sh handling from FILES-driven configuration and improve git worktree detection [74b1f1d]
> - Revised deployment security guide documentation across all language versions to clarify `COMPOSE_FILE` configuration and pinned image behavior [2f285b3]
> - Restructured deployment security guide section 16.2 across all language locales (English, Spanish, Traditional Chinese, Simplified Chinese) from explanatory paragraphs into a concise 4-step numbered procedure for pinning Docker image versions [6f865db]
> - Consolidated and clarified comments for `ACCESS_API_KEY` and `ACCESS_ANON_KEY` environment variables in the example environment configuration [6f865db]
> - Refined inline documentation comments in the deployment setup script without modifying any executable code [6f865db]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional API access key configuration for Docker Compose deployments.
  * Setup now generates prefixed access and anonymous API keys.
  * Added HTTPS-based installation for environments without Git.
  * Added support for pinned release or branch references during installation.

* **Documentation**
  * Updated rollback guidance in English, Spanish, Chinese, and Traditional Chinese to use Compose overlays for image version pinning.
  * Clarified overlay behavior and updated restoration step numbering.
  * Documented API key generation, required prefixes, and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->