### PR TITLE
docs(compute): replace DockerProvider's orphaned isCloudManaged docblock

### DIFF
--- a/backend/src/providers/compute/docker.provider.ts
+++ b/backend/src/providers/compute/docker.provider.ts
@@ -58,13 +58,10 @@ function escapeRegExp(value: string): string {
 }
 
 /**
- * True when this backend belongs to a cloud-managed project.
+ * Compute provider backed by the local Docker daemon, for self-hosted instances.
  *
- * Both signals are checked because they answer slightly different questions and
- * either one being true is disqualifying: `isCloudEnvironment()` asks "am I
- * running on InsForge Cloud infrastructure", while a configured cloud compute
- * pair asks "is this project's control plane elsewhere". A guard that protects
- * tenant isolation should fail closed on either.
+ * The cloud guard that keeps this driver off cloud-managed projects lives in
+ * `isConfigured()`, which documents the signal it reads and the trade it accepts.
  */
 export class DockerProvider implements ComputeProvider {
   private static instance: DockerProvider;


### PR DESCRIPTION
## Summary

Closes #1948

`backend/src/providers/compute/docker.provider.ts` carried the JSDoc of `isCloudManaged()`, a helper deleted in `a7fe999f5`. With the function gone the block landed on `export class DockerProvider`, so it read as the class's documentation while describing a boolean, and what it claimed was no longer true: the guard checks one signal (`isCloudEnvironment()`), not two, and does not fail closed on a configured cloud control plane.

That also contradicted the comment twenty lines below it, above `isConfigured()`, which records the opposite as a deliberate trade:

> A cloud-proxied deployment with no instance profile would slip past this, which our provisioning does not produce; that is the accepted trade rather than an oversight.

Since it is the block an IDE surfaces on hover, a reader came away thinking a tenant-isolation guard was stronger than it is.

## What changed

Replaced the orphaned block with a short class-level docblock that says what the class is and points at `isConfigured()` for the guard. The `isConfigured()` comment is now the single description of the guard, including the recorded trade — nothing was lost.

Comment-only: no behaviour change, no test change.

## Verification

- `npx prettier --check backend/src/providers/compute/docker.provider.ts` passes.
- `grep -n "isCloudEnvironment" backend/src/providers/compute/docker.provider.ts` — the only remaining references are the import and the check inside `isConfigured()`; no comment claims two signals.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces an incorrect docblock on `DockerProvider` that described a deleted `isCloudManaged()` helper and claimed a two-signal cloud guard. The class now has a concise description and points to `isConfigured()` as the sole source of guard semantics, preventing misleading IDE hover docs.

**Review notes**
- Comment-only change; no behavior, interfaces, or tests affected.
- Formatter passes; `isCloudEnvironment()` appears only in the import and inside `isConfigured()`.

<sup>Written for commit 551e864a5fd9810c86d4fefb85e9957c758f8ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation for the Docker compute provider to clarify its local usage and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->