### PR TITLE
feat(dashboard): observability timestamps in local time, UTC on hover

### DIFF
--- a/packages/dashboard/src/features/compute/components/ServiceEvents.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceEvents.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { RefreshCw } from 'lucide-react';
 import { Button } from '@insforge/ui';
 import { useServiceEvents } from '#features/compute/hooks/useComputeServices';
+import { formatLocalLogTime, formatUtcTime } from '#lib/utils/utils';
 
 interface ServiceEventsProps {
   serviceId: string;
@@ -47,13 +48,8 @@ export function ServiceEvents({ serviceId }: ServiceEventsProps) {
           <pre className="text-xs font-mono text-muted-foreground space-y-0.5">
             {events.map((entry, i) => (
               <div key={i}>
-                <span className="text-foreground/60">
-                  {(() => {
-                    const d = new Date(entry.timestamp);
-                    return isNaN(d.getTime())
-                      ? String(entry.timestamp)
-                      : d.toISOString().replace('T', ' ').slice(0, 19);
-                  })()}
+                <span className="text-foreground/60" title={formatUtcTime(entry.timestamp)}>
+                  {formatLocalLogTime(entry.timestamp)}
                 </span>
                 {'  '}
                 {entry.message}

--- a/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
+++ b/packages/dashboard/src/features/compute/components/ServiceLogs.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { RefreshCw, Play, Pause } from 'lucide-react';
 import { Button } from '@insforge/ui';
 import { useServiceLogs } from '#features/compute/hooks/useComputeServices';
+import { formatLocalLogTime, formatUtcTime } from '#lib/utils/utils';
 
 interface ServiceLogsProps {
   serviceId: string;
@@ -56,13 +57,8 @@ export function ServiceLogs({ serviceId }: ServiceLogsProps) {
           <pre className="text-xs font-mono text-muted-foreground space-y-0.5">
             {lines.map((entry, i) => (
               <div key={`${entry.timestamp}-${i}`}>
-                <span className="text-foreground/60">
-                  {(() => {
-                    const d = new Date(entry.timestamp);
-                    return isNaN(d.getTime())
-                      ? String(entry.timestamp)
-                      : d.toISOString().replace('T', ' ').slice(0, 19);
-                  })()}
+                <span className="text-foreground/60" title={formatUtcTime(entry.timestamp)}>
+                  {formatLocalLogTime(entry.timestamp)}
                 </span>
                 {'  '}
                 {entry.message}

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -4,6 +4,7 @@ import { Info } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '#components';
 import type { DashboardMetricDataPoint } from '#types';
 import { aggregateMetricSeries } from '#features/dashboard/utils/aggregateMetricSeries';
+import { formatUtcTime } from '#lib/utils/utils';
 
 export interface MetricChartCardProps {
   title: string;
@@ -381,7 +382,10 @@ export function MetricChartCard({
             {isLoading ? '—' : renderValue(aggregates.latest)}
           </p>
           {!isLoading && latestTimestamp !== null && (
-            <p className="text-xs leading-4 text-muted-foreground">
+            <p
+              className="text-xs leading-4 text-muted-foreground"
+              title={formatUtcTime(latestTimestamp * 1000)}
+            >
               {new Date(latestTimestamp * 1000).toLocaleString(undefined, {
                 month: 'short',
                 day: 'numeric',

--- a/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/AuditsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RefreshCw, Trash2, ExternalLink } from 'lucide-react';
 import { LogsDataGrid, type LogsColumnDef } from '#features/logs/components';
-import { formatTime } from '#lib/utils/utils';
+import { formatTime, formatUtcTime } from '#lib/utils/utils';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import { usePageSize } from '#lib/hooks/usePageSize';
 import { Button, ConfirmDialog, cn } from '@insforge/ui';
@@ -106,7 +106,10 @@ export default function AuditsPage() {
 
           return (
             <div className="flex w-full items-center gap-2">
-              <p className="min-w-0 flex-1 truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
+              <p
+                className="min-w-0 flex-1 truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]"
+                title={formatUtcTime(String(row.createdAt ?? ''))}
+              >
                 {`${timestamp} - ${details}`}
               </p>
               <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/packages/dashboard/src/features/logs/pages/FunctionLogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/FunctionLogsPage.tsx
@@ -12,7 +12,7 @@ import {
   BuildLogsView,
   SeverityFilterDropdown,
 } from '#features/logs/components';
-import { formatTime } from '#lib/utils/utils';
+import { formatTime, formatUtcTime } from '#lib/utils/utils';
 import { LogSchema } from '@insforge/shared-schemas';
 import { usePageSize } from '#lib/hooks/usePageSize';
 
@@ -72,7 +72,10 @@ export default function FunctionLogsPage() {
         name: t('logs.time', { defaultValue: 'Time' }),
         width: '240px',
         renderCell: ({ row }) => (
-          <p className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
+          <p
+            className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]"
+            title={formatUtcTime(String(row.timestamp ?? ''))}
+          >
             {formatTime(String(row.timestamp ?? ''))}
           </p>
         ),

--- a/packages/dashboard/src/features/logs/pages/LogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/LogsPage.tsx
@@ -11,7 +11,7 @@ import {
   LogDetailPanel,
   SeverityFilterDropdown,
 } from '#features/logs/components';
-import { formatTime } from '#lib/utils/utils';
+import { formatTime, formatUtcTime } from '#lib/utils/utils';
 import { LogSchema } from '@insforge/shared-schemas';
 import { usePageSize } from '#lib/hooks/usePageSize';
 
@@ -64,7 +64,10 @@ export default function LogsPage() {
         name: t('logs.time', { defaultValue: 'Time' }),
         width: '240px',
         renderCell: ({ row }) => (
-          <p className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
+          <p
+            className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]"
+            title={formatUtcTime(String(row.timestamp ?? ''))}
+          >
             {formatTime(String(row.timestamp ?? ''))}
           </p>
         ),

--- a/packages/dashboard/src/features/logs/pages/MCPLogsPage.tsx
+++ b/packages/dashboard/src/features/logs/pages/MCPLogsPage.tsx
@@ -4,7 +4,7 @@ import { DataGridEmptyState, EmptyState, TableHeader } from '#components';
 import { LogsDataGrid, type LogsColumnDef } from '#features/logs/components';
 import { useMcpUsage } from '#features/logs/hooks/useMcpUsage';
 import type { McpUsageRecord } from '#features/logs/services/usage.service';
-import { formatTime } from '#lib/utils/utils';
+import { formatTime, formatUtcTime } from '#lib/utils/utils';
 import { usePageSize } from '#lib/hooks/usePageSize';
 
 export default function MCPLogsPage() {
@@ -45,7 +45,10 @@ export default function MCPLogsPage() {
         name: t('logs.time', { defaultValue: 'Time' }),
         width: '260px',
         renderCell: ({ row }) => (
-          <p className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]">
+          <p
+            className="truncate text-[13px] font-normal leading-[18px] text-[rgb(var(--foreground))]"
+            title={formatUtcTime(String(row.created_at ?? ''))}
+          >
             {formatTime(String(row.created_at ?? ''))}
           </p>
         ),

--- a/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
+++ b/packages/dashboard/src/lib/utils/__tests__/utils.test.ts
@@ -5,7 +5,9 @@ import {
   compareVersions,
   convertValueForColumn,
   formatDate,
+  formatLocalLogTime,
   formatTime,
+  formatUtcTime,
   formatValueForDisplay,
   isEmptyValue,
 } from '#lib/utils/utils';
@@ -45,6 +47,26 @@ describe('formatDate', () => {
   it('formats valid ISO dates and preserves invalid input', () => {
     expect(formatDate('2026-05-17T12:30:00')).toBe('May 17, 2026');
     expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('formatUtcTime', () => {
+  it('renders UTC regardless of the viewer timezone, from strings or epoch ms', () => {
+    expect(formatUtcTime('2026-05-17T12:30:00Z')).toBe('2026-05-17 12:30:00 UTC');
+    expect(formatUtcTime(Date.UTC(2026, 4, 17, 12, 30, 0))).toBe('2026-05-17 12:30:00 UTC');
+    expect(formatUtcTime('not-a-date')).toBe('not-a-date');
+  });
+});
+
+describe('formatLocalLogTime', () => {
+  it('renders the compact log shape in local time and preserves invalid input', () => {
+    const epoch = Date.UTC(2026, 4, 17, 12, 30, 0);
+    // Expected value computed with the same local-timezone conversion the
+    // helper performs, so the test passes in any TZ while still asserting
+    // the epoch-ms and string inputs agree.
+    expect(formatLocalLogTime(epoch)).toBe(formatLocalLogTime('2026-05-17T12:30:00Z'));
+    expect(formatLocalLogTime(epoch)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    expect(formatLocalLogTime('not-a-date')).toBe('not-a-date');
   });
 });
 

--- a/packages/dashboard/src/lib/utils/utils.ts
+++ b/packages/dashboard/src/lib/utils/utils.ts
@@ -177,6 +177,34 @@ export function formatTime(timestamp: string): string {
 }
 
 /**
+ * Formats a timestamp as UTC, for hover tooltips on timestamps that display
+ * in the viewer's local time (Supabase/Render convention: local shown, UTC on hover)
+ * @param timestamp - ISO timestamp string or epoch milliseconds
+ * @returns UTC string (e.g., "2025-01-15 15:30:00 UTC"), or the input stringified if unparseable
+ */
+export function formatUtcTime(timestamp: string | number | Date): string {
+  const date = typeof timestamp === 'string' ? parseISO(timestamp) : new Date(timestamp);
+  if (!isValid(date)) {
+    return String(timestamp);
+  }
+  return `${date.toISOString().replace('T', ' ').slice(0, 19)} UTC`;
+}
+
+/**
+ * Formats a timestamp in the viewer's local time using the compact log-line
+ * shape (e.g., "2025-01-15 15:30:00"); pair with formatUtcTime as the hover title
+ * @param timestamp - ISO timestamp string or epoch milliseconds
+ * @returns Local-time string, or the input stringified if unparseable
+ */
+export function formatLocalLogTime(timestamp: string | number | Date): string {
+  const date = typeof timestamp === 'string' ? parseISO(timestamp) : new Date(timestamp);
+  if (!isValid(date)) {
+    return String(timestamp);
+  }
+  return format(date, 'yyyy-MM-dd HH:mm:ss');
+}
+
+/**
  * Formats a timestamp string to a date-only format
  * @param timestamp - ISO timestamp string
  * @returns Formatted date string (e.g., "Jan 15, 2025")


### PR DESCRIPTION
## Summary

Observability timestamps now display in the viewer's **local timezone**, with the **UTC time revealed on hover** (native `title` tooltip) — matching the Supabase/Render convention.

## Changes

- **compute `ServiceLogs` / `ServiceEvents`**: these were the real offenders — they rendered raw UTC via `toISOString()`. Now they show local time in the same compact `YYYY-MM-DD HH:mm:ss` shape, with UTC on hover.
- **Logs / Function Logs / MCP Logs / Audits time cells**: already local via `formatTime` (date-fns renders local); added the UTC hover title for parity.
- **`MetricChartCard` headline timestamp**: already local; added UTC hover title. Chart hover tooltips were already local-time.
- **New shared helpers** `formatLocalLogTime` / `formatUtcTime` in `lib/utils/utils.ts`, unit-tested timezone-independently (epoch-ms and `Z`-string inputs must agree; UTC output asserted exactly).

## Not touched

- AI usage pages pin `timeZone: 'UTC'` intentionally (daily billing buckets align with metering days) — left as is.

## Verification

- `tsc --noEmit` clean
- unit suite 95 passed (2 new), component suite 143 passed
- eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaeYG3veJq1mpVkG39dj5S


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show observability timestamps in the viewer’s local time, with exact UTC shown on hover. This fixes compute logs/events and adds consistent UTC-hover titles across logs and metrics.

- **New Features**
  - Compute `ServiceLogs` and `ServiceEvents` now render local `YYYY-MM-DD HH:mm:ss`, with UTC on hover.
  - Logs, Function Logs, MCP Logs, Audits, and the `MetricChartCard` headline now show UTC on hover; existing local display remains.
  - Added `formatLocalLogTime` and `formatUtcTime` helpers with timezone-independent tests; AI usage pages remain UTC by design.

<sup>Written for commit 7e7347853acd905bd703e63c9f95e1bdf4d96d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Display observability timestamps in local time with UTC on hover
> - Adds `formatLocalLogTime` and `formatUtcTime` utility functions in [`utils.ts`](https://github.com/InsForge/InsForge/pull/1921/files#diff-3e639d488908e76be05d160922d884d0fd7d145994909c3458fc547ab6c9544c) that format timestamps as `yyyy-MM-dd HH:mm:ss` in local time and UTC respectively, with graceful fallback for invalid inputs.
> - Updates service events, service logs, metric chart cards, audit logs, function logs, general logs, and MCP logs to show local time as visible text and UTC time in a `title` tooltip on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e73478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->