### PR TITLE
fix(dashboard): ignore invalid metric timestamps

### DIFF
--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -218,7 +218,7 @@ export function MetricChartCard({
   );
   const gradientId = useId();
   const xAxisTicks = useMemo(() => {
-    const finite = data.filter((p) => Number.isFinite(p.value));
+    const finite = data.filter((p) => Number.isFinite(p.value) && Number.isFinite(p.timestamp));
     const end =
       finite.length > 0 ? finite[finite.length - 1].timestamp : Math.floor(Date.now() / 1000);
     const start = end - rangeSeconds;
@@ -236,7 +236,11 @@ export function MetricChartCard({
   const latestTimestamp = useMemo(() => {
     let latest: number | null = null;
     for (const point of statsSeries) {
-      if (Number.isFinite(point.value) && (latest === null || point.timestamp > latest)) {
+      if (
+        Number.isFinite(point.value) &&
+        Number.isFinite(point.timestamp) &&
+        (latest === null || point.timestamp > latest)
+      ) {
         latest = point.timestamp;
       }
     }

--- a/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/MetricChartCard.tsx
@@ -121,7 +121,7 @@ function buildSparkline(
   plotRange: [number, number] = [0, SPARKLINE_WIDTH]
 ): SparklineGeometry {
   const finite = data
-    .filter((p) => Number.isFinite(p.value))
+    .filter((p) => Number.isFinite(p.value) && Number.isFinite(p.timestamp))
     .sort((a, b) => a.timestamp - b.timestamp);
   if (finite.length < 2) {
     return { line: '', area: '', points: [], min: null, max: null };

--- a/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/ObservabilitySection.tsx
@@ -132,7 +132,7 @@ export function buildDiskBreakdown(
   const nearestUsed = (ts: number): number | null => {
     let best: DashboardMetricDataPoint | null = null;
     for (const point of used) {
-      if (!Number.isFinite(point.value)) {
+      if (!Number.isFinite(point.value) || !Number.isFinite(point.timestamp)) {
         continue;
       }
       if (!best || Math.abs(point.timestamp - ts) < Math.abs(best.timestamp - ts)) {

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/MetricChartCard.test.tsx
@@ -62,6 +62,26 @@ describe('MetricChartCard rendering modes', () => {
     expect(Math.abs(gaps[0] - gaps[1])).toBeGreaterThan(10);
   });
 
+  it('ignores points with non-finite timestamps when building the chart', () => {
+    const { container } = render(
+      <MetricChartCard
+        {...base}
+        data={pts([
+          [NaN, 100],
+          [1000, 50],
+          [2000, 60],
+        ])}
+      />
+    );
+
+    const paths = [...container.querySelectorAll('svg path')];
+    expect(paths.length).toBeGreaterThan(0);
+
+    for (const path of paths) {
+      expect(path.getAttribute('d')).not.toContain('NaN');
+    }
+  });
+
   it('capacity fallback does not stack the oldest bars on one another', () => {
     // buildSparkline mapped timestamps across the full 434px width and `bars`
     // then clamped with Math.max(Y_AXIS_LABEL_WIDTH + 2, ...). Clamping does not

--- a/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
+++ b/packages/dashboard/src/features/dashboard/components/observability/__tests__/buildDiskBreakdown.test.ts
@@ -32,6 +32,19 @@ describe('buildDiskBreakdown', () => {
     expect(breakdown!.system[0].value).toBe(0);
   });
 
+  it('ignores used samples with non-finite timestamps', () => {
+    const breakdown = buildDiskBreakdown(
+      pts([[1000, 30]]),
+      pts([[1000, 20]]),
+      pts([
+        [NaN, 999],
+        [1000, 100],
+      ])
+    );
+
+    expect(breakdown!.system[0].value).toBe(50);
+  });
+
   it('drops samples with no nearby used reading instead of fabricating System as zero', () => {
     const breakdown = buildDiskBreakdown(
       pts([

--- a/packages/dashboard/src/features/dashboard/utils/__tests__/aggregateMetricSeries.test.ts
+++ b/packages/dashboard/src/features/dashboard/utils/__tests__/aggregateMetricSeries.test.ts
@@ -24,4 +24,12 @@ describe('aggregateMetricSeries', () => {
 
     expect(aggregateMetricSeries([point(10, NaN)])).toEqual({ avg: null, max: null, latest: null });
   });
+
+  it('ignores points with non-finite timestamps', () => {
+    const result = aggregateMetricSeries([point(NaN, 100), point(10, 80), point(20, 90)]);
+
+    expect(result.avg).toBe(85);
+    expect(result.max).toBe(90);
+    expect(result.latest).toBe(90);
+  });
 });

--- a/packages/dashboard/src/features/dashboard/utils/aggregateMetricSeries.ts
+++ b/packages/dashboard/src/features/dashboard/utils/aggregateMetricSeries.ts
@@ -7,7 +7,9 @@ export interface MetricAggregates {
 }
 
 export function aggregateMetricSeries(data: DashboardMetricDataPoint[]): MetricAggregates {
-  const finite = data.filter((point) => Number.isFinite(point.value));
+  const finite = data.filter(
+    (point) => Number.isFinite(point.value) && Number.isFinite(point.timestamp)
+  );
   if (finite.length === 0) {
     return { avg: null, max: null, latest: null };
   }


### PR DESCRIPTION
## Summary

Fixes an observability dashboard issue where `aggregateMetricSeries` could select a metric point with a non-finite timestamp as the `LATEST` reading.

### Changes

- Require both `value` and `timestamp` to be finite when aggregating metric points.
- Add a regression test for `NaN` timestamps.
- Invalid timestamp points are now excluded from `avg`, `max`, and `latest`.

## Validation

- [x] Targeted `aggregateMetricSeries` tests — 4/4 passed
- [x] Full dashboard unit suite — 21 test files / 109 tests passed
- [x] `git diff --check`
- [ ] Typecheck

Typecheck currently reports unrelated pre-existing errors in the Compute/shared-schema integration. No Compute files were changed as part of this PR.

## Issue

Closes #1955 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely ignores metric points with non-finite timestamps in aggregation and charts. Previously, invalid timestamps could be picked as LATEST and included in avg/max and disk breakdown; now both value and timestamp must be finite, so invalid points are excluded.

- `aggregateMetricSeries` filters to finite value and timestamp; if none remain, returns { avg: null, max: null, latest: null }.
- `MetricChartCard` skips non-finite timestamps when building the sparkline, computing x-axis ticks/range, and selecting the latest timestamp to prevent NaN SVG paths.
- `buildDiskBreakdown` ignores used samples with non-finite timestamps when selecting the nearest-used sample; adds regression tests across aggregation, charting, and breakdown.

<sup>Written for commit 78a481b2561815b55c7f93c33545422e08ba8a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded data points with invalid timestamps from metric aggregation and chart rendering.
  * Prevented invalid timestamps from affecting disk usage breakdowns.
  * Ensured only points with finite values and timestamps contribute to results.
  * Preserved correct aggregation and latest-point selection for valid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->