### PR TITLE
fix(storage): align list response schema

### DIFF
--- a/backend/src/api/routes/storage/index.routes.ts
+++ b/backend/src/api/routes/storage/index.routes.ts
@@ -9,6 +9,7 @@ import {
   ERROR_CODES,
   createBucketRequestSchema,
   deleteObjectsRequestSchema,
+  listObjectsResponseSchema,
   updateBucketRequestSchema,
   updateStorageConfigRequestSchema,
   createS3AccessKeyRequestSchema,
@@ -271,20 +272,20 @@ router.get(
         !!req.hasApiKey
       );
 
-      successResponse(
-        res,
-        {
-          data: result.objects,
-          pagination: {
-            offset: offset,
-            limit: limit,
-            total: result.total,
-          },
-          nextActions:
-            'You can use PUT /api/storage/buckets/:bucketName/objects/:objectKey to create or replace a specific key, POST /api/storage/buckets/:bucketName/objects to upload with an auto-generated key, and GET /api/storage/buckets/:bucketName/objects/:objectKey to download an object.',
+      const response = {
+        data: result.objects,
+        pagination: {
+          offset: offset,
+          limit: limit,
+          total: result.total,
         },
-        200
-      );
+        nextActions:
+          'You can use PUT /api/storage/buckets/:bucketName/objects/:objectKey to create or replace a specific key, POST /api/storage/buckets/:bucketName/objects to upload with an auto-generated key, and GET /api/storage/buckets/:bucketName/objects/:objectKey to download an object.',
+      };
+
+      listObjectsResponseSchema.parse(response);
+
+      successResponse(res, response, 200);
     } catch (error) {
       next(error);
     }

--- a/backend/src/services/storage/storage.service.ts
+++ b/backend/src/services/storage/storage.service.ts
@@ -442,7 +442,7 @@ export class StorageService {
         objects: objectsResult.rows.map((obj) => ({
           ...obj,
           mimeType: obj.mime_type,
-          uploadedAt: obj.uploaded_at,
+          uploadedAt: obj.uploaded_at.toISOString(),
           url: this.buildObjectUrl(bucket, obj.key, obj.etag || obj.uploaded_at),
         })),
         total: parseInt(totalResult.rows[0].count, 10),

--- a/backend/tests/unit/storage-object-is-visible.test.ts
+++ b/backend/tests/unit/storage-object-is-visible.test.ts
@@ -238,7 +238,7 @@ describe('StorageService.getObjectMetadataVisible — RLS-gated visibility check
       key: 'alice/cat.jpg',
       size: 42,
       mimeType: 'image/jpeg',
-      uploadedAt,
+      uploadedAt: uploadedAt.toISOString(),
     });
     expect(calls.map((c) => c.sql)).toEqual([
       'SELECT * FROM storage.objects WHERE bucket = $1 ORDER BY key LIMIT $2 OFFSET $3',

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -9,6 +9,7 @@ const storageMocks = vi.hoisted(() => ({
   getObjectMetadataRow: vi.fn(),
   getObject: vi.fn(),
   objectIsVisible: vi.fn(),
+  listObjects: vi.fn(),
   deleteObjects: vi.fn(),
   // Default undefined return keeps existing tests on the buffered local path.
   isS3Provider: vi.fn(),
@@ -111,6 +112,63 @@ describe('Storage routes', () => {
     server?.close();
     server = undefined;
     vi.clearAllMocks();
+  });
+
+  test('list objects route returns the shared response schema', async () => {
+    vi.resetModules();
+    storageMocks.listObjects.mockResolvedValue({
+      objects: [
+        {
+          key: 'logo.png',
+          bucket: 'photos',
+          size: 123,
+          uploadedAt: '2026-08-14T00:00:00.000Z',
+          url: 'https://example.test/logo.png',
+        },
+      ],
+      total: 1,
+    });
+
+    const { storageRouter } = await import('../../src/api/routes/storage/index.routes.js');
+    const app = express();
+    app.use('/api/storage', storageRouter);
+    app.use(routeErrorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, resolve);
+    });
+    const address = server?.address();
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port');
+    }
+
+    const response = await get(address.port, '/api/storage/buckets/photos/objects?limit=10&offset=2');
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      data: [
+        {
+          key: 'logo.png',
+          bucket: 'photos',
+          size: 123,
+          uploadedAt: '2026-08-14T00:00:00.000Z',
+          url: 'https://example.test/logo.png',
+        },
+      ],
+      pagination: { offset: 2, limit: 10, total: 1 },
+      nextActions:
+        'You can use PUT /api/storage/buckets/:bucketName/objects/:objectKey to create or replace a specific key, POST /api/storage/buckets/:bucketName/objects to upload with an auto-generated key, and GET /api/storage/buckets/:bucketName/objects/:objectKey to download an object.',
+    });
+    expect(storageMocks.listObjects).toHaveBeenCalledWith(
+      undefined,
+      'photos',
+      undefined,
+      10,
+      2,
+      undefined,
+      false
+    );
   });
 
   test('batch delete route validates body and delegates to storage service', async () => {

--- a/backend/tests/unit/storage-routes.test.ts
+++ b/backend/tests/unit/storage-routes.test.ts
@@ -143,7 +143,10 @@ describe('Storage routes', () => {
       throw new Error('Test server did not bind to a TCP port');
     }
 
-    const response = await get(address.port, '/api/storage/buckets/photos/objects?limit=10&offset=2');
+    const response = await get(
+      address.port,
+      '/api/storage/buckets/photos/objects?limit=10&offset=2'
+    );
 
     expect(response.statusCode, response.body).toBe(200);
     expect(JSON.parse(response.body)).toEqual({

--- a/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
+++ b/packages/dashboard/src/features/storage/services/__tests__/storage.service.test.ts
@@ -58,6 +58,34 @@ describe('storageService', () => {
     expect(apiClientMock.request).not.toHaveBeenCalled();
   });
 
+  it('maps the API list response to the dashboard object list', async () => {
+    apiClientMock.request.mockResolvedValue({
+      data: [
+        {
+          key: 'logo.png',
+          bucket: 'photos',
+          size: 123,
+          uploadedAt: '2026-08-14T00:00:00.000Z',
+          url: 'https://example.test/logo.png',
+        },
+      ],
+      pagination: { offset: 0, limit: 100, total: 1 },
+    });
+
+    await expect(storageService.listObjects('photos')).resolves.toEqual({
+      objects: [
+        {
+          key: 'logo.png',
+          bucket: 'photos',
+          size: 123,
+          uploadedAt: '2026-08-14T00:00:00.000Z',
+          url: 'https://example.test/logo.png',
+        },
+      ],
+      pagination: { offset: 0, limit: 100, total: 1 },
+    });
+  });
+
   it('chunks deletes into batches of 1000 objects', async () => {
     apiClientMock.request
       .mockResolvedValueOnce({

--- a/packages/dashboard/src/features/storage/services/storage.service.ts
+++ b/packages/dashboard/src/features/storage/services/storage.service.ts
@@ -15,6 +15,11 @@ export interface ListObjectsParams {
   offset?: number;
 }
 
+type DashboardListObjectsResponse = {
+  objects: StorageFileSchema[];
+  pagination: ListObjectsResponseSchema['pagination'];
+};
+
 export const storageService = {
   // List all buckets
   async listBuckets(): Promise<StorageBucketSchema[]> {
@@ -30,7 +35,7 @@ export const storageService = {
     bucketName: string,
     params?: ListObjectsParams,
     searchQuery?: string
-  ): Promise<ListObjectsResponseSchema> {
+  ): Promise<DashboardListObjectsResponse> {
     const searchParams = new URLSearchParams();
     if (params?.prefix) {
       searchParams.append('prefix', params.prefix);

--- a/packages/shared-schemas/src/storage-api.schema.ts
+++ b/packages/shared-schemas/src/storage-api.schema.ts
@@ -11,12 +11,13 @@ export const updateBucketRequestSchema = z.object({
 });
 
 export const listObjectsResponseSchema = z.object({
-  objects: z.array(storageFileSchema),
+  data: z.array(storageFileSchema),
   pagination: z.object({
     offset: z.number(),
     limit: z.number(),
     total: z.number(),
   }),
+  nextActions: z.string().optional(),
 });
 
 export const deleteObjectsRequestSchema = z.object({


### PR DESCRIPTION
Closes #1945

## Summary
- align the shared list-objects schema with the API response (`data`) and retain `nextActions`
- validate the route payload against the shared schema without changing the emitted object data
- preserve the dashboard’s internal `objects` view model

## Validation
- `npx turbo run typecheck`
- `npx turbo run lint`
- `npx turbo run test`
- `npx turbo run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the storage list response schema with the API, validates the route response at runtime, and explicitly serializes listed object timestamps. Previously the shared schema used objects and the route did not validate; now the schema uses data (with optional nextActions), the route parses against it, and uploadedAt is serialized to ISO strings. The dashboard keeps its internal objects view model via a simple mapping.

**Migration**
- Update any code using `listObjectsResponseSchema` to read `data` instead of `objects`.
- If you validate/serialize the response, allow the optional `nextActions` field and expect `uploadedAt` as an ISO string.
- No changes required for HTTP clients or `packages/dashboard` call sites.

<sup>Written for commit c74075f87580eb5b94335919ec975338a27d8f5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved storage object listing with consistent object data, pagination details, and optional next-action guidance.
  * Updated the dashboard storage view to correctly display object lists and preserve pagination information.
  * Standardized upload timestamps in storage listings to ISO-8601 format.

* **Bug Fixes**
  * Improved validation and reliability of storage listing responses across the API and dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->