### PR TITLE
Add OpenAPI 3.0.3 spec for webscraper/Apify integration API

### DIFF
--- a/openapi/webscraper.yaml
+++ b/openapi/webscraper.yaml
@@ -664,6 +664,7 @@ components:
       properties:
         datasetId:
           type: string
+          nullable: true
           description: ID of the latest Apify dataset
         items:
           type: array

--- a/openapi/webscraper.yaml
+++ b/openapi/webscraper.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  title: Insforge Webscraper API
+  title: InsForge Webscraper API
   version: 1.0.0
   description: Administrative API for managing Apify integration and accessing Apify resources
 
@@ -21,29 +21,28 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - connected
+                  - connection
                 properties:
                   connected:
                     type: boolean
                   connection:
                     $ref: '#/components/schemas/ApifyConnection'
-                required:
-                  - connected
-                  - connection
               example:
                 connected: true
                 connection:
-                  username: "apify-user"
-                  email: "user@example.com"
+                  apifyUsername: "apify-user"
+                  apifyEmail: "user@example.com"
+                  connectedAt: "2026-08-16T12:00:00.000Z"
         '404':
           description: Apify is not connected
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -52,6 +51,18 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve connection from Apify
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve Apify connection
           content:
             application/json:
               schema:
@@ -100,18 +111,17 @@ paths:
           content:
             application/json:
               schema:
-                type: string
-              example: "apify_api_xxxxxxxxxxxxxxxxxxxx"
+                $ref: '#/components/schemas/ApifyTokenResponse'
+              example:
+                accessToken: "apify_api_xxxxxxxxxxxxxxxxxxxx"
         '404':
           description: Apify is not connected
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -120,6 +130,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve Apify token from upstream provider
           content:
             application/json:
               schema:
@@ -162,11 +178,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -175,6 +189,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve runs from Apify
           content:
             application/json:
               schema:
@@ -217,11 +237,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -230,6 +248,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve actors from Apify
           content:
             application/json:
               schema:
@@ -272,11 +296,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -285,6 +307,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve datasets from Apify
           content:
             application/json:
               schema:
@@ -322,16 +350,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApifyLatestDataResponse'
+              example:
+                datasetId: "abc123"
+                items:
+                  - title: "Example"
+                    url: "https://example.com"
         '404':
           description: Apify is not connected
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/NotConnectedError'
               example:
-                error: "NOT_FOUND"
-                message: "Apify is not connected"
-                statusCode: 404
+                error: "not_connected"
         '401':
           description: Unauthorized
           content:
@@ -340,6 +371,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to retrieve latest data from Apify
           content:
             application/json:
               schema:
@@ -368,15 +405,9 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - apiToken
-              properties:
-                apiToken:
-                  type: string
-                  minLength: 1
-                  description: Apify API token
-                  example: "apify_api_xxxxxxxxxxxxxxxxxxxx"
+              $ref: '#/components/schemas/ApifyConfigRequest'
+            example:
+              apiToken: "apify_api_xxxxxxxxxxxxxxxxxxxx"
       responses:
         '200':
           description: Apify configuration updated successfully
@@ -417,6 +448,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to validate Apify token with upstream provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Failed to configure Apify
           content:
@@ -435,10 +472,51 @@ components:
     ApifyConnection:
       type: object
       description: Apify connection metadata returned by the configured provider
+      required:
+        - apifyUsername
+      properties:
+        apifyUsername:
+          type: string
+          description: Apify username associated with the connection
+        apifyEmail:
+          type: string
+          format: email
+          nullable: true
+          description: Apify account email address
+        connectedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the Apify connection was established
       additionalProperties: true
       example:
-        username: "apify-user"
-        email: "user@example.com"
+        apifyUsername: "apify-user"
+        apifyEmail: "user@example.com"
+        connectedAt: "2026-08-16T12:00:00.000Z"
+
+    ApifyTokenResponse:
+      type: object
+      required:
+        - accessToken
+      properties:
+        accessToken:
+          type: string
+          description: Apify API access token
+      additionalProperties: false
+
+    ApifyConfigRequest:
+      type: object
+      required:
+        - apiToken
+      properties:
+        apiToken:
+          type: string
+          minLength: 1
+          maxLength: 512
+          pattern: '.*\S.*'
+          description: Apify API token. Must contain at least one non-whitespace character.
+          example: "apify_api_xxxxxxxxxxxxxxxxxxxx"
+      additionalProperties: false
 
     ApifyConfig:
       type: object
@@ -458,31 +536,155 @@ components:
               type: string
               nullable: true
               description: Masked representation of the Apify API token
+          additionalProperties: false
           example:
             configured: true
             maskedKey: "apify_api••••••••1234"
+      additionalProperties: false
+
+    ApifyRun:
+      type: object
+      description: Apify actor run
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Unique Apify run ID
+        actId:
+          type: string
+          nullable: true
+          description: Apify actor ID
+        status:
+          type: string
+          description: Run status
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        defaultDatasetId:
+          type: string
+          nullable: true
+          description: Dataset generated by the run
+      additionalProperties: true
 
     ApifyRunsResponse:
       type: object
-      description: Apify runs response returned by the Apify provider
+      required:
+        - runs
+      properties:
+        runs:
+          type: array
+          description: Apify actor runs
+          items:
+            $ref: '#/components/schemas/ApifyRun'
+      additionalProperties: false
+
+    ApifyActor:
+      type: object
+      description: Apify actor
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Unique Apify actor ID
+        name:
+          type: string
+          nullable: true
+          description: Actor name
+        username:
+          type: string
+          nullable: true
+          description: Apify username that owns the actor
+        title:
+          type: string
+          nullable: true
+          description: Actor title
       additionalProperties: true
 
     ApifyActorsResponse:
       type: object
-      description: Apify actors response returned by the Apify provider
+      required:
+        - actors
+      properties:
+        actors:
+          type: array
+          description: Apify actors
+          items:
+            $ref: '#/components/schemas/ApifyActor'
+      additionalProperties: false
+
+    ApifyDataset:
+      type: object
+      description: Apify dataset
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Unique Apify dataset ID
+        name:
+          type: string
+          nullable: true
+          description: Dataset name
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Dataset creation timestamp
+        itemCount:
+          type: integer
+          minimum: 0
+          nullable: true
+          description: Number of records in the dataset
       additionalProperties: true
 
     ApifyDatasetsResponse:
       type: object
-      description: Apify datasets response returned by the Apify provider
-      additionalProperties: true
+      required:
+        - datasets
+      properties:
+        datasets:
+          type: array
+          description: Apify datasets
+          items:
+            $ref: '#/components/schemas/ApifyDataset'
+      additionalProperties: false
 
     ApifyLatestDataResponse:
-      type: array
-      description: Records from the latest Apify dataset
-      items:
-        type: object
-        additionalProperties: true
+      type: object
+      required:
+        - datasetId
+        - items
+      properties:
+        datasetId:
+          type: string
+          description: ID of the latest Apify dataset
+        items:
+          type: array
+          description: Records from the latest Apify dataset
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: false
+
+    NotConnectedError:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - not_connected
+          description: Indicates that Apify is not connected
+          example: "not_connected"
+      additionalProperties: false
 
     ErrorResponse:
       type: object

--- a/openapi/webscraper.yaml
+++ b/openapi/webscraper.yaml
@@ -1,0 +1,509 @@
+openapi: 3.0.3
+
+info:
+  title: Insforge Webscraper API
+  version: 1.0.0
+  description: Administrative API for managing Apify integration and accessing Apify resources
+
+paths:
+  /api/webscraper/apify/connection:
+    get:
+      summary: Get Apify connection
+      description: Returns the current Apify connection status and connection metadata
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Apify is connected
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                  connection:
+                    $ref: '#/components/schemas/ApifyConnection'
+                required:
+                  - connected
+                  - connection
+              example:
+                connected: true
+                connection:
+                  username: "apify-user"
+                  email: "user@example.com"
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      summary: Disconnect Apify
+      description: Disconnect the project's Apify integration
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Apify disconnected successfully
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to disconnect Apify
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/token:
+    get:
+      summary: Get Apify API token
+      description: Retrieve the configured Apify API token. Admin only because this endpoint returns the sensitive token value.
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Apify API token
+          content:
+            application/json:
+              schema:
+                type: string
+              example: "apify_api_xxxxxxxxxxxxxxxxxxxx"
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve Apify token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/runs:
+    get:
+      summary: List Apify runs
+      description: Returns recent Apify actor runs
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of runs to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 10
+          example: 10
+      responses:
+        '200':
+          description: List of Apify runs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApifyRunsResponse'
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve Apify runs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/actors:
+    get:
+      summary: List Apify actors
+      description: Returns recently used Apify actors
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of actors to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          example: 20
+      responses:
+        '200':
+          description: List of Apify actors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApifyActorsResponse'
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve Apify actors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/datasets:
+    get:
+      summary: List Apify datasets
+      description: Returns recently created Apify datasets
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of datasets to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          example: 20
+      responses:
+        '200':
+          description: List of Apify datasets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApifyDatasetsResponse'
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve Apify datasets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/data:
+    get:
+      summary: Get latest Apify data
+      description: Returns a preview of records from the latest Apify run dataset
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of dataset records to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 20
+            default: 5
+          example: 5
+      responses:
+        '200':
+          description: Latest Apify dataset records
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApifyLatestDataResponse'
+        '404':
+          description: Apify is not connected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Apify is not connected"
+                statusCode: 404
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to retrieve latest Apify data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/webscraper/apify/config:
+    put:
+      summary: Configure Apify API token
+      description: >-
+        Validate and store an Apify API token for self-hosted deployments.
+        The token is verified against Apify before it is persisted.
+        This endpoint is not available in InsForge Cloud because Cloud
+        manages the Apify connection through OAuth.
+      tags:
+        - Apify
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - apiToken
+              properties:
+                apiToken:
+                  type: string
+                  minLength: 1
+                  description: Apify API token
+                  example: "apify_api_xxxxxxxxxxxxxxxxxxxx"
+      responses:
+        '200':
+          description: Apify configuration updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApifyConfig'
+              example:
+                token:
+                  configured: true
+                  maskedKey: "apify_api••••••••1234"
+        '400':
+          description: Invalid input or Apify configuration is managed by InsForge Cloud
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidInput:
+                  value:
+                    error: "INVALID_INPUT"
+                    message: "Validation error: API token is required"
+                    statusCode: 400
+                cloudEnvironment:
+                  value:
+                    error: "INVALID_INPUT"
+                    message: "The Apify connection is managed by InsForge Cloud."
+                    statusCode: 400
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - Admin only
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Failed to configure Apify
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ApifyConnection:
+      type: object
+      description: Apify connection metadata returned by the configured provider
+      additionalProperties: true
+      example:
+        username: "apify-user"
+        email: "user@example.com"
+
+    ApifyConfig:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: object
+          required:
+            - configured
+            - maskedKey
+          properties:
+            configured:
+              type: boolean
+              description: Whether an Apify API token is configured
+            maskedKey:
+              type: string
+              nullable: true
+              description: Masked representation of the Apify API token
+          example:
+            configured: true
+            maskedKey: "apify_api••••••••1234"
+
+    ApifyRunsResponse:
+      type: object
+      description: Apify runs response returned by the Apify provider
+      additionalProperties: true
+
+    ApifyActorsResponse:
+      type: object
+      description: Apify actors response returned by the Apify provider
+      additionalProperties: true
+
+    ApifyDatasetsResponse:
+      type: object
+      description: Apify datasets response returned by the Apify provider
+      additionalProperties: true
+
+    ApifyLatestDataResponse:
+      type: array
+      description: Records from the latest Apify dataset
+      items:
+        type: object
+        additionalProperties: true
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - statusCode
+      properties:
+        error:
+          type: string
+          description: Error code for programmatic handling
+          example: "INVALID_INPUT"
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Invalid input data"
+        statusCode:
+          type: integer
+          description: HTTP status code
+          example: 400
+        nextActions:
+          type: string
+          description: Suggested action to resolve the error
+          example: "Check the request body format"


### PR DESCRIPTION
## Summary

Add the OpenAPI specification for the Apify webscraper administrative API.

## Changes

* Added `openapi/webscraper.yaml`.
* Documented Apify connection status and disconnect endpoints.
* Documented Apify token access.
* Documented Apify runs, actors, datasets, and latest data endpoints.
* Documented self-hosted Apify token configuration.
* Added admin bearer authentication.
* Added request/query parameter schemas and validation constraints.
* Added Apify configuration and error response schemas.
* Added examples for successful and error responses.

## Validation

* Verified the OpenAPI specification against the implemented Apify webscraper routes.
* Confirmed all documented endpoints are admin-only.
* Confirmed request parameters, responses, and error responses match the API implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAPI 3.0.3 spec for the admin-only Apify webscraper API so clients can generate SDKs and we lock parameter/response contracts. Previously undocumented endpoints now include authentication, validation, and error shapes. No runtime behavior changes.

- Documents 8 endpoints: connection (get/delete), token read, runs, actors, datasets, latest data, and self-hosted token config.
- Applies JWT `bearerAuth` to all endpoints; unauthorized returns 401, non-admin returns 403.
- Defines query limits: runs (1–200, default 10), actors/datasets (1–100, default 20), latest data (1–20, default 5).
- Standardizes errors: 404 returns `{ error: "not_connected" }`; adds 502 for Apify upstream failures; all errors use a single `ErrorResponse` schema.
- Sets exact response shapes: token returns `{ accessToken }`; latest data returns `{ datasetId, items }`; runs/actors/datasets use typed list response schemas; connection metadata updated to match backend.
- Provider payload objects keep `additionalProperties: true` to pass through Apify fields, with success/error examples.
- Self-hosted only: `/api/webscraper/apify/config` validates `apiToken` with maxLength and non-whitespace rules and persists it; Cloud returns 400 with “The Apify connection is managed by InsForge Cloud.”

<sup>Written for commit f8c700d9ed020fe87c7232433b8bd8315c4d4b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API documentation for authenticated Apify web-scraping operations.
  * Documented connection management, token access, runs, actors, datasets, latest data, and configuration endpoints.
  * Added request validation details, standardized error responses, bearer JWT security, and response schemas.
  * Clarified authorization requirements and expected responses for successful, disconnected, invalid, upstream, and server-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->