### PR TITLE
Disk breakdown: semantic colors (Database green / WAL amber / System gray)

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -328,8 +328,9 @@ export function ObservabilitySection() {
                               defaultValue: 'Used',
                             }),
                           },
-                          // Supabase palette: Database orange, WAL light green,
-                          // System green; stacked bottom-up in that order.
+                          // Semantic palette: Database emerald (your data),
+                          // WAL amber (the log), System gray (not yours to
+                          // manage); stacked bottom-up in that order.
                           components: diskCardProps.breakdown
                             ? [
                                 {

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -337,7 +337,7 @@ export function ObservabilitySection() {
                                   label: t('overview.metrics.diskUsed.database', {
                                     defaultValue: 'Database',
                                   }),
-                                  fillClass: 'fill-orange-300',
+                                  fillClass: 'fill-emerald-400',
                                   data: diskCardProps.breakdown.database,
                                 },
                                 {
@@ -345,7 +345,7 @@ export function ObservabilitySection() {
                                   label: t('overview.metrics.diskUsed.wal', {
                                     defaultValue: 'WAL',
                                   }),
-                                  fillClass: 'fill-emerald-200',
+                                  fillClass: 'fill-amber-300',
                                   data: diskCardProps.breakdown.wal,
                                 },
                                 {
@@ -353,7 +353,7 @@ export function ObservabilitySection() {
                                   label: t('overview.metrics.diskUsed.system', {
                                     defaultValue: 'System',
                                   }),
-                                  fillClass: 'fill-emerald-400',
+                                  fillClass: 'fill-zinc-500',
                                   data: diskCardProps.breakdown.system,
                                 },
                               ]
@@ -391,21 +391,21 @@ export function ObservabilitySection() {
                                         defaultValue: 'Database',
                                       }),
                                       value: `${BYTES_SIZE(db)}${pct(db)}`,
-                                      swatchClass: 'bg-orange-300',
+                                      swatchClass: 'bg-emerald-400',
                                     },
                                     {
                                       label: t('overview.metrics.diskUsed.wal', {
                                         defaultValue: 'WAL',
                                       }),
                                       value: `${BYTES_SIZE(wal)}${pct(wal)}`,
-                                      swatchClass: 'bg-emerald-200',
+                                      swatchClass: 'bg-amber-300',
                                     },
                                     {
                                       label: t('overview.metrics.diskUsed.system', {
                                         defaultValue: 'System',
                                       }),
                                       value: `${BYTES_SIZE(system)}${pct(system)}`,
-                                      swatchClass: 'bg-emerald-400',
+                                      swatchClass: 'bg-zinc-500',
                                     },
                                     {
                                       label: t('overview.metrics.diskUsed.total', {


### PR DESCRIPTION
First live render feedback (Tony): WAL light-green vs System green read as shades of the same thing, and Database's orange sliver disappears at real sizes. Recolor to semantic: **Database = emerald** (your data, house primary), **WAL = amber** (log), **System = zinc gray** (not yours to manage). Legend + tooltip swatches derive from the same classes.

All-charts audit alongside: CPU/Memory threshold lines and Network cards verified structurally sound in the same pass — no other changes needed.

Tests: component 138/138, tsc, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kbhm3x6R6B4vy5Z2H8mKb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated disk usage breakdown to semantic colors: Database = emerald, WAL = amber, System = zinc gray. Chart, legend, and tooltip now share the same classes for consistent swatches at small sizes, and a stale palette comment was corrected.

<sup>Written for commit 6a3f13d0185bc3c0b466079bf04938dbb6f6b138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update disk breakdown semantic colors to emerald, amber, and zinc in the Observability section
> Changes the color mapping in the Disk Used breakdown chart and tooltip in [ObservabilitySection.tsx](https://github.com/InsForge/InsForge/pull/1904/files#diff-4d4de4387f9c09a7f1ba64970502fcff25a504fc213a5153d41e8347edd15ba2): database segment moves to emerald-400, WAL segment to amber-300, and system segment to zinc-500. Both the chart `fillClass` and tooltip `swatchClass` are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f02c7e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated disk usage chart colors for improved visual distinction:
    * Database: emerald
    * WAL: amber
    * System: zinc
  * Applied the updated colors consistently to chart segments and tooltip indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->