### PR TITLE
docs(deploy): point localized security guides at deploy/backup.sh

### DIFF
--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -1011,13 +1011,16 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-By default, backups land in `~/insforge/backups/` and files older than 14 days are removed. Override retention:
+By default, backups land in `~/insforge/backups/` and files older than 14 days are removed. Override retention, or the destination directory:
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restore a database dump:
+The script runs under `umask 077`, so the database dump is readable only by the user that runs it. Don't substitute a hand-written script: without `umask 077`, the default `umask 022` leaves `db_*.sql` world-readable (`-rw-r--r--`), and that file contains every table in your application.
+
+Restore a database dump (adjust the path if you set `BACKUP_DIR`):
 
 ```bash
 cd ~/insforge
@@ -1034,7 +1037,7 @@ crontab -e
 Add this line for daily backups at 3:00 AM (adjust the path if your install lives elsewhere):
 
 ```cron
-0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * mkdir -p /home/deploy/insforge/backups && /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 Off-Site Backups (Recommended)
@@ -1113,7 +1116,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -824,6 +824,15 @@ Por defecto, el backend permite todos los orígenes. Refleja el encabezado `Orig
 
 #### 14.1 Haz una copia de seguridad de la base de datos
 
+Para obtener un volcado de la base de datos y una copia de `.env` en un solo paso, usa el script de copia de seguridad incluido:
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+O haz el volcado manualmente:
+
 ```bash
 cd ~/insforge
 source .env
@@ -984,49 +993,29 @@ docker compose up -d
 
 Configura una tarea cron para copias de seguridad automáticas diarias:
 
-#### 17.1 Crea un script de copia de seguridad
+#### 17.1 Ejecuta el script de copia de seguridad
+
+Las instalaciones autoalojadas incluyen `deploy/backup.sh` (proporcionado por `deploy/setup.sh`). Vuelca Postgres y copia `.env` en un directorio `backups/` dentro de la raíz de tu instalación.
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y los archivos con más de 14 días se eliminan. Para cambiar la retención:
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+El script se ejecuta con `umask 077`, por lo que el volcado de la base de datos solo puede leerlo el usuario que lo ejecuta. No lo sustituyas por un script propio: sin `umask 077`, con la `umask 022` predeterminada el archivo `db_*.sql` queda legible para todos los usuarios (`-rw-r--r--`), y contiene todas las tablas de tu aplicación.
+
+Restaura un volcado de la base de datos:
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 Programa con Cron
@@ -1035,10 +1024,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-Añade esta línea para copias de seguridad diarias a las 3:00 a. m.:
+Añade esta línea para copias de seguridad diarias a las 3:00 a. m. (ajusta la ruta si tu instalación está en otra ubicación):
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 Copias de seguridad fuera del sitio (recomendado)
@@ -1117,7 +1106,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -1002,15 +1002,16 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y los archivos con más de 14 días se eliminan. Para cambiar la retención:
+De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y los archivos con más de 14 días se eliminan. Para cambiar la retención o el directorio de destino:
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
 El script se ejecuta con `umask 077`, por lo que el volcado de la base de datos solo puede leerlo el usuario que lo ejecuta. No lo sustituyas por un script propio: sin `umask 077`, con la `umask 022` predeterminada el archivo `db_*.sql` queda legible para todos los usuarios (`-rw-r--r--`), y contiene todas las tablas de tu aplicación.
 
-Restaura un volcado de la base de datos:
+Restaura un volcado de la base de datos (ajusta la ruta si has definido `BACKUP_DIR`):
 
 ```bash
 cd ~/insforge
@@ -1027,7 +1028,7 @@ crontab -e
 Añade esta línea para copias de seguridad diarias a las 3:00 a. m. (ajusta la ruta si tu instalación está en otra ubicación):
 
 ```cron
-0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * mkdir -p /home/deploy/insforge/backups && /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 Copias de seguridad fuera del sitio (recomendado)
@@ -1106,7 +1107,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -1000,15 +1000,16 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-預設情況下，備份檔案會存放在 `~/insforge/backups/`，超過 14 天的檔案會被刪除。可覆寫保留天數：
+預設情況下，備份檔案會存放在 `~/insforge/backups/`，超過 14 天的檔案會被刪除。可覆寫保留天數，或變更目標目錄：
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
 該腳本以 `umask 077` 執行，因此資料庫匯出檔案僅限執行者本人可讀。請勿改用自行撰寫的腳本：若沒有 `umask 077`，在預設的 `umask 022` 下產生的 `db_*.sql` 將是全域可讀的（`-rw-r--r--`），而該檔案包含你的全部應用資料表。
 
-還原資料庫匯出檔案：
+還原資料庫匯出檔案（若你設定了 `BACKUP_DIR`，請相應調整路徑）：
 
 ```bash
 cd ~/insforge
@@ -1025,7 +1026,7 @@ crontab -e
 新增以下這一行，讓每天凌晨 3:00 執行備份（若你的安裝位於其他位置，請調整路徑）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * mkdir -p /home/deploy/insforge/backups && /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 異地備份（建議）
@@ -1104,7 +1105,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -823,6 +823,15 @@ tmpfs:
 
 #### 14.1 備份資料庫
 
+如需一步完成資料庫匯出與 `.env` 複製，請使用隨附的備份腳本：
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+或手動匯出：
+
 ```bash
 cd ~/insforge
 source .env
@@ -982,49 +991,29 @@ docker compose up -d
 
 設定一個 cron 工作以進行每日自動備份：
 
-#### 17.1 建立備份腳本
+#### 17.1 執行備份腳本
+
+自架安裝包含 `deploy/backup.sh`（由 `deploy/setup.sh` 提供）。它會匯出 Postgres 資料庫，並將 `.env` 複製到安裝根目錄下的 `backups/` 目錄中。
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+預設情況下，備份檔案會存放在 `~/insforge/backups/`，超過 14 天的檔案會被刪除。可覆寫保留天數：
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+該腳本以 `umask 077` 執行，因此資料庫匯出檔案僅限執行者本人可讀。請勿改用自行撰寫的腳本：若沒有 `umask 077`，在預設的 `umask 022` 下產生的 `db_*.sql` 將是全域可讀的（`-rw-r--r--`），而該檔案包含你的全部應用資料表。
+
+還原資料庫匯出檔案：
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 排程
@@ -1033,10 +1022,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-新增以下這一行，讓每天凌晨 3:00 執行備份：
+新增以下這一行，讓每天凌晨 3:00 執行備份（若你的安裝位於其他位置，請調整路徑）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 異地備份（建議）
@@ -1115,7 +1104,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -999,15 +999,16 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-默认情况下，备份文件保存在 `~/insforge/backups/`，超过 14 天的文件会被删除。可覆盖保留天数：
+默认情况下，备份文件保存在 `~/insforge/backups/`，超过 14 天的文件会被删除。可覆盖保留天数，或更改目标目录：
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
 该脚本以 `umask 077` 运行，因此数据库导出文件仅对运行它的用户可读。请不要改用自行编写的脚本：如果没有 `umask 077`，在默认的 `umask 022` 下生成的 `db_*.sql` 将是全局可读的（`-rw-r--r--`），而该文件包含你的全部应用数据表。
 
-恢复数据库导出文件：
+恢复数据库导出文件（如果你设置了 `BACKUP_DIR`，请相应调整路径）：
 
 ```bash
 cd ~/insforge
@@ -1024,7 +1025,7 @@ crontab -e
 添加以下这一行以每天凌晨 3:00 进行备份（如果你的安装位于其他位置，请调整路径）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * mkdir -p /home/deploy/insforge/backups && /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 异地备份（推荐）
@@ -1103,7 +1104,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -822,6 +822,15 @@ tmpfs:
 
 #### 14.1 备份数据库
 
+如需一步完成数据库导出和 `.env` 复制，请使用随附的备份脚本：
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+或手动导出：
+
 ```bash
 cd ~/insforge
 source .env
@@ -981,49 +990,29 @@ docker compose up -d
 
 设置一个 cron 任务以进行每日自动备份：
 
-#### 17.1 创建备份脚本
+#### 17.1 运行备份脚本
+
+自托管安装包含 `deploy/backup.sh`（由 `deploy/setup.sh` 提供）。它会导出 Postgres 数据库，并将 `.env` 复制到安装根目录下的 `backups/` 目录中。
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+默认情况下，备份文件保存在 `~/insforge/backups/`，超过 14 天的文件会被删除。可覆盖保留天数：
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+该脚本以 `umask 077` 运行，因此数据库导出文件仅对运行它的用户可读。请不要改用自行编写的脚本：如果没有 `umask 077`，在默认的 `umask 022` 下生成的 `db_*.sql` 将是全局可读的（`-rw-r--r--`），而该文件包含你的全部应用数据表。
+
+恢复数据库导出文件：
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 设置计划任务
@@ -1032,10 +1021,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-添加以下这一行以每天凌晨 3:00 进行备份：
+添加以下这一行以每天凌晨 3:00 进行备份（如果你的安装位于其他位置，请调整路径）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 异地备份（推荐）
@@ -1114,7 +1103,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────


### PR DESCRIPTION
Closes #1925

## Summary

#1913 replaced the hand-rolled backup procedure in the English deployment security guide with the shipped `deploy/backup.sh`. The `zh`, `zh-Hant` and `es` copies were not updated, so all three still walked the reader through writing their own script at `~/insforge/backup.sh`.

This is not just staleness. The script those guides tell readers to write has **no `umask` and no `chmod`**, so under the default `umask 022` the Postgres dump lands world-readable:

```
the localized guides' script          the shipped deploy/backup.sh
  backups/         drwxr-xr-x           backups/         drwx------
  backups/db_*.sql -rw-r--r--   <-- !   backups/db_*.sql -rw-------
```

That dump contains every application table, so on a shared host any local user can read it. `deploy/backup.sh` opens with `umask 077`, which is precisely what prevents it. A security guide is the worst page for this drift to land on.

## What changed

Ported the English §17.1 across all three locales, keeping each file's own translated prose style. I also added a sentence stating *why* the shipped script shouldn't be swapped for a hand-written one — without it, a reader who already has the old script has no reason to stop using it, which struck me as the point of the fix rather than just removing the snippet.

While verifying, I found the same drift in two more places the issue didn't mention:

- **§14.1** — English leads with `./deploy/backup.sh` before the manual `pg_dump`; the three locales only had the manual path (also umask-less).
- **§17.2 cron line and the quick-reference cheat sheet** — both still pointed at `~/insforge/backup.sh`, a path that no longer exists, so those commands were simply broken.

Leaving those would have meant a reader following §14.1 or the cheat sheet hit the identical problem the issue was filed about. Happy to split them out if reviewers would rather keep this to §17.1 alone.

## Out of scope

The issue's root-cause section notes that `scripts/check-docs-i18n-parity.sh` only checks that a translated file *exists*, never that its content still matches — which is why this drifted silently. That's a real gap, but it's a CI change rather than a docs correction, so I've left it alone. Worth its own issue.

## How did you test this change?

Docs-only change; no code paths touched. Verified mechanically:

```
$ grep -c 'deploy/backup.sh' <each guide>
docs/deployment              6      (unchanged)
docs/zh/deployment           6      (was 0)
docs/zh-Hant/deployment      6      (was 0)
docs/es/deployment           6      (was 0)

$ grep -rn 'nano ~/insforge/backup.sh\|chmod +x ~/insforge/backup.sh' docs/ | wc -l
0

$ grep -rn 'insforge/backup.sh' docs/ | grep -v 'deploy/backup.sh' | wc -l
0                                  # no stale cron paths left
```

All four locales now reference `deploy/backup.sh` in the same six places, and the three diffs are structurally identical.

`scripts/check-docs-i18n-parity.sh` reports 27 `missing translation` warnings and exits 1 — **identical before and after this change** (verified by stashing). Those are unrelated pages with no translation at all, pre-existing on main.

I read the resulting zh/zh-Hant/es sections in full rather than machine-translating in place; the surrounding numbered-section structure and code blocks are byte-identical to English where they should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update localized deployment security guides (`zh`, `zh-Hant`, `es`) to use the shipped `deploy/backup.sh`, and bring English to parity. Fix cron and quick‑reference paths, document `BACKUP_DIR`, and add the `umask 077` rationale to prevent world‑readable dumps.

- **Bug Fixes**
  - Ported English §17.1 across locales; made §14.1 lead with the script; removed hand-written `~/insforge/backup.sh` steps.
  - Documented `BACKUP_DIR` alongside `RETENTION_DAYS`, added a restore example, and explained why `umask 077` matters in all four locales.
  - Fixed cron example: prepend `mkdir -p` and point to `/home/deploy/insforge/deploy/backup.sh`.
  - Fixed quick-reference to use absolute `~/insforge/deploy/backup.sh` to avoid CWD-dependent failures.

<sup>Written for commit dd22a40db629747fbd0efad10848e3317eccd646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment security guides with the standard backup workflow.
  * Documented combined PostgreSQL and `.env` backups, secure permissions, and the default 14-day retention period.
  * Added instructions for customizing retention and restoring database backups.
  * Updated automated scheduling and quick-reference commands to use the provided backup script.
  * Clarified the distinction between automated and manual database backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->