### PR TITLE
docs(readme): self-host with setup.sh instead of .env.example placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,22 +114,46 @@ If you find InsForge useful or interesting, a GitHub Star ⭐️ would be greatl
 
 ### Self-hosted: Docker Compose
 
-Prerequisites: [Docker](https://www.docker.com/) + [Node.js](https://nodejs.org/)
+Prerequisites: [Docker](https://www.docker.com/) with Compose v2.
 
 #### 1. Setup
 
-You can run InsForge locally using Docker Compose. This will start a local InsForge instance on your machine.
+```bash
+curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/insforge
+```
+
+Fetches the files the stack reads and generates `JWT_SECRET`, `ENCRYPTION_KEY`,
+`POSTGRES_PASSWORD`, `ROOT_ADMIN_PASSWORD`, and the two access keys into
+`~/insforge/.env` (mode 600). Nothing is started, and re-running leaves an
+existing `.env` untouched.
+
+```bash
+cd ~/insforge
+$EDITOR .env          # API_BASE_URL, VITE_API_BASE_URL — the URL browsers will use
+docker compose up -d
+```
+
+`.env` sets `COMPOSE_FILE`, so plain `docker compose` commands work from that
+directory — no `-f` flags to remember.
 
 [![Deploy on Docker][docker-btn]][docker-deploy]
 
-Or run from source:
+<details>
+<summary>Building from source instead</summary>
+
+For working on InsForge itself. `docker-compose.prod.yml` reads the same
+variables but generates nothing, so set the secrets in `.env` yourself before
+starting anything you expose.
+
 ```bash
-# Run with Docker
 git clone https://github.com/InsForge/InsForge.git
 cd InsForge
 cp .env.example .env
+$EDITOR .env          # JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD, ROOT_ADMIN_PASSWORD
 docker compose -f docker-compose.prod.yml up
 ```
+
+</details>
 
 #### 2. Connect InsForge MCP
 
@@ -138,7 +162,7 @@ Open [http://localhost:7130](http://localhost:7130)
 Follow the steps to connect InsForge MCP Server
 
 <div align="center">
-  <img src="assets/connect.png" alt="Connect InsForge MCP" width="600">
+<img src="assets/connect.png" alt="Connect InsForge MCP" width="600">
 </div>
 
 #### 3. Verify installation
@@ -150,16 +174,28 @@ I'm using InsForge as my backend platform, call InsForge MCP's fetch-docs tool t
 
 #### 4. Running Multiple Projects
 
-You can run multiple InsForge projects on the same host by using different ports and project names.
+Give each project its own directory:
 
 ```bash
-# Create a separate env file for each project
-cp .env.example .env.project1
-cp .env.example .env.project2
+curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/project1
+curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/project2
 ```
 
-Edit `.env.project2` with different ports:
+Then give each a project name and its own ports. Both `.env` files start with
+`COMPOSE_PROJECT_NAME=insforge`, and **two directories sharing that name share
+containers** — the second `up -d` adopts the first's, rebuilt with the second's
+config. Set it before starting anything.
+
+`~/project1/.env`:
+
 ```
+COMPOSE_PROJECT_NAME=project1
+```
+
+`~/project2/.env`:
+
+```
+COMPOSE_PROJECT_NAME=project2
 POSTGRES_PORT=5442
 POSTGREST_PORT=5440
 APP_PORT=7230
@@ -167,30 +203,32 @@ AUTH_PORT=7231
 DENO_PORT=7233
 ```
 
-Start each project with a unique name:
+Now each directory is a separate instance with its own containers, volumes,
+database, and secrets:
+
 ```bash
-docker compose -f docker-compose.prod.yml --env-file .env.project1 -p project1 up -d
-docker compose -f docker-compose.prod.yml --env-file .env.project2 -p project2 up -d
+cd ~/project1 && docker compose up -d
+cd ~/project2 && docker compose up -d
 ```
 
-Each project gets its own isolated database, storage, and configuration. Manage them with:
-```bash
-docker compose -f docker-compose.prod.yml --env-file .env.project1 -p project1 ps      # status
-docker compose -f docker-compose.prod.yml --env-file .env.project1 -p project1 logs -f  # logs
-docker compose -f docker-compose.prod.yml --env-file .env.project1 -p project1 down     # stop
-```
+`docker compose ps`, `logs -f`, and `down` operate on whichever directory you
+run them from.
 
 #### 5. Storage Backends (Optional)
 
-InsForge stores files on the local filesystem by default. Backing storage with an S3-compatible store also enables the S3-compatible gateway at `/storage/v1/s3` (use `aws` CLI, rclone, or any AWS SDK against your InsForge Storage):
+InsForge stores files on the local filesystem by default. Backing storage with an S3-compatible store also enables the S3-compatible gateway at `/storage/v1/s3` (use `aws` CLI, rclone, or any AWS SDK against your InsForge Storage).
 
-```bash
-# Bundled MinIO — one command, store stays internal to the Docker network
-docker compose -f docker-compose.prod.yml -f docker-compose.minio.yml up -d
+Append the overlay to `COMPOSE_FILE` in `.env`:
+
+```env
+# Bundled MinIO — store stays internal to the Docker network
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.minio.yml
 
 # Bundled RustFS (Apache-2.0 licensed alternative)
-docker compose -f docker-compose.prod.yml -f docker-compose.rustfs.yml up -d
+COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.rustfs.yml
 ```
+
+Then `docker compose up -d` as usual.
 
 The overlays ship with default store credentials — set `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` (or `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY`) in `.env` before production use.
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup
 
 Fetches the files the stack reads and generates `JWT_SECRET`, `ENCRYPTION_KEY`,
 `POSTGRES_PASSWORD`, `ROOT_ADMIN_PASSWORD`, and the two access keys into
-`~/insforge/.env` (mode 600). Nothing is started, and re-running leaves an
-existing `.env` untouched.
+`~/insforge/.env` (mode 600). Nothing is started. Re-running refreshes the files
+and keeps every value you have set — it only ever adds `COMPOSE_FILE`, or points
+it at this checkout's compose file if it still names the development one.
 
 ```bash
 cd ~/insforge
@@ -149,9 +150,18 @@ starting anything you expose.
 git clone https://github.com/InsForge/InsForge.git
 cd InsForge
 cp .env.example .env
-$EDITOR .env          # JWT_SECRET, ENCRYPTION_KEY, POSTGRES_PASSWORD, ROOT_ADMIN_PASSWORD
+$EDITOR .env
 docker compose -f docker-compose.prod.yml up
 ```
+
+Set `JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, and
+`ROOT_ADMIN_PASSWORD` — `.env.example` ships placeholders for them, and the
+compose file falls back to published defaults for any you leave unset. Set
+`ACCESS_API_KEY` and `ACCESS_ANON_KEY` too if you want to know your own keys;
+left empty, the backend generates a pair only it knows.
+
+This path passes `-f` explicitly, which overrides `COMPOSE_FILE`. Add overlays as
+further `-f` flags rather than editing that variable.
 
 </details>
 
@@ -188,13 +198,13 @@ config. Set it before starting anything.
 
 `~/project1/.env`:
 
-```
+```env
 COMPOSE_PROJECT_NAME=project1
 ```
 
 `~/project2/.env`:
 
-```
+```env
 COMPOSE_PROJECT_NAME=project2
 POSTGRES_PORT=5442
 POSTGREST_PORT=5440
@@ -218,17 +228,21 @@ run them from.
 
 InsForge stores files on the local filesystem by default. Backing storage with an S3-compatible store also enables the S3-compatible gateway at `/storage/v1/s3` (use `aws` CLI, rclone, or any AWS SDK against your InsForge Storage).
 
-Append the overlay to `COMPOSE_FILE` in `.env`:
+Append one overlay to `COMPOSE_FILE` in `.env`. Bundled MinIO, whose store stays
+internal to the Docker network:
 
 ```env
-# Bundled MinIO — store stays internal to the Docker network
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.minio.yml
+```
 
-# Bundled RustFS (Apache-2.0 licensed alternative)
+Or RustFS, an Apache-2.0 licensed alternative:
+
+```env
 COMPOSE_FILE=deploy/docker-compose/docker-compose.yml:docker-compose.rustfs.yml
 ```
 
-Then `docker compose up -d` as usual.
+Keep one — the file is read as shell assignments, so a second line replaces the
+first. Then `docker compose up -d` as usual.
 
 The overlays ship with default store credentials — set `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` (or `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY`) in `.env` before production use.
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -4,8 +4,9 @@
 #   curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/insforge
 #   sh deploy/setup.sh .        # re-apply after `git merge`, see below
 #
-# Safe to re-run: an existing .env is left untouched. Starts nothing — review
-# .env first, since Postgres reads it only at first boot.
+# Safe to re-run: your values are kept, only COMPOSE_FILE is added or
+# corrected. Starts nothing — review .env first, since Postgres reads it only
+# at first boot.
 #
 # Environment:
 #   INSFORGE_REF=vX.Y.Z   A tag, branch or commit instead of main.
@@ -204,7 +205,7 @@ fi
 
 if [ -f "$ENV_FILE" ]; then
   pin_compose_file
-  echo "Checkout refreshed. $ROOT/.env already exists — left untouched."
+  echo "Checkout refreshed. $ROOT/.env already exists — your values are kept."
   echo "Compare it against .env.example for variables added since you created it."
   exit 0
 fi


### PR DESCRIPTION
The self-host section told people to `cp .env.example .env` and start `docker-compose.prod.yml`. That produces an install running on the placeholder secrets committed to this repository:

```
JWT_SECRET           your-secret-key-here-must-be-32-char-or-above
POSTGRES_PASSWORD    postgres
ROOT_ADMIN_PASSWORD  change-this-password
ENCRYPTION_KEY       empty → falls back to JWT_SECRET
```

`docker-compose.prod.yml` reads each through `${VAR:-default}`, so nothing warns and nothing fails. Anyone following the README ran a backend whose token-signing key is a string printed in a public repo.

`deploy/setup.sh` generates all of them and has shipped since v2.3.0 — the deployment guides already lead with it. This does the same in the README.

## Also fixed

**Multiple projects.** Both `.env` files start with `COMPOSE_PROJECT_NAME=insforge`, so two directories share containers: the second `up -d` adopts the first's and rebuilds them with the second's config, and a later `down` removes them. The old `-p project1` flags handled this; the section now sets `COMPOSE_PROJECT_NAME` in each `.env` instead, which is one value rather than a flag on every command.

**Storage overlays.** The `-f docker-compose.prod.yml -f docker-compose.minio.yml` form only works in a from-source checkout. In a setup.sh checkout the overlay appends to `COMPOSE_FILE`, which is what the [self-hosted storage guide](https://docs.insforge.dev/deployment/self-host-storage) already documents.

**Prerequisites** said Node.js — the compose path does not use it.

Building from source is kept, collapsed under a `<details>`, and now says outright that it generates no secrets.

## Verification

Ran the section verbatim:

- `setup.sh` into a fresh directory → `.env` has 0 placeholder values, all secrets generated
- `COMPOSE_FILE=…/docker-compose.yml:docker-compose.minio.yml` → `docker compose config --services` resolves 6 services including `minio`
- two directories with different `COMPOSE_PROJECT_NAME` → two compose projects
- the second came up healthy: `{"status":"ok","version":"2.3.0"}`

## Not in scope

Leading with `insforge local start` is #1870, which waits on InsForge/CLI#226.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the self-host README to use `deploy/setup.sh` for Docker Compose installs. It generates real secrets by default, corrects rerun behavior, and clarifies multi-project, storage, and source-build setups.

- **Bug Fixes**
  - Replace `cp .env.example .env` with `setup.sh` to generate `JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, `ROOT_ADMIN_PASSWORD`, and access keys by default; on rerun it keeps your values and only adds/corrects `COMPOSE_FILE`.
  - Require Docker Compose v2; remove Node.js from prerequisites for the Compose path; add a note to set `API_BASE_URL`/`VITE_API_BASE_URL` before starting.
  - Multi-project: set `COMPOSE_PROJECT_NAME` in each directory to avoid shared containers; run `docker compose` from each directory; example ports for a second project.
  - Storage overlays: append MinIO or RustFS to `COMPOSE_FILE` in `.env`; keep only one line (shell assignment); matches deploy guides and works in `setup.sh` checkouts.
  - Source build: keep a collapsed section; passing `-f docker-compose.prod.yml` overrides `COMPOSE_FILE`; add overlays with extra `-f` flags; call out `ACCESS_API_KEY`/`ACCESS_ANON_KEY` as optional but recommended to know your own keys.

<sup>Written for commit 452659a2dc878a1adc9f41eab632772ff62f4f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update self-hosting docs in README to use `setup.sh` bootstrap script
> - Replaces manual `.env.example` placeholder instructions with a `curl`-based bootstrap script (`deploy/setup.sh`) that fetches stack files and auto-generates secrets into `~/insforge/.env`.
> - Updates multi-project setup to use separate directories initialized via the script, with `COMPOSE_PROJECT_NAME` and optional port overrides per project, removing the need for `-f` or `-p` flags.
> - Storage backend overlays (MinIO, RustFS) are now appended to `COMPOSE_FILE` in `.env` rather than passed on the command line.
> - Adds a collapsible "build from source" section covering `docker-compose.prod.yml` and manual secret configuration.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1901 opened
>
> - Rewrote production setup instructions to use `setup.sh` script workflow [452659a]
> - Updated `setup.sh` comments and messaging to clarify preservation of user values [452659a]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e17fdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the self-hosted Docker Compose quickstart to require Docker Compose v2.
  * Added setup instructions for provisioning configuration files and generating secrets without starting services.
  * Clarified API URL configuration, automatic Compose settings, source builds, and Compose overlays.
  * Documented multi-project deployments with separate directories, project names, custom ports, and project-local commands.
  * Expanded MinIO and RustFS storage guidance, including overlay credentials, external S3-compatible providers, and proxy mode.
* **Bug Fixes**
  * Clarified that setup reruns preserve existing environment values while correcting Compose configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->