### PR TITLE
docs(deploy): run setup.sh per directory for multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Then give each a project name and its own ports. Both `.env` files start with
 containers** — the second `up -d` adopts the first's, rebuilt with the second's
 config. Set it before starting anything.
 
-`~/project1/.env`:
+`~/project1/.env` keeps the default ports — which collide with the `~/insforge`
+instance from the quickstart above if it is still running. Stop that one, or give
+`project1` its own ports the way `project2` has:
 
 ```env
 COMPOSE_PROJECT_NAME=project1

--- a/deploy/docker-deploy.md
+++ b/deploy/docker-deploy.md
@@ -64,7 +64,9 @@ directories sharing that name share containers** — the second `up -d` adopts t
 first's and recreates them with the second's config. Set it before starting
 anything.
 
-`~/project1/.env` keeps the default ports:
+`~/project1/.env` keeps the default ports — which collide with the `~/insforge`
+instance from the quickstart above if it is still running. Stop that one, or give
+`project1` its own ports the way `project2` has:
 
 ```ini
 COMPOSE_PROJECT_NAME=project1

--- a/deploy/docker-deploy.md
+++ b/deploy/docker-deploy.md
@@ -46,33 +46,32 @@ Open your browser and navigate to `http://localhost:7130`, you can see the InsFo
 
 You can run multiple InsForge projects on the same host by using different ports and project names.
 
-### Step 1: Create a separate env file for each project
+### Step 1: Run the setup script once per directory
 
 ```bash
-cp .env.example .env.project1
-cp .env.example .env.project2
+curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/project1
+curl -fsSL https://raw.githubusercontent.com/InsForge/InsForge/main/deploy/setup.sh | sh -s ~/project2
 ```
 
-`.env.example` ships the development value for `COMPOSE_FILE`, and the checkout
-does not contain that file — set it in each copy:
+A directory each, so each gets its own generated secrets. Copying `.env.example`
+instead would give both the placeholder values it ships — the same published
+`JWT_SECRET` on every instance.
 
-```ini
-COMPOSE_FILE=deploy/docker-compose/docker-compose.yml
-```
+### Step 2: Give each one its own project name and ports
 
-### Step 2: Give each env file its own project name and ports
+Both `.env` files start with `COMPOSE_PROJECT_NAME=insforge`, and **two
+directories sharing that name share containers** — the second `up -d` adopts the
+first's and recreates them with the second's config. Set it before starting
+anything.
 
-**.env.project1** (default ports):
+`~/project1/.env` keeps the default ports:
+
 ```ini
 COMPOSE_PROJECT_NAME=project1
-POSTGRES_PORT=5432
-POSTGREST_PORT=5430
-APP_PORT=7130
-AUTH_PORT=7131
-DENO_PORT=7133
 ```
 
-**.env.project2** (different ports):
+`~/project2/.env` needs its own:
+
 ```ini
 COMPOSE_PROJECT_NAME=project2
 POSTGRES_PORT=5442
@@ -82,31 +81,29 @@ AUTH_PORT=7231
 DENO_PORT=7233
 ```
 
-Make sure each project has its own `JWT_SECRET` and `ROOT_ADMIN_PASSWORD`.
-
 ### Step 3: Start each project
 
 ```bash
-docker compose --env-file .env.project1 up -d
-docker compose --env-file .env.project2 up -d
+cd ~/project1 && docker compose up -d
+cd ~/project2 && docker compose up -d
 ```
 
-`COMPOSE_PROJECT_NAME` gives each one isolated containers, volumes, and networks; the ports keep them from colliding on the host. Leaving two env files on the same name is what you have to avoid — `docker compose up` with either one adopts and recreates the other's containers.
+`COMPOSE_PROJECT_NAME` gives each one isolated containers, volumes, and networks; the ports keep them from colliding on the host.
 
 ### Managing multiple instances
 
 ```bash
 # Check status
-docker compose --env-file .env.project1 ps
+cd ~/project1 && docker compose ps
 
 # View logs
-docker compose --env-file .env.project1 logs -f
+cd ~/project1 && docker compose logs -f
 
 # Stop an instance
-docker compose --env-file .env.project1 down
+cd ~/project1 && docker compose down
 
 # Stop and remove all data
-docker compose --env-file .env.project1 down -v
+cd ~/project1 && docker compose down -v
 ```
 
 Each project has its own database, storage, and configuration. They are completely independent.


### PR DESCRIPTION
`deploy/docker-deploy.md` told readers to `cp .env.example .env.project1` for each instance. That file ships placeholders, so every instance came up on the same published values:

```
JWT_SECRET          = your-secret-key-here-must-be-32-char-or-above
POSTGRES_PASSWORD   = postgres
ROOT_ADMIN_PASSWORD = change-this-password
```

The note underneath asked readers to give each project its own `JWT_SECRET` and `ROOT_ADMIN_PASSWORD` — two of the six, phrased as hardening rather than as "these are printed in the public repo".

Running `setup.sh` into a directory each generates a real set per instance, and matches the multi-project section the README already has after #1901.

The `--env-file .env.projectN` form goes with it: one `.env` per directory means plain `docker compose` from inside that directory, which is what `COMPOSE_FILE` is there for.

Verified end to end — two directories get different, non-placeholder secrets, and Compose resolves them as separate projects:

```
project1 -> compose project: project1
project2 -> compose project: project2
```

Also closes #1870, whose remaining half was this file. Its README half was superseded by #1901, and leading the self-host quickstart with `insforge local start` conflated a development backend with self-hosting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update multi-instance Docker docs to run `setup.sh` per directory, creating unique secrets and a per-dir `.env`. Replace `.env.example`/`--env-file` with running `docker compose` in each dir using unique `COMPOSE_PROJECT_NAME` and ports, and note `project1`’s defaults conflict with the quickstart `~/insforge`.

<sup>Written for commit 6ef77f0b983b95aa914c451a725234ac569da96a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update multi-instance deployment docs to run `setup.sh` per directory
> Rewrites the multi-instance setup section in [deploy/docker-deploy.md](https://github.com/InsForge/InsForge/pull/1902/files#diff-5ed00744d268f99e135ac7e6d7d5463e42c2cfcfebd8029341b6607eee4e8b4b) to use per-directory `setup.sh` invocations instead of manually copying `.env` files.
>
> - Each instance directory gets its own `curl deploy/setup.sh` call, ensuring distinct secrets are generated per instance
> - Warns that copying `.env.example` between directories would duplicate `JWT_SECRET`, which is a security risk
> - Updates Step 2 to highlight that both generated `.env` files default to `COMPOSE_PROJECT_NAME=insforge`, and that directories sharing this name will share containers — users must set unique names before starting
> - Updates Step 3 and management commands (`ps`, `logs`, `down`) to work by `cd`-ing into each project directory rather than using `--env-file` flags
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d05d5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple-instance Docker deployment instructions to generate separate configuration and secrets for each project.
  * Clarified project-specific names, port assignments, and startup and management commands.
  * Documented isolation between containers, volumes, and networks for independently managed projects.
  * Explained that the default-port project can conflict with the quickstart instance and must be stopped or assigned alternate ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->