### PR TITLE
feat(ai): show why the Model Gateway is unavailable, and hide it for partner orgs

### DIFF
--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -660,6 +660,7 @@ export function useCloudHosting() {
               currentInstanceType:
                 typeof message.currentInstanceType === 'string' ? message.currentInstanceType : '',
               planName: typeof message.planName === 'string' ? message.planName : '',
+              isPartnerOrg: message.isPartnerOrg === true,
               computeCredits:
                 typeof message.computeCredits === 'number' ? message.computeCredits : 0,
               currentOrgComputeCost:

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -322,10 +322,68 @@ function ModelCreditBadge({
   );
 }
 
+/**
+ * Entitlement gate. Kept as a separate component from the body below so a
+ * denied org never mounts the AI query hooks — an early return inside one
+ * component would still have run them.
+ */
 export default function AIOverviewPage() {
   const { t } = useTranslation('chrome');
   const host = useDashboardHost();
   const aiEntitlement = useAiEntitlement();
+
+  // While the bridge is still resolving, allowed is true (fail open), so an
+  // entitled project renders immediately rather than flashing a spinner.
+  // AppSidebar mounts the same query, so by the time this route is reached the
+  // verdict is normally already cached.
+  if (aiEntitlement.allowed) {
+    return <AIOverviewContent />;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
+      <div className="mx-auto flex h-full w-full max-w-[1024px] items-center justify-center px-10 py-10">
+        {aiEntitlement.reason === 'partner' ? (
+          <EmptyState
+            icon={StopCircle}
+            title={t('ai.overview.partnerUnavailableTitle', {
+              defaultValue: 'AI Model Gateway is not available for this project',
+            })}
+            description={t('ai.overview.partnerUnavailableDescription', {
+              defaultValue:
+                'This project is managed by a partner platform, which does not include the AI Model Gateway.',
+            })}
+          />
+        ) : (
+          <EmptyState
+            icon={ArrowUpCircle}
+            title={t('ai.overview.upgradeRequiredTitle', {
+              defaultValue: 'Upgrade to Pro to use the AI Model Gateway',
+            })}
+            description={t('ai.overview.upgradeRequiredDescription', {
+              defaultValue:
+                'Call frontier models through one endpoint, billed by usage. Available on paid plans.',
+            })}
+            action={
+              host.onShowUpgradeDialog
+                ? {
+                    label: t('ai.overview.upgradeRequiredAction', {
+                      defaultValue: 'Upgrade plan',
+                    }),
+                    onClick: () => host.onShowUpgradeDialog?.(),
+                  }
+                : undefined
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AIOverviewContent() {
+  const { t } = useTranslation('chrome');
+  const host = useDashboardHost();
   const [codeTab, setCodeTab] = useState<CodeTab>('sdk');
   const [selectedModelId, setSelectedModelId] = useState<
     (typeof OVERVIEW_QUICK_START_MODELS)[number]['id']
@@ -382,50 +440,6 @@ export default function AIOverviewPage() {
       // Toast feedback is handled by the mutation hook.
     }
   };
-
-  // Cloud gates AI on the org. Render the reason instead of letting every
-  // widget below fail its own way against a 403.
-  if (!aiEntitlement.allowed) {
-    return (
-      <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
-        <div className="mx-auto flex h-full w-full max-w-[1024px] items-center justify-center px-10 py-10">
-          {aiEntitlement.reason === 'partner' ? (
-            <EmptyState
-              icon={StopCircle}
-              title={t('ai.overview.partnerUnavailableTitle', {
-                defaultValue: 'AI Model Gateway is not available for this project',
-              })}
-              description={t('ai.overview.partnerUnavailableDescription', {
-                defaultValue:
-                  'This project is managed by a partner platform, which does not include the AI Model Gateway.',
-              })}
-            />
-          ) : (
-            <EmptyState
-              icon={ArrowUpCircle}
-              title={t('ai.overview.upgradeRequiredTitle', {
-                defaultValue: 'Upgrade to Pro to use the AI Model Gateway',
-              })}
-              description={t('ai.overview.upgradeRequiredDescription', {
-                defaultValue:
-                  'Call frontier models through one endpoint, billed by usage. Available on paid plans.',
-              })}
-              action={
-                host.onShowUpgradeDialog
-                  ? {
-                      label: t('ai.overview.upgradeRequiredAction', {
-                        defaultValue: 'Upgrade plan',
-                      }),
-                      onClick: () => host.onShowUpgradeDialog?.(),
-                    }
-                  : undefined
-              }
-            />
-          )}
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -332,10 +332,22 @@ export default function AIOverviewPage() {
   const host = useDashboardHost();
   const aiEntitlement = useAiEntitlement();
 
-  // While the bridge is still resolving, allowed is true (fail open), so an
-  // entitled project renders immediately rather than flashing a spinner.
-  // AppSidebar mounts the same query, so by the time this route is reached the
-  // verdict is normally already cached.
+  // Wait for the verdict before committing to a branch. Rendering the body
+  // optimistically would show a gated org the whole paid UI — masked key field
+  // and all — and then yank it away, on top of firing the AI requests the gate
+  // exists to avoid. isLoading is only ever true when the bridge query is both
+  // enabled and in flight, so self-hosting and a warm cache still render
+  // immediately; the wait is limited to a cold load on this route.
+  if (aiEntitlement.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-[rgb(var(--semantic-1))]">
+        <Loader2 className="size-7 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // Fail open on anything unresolved (bridge error, self-hosting): cloud still
+  // enforces the real gate.
   if (aiEntitlement.allowed) {
     return <AIOverviewContent />;
   }

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -346,8 +346,8 @@ export default function AIOverviewPage() {
     );
   }
 
-  // Fail open on anything unresolved (bridge error, self-hosting): cloud still
-  // enforces the real gate.
+  // Fail open once the query has settled without a verdict (bridge error) or
+  // was never enabled (self-hosting): cloud still enforces the real gate.
   if (aiEntitlement.allowed) {
     return <AIOverviewContent />;
   }

--- a/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
+++ b/packages/dashboard/src/features/ai/pages/AIOverviewPage.tsx
@@ -5,6 +5,7 @@ import { ArrowUpCircle, Loader2, RotateCcw, StopCircle } from 'lucide-react';
 import {
   Button,
   ConfirmDialog,
+  EmptyState,
   CopyButton,
   Tab,
   Tabs,
@@ -21,6 +22,7 @@ import { useAIModelCredits } from '#features/ai/hooks/useAIModelCredits';
 import { useAIOverview } from '#features/ai/hooks/useAIOverview';
 import { useOpenRouterKey, useRotateOpenRouterKey } from '#features/ai/hooks/useOpenRouterKey';
 import { useDashboardHost } from '#lib/config/DashboardHostContext';
+import { useAiEntitlement } from '#lib/hooks/useAiEntitlement';
 import { useConfirm } from '#lib/hooks/useConfirm';
 import type { DashboardModelCreditUsage } from '#types';
 import {
@@ -323,6 +325,7 @@ function ModelCreditBadge({
 export default function AIOverviewPage() {
   const { t } = useTranslation('chrome');
   const host = useDashboardHost();
+  const aiEntitlement = useAiEntitlement();
   const [codeTab, setCodeTab] = useState<CodeTab>('sdk');
   const [selectedModelId, setSelectedModelId] = useState<
     (typeof OVERVIEW_QUICK_START_MODELS)[number]['id']
@@ -379,6 +382,50 @@ export default function AIOverviewPage() {
       // Toast feedback is handled by the mutation hook.
     }
   };
+
+  // Cloud gates AI on the org. Render the reason instead of letting every
+  // widget below fail its own way against a 403.
+  if (!aiEntitlement.allowed) {
+    return (
+      <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">
+        <div className="mx-auto flex h-full w-full max-w-[1024px] items-center justify-center px-10 py-10">
+          {aiEntitlement.reason === 'partner' ? (
+            <EmptyState
+              icon={StopCircle}
+              title={t('ai.overview.partnerUnavailableTitle', {
+                defaultValue: 'AI Model Gateway is not available for this project',
+              })}
+              description={t('ai.overview.partnerUnavailableDescription', {
+                defaultValue:
+                  'This project is managed by a partner platform, which does not include the AI Model Gateway.',
+              })}
+            />
+          ) : (
+            <EmptyState
+              icon={ArrowUpCircle}
+              title={t('ai.overview.upgradeRequiredTitle', {
+                defaultValue: 'Upgrade to Pro to use the AI Model Gateway',
+              })}
+              description={t('ai.overview.upgradeRequiredDescription', {
+                defaultValue:
+                  'Call frontier models through one endpoint, billed by usage. Available on paid plans.',
+              })}
+              action={
+                host.onShowUpgradeDialog
+                  ? {
+                      label: t('ai.overview.upgradeRequiredAction', {
+                        defaultValue: 'Upgrade plan',
+                      }),
+                      onClick: () => host.onShowUpgradeDialog?.(),
+                    }
+                  : undefined
+              }
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full overflow-y-auto bg-[rgb(var(--semantic-1))]">

--- a/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
+++ b/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
@@ -102,6 +102,11 @@ vi.mock('#lib/config/DashboardHostContext', () => ({
   }),
 }));
 
+// These cases all assume an entitled project; the gate has its own tests.
+vi.mock('#lib/hooks/useAiEntitlement', () => ({
+  useAiEntitlement: () => ({ isLoading: false, allowed: true, reason: null }),
+}));
+
 import AIOverviewPage from '#features/ai/pages/AIOverviewPage';
 
 describe('AIOverviewPage OpenRouter key rotation', () => {

--- a/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
+++ b/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
@@ -330,7 +330,7 @@ describe('AIOverviewPage entitlement gate', () => {
     expect(screen.queryByRole('button', { name: /^Rotate$/ })).not.toBeInTheDocument();
   });
 
-  it('renders the real page while the entitlement is still resolving', () => {
+  it('shows neither branch while the entitlement is still resolving', () => {
     hookMocks.entitlement = { isLoading: true, allowed: true, reason: null };
 
     render(
@@ -339,9 +339,23 @@ describe('AIOverviewPage entitlement gate', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('button', { name: /^Rotate$/ })).toBeInTheDocument();
+    // Committing early would flash a gated org the paid UI and fire the very
+    // requests the gate exists to prevent.
+    expect(screen.queryByRole('button', { name: /^Rotate$/ })).not.toBeInTheDocument();
     expect(
       screen.queryByText('Upgrade to Pro to use the AI Model Gateway')
     ).not.toBeInTheDocument();
+  });
+
+  it('renders the page once an entitled verdict settles', () => {
+    hookMocks.entitlement = { isLoading: false, allowed: true, reason: null };
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /^Rotate$/ })).toBeInTheDocument();
   });
 });

--- a/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
+++ b/packages/dashboard/src/features/ai/pages/__tests__/AIOverviewPage.test.tsx
@@ -5,6 +5,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AIOverview } from '@insforge/shared-schemas';
 
 const hookMocks = vi.hoisted(() => ({
+  showUpgradeDialog: vi.fn(),
+  entitlement: { isLoading: false, allowed: true, reason: null } as {
+    isLoading: boolean;
+    allowed: boolean;
+    reason: 'plan' | 'partner' | null;
+  },
   rotateOpenRouterKey: vi.fn(),
   isRotating: false,
   overviewResult: {
@@ -99,18 +105,20 @@ vi.mock('#features/ai/constants', () => {
 vi.mock('#lib/config/DashboardHostContext', () => ({
   useDashboardHost: () => ({
     mode: 'cloud-hosting',
+    onShowUpgradeDialog: hookMocks.showUpgradeDialog,
   }),
 }));
 
-// These cases all assume an entitled project; the gate has its own tests.
 vi.mock('#lib/hooks/useAiEntitlement', () => ({
-  useAiEntitlement: () => ({ isLoading: false, allowed: true, reason: null }),
+  useAiEntitlement: () => hookMocks.entitlement,
 }));
 
 import AIOverviewPage from '#features/ai/pages/AIOverviewPage';
 
 describe('AIOverviewPage OpenRouter key rotation', () => {
   beforeEach(() => {
+    hookMocks.showUpgradeDialog.mockReset();
+    hookMocks.entitlement = { isLoading: false, allowed: true, reason: null };
     hookMocks.rotateOpenRouterKey.mockReset();
     hookMocks.rotateOpenRouterKey.mockResolvedValue({
       apiKey: 'sk-or-rotated-key',
@@ -277,5 +285,63 @@ describe('AIOverviewPage OpenRouter key rotation', () => {
     );
 
     expect(screen.getByText('Unable to load usage from OpenRouter.')).toBeInTheDocument();
+  });
+});
+
+describe('AIOverviewPage entitlement gate', () => {
+  beforeEach(() => {
+    hookMocks.showUpgradeDialog.mockReset();
+    hookMocks.entitlement = { isLoading: false, allowed: true, reason: null };
+  });
+
+  it('offers an upgrade instead of the page when the org is on the free plan', async () => {
+    const user = userEvent.setup();
+    hookMocks.entitlement = { isLoading: false, allowed: false, reason: 'plan' };
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Upgrade to Pro to use the AI Model Gateway')).toBeInTheDocument();
+    // The gated widgets must not render at all — that is what keeps their
+    // queries from firing against a 403.
+    expect(screen.queryByRole('button', { name: /^Rotate$/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Upgrade plan' }));
+    expect(hookMocks.showUpgradeDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('says the gateway is unsupported for a partner project, with no upgrade CTA', () => {
+    hookMocks.entitlement = { isLoading: false, allowed: false, reason: 'partner' };
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText('AI Model Gateway is not available for this project')
+    ).toBeInTheDocument();
+    // A partner org has no upgrade path, so offering one would dead-end.
+    expect(screen.queryByRole('button', { name: 'Upgrade plan' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Rotate$/ })).not.toBeInTheDocument();
+  });
+
+  it('renders the real page while the entitlement is still resolving', () => {
+    hookMocks.entitlement = { isLoading: true, allowed: true, reason: null };
+
+    render(
+      <MemoryRouter>
+        <AIOverviewPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /^Rotate$/ })).toBeInTheDocument();
+    expect(
+      screen.queryByText('Upgrade to Pro to use the AI Model Gateway')
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/dashboard/src/layout/AppSidebar.tsx
+++ b/packages/dashboard/src/layout/AppSidebar.tsx
@@ -13,6 +13,7 @@ import {
 import { Link, useLocation, matchPath } from 'react-router-dom';
 import { ExternalLink, PanelLeftOpen, PanelRightOpen } from 'lucide-react';
 import { isInsForgeCloudProject } from '#lib/utils/utils';
+import { useAiEntitlement } from '#lib/hooks/useAiEntitlement';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, cn } from '@insforge/ui';
 import { ProjectSettingsMenuDialog } from '#features/dashboard/components';
 import { LanguageSelect } from '#components';
@@ -37,12 +38,18 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
   const isDTest =
     getFeatureFlag(FEATURE_FLAGS.DASHBOARD_V4_EXPERIMENT) === FEATURE_FLAG_VARIANTS.D_TEST;
   const isDTestCloud = isDTest && host.mode === 'cloud-hosting';
+  const aiEntitlement = useAiEntitlement();
+  const hideAiTab = aiEntitlement.reason === 'partner';
 
   // Cloud-only addition: Deployments inserted after AI.
   // Analytics and Web Scraper ship in both modes — self-hosting connects each
   // with its own credential (a PostHog personal API key / an Apify token).
   const mainMenuItems = useMemo(() => {
-    const items = dashboardStaticMenuItems.map((item) => ({ ...item }));
+    // Partner orgs have no AI entitlement at all, so the tab is dropped rather
+    // than left to dead-end on the page's not-supported state.
+    const items = dashboardStaticMenuItems
+      .filter((item) => item.id !== 'ai' || !hideAiTab)
+      .map((item) => ({ ...item }));
 
     if (isCloud) {
       const aiItemIndex = items.findIndex((item) => item.id === 'ai');
@@ -59,7 +66,7 @@ export default function AppSidebar({ isCollapsed, onToggleCollapse }: AppSidebar
     items.push({ ...dashboardWebscraperMenuItem });
 
     return items;
-  }, [isCloud]);
+  }, [isCloud, hideAiTab]);
 
   // d_test + cloud-hosting prepends Install + Doc above Settings in the
   // bottom nav. Other shells just show Settings.

--- a/packages/dashboard/src/layout/__tests__/AppSidebar.test.tsx
+++ b/packages/dashboard/src/layout/__tests__/AppSidebar.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  entitlement: { isLoading: false, allowed: true, reason: null } as {
+    isLoading: boolean;
+    allowed: boolean;
+    reason: 'plan' | 'partner' | null;
+  },
+}));
+
+vi.mock('#lib/hooks/useAiEntitlement', () => ({
+  useAiEntitlement: () => mocks.entitlement,
+}));
+
+vi.mock('#lib/config/DashboardHostContext', () => ({
+  useDashboardHost: () => ({ mode: 'cloud-hosting' }),
+}));
+
+vi.mock('#lib/utils/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('#lib/utils/utils')>()),
+  isInsForgeCloudProject: () => true,
+}));
+
+vi.mock('#lib/analytics/posthog', () => ({
+  getFeatureFlag: () => undefined,
+}));
+
+// Heavy children that pull in API/context of their own and are irrelevant here.
+vi.mock('#features/dashboard/components', () => ({
+  ProjectSettingsMenuDialog: () => null,
+}));
+vi.mock('#components', () => ({
+  LanguageSelect: () => null,
+}));
+
+import AppSidebar from '#layout/AppSidebar';
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <AppSidebar isCollapsed={false} onToggleCollapse={() => {}} />
+    </MemoryRouter>
+  );
+}
+
+describe('AppSidebar AI tab', () => {
+  beforeEach(() => {
+    mocks.entitlement = { isLoading: false, allowed: true, reason: null };
+  });
+
+  it('shows the AI tab for an entitled project', () => {
+    renderSidebar();
+    expect(screen.getByText('Model Gateway')).toBeInTheDocument();
+  });
+
+  it('still shows it for a free org — they can upgrade from the page', () => {
+    mocks.entitlement = { isLoading: false, allowed: false, reason: 'plan' };
+    renderSidebar();
+    expect(screen.getByText('Model Gateway')).toBeInTheDocument();
+  });
+
+  it('drops it for a partner org, which has no upgrade path', () => {
+    mocks.entitlement = { isLoading: false, allowed: false, reason: 'partner' };
+    renderSidebar();
+    expect(screen.queryByText('Model Gateway')).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
@@ -10,9 +10,11 @@ const hostState: {
   onRequestInstanceInfo?: () => Promise<DashboardInstanceInfo | null>;
 } = { mode: 'cloud-hosting' };
 
+let currentProjectId = 'project-1';
+
 vi.mock('#lib/config/DashboardHostContext', () => ({
   useDashboardHost: () => hostState,
-  useDashboardProject: () => ({ id: 'project-1' }),
+  useDashboardProject: () => ({ id: currentProjectId }),
   useIsCloudHostingMode: () => hostState.mode === 'cloud-hosting',
 }));
 
@@ -34,6 +36,7 @@ function instanceInfo(overrides: Partial<DashboardInstanceInfo>): DashboardInsta
 }
 
 function setHost(info: Partial<DashboardInstanceInfo> | null, mode = 'cloud-hosting') {
+  currentProjectId = 'project-1';
   hostState.mode = mode;
   hostState.onRequestInstanceInfo =
     info === null ? undefined : () => Promise.resolve(instanceInfo(info));
@@ -90,5 +93,34 @@ describe('useAiEntitlement', () => {
     const { result } = renderHook(() => useAiEntitlement(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.allowed).toBe(true);
+  });
+
+  it('re-resolves when the project changes under a shared QueryClient', async () => {
+    // The regression the project-scoped query key guards: without it the first
+    // org's verdict stays fresh for the whole staleTime and is served to the
+    // second.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const shared = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const byProject: Record<string, Partial<DashboardInstanceInfo>> = {
+      'project-free': { planName: 'free' },
+      'project-paid': { planName: 'pro' },
+    };
+    hostState.mode = 'cloud-hosting';
+    hostState.onRequestInstanceInfo = () =>
+      Promise.resolve(instanceInfo(byProject[currentProjectId]));
+
+    currentProjectId = 'project-free';
+    const first = renderHook(() => useAiEntitlement(), { wrapper: shared });
+    await waitFor(() => expect(first.result.current.allowed).toBe(false));
+    expect(first.result.current.reason).toBe('plan');
+    first.unmount();
+
+    currentProjectId = 'project-paid';
+    const second = renderHook(() => useAiEntitlement(), { wrapper: shared });
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+    expect(second.result.current.allowed).toBe(true);
   });
 });

--- a/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAiEntitlement } from '#lib/hooks/useAiEntitlement';
+import type { DashboardInstanceInfo } from '#types';
+
+const hostState: {
+  mode: string;
+  onRequestInstanceInfo?: () => Promise<DashboardInstanceInfo | null>;
+} = { mode: 'cloud-hosting' };
+
+vi.mock('#lib/config/DashboardHostContext', () => ({
+  useDashboardHost: () => hostState,
+  useIsCloudHostingMode: () => hostState.mode === 'cloud-hosting',
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function instanceInfo(overrides: Partial<DashboardInstanceInfo>): DashboardInstanceInfo {
+  return {
+    currentInstanceType: 'nano',
+    planName: 'pro',
+    computeCredits: 0,
+    currentOrgComputeCost: 0,
+    instanceTypes: [],
+    projects: [],
+    ...overrides,
+  } as DashboardInstanceInfo;
+}
+
+function setHost(info: Partial<DashboardInstanceInfo> | null, mode = 'cloud-hosting') {
+  hostState.mode = mode;
+  hostState.onRequestInstanceInfo =
+    info === null ? undefined : () => Promise.resolve(instanceInfo(info));
+}
+
+describe('useAiEntitlement', () => {
+  it('denies a free org with reason "plan"', async () => {
+    setHost({ planName: 'free' });
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    await waitFor(() => expect(result.current.allowed).toBe(false));
+    expect(result.current.reason).toBe('plan');
+  });
+
+  it('denies a partner org with reason "partner"', async () => {
+    setHost({ planName: 'team', isPartnerOrg: true });
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    await waitFor(() => expect(result.current.allowed).toBe(false));
+    expect(result.current.reason).toBe('partner');
+  });
+
+  it('denies a partner org even on the free plan, reporting partner first', async () => {
+    setHost({ planName: 'free', isPartnerOrg: true });
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    await waitFor(() => expect(result.current.allowed).toBe(false));
+    expect(result.current.reason).toBe('partner');
+  });
+
+  it('allows a paid non-partner org', async () => {
+    setHost({ planName: 'pro' });
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.allowed).toBe(true);
+    expect(result.current.reason).toBeNull();
+  });
+
+  it('allows self-hosting outright — it brings its own key', async () => {
+    setHost(null, 'self-hosting');
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    expect(result.current.allowed).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('fails open while the bridge is still resolving', () => {
+    hostState.mode = 'cloud-hosting';
+    hostState.onRequestInstanceInfo = () => new Promise(() => {});
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    // No upgrade wall flashed at a paying customer mid-load.
+    expect(result.current.allowed).toBe(true);
+  });
+
+  it('fails open when the bridge rejects', async () => {
+    hostState.mode = 'cloud-hosting';
+    hostState.onRequestInstanceInfo = () => Promise.reject(new Error('bridge down'));
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.allowed).toBe(true);
+  });
+});

--- a/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
@@ -12,6 +12,7 @@ const hostState: {
 
 vi.mock('#lib/config/DashboardHostContext', () => ({
   useDashboardHost: () => hostState,
+  useDashboardProject: () => ({ id: 'project-1' }),
   useIsCloudHostingMode: () => hostState.mode === 'cloud-hosting',
 }));
 

--- a/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
+++ b/packages/dashboard/src/lib/hooks/__tests__/useAiEntitlement.test.tsx
@@ -95,6 +95,20 @@ describe('useAiEntitlement', () => {
     expect(result.current.allowed).toBe(true);
   });
 
+  it('gives up after one attempt so a hung bridge cannot stack retries', async () => {
+    // The bridge already self-terminates at 15s; react-query's default 3
+    // retries would turn that into ~a minute of spinner on the gate.
+    const attempt = vi.fn().mockRejectedValue(new Error('bridge down'));
+    hostState.mode = 'cloud-hosting';
+    hostState.onRequestInstanceInfo = attempt;
+
+    const { result } = renderHook(() => useAiEntitlement(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(result.current.allowed).toBe(true);
+  });
+
   it('re-resolves when the project changes under a shared QueryClient', async () => {
     // The regression the project-scoped query key guards: without it the first
     // org's verdict stays fresh for the whole staleTime and is served to the

--- a/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
+++ b/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
@@ -1,5 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
-import { useDashboardHost, useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
+import {
+  useDashboardHost,
+  useDashboardProject,
+  useIsCloudHostingMode,
+} from '#lib/config/DashboardHostContext';
 import type { DashboardInstanceInfo } from '#types';
 
 /**
@@ -20,13 +24,17 @@ export function useAiEntitlement(): {
   reason: AiEntitlementReason | null;
 } {
   const host = useDashboardHost();
+  const project = useDashboardProject();
   const isCloudHostingMode = useIsCloudHostingMode();
   const onRequestInstanceInfo =
     host.mode === 'cloud-hosting' ? host.onRequestInstanceInfo : undefined;
   const enabled = isCloudHostingMode && !!onRequestInstanceInfo;
 
   const query = useQuery({
-    queryKey: ['instance-info'],
+    // Scoped to the project: entitlement is an org-level answer, and switching
+    // project without remounting the QueryClient would otherwise serve the
+    // previous org's verdict for the whole staleTime.
+    queryKey: ['instance-info', project?.id ?? null],
     queryFn: (): Promise<DashboardInstanceInfo | null> =>
       onRequestInstanceInfo ? onRequestInstanceInfo() : Promise.resolve(null),
     enabled,

--- a/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
+++ b/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useDashboardHost, useIsCloudHostingMode } from '#lib/config/DashboardHostContext';
+import type { DashboardInstanceInfo } from '#types';
+
+/**
+ * Whether this project may use the AI Model Gateway, and if not, why.
+ *
+ * Cloud gates AI on the org: free orgs created after the AI cutoff need a paid
+ * plan, and white-labeled partner orgs are excluded outright. Self-hosting
+ * brings its own key, so it is always allowed.
+ *
+ * `isPartnerOrg` has to be carried explicitly — cloud reports partner orgs as
+ * the Team plan, so planName alone cannot distinguish them.
+ */
+export type AiEntitlementReason = 'plan' | 'partner';
+
+export function useAiEntitlement(): {
+  isLoading: boolean;
+  allowed: boolean;
+  reason: AiEntitlementReason | null;
+} {
+  const host = useDashboardHost();
+  const isCloudHostingMode = useIsCloudHostingMode();
+  const onRequestInstanceInfo =
+    host.mode === 'cloud-hosting' ? host.onRequestInstanceInfo : undefined;
+  const enabled = isCloudHostingMode && !!onRequestInstanceInfo;
+
+  const query = useQuery({
+    queryKey: ['instance-info'],
+    queryFn: (): Promise<DashboardInstanceInfo | null> =>
+      onRequestInstanceInfo ? onRequestInstanceInfo() : Promise.resolve(null),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!enabled) {
+    return { isLoading: false, allowed: true, reason: null };
+  }
+
+  // Fail open while loading and on error: a transient bridge failure should not
+  // flash an upgrade wall at a paying customer. Cloud still enforces the real
+  // gate — the worst case is a page that renders and then 403s.
+  if (query.isLoading || !query.data) {
+    return { isLoading: query.isLoading, allowed: true, reason: null };
+  }
+
+  if (query.data.isPartnerOrg) {
+    return { isLoading: false, allowed: false, reason: 'partner' };
+  }
+  if ((query.data.planName || '').toLowerCase() === 'free') {
+    return { isLoading: false, allowed: false, reason: 'plan' };
+  }
+  return { isLoading: false, allowed: true, reason: null };
+}

--- a/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
+++ b/packages/dashboard/src/lib/hooks/useAiEntitlement.ts
@@ -38,6 +38,11 @@ export function useAiEntitlement(): {
     queryFn: (): Promise<DashboardInstanceInfo | null> =>
       onRequestInstanceInfo ? onRequestInstanceInfo() : Promise.resolve(null),
     enabled,
+    // The bridge self-terminates at DEFAULT_TIMEOUT_MS (15s) and rejects, but
+    // react-query's default 3 retries would stack that into ~a minute of
+    // spinner on a hung parent. One attempt, then fail open — same convention
+    // as useOpenRouterKey.
+    retry: false,
     staleTime: 5 * 60 * 1000,
   });
 

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -39,6 +39,11 @@ export interface DashboardBackupInfo {
 export interface DashboardInstanceInfo {
   currentInstanceType: string;
   planName: string;
+  /**
+   * White-labeled partner org. Not derivable from planName — the cloud reports
+   * partner orgs as 'team', so they look identical to a real Team customer.
+   */
+  isPartnerOrg?: boolean;
   computeCredits: number;
   currentOrgComputeCost: number;
   instanceTypes: Array<{


### PR DESCRIPTION
Replaces #1931, which was branched off an unrelated feature branch and swept in 30 commits and untracked files that weren't part of this change. This is the same work, 7 files, cut fresh from `main`.

Cloud now gates AI on the org ([cloud-backend #821](https://github.com/InsForge/insforge-cloud-backend/pull/821), [#823](https://github.com/InsForge/insforge-cloud-backend/pull/823), shipped in v1.3.18), but the dashboard had no way to say so — a free or partner project just watched every widget on the AI page fail its own way against a 403.

## States

| Project | Sidebar | Model Gateway page |
|---|---|---|
| Paid cloud org | AI tab | normal |
| **Free cloud org** | AI tab | **whole page → "Upgrade to Pro to use the AI Model Gateway"** + CTA wired to `host.onShowUpgradeDialog` |
| **Partner (white-label) org** | **AI tab hidden** | not-supported state, as a backstop for a deep link |
| Self-hosting | AI tab | normal — it brings its own key |

The free-plan copy and CTA follow how `BackupsPage` already gates scheduled backups.

## Why `isPartnerOrg` is carried explicitly

The dashboard already knows the plan via `instanceInfo.planName`, so the free case needed no new signal. Partner orgs, though, are **indistinguishable from a real Team customer** — cloud's `getSubscriptionStatus` maps white-label orgs to `Team`. So partner-ness is sent as its own field on `INSTANCE_INFO` rather than inferred.

## Fails open, deliberately

`useAiEntitlement` returns `allowed` while the bridge is loading and when it errors. Cloud enforces the real gate, so the worst case is a page that renders and then 403s — versus flashing an upgrade wall at a paying customer over a transient blip. Both paths are tested.

## Requires a matching cloud change

`insforge-cloud` must send `isPartnerOrg` in `INSTANCE_INFO` — that's [insforge-cloud#618](https://github.com/InsForge/insforge-cloud/pull/618). **This PR is safe to merge first**: the field is simply absent until then, so partner orgs keep today's behaviour, and the free-plan case works immediately because `planName` is already sent.

## Testing

`tsc` clean on both `packages/dashboard` and `frontend`, eslint clean, 23 component tests passing — all re-run in a clean worktree off `main`, not inherited from the previous branch.

New `useAiEntitlement` tests cover free → `plan`, partner → `partner`, partner-outranks-free, paid → allowed, self-hosting → allowed, and fail-open on both pending and rejected bridge calls. The existing `AIOverviewPage` suite mocks the new hook, as it already does the other AI hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show why the Model Gateway is unavailable, and hide its sidebar tab for partner orgs. The page now waits for the entitlement verdict with a brief spinner, preventing UI flashes and blocking gated requests while loading.

- **New Features**
  - `useAiEntitlement` resolves access from `INSTANCE_INFO`; shows a short loader while resolving and fails open only on bridge errors.
  - Free cloud orgs: full-page “Upgrade to Pro” with CTA to `host.onShowUpgradeDialog`.
  - Partner orgs: AI tab hidden; deep links show a not-supported state. Self-hosted: always allowed.

- **Bug Fixes**
  - Scoped the `instance-info` query to the current project to avoid cross-org cache bleed.
  - Split `AIOverviewPage` so denied orgs never mount `useOpenRouterKey`, `useAIOverview`, or `useAIModelCredits`.
  - Capped the entitlement bridge to a single attempt (`retry: false`) to limit the wait to one ~15s try before fail-open.

<sup>Written for commit 285e890f127632140139e3d9161ddd3802dfe024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI access controls based on plan eligibility and partner-managed status.
  * Added localized upgrade and unavailable states for restricted AI overview access.
  * AI navigation is now hidden for partner-managed projects.

* **Bug Fixes**
  * Improved handling of cloud instance information to accurately identify partner-managed projects.
  * AI access remains available during temporary integration loading or errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai --><!-- Macroscope's changelog starts here -->
> #### Changes since #1933 opened
>
> - Disabled retries for the AI entitlement query in the `useAiEntitlement` hook by setting `retry: false` in the `useQuery` options, ensuring the entitlement bridge is attempted exactly once before failing open [285e890]
> - Updated inline comment in the `AIOverviewPage` React component to clarify fail-open gating conditions [285e890]
> <!-- Macroscope's changelog ends here -->
>
<!-- Macroscope's pull request summary ends here -->