### PR TITLE
fix(dashboard): correct observability chart x-axis labels

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -178,7 +178,7 @@ export function getMetricXAxisTimestamps(
   nowSeconds = Math.floor(Date.now() / 1000)
 ): [number, number, number] {
   const latestTimestamp = data.reduce<number | null>((latest, point) => {
-    if (!Number.isFinite(point.value)) {
+    if (!Number.isFinite(point.value) || !Number.isFinite(point.timestamp)) {
       return latest;
     }
     return latest === null || point.timestamp > latest ? point.timestamp : latest;

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -171,6 +171,23 @@ function formatHoverTime(ts: number, rangeSeconds: number): string {
   return `${date} ${time}`;
 }
 
+/** Return the time-window endpoints used by the chart's x-axis labels. */
+export function getMetricXAxisTimestamps(
+  data: DashboardMetricDataPoint[],
+  rangeSeconds: number,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): [number, number, number] {
+  const latestTimestamp = data.reduce<number | null>((latest, point) => {
+    if (!Number.isFinite(point.value)) {
+      return latest;
+    }
+    return latest === null || point.timestamp > latest ? point.timestamp : latest;
+  }, null);
+  const end = latestTimestamp ?? nowSeconds;
+  const start = end - rangeSeconds;
+  return [start, start + Math.floor(rangeSeconds / 2), end];
+}
+
 const FIXED_PERCENT_DOMAIN: [number, number] = [0, 100];
 
 export function MetricChartCard({
@@ -218,12 +235,9 @@ export function MetricChartCard({
   );
   const gradientId = useId();
   const xAxisTicks = useMemo(() => {
-    const finite = data.filter((p) => Number.isFinite(p.value));
-    const end =
-      finite.length > 0 ? finite[finite.length - 1].timestamp : Math.floor(Date.now() / 1000);
-    const start = end - rangeSeconds;
-    const mid = start + Math.floor(rangeSeconds / 2);
-    return [start, mid, end].map((ts) => formatHoverTime(ts, rangeSeconds));
+    return getMetricXAxisTimestamps(data, rangeSeconds).map((ts) =>
+      formatHoverTime(ts, rangeSeconds)
+    );
   }, [data, rangeSeconds]);
   const svgRef = useRef<SVGSVGElement>(null);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
@@ -20,18 +20,34 @@ const base = {
 const svgRects = (container: HTMLElement) => [...container.querySelectorAll('svg rect')];
 
 describe('MetricChartCard rendering modes', () => {
-  it('anchors x-axis timestamps to the newest reading when data is unordered', () => {
+  it('anchors x-axis timestamps to the newest valid reading when data is unordered', () => {
     expect(
       getMetricXAxisTimestamps(
         pts([
-          [1300, 20],
+          [Number.NaN, 30],
           [1000, 10],
-          [1200, Number.NaN],
+          [1300, 20],
+          [1400, Number.NaN],
         ]),
         300,
         9999
       )
     ).toEqual([1000, 1150, 1300]);
+
+    expect(getMetricXAxisTimestamps([], 300, 9999)).toEqual([9699, 9849, 9999]);
+  });
+
+  it('ignores readings with non-finite timestamps', () => {
+    expect(
+      getMetricXAxisTimestamps(
+        pts([
+          [Number.NaN, 99],
+          [Number.POSITIVE_INFINITY, 100],
+        ]),
+        300,
+        9999
+      )
+    ).toEqual([9699, 9849, 9999]);
   });
 
   it('barChart mode draws bars instead of the line/area, destructive above the threshold', () => {

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
@@ -1,7 +1,10 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import '#lib/i18n';
-import { MetricChartCard } from '#features/dashboard/components/observability/MetricChartCard';
+import {
+  getMetricXAxisTimestamps,
+  MetricChartCard,
+} from '#features/dashboard/components/observability/MetricChartCard';
 
 const pts = (pairs: Array<[number, number]>) =>
   pairs.map(([timestamp, value]) => ({ timestamp, value }));
@@ -17,6 +20,20 @@ const base = {
 const svgRects = (container: HTMLElement) => [...container.querySelectorAll('svg rect')];
 
 describe('MetricChartCard rendering modes', () => {
+  it('anchors x-axis timestamps to the newest reading when data is unordered', () => {
+    expect(
+      getMetricXAxisTimestamps(
+        pts([
+          [1300, 20],
+          [1000, 10],
+          [1200, Number.NaN],
+        ]),
+        300,
+        9999
+      )
+    ).toEqual([1000, 1150, 1300]);
+  });
+
   it('barChart mode draws bars instead of the line/area, destructive above the threshold', () => {
     const { container } = render(
       <MetricChartCard


### PR DESCRIPTION
## Description


Fix observability chart x-axis labels when metric data arrives unordered.

Metric responses may not always arrive chronologically. Previously, the x-axis end label was derived from the last item in the response array rather than the newest timestamp. This could cause the displayed time labels to mismatch the actual chart data.

This change derives the chart time window from the newest finite metric timestamp, ensuring the x-axis reflects the actual latest reading regardless of response ordering.

Fixes #1944

### Test Added

Added a regression test verifying that:

* Unordered metric data produces correct x-axis timestamps based on the newest reading.
* Non-finite timestamp values are ignored when determining the chart time window.

### Validation

* 145 dashboard component tests passed across 38 test files
* Touched-file ESLint passed
* `git diff --check` passed
* Full typecheck remains blocked by pre-existing `ComputePage.tsx` errors involving missing `providerInstanceId`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes observability chart x-axis labels by anchoring them to the newest valid metric timestamp, so labels match the latest reading even when data is unordered or contains invalid values.

- Old: end label came from the last array item. New: compute start/mid/end from the newest finite timestamp among points with finite value and timestamp; fall back to current time if none.
- Adds and exports getMetricXAxisTimestamps and uses it in MetricChartCard; tests cover unordered data and non-finite timestamps.
- No prop or API changes to MetricChartCard; only x-axis label computation is affected.

<sup>Written for commit a8c5f7edf011300696ee3898e4cd66e9cbf78f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric chart time-axis labels when readings arrive out of order.
  * Charts now anchor their time range to the newest valid reading and ignore invalid values.
  * Added a fallback to the current time when no valid metric readings are available.
  * Ensured chart ranges remain stable when data is incomplete or invalid.

* **Tests**
  * Added coverage for unordered readings and invalid metric values.
  * Added coverage for empty metric data and fallback time ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix observability chart x-axis labels to anchor to the newest valid timestamp
> - Extracts a new `getMetricXAxisTimestamps` utility in [MetricChartCard.tsx](https://github.com/InsForge/InsForge/pull/1943/files#diff-6c59402e5bdc7fe1aae45ecea455773b19caa4d2fe4a692e6a0ed7ccd27dedd6) that computes three x-axis anchors `[start, mid, end]` from chart data.
> - The new logic finds the maximum timestamp among points where both value and timestamp are finite, falling back to the current time when no valid data exists.
> - Replaces the previous in-place computation, which used the last element with a finite value and did not validate timestamp finiteness, causing incorrect labels when data was unordered or contained non-finite timestamps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8c5f7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->