### PR TITLE
feat(memory): add a forget endpoint to /api/memory

### DIFF
--- a/backend/src/api/routes/memory/index.routes.ts
+++ b/backend/src/api/routes/memory/index.routes.ts
@@ -8,6 +8,7 @@ import {
   rememberRequestSchema,
   recallRequestSchema,
   forgetRequestSchema,
+  forgetResponseSchema,
   memoryIndexRequestSchema,
 } from '@insforge/shared-schemas';
 
@@ -66,7 +67,8 @@ router.post('/forget', async (req: AuthRequest, res: Response, next: NextFunctio
       );
     }
     const forgotten = await memoryService.forget(parsed.data);
-    successResponse(res, { forgotten });
+    const response = forgetResponseSchema.parse({ forgotten });
+    successResponse(res, response);
   } catch (error) {
     next(error);
   }

--- a/backend/src/api/routes/memory/index.routes.ts
+++ b/backend/src/api/routes/memory/index.routes.ts
@@ -8,8 +8,8 @@ import {
   rememberRequestSchema,
   recallRequestSchema,
   forgetRequestSchema,
-  forgetResponseSchema,
   memoryIndexRequestSchema,
+  type ForgetResponse,
 } from '@insforge/shared-schemas';
 
 const router = Router();
@@ -67,8 +67,7 @@ router.post('/forget', async (req: AuthRequest, res: Response, next: NextFunctio
       );
     }
     const forgotten = await memoryService.forget(parsed.data);
-    const response = forgetResponseSchema.parse({ forgotten });
-    successResponse(res, response);
+    successResponse<ForgetResponse>(res, { forgotten });
   } catch (error) {
     next(error);
   }

--- a/backend/src/api/routes/memory/index.routes.ts
+++ b/backend/src/api/routes/memory/index.routes.ts
@@ -7,6 +7,7 @@ import {
   ERROR_CODES,
   rememberRequestSchema,
   recallRequestSchema,
+  forgetRequestSchema,
   memoryIndexRequestSchema,
 } from '@insforge/shared-schemas';
 
@@ -48,6 +49,24 @@ router.post('/recall', async (req: AuthRequest, res: Response, next: NextFunctio
     }
     const memories = await memoryService.recall(parsed.data);
     successResponse(res, { memories });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/memory/forget
+router.post('/forget', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const parsed = forgetRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new AppError(
+        `Validation error: ${parsed.error.errors.map((e) => e.message).join(', ')}`,
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
+    const forgotten = await memoryService.forget(parsed.data);
+    successResponse(res, { forgotten });
   } catch (error) {
     next(error);
   }

--- a/backend/src/services/memory/memory.service.ts
+++ b/backend/src/services/memory/memory.service.ts
@@ -162,6 +162,27 @@ Examples:
     }));
   }
 
+  // Remove memories by explicit id. The scope predicate is the guard, not a
+  // filter: recall() and index() only ever hand a caller ids from its own
+  // scope, so an id from anywhere else is either stale or invented and must
+  // not delete a row. Returns the ids actually removed, so an unknown id is
+  // reported as absent rather than as an error — the caller can retry a
+  // partly-applied call without special-casing it.
+  async forget(params: { scope: string; ids: string[] }): Promise<string[]> {
+    const pool = this.dbManager.getPool();
+    const result = await pool.query(
+      `DELETE FROM memory.memories WHERE scope = $1 AND id = ANY($2::uuid[]) RETURNING id`,
+      [params.scope, params.ids]
+    );
+    const forgotten = result.rows.map((r) => String(r.id));
+    logger.debug('memory.forget', {
+      scope: params.scope,
+      requested: params.ids.length,
+      forgotten: forgotten.length,
+    });
+    return forgotten;
+  }
+
   private async findSimilar(
     scope: string,
     embedding: number[],

--- a/backend/tests/integration/memory-forget.test.ts
+++ b/backend/tests/integration/memory-forget.test.ts
@@ -1,0 +1,117 @@
+import { PgTestClient } from 'insforge-test';
+import { getConnections } from './utils';
+
+let db: PgTestClient;
+let teardown: () => Promise<void>;
+
+// MemoryService reaches for the pool through DatabaseManager; point that at the
+// test database so forget() runs its real statement against real Postgres.
+// getPool is called per-query, so the closure resolves db after beforeAll.
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: { getInstance: () => ({ getPool: () => db }) },
+}));
+
+// forget() touches neither of these, but importing the service constructs them.
+vi.mock('../../src/services/ai/embedding.service.js', () => ({
+  EmbeddingService: { getInstance: () => ({}) },
+}));
+vi.mock('../../src/services/ai/chat-completion.service.js', () => ({
+  ChatCompletionService: { getInstance: () => ({}) },
+}));
+
+const SCOPE_A = 'proj-a';
+const SCOPE_B = 'proj-b';
+
+// embedding is VECTOR(1536) NOT NULL. The value is irrelevant to forget(), which
+// never reads it, so a constant vector avoids needing an embedding provider.
+const VECTOR_LITERAL = `('[' || array_to_string(array_fill(0.1::float8, ARRAY[1536]), ',') || ']')::vector`;
+
+async function seed(scope: string, title: string): Promise<string> {
+  const res = await db.query<{ id: string }>(
+    `INSERT INTO memory.memories (scope, kind, title, content, embedding)
+     VALUES ($1, 'fact', $2, $3, ${VECTOR_LITERAL})
+     RETURNING id`,
+    [scope, title, `content for ${title}`]
+  );
+  return res.rows[0].id;
+}
+
+async function scopeIds(scope: string): Promise<string[]> {
+  const res = await db.query<{ id: string }>(
+    `SELECT id FROM memory.memories WHERE scope = $1 ORDER BY title`,
+    [scope]
+  );
+  return res.rows.map((r) => r.id);
+}
+
+let memoryService: { forget(p: { scope: string; ids: string[] }): Promise<string[]> };
+
+beforeAll(async () => {
+  ({ db, teardown } = await getConnections());
+  const { MemoryService } = await import('../../src/services/memory/memory.service.js');
+  memoryService = MemoryService.getInstance();
+});
+
+afterAll(() => teardown());
+afterEach(() => db.afterEach());
+
+beforeEach(async () => {
+  await db.beforeEach();
+  // memory is a platform-internal schema: migration 050 adds no grants, so only
+  // its owner can reach it. The backend's own pool connects as POSTGRES_USER,
+  // so run as postgres here rather than the harness's default request role.
+  db.setContext({ role: 'postgres' });
+});
+
+describe('MemoryService.forget against Postgres', () => {
+  it('deletes a memory in the caller scope and reports its id', async () => {
+    const id = await seed(SCOPE_A, 'a1');
+
+    await expect(memoryService.forget({ scope: SCOPE_A, ids: [id] })).resolves.toEqual([id]);
+    await expect(scopeIds(SCOPE_A)).resolves.toEqual([]);
+  });
+
+  // The reason the scope predicate is in the statement rather than left to the
+  // caller: an id from another scope is stale or invented, and forget cannot be
+  // undone. This is the assertion the mocked-pool unit test cannot make.
+  it('refuses an id from another scope and leaves that row in place', async () => {
+    const idA = await seed(SCOPE_A, 'a1');
+    const idB = await seed(SCOPE_B, 'b1');
+
+    await expect(memoryService.forget({ scope: SCOPE_A, ids: [idB] })).resolves.toEqual([]);
+
+    await expect(scopeIds(SCOPE_B)).resolves.toEqual([idB]);
+    await expect(scopeIds(SCOPE_A)).resolves.toEqual([idA]);
+  });
+
+  it('deletes only the ids that exist in the scope, ignoring the rest', async () => {
+    const keep = await seed(SCOPE_A, 'a1');
+    const drop = await seed(SCOPE_A, 'a2');
+    const idB = await seed(SCOPE_B, 'b1');
+    const ghost = '99999999-9999-4999-8999-999999999999';
+
+    const forgotten = await memoryService.forget({
+      scope: SCOPE_A,
+      ids: [drop, ghost, idB],
+    });
+
+    expect(forgotten).toEqual([drop]);
+    await expect(scopeIds(SCOPE_A)).resolves.toEqual([keep]);
+    await expect(scopeIds(SCOPE_B)).resolves.toEqual([idB]);
+  });
+
+  it('is idempotent — repeating a delete reports nothing the second time', async () => {
+    const id = await seed(SCOPE_A, 'a1');
+
+    await expect(memoryService.forget({ scope: SCOPE_A, ids: [id] })).resolves.toEqual([id]);
+    await expect(memoryService.forget({ scope: SCOPE_A, ids: [id] })).resolves.toEqual([]);
+  });
+
+  it('reports an unknown id as forgotten nothing rather than failing', async () => {
+    await seed(SCOPE_A, 'a1');
+    const ghost = '99999999-9999-4999-8999-999999999999';
+
+    await expect(memoryService.forget({ scope: SCOPE_A, ids: [ghost] })).resolves.toEqual([]);
+    await expect(scopeIds(SCOPE_A)).resolves.toHaveLength(1);
+  });
+});

--- a/backend/tests/manual/test-memory-forget.sh
+++ b/backend/tests/manual/test-memory-forget.sh
@@ -17,6 +17,10 @@ SCOPE_A="test-forget-a-$$"
 SCOPE_B="test-forget-b-$$"
 GHOST_ID="99999999-9999-4999-8999-999999999999"
 
+# Every curl below carries --max-time, so a hung backend cannot stall the run,
+# and so the exit-path cleanup stays bounded while it has INT/TERM ignored.
+CURL_TIMEOUT=30
+
 # The memory routes are behind verifyApiKey, not admin JWT.
 echo "🔑 Getting API key..."
 api_key=$(get_admin_api_key)
@@ -24,7 +28,7 @@ api_key=$(get_admin_api_key)
 if [ -z "$api_key" ]; then
     admin_token=$(get_admin_token)
     if [ -n "$admin_token" ]; then
-        api_key_response=$(curl -s "$API_BASE/metadata/api-key" \
+        api_key_response=$(curl -s --max-time "$CURL_TIMEOUT" "$API_BASE/metadata/api-key" \
             -H "Authorization: Bearer $admin_token")
         api_key=$(echo "$api_key_response" | grep -o '"apiKey":"[^"]*' | cut -d'"' -f4 || true)
     fi
@@ -38,10 +42,6 @@ print_success "Got API key"
 echo ""
 
 # Helpers ---------------------------------------------------------------------
-
-# --max-time so a hung backend cannot stall the run, and so the exit-path
-# cleanup below stays bounded while it has INT/TERM ignored.
-CURL_TIMEOUT=30
 
 # memory_post <endpoint> <json> -> body on stdout
 memory_post() {
@@ -278,7 +278,7 @@ echo ""
 # 7. Auth ---------------------------------------------------------------------
 
 echo "📊 Test 7: the endpoint requires an API key..."
-noauth_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/forget" \
+noauth_status=$(curl -s --max-time "$CURL_TIMEOUT" -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/forget" \
     -H "Content-Type: application/json" \
     -d "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$GHOST_ID\"]}")
 

--- a/backend/tests/manual/test-memory-forget.sh
+++ b/backend/tests/manual/test-memory-forget.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+# Agent memory forget test script
+# Tests the /api/memory/forget endpoint
+#
+# Manual rather than automated: seeding memories goes through /api/memory/remember,
+# which embeds each candidate and runs the reconcile completion, so a run spends
+# real OpenRouter calls. Same reason test-ai-embeddings.sh lives here.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/../test-config.sh"
+
+echo "🧪 Testing agent memory forget endpoint..."
+
+API_BASE="$TEST_API_BASE"
+SCOPE_A="test-forget-a-$$"
+SCOPE_B="test-forget-b-$$"
+GHOST_ID="99999999-9999-4999-8999-999999999999"
+
+# The memory routes are behind verifyApiKey, not admin JWT.
+echo "🔑 Getting API key..."
+api_key=$(get_admin_api_key)
+
+if [ -z "$api_key" ]; then
+    admin_token=$(get_admin_token)
+    if [ -n "$admin_token" ]; then
+        api_key_response=$(curl -s "$API_BASE/metadata/api-key" \
+            -H "Authorization: Bearer $admin_token")
+        api_key=$(echo "$api_key_response" | grep -o '"apiKey":"[^"]*' | cut -d'"' -f4 || true)
+    fi
+fi
+
+if [ -z "$api_key" ]; then
+    print_fail "Could not get an API key (set ACCESS_API_KEY, or configure root admin credentials)"
+    exit_with_status
+fi
+print_success "Got API key"
+echo ""
+
+# Helpers ---------------------------------------------------------------------
+
+# memory_post <endpoint> <json> -> body on stdout
+memory_post() {
+    curl -s -X POST "$API_BASE/memory/$1" \
+        -H "Authorization: Bearer $api_key" \
+        -H "Content-Type: application/json" \
+        -d "$2"
+}
+
+# memory_status <endpoint> <json> -> http status on stdout
+memory_status() {
+    curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/$1" \
+        -H "Authorization: Bearer $api_key" \
+        -H "Content-Type: application/json" \
+        -d "$2"
+}
+
+remember_one() {
+    memory_post remember \
+        "{\"scope\":\"$1\",\"kind\":\"$2\",\"title\":\"$3\",\"content\":\"$4\"}"
+}
+
+# ids_in_scope <scope> -> newline-separated ids
+ids_in_scope() {
+    memory_post index "{\"scope\":\"$1\"}" \
+        | grep -o '"id":"[^"]*' | cut -d'"' -f4 || true
+}
+
+count_in_scope() {
+    ids_in_scope "$1" | grep -c . || true
+}
+
+# Seed ------------------------------------------------------------------------
+
+echo "🌱 Seeding memories in two scopes..."
+seed_response=$(remember_one "$SCOPE_A" "fact" "pg port" \
+    "The local InsForge Postgres listens on host port 5432.")
+
+if ! echo "$seed_response" | grep -q '"results"'; then
+    print_fail "Could not seed a memory via /api/memory/remember"
+    echo "Response: $seed_response"
+    print_info "remember needs an embedding model — on self-host, set OPENROUTER_API_KEY."
+    exit_with_status
+fi
+
+remember_one "$SCOPE_A" "decision" "rrf k" \
+    "Recall fuses the vector and keyword arms with RRF at k=60." > /dev/null
+remember_one "$SCOPE_A" "reference" "stale fact" \
+    "The job queue for this project runs on Redis." > /dev/null
+remember_one "$SCOPE_B" "fact" "other scope" \
+    "This memory belongs to a different scope entirely." > /dev/null
+
+seeded_a=$(count_in_scope "$SCOPE_A")
+if [ "$seeded_a" -eq 3 ]; then
+    print_success "Seeded 3 memories in scope A"
+else
+    print_fail "Expected 3 memories in scope A, got $seeded_a"
+    exit_with_status
+fi
+
+victim_id=$(ids_in_scope "$SCOPE_A" | sed -n '1p')
+id_b=$(ids_in_scope "$SCOPE_B" | sed -n '1p')
+echo ""
+
+# 1. The scope guard ----------------------------------------------------------
+
+echo "📊 Test 1: an id from another scope must not be deleted..."
+cross_response=$(memory_post forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$id_b\"]}")
+
+if echo "$cross_response" | grep -q '"forgotten":\[\]'; then
+    print_success "Cross-scope delete forgot nothing"
+else
+    print_fail "Cross-scope delete returned something"
+    echo "Response: $cross_response"
+fi
+
+survivors_b=$(count_in_scope "$SCOPE_B")
+if [ "$survivors_b" -eq 1 ]; then
+    print_success "Scope B's memory survived"
+else
+    print_fail "Scope B's memory was deleted from another scope (count: $survivors_b)"
+fi
+echo ""
+
+# 2. Unknown ids --------------------------------------------------------------
+
+echo "📊 Test 2: an unknown id is absent rather than an error..."
+status=$(memory_status forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$GHOST_ID\"]}")
+ghost_response=$(memory_post forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$GHOST_ID\"]}")
+
+if [ "$status" -eq 200 ]; then
+    print_success "Unknown id returned 200"
+else
+    print_fail "Expected 200 for an unknown id, got $status"
+fi
+
+if echo "$ghost_response" | grep -q '"forgotten":\[\]'; then
+    print_success "Unknown id reported as forgotten nothing"
+else
+    print_fail "Unknown id did not come back empty"
+    echo "Response: $ghost_response"
+fi
+echo ""
+
+# 3. A real delete ------------------------------------------------------------
+
+echo "📊 Test 3: deletes in scope and echoes only what it removed..."
+mixed_response=$(memory_post forget \
+    "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$victim_id\",\"$GHOST_ID\"]}")
+
+if echo "$mixed_response" | grep -q "\"$victim_id\"" && \
+   ! echo "$mixed_response" | grep -q "$GHOST_ID"; then
+    print_success "Echoed the real id and not the ghost"
+else
+    print_fail "Unexpected forgotten list"
+    echo "Response: $mixed_response"
+fi
+
+remaining_a=$(count_in_scope "$SCOPE_A")
+if [ "$remaining_a" -eq 2 ]; then
+    print_success "Scope A down to 2 memories"
+else
+    print_fail "Expected 2 memories left in scope A, got $remaining_a"
+fi
+echo ""
+
+# 4. Idempotency --------------------------------------------------------------
+
+echo "📊 Test 4: repeating the same delete is a no-op..."
+repeat_status=$(memory_status forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$victim_id\"]}")
+repeat_response=$(memory_post forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$victim_id\"]}")
+
+if [ "$repeat_status" -eq 200 ] && echo "$repeat_response" | grep -q '"forgotten":\[\]'; then
+    print_success "Repeated delete returned 200 and forgot nothing"
+else
+    print_fail "Repeated delete was not a no-op (status: $repeat_status)"
+    echo "Response: $repeat_response"
+fi
+echo ""
+
+# 5. The memory is really gone from recall ------------------------------------
+
+echo "📊 Test 5: a forgotten memory no longer comes back from recall..."
+# threshold 1.0 is unsatisfiable for cosine similarity, so this exercises the
+# keyword arm alone — the arm that would still match the deleted row's tokens.
+recall_response=$(memory_post recall \
+    "{\"scope\":\"$SCOPE_A\",\"query\":\"Redis job queue\",\"limit\":5,\"threshold\":1.0}")
+
+if echo "$recall_response" | grep -q "Redis"; then
+    print_fail "Recall still returns the forgotten memory"
+    echo "Response: $recall_response"
+else
+    print_success "Recall no longer returns it"
+fi
+echo ""
+
+# 6. Validation ---------------------------------------------------------------
+
+echo "📊 Test 6: request validation..."
+bad_uuid_status=$(memory_status forget "{\"scope\":\"$SCOPE_A\",\"ids\":[\"not-a-uuid\"]}")
+if [ "$bad_uuid_status" -eq 400 ]; then
+    print_success "Non-uuid id rejected with 400"
+else
+    print_fail "Expected 400 for a non-uuid id, got $bad_uuid_status"
+fi
+
+empty_status=$(memory_status forget "{\"scope\":\"$SCOPE_A\",\"ids\":[]}")
+if [ "$empty_status" -eq 400 ]; then
+    print_success "Empty id list rejected with 400"
+else
+    print_fail "Expected 400 for an empty id list, got $empty_status"
+fi
+
+missing_status=$(memory_status forget "{\"scope\":\"$SCOPE_A\"}")
+if [ "$missing_status" -eq 400 ]; then
+    print_success "Missing ids rejected with 400"
+else
+    print_fail "Expected 400 when ids is missing, got $missing_status"
+fi
+echo ""
+
+# 7. Auth ---------------------------------------------------------------------
+
+echo "📊 Test 7: the endpoint requires an API key..."
+noauth_status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/forget" \
+    -H "Content-Type: application/json" \
+    -d "{\"scope\":\"$SCOPE_A\",\"ids\":[\"$GHOST_ID\"]}")
+
+if [ "$noauth_status" -eq 401 ]; then
+    print_success "Request without an API key returned 401 as expected"
+else
+    print_fail "Expected 401 for an unauthenticated request, got $noauth_status"
+fi
+echo ""
+
+# Cleanup ---------------------------------------------------------------------
+
+echo "🧹 Removing the seeded memories..."
+for scope in "$SCOPE_A" "$SCOPE_B"; do
+    remaining=$(ids_in_scope "$scope" | sed 's/.*/"&"/' | paste -sd, - || true)
+    if [ -n "$remaining" ]; then
+        memory_post forget "{\"scope\":\"$scope\",\"ids\":[$remaining]}" > /dev/null
+    fi
+    left=$(count_in_scope "$scope")
+    if [ "$left" -eq 0 ]; then
+        print_success "Scope $scope emptied"
+    else
+        print_fail "Scope $scope still holds $left memories — remove them manually"
+    fi
+done
+echo ""
+
+print_success "🎉 Agent memory forget test completed!"
+exit_with_status

--- a/backend/tests/manual/test-memory-forget.sh
+++ b/backend/tests/manual/test-memory-forget.sh
@@ -60,6 +60,11 @@ remember_one() {
         "{\"scope\":\"$1\",\"kind\":\"$2\",\"title\":\"$3\",\"content\":\"$4\"}"
 }
 
+# id_from_remember <remember response> -> the id it stored
+id_from_remember() {
+    echo "$1" | grep -o '"id":"[^"]*' | cut -d'"' -f4 || true
+}
+
 # ids_in_scope <scope> -> newline-separated ids
 ids_in_scope() {
     memory_post index "{\"scope\":\"$1\"}" \
@@ -85,10 +90,17 @@ fi
 
 remember_one "$SCOPE_A" "decision" "rrf k" \
     "Recall fuses the vector and keyword arms with RRF at k=60." > /dev/null
-remember_one "$SCOPE_A" "reference" "stale fact" \
-    "The job queue for this project runs on Redis." > /dev/null
-remember_one "$SCOPE_B" "fact" "other scope" \
-    "This memory belongs to a different scope entirely." > /dev/null
+
+# Test 5 asserts this specific memory stops coming back from recall, so capture
+# the id it was stored under rather than picking one out of the index — index
+# orders by updated_at DESC, which is not a promise about which row is first.
+stale_response=$(remember_one "$SCOPE_A" "reference" "stale fact" \
+    "The job queue for this project runs on Redis.")
+victim_id=$(id_from_remember "$stale_response")
+
+scope_b_response=$(remember_one "$SCOPE_B" "fact" "other scope" \
+    "This memory belongs to a different scope entirely.")
+id_b=$(id_from_remember "$scope_b_response")
 
 seeded_a=$(count_in_scope "$SCOPE_A")
 if [ "$seeded_a" -eq 3 ]; then
@@ -98,8 +110,12 @@ else
     exit_with_status
 fi
 
-victim_id=$(ids_in_scope "$SCOPE_A" | sed -n '1p')
-id_b=$(ids_in_scope "$SCOPE_B" | sed -n '1p')
+if [ -n "$victim_id" ] && [ -n "$id_b" ]; then
+    print_success "Captured the fixture ids to delete"
+else
+    print_fail "Seeding did not return an id (victim_id='$victim_id', id_b='$id_b')"
+    exit_with_status
+fi
 echo ""
 
 # 1. The scope guard ----------------------------------------------------------

--- a/backend/tests/manual/test-memory-forget.sh
+++ b/backend/tests/manual/test-memory-forget.sh
@@ -39,9 +39,13 @@ echo ""
 
 # Helpers ---------------------------------------------------------------------
 
+# --max-time so a hung backend cannot stall the run, and so the exit-path
+# cleanup below stays bounded while it has INT/TERM ignored.
+CURL_TIMEOUT=30
+
 # memory_post <endpoint> <json> -> body on stdout
 memory_post() {
-    curl -s -X POST "$API_BASE/memory/$1" \
+    curl -s --max-time "$CURL_TIMEOUT" -X POST "$API_BASE/memory/$1" \
         -H "Authorization: Bearer $api_key" \
         -H "Content-Type: application/json" \
         -d "$2"
@@ -49,7 +53,7 @@ memory_post() {
 
 # memory_status <endpoint> <json> -> http status on stdout
 memory_status() {
-    curl -s -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/$1" \
+    curl -s --max-time "$CURL_TIMEOUT" -o /dev/null -w "%{http_code}" -X POST "$API_BASE/memory/$1" \
         -H "Authorization: Bearer $api_key" \
         -H "Content-Type: application/json" \
         -d "$2"
@@ -99,7 +103,12 @@ cleanup_memory_scopes() {
 
 memory_exit_handler() {
     local exit_code=$?
-    trap - EXIT ERR INT TERM   # no re-entry while cleaning up
+    # Clear EXIT/ERR so cleanup cannot re-enter this handler. Ignore INT/TERM
+    # rather than restoring their default action: the default would let a second
+    # Ctrl-C kill the shell partway through the cleanup requests, which is the
+    # leak this trap exists to prevent. curl's --max-time bounds the window.
+    trap - EXIT ERR
+    trap '' INT TERM
     cleanup_memory_scopes
     ( exit "$exit_code" )      # restore $? for handle_exit's own check
     handle_exit

--- a/backend/tests/manual/test-memory-forget.sh
+++ b/backend/tests/manual/test-memory-forget.sh
@@ -75,6 +75,37 @@ count_in_scope() {
     ids_in_scope "$1" | grep -c . || true
 }
 
+# Cleanup on every exit path --------------------------------------------------
+
+# test-config.sh traps EXIT/ERR/INT/TERM with handle_exit, which runs
+# cleanup_test_data — that only knows about tables, users and buckets, so
+# memories seeded below would survive an early exit_with_status. Wrap the
+# shared handler rather than replacing it: a bash trap is not additive, so
+# re-trapping without delegating would drop the harness's own cleanup.
+memory_cleanup_done=0
+cleanup_memory_scopes() {
+    if [ "$memory_cleanup_done" -eq 1 ]; then
+        return 0
+    fi
+    memory_cleanup_done=1
+    local scope remaining
+    for scope in "$SCOPE_A" "$SCOPE_B"; do
+        remaining=$(ids_in_scope "$scope" | sed 's/.*/"&"/' | paste -sd, - || true)
+        if [ -n "$remaining" ]; then
+            memory_post forget "{\"scope\":\"$scope\",\"ids\":[$remaining]}" > /dev/null || true
+        fi
+    done
+}
+
+memory_exit_handler() {
+    local exit_code=$?
+    trap - EXIT ERR INT TERM   # no re-entry while cleaning up
+    cleanup_memory_scopes
+    ( exit "$exit_code" )      # restore $? for handle_exit's own check
+    handle_exit
+}
+trap memory_exit_handler EXIT ERR INT TERM
+
 # Seed ------------------------------------------------------------------------
 
 echo "🌱 Seeding memories in two scopes..."
@@ -252,11 +283,8 @@ echo ""
 # Cleanup ---------------------------------------------------------------------
 
 echo "🧹 Removing the seeded memories..."
+cleanup_memory_scopes
 for scope in "$SCOPE_A" "$SCOPE_B"; do
-    remaining=$(ids_in_scope "$scope" | sed 's/.*/"&"/' | paste -sd, - || true)
-    if [ -n "$remaining" ]; then
-        memory_post forget "{\"scope\":\"$scope\",\"ids\":[$remaining]}" > /dev/null
-    fi
     left=$(count_in_scope "$scope")
     if [ "$left" -eq 0 ]; then
         print_success "Scope $scope emptied"

--- a/backend/tests/unit/memory-routes.test.ts
+++ b/backend/tests/unit/memory-routes.test.ts
@@ -1,0 +1,151 @@
+import express, { type ErrorRequestHandler } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const memoryServiceMock = vi.hoisted(() => ({
+  remember: vi.fn(),
+  recall: vi.fn(),
+  index: vi.fn(),
+  forget: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({ hasApiKey: true }));
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+// The memory router mounts verifyApiKey for every route, so the 401 path is the
+// middleware's. Drive it from a flag rather than bypassing it, to keep the
+// route's auth boundary in the test.
+vi.mock('../../src/api/middlewares/auth.js', () => ({
+  verifyApiKey: (
+    req: { authenticated?: boolean; hasApiKey?: boolean },
+    res: { status: (c: number) => { json: (b: unknown) => void } },
+    next: () => void
+  ) => {
+    if (!authMock.hasApiKey) {
+      res.status(401).json({ message: 'No API key provided', code: 'AUTH_INVALID_API_KEY' });
+      return;
+    }
+    req.authenticated = true;
+    req.hasApiKey = true;
+    next();
+  },
+}));
+
+vi.mock('../../src/services/memory/memory.service.js', () => ({
+  MemoryService: { getInstance: () => memoryServiceMock },
+}));
+
+const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  void _next;
+  const statusCode =
+    error instanceof Error && 'statusCode' in error && typeof error.statusCode === 'number'
+      ? error.statusCode
+      : 500;
+  const code =
+    error instanceof Error && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : undefined;
+  res.status(statusCode).json({
+    message: error instanceof Error ? error.message : 'Error',
+    ...(code ? { code } : {}),
+  });
+};
+
+async function createApp() {
+  const { memoryRouter } = await import('../../src/api/routes/memory/index.routes.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/memory', memoryRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const ID_A = '11111111-1111-4111-8111-111111111111';
+const ID_B = '22222222-2222-4222-8222-222222222222';
+
+describe('POST /api/memory/forget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.hasApiKey = true;
+  });
+
+  it('returns the forgotten ids and passes scope and ids through to the service', async () => {
+    memoryServiceMock.forget.mockResolvedValue([ID_A]);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/memory/forget')
+      .send({ scope: 'proj', ids: [ID_A, ID_B] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ forgotten: [ID_A] });
+    expect(memoryServiceMock.forget).toHaveBeenCalledWith({ scope: 'proj', ids: [ID_A, ID_B] });
+  });
+
+  it('defaults the scope when the body omits it', async () => {
+    memoryServiceMock.forget.mockResolvedValue([]);
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/memory/forget')
+      .send({ ids: [ID_A] });
+
+    expect(res.status).toBe(200);
+    expect(memoryServiceMock.forget).toHaveBeenCalledWith({ scope: 'default', ids: [ID_A] });
+  });
+
+  it('rejects a non-uuid id with 400 and never reaches the service', async () => {
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/memory/forget')
+      .send({ scope: 'proj', ids: ['not-a-uuid'] });
+
+    expect(res.status).toBe(400);
+    expect(memoryServiceMock.forget).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty id list with 400', async () => {
+    const app = await createApp();
+
+    const res = await request(app).post('/api/memory/forget').send({ scope: 'proj', ids: [] });
+
+    expect(res.status).toBe(400);
+    expect(memoryServiceMock.forget).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing id list with 400', async () => {
+    const app = await createApp();
+
+    const res = await request(app).post('/api/memory/forget').send({ scope: 'proj' });
+
+    expect(res.status).toBe(400);
+    expect(memoryServiceMock.forget).not.toHaveBeenCalled();
+  });
+
+  it('requires an API key', async () => {
+    authMock.hasApiKey = false;
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/memory/forget')
+      .send({ ids: [ID_A] });
+
+    expect(res.status).toBe(401);
+    expect(memoryServiceMock.forget).not.toHaveBeenCalled();
+  });
+
+  it('forwards a service failure to the error handler rather than returning 200', async () => {
+    memoryServiceMock.forget.mockRejectedValue(new Error('delete boom'));
+    const app = await createApp();
+
+    const res = await request(app)
+      .post('/api/memory/forget')
+      .send({ ids: [ID_A] });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/tests/unit/memory.service.test.ts
+++ b/backend/tests/unit/memory.service.test.ts
@@ -34,6 +34,7 @@ function installPool() {
     if (sql.includes('UPDATE memory.memories')) return { rows: [] };
     if (sql.includes('WITH q AS')) return { rows: [] }; // recall (overridden per-test)
     if (sql.includes('ORDER BY updated_at DESC')) return { rows: [] }; // index
+    if (sql.includes('DELETE FROM memory.memories')) return { rows: [] }; // forget
     return { rows: similarRows }; // findSimilar
   });
 }
@@ -168,5 +169,34 @@ describe('MemoryService.recall / index', () => {
     expect(res).toEqual([
       { id: 'i1', kind: 'decision', title: 'D', updated_at: '2026-02-02T00:00:00.000Z' },
     ]);
+  });
+});
+
+describe('MemoryService.forget', () => {
+  const idA = '11111111-1111-4111-8111-111111111111';
+  const idB = '22222222-2222-4222-8222-222222222222';
+
+  it('deletes within the scope and echoes the ids actually removed', async () => {
+    poolQueryMock.mockImplementationOnce(async () => ({ rows: [{ id: idA }, { id: idB }] }));
+    const res = await service.forget({ scope: 's', ids: [idA, idB] });
+    expect(res).toEqual([idA, idB]);
+  });
+
+  it('scopes the delete, so an id belonging to another scope removes nothing', async () => {
+    const res = await service.forget({ scope: 'other', ids: [idA] });
+    expect(res).toEqual([]);
+    const del = poolQueryMock.mock.calls.find(([sql]) =>
+      String(sql).includes('DELETE FROM memory.memories')
+    );
+    expect(del).toBeDefined();
+    // The scope predicate is the guard against a stale or hallucinated id, so
+    // assert it is in the statement rather than only that the row count was 0.
+    expect(String(del![0])).toContain('WHERE scope = $1');
+    expect(del![1]).toEqual(['other', [idA]]);
+  });
+
+  it('reports an unknown id as absent rather than failing the call', async () => {
+    poolQueryMock.mockImplementationOnce(async () => ({ rows: [{ id: idA }] }));
+    await expect(service.forget({ scope: 's', ids: [idA, idB] })).resolves.toEqual([idA]);
   });
 });

--- a/packages/shared-schemas/src/memory-api.schema.ts
+++ b/packages/shared-schemas/src/memory-api.schema.ts
@@ -63,6 +63,23 @@ export const recallResponseSchema = z.object({
 });
 export type RecallResponse = z.infer<typeof recallResponseSchema>;
 
+// POST /api/memory/forget
+// Removal is by explicit id only, and always within a scope: a model that can
+// hallucinate a target_id for the reconcile UPDATE can hallucinate one here
+// too, and this is the verb that cannot be undone.
+export const forgetRequestSchema = z.object({
+  scope: z.string().min(1).default('default'),
+  ids: z.array(z.string().uuid()).min(1).max(100),
+});
+export type ForgetRequest = z.infer<typeof forgetRequestSchema>;
+
+// Echoes only the ids actually removed; an id that does not exist in this
+// scope is simply absent, so a retry of a partly-applied call is a no-op.
+export const forgetResponseSchema = z.object({
+  forgotten: z.array(z.string().uuid()),
+});
+export type ForgetResponse = z.infer<typeof forgetResponseSchema>;
+
 // POST /api/memory/index — cheap title-only listing (the always-load tier)
 export const memoryIndexRequestSchema = z.object({
   scope: z.string().min(1).default('default'),


### PR DESCRIPTION
## Summary

Closes #1929

`/api/memory` is `remember` / `recall` / `index`, and `MemoryService` has three public methods to match. There is no way to remove a stored fact, and the data API can't stand in for one: migration 056 exposes schemas to PostgREST on a deny-list, and [`memory` is named in it](https://github.com/InsForge/InsForge/blob/ddfbea335dd4e46ec132e3bf6584ee0f58de2dc9/backend/src/infra/database/migrations/056_expose-custom-schemas-to-postgrest.sql#L64) alongside `auth` and `storage`. The only delete path that exists is `POST /api/database/advance/rawsql` behind `verifyAdmin`, while the memory routes are `verifyApiKey` (the CLI / agent). So an agent can't remove anything it stored, through any route.

This adds the fourth verb.

```jsonc
// POST /api/memory/forget
{ "scope": "default", "ids": ["<uuid>", "<uuid>"] }

// 200
{ "forgotten": ["<uuid>"] }
```

```sql
DELETE FROM memory.memories WHERE scope = $1 AND id = ANY($2::uuid[]) RETURNING id
```

The scope predicate is the guard rather than a filter, and it's the part I'd most like reviewed. `recall()` and `index()` only ever hand a caller ids from its own scope, so an id from anywhere else is stale or invented and shouldn't delete a row. This is the same defense `remember()` already applies on the reconcile path, where an `UPDATE` is honored only when `target_id` is a real UUID *and* appears in the matched set. A model that can hallucinate an id for `UPDATE` can hallucinate one for `forget`, and `forget` is the verb that can't be undone, so I wanted the guard in the statement rather than in a caller's discipline.

Two smaller choices, both matching something already here:

- **`POST /forget` with `scope` in the body**, because the other three routes are all POST with `scope` in the body. A `DELETE /api/memory/:id` would break that and drop the scope guard.
- **An unknown id comes back absent from `forgotten` rather than as a 404**, so retrying a partly-applied call is a no-op. `remember` already prefers a `NOOP` result over an error in the analogous spot.

Kept out on purpose: tombstones. A hard delete means a forgotten fact can return: the next transcript mentioning it extracts, finds nothing above `RECONCILE_THRESHOLD`, and `ADD`s it again. Preventing that needs a migration plus a filter in `recall`, `index`, *and* the reconcile match set, and it has a design question inside it (is forgetting an erasure, or an assertion that something is false?). That felt like the wrong thing to smuggle into this PR. Happy to open it separately if resurrection matters to you.

No migration, no new dependency, and nothing in `openapi/`, since memory has no spec there yet.

## How did you test this change?

Everything below ran on `feat/memory-forget-endpoint` off `main` @ `ddfbea3`.

Three cases added to `backend/tests/unit/memory.service.test.ts`, in the existing mocked-pool style:

| case | asserts |
|---|---|
| deletes within the scope and echoes the ids actually removed | the `RETURNING id` rows come back as `forgotten` |
| an id belonging to another scope removes nothing | `WHERE scope = $1` is present in the statement, and params are `['other', [idA]]` |
| an unknown id is absent rather than failing the call | a partial match resolves to just the matched id, no throw |

The scope test asserts on the SQL and the bound parameters rather than only on a zero row count, since a mocked pool would report zero rows either way. That assertion is what fails if the predicate is ever dropped.

`backend/tests/manual/test-memory-forget.sh` runs 18 assertions against a local `docker compose` stack with an OpenRouter key configured. All of them pass:

| # | check |
|---|---|
| 1 | an id belonging to another scope is **not** deleted, and the row survives |
| 2 | an unknown id returns 200 with an empty `forgotten` |
| 3 | a mixed real + unknown call echoes only the real id, and the scope drops by one |
| 4 | repeating the same delete is a no-op |
| 5 | a forgotten memory stops coming back from `recall` |
| 6 | non-uuid, empty array, and missing `ids` each return 400 |
| 7 | no API key returns 401 |

Test 5 sends `threshold: 1.0`. Cosine similarity never exceeds 1.0, so the vector arm's filter can't be satisfied and the assertion runs against the keyword arm alone, which has no threshold of its own and would still match the deleted row's tokens.

It's in `tests/manual/` rather than `tests/local/` because seeding goes through `remember`, which embeds each candidate and runs the reconcile completion, so a run spends OpenRouter credits. `run-all-tests.sh` auto-discovers `local/test-*.sh`, and nothing in `local/` currently needs an AI key. `test-ai-embeddings.sh` is in `manual/` for the same reason, so this follows that precedent rather than adding a key requirement to the shared suite.

I also ran a negative control on the scope guard, since a test that can't fail proves nothing. With `scope = $1` removed from the `DELETE`, leaving an otherwise valid statement, exactly 2 of the 18 assertions fail, both in test 1, and scope B is emptied. Restoring the predicate returns it to 18/18.

Results:

- `tests/manual/test-memory-forget.sh` — 18 passed, 0 failed, exit 0
- `vitest run tests/unit/memory.service.test.ts` — 12 passed (9 existing + 3 new)
- `vitest run tests/unit` — 2325 passed, 21 skipped, 0 failures across 194 files
- `turbo run typecheck` for `insforge-backend` and `@insforge/shared-schemas` — both clean
- `eslint` and `prettier --check` on the changed files — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds POST `/api/memory/forget` so agents can delete memories by UUID within a scope. Previously there was no delete path; now deletions are scope-guarded, idempotent, and ignore cross-scope or unknown IDs.

- Contract: accepts `scope` and 1–100 `ids[]`, returns `forgotten[]` of actually deleted IDs. Validates the request via `forgetRequestSchema` and types the response as `ForgetResponse` in `@insforge/shared-schemas`.
- Enforcement: SQL deletes with `WHERE scope = $1 AND id = ANY($2::uuid[])`, so only in-scope IDs are removed; retries are safe.
- Tests: adds service, route, and integration tests plus a manual e2e script. The script cleans up seeded memories on early exits and times out all curl calls; verifies deleted memories no longer appear in recall.
- Auth: requires API key; unauthenticated requests return 401.
- No migrations or new dependencies.

<sup>Written for commit 484c7c820449feab9f161b0d44eb86a28a44a7eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add POST /api/memory/forget endpoint to delete memories by ID within a scope
> - Adds `POST /api/memory/forget` route in [index.routes.ts](https://github.com/InsForge/InsForge/pull/1932/files#diff-4596b7baa58a73a8f1034325c3b1b6d19896967d10f18f424a312146dcd7eb2f) that accepts a scope and a list of UUIDs, deletes matching rows, and returns `{ forgotten: [ids] }`.
> - Adds `MemoryService.forget` in [memory.service.ts](https://github.com/InsForge/InsForge/pull/1932/files#diff-851b6d82813f564b587c96cfefcdcc6a55862cd9369dcb9bd89bd6ab0587f401) using `DELETE ... WHERE scope = $1 AND id = ANY($2::uuid[]) RETURNING id`; IDs outside the scope or unknown are silently ignored.
> - Adds `forgetRequestSchema` (scope defaults to `'default'`, 1–100 UUID ids required) and `forgetResponseSchema` in [memory-api.schema.ts](https://github.com/InsForge/InsForge/pull/1932/files#diff-d8cb2651ed121a93b57a9dda065c9ed3ad93201932be636169041100e413fd3c).
> - Covers the feature with integration tests, unit tests, and a manual bash test script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e58ffce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for forgetting memories.
  * Delete up to 100 memories by ID within a specified scope.
  * Responses list only memories successfully removed.
  * Scope isolation prevents deleting memories from other scopes.
  * Repeated requests are safe, and unknown IDs are handled gracefully.

* **Bug Fixes**
  * Added validation for malformed requests and unauthenticated access.
  * Improved handling of invalid, missing, or out-of-scope memory IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->