### PR TITLE
docs(contributing): fix step 8 for fork contributors who cannot re-request review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ All contributions must include appropriate tests. Follow these guidelines:
 5. Update documentation as needed
 6. Keep your PR focused on a single feature or bug fix
 7. Be responsive to code review feedback
-8. **After you address review comments, re-request a review from your assigned reviewer** (use the 🔁 button next to their name in the Reviewers section). This is how the reviewer is notified that your changes are ready for another look — without it, your PR may sit unnoticed.
+8. **After you address review comments, re-request a review from your assigned reviewer.** If you have write access, use the 🔁 button next to their name in the Reviewers section. If you are working from a fork and do not see that control, leave a short comment on the PR instead (for example, "Addressed the review, ready for another look") — the reviewer will be notified via the comment thread. Without either signal, your PR may sit unnoticed.
 
 ## Code Style
 


### PR DESCRIPTION
Closes #1953

## Summary

Step 8 of the PR process tells contributors to use the 🔁 re-request review button, but fork contributors don't have write access so this button is unavailable to them.

## What changed

Updated step 8 to offer both paths:
- Write access: use the 🔁 button (unchanged)
- Fork contributors: leave a comment on the PR to notify the reviewer

## Acceptance criteria

- Step 8 no longer instructs an action that fork-based contributors cannot perform
- The guide names a concrete alternative signal for fork contributors
- A contributor following the guide from a fork reaches a step they can complete


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies step 8 in CONTRIBUTING so fork contributors can request re-review. Previously everyone was told to use the 🔁 button; now users with write access still use the button, and fork contributors leave a comment to notify the reviewer.

- Reviewers should treat fork-contributor comments requesting re-review as the signal to take another look.
- No code or rollout changes.

<sup>Written for commit bc221f35976d0a45c07614d6c419760cdd5ef53e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for contributors working from forks who cannot re-request a review.
  * Instructs them to comment on the pull request to notify the reviewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->