### PR TITLE
Disk card: data-scoped frame (ceiling = your space, System becomes a footnote)

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -186,16 +186,39 @@ export function ObservabilitySection() {
       data?.metrics.find((m) => m.metric === 'disk_wal')?.data,
       diskUsedData
     );
+    // Data-scoped ceiling (Tony's call, 2026-08-08): subtract the OS/runtime
+    // from both sides so the chart talks about the user's space, the way the
+    // Supabase data-volume chart does — but subtract the MEASURED System
+    // rather than a hardcoded constant (the retired 4GiB hack showed how a
+    // guess drifts and clamps). Ceiling = database + wal + free space; the
+    // System figure moves to a tooltip footnote.
+    const systemLatest = breakdown?.system.length
+      ? breakdown.system[breakdown.system.length - 1].value
+      : null;
+    const dataCeiling =
+      totalBytes !== null && systemLatest !== null
+        ? Math.max(0, totalBytes - systemLatest)
+        : totalBytes;
+    // With a breakdown, the card's primary series (headline + AVG/MAX/LATEST)
+    // is the user's data (database + wal per sample) — raw disk_used would
+    // read over the data-scoped ceiling.
+    const dataUsed = breakdown
+      ? breakdown.database.map((point, i) => ({
+          timestamp: point.timestamp,
+          value: point.value + (breakdown.wal[i]?.value ?? 0),
+        }))
+      : diskUsedData;
     return {
-      data: diskUsedData,
-      fixedDomain: (totalBytes !== null ? [0, totalBytes] : undefined) as
+      data: dataUsed,
+      fixedDomain: (dataCeiling !== null ? [0, dataCeiling] : undefined) as
         | [number, number]
         | undefined,
       // Capacity chart (Supabase-style): dashed ceiling at the provisioned
       // size, a mid gridline, bars for the samples. No 90% threshold line —
       // the ceiling is the reference, and two dashed lines collide visually.
-      ticks: totalBytes !== null ? [0, totalBytes / 2, totalBytes] : [],
-      totalBytes,
+      ticks: dataCeiling !== null ? [0, dataCeiling / 2, dataCeiling] : [],
+      totalBytes: dataCeiling,
+      systemLatest,
       breakdown,
       // The hovered value as a share of the provisioned disk.
       tooltipDetail:
@@ -349,14 +372,6 @@ export function ObservabilitySection() {
                                   fillClass: 'fill-amber-300',
                                   data: diskCardProps.breakdown.wal,
                                 },
-                                {
-                                  key: 'system',
-                                  label: t('overview.metrics.diskUsed.system', {
-                                    defaultValue: 'System',
-                                  }),
-                                  fillClass: 'fill-zinc-500',
-                                  data: diskCardProps.breakdown.system,
-                                },
                               ]
                             : undefined,
                           tooltipRows: ((breakdown) =>
@@ -392,7 +407,7 @@ export function ObservabilitySection() {
                                         defaultValue: 'Database',
                                       }),
                                       value: `${BYTES_SIZE(db)}${pct(db)}`,
-                                      swatchClass: 'bg-emerald-400',
+                                      swatchClass: 'bg-emerald-300',
                                     },
                                     {
                                       label: t('overview.metrics.diskUsed.wal', {
@@ -402,17 +417,19 @@ export function ObservabilitySection() {
                                       swatchClass: 'bg-amber-300',
                                     },
                                     {
-                                      label: t('overview.metrics.diskUsed.system', {
-                                        defaultValue: 'System',
-                                      }),
-                                      value: `${BYTES_SIZE(system)}${pct(system)}`,
-                                      swatchClass: 'bg-zinc-500',
-                                    },
-                                    {
                                       label: t('overview.metrics.diskUsed.total', {
                                         defaultValue: 'Total',
                                       }),
-                                      value: `${BYTES_SIZE(db + wal + system)}${pct(db + wal + system)}`,
+                                      value: `${BYTES_SIZE(db + wal)}${pct(db + wal)}`,
+                                    },
+                                    // Footnote, not a component: where the rest of
+                                    // the physical disk went. Kept out of the bars
+                                    // and the ceiling on purpose.
+                                    {
+                                      label: t('overview.metrics.diskUsed.systemExcluded', {
+                                        defaultValue: 'System & runtime',
+                                      }),
+                                      value: `${BYTES_SIZE(system)} · ${t('overview.metrics.diskUsed.notCounted', { defaultValue: 'not counted' })}`,
                                     },
                                   ];
                                   return rows;

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -220,10 +220,12 @@ export function ObservabilitySection() {
       totalBytes: dataCeiling,
       systemLatest,
       breakdown,
-      // The hovered value as a share of the provisioned disk.
+      // The hovered value as a share of the SAME ceiling the chart draws —
+      // data-scoped when the breakdown is present (review round 1 caught the
+      // raw-total denominator contradicting the row block).
       tooltipDetail:
-        totalBytes !== null && totalBytes > 0
-          ? (v: number) => `${((v / totalBytes) * 100).toFixed(1)}% of ${BYTES_SIZE(totalBytes)}`
+        dataCeiling !== null && dataCeiling > 0
+          ? (v: number) => `${((v / dataCeiling) * 100).toFixed(1)}% of ${BYTES_SIZE(dataCeiling)}`
           : undefined,
     };
   }, [data]);

--- a/packages/dashboard/src/lib/i18n/locales/en.json
+++ b/packages/dashboard/src/lib/i18n/locales/en.json
@@ -174,7 +174,9 @@
         "database": "Database",
         "wal": "WAL",
         "system": "System",
-        "total": "Total"
+        "total": "Total",
+        "systemExcluded": "System & runtime",
+        "notCounted": "not counted"
       }
     },
     "memoryAdvisory": {

--- a/packages/dashboard/src/lib/i18n/locales/es.json
+++ b/packages/dashboard/src/lib/i18n/locales/es.json
@@ -174,7 +174,9 @@
         "database": "Base de datos",
         "wal": "WAL",
         "system": "Sistema",
-        "total": "Total"
+        "total": "Total",
+        "systemExcluded": "Sistema y runtime",
+        "notCounted": "no contado"
       }
     },
     "memoryAdvisory": {

--- a/packages/dashboard/src/lib/i18n/locales/zh-CN.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-CN.json
@@ -165,7 +165,9 @@
         "database": "数据库",
         "wal": "WAL",
         "system": "系统",
-        "total": "总计"
+        "total": "总计",
+        "systemExcluded": "系统与运行时",
+        "notCounted": "不计入"
       }
     },
     "memoryAdvisory": {

--- a/packages/dashboard/src/lib/i18n/locales/zh-TW.json
+++ b/packages/dashboard/src/lib/i18n/locales/zh-TW.json
@@ -165,7 +165,9 @@
         "database": "資料庫",
         "wal": "WAL",
         "system": "系統",
-        "total": "總計"
+        "total": "總計",
+        "systemExcluded": "系統與執行時",
+        "notCounted": "不計入"
       }
     },
     "memoryAdvisory": {


### PR DESCRIPTION
Live-prod design feedback (Tony): the measured System slab (5.5GB of an 8GB single-volume instance) drowned the user-actionable data. Supabase avoids this structurally — their chart shows a dedicated data volume and never the OS disk. We get the same frame on a single volume by scoping the chart to data:

- **Ceiling** (dashed Disk Size) = disk total − measured System = database + wal + **free space** — the space your data can actually grow into. Measured, not the retired 4GiB constant, so it adapts per instance and can't clamp.
- **Bars / headline / AVG-MAX-LATEST** all describe Database + WAL — one consistent frame (first cut mixed frames: 1.2GB headline over a 3.4GB data ceiling; caught in harness, fixed).
- **System leaves the chart**, kept as a tooltip footnote: `System & runtime: 5.5 GB · not counted`.
- Fallback (no breakdown series): unchanged raw used/total frame.

Harness verification with real QA-project series: headline 714MB (db+wal), ceiling 3.4GB, growth cluster clearly visible, Supabase-parity tooltip. Tests 138/138 + 85/85, tsc, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kbhm3x6R6B4vy5Z2H8mKb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the Disk Used card to user data by subtracting measured System from the ceiling and series. Shows Database + WAL over a data ceiling (db + WAL + free), with System moved to a tooltip footnote.

- **New Features**
  - Ceiling, ticks, and tooltip percentage use total − measured System.
  - Primary series is Database + WAL; headline and AVG/MAX/LATEST match.
  - System removed from bars; footnote shows “System & runtime … not counted.”
  - Fallback keeps used/total when breakdown is unavailable.
  - Database swatch set to `bg-emerald-300`; added i18n keys for systemExcluded/notCounted in en, es, zh-CN, zh-TW.

<sup>Written for commit 5aacb67f70e42ebfe5313cdf5548a174102434ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope disk card chart ceiling to user data, moving system usage to a tooltip footnote
> - The Disk Used chart now plots only database + WAL bytes and sets the chart ceiling to provisioned size minus measured system usage, so the y-axis reflects user-available space.
> - The stacked breakdown no longer includes a 'System' segment; instead, system usage appears as a non-stacked footnote row labeled 'System & runtime' with a 'not counted' note.
> - The database swatch color changes from its previous color to `bg-emerald-300`; percentage and ceiling label remain based on provisioned size.
> - Adds translation keys for the new footnote labels in English, Spanish, Simplified Chinese, and Traditional Chinese.
> - Behavioral Change: Users will see a lower chart ceiling and no system bar segment; the total value in the tooltip now reflects database + WAL only.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1907 opened
>
> - Changed disk usage tooltip percentage calculation in `ObservabilitySection` component to use `dataCeiling` as denominator instead of `totalBytes` [5aacb67]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2404041.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated disk usage charts to focus on database and WAL storage.
  * System and runtime usage is now shown separately as excluded from totals.
  * Added clearer tooltip details, including total capacity and uncounted usage.
  * Refined disk usage totals, percentages, and database color styling.
* **Localization**
  * Added disk usage labels and explanatory text in English, Spanish, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->