### PR TITLE
fix(ai): load .env.local in Quick Start scripts

### DIFF
--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -133,7 +133,9 @@ export const QUICK_START_COPY: Record<
 export function getQuickStartScript(mode: QuickStartMode, model: string) {
   if (mode === 'image') {
     return `import OpenAI from 'openai';
-import 'dotenv/config';
+import { config } from 'dotenv';
+
+config({ path: '.env.local', quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',
@@ -154,7 +156,9 @@ console.log(message?.images?.[0]?.image_url?.url);`;
   }
 
   if (mode === 'video') {
-    return `import 'dotenv/config';
+    return `import { config } from 'dotenv';
+
+config({ path: '.env.local', quiet: true });
 
 const response = await fetch('https://openrouter.ai/api/v1/videos', {
   method: 'POST',
@@ -186,7 +190,9 @@ console.log(result);`;
 
   if (mode === 'embeddings') {
     return `import OpenAI from 'openai';
-import 'dotenv/config';
+import { config } from 'dotenv';
+
+config({ path: '.env.local', quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',
@@ -204,7 +210,9 @@ console.log('Usage:', response.usage);`;
   }
 
   return `import OpenAI from 'openai';
-import 'dotenv/config';
+import { config } from 'dotenv';
+
+config({ path: '.env.local', quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',

--- a/packages/dashboard/src/features/ai/constants.ts
+++ b/packages/dashboard/src/features/ai/constants.ts
@@ -135,7 +135,7 @@ export function getQuickStartScript(mode: QuickStartMode, model: string) {
     return `import OpenAI from 'openai';
 import { config } from 'dotenv';
 
-config({ path: '.env.local', quiet: true });
+config({ path: ['.env.local', '.env'], quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',
@@ -158,7 +158,7 @@ console.log(message?.images?.[0]?.image_url?.url);`;
   if (mode === 'video') {
     return `import { config } from 'dotenv';
 
-config({ path: '.env.local', quiet: true });
+config({ path: ['.env.local', '.env'], quiet: true });
 
 const response = await fetch('https://openrouter.ai/api/v1/videos', {
   method: 'POST',
@@ -192,7 +192,7 @@ console.log(result);`;
     return `import OpenAI from 'openai';
 import { config } from 'dotenv';
 
-config({ path: '.env.local', quiet: true });
+config({ path: ['.env.local', '.env'], quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',
@@ -212,7 +212,7 @@ console.log('Usage:', response.usage);`;
   return `import OpenAI from 'openai';
 import { config } from 'dotenv';
 
-config({ path: '.env.local', quiet: true });
+config({ path: ['.env.local', '.env'], quiet: true });
 
 const openai = new OpenAI({
   baseURL: 'https://openrouter.ai/api/v1',


### PR DESCRIPTION
## Summary

Closes #1891

All four Quick Start snippets (text, image, video, embeddings) open with a bare `import 'dotenv/config'`, which loads `.env`. Step 3 of the same page tells you to put your key in `.env.local`: `AIQuickStartPage.tsx:275` for the copy, `:279` for the badge. Following the page exactly therefore leaves `OPENROUTER_API_KEY` undefined, and the first request fails authentication with nothing on the page to explain why.

This is option A from the issue. The scripts now read the file the page already names, so the UI copy and the four locale files stay as they are.

```diff
-import 'dotenv/config';
+import { config } from 'dotenv';
+
+config({ path: '.env.local', quiet: true });
```

Applied at all four call sites in `packages/dashboard/src/features/ai/constants.ts`. `quiet: true` is there because dotenv v17 otherwise prints `◇ injected env (1) from .env.local // tip: ...` into the script's own output.

## How did you test this change?

Reproduced the bug and confirmed the fix against dotenv 17.4.2, using a scratch ESM project with `OPENROUTER_API_KEY` in `.env.local` and no `.env` present:

| script | result |
|---|---|
| `import 'dotenv/config'` (current) | `KEY = undefined` |
| `config({ path: '.env.local', quiet: true })` (this PR) | key loads, no extra output |
| `config({ path: '.env.local' })` | key loads, but prints the `◇ injected env` notice |

That third row is why `quiet` is included rather than left off.

Also ran:

- `packages/dashboard` unit tests in the container: 9 passed across `constants.test.ts` and `ai.service.test.ts`. Nothing in the suite asserts on the dotenv lines, so no assertion needed updating.
- Prettier on the host: clean.
- Confirmed the diff touches one file. `AIQuickStartPage.tsx` and the locale files are unchanged, which is what keeps this to option A.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quick Start scripts now load `.env.local` first with `.env` as a fallback, so `OPENROUTER_API_KEY` is picked up when users follow the docs. Also silences `dotenv` v17's injection log to keep script output clean.

- **Bug Fixes**
  - Replaced `import 'dotenv/config'` with `import { config } from 'dotenv'; config({ path: ['.env.local', '.env'], quiet: true })` in all four Quick Start snippets (text, image, video, embeddings).
  - Preserves existing `.env` setups while keeping `.env.local` precedence; no changes to UI copy or locale text.

<sup>Written for commit 5a51292329d79b521a5e4c95a4f0321ccff6a587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load `.env.local` in Quick Start scripts generated by `getQuickStartScript`
> Replaces the side-effect `import 'dotenv/config'` with an explicit `config({ path: ['.env.local', '.env'], quiet: true })` call in all Quick Start script variants in [constants.ts](https://github.com/InsForge/InsForge/pull/1927/files#diff-6e0469653322f877c0f2586d4f45b993a0786400fa047f4c64360e5fb7c6a68b). This ensures `.env.local` is picked up when users run the generated scripts locally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a51292.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quick Start scripts for image, video, embeddings, and text templates by loading local environment settings before fallback settings.
  * Reduced unnecessary startup output during environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->