### PR TITLE
feat(deploy): add deploy/backup.sh for self-host backups

### DIFF
--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Back up a self-hosted InsForge install: logical Postgres dump + .env copy.
+#
+# Run by path (use the shebang — this script requires bash):
+#   ~/insforge/deploy/backup.sh
+#   ./deploy/backup.sh              # when cwd is the install root
+#
+# Requires a running stack and a readable .env beside this checkout.
+# Override defaults:
+#   RETENTION_DAYS=30 ./deploy/backup.sh
+#   BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
+set -euo pipefail
+
+INSTALL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$INSTALL_ROOT/.env"
+BACKUP_DIR="${BACKUP_DIR:-$INSTALL_ROOT/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+DUMP_PATH="$BACKUP_DIR/db_$TIMESTAMP.sql"
+DUMP_TMP="${DUMP_PATH}.tmp"
+
+trap 'echo "[$(date -Iseconds)] ERROR: Backup failed at line $LINENO" >&2; rm -f "$DUMP_TMP"; exit 1' ERR
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "No .env at $ENV_FILE — run deploy/setup.sh in this directory first." >&2
+  exit 1
+fi
+
+if ! [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "RETENTION_DAYS must be a non-negative integer (got: $RETENTION_DAYS)" >&2
+  exit 1
+fi
+
+cd "$INSTALL_ROOT"
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+mkdir -p "$BACKUP_DIR"
+
+docker compose exec -T postgres \
+  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
+  > "$DUMP_TMP"
+
+if [ ! -s "$DUMP_TMP" ]; then
+  rm -f "$DUMP_TMP"
+  echo "pg_dump produced an empty file — is postgres running?" >&2
+  exit 1
+fi
+
+mv "$DUMP_TMP" "$DUMP_PATH"
+cp "$ENV_FILE" "$BACKUP_DIR/env_$TIMESTAMP.bak"
+
+find "$BACKUP_DIR" -name 'db_*.sql' -mtime +"$RETENTION_DAYS" -delete
+find "$BACKUP_DIR" -name 'env_*.bak' -mtime +"$RETENTION_DAYS" -delete
+
+echo "[$(date -Iseconds)] Backup completed: db_$TIMESTAMP.sql"

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -10,6 +10,7 @@
 #   RETENTION_DAYS=30 ./deploy/backup.sh
 #   BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 set -euo pipefail
+umask 077
 
 INSTALL_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ENV_FILE="$INSTALL_ROOT/.env"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -86,6 +86,7 @@ if [ -n "${INSFORGE_NO_GIT:-}" ] || ! command -v git >/dev/null 2>&1; then
     curl -fsSL "$RAW/${REF:-main}/$f" -o "$f" ||
       { echo "Could not fetch $f at ${REF:-main} from $RAW." >&2; exit 1; }
   done
+  chmod +x deploy/backup.sh
   NO_GIT=1
 fi
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -57,6 +57,7 @@ docker-compose.rustfs.yml
 functions/deno.json
 functions/server.ts
 functions/worker-template.js
+deploy/backup.sh
 deploy/docker-compose/docker-compose.yml
 deploy/docker-init/db/db-init.sql
 deploy/docker-init/db/jwt.sql

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -833,6 +833,15 @@ By default the backend allows all origins. It reflects the request's `Origin` he
 
 #### 14.1 Back Up the Database
 
+For a database dump and `.env` copy in one step, use the shipped backup script:
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+Or dump manually:
+
 ```bash
 cd ~/insforge
 source .env
@@ -991,51 +1000,29 @@ docker compose up -d
 
 ### 17. Automated Backups
 
-Set up a cron job for daily automated backups:
+Set up a cron job for daily automated backups.
 
-#### 17.1 Create a Backup Script
+#### 17.1 Run the Backup Script
+
+Self-host installs include `deploy/backup.sh` (delivered by `deploy/setup.sh`). It dumps Postgres and copies `.env` into a `backups/` directory under your install root.
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+By default, backups land in `~/insforge/backups/` and files older than 14 days are removed. Override retention:
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+Restore a database dump:
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 Schedule with Cron
@@ -1044,10 +1031,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-Add this line for daily backups at 3:00 AM:
+Add this line for daily backups at 3:00 AM (adjust the path if your install lives elsewhere):
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 Off-Site Backups (Recommended)
@@ -1126,7 +1113,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────


### PR DESCRIPTION
## Summary

Self-host installs get a backup script shipped with the rest of the deploy files.

Right now `setup.sh` sets everything up, but backups are only documented as something you copy-paste from the security guide into `~/insforge/backup.sh`. That’s easy to skip and hard to keep in sync when the docs change.

This PR adds `deploy/backup.sh`, includes it in the `setup.sh` file list, and updates the security guide to point at it.

Closes #1911

## What it does

Running `./deploy/backup.sh` from your install directory:

1. Dumps Postgres to `backups/db_<timestamp>.sql`
2. Copies `.env` to `backups/env_<timestamp>.bak`
3. Deletes backups older than 14 days (override with `RETENTION_DAYS`)

The script reads `.env` itself, so `docker compose` picks up the right project name and database credentials.

## Files changed

- `deploy/backup.sh` — new script
- `deploy/setup.sh` — added to sparse checkout manifest
- `docs/deployment/deployment-security-guide.md` — §14, §17, and quick reference updated

## How to test

```bash
cd ~/insforge
./deploy/backup.sh
ls backups/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `deploy/backup.sh` for self-host backups. It dumps Postgres, copies `.env`, prunes old backups, uses secure file permissions, and ships via `deploy/setup.sh`; docs now reference the script.

- **New Features**
  - Run `./deploy/backup.sh` from the install root to create `backups/db_<timestamp>.sql` and `backups/env_<timestamp>.bak`.
  - Reads `.env` so `docker compose` uses the right project and DB credentials.
  - Supports `RETENTION_DAYS` (default 14) and `BACKUP_DIR` overrides.

- **Bug Fixes**
  - Set `umask 077` so backup files aren’t world-readable.
  - Ensure `deploy/backup.sh` is executable in `INSFORGE_NO_GIT` installs via `chmod +x` in `deploy/setup.sh`.

<sup>Written for commit b7fa85a913a1579566eb5ff093b2e9e38280231f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `deploy/backup.sh` for self-hosted Postgres and `.env` backups
> - Adds [deploy/backup.sh](https://github.com/InsForge/InsForge/pull/1913/files#diff-ec6692a6f5452ee301d385c1dcd7d6afdbe8a24a78f01357367b688d1d2b1a31), a bash script that dumps the Postgres database via `docker compose exec` and copies `.env` into a timestamped `backups/` directory, with configurable retention pruning via `RETENTION_DAYS`.
> - Uses a temp file with a non-empty check and an error trap to avoid writing corrupt dumps.
> - Updates [deploy/setup.sh](https://github.com/InsForge/InsForge/pull/1913/files#diff-d53dc0f54c4de6ba9bc4cca89ecb3f74cb04caa68315b0044f92f577dd8f7031) to fetch and `chmod +x` the script during non-git installs.
> - Updates the deployment security guide to reference `./deploy/backup.sh` as the preferred backup command, with cron and restore examples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7fa85a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backup utility for PostgreSQL databases and environment configuration.
  * Backups are timestamped, validated, and automatically cleaned up using configurable retention settings.
  * Added failure reporting for backup operations.
  * The utility is included automatically during HTTPS/no-Git setup.

* **Documentation**
  * Updated deployment guidance with automated backup setup, restore instructions, retention defaults, and cron configuration.
  * Clarified the distinction between automated backups and manual database dumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->