### PR TITLE
fix(dashboard): include latest disk reading in chart

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -168,6 +168,58 @@ export function buildDiskBreakdown(
   return alignedDb.length ? { database: alignedDb, wal: alignedWal, system } : null;
 }
 
+export function densifyDiskBreakdown(
+  breakdown: {
+    database: DashboardMetricDataPoint[];
+    wal: DashboardMetricDataPoint[];
+    system: DashboardMetricDataPoint[];
+  },
+  range: DashboardMetricsRange
+): {
+  database: DashboardMetricDataPoint[];
+  wal: DashboardMetricDataPoint[];
+  system: DashboardMetricDataPoint[];
+} {
+  const DISK_SLOTS = 48;
+  const source = breakdown.database;
+  const windowEnd = source[source.length - 1].timestamp;
+  const step = RANGE_SECONDS[range] / DISK_SLOTS;
+  const windowStart = windowEnd - RANGE_SECONDS[range];
+
+  const database: DashboardMetricDataPoint[] = [];
+  const wal: DashboardMetricDataPoint[] = [];
+  const system: DashboardMetricDataPoint[] = [];
+
+  let idx = 0;
+
+  for (let slot = 0; slot < DISK_SLOTS; slot++) {
+    const slotTime = windowStart + (slot + 1) * step;
+
+    while (idx + 1 < source.length && source[idx + 1].timestamp <= slotTime) {
+      idx += 1;
+    }
+
+    const ts = source[idx].timestamp;
+
+    database.push({
+      timestamp: ts,
+      value: source[idx].value,
+    });
+
+    wal.push({
+      timestamp: ts,
+      value: breakdown.wal[idx].value,
+    });
+
+    system.push({
+      timestamp: ts,
+      value: breakdown.system[idx].value,
+    });
+  }
+
+  return { database, wal, system };
+}
+
 export function ObservabilitySection() {
   const { t } = useTranslation('chrome');
   const isCloudHostingMode = useIsCloudHostingMode();
@@ -219,30 +271,7 @@ export function ObservabilitySection() {
     // fill; slots before the first sample take that first sample). Slots
     // keep the SOURCE sample's timestamp, so hovering any thin bar shows a
     // real reading and its real time, never an interpolated one.
-    const DISK_SLOTS = 48;
-    const densified = breakdown
-      ? (() => {
-          const source = breakdown.database;
-          const windowEnd = source[source.length - 1].timestamp;
-          const step = RANGE_SECONDS[range] / DISK_SLOTS;
-          const windowStart = windowEnd - RANGE_SECONDS[range];
-          const database: DashboardMetricDataPoint[] = [];
-          const wal: DashboardMetricDataPoint[] = [];
-          const system: DashboardMetricDataPoint[] = [];
-          let idx = 0;
-          for (let slot = 0; slot < DISK_SLOTS; slot++) {
-            const slotTime = windowStart + (slot + 0.5) * step;
-            while (idx + 1 < source.length && source[idx + 1].timestamp <= slotTime) {
-              idx += 1;
-            }
-            const ts = source[idx].timestamp;
-            database.push({ timestamp: ts, value: source[idx].value });
-            wal.push({ timestamp: ts, value: breakdown.wal[idx].value });
-            system.push({ timestamp: ts, value: breakdown.system[idx].value });
-          }
-          return { database, wal, system };
-        })()
-      : null;
+    const densified = breakdown ? densifyDiskBreakdown(breakdown, range) : null;
     // With a breakdown the chart's primary series is the per-slot used total
     // (the same stack the bars draw), but AVG/MAX/LATEST and the headline
     // timestamp are computed from the RAW per-sample totals — averaging the

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildDiskBreakdown , densifyDiskBreakdown } from '#features/dashboard/components/observability/ObservabilitySection';
+import {
+  buildDiskBreakdown,
+  densifyDiskBreakdown,
+} from '#features/dashboard/components/observability/ObservabilitySection';
 
 const pts = (pairs: Array<[number, number]>) =>
   pairs.map(([timestamp, value]) => ({ timestamp, value }));

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildDiskBreakdown } from '#features/dashboard/components/observability/ObservabilitySection';
+import { buildDiskBreakdown , densifyDiskBreakdown } from '#features/dashboard/components/observability/ObservabilitySection';
 
 const pts = (pairs: Array<[number, number]>) =>
   pairs.map(([timestamp, value]) => ({ timestamp, value }));
@@ -65,5 +65,98 @@ describe('buildDiskBreakdown', () => {
     );
     expect(breakdown!.database).toHaveLength(1);
     expect(breakdown!.database[0].timestamp).toBe(1000);
+  });
+});
+
+describe('densifyDiskBreakdown', () => {
+  it.each([
+    ['1h', 3600],
+    ['6h', 21600],
+    ['24h', 86400],
+    ['3d', 259200],
+  ] as const)('includes the newest sample for %s range', (range, windowSeconds) => {
+    const newestTimestamp = windowSeconds;
+
+    const breakdown = {
+      database: pts([
+        [0, 100],
+        [windowSeconds - 900, 200],
+        [newestTimestamp, 500],
+      ]),
+      wal: pts([
+        [0, 10],
+        [windowSeconds - 900, 20],
+        [newestTimestamp, 50],
+      ]),
+      system: pts([
+        [0, 1000],
+        [windowSeconds - 900, 1100],
+        [newestTimestamp, 1400],
+      ]),
+    };
+
+    const result = densifyDiskBreakdown(breakdown, range);
+    const lastPoint = result.database[result.database.length - 1];
+
+    expect(lastPoint).toEqual({
+      timestamp: newestTimestamp,
+      value: 500,
+    });
+  });
+
+  it.each([
+    ['1-minute cadence', 60],
+    ['15-minute cadence', 900],
+  ] as const)('includes the newest sample with %s', (_label, cadence) => {
+    const newestTimestamp = 3600;
+
+    const breakdown = {
+      database: pts([
+        [newestTimestamp - cadence * 2, 100],
+        [newestTimestamp - cadence, 200],
+        [newestTimestamp, 500],
+      ]),
+      wal: pts([
+        [newestTimestamp - cadence * 2, 10],
+        [newestTimestamp - cadence, 20],
+        [newestTimestamp, 50],
+      ]),
+      system: pts([
+        [newestTimestamp - cadence * 2, 1000],
+        [newestTimestamp - cadence, 1100],
+        [newestTimestamp, 1400],
+      ]),
+    };
+
+    const result = densifyDiskBreakdown(breakdown, '1h');
+    const lastPoint = result.database[result.database.length - 1];
+
+    expect(lastPoint).toEqual({
+      timestamp: newestTimestamp,
+      value: 500,
+    });
+  });
+
+  it('preserves the source timestamp for the newest sample', () => {
+    const breakdown = {
+      database: pts([
+        [0, 100],
+        [3600, 500],
+      ]),
+      wal: pts([
+        [0, 10],
+        [3600, 50],
+      ]),
+      system: pts([
+        [0, 1000],
+        [3600, 1400],
+      ]),
+    };
+
+    const result = densifyDiskBreakdown(breakdown, '1h');
+    const lastPoint = result.database[result.database.length - 1];
+
+    expect(lastPoint.timestamp).toBe(3600);
+    expect(lastPoint.value).toBe(500);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1920.

The disk chart densification used the center of each slot when selecting the latest source sample. Since the chart window ends at the newest reading, the final slot center was always half a step before `windowEnd`, causing the newest reading to never appear in the chart.

### Changes

- Extracted disk densification into `densifyDiskBreakdown()`.
- Changed slot lookup from the slot center to the slot end boundary.
- The final slot now reaches `windowEnd`, so the newest disk reading is included.
- Preserved the original source timestamp for each densified point.
- Added regression tests covering:
  - 1h, 6h, 24h, and 3d ranges
  - 1-minute cadence
  - 15-minute cadence
  - preservation of the newest source timestamp

### Validation

- `npm run test:unit` — **100/100 tests passed**
- Focused `buildDiskBreakdown.test.ts` — **13/13 tests passed**
- `npm run lint` — **passed**
- `git diff --check` — **passed**
- `npm run typecheck` — currently reports 2 unrelated existing errors in `ComputePage.tsx` regarding `providerInstanceId`; that file is unchanged by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the disk usage chart so the newest reading always shows. Densification now aligns to each slot’s end, so the final slot reaches the chart window end.

- **Bug Fixes**
  - Select the sample at the end of each slot (not the center) during densification, ensuring the latest reading appears.
  - Preserve original source timestamps; added regression tests across 1h/6h/24h/3d ranges and 1m/15m cadences.

<sup>Written for commit d44ea1a615f77d0cdf8112b0923b177b09106a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix disk breakdown chart to include the latest disk reading in the last slot
> The previous densification used slot midpoints (`windowStart + (slot + 0.5) * step`), which caused the newest sample to fall outside the last slot and be dropped from the chart. The new `densifyDiskBreakdown` util in [ObservabilitySection.tsx](https://github.com/InsForge/InsForge/pull/1923/files#diff-4d4de4387f9c09a7f1ba64970502fcff25a504fc213a5153d41e8347edd15ba2) uses end-aligned slots (`windowStart + (slot + 1) * step`) with a `<= slotTime` guard, so the last slot always captures the latest reading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0233b67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk usage charts across supported time ranges and sampling intervals.
  * Ensured the newest available disk data is retained and displayed correctly.
  * Updated chart sampling to use each time slot’s ending timestamp for more accurate results.

* **Tests**
  * Added coverage for disk data continuity, sampling cadences, time ranges, and source timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->