### PR TITLE
fix(dashboard): stop the capacity fallback stacking its oldest bars

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -71,6 +71,12 @@ const SPARKLINE_HEIGHT = 100;
 // threshold dashed line and reference grid start after them.
 const Y_AXIS_LABEL_WIDTH = 29;
 
+/** Bar width for `count` samples sharing the plot. */
+function barWidthFor(count: number): number {
+  const slot = (SPARKLINE_WIDTH - Y_AXIS_LABEL_WIDTH) / Math.max(1, count);
+  return Math.max(1.5, slot * 0.85);
+}
+
 interface SparklinePoint {
   x: number;
   y: number;
@@ -86,10 +92,33 @@ interface SparklineGeometry {
   max: number | null;
 }
 
+/**
+ * Map a timestamp onto the chart's x axis.
+ *
+ * `plotRange` is the span samples may occupy. It defaults to the whole width,
+ * which is what the line/area variant wants: no y-axis gutter to clear, and the
+ * stroke should reach both edges.
+ *
+ * The single-color capacity fallback passes its bar region instead. Mapping into
+ * the region matters because clamping into it does not relocate a sample that
+ * lands in the gutter, it pins every such sample to the same x.
+ */
+function timestampToX(
+  timestamp: number,
+  windowStart: number,
+  tRange: number,
+  plotRange: [number, number]
+): number {
+  const [left, right] = plotRange;
+  const progress = (timestamp - windowStart) / tRange;
+  return left + Math.max(0, Math.min(1, progress)) * (right - left);
+}
+
 function buildSparkline(
   data: DashboardMetricDataPoint[],
   rangeSeconds: number,
-  fixedDomain?: [number, number]
+  fixedDomain?: [number, number],
+  plotRange: [number, number] = [0, SPARKLINE_WIDTH]
 ): SparklineGeometry {
   const finite = data
     .filter((p) => Number.isFinite(p.value))
@@ -113,8 +142,7 @@ function buildSparkline(
   const tRange = Math.max(1, windowEnd - windowStart);
 
   const points: SparklinePoint[] = finite.map((p) => {
-    const rawX = ((p.timestamp - windowStart) / tRange) * SPARKLINE_WIDTH;
-    const x = Math.max(0, Math.min(SPARKLINE_WIDTH, rawX));
+    const x = timestampToX(p.timestamp, windowStart, tRange, plotRange);
     const y = SPARKLINE_HEIGHT - ((p.value - min) / valueRange) * SPARKLINE_HEIGHT;
     return { x, y, timestamp: p.timestamp, value: p.value };
   });
@@ -169,9 +197,24 @@ export function MetricChartCard({
   // turn AVG into a slot-weighted artifact of the densification pass.
   const statsSeries = statsData ?? data;
   const aggregates = useMemo(() => aggregateMetricSeries(statsSeries), [statsSeries]);
+  // The single-color capacity fallback keeps timestamp-proportional placement,
+  // so its samples have to be mapped into the bar region rather than clamped
+  // into it by `bars` below. Bars are centered on the sample x, hence the half
+  // width of inset on each side: that makes the clamp there a true no-op.
+  const fallbackPlotRange = useMemo((): [number, number] | undefined => {
+    if (!capacity || capacity.components?.length || barChart) {
+      return undefined;
+    }
+    const count = data.filter((p) => Number.isFinite(p.value)).length;
+    if (count < 2) {
+      return undefined;
+    }
+    const width = barWidthFor(count);
+    return [Y_AXIS_LABEL_WIDTH + 2 + width / 2, SPARKLINE_WIDTH - width / 2];
+  }, [capacity, barChart, data]);
   const sparkline = useMemo(
-    () => buildSparkline(data, rangeSeconds, effectiveDomain),
-    [data, rangeSeconds, effectiveDomain]
+    () => buildSparkline(data, rangeSeconds, effectiveDomain, fallbackPlotRange),
+    [data, rangeSeconds, effectiveDomain, fallbackPlotRange]
   );
   const gradientId = useId();
   const xAxisTicks = useMemo(() => {
@@ -250,10 +293,11 @@ export function MetricChartCard({
     if (!active || displayPoints.length === 0) {
       return [];
     }
-    const slot = (SPARKLINE_WIDTH - Y_AXIS_LABEL_WIDTH) / displayPoints.length;
-    const width = Math.max(1.5, slot * 0.85);
-    // Clamp into the plot area: a no-op for the uniform slots (barChart), but
-    // the capacity fallback's timestamp-proportional x can sit at either edge.
+    const width = barWidthFor(displayPoints.length);
+    // Both variants now arrive pre-fitted to the plot: barChart via uniform
+    // slots, the capacity fallback via fallbackPlotRange. The clamp stays as a
+    // backstop against rounding at the edges, but it no longer decides
+    // placement, which is what made it collapse the oldest bars.
     return displayPoints.map((point) => ({
       x: Math.max(Y_AXIS_LABEL_WIDTH + 2, Math.min(point.x - width / 2, SPARKLINE_WIDTH - width)),
       y: point.y,

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
@@ -62,6 +62,40 @@ describe('MetricChartCard rendering modes', () => {
     expect(Math.abs(gaps[0] - gaps[1])).toBeGreaterThan(10);
   });
 
+  it('capacity fallback does not stack the oldest bars on one another', () => {
+    // buildSparkline mapped timestamps across the full 434px width and `bars`
+    // then clamped with Math.max(Y_AXIS_LABEL_WIDTH + 2, ...). Clamping does not
+    // move a sample out of the 29px y-axis gutter, it pins every gutter sample
+    // to the same x, so the oldest bars were painted over each other: 5 of 60 at
+    // a one-minute cadence. #1919 fixed the uniform-slot modes; this one kept
+    // timestamp placement and kept the bug.
+    const count = 60;
+    const rangeSeconds = 3600;
+    const step = rangeSeconds / (count - 1);
+    const { container } = render(
+      <MetricChartCard
+        {...base}
+        rangeSeconds={rangeSeconds}
+        fixedDomain={[0, 100]}
+        formatAxisLabel={(v) => `${v}`}
+        capacity={{ ticks: [0, 100], legend: { ceiling: 'Size', used: 'Used' } }}
+        data={pts(
+          Array.from(
+            { length: count },
+            (_, i) => [1000 + i * step, 50 + (i % 7)] as [number, number]
+          )
+        )}
+      />
+    );
+    const xs = svgRects(container).map((r) => parseFloat(r.getAttribute('x') ?? '0'));
+
+    expect(xs).toHaveLength(count);
+    expect(new Set(xs).size).toBe(count);
+    // And still inside the plot, clear of the y-axis labels.
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(31);
+    expect(Math.max(...xs)).toBeLessThanOrEqual(434);
+  });
+
   it('computes AVG/MAX/LATEST from statsData, not the densified display series', () => {
     // Densified data forward-fills one reading into three slots; averaging it
     // would give 15, but the raw readings average 20.


### PR DESCRIPTION
Closes #1916.

### The defect

`MetricChartCard`'s capacity charts (the disk card's Database/WAL/System stack, and the plain bar variant) map a sample's timestamp across the full chart width, then clamp the result into the plot region:

```ts
const rawX = ((point.timestamp - windowStart) / Math.max(1, rangeSeconds)) * SPARKLINE_WIDTH;
const x = Math.max(Y_AXIS_LABEL_WIDTH + 2, Math.min(rawX, SPARKLINE_WIDTH - width));
```

`SPARKLINE_WIDTH` is 434 and `Y_AXIS_LABEL_WIDTH` is 29, so the first 29px of the time window map into the y-axis label gutter. The `Math.max` does not move those samples into the plot, it pins all of them to the same x. They render on top of each other and all but one are painted over.

Running that mapping verbatim for evenly spaced samples over the default 1h range:

```
30 samples over 1h:  3 bars pinned to x=31, first distinct x=44.90, bar width=11.47
60 samples over 1h:  5 bars pinned to x=31, first distinct x=36.78, bar width=5.74
120 samples over 1h: 9 bars pinned to x=31, first distinct x=32.82, bar width=2.87
```

The collapsed share is `29/434` of the samples, about 6.7%, whatever the range. The clamp is what hides it: nothing is drawn outside the plot, so it looks right while it is quietly overlapping bars.

Second symptom, same cause: hover hit-testing and the hover marker read `sparkline.points[i].x`, which is **unclamped**, while the bar is drawn clamped. In that region the marker sits left of the bar whose value the tooltip reports.

### The fix

Map into the plot region instead of clamping into it, via one `timestampToX` helper shared by `buildSparkline` and `stackedBars`. That keeps the bars and the hover hit-testing on a single coordinate system, which is what makes the second symptom go away rather than papering over it. The region stops one bar width short of the right edge, because a bar is anchored at its left edge and would otherwise be clipped.

The line/area variant passes no plot range and keeps the full width, so **non-capacity charts are pixel-identical**. It has no y-axis gutter to clear and its stroke should reach both edges.

### Tests

New `chartGeometry.test.ts` covers the mapping directly: 30/60/120 samples over 1h each produce that many distinct x positions (the assertion the old mapping fails), the oldest sample sits at the plot's left edge rather than in the gutter, the newest bar's right edge stays inside the viewport, out-of-window samples clamp to the edges, and the line/area variant still spans 0 to 434.

### Gates

- `@insforge/dashboard` typecheck: clean
- dashboard suite: 231 passed, up from 224, plus 6 pre-existing `LocaleProvider` failures that reproduce identically on unmodified `main` under local Node 26 and are green on CI's Node 20 (`main` @ e82686860 is green on all checks)
- eslint and prettier: clean

### Scope note

This only changes the x mapping. It does not touch the colors, the ceiling, the tooltip content or anything else from the recent design rounds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capacity bars stacking by mapping timestamps into the bar region instead of clamping. Bars render distinctly and the hover marker aligns; other chart variants remain unchanged.

- **Bug Fixes**
  - Added `timestampToX` and used it in `buildSparkline` to map x within a `fallbackPlotRange` for the single-color capacity mode; stacked and `barChart` modes keep uniform slots.
  - Used `barWidthFor` for consistent bar width and inset bars by half a width so clamping is only a backstop at the edges.
  - Added a regression test in `MetricChartCard.test.tsx` verifying 60 capacity samples produce 60 distinct x positions and stay inside the plot.

<sup>Written for commit d5b604e71b9a2696e9b9f5d67410dd348cb471f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix capacity chart bars stacking at the left gutter in the dashboard
> - Adds `timestampToX` to map timestamps into an explicit plot region, replacing scattered raw x computations that collapsed distinct timestamps onto a single x near the y-axis gutter.
> - Adds `barWidthFor` to compute a consistent bar width from sample count, shared across the `bars` and `stackedBars` memo hooks in [`MetricChartCard.tsx`](https://github.com/InsForge/InsForge/pull/1917/files#diff-6c59402e5bdc7fe1aae45ecea455773b19caa4d2fe4a692e6a0ed7ccd27dedd6).
> - In capacity mode, `buildSparkline` now receives a narrowed `plotRange` that reserves space for the newest bar on the right and starts just past the label gutter on the left; non-capacity variants are unchanged.
> - Adds geometry unit tests in [`chartGeometry.test.ts`](https://github.com/InsForge/InsForge/pull/1917/files#diff-fc1471f2b8e6de65bf771976ee8aacde6e455a701c86ff1df5ef6186d930b3f1) covering bar width, x mapping, edge clamping, and full-width line behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1983a8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity chart rendering so bars are positioned accurately within the plot area.
  * Prevented older bars from overlapping the chart’s y-axis gutter.
  * Enhanced bar sizing and timestamp placement across larger time ranges.

* **Tests**
  * Added regression coverage for capacity charts with extended time-series data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->