### PR TITLE
Disk breakdown: Database band on the house emerald-300 accent

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -338,7 +338,7 @@ export function ObservabilitySection() {
                                   label: t('overview.metrics.diskUsed.database', {
                                     defaultValue: 'Database',
                                   }),
-                                  fillClass: 'fill-emerald-400',
+                                  fillClass: 'fill-emerald-300',
                                   data: diskCardProps.breakdown.database,
                                 },
                                 {
@@ -392,7 +392,7 @@ export function ObservabilitySection() {
                                         defaultValue: 'Database',
                                       }),
                                       value: `${BYTES_SIZE(db)}${pct(db)}`,
-                                      swatchClass: 'bg-emerald-400',
+                                      swatchClass: 'bg-emerald-300',
                                     },
                                     {
                                       label: t('overview.metrics.diskUsed.wal', {


### PR DESCRIPTION
Theme-fit pass (Tony): the dashboard's accent family is emerald-300 everywhere (chart lines, areas, pills); the Database band was emerald-400 and read off-brand beside them. One-shade alignment; amber (WAL) and zinc (System) unchanged. Tests 138/138, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kbhm3x6R6B4vy5Z2H8mKb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Database band in the disk usage breakdown to the dashboard’s standard `emerald-300` accent for visual consistency. Updates the area fill and legend swatch; WAL (amber) and System (zinc) remain unchanged.

<sup>Written for commit d7337ce890bc551216f6af3e3f3185603cc180d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update database segment color to emerald-300 in Disk Used chart
> Changes the database band color in the Disk Used stacked sparkline and legend from `emerald-400` to `emerald-300` in [ObservabilitySection.tsx](https://github.com/InsForge/InsForge/pull/1905/files#diff-4d4de4387f9c09a7f1ba64970502fcff25a504fc213a5153d41e8347edd15ba2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7337ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the database color in the disk usage chart for improved visual consistency.
  * Applied the updated color to both chart segments and tooltip indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->