### PR TITLE
docs: agents-only pointer to agents.insforge.dev on introduction page

### DIFF
--- a/docs/es/introduction.mdx
+++ b/docs/es/introduction.mdx
@@ -19,6 +19,10 @@ description: "Introducción a InsForge, la plataforma backend open source nativa
   https://insforge.dev/skill.md for the canonical setup workflow.
 </div>
 
+<Visibility for="agents">
+  **Agent workflow:** Use [InsForge for agents](https://agents.insforge.dev/) to choose a task-specific workflow. When the user is ready to create or connect a project, continue to [auth.md](https://agents.insforge.dev/auth.md).
+</Visibility>
+
 InsForge proporciona a su agente de codificación Base de datos, Autenticación, Almacenamiento, Tiempo real, Funciones de borde, Sitios y una Puerta de enlace de modelo para completar aplicaciones de pila completa de extremo a extremo.
 
 ## Conectar primero

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -19,6 +19,10 @@ description: "InsForge is the open-source backend for agentic coding, bundling P
   https://insforge.dev/skill.md for the canonical setup workflow.
 </div>
 
+<Visibility for="agents">
+  **Agent workflow:** Use [InsForge for agents](https://agents.insforge.dev/) to choose a task-specific workflow. When the user is ready to create or connect a project, continue to [auth.md](https://agents.insforge.dev/auth.md).
+</Visibility>
+
 InsForge gives your coding agent Database, Authentication, Storage, Realtime, Edge Functions, Sites, and a Model Gateway to ship full-stack apps end to end.
 
 ## Connect first

--- a/docs/zh-Hant/introduction.mdx
+++ b/docs/zh-Hant/introduction.mdx
@@ -19,6 +19,10 @@ description: "InsForge 是專為 AI 代理程式編碼打造的一體化開源�
   https://insforge.dev/skill.md for the canonical setup workflow.
 </div>
 
+<Visibility for="agents">
+  **Agent workflow:** Use [InsForge for agents](https://agents.insforge.dev/) to choose a task-specific workflow. When the user is ready to create or connect a project, continue to [auth.md](https://agents.insforge.dev/auth.md).
+</Visibility>
+
 InsForge 為您的編碼代理提供資料庫、身份驗證、儲存、即時、邊緣函數、網站和模型網關，以端到端地完成全棧應用程式。
 
 ## 首先連接

--- a/docs/zh/introduction.mdx
+++ b/docs/zh/introduction.mdx
@@ -19,6 +19,10 @@ description: "InsForge 是面向 AI 代理编码的一体化开源后端平台�
   https://insforge.dev/skill.md for the canonical setup workflow.
 </div>
 
+<Visibility for="agents">
+  **Agent workflow:** Use [InsForge for agents](https://agents.insforge.dev/) to choose a task-specific workflow. When the user is ready to create or connect a project, continue to [auth.md](https://agents.insforge.dev/auth.md).
+</Visibility>
+
 InsForge 为您的编码代理提供数据库、身份验证、存储、实时、边缘函数、网站和模型网关，以端到端地完成全栈应用程序。
 
 ## 首先连接


### PR DESCRIPTION
## What

Adds a `<Visibility for="agents">` block to `docs/introduction.mdx`, directly below the existing hidden `IMPORTANT FOR AI AGENTS` div:

> **Agent workflow:** Use [InsForge for agents](https://agents.insforge.dev/) to choose a task-specific workflow. When the user is ready to create or connect a project, continue to [auth.md](https://agents.insforge.dev/auth.md).

Mintlify's Visibility component renders this only in the Markdown/agent view (`introduction.md`); it is hidden on the human web page — the repo-source equivalent of the web editor's "/visibility → Visible to agents only" that the partner requested.

## Why

Sherpa (Norbu) shipped v1 of agents.insforge.dev and wants to measure whether task-specific agent routes increase the % of agents reaching auth.md. This is 3 of 3 requested changes; changes 1–2 (insforge.dev `index.md` + `llms.txt`) are in InsForge/insforge-cloud#620.

## Verification

- `npx mint validate` passes.
- `agents.insforge.dev/auth.md` verified byte-identical to canonical `insforge.dev/skill.md` (2026-08-16).
- Site is served from Sherpa's edge (CNAME `edge.withsherpa.ai`) — content is under partner control going forward; noted in #620 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZaoLMs3PseiLeivXfZWwH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agents-only Visibility block to `docs/introduction.mdx` and mirrors it in `docs/es/`, `docs/zh/`, and `docs/zh-Hant` introductions. Previously agents saw only a hidden note; now the pointer renders in the agent Markdown view. The human-facing web page is unchanged.

**Review notes**
- Renders only in the Markdown/agent view; no impact on the web site.
- Inserts Mintlify `<Visibility for="agents">` below the existing hidden agent notice in all four locale files.
- Links: `https://agents.insforge.dev/` and `https://agents.insforge.dev/auth.md`.
- Localized files keep English agent text per `DOCS_I18N`.
- `npx mint validate` passes; complements InsForge/insforge-cloud#620.

<sup>Written for commit d128de916e01b4653af372001aa033a78d77cbc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add agent-only pointer to agents.insforge.dev on the introduction page
> Adds a `Visibility`-gated note block in [introduction.mdx](https://github.com/InsForge/InsForge/pull/1971/files#diff-0166b0574213b999964155797259928739a25e0a09d0442bdd14ff8307dcca30) that is shown only to agents. The note links to `agents.insforge.dev` and directs agent users to the auth setup guide when creating or connecting a project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f78937.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added agent-only guidance for selecting workflows and completing authentication setup.
  * Updated the introduction documentation in English, Spanish, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->