### PR TITLE
fix(s3-gateway): correct ListObjectsV2 truncation and continuation semantics

### DIFF
--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -13,6 +13,11 @@ const DB_WINDOW = 1000;
 const MAX_DB_PAGES = 200;
 
 const CONTINUATION_VERSION = 1;
+// Marks a token as the versioned payload rather than the bare object key the
+// previous format used. NUL is the one byte that can never begin a legacy
+// token: storage.objects.key is Postgres `text`, which cannot hold U+0000, so
+// no stored key can start with it and the two formats can never be confused.
+const CONTINUATION_MARKER = 0x00;
 
 /**
  * Where the previous page stopped. `key` is the last raw object key that was
@@ -34,16 +39,27 @@ function encodeContinuation(cursor: Continuation): string {
     cursor.prefix === undefined
       ? { v: CONTINUATION_VERSION, k: cursor.key }
       : { v: CONTINUATION_VERSION, k: cursor.key, p: cursor.prefix };
-  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return Buffer.concat([
+    Buffer.from([CONTINUATION_MARKER]),
+    Buffer.from(JSON.stringify(payload), 'utf8'),
+  ]).toString('base64url');
 }
 
 function decodeContinuation(token: string): Continuation | undefined {
-  const decoded = Buffer.from(token, 'base64url').toString('utf8');
-  if (!decoded) {
+  const raw = Buffer.from(token, 'base64url');
+  if (raw.length === 0) {
     return undefined;
   }
+  if (raw[0] !== CONTINUATION_MARKER) {
+    // Tokens issued before the versioned payload were the bare object key.
+    return { key: raw.toString('utf8') };
+  }
   try {
-    const parsed = JSON.parse(decoded) as { v?: unknown; k?: unknown; p?: unknown };
+    const parsed = JSON.parse(raw.subarray(1).toString('utf8')) as {
+      v?: unknown;
+      k?: unknown;
+      p?: unknown;
+    };
     if (parsed?.v === CONTINUATION_VERSION && typeof parsed.k === 'string') {
       // Tokens come back from the caller, so only honour a carried prefix that
       // the cursor key actually sits under. That is the one shape this handler
@@ -54,10 +70,9 @@ function decodeContinuation(token: string): Continuation | undefined {
       return { key: parsed.k, prefix: carried };
     }
   } catch {
-    // Not a versioned payload, so fall through to the legacy format below.
+    // Marked but unparseable, so there is no position to resume from.
   }
-  // Tokens issued before the versioned payload were the bare object key.
-  return { key: decoded };
+  return undefined;
 }
 
 export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -14,10 +14,17 @@ const MAX_KEYS_LIMIT = 1000;
 const DB_WINDOW = 1000;
 const MAX_DB_PAGES = 200;
 
-// A continuation token is the cursor key prefixed by a truncated HMAC that
-// binds it to the listing that issued it. 128 bits is well past what forging a
-// position is worth, and keeps the token short.
+// A continuation token is `base64url(cursor key).base64url(signature)`, where
+// the signature is a truncated HMAC binding the key to the listing that issued
+// it. 128 bits is well past what forging a position is worth, and keeps the
+// token short.
+//
+// The separator is what makes the format self-describing. base64url output
+// never contains a dot, so a token without one is unambiguously an unsigned
+// token from a release before this, and is handled as such rather than being
+// misread as a signed one.
 const CONTINUATION_SIGNATURE_BYTES = 16;
+const CONTINUATION_SEPARATOR = '.';
 
 /** The listing parameters a continuation token is only valid within. */
 interface ListingScope {
@@ -40,27 +47,39 @@ function continuationSignature(scope: ListingScope, key: string): Buffer {
     .subarray(0, CONTINUATION_SIGNATURE_BYTES);
 }
 function encodeContinuation(scope: ListingScope, key: string): string {
-  return Buffer.concat([continuationSignature(scope, key), Buffer.from(key, 'utf8')]).toString(
-    'base64url'
-  );
+  const payload = Buffer.from(key, 'utf8').toString('base64url');
+  const signature = continuationSignature(scope, key).toString('base64url');
+  return `${payload}${CONTINUATION_SEPARATOR}${signature}`;
 }
 
 /**
- * The cursor key a token carries, or undefined when the token is not one this
- * server issued for this listing. Nothing else in the request is trusted to
- * decide where a page resumes.
+ * Where a token says to resume, and whether this server can prove it issued it
+ * for this listing. Only a proven token gets to suppress a CommonPrefix; an
+ * unsigned one is treated as a plain position, which is no more than the caller
+ * could already ask for with start-after.
  */
-function decodeContinuation(scope: ListingScope, token: string): string | undefined {
-  const raw = Buffer.from(token, 'base64url');
-  if (raw.length <= CONTINUATION_SIGNATURE_BYTES) {
+interface ResumePoint {
+  key: string;
+  verified: boolean;
+}
+
+function decodeContinuation(scope: ListingScope, token: string): ResumePoint | undefined {
+  const separator = token.indexOf(CONTINUATION_SEPARATOR);
+  if (separator === -1) {
+    // Issued before tokens were signed. Honour the position so a listing walk
+    // that spans the upgrade still advances, but not the suppression, which
+    // depends on this server having issued the page it came from.
+    const key = Buffer.from(token, 'base64url').toString('utf8');
+    return key === '' ? undefined : { key, verified: false };
+  }
+
+  const key = Buffer.from(token.slice(0, separator), 'base64url').toString('utf8');
+  const claimed = Buffer.from(token.slice(separator + 1), 'base64url');
+  const expected = continuationSignature(scope, key);
+  if (claimed.length !== expected.length || !crypto.timingSafeEqual(claimed, expected)) {
     return undefined;
   }
-  const claimed = raw.subarray(0, CONTINUATION_SIGNATURE_BYTES);
-  const key = raw.subarray(CONTINUATION_SIGNATURE_BYTES).toString('utf8');
-  if (!crypto.timingSafeEqual(claimed, continuationSignature(scope, key))) {
-    return undefined;
-  }
-  return key;
+  return { key, verified: true };
 }
 
 /**
@@ -136,9 +155,9 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   const continuationToken = q['continuation-token'];
   const startAfter = q['start-after'];
   const resumeFrom = continuationToken ? decodeContinuation(scope, continuationToken) : undefined;
-  // A token that does not verify was not issued by this server for this
-  // listing, so it names no position we can resume from. Restarting silently
-  // would answer 200 with keys the caller has already processed.
+  // A signed token that does not verify was tampered with, or belongs to a
+  // different listing, so it names no position to resume from. Restarting
+  // silently would answer 200 with keys the caller has already processed.
   if (continuationToken && resumeFrom === undefined) {
     sendS3Error(res, 'InvalidArgument', 'The continuation token provided is incorrect', {
       resource: req.path,
@@ -147,16 +166,19 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     return;
   }
   // The CommonPrefix a resumed page must not repeat, recomputed from the cursor
-  // under this request's own prefix and delimiter. Only a verified token gets
-  // this: a caller-supplied start-after is a plain position, and S3 still lists
-  // the group its key happens to sit in.
-  const suppressPrefix = resumeFrom ? collapsedPrefix(resumeFrom, prefix, delimiter) : undefined;
+  // under this request's own prefix and delimiter. Only a verified token earns
+  // this, because choosing the cursor chooses which group disappears. A
+  // start-after, or an unsigned token, is a plain position: S3 still lists the
+  // group its key happens to sit in.
+  const suppressPrefix = resumeFrom?.verified
+    ? collapsedPrefix(resumeFrom.key, prefix, delimiter)
+    : undefined;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
   // Track the last DB row key we advanced past for continuation.
   const contents: Array<{ Key: string; Size: number; ETag: string; LastModified: string }> = [];
   const commonPrefixesSet = new Set<string>();
-  let cursor: string | undefined = resumeFrom ?? (startAfter || undefined);
+  let cursor: string | undefined = resumeFrom?.key ?? (startAfter || undefined);
 
   // max-keys=0 asks for no entries at all, so there is nothing to scan and
   // nothing is left unread from the caller's point of view. Scanning anyway

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -45,7 +45,13 @@ function decodeContinuation(token: string): Continuation | undefined {
   try {
     const parsed = JSON.parse(decoded) as { v?: unknown; k?: unknown; p?: unknown };
     if (parsed?.v === CONTINUATION_VERSION && typeof parsed.k === 'string') {
-      return { key: parsed.k, prefix: typeof parsed.p === 'string' ? parsed.p : undefined };
+      // Tokens come back from the caller, so only honour a carried prefix that
+      // the cursor key actually sits under. That is the one shape this handler
+      // ever issues, and an inconsistent pair would otherwise suppress a
+      // CommonPrefix no earlier page had returned.
+      const carried =
+        typeof parsed.p === 'string' && parsed.k.startsWith(parsed.p) ? parsed.p : undefined;
+      return { key: parsed.k, prefix: carried };
     }
   } catch {
     // Not a versioned payload, so fall through to the legacy format below.

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -12,15 +12,46 @@ const MAX_KEYS_LIMIT = 1000;
 const DB_WINDOW = 1000;
 const MAX_DB_PAGES = 200;
 
-function encodeContinuation(key: string): string {
-  return Buffer.from(key, 'utf8').toString('base64url');
+const CONTINUATION_VERSION = 1;
+
+/**
+ * Where the previous page stopped. `key` is the last raw object key that was
+ * consumed; `prefix` is the CommonPrefix that key collapsed into, if any.
+ *
+ * The prefix matters because a CommonPrefix stands in for many raw keys. When a
+ * page ends part-way through such a group, the cursor still points inside it, so
+ * the next page would rebuild the same CommonPrefix and return it a second time.
+ * Carrying it in the token lets the next page consume the rest of that group
+ * without emitting anything.
+ */
+interface Continuation {
+  key: string;
+  prefix?: string;
 }
 
-function decodeContinuation(token: string | undefined): string | undefined {
-  if (!token) {
+function encodeContinuation(cursor: Continuation): string {
+  const payload =
+    cursor.prefix === undefined
+      ? { v: CONTINUATION_VERSION, k: cursor.key }
+      : { v: CONTINUATION_VERSION, k: cursor.key, p: cursor.prefix };
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function decodeContinuation(token: string): Continuation | undefined {
+  const decoded = Buffer.from(token, 'base64url').toString('utf8');
+  if (!decoded) {
     return undefined;
   }
-  return Buffer.from(token, 'base64url').toString('utf8');
+  try {
+    const parsed = JSON.parse(decoded) as { v?: unknown; k?: unknown; p?: unknown };
+    if (parsed?.v === CONTINUATION_VERSION && typeof parsed.k === 'string') {
+      return { key: parsed.k, prefix: typeof parsed.p === 'string' ? parsed.p : undefined };
+    }
+  } catch {
+    // Not a versioned payload, so fall through to the legacy format below.
+  }
+  // Tokens issued before the versioned payload were the bare object key.
+  return { key: decoded };
 }
 
 export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
@@ -62,21 +93,35 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     }
     maxKeys = parsed;
   }
-  const startAfterInput = q['start-after'] ?? decodeContinuation(q['continuation-token']);
+
+  // S3 ignores start-after whenever continuation-token is present, so the token
+  // decides the starting point on its own once the caller supplies one.
+  const continuationToken = q['continuation-token'];
+  const startAfter = q['start-after'];
+  const resumeFrom = continuationToken ? decodeContinuation(continuationToken) : undefined;
+  const suppressPrefix = resumeFrom?.prefix;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
-  // Track the last DB row key we advanced past for continuation.
+  // Track the last DB row we advanced past for continuation.
   const contents: Array<{ Key: string; Size: number; ETag: string; LastModified: string }> = [];
   const commonPrefixesSet = new Set<string>();
-  let cursor: string | undefined = startAfterInput;
-  let exhausted = false;
-  let truncated = false;
+  let cursor: Continuation | undefined = continuationToken
+    ? resumeFrom
+    : startAfter
+      ? { key: startAfter }
+      : undefined;
 
-  for (let page = 0; page < MAX_DB_PAGES; page++) {
+  // max-keys=0 asks for no entries at all, so there is nothing to scan and
+  // nothing is left unread from the caller's point of view. Scanning anyway
+  // stopped on the first row and reported IsTruncated=true with no token to
+  // follow, which loops SDK paginators on every non-empty bucket.
+  let exhausted = maxKeys === 0;
+
+  for (let page = 0; !exhausted && page < MAX_DB_PAGES; page++) {
     const rows = await svc.listObjectsV2Db({
       bucket,
       prefix,
-      startAfter: cursor,
+      startAfter: cursor?.key,
       maxKeys: DB_WINDOW,
     });
     if (rows.length === 0) {
@@ -86,9 +131,9 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
 
     let stoppedEarly = false;
     for (const r of rows) {
-      const visible = contents.length + commonPrefixesSet.size;
-      if (visible >= maxKeys) {
-        truncated = true;
+      // maxKeys >= 1 here, so the first row of the first page is always
+      // consumed and `cursor` is set before any early stop can happen.
+      if (contents.length + commonPrefixesSet.size >= maxKeys) {
         stoppedEarly = true;
         break;
       }
@@ -97,15 +142,13 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
         const idx = tail.indexOf(delimiter);
         if (idx >= 0) {
           const pfx = prefix + tail.slice(0, idx + delimiter.length);
-          if (!commonPrefixesSet.has(pfx)) {
-            if (visible + 1 > maxKeys) {
-              truncated = true;
-              stoppedEarly = true;
-              break;
-            }
+          // Rows still inside the CommonPrefix the previous page ended on. That
+          // prefix was already returned there, so consume them without emitting
+          // anything rather than listing the same prefix on two pages.
+          if (pfx !== suppressPrefix) {
             commonPrefixesSet.add(pfx);
           }
-          cursor = r.key;
+          cursor = { key: r.key, prefix: pfx };
           continue;
         }
       }
@@ -115,7 +158,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
         ETag: `"${r.etag ?? ''}"`,
         LastModified: r.lastModified.toISOString(),
       });
-      cursor = r.key;
+      cursor = { key: r.key };
     }
     if (stoppedEarly) {
       break;
@@ -125,11 +168,16 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
       break;
     }
   }
-  if (!exhausted && !truncated && contents.length + commonPrefixesSet.size >= maxKeys) {
-    truncated = true;
-  }
 
-  const nextContinuation = truncated && cursor ? encodeContinuation(cursor) : undefined;
+  // Anything other than a clean walk to the end of the listing leaves rows
+  // behind. That covers hitting maxKeys and also hitting MAX_DB_PAGES, which
+  // used to report a complete listing while silently dropping the tail.
+  //
+  // IsTruncated and NextContinuationToken are derived together so they can
+  // never disagree: a paginator that sees truncation without a token re-issues
+  // the identical request forever.
+  const nextContinuation = !exhausted && cursor ? encodeContinuation(cursor) : undefined;
+  const truncated = nextContinuation !== undefined;
 
   const xml = toXml({
     ListBucketResult: {

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -12,45 +12,28 @@ const MAX_KEYS_LIMIT = 1000;
 const DB_WINDOW = 1000;
 const MAX_DB_PAGES = 200;
 
-const CONTINUATION_VERSION = 1;
-// Marks a token as the versioned payload rather than the bare object key the
-// previous format used. NUL is the one byte that can never begin a legacy
-// token: storage.objects.key is Postgres `text`, which cannot hold U+0000, so
-// no stored key can start with it and the two formats can never be confused.
-const CONTINUATION_MARKER = 0x00;
-
-/**
- * Where the previous page stopped. `key` is the last raw object key that was
- * consumed; `prefix` is the CommonPrefix that key collapsed into, if any.
- *
- * The prefix matters because a CommonPrefix stands in for many raw keys. When a
- * page ends part-way through such a group, the cursor still points inside it, so
- * the next page would rebuild the same CommonPrefix and return it a second time.
- * Carrying it in the token lets the next page consume the rest of that group
- * without emitting anything.
- */
-interface Continuation {
-  key: string;
-  prefix?: string;
+function encodeContinuation(key: string): string {
+  return Buffer.from(key, 'utf8').toString('base64url');
 }
 
-function encodeContinuation(cursor: Continuation): string {
-  const payload =
-    cursor.prefix === undefined
-      ? { v: CONTINUATION_VERSION, k: cursor.key }
-      : { v: CONTINUATION_VERSION, k: cursor.key, p: cursor.prefix };
-  return Buffer.concat([
-    Buffer.from([CONTINUATION_MARKER]),
-    Buffer.from(JSON.stringify(payload), 'utf8'),
-  ]).toString('base64url');
+function decodeContinuation(token: string): string | undefined {
+  const key = Buffer.from(token, 'base64url').toString('utf8');
+  return key === '' ? undefined : key;
 }
 
 /**
  * The CommonPrefix a key collapses into for the given listing parameters, or
- * undefined when the key is listed on its own. This is the single definition of
- * grouping: the scan and the continuation check both go through it, so a
- * carried prefix can only ever be honoured when this request would have
- * produced it from the same key.
+ * undefined when the key is listed on its own.
+ *
+ * This is the single definition of grouping, and it is what lets a continuation
+ * token stay a bare position. A CommonPrefix stands in for many raw keys, so a
+ * page that ends part-way through such a group leaves the cursor inside it, and
+ * the next page would otherwise rebuild and return that prefix a second time.
+ * Rather than carry the prefix in the token, the next page recomputes it from
+ * the cursor key: the cursor only ever lands mid-group when the page it came
+ * from already returned that prefix, and it collapses to nothing when the page
+ * ended on a plain key. So the state cannot be inconsistent, or forged into
+ * suppressing a prefix this request would not itself rebuild from that key.
  */
 function collapsedPrefix(
   key: string,
@@ -63,30 +46,6 @@ function collapsedPrefix(
   const tail = key.slice(prefix.length);
   const idx = tail.indexOf(delimiter);
   return idx >= 0 ? prefix + tail.slice(0, idx + delimiter.length) : undefined;
-}
-
-function decodeContinuation(token: string): Continuation | undefined {
-  const raw = Buffer.from(token, 'base64url');
-  if (raw.length === 0) {
-    return undefined;
-  }
-  if (raw[0] !== CONTINUATION_MARKER) {
-    // Tokens issued before the versioned payload were the bare object key.
-    return { key: raw.toString('utf8') };
-  }
-  try {
-    const parsed = JSON.parse(raw.subarray(1).toString('utf8')) as {
-      v?: unknown;
-      k?: unknown;
-      p?: unknown;
-    };
-    if (parsed?.v === CONTINUATION_VERSION && typeof parsed.k === 'string') {
-      return { key: parsed.k, prefix: typeof parsed.p === 'string' ? parsed.p : undefined };
-    }
-  } catch {
-    // Marked but unparseable, so there is no position to resume from.
-  }
-  return undefined;
 }
 
 export async function handle(req: S3GatewayRequest, res: Response): Promise<void> {
@@ -134,32 +93,17 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   const continuationToken = q['continuation-token'];
   const startAfter = q['start-after'];
   const resumeFrom = continuationToken ? decodeContinuation(continuationToken) : undefined;
-  // A token we cannot read carries no position. Restarting from the beginning
-  // would answer 200 with keys the caller has already processed, so say so
-  // instead, which is what S3 does for a token it does not recognise.
-  if (continuationToken && !resumeFrom) {
-    sendS3Error(res, 'InvalidArgument', 'The continuation token provided is incorrect', {
-      resource: req.path,
-      requestId: req.s3Auth.requestId,
-    });
-    return;
-  }
-  // A carried prefix describes the listing that issued it. Honour it only when
-  // the cursor key still collapses to exactly that prefix under this request's
-  // prefix and delimiter, so state that no longer applies (a changed or dropped
-  // delimiter, a changed prefix) or that never applied cannot drop an entry.
-  const suppressPrefix =
-    resumeFrom?.prefix !== undefined &&
-    collapsedPrefix(resumeFrom.key, prefix, delimiter) === resumeFrom.prefix
-      ? resumeFrom.prefix
-      : undefined;
+  // The CommonPrefix a resumed page must not repeat, recomputed from the cursor
+  // under this request's own prefix and delimiter. Only a token gets this: a
+  // caller-supplied start-after is a plain position, and S3 still lists the
+  // group its key happens to sit in.
+  const suppressPrefix = resumeFrom ? collapsedPrefix(resumeFrom, prefix, delimiter) : undefined;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
-  // Track the last DB row we advanced past for continuation.
+  // Track the last DB row key we advanced past for continuation.
   const contents: Array<{ Key: string; Size: number; ETag: string; LastModified: string }> = [];
   const commonPrefixesSet = new Set<string>();
-  let cursor: Continuation | undefined =
-    resumeFrom ?? (startAfter ? { key: startAfter } : undefined);
+  let cursor: string | undefined = resumeFrom ?? (startAfter || undefined);
 
   // max-keys=0 asks for no entries at all, so there is nothing to scan and
   // nothing is left unread from the caller's point of view. Scanning anyway
@@ -171,7 +115,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     const rows = await svc.listObjectsV2Db({
       bucket,
       prefix,
-      startAfter: cursor?.key,
+      startAfter: cursor,
       maxKeys: DB_WINDOW,
     });
     if (rows.length === 0) {
@@ -195,7 +139,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
         if (pfx !== suppressPrefix) {
           commonPrefixesSet.add(pfx);
         }
-        cursor = { key: r.key, prefix: pfx };
+        cursor = r.key;
         continue;
       }
       contents.push({
@@ -204,7 +148,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
         ETag: `"${r.etag ?? ''}"`,
         LastModified: r.lastModified.toISOString(),
       });
-      cursor = { key: r.key };
+      cursor = r.key;
     }
     if (stoppedEarly) {
       break;

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -33,7 +33,20 @@ interface ListingScope {
   delimiter: string | undefined;
 }
 
-function continuationSignature(scope: ListingScope, key: string): Buffer {
+/**
+ * The HMAC key, or undefined when the instance has no JWT_SECRET configured.
+ *
+ * Signing with the empty string would be worse than not signing at all: the key
+ * is then public, so anyone could mint a token that verifies, and the code would
+ * grant it the trust a real signature earns. Without a secret this handler
+ * issues unsigned tokens instead, which cost only the CommonPrefix de-duplication
+ * across pages and leave the listing no worse than it is today.
+ */
+function continuationSigningKey(): string | undefined {
+  return appConfig.app.jwtSecret || undefined;
+}
+
+function continuationSignature(secret: string, scope: ListingScope, key: string): Buffer {
   // Length-prefix every field so no combination of bucket, prefix, delimiter
   // and key can be rearranged into the same signed string. Keys and delimiters
   // are arbitrary text, so there is no separator character safe to reserve.
@@ -41,15 +54,19 @@ function continuationSignature(scope: ListingScope, key: string): Buffer {
     .map((field) => `${Buffer.byteLength(field, 'utf8')}:${field}`)
     .join('');
   return crypto
-    .createHmac('sha256', appConfig.app.jwtSecret)
+    .createHmac('sha256', secret)
     .update(signed)
     .digest()
     .subarray(0, CONTINUATION_SIGNATURE_BYTES);
 }
+
 function encodeContinuation(scope: ListingScope, key: string): string {
   const payload = Buffer.from(key, 'utf8').toString('base64url');
-  const signature = continuationSignature(scope, key).toString('base64url');
-  return `${payload}${CONTINUATION_SEPARATOR}${signature}`;
+  const secret = continuationSigningKey();
+  if (!secret) {
+    return payload;
+  }
+  return `${payload}${CONTINUATION_SEPARATOR}${continuationSignature(secret, scope, key).toString('base64url')}`;
 }
 
 /**
@@ -66,16 +83,24 @@ interface ResumePoint {
 function decodeContinuation(scope: ListingScope, token: string): ResumePoint | undefined {
   const separator = token.indexOf(CONTINUATION_SEPARATOR);
   if (separator === -1) {
-    // Issued before tokens were signed. Honour the position so a listing walk
-    // that spans the upgrade still advances, but not the suppression, which
-    // depends on this server having issued the page it came from.
+    // Issued before tokens were signed, or by an instance with no signing key.
+    // Honour the position so a listing walk that spans the upgrade still
+    // advances, but not the suppression, which depends on this server having
+    // issued the page it came from.
     const key = Buffer.from(token, 'base64url').toString('utf8');
     return key === '' ? undefined : { key, verified: false };
   }
 
+  const secret = continuationSigningKey();
+  if (!secret) {
+    // Nothing to verify against, and this instance never issues signed tokens,
+    // so a signed one did not come from here.
+    return undefined;
+  }
+
   const key = Buffer.from(token.slice(0, separator), 'base64url').toString('utf8');
   const claimed = Buffer.from(token.slice(separator + 1), 'base64url');
-  const expected = continuationSignature(scope, key);
+  const expected = continuationSignature(secret, scope, key);
   if (claimed.length !== expected.length || !crypto.timingSafeEqual(claimed, expected)) {
     return undefined;
   }
@@ -154,11 +179,15 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   const scope: ListingScope = { bucket, prefix, delimiter };
   const continuationToken = q['continuation-token'];
   const startAfter = q['start-after'];
-  const resumeFrom = continuationToken ? decodeContinuation(scope, continuationToken) : undefined;
+  // Presence, not truthiness: `continuation-token=` is a token the caller
+  // supplied and expects to resume from, so it must be rejected rather than
+  // quietly falling through to start-after.
+  const resumeFrom =
+    continuationToken !== undefined ? decodeContinuation(scope, continuationToken) : undefined;
   // A signed token that does not verify was tampered with, or belongs to a
   // different listing, so it names no position to resume from. Restarting
   // silently would answer 200 with keys the caller has already processed.
-  if (continuationToken && resumeFrom === undefined) {
+  if (continuationToken !== undefined && resumeFrom === undefined) {
     sendS3Error(res, 'InvalidArgument', 'The continuation token provided is incorrect', {
       resource: req.path,
       requestId: req.s3Auth.requestId,

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -120,17 +120,24 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   const continuationToken = q['continuation-token'];
   const startAfter = q['start-after'];
   const resumeFrom = continuationToken ? decodeContinuation(continuationToken) : undefined;
+  // A token we cannot read carries no position. Restarting from the beginning
+  // would answer 200 with keys the caller has already processed, so say so
+  // instead, which is what S3 does for a token it does not recognise.
+  if (continuationToken && !resumeFrom) {
+    sendS3Error(res, 'InvalidArgument', 'The continuation token provided is incorrect', {
+      resource: req.path,
+      requestId: req.s3Auth.requestId,
+    });
+    return;
+  }
   const suppressPrefix = resumeFrom?.prefix;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
   // Track the last DB row we advanced past for continuation.
   const contents: Array<{ Key: string; Size: number; ETag: string; LastModified: string }> = [];
   const commonPrefixesSet = new Set<string>();
-  let cursor: Continuation | undefined = continuationToken
-    ? resumeFrom
-    : startAfter
-      ? { key: startAfter }
-      : undefined;
+  let cursor: Continuation | undefined =
+    resumeFrom ?? (startAfter ? { key: startAfter } : undefined);
 
   // max-keys=0 asks for no entries at all, so there is nothing to scan and
   // nothing is left unread from the caller's point of view. Scanning anyway

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -1,5 +1,7 @@
+import crypto from 'crypto';
 import { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
+import { appConfig } from '@/infra/config/app.config.js';
 import { sendS3Error } from '../errors.js';
 import { toXml } from '../xml.js';
 import { S3GatewayRequest, getS3Bucket } from '../request.js';
@@ -12,13 +14,53 @@ const MAX_KEYS_LIMIT = 1000;
 const DB_WINDOW = 1000;
 const MAX_DB_PAGES = 200;
 
-function encodeContinuation(key: string): string {
-  return Buffer.from(key, 'utf8').toString('base64url');
+// A continuation token is the cursor key prefixed by a truncated HMAC that
+// binds it to the listing that issued it. 128 bits is well past what forging a
+// position is worth, and keeps the token short.
+const CONTINUATION_SIGNATURE_BYTES = 16;
+
+/** The listing parameters a continuation token is only valid within. */
+interface ListingScope {
+  bucket: string;
+  prefix: string;
+  delimiter: string | undefined;
 }
 
-function decodeContinuation(token: string): string | undefined {
-  const key = Buffer.from(token, 'base64url').toString('utf8');
-  return key === '' ? undefined : key;
+function continuationSignature(scope: ListingScope, key: string): Buffer {
+  // Length-prefix every field so no combination of bucket, prefix, delimiter
+  // and key can be rearranged into the same signed string. Keys and delimiters
+  // are arbitrary text, so there is no separator character safe to reserve.
+  const signed = ['insforge:s3:listv2:v1', scope.bucket, scope.prefix, scope.delimiter ?? '', key]
+    .map((field) => `${Buffer.byteLength(field, 'utf8')}:${field}`)
+    .join('');
+  return crypto
+    .createHmac('sha256', appConfig.app.jwtSecret)
+    .update(signed)
+    .digest()
+    .subarray(0, CONTINUATION_SIGNATURE_BYTES);
+}
+function encodeContinuation(scope: ListingScope, key: string): string {
+  return Buffer.concat([continuationSignature(scope, key), Buffer.from(key, 'utf8')]).toString(
+    'base64url'
+  );
+}
+
+/**
+ * The cursor key a token carries, or undefined when the token is not one this
+ * server issued for this listing. Nothing else in the request is trusted to
+ * decide where a page resumes.
+ */
+function decodeContinuation(scope: ListingScope, token: string): string | undefined {
+  const raw = Buffer.from(token, 'base64url');
+  if (raw.length <= CONTINUATION_SIGNATURE_BYTES) {
+    return undefined;
+  }
+  const claimed = raw.subarray(0, CONTINUATION_SIGNATURE_BYTES);
+  const key = raw.subarray(CONTINUATION_SIGNATURE_BYTES).toString('utf8');
+  if (!crypto.timingSafeEqual(claimed, continuationSignature(scope, key))) {
+    return undefined;
+  }
+  return key;
 }
 
 /**
@@ -90,13 +132,24 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
 
   // S3 ignores start-after whenever continuation-token is present, so the token
   // decides the starting point on its own once the caller supplies one.
+  const scope: ListingScope = { bucket, prefix, delimiter };
   const continuationToken = q['continuation-token'];
   const startAfter = q['start-after'];
-  const resumeFrom = continuationToken ? decodeContinuation(continuationToken) : undefined;
+  const resumeFrom = continuationToken ? decodeContinuation(scope, continuationToken) : undefined;
+  // A token that does not verify was not issued by this server for this
+  // listing, so it names no position we can resume from. Restarting silently
+  // would answer 200 with keys the caller has already processed.
+  if (continuationToken && resumeFrom === undefined) {
+    sendS3Error(res, 'InvalidArgument', 'The continuation token provided is incorrect', {
+      resource: req.path,
+      requestId: req.s3Auth.requestId,
+    });
+    return;
+  }
   // The CommonPrefix a resumed page must not repeat, recomputed from the cursor
-  // under this request's own prefix and delimiter. Only a token gets this: a
-  // caller-supplied start-after is a plain position, and S3 still lists the
-  // group its key happens to sit in.
+  // under this request's own prefix and delimiter. Only a verified token gets
+  // this: a caller-supplied start-after is a plain position, and S3 still lists
+  // the group its key happens to sit in.
   const suppressPrefix = resumeFrom ? collapsedPrefix(resumeFrom, prefix, delimiter) : undefined;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
@@ -166,7 +219,7 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
   // IsTruncated and NextContinuationToken are derived together so they can
   // never disagree: a paginator that sees truncation without a token re-issues
   // the identical request forever.
-  const nextContinuation = !exhausted && cursor ? encodeContinuation(cursor) : undefined;
+  const nextContinuation = !exhausted && cursor ? encodeContinuation(scope, cursor) : undefined;
   const truncated = nextContinuation !== undefined;
 
   const xml = toXml({

--- a/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
+++ b/backend/src/api/routes/s3-gateway/commands/list-objects-v2.ts
@@ -45,6 +45,26 @@ function encodeContinuation(cursor: Continuation): string {
   ]).toString('base64url');
 }
 
+/**
+ * The CommonPrefix a key collapses into for the given listing parameters, or
+ * undefined when the key is listed on its own. This is the single definition of
+ * grouping: the scan and the continuation check both go through it, so a
+ * carried prefix can only ever be honoured when this request would have
+ * produced it from the same key.
+ */
+function collapsedPrefix(
+  key: string,
+  prefix: string,
+  delimiter: string | undefined
+): string | undefined {
+  if (!delimiter || !key.startsWith(prefix)) {
+    return undefined;
+  }
+  const tail = key.slice(prefix.length);
+  const idx = tail.indexOf(delimiter);
+  return idx >= 0 ? prefix + tail.slice(0, idx + delimiter.length) : undefined;
+}
+
 function decodeContinuation(token: string): Continuation | undefined {
   const raw = Buffer.from(token, 'base64url');
   if (raw.length === 0) {
@@ -61,13 +81,7 @@ function decodeContinuation(token: string): Continuation | undefined {
       p?: unknown;
     };
     if (parsed?.v === CONTINUATION_VERSION && typeof parsed.k === 'string') {
-      // Tokens come back from the caller, so only honour a carried prefix that
-      // the cursor key actually sits under. That is the one shape this handler
-      // ever issues, and an inconsistent pair would otherwise suppress a
-      // CommonPrefix no earlier page had returned.
-      const carried =
-        typeof parsed.p === 'string' && parsed.k.startsWith(parsed.p) ? parsed.p : undefined;
-      return { key: parsed.k, prefix: carried };
+      return { key: parsed.k, prefix: typeof parsed.p === 'string' ? parsed.p : undefined };
     }
   } catch {
     // Marked but unparseable, so there is no position to resume from.
@@ -130,7 +144,15 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
     });
     return;
   }
-  const suppressPrefix = resumeFrom?.prefix;
+  // A carried prefix describes the listing that issued it. Honour it only when
+  // the cursor key still collapses to exactly that prefix under this request's
+  // prefix and delimiter, so state that no longer applies (a changed or dropped
+  // delimiter, a changed prefix) or that never applied cannot drop an entry.
+  const suppressPrefix =
+    resumeFrom?.prefix !== undefined &&
+    collapsedPrefix(resumeFrom.key, prefix, delimiter) === resumeFrom.prefix
+      ? resumeFrom.prefix
+      : undefined;
 
   // Accumulate visible entries (Contents + CommonPrefixes) up to maxKeys.
   // Track the last DB row we advanced past for continuation.
@@ -165,20 +187,16 @@ export async function handle(req: S3GatewayRequest, res: Response): Promise<void
         stoppedEarly = true;
         break;
       }
-      if (delimiter) {
-        const tail = r.key.slice(prefix.length);
-        const idx = tail.indexOf(delimiter);
-        if (idx >= 0) {
-          const pfx = prefix + tail.slice(0, idx + delimiter.length);
-          // Rows still inside the CommonPrefix the previous page ended on. That
-          // prefix was already returned there, so consume them without emitting
-          // anything rather than listing the same prefix on two pages.
-          if (pfx !== suppressPrefix) {
-            commonPrefixesSet.add(pfx);
-          }
-          cursor = { key: r.key, prefix: pfx };
-          continue;
+      const pfx = collapsedPrefix(r.key, prefix, delimiter);
+      if (pfx !== undefined) {
+        // Rows still inside the CommonPrefix the previous page ended on. That
+        // prefix was already returned there, so consume them without emitting
+        // anything rather than listing the same prefix on two pages.
+        if (pfx !== suppressPrefix) {
+          commonPrefixesSet.add(pfx);
         }
+        cursor = { key: r.key, prefix: pfx };
+        continue;
       }
       contents.push({
         Key: r.key,

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Response } from 'express';
+import { StorageService } from '@/services/storage/storage.service.js';
+import { handle } from '@/api/routes/s3-gateway/commands/list-objects-v2.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface DbRow {
+  key: string;
+  size: number;
+  etag: string | null;
+  lastModified: Date;
+}
+
+function row(key: string): DbRow {
+  return { key, size: 1, etag: 'e', lastModified: new Date('2026-01-01T00:00:00.000Z') };
+}
+
+/**
+ * Stands in for storage.objects: keys sorted ascending, filtered by prefix and
+ * an exclusive `startAfter`, windowed by `maxKeys`. This is exactly the
+ * contract of StorageService.listObjectsV2Db.
+ */
+function fakeTable(keys: string[]) {
+  const sorted = [...keys].sort();
+  return (params: { prefix?: string; startAfter?: string; maxKeys: number }): DbRow[] =>
+    sorted
+      .filter((k) => k.startsWith(params.prefix ?? ''))
+      .filter((k) => params.startAfter === undefined || k > params.startAfter)
+      .slice(0, params.maxKeys)
+      .map(row);
+}
+
+interface ListResult {
+  status: number;
+  xml: string;
+  isTruncated: boolean;
+  keyCount: number;
+  nextToken?: string;
+  contents: string[];
+  commonPrefixes: string[];
+  dbCalls: number;
+}
+
+async function list(keys: string[], query: Record<string, string> = {}): Promise<ListResult> {
+  const svc = StorageService.getInstance();
+  vi.spyOn(svc, 'bucketExists').mockResolvedValue(true);
+  const table = fakeTable(keys);
+  let dbCalls = 0;
+  vi.spyOn(svc, 'listObjectsV2Db').mockImplementation(async (params) => {
+    dbCalls++;
+    return table(params);
+  });
+
+  const status = vi.fn().mockReturnThis();
+  const type = vi.fn().mockReturnThis();
+  const send = vi.fn();
+  const res = { status, type, send } as unknown as Response;
+
+  const req = {
+    query,
+    path: '/test-bucket',
+    s3Bucket: 'test-bucket',
+    s3Key: null,
+    s3Op: 'ListObjectsV2',
+    s3Auth: { requestId: 'test-req' },
+  };
+
+  await handle(req as never, res);
+
+  const xml = (send.mock.calls[0]?.[0] as string) ?? '';
+  const capture = (tag: string) => xml.match(new RegExp(`<${tag}>(.*?)</${tag}>`))?.[1];
+  const captureAll = (tag: string) =>
+    [...xml.matchAll(new RegExp(`<${tag}>(.*?)</${tag}>`, 'g'))].map((m) => m[1]);
+
+  return {
+    status: status.mock.calls[0]?.[0] as number,
+    xml,
+    isTruncated: capture('IsTruncated') === 'true',
+    keyCount: Number(capture('KeyCount')),
+    nextToken: capture('NextContinuationToken'),
+    contents: captureAll('Key'),
+    commonPrefixes: captureAll('Prefix').filter((p) => p !== (query.prefix ?? '')),
+    dbCalls,
+  };
+}
+
+/** Walks every page the way an SDK paginator does, and returns what it saw. */
+async function listAllPages(keys: string[], query: Record<string, string> = {}) {
+  const contents: string[] = [];
+  const commonPrefixes: string[] = [];
+  let token: string | undefined;
+  let pages = 0;
+
+  do {
+    const page = await list(keys, token ? { ...query, 'continuation-token': token } : query);
+    expect(page.status).toBe(200);
+    // A paginator can only continue when truncation comes with a token.
+    if (page.isTruncated) {
+      expect(page.nextToken).toBeDefined();
+    }
+    contents.push(...page.contents);
+    commonPrefixes.push(...page.commonPrefixes);
+    token = page.isTruncated ? page.nextToken : undefined;
+    pages++;
+    expect(pages).toBeLessThan(50);
+  } while (token);
+
+  return { contents, commonPrefixes, pages };
+}
+
+describe('ListObjectsV2 max-keys=0', () => {
+  it('returns an empty, untruncated listing instead of truncating with no token', async () => {
+    const result = await list(['a.txt', 'b.txt'], { 'max-keys': '0' });
+
+    expect(result.status).toBe(200);
+    expect(result.keyCount).toBe(0);
+    expect(result.isTruncated).toBe(false);
+    expect(result.nextToken).toBeUndefined();
+    expect(result.xml).toContain('<MaxKeys>0</MaxKeys>');
+  });
+
+  it('does not query the database at all', async () => {
+    const result = await list(['a.txt', 'b.txt'], { 'max-keys': '0' });
+
+    expect(result.dbCalls).toBe(0);
+  });
+
+  it('still rejects a negative or non-integer max-keys', async () => {
+    const negative = await list(['a.txt'], { 'max-keys': '-1' });
+    expect(negative.status).toBe(400);
+    expect(negative.xml).toContain('InvalidArgument');
+
+    const fractional = await list(['a.txt'], { 'max-keys': '1.5' });
+    expect(fractional.status).toBe(400);
+  });
+});
+
+describe('ListObjectsV2 truncation contract', () => {
+  it('advertises truncation with a usable token when a page fills up', async () => {
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'max-keys': '2' });
+
+    expect(result.contents).toEqual(['a.txt', 'b.txt']);
+    expect(result.isTruncated).toBe(true);
+    expect(result.nextToken).toBeDefined();
+  });
+
+  it('does not advertise truncation when the listing ends exactly on the limit', async () => {
+    const result = await list(['a.txt', 'b.txt'], { 'max-keys': '2' });
+
+    expect(result.isTruncated).toBe(false);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it('resumes from the token without repeating or skipping keys', async () => {
+    const keys = ['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt'];
+
+    const { contents, pages } = await listAllPages(keys, { 'max-keys': '2' });
+
+    expect(contents).toEqual(keys);
+    expect(pages).toBe(3);
+  });
+
+  it('reports truncation when the per-request scan cap stops the walk early', async () => {
+    const svc = StorageService.getInstance();
+    vi.spyOn(svc, 'bucketExists').mockResolvedValue(true);
+    // Every window is a full page of keys inside one folder, so the visible
+    // entry count never reaches maxKeys and the scan runs until the internal
+    // page cap stops it with rows still unread.
+    let seq = 0;
+    vi.spyOn(svc, 'listObjectsV2Db').mockImplementation(async (params) =>
+      Array.from({ length: params.maxKeys }, () => row(`folder/${String(seq++).padStart(9, '0')}`))
+    );
+
+    const status = vi.fn().mockReturnThis();
+    const type = vi.fn().mockReturnThis();
+    const send = vi.fn();
+    const res = { status, type, send } as unknown as Response;
+    const req = {
+      query: { delimiter: '/' },
+      path: '/test-bucket',
+      s3Bucket: 'test-bucket',
+      s3Key: null,
+      s3Op: 'ListObjectsV2',
+      s3Auth: { requestId: 'test-req' },
+    };
+
+    await handle(req as never, res);
+
+    const xml = send.mock.calls[0][0] as string;
+    expect(xml).toContain('<IsTruncated>true</IsTruncated>');
+    expect(xml).toContain('<NextContinuationToken>');
+  });
+});
+
+describe('ListObjectsV2 delimiter pagination', () => {
+  it('does not return a CommonPrefix that a previous page already returned', async () => {
+    // "a/" spans two DB rows, so a page break lands inside the group.
+    const keys = ['a/1', 'a/2', 'b/1'];
+
+    const { commonPrefixes } = await listAllPages(keys, { delimiter: '/', 'max-keys': '1' });
+
+    expect(commonPrefixes).toEqual(['a/', 'b/']);
+  });
+
+  it('keeps folders and loose keys in order across pages', async () => {
+    const keys = ['docs/a', 'docs/b', 'docs/c', 'notes.txt', 'photos/x', 'photos/y', 'readme.md'];
+
+    const { contents, commonPrefixes } = await listAllPages(keys, {
+      delimiter: '/',
+      'max-keys': '2',
+    });
+
+    expect(commonPrefixes).toEqual(['docs/', 'photos/']);
+    expect(contents).toEqual(['notes.txt', 'readme.md']);
+  });
+
+  it('collapses a group that spans several pages into exactly one CommonPrefix', async () => {
+    const keys = [...Array(10).keys()].map((i) => `bulk/${i}`).concat('zz.txt');
+
+    const { contents, commonPrefixes } = await listAllPages(keys, {
+      delimiter: '/',
+      'max-keys': '1',
+    });
+
+    expect(commonPrefixes).toEqual(['bulk/']);
+    expect(contents).toEqual(['zz.txt']);
+  });
+
+  it('scopes CommonPrefixes to the requested prefix', async () => {
+    const keys = ['top/nested/a', 'top/nested/b', 'top/leaf.txt', 'other/x'];
+
+    const { contents, commonPrefixes } = await listAllPages(keys, {
+      delimiter: '/',
+      prefix: 'top/',
+      'max-keys': '1',
+    });
+
+    expect(commonPrefixes).toEqual(['top/nested/']);
+    expect(contents).toEqual(['top/leaf.txt']);
+  });
+});
+
+describe('ListObjectsV2 start-after and continuation-token', () => {
+  it('starts after the given key when only start-after is supplied', async () => {
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'start-after': 'a.txt' });
+
+    expect(result.contents).toEqual(['b.txt', 'c.txt']);
+  });
+
+  it('ignores start-after when a continuation token is present', async () => {
+    const first = await list(['a.txt', 'b.txt', 'c.txt'], { 'max-keys': '1' });
+    expect(first.nextToken).toBeDefined();
+
+    const second = await list(['a.txt', 'b.txt', 'c.txt'], {
+      'max-keys': '1',
+      'start-after': 'c.txt',
+      'continuation-token': first.nextToken as string,
+    });
+
+    // start-after would have resumed past c.txt and returned nothing.
+    expect(second.contents).toEqual(['b.txt']);
+  });
+
+  it('accepts a legacy bare-key continuation token', async () => {
+    const legacy = Buffer.from('a.txt', 'utf8').toString('base64url');
+
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'continuation-token': legacy });
+
+    expect(result.contents).toEqual(['b.txt', 'c.txt']);
+  });
+});

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -44,16 +44,17 @@ interface ListResult {
   dbCalls: number;
 }
 
-async function list(keys: string[], query: Record<string, string> = {}): Promise<ListResult> {
+/** Installs the storage stubs and hands back the listObjectsV2Db spy. */
+function stubStorage(
+  rows: (params: { prefix?: string; startAfter?: string; maxKeys: number }) => DbRow[]
+) {
   const svc = StorageService.getInstance();
   vi.spyOn(svc, 'bucketExists').mockResolvedValue(true);
-  const table = fakeTable(keys);
-  let dbCalls = 0;
-  vi.spyOn(svc, 'listObjectsV2Db').mockImplementation(async (params) => {
-    dbCalls++;
-    return table(params);
-  });
+  return vi.spyOn(svc, 'listObjectsV2Db').mockImplementation(async (params) => rows(params));
+}
 
+/** Runs one ListObjectsV2 request against whatever stubs are installed. */
+async function invoke(query: Record<string, string>): Promise<Omit<ListResult, 'dbCalls'>> {
   const status = vi.fn().mockReturnThis();
   const type = vi.fn().mockReturnThis();
   const send = vi.fn();
@@ -83,8 +84,13 @@ async function list(keys: string[], query: Record<string, string> = {}): Promise
     nextToken: capture('NextContinuationToken'),
     contents: captureAll('Key'),
     commonPrefixes: captureAll('Prefix').filter((p) => p !== (query.prefix ?? '')),
-    dbCalls,
   };
+}
+
+async function list(keys: string[], query: Record<string, string> = {}): Promise<ListResult> {
+  const table = fakeTable(keys);
+  const spy = stubStorage(table);
+  return { ...(await invoke(query)), dbCalls: spy.mock.calls.length };
 }
 
 /** Walks every page the way an SDK paginator does, and returns what it saw. */
@@ -164,34 +170,49 @@ describe('ListObjectsV2 truncation contract', () => {
   });
 
   it('reports truncation when the per-request scan cap stops the walk early', async () => {
-    const svc = StorageService.getInstance();
-    vi.spyOn(svc, 'bucketExists').mockResolvedValue(true);
     // Every window is a full page of keys inside one folder, so the visible
     // entry count never reaches maxKeys and the scan runs until the internal
     // page cap stops it with rows still unread.
     let seq = 0;
-    vi.spyOn(svc, 'listObjectsV2Db').mockImplementation(async (params) =>
+    stubStorage((params) =>
       Array.from({ length: params.maxKeys }, () => row(`folder/${String(seq++).padStart(9, '0')}`))
     );
 
-    const status = vi.fn().mockReturnThis();
-    const type = vi.fn().mockReturnThis();
-    const send = vi.fn();
-    const res = { status, type, send } as unknown as Response;
-    const req = {
-      query: { delimiter: '/' },
-      path: '/test-bucket',
-      s3Bucket: 'test-bucket',
-      s3Key: null,
-      s3Op: 'ListObjectsV2',
-      s3Auth: { requestId: 'test-req' },
-    };
+    const result = await invoke({ delimiter: '/' });
 
-    await handle(req as never, res);
+    expect(result.isTruncated).toBe(true);
+    expect(result.nextToken).toBeDefined();
+  });
 
-    const xml = send.mock.calls[0][0] as string;
-    expect(xml).toContain('<IsTruncated>true</IsTruncated>');
-    expect(xml).toContain('<NextContinuationToken>');
+  it('terminates on an empty page when the scan cap lands on the end of the data', async () => {
+    // The cap cannot tell "one more full window exists" from "the data ended on
+    // a window boundary" without another query, so it reports truncation rather
+    // than claiming a completeness it has not verified. The follow-up page must
+    // then close the walk cleanly instead of handing back another token.
+    let remainingWindows = 200;
+    let seq = 0;
+    stubStorage((params) => {
+      if (remainingWindows === 0) {
+        return [];
+      }
+      remainingWindows--;
+      return Array.from({ length: params.maxKeys }, () =>
+        row(`folder/${String(seq++).padStart(9, '0')}`)
+      );
+    });
+
+    const first = await invoke({ delimiter: '/' });
+    expect(first.isTruncated).toBe(true);
+    expect(first.commonPrefixes).toEqual(['folder/']);
+
+    const second = await invoke({
+      delimiter: '/',
+      'continuation-token': first.nextToken as string,
+    });
+
+    expect(second.keyCount).toBe(0);
+    expect(second.isTruncated).toBe(false);
+    expect(second.nextToken).toBeUndefined();
   });
 });
 
@@ -262,6 +283,21 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
 
     // start-after would have resumed past c.txt and returned nothing.
     expect(second.contents).toEqual(['b.txt']);
+  });
+
+  it('ignores a carried prefix the cursor key does not sit under', async () => {
+    const inconsistent = Buffer.from(JSON.stringify({ v: 1, k: 'a/1', p: 'b/' }), 'utf8').toString(
+      'base64url'
+    );
+
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'continuation-token': inconsistent,
+    });
+
+    // "b/" is still listed: a token cannot suppress a prefix its cursor is not
+    // inside, so no page can be made to drop an entry it never returned.
+    expect(result.commonPrefixes).toEqual(['a/', 'b/']);
   });
 
   it('accepts a legacy bare-key continuation token', async () => {

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -306,6 +306,22 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
     expect(result.commonPrefixes).toEqual(['a/', 'b/']);
   });
 
+  it('ignores a carried prefix once the delimiter stops producing it', async () => {
+    // Token issued by a delimiter=/ walk, replayed against a request that
+    // groups differently. The carried state describes a listing that no longer
+    // exists, so it must not silently remove an entry from this one.
+    const issued = versionedToken({ v: 1, k: 'a/1', p: 'a/' });
+
+    const noDelimiter = await list(['a/1', 'a/2', 'b/1'], { 'continuation-token': issued });
+    expect(noDelimiter.contents).toEqual(['a/2', 'b/1']);
+
+    const otherDelimiter = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '-',
+      'continuation-token': issued,
+    });
+    expect(otherDelimiter.contents).toEqual(['a/2', 'b/1']);
+  });
+
   it('accepts a legacy bare-key continuation token', async () => {
     const legacy = Buffer.from('a.txt', 'utf8').toString('base64url');
 

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -18,12 +18,9 @@ function row(key: string): DbRow {
   return { key, size: 1, etag: 'e', lastModified: new Date('2026-01-01T00:00:00.000Z') };
 }
 
-/** Builds a versioned continuation token the way the handler does. */
-function versionedToken(payload: Record<string, unknown>): string {
-  return Buffer.concat([
-    Buffer.from([0x00]),
-    Buffer.from(JSON.stringify(payload), 'utf8'),
-  ]).toString('base64url');
+/** Builds a continuation token for a cursor key, the way the handler does. */
+function keyToken(key: string): string {
+  return Buffer.from(key, 'utf8').toString('base64url');
 }
 
 /**
@@ -293,79 +290,56 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
     expect(second.contents).toEqual(['b.txt']);
   });
 
-  it('ignores a carried prefix the cursor key does not sit under', async () => {
-    const inconsistent = versionedToken({ v: 1, k: 'a/1', p: 'b/' });
+  it('suppresses only the group the cursor is inside, never a later one', async () => {
+    const token = keyToken('a/1');
 
     const result = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '/',
-      'continuation-token': inconsistent,
+      'continuation-token': token,
     });
 
-    // "b/" is still listed: a token cannot suppress a prefix its cursor is not
-    // inside, so no page can be made to drop an entry it never returned.
-    expect(result.commonPrefixes).toEqual(['a/', 'b/']);
+    // "b/" is still listed. Suppression is recomputed from the cursor key, so a
+    // token cannot name a prefix its own position is not inside.
+    expect(result.commonPrefixes).toEqual(['b/']);
   });
 
-  it('ignores a carried prefix once the delimiter stops producing it', async () => {
-    // Token issued by a delimiter=/ walk, replayed against a request that
-    // groups differently. The carried state describes a listing that no longer
-    // exists, so it must not silently remove an entry from this one.
-    const issued = versionedToken({ v: 1, k: 'a/1', p: 'a/' });
+  it('suppresses nothing once the delimiter stops producing a group', async () => {
+    // A token issued by a delimiter=/ walk, replayed against a request that
+    // groups differently. The cursor no longer collapses into anything, so
+    // nothing may be dropped from this listing.
+    const token = keyToken('a/1');
 
-    const noDelimiter = await list(['a/1', 'a/2', 'b/1'], { 'continuation-token': issued });
+    const noDelimiter = await list(['a/1', 'a/2', 'b/1'], { 'continuation-token': token });
     expect(noDelimiter.contents).toEqual(['a/2', 'b/1']);
 
     const otherDelimiter = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '-',
-      'continuation-token': issued,
+      'continuation-token': token,
     });
     expect(otherDelimiter.contents).toEqual(['a/2', 'b/1']);
   });
 
-  it('accepts a legacy bare-key continuation token', async () => {
-    const legacy = Buffer.from('a.txt', 'utf8').toString('base64url');
-
-    const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'continuation-token': legacy });
-
-    expect(result.contents).toEqual(['b.txt', 'c.txt']);
-  });
-
-  it('rejects a marked token it cannot read instead of restarting the walk', async () => {
-    const marked = Buffer.concat([Buffer.from([0x00]), Buffer.from('not json', 'utf8')]).toString(
-      'base64url'
-    );
-
-    const result = await list(['a.txt', 'b.txt'], { 'continuation-token': marked });
-
-    // Restarting would answer 200 with keys the caller had already processed.
-    expect(result.status).toBe(400);
-    expect(result.xml).toContain('InvalidArgument');
-    expect(result.contents).toEqual([]);
-  });
-
-  it('rejects a marked token whose payload is the wrong shape', async () => {
-    const wrongShape = versionedToken({ v: 99, k: 'a.txt' });
-
-    const result = await list(['a.txt', 'b.txt'], { 'continuation-token': wrongShape });
-
-    expect(result.status).toBe(400);
-    expect(result.xml).toContain('InvalidArgument');
-  });
-
-  it('reads a legacy token for a key shaped like the versioned payload as that key', async () => {
-    // An object key may be any text, including our own envelope. The NUL marker
-    // is what separates the formats, and Postgres text cannot hold NUL, so a
-    // stored key can never impersonate a versioned token.
-    const impostor = JSON.stringify({ v: 1, k: 'c.txt' });
-    const legacy = Buffer.from(impostor, 'utf8').toString('base64url');
-
-    // Sorted, these are: c.txt, impostor, impostor-next. Resuming after the
-    // impostor key returns one row; resuming after the embedded "c.txt" would
-    // return two and replay a key the caller had already seen.
-    const result = await list(['c.txt', impostor, `${impostor}-next`], {
-      'continuation-token': legacy,
+  it('does not suppress a group for a caller-supplied start-after', async () => {
+    // start-after is a plain position, not a resumed page, so the group its key
+    // sits in has not been returned to anyone yet.
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'start-after': 'a/1',
     });
 
+    expect(result.commonPrefixes).toEqual(['a/', 'b/']);
+  });
+
+  it('resumes from a token whose key is arbitrary text', async () => {
+    // Object keys may be any text. The token is just that key, so nothing about
+    // its content can change how it is read.
+    const awkward = '{"k":"c.txt"}';
+
+    const result = await list(['c.txt', awkward, `${awkward}-next`], {
+      'continuation-token': keyToken(awkward),
+    });
+
+    // Sorted these are c.txt, awkward, awkward-next, so only the last remains.
     expect(result.keyCount).toBe(1);
     expect(result.contents).not.toContain('c.txt');
   });

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -18,6 +18,14 @@ function row(key: string): DbRow {
   return { key, size: 1, etag: 'e', lastModified: new Date('2026-01-01T00:00:00.000Z') };
 }
 
+/** Builds a versioned continuation token the way the handler does. */
+function versionedToken(payload: Record<string, unknown>): string {
+  return Buffer.concat([
+    Buffer.from([0x00]),
+    Buffer.from(JSON.stringify(payload), 'utf8'),
+  ]).toString('base64url');
+}
+
 /**
  * Stands in for storage.objects: keys sorted ascending, filtered by prefix and
  * an exclusive `startAfter`, windowed by `maxKeys`. This is exactly the
@@ -286,9 +294,7 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
   });
 
   it('ignores a carried prefix the cursor key does not sit under', async () => {
-    const inconsistent = Buffer.from(JSON.stringify({ v: 1, k: 'a/1', p: 'b/' }), 'utf8').toString(
-      'base64url'
-    );
+    const inconsistent = versionedToken({ v: 1, k: 'a/1', p: 'b/' });
 
     const result = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '/',
@@ -306,5 +312,23 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
     const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'continuation-token': legacy });
 
     expect(result.contents).toEqual(['b.txt', 'c.txt']);
+  });
+
+  it('reads a legacy token for a key shaped like the versioned payload as that key', async () => {
+    // An object key may be any text, including our own envelope. The NUL marker
+    // is what separates the formats, and Postgres text cannot hold NUL, so a
+    // stored key can never impersonate a versioned token.
+    const impostor = JSON.stringify({ v: 1, k: 'c.txt' });
+    const legacy = Buffer.from(impostor, 'utf8').toString('base64url');
+
+    // Sorted, these are: c.txt, impostor, impostor-next. Resuming after the
+    // impostor key returns one row; resuming after the embedded "c.txt" would
+    // return two and replay a key the caller had already seen.
+    const result = await list(['c.txt', impostor, `${impostor}-next`], {
+      'continuation-token': legacy,
+    });
+
+    expect(result.keyCount).toBe(1);
+    expect(result.contents).not.toContain('c.txt');
   });
 });

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -1,11 +1,21 @@
 import crypto from 'crypto';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
 import { appConfig } from '@/infra/config/app.config.js';
 import { handle } from '@/api/routes/s3-gateway/commands/list-objects-v2.js';
 
+// appConfig is read at call time, and is loaded once at import, so the secret is
+// set on the object rather than through the environment.
+const ORIGINAL_JWT_SECRET = appConfig.app.jwtSecret;
+const TEST_JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+
+beforeEach(() => {
+  appConfig.app.jwtSecret = TEST_JWT_SECRET;
+});
+
 afterEach(() => {
+  appConfig.app.jwtSecret = ORIGINAL_JWT_SECRET;
   vi.restoreAllMocks();
 });
 
@@ -417,7 +427,62 @@ describe('ListObjectsV2 continuation-token authenticity', () => {
   });
 });
 
+describe('ListObjectsV2 continuation tokens without a signing key', () => {
+  // JWT_SECRET is the HMAC key. An empty one is public, so signing with it would
+  // hand a forged token the trust a real signature earns.
+  const withoutSecret = () => {
+    appConfig.app.jwtSecret = '';
+  };
+
+  it('issues unsigned tokens rather than signing with an empty key', async () => {
+    withoutSecret();
+
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], { 'max-keys': '1' });
+
+    expect(result.nextToken).toBeDefined();
+    expect(result.nextToken).not.toContain('.');
+  });
+
+  it('grants no suppression, so a listing is complete rather than wrong', async () => {
+    withoutSecret();
+
+    const first = await list(['a/1', 'a/2', 'b/1'], { delimiter: '/', 'max-keys': '1' });
+    const second = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'max-keys': '1',
+      'continuation-token': first.nextToken as string,
+    });
+
+    // Degrades to the pre-existing duplicate, never to a missing folder.
+    expect(second.status).toBe(200);
+    expect(second.commonPrefixes).toEqual(['a/']);
+  });
+
+  it('rejects a signed token, which cannot have come from this instance', async () => {
+    const issued = signedToken('a/1', { delimiter: '/' });
+    withoutSecret();
+
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'continuation-token': issued,
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+});
+
 describe('ListObjectsV2 unsigned continuation tokens', () => {
+  it('rejects an empty continuation-token instead of falling back to start-after', async () => {
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], {
+      'continuation-token': '',
+      'start-after': 'a.txt',
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+
   it('still resumes a walk that started before tokens were signed', async () => {
     // An upgrade must not strand a paginator mid-listing, so the position an
     // unsigned token names is honoured.

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -314,6 +314,28 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
     expect(result.contents).toEqual(['b.txt', 'c.txt']);
   });
 
+  it('rejects a marked token it cannot read instead of restarting the walk', async () => {
+    const marked = Buffer.concat([Buffer.from([0x00]), Buffer.from('not json', 'utf8')]).toString(
+      'base64url'
+    );
+
+    const result = await list(['a.txt', 'b.txt'], { 'continuation-token': marked });
+
+    // Restarting would answer 200 with keys the caller had already processed.
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+    expect(result.contents).toEqual([]);
+  });
+
+  it('rejects a marked token whose payload is the wrong shape', async () => {
+    const wrongShape = versionedToken({ v: 99, k: 'a.txt' });
+
+    const result = await list(['a.txt', 'b.txt'], { 'continuation-token': wrongShape });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+
   it('reads a legacy token for a key shaped like the versioned payload as that key', async () => {
     // An object key may be any text, including our own envelope. The NUL marker
     // is what separates the formats, and Postgres text cannot hold NUL, so a

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -37,7 +37,12 @@ function signedToken(
     .update(fields.map((field) => `${Buffer.byteLength(field, 'utf8')}:${field}`).join(''))
     .digest()
     .subarray(0, 16);
-  return Buffer.concat([signature, Buffer.from(key, 'utf8')]).toString('base64url');
+  return `${Buffer.from(key, 'utf8').toString('base64url')}.${signature.toString('base64url')}`;
+}
+
+/** The unsigned token format shipped before continuation tokens were signed. */
+function legacyToken(key: string): string {
+  return Buffer.from(key, 'utf8').toString('base64url');
 }
 
 /**
@@ -333,7 +338,7 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
 
   it('resumes from a token whose key is arbitrary text', async () => {
     // Object keys may be any text, and the signature covers the key verbatim.
-    const awkward = '{"k":"c.txt"}';
+    const awkward = '{"k":"c.txt"}.plus.dots';
 
     const result = await list(['c.txt', awkward, `${awkward}-next`], {
       'continuation-token': signedToken(awkward),
@@ -346,12 +351,27 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
 });
 
 describe('ListObjectsV2 continuation-token authenticity', () => {
-  it('rejects a token this server did not issue', async () => {
-    // A caller who can write their own token could otherwise pick a cursor
-    // whose group is then suppressed, dropping a folder from the listing.
-    const forged = Buffer.concat([Buffer.alloc(16, 0x11), Buffer.from('a/1', 'utf8')]).toString(
-      'base64url'
-    );
+  it('accepts the token it issued for the same listing', async () => {
+    const first = await list(['a/1', 'a/2', 'b/1'], { delimiter: '/', 'max-keys': '1' });
+    expect(first.nextToken).toBeDefined();
+
+    const second = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'max-keys': '1',
+      'continuation-token': first.nextToken as string,
+    });
+
+    expect(second.status).toBe(200);
+    expect(second.commonPrefixes).toEqual(['b/']);
+  });
+
+  it('rejects a signed token whose signature does not verify', async () => {
+    // Without this, a caller who writes their own token picks a cursor whose
+    // group is then suppressed, and a folder goes missing from the listing.
+    const forged = `${Buffer.from('a/1', 'utf8').toString('base64url')}.${Buffer.alloc(
+      16,
+      0x11
+    ).toString('base64url')}`;
 
     const result = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '/',
@@ -362,21 +382,9 @@ describe('ListObjectsV2 continuation-token authenticity', () => {
     expect(result.xml).toContain('InvalidArgument');
   });
 
-  it('rejects a token that is too short to carry a signature', async () => {
-    const stub = Buffer.from('short', 'utf8').toString('base64url');
-
-    const result = await list(['a.txt'], { 'continuation-token': stub });
-
-    expect(result.status).toBe(400);
-    expect(result.xml).toContain('InvalidArgument');
-  });
-
   it('rejects a token whose cursor key was edited after signing', async () => {
-    const token = signedToken('a/1', { delimiter: '/' });
-    const raw = Buffer.from(token, 'base64url');
-    const tampered = Buffer.concat([raw.subarray(0, 16), Buffer.from('a/9', 'utf8')]).toString(
-      'base64url'
-    );
+    const signature = signedToken('a/1', { delimiter: '/' }).split('.')[1];
+    const tampered = `${Buffer.from('a/9', 'utf8').toString('base64url')}.${signature}`;
 
     const result = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '/',
@@ -384,12 +392,11 @@ describe('ListObjectsV2 continuation-token authenticity', () => {
     });
 
     expect(result.status).toBe(400);
-    expect(result.xml).toContain('InvalidArgument');
   });
 
   it('rejects a token replayed against a different listing', async () => {
-    // Same cursor, but the signature binds bucket, prefix and delimiter, so
-    // state cannot leak between listings that group differently.
+    // The signature binds bucket, prefix and delimiter, so suppression state
+    // cannot leak between listings that group differently.
     const issued = signedToken('a/1', { delimiter: '/' });
 
     const otherDelimiter = await list(['a/1', 'a/2', 'b/1'], {
@@ -408,18 +415,29 @@ describe('ListObjectsV2 continuation-token authenticity', () => {
     });
     expect(otherPrefix.status).toBe(400);
   });
+});
 
-  it('accepts the token it issued for the same listing', async () => {
-    const first = await list(['a/1', 'a/2', 'b/1'], { delimiter: '/', 'max-keys': '1' });
-    expect(first.nextToken).toBeDefined();
-
-    const second = await list(['a/1', 'a/2', 'b/1'], {
-      delimiter: '/',
-      'max-keys': '1',
-      'continuation-token': first.nextToken as string,
+describe('ListObjectsV2 unsigned continuation tokens', () => {
+  it('still resumes a walk that started before tokens were signed', async () => {
+    // An upgrade must not strand a paginator mid-listing, so the position an
+    // unsigned token names is honoured.
+    const result = await list(['a.txt', 'b.txt', 'c.txt'], {
+      'continuation-token': legacyToken('a.txt'),
     });
 
-    expect(second.status).toBe(200);
-    expect(second.commonPrefixes).toEqual(['b/']);
+    expect(result.status).toBe(200);
+    expect(result.contents).toEqual(['b.txt', 'c.txt']);
+  });
+
+  it('does not let an unsigned token suppress a group', async () => {
+    // Position only. Anyone can write one of these, so it earns no more than a
+    // start-after does, and "a/" is still listed.
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'continuation-token': legacyToken('a/1'),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.commonPrefixes).toEqual(['a/', 'b/']);
   });
 });

--- a/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
+++ b/backend/tests/unit/s3-gateway-list-objects-v2.test.ts
@@ -1,6 +1,8 @@
+import crypto from 'crypto';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { Response } from 'express';
 import { StorageService } from '@/services/storage/storage.service.js';
+import { appConfig } from '@/infra/config/app.config.js';
 import { handle } from '@/api/routes/s3-gateway/commands/list-objects-v2.js';
 
 afterEach(() => {
@@ -18,9 +20,24 @@ function row(key: string): DbRow {
   return { key, size: 1, etag: 'e', lastModified: new Date('2026-01-01T00:00:00.000Z') };
 }
 
-/** Builds a continuation token for a cursor key, the way the handler does. */
-function keyToken(key: string): string {
-  return Buffer.from(key, 'utf8').toString('base64url');
+/** Mints a continuation token the way the handler does, for the same listing. */
+function signedToken(
+  key: string,
+  scope: { bucket?: string; prefix?: string; delimiter?: string } = {}
+): string {
+  const fields = [
+    'insforge:s3:listv2:v1',
+    scope.bucket ?? 'test-bucket',
+    scope.prefix ?? '',
+    scope.delimiter ?? '',
+    key,
+  ];
+  const signature = crypto
+    .createHmac('sha256', appConfig.app.jwtSecret)
+    .update(fields.map((field) => `${Buffer.byteLength(field, 'utf8')}:${field}`).join(''))
+    .digest()
+    .subarray(0, 16);
+  return Buffer.concat([signature, Buffer.from(key, 'utf8')]).toString('base64url');
 }
 
 /**
@@ -291,7 +308,7 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
   });
 
   it('suppresses only the group the cursor is inside, never a later one', async () => {
-    const token = keyToken('a/1');
+    const token = signedToken('a/1', { delimiter: '/' });
 
     const result = await list(['a/1', 'a/2', 'b/1'], {
       delimiter: '/',
@@ -301,22 +318,6 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
     // "b/" is still listed. Suppression is recomputed from the cursor key, so a
     // token cannot name a prefix its own position is not inside.
     expect(result.commonPrefixes).toEqual(['b/']);
-  });
-
-  it('suppresses nothing once the delimiter stops producing a group', async () => {
-    // A token issued by a delimiter=/ walk, replayed against a request that
-    // groups differently. The cursor no longer collapses into anything, so
-    // nothing may be dropped from this listing.
-    const token = keyToken('a/1');
-
-    const noDelimiter = await list(['a/1', 'a/2', 'b/1'], { 'continuation-token': token });
-    expect(noDelimiter.contents).toEqual(['a/2', 'b/1']);
-
-    const otherDelimiter = await list(['a/1', 'a/2', 'b/1'], {
-      delimiter: '-',
-      'continuation-token': token,
-    });
-    expect(otherDelimiter.contents).toEqual(['a/2', 'b/1']);
   });
 
   it('does not suppress a group for a caller-supplied start-after', async () => {
@@ -331,16 +332,94 @@ describe('ListObjectsV2 start-after and continuation-token', () => {
   });
 
   it('resumes from a token whose key is arbitrary text', async () => {
-    // Object keys may be any text. The token is just that key, so nothing about
-    // its content can change how it is read.
+    // Object keys may be any text, and the signature covers the key verbatim.
     const awkward = '{"k":"c.txt"}';
 
     const result = await list(['c.txt', awkward, `${awkward}-next`], {
-      'continuation-token': keyToken(awkward),
+      'continuation-token': signedToken(awkward),
     });
 
     // Sorted these are c.txt, awkward, awkward-next, so only the last remains.
     expect(result.keyCount).toBe(1);
     expect(result.contents).not.toContain('c.txt');
+  });
+});
+
+describe('ListObjectsV2 continuation-token authenticity', () => {
+  it('rejects a token this server did not issue', async () => {
+    // A caller who can write their own token could otherwise pick a cursor
+    // whose group is then suppressed, dropping a folder from the listing.
+    const forged = Buffer.concat([Buffer.alloc(16, 0x11), Buffer.from('a/1', 'utf8')]).toString(
+      'base64url'
+    );
+
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'continuation-token': forged,
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+
+  it('rejects a token that is too short to carry a signature', async () => {
+    const stub = Buffer.from('short', 'utf8').toString('base64url');
+
+    const result = await list(['a.txt'], { 'continuation-token': stub });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+
+  it('rejects a token whose cursor key was edited after signing', async () => {
+    const token = signedToken('a/1', { delimiter: '/' });
+    const raw = Buffer.from(token, 'base64url');
+    const tampered = Buffer.concat([raw.subarray(0, 16), Buffer.from('a/9', 'utf8')]).toString(
+      'base64url'
+    );
+
+    const result = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'continuation-token': tampered,
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.xml).toContain('InvalidArgument');
+  });
+
+  it('rejects a token replayed against a different listing', async () => {
+    // Same cursor, but the signature binds bucket, prefix and delimiter, so
+    // state cannot leak between listings that group differently.
+    const issued = signedToken('a/1', { delimiter: '/' });
+
+    const otherDelimiter = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '-',
+      'continuation-token': issued,
+    });
+    expect(otherDelimiter.status).toBe(400);
+
+    const noDelimiter = await list(['a/1', 'a/2', 'b/1'], { 'continuation-token': issued });
+    expect(noDelimiter.status).toBe(400);
+
+    const otherPrefix = await list(['a/1', 'a/2'], {
+      delimiter: '/',
+      prefix: 'a',
+      'continuation-token': issued,
+    });
+    expect(otherPrefix.status).toBe(400);
+  });
+
+  it('accepts the token it issued for the same listing', async () => {
+    const first = await list(['a/1', 'a/2', 'b/1'], { delimiter: '/', 'max-keys': '1' });
+    expect(first.nextToken).toBeDefined();
+
+    const second = await list(['a/1', 'a/2', 'b/1'], {
+      delimiter: '/',
+      'max-keys': '1',
+      'continuation-token': first.nextToken as string,
+    });
+
+    expect(second.status).toBe(200);
+    expect(second.commonPrefixes).toEqual(['b/']);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1959.

`ListObjectsV2` had four pagination defects, all reachable from a stock `@aws-sdk/client-s3` paginator or `aws s3 ls`. Each one is fixed below with a regression test that fails on `main`.

**`max-keys=0` advertised truncation with no token.** The scan started unconditionally, tripped `visible (0) >= maxKeys (0)` on the first row, and returned `IsTruncated=true` while `cursor` was still `undefined`, so no `NextContinuationToken` was emitted. `paginateListObjectsV2` loops while `IsTruncated` is set, so it re-issues the identical request forever on any non-empty bucket. It now short-circuits to `KeyCount=0, IsTruncated=false` without touching the database.

**The internal scan cap hid truncation.** When the walk exited on `MAX_DB_PAGES` rather than on `maxKeys` or end-of-data, the post-loop guard only set `truncated` if `visible >= maxKeys`. A listing that collapses into few `CommonPrefixes` never reaches `maxKeys`, so the response claimed the listing was complete with rows still unread. `IsTruncated` and `NextContinuationToken` are now derived from one expression, so the cap reports truncation with a usable cursor and the two can never disagree.

**A `CommonPrefix` was returned on every page it spanned.** The cursor tracked the last raw key consumed, including keys that had collapsed into a `CommonPrefix`. A page ending inside such a group left the cursor inside it, so the next page rebuilt and re-emitted the same prefix from a fresh set. Keys `a/1, a/2, b/1` at `delimiter=/`, `max-keys=1` returned `["a/", "a/", "b/"]`; a folder of ten objects walked one key at a time was listed ten times. A resumed page now recomputes the prefix its cursor sits in and consumes the remainder of that group without emitting it.

**`start-after` overrode `continuation-token`.** S3 ignores `start-after` whenever `continuation-token` is present. The old precedence meant a client that sets both (SDKs preserve the caller's `StartAfter` across pages) resumed every page from the same fixed point.

## Notes for the reviewer

- Grouping now has a single definition, `collapsedPrefix(key, prefix, delimiter)`, used by both the scan and the resume check. The prefix to suppress is derived from the cursor rather than carried in the token, so it cannot go stale or disagree with itself: the cursor only lands mid-group when the page it came from already returned that prefix, and collapses to nothing when that page ended on a plain key.
- Because choosing the cursor chooses which group is suppressed, the token is authenticated: `base64url(key).base64url(signature)`, where the signature is a truncated HMAC over bucket, prefix, delimiter and key, using the same `JWT_SECRET` and namespaced-string pattern as `TokenManager.generateCsrfToken`. A signed token that does not verify is answered with `InvalidArgument`, as S3 does, so suppression is reachable only through a token this server issued for this exact listing.
- base64url output never contains a dot, so a token without one is unambiguously an unsigned token from before this change. Those keep working as plain positions, without earning suppression, so a listing walk that spans the upgrade still advances rather than failing; at worst it repeats one `CommonPrefix`, which is what it would have done on `main` anyway.
- If `JWT_SECRET` is unset there is no key to sign with, and HMAC with the empty string would be worse than no signature: the key is public, so a forged token would verify. In that case the handler issues unsigned tokens and rejects signed ones. Suppression is not granted, so the listing degrades to the duplicate `CommonPrefix` it has on `main` rather than to a missing folder.
- Suppression applies only when resuming from a token. A caller-supplied `start-after` is a plain position, so the group its key happens to sit in is still listed, matching S3.
- The `visible + 1 > maxKeys` branch inside the delimiter path was unreachable: the loop head already guarantees `visible <= maxKeys - 1`. Removed rather than carried forward.
- No change to `StorageService.listObjectsV2Db`, or to any response field other than `IsTruncated` / `NextContinuationToken` / `CommonPrefixes`. `max-keys` validation, the 1000 cap, and the `DB_WINDOW` / `MAX_DB_PAGES` bounds are untouched.

## How did you test this change?

New unit suite `backend/tests/unit/s3-gateway-list-objects-v2.test.ts` (27 tests). It fakes `listObjectsV2Db` with the same contract the real query has (sorted keys, prefix filter, exclusive `startAfter`, window limit) and drives the handler the way an SDK paginator does: follow `NextContinuationToken` until `IsTruncated` is false, then assert the union of every page.

Coverage: `max-keys=0` (empty, untruncated, zero DB calls) and that negative and fractional values are still rejected; truncation with and without a full page; a paginated walk that returns every key exactly once; the scan cap reporting truncation, and the follow-up page closing that walk cleanly; `CommonPrefix` de-duplication for a group spanning two pages, a group spanning many pages, and a scoped `prefix=`; `start-after` alone, `start-after` ignored under a continuation token, `start-after` not suppressing a group, a token not suppressing a group its cursor is outside, and a cursor key made of arbitrary text.

Token authenticity has its own group: the positive case that a token the server issued resumes cleanly, a signature that does not verify, a cursor key edited after signing, and a token replayed against a different delimiter and a different prefix. Unsigned tokens have their own: that one still resumes a walk, and that it cannot suppress a group.

Thirteen of the twenty-seven fail on `main` and pass here. The clearest ones:

```
× does not return a CommonPrefix that a previous page already returned
  expected [ 'a/', 'a/', 'b/' ] to deeply equal [ 'a/', 'b/' ]

× collapses a group that spans several pages into exactly one CommonPrefix
  expected [ 'bulk/', 'bulk/', 'bulk/', ...(7) ] to deeply equal [ 'bulk/' ]
```

Also run locally: full backend unit suite (`npx vitest run`, 2396 passed, 21 skipped), `tsc --noEmit`, `eslint`, and `prettier --check` on both changed files.
