### PR TITLE
fix(functions): hide generated route inventories

### DIFF
--- a/backend/src/providers/functions/deno-subhosting.provider.ts
+++ b/backend/src/providers/functions/deno-subhosting.provider.ts
@@ -1014,7 +1014,6 @@ const dispatch = async (req: Request): Promise<Response> => {
     return new Response(JSON.stringify({
       status: "ok",
       type: "insforge-functions",
-      functions: [],
       timestamp: new Date().toISOString(),
     }), {
       headers: { "Content-Type": "application/json" }
@@ -1080,7 +1079,6 @@ const dispatch = async (req: Request): Promise<Response> => {
       return new Response(JSON.stringify({
         status: "ok",
         type: "insforge-functions",
-        functions: Object.keys(routes),
         timestamp: new Date().toISOString(),
       }), {
         headers: { "Content-Type": "application/json" }
@@ -1094,7 +1092,6 @@ const dispatch = async (req: Request): Promise<Response> => {
     if (!slug || !routes[slug]) {
       return new Response(JSON.stringify({
         error: "Function not found",
-        available: Object.keys(routes),
       }), {
         status: 404,
         headers: { "Content-Type": "application/json" }

--- a/backend/tests/unit/deno-subhosting-router.test.ts
+++ b/backend/tests/unit/deno-subhosting-router.test.ts
@@ -103,5 +103,11 @@ describe('generated Deno Subhosting router', () => {
       type: 'insforge-functions',
       timestamp: expect.any(String),
     });
+
+    const missing = await dispatch(
+      new Request('https://functions.example/not-a-function'),
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: 'No functions deployed' });
   });
 });

--- a/backend/tests/unit/deno-subhosting-router.test.ts
+++ b/backend/tests/unit/deno-subhosting-router.test.ts
@@ -104,9 +104,7 @@ describe('generated Deno Subhosting router', () => {
       timestamp: expect.any(String),
     });
 
-    const missing = await dispatch(
-      new Request('https://functions.example/not-a-function'),
-    );
+    const missing = await dispatch(new Request('https://functions.example/not-a-function'));
     expect(missing.status).toBe(404);
     expect(await missing.json()).toEqual({ error: 'No functions deployed' });
   });

--- a/backend/tests/unit/deno-subhosting-router.test.ts
+++ b/backend/tests/unit/deno-subhosting-router.test.ts
@@ -1,0 +1,107 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import {
+  DenoSubhostingProvider,
+  type FunctionDefinition,
+} from '@/providers/functions/deno-subhosting.provider.js';
+
+type RouterGenerator = {
+  generateRouter(functions: FunctionDefinition[]): string;
+};
+
+type Dispatch = (request: Request) => Promise<Response>;
+
+function executeGeneratedRouter(functions: FunctionDefinition[]): Dispatch {
+  const provider = DenoSubhostingProvider.getInstance() as unknown as RouterGenerator;
+  const generatedRouter = provider
+    .generateRouter(functions)
+    .replace(
+      "import { AsyncLocalStorage } from 'node:async_hooks';",
+      'const { AsyncLocalStorage } = globalThis.__testRuntime__;'
+    )
+    .replace(
+      /import (_[A-Za-z0-9_]+) from "\.\/functions\/[^"]+";/g,
+      'const $1 = async () => new Response("ok");'
+    )
+    .replace('export {};', '');
+
+  let dispatch: Dispatch | undefined;
+  const compiledRouter = ts.transpileModule(generatedRouter, {
+    compilerOptions: {
+      module: ts.ModuleKind.None,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+
+  runInNewContext(compiledRouter, {
+    URL,
+    Request,
+    Response,
+    __testRuntime__: { AsyncLocalStorage },
+    Deno: {
+      serve(handler: Dispatch) {
+        dispatch = handler;
+      },
+    },
+  });
+
+  if (!dispatch) {
+    throw new Error('Generated router did not register a request dispatcher');
+  }
+
+  return dispatch;
+}
+
+describe('generated Deno Subhosting router', () => {
+  it('does not disclose deployed slugs in an unknown-function response', async () => {
+    const dispatch = executeGeneratedRouter([
+      {
+        slug: 'merchant-private-alpha',
+        code: 'export default async () => new Response("ok")',
+      },
+      {
+        slug: 'merchant-private-beta',
+        code: 'export default async () => new Response("ok")',
+      },
+    ]);
+
+    const missing = await dispatch(new Request('https://functions.example/not-a-function'));
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: 'Function not found' });
+  });
+
+  it('does not disclose deployed slugs in a populated-router health response', async () => {
+    const dispatch = executeGeneratedRouter([
+      {
+        slug: 'merchant-private-alpha',
+        code: 'export default async () => new Response("ok")',
+      },
+      {
+        slug: 'merchant-private-beta',
+        code: 'export default async () => new Response("ok")',
+      },
+    ]);
+
+    const health = await dispatch(new Request('https://functions.example/health'));
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({
+      status: 'ok',
+      type: 'insforge-functions',
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('keeps the empty-router health payload free of a function inventory', async () => {
+    const dispatch = executeGeneratedRouter([]);
+
+    const health = await dispatch(new Request('https://functions.example/health'));
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({
+      status: 'ok',
+      type: 'insforge-functions',
+      timestamp: expect.any(String),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- remove deployed-function inventories from generated Deno Subhosting health responses
- return the documented bare 404 body for unknown slugs
- execute the generated router in a Node-only regression test covering populated and empty routers

Closes #1862 (disclosure-only remaining scope). The reserved `health` slug landed separately in #1936; OpenAPI follow-up is #1962.

## Root cause

The generated public router serialized `Object.keys(routes)` in unauthenticated health and unknown-slug responses.

## Validation

- `npm test -- --run tests/unit/deno-subhosting-router.test.ts`
- `npm run lint` (passes; 5 pre-existing warnings)
- `npm run typecheck`
- `npm test` (2,372 passed, 21 skipped)
- `npm run build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide deployed function inventories from router health and 404 responses
> - Removes the `functions` field from `/health` and `/` endpoint responses in the generated Deno Subhosting router, so deployed function slugs are no longer disclosed.
> - Removes the `available` field from 404 responses when an unknown function slug is requested.
> - Adds unit tests in [`deno-subhosting-router.test.ts`](https://github.com/InsForge/InsForge/pull/1961/files#diff-a067ef7198ec69dc371aa9bcf051c0228dd6992fa446c574e1f3178802c5229d) covering all three cases to prevent regression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67b1ab1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health-check responses now return only status, type, and timestamp information.
  * Unknown function responses no longer include an availability field.
* **Tests**
  * Added coverage for health checks with empty and populated routers.
  * Added validation for unknown-function responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->