### PR TITLE
fix(functions): reject reserved function slugs instead of silently shadowing them

### DIFF
--- a/backend/src/services/functions/function.service.ts
+++ b/backend/src/services/functions/function.service.ts
@@ -7,6 +7,8 @@ import {
   FunctionSchema,
   ListFunctionsResponse,
   DeploymentResult,
+  isReservedFunctionSlug,
+  reservedFunctionSlugMessage,
 } from '@insforge/shared-schemas';
 import logger from '@/utils/logger.js';
 import { Pool } from 'pg';
@@ -147,6 +149,14 @@ export class FunctionService {
   ): Promise<{ function: FunctionSchema; deployment?: DeploymentResult | null }> {
     const { name, code, description, status } = data;
     const slug = data.slug || name.toLowerCase().replace(/\s+/g, '-');
+
+    // Reject slugs the generated router serves itself. Checked here rather than
+    // only in the request schema because an omitted slug is derived from the
+    // name, so `{ name: "Health" }` reaches this point with slug "health"
+    // without ever passing through the schema's slug validation (issue #1862).
+    if (isReservedFunctionSlug(slug)) {
+      throw new AppError(reservedFunctionSlugMessage, 400, ERROR_CODES.FUNCTION_SLUG_RESERVED);
+    }
 
     // Validate only platform contract constraints; runtime security is enforced by the runtime/provider.
     this.validateCode(code);

--- a/backend/tests/unit/function-reserved-slug.test.ts
+++ b/backend/tests/unit/function-reserved-slug.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ERROR_CODES,
+  RESERVED_FUNCTION_SLUGS,
+  isReservedFunctionSlug,
+  uploadFunctionRequestSchema,
+} from '@insforge/shared-schemas';
+import { FunctionService } from '../../src/services/functions/function.service.js';
+
+const clientQueryMock = vi.fn();
+const releaseMock = vi.fn();
+
+const mockPool = {
+  query: vi.fn(),
+  connect: vi.fn().mockResolvedValue({
+    query: clientQueryMock,
+    release: releaseMock,
+  }),
+};
+
+vi.mock('../../src/infra/database/database.manager.js', () => ({
+  DatabaseManager: {
+    getInstance: () => ({
+      getPool: () => mockPool,
+    }),
+  },
+}));
+
+vi.mock('../../src/providers/functions/deno-subhosting.provider.js', () => ({
+  DenoSubhostingProvider: {
+    getInstance: () => ({
+      isConfigured: vi.fn().mockReturnValue(false),
+      checkCode: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock('../../src/services/secrets/secret.service.js', () => ({
+  SecretService: {
+    getInstance: () => ({}),
+  },
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+/**
+ * Regression tests for issue #1862 — a function slugged `health` deploys
+ * successfully but is permanently shadowed by the generated router's built-in
+ * health route, so it can never be invoked.
+ */
+describe('reserved function slugs', () => {
+  describe('isReservedFunctionSlug', () => {
+    it('flags every reserved slug', () => {
+      for (const slug of RESERVED_FUNCTION_SLUGS) {
+        expect(isReservedFunctionSlug(slug)).toBe(true);
+      }
+    });
+
+    it('is case-insensitive, since the router compares a lowercased path', () => {
+      expect(isReservedFunctionSlug('Health')).toBe(true);
+      expect(isReservedFunctionSlug('HEALTH')).toBe(true);
+    });
+
+    it('does not flag slugs that merely contain a reserved word', () => {
+      expect(isReservedFunctionSlug('health-check')).toBe(false);
+      expect(isReservedFunctionSlug('my-health')).toBe(false);
+      expect(isReservedFunctionSlug('healthy')).toBe(false);
+    });
+  });
+
+  describe('uploadFunctionRequestSchema', () => {
+    const base = { name: 'Some Function', code: 'export default () => {}' };
+
+    it('rejects an explicit reserved slug', () => {
+      const result = uploadFunctionRequestSchema.safeParse({ ...base, slug: 'health' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a reserved slug in a different case', () => {
+      const result = uploadFunctionRequestSchema.safeParse({ ...base, slug: 'Health' });
+      expect(result.success).toBe(false);
+    });
+
+    it('still accepts ordinary slugs', () => {
+      const result = uploadFunctionRequestSchema.safeParse({ ...base, slug: 'health-check' });
+      expect(result.success).toBe(true);
+    });
+
+    it('still rejects malformed slugs with the format error', () => {
+      const result = uploadFunctionRequestSchema.safeParse({ ...base, slug: 'not a slug' });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.message).toContain('Invalid slug format');
+    });
+  });
+
+  describe('FunctionService.createFunction', () => {
+    let service: FunctionService;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      service = FunctionService.getInstance();
+    });
+
+    it('rejects an explicit reserved slug before touching the database', async () => {
+      await expect(
+        service.createFunction({
+          name: 'Health',
+          slug: 'health',
+          code: 'export default () => {}',
+          status: 'active',
+        })
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: ERROR_CODES.FUNCTION_SLUG_RESERVED,
+      });
+
+      expect(mockPool.connect).not.toHaveBeenCalled();
+    });
+
+    // The schema's slug refine cannot catch this: with no slug supplied the
+    // service derives one from the name, so validation never sees "health".
+    it('rejects a reserved slug derived from the function name', async () => {
+      await expect(
+        service.createFunction({
+          name: 'Health',
+          code: 'export default () => {}',
+          status: 'active',
+        })
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: ERROR_CODES.FUNCTION_SLUG_RESERVED,
+      });
+
+      expect(mockPool.connect).not.toHaveBeenCalled();
+    });
+
+    it('allows a non-reserved slug derived from the function name', async () => {
+      clientQueryMock
+        .mockResolvedValueOnce({}) // INSERT
+        .mockResolvedValueOnce({}) // UPDATE deployed_at
+        .mockResolvedValueOnce({
+          rows: [{ id: 'id-1', slug: 'health-check', name: 'Health Check', status: 'active' }],
+        });
+
+      const result = await service.createFunction({
+        name: 'Health Check',
+        code: 'export default () => {}',
+        status: 'active',
+      });
+
+      expect(result.function.slug).toBe('health-check');
+    });
+  });
+});

--- a/packages/shared-schemas/src/error-codes.schema.ts
+++ b/packages/shared-schemas/src/error-codes.schema.ts
@@ -103,6 +103,7 @@ const functionErrorCodes = [
   'FUNCTION_ALREADY_EXISTS',
   'FUNCTION_DEPLOYMENT_NOT_FOUND',
   'FUNCTION_NOT_FOUND',
+  'FUNCTION_SLUG_RESERVED',
 ] as const;
 
 const scheduleErrorCodes = ['SCHEDULE_INVALID_CRON', 'SCHEDULE_NOT_FOUND'] as const;

--- a/packages/shared-schemas/src/functions-api.schema.ts
+++ b/packages/shared-schemas/src/functions-api.schema.ts
@@ -1,6 +1,24 @@
 import { z } from 'zod';
 import { functionSchema } from './functions.schema.js';
 
+/**
+ * Slugs claimed by the generated function router's own built-in routes.
+ *
+ * The router answers these paths before it dispatches to `routes[slug]`, so a
+ * function deployed under one of them deploys successfully but can never be
+ * invoked — the built-in handler responds instead, with no error and no
+ * warning. Rejecting them at validation turns that silent shadowing into an
+ * explicit failure (issue #1862).
+ */
+export const RESERVED_FUNCTION_SLUGS = ['health'] as const;
+
+export const isReservedFunctionSlug = (slug: string): boolean =>
+  (RESERVED_FUNCTION_SLUGS as readonly string[]).includes(slug.toLowerCase());
+
+export const reservedFunctionSlugMessage = `Reserved slug - "${RESERVED_FUNCTION_SLUGS.join('", "')}" ${
+  RESERVED_FUNCTION_SLUGS.length === 1 ? 'is' : 'are'
+} used by the functions runtime and cannot be used as a function slug`;
+
 export const uploadFunctionRequestSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   slug: z
@@ -9,6 +27,7 @@ export const uploadFunctionRequestSchema = z.object({
       /^[a-zA-Z0-9_-]+$/,
       'Invalid slug format - must be alphanumeric with hyphens or underscores only'
     )
+    .refine((slug) => !isReservedFunctionSlug(slug), reservedFunctionSlugMessage)
     .optional(),
   code: z.string().min(1),
   description: z.string().optional(),


### PR DESCRIPTION
> **Issue:** #1862 (assigned to me). Intentionally `Refs`, not `Closes` — see [Scope](#scope): this implements 1 of the 3 fixes that issue describes, so it should not auto-close it.

## Summary

Addresses the **second, independent defect** in #1862: a function slugged `health` deploys successfully but can never be invoked.

The generated router checks `pathname === "/health" || pathname === "/"` *before* it looks up `routes[slug]` (`deno-subhosting.provider.ts:1079` vs `:1091`), and `slug` was validated only as `/^[a-zA-Z0-9_-]+$/`. So deploying a function named `health` silently succeeds and the platform health handler answers every call to it — no error, no warning, no way for the deployer to notice.

This PR reserves those slugs at validation so the deploy fails loudly instead:

- `RESERVED_FUNCTION_SLUGS` + an `isReservedFunctionSlug` helper and shared message in `functions-api.schema.ts`, wired into the upload request schema's `slug` field via `.refine()`.
- A guard in `FunctionService.createFunction`. **The schema refine alone is not sufficient** — when `slug` is omitted it is derived from the name (`data.slug || name.toLowerCase()...`), so `{ name: "Health" }` arrives at the service as slug `health` having never passed through slug validation. The guard runs before any DB work and throws a 400.
- New `FUNCTION_SLUG_RESERVED` shared error code.

## Scope

This is **item 3 only** of the three suggested fixes in #1862. Items 1 and 2 (dropping `available` from the 404 body and `functions` from the health payload) are the reporter's to take — @iPLAYCAFE-dev offered to PR them, and they're a separate concern from this correctness bug.

That is why the footer is `Refs #1862` rather than `Closes #1862`: merging this should not close an issue with two of its three items outstanding. Happy to switch if maintainers would rather split #1862 into per-item sub-issues.

### Two things worth flagging for review

1. **Existing deployments are unaffected.** The shadowing lives in the generated deployment entrypoint, so already-deployed projects keep the old router until their next deploy. This change stops *new* functions from entering the broken state; it does not retroactively fix one. If anyone already has a deployed `health` function, it stays unreachable (as it is today) and will now fail on its next create.
2. **The self-hosted runtime shadows more narrowly than the issue implies.** `functions/server.ts` matches `/^\/([a-zA-Z0-9_-]+)$/` with no subpath support and only tests `pathname === '/health'`, so only a literal `health` slug collides there — whereas Subhosting also swallows `/` and every `health/*` subpath. Reserving the slug covers both.

I deliberately kept `RESERVED_FUNCTION_SLUGS` to just `health` rather than speculatively adding others, since that is the only path both runtimes actually claim today. It is a single array to extend if more built-ins appear.

## How did you test this change?

New unit test `backend/tests/unit/function-reserved-slug.test.ts` (10 cases) covering the helper, the schema, and the service:

- explicit reserved slug rejected; case variants (`Health`, `HEALTH`) rejected
- **slug derived from the name** rejected — the case the schema cannot catch
- both rejections asserted to happen *before* `pool.connect()`, i.e. no DB write
- near-misses still allowed: `health-check`, `my-health`, `healthy`
- pre-existing malformed-slug error preserved

Verified the tests actually catch the bug: stashing the source change makes **7 of 10 fail**; with the fix all 10 pass.

Also run locally:
- Full backend unit suite: **2332 passed, 21 skipped, 0 failures** (199 files)
- `tsc --noEmit` on backend: clean
- `eslint` on all four changed files: clean
- `prettier --check`: clean
- `@insforge/shared-schemas` builds clean

**Not run:** `npm run test:e2e`, which CONTRIBUTING.md's development workflow asks for — it needs Docker and a running stack, which I did not spin up. Flagging so the list above isn't read as a full pass. The change is backend validation logic with no HTTP-surface or migration component, so I'd expect unit coverage to be the load-bearing part here, but happy to run e2e if CI doesn't cover it.

Refs #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)