### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=InsForge/InsForge&type=Date)](https://www.star-history.com/#InsForge/InsForge&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=InsForge/InsForge&type=Date)](https://star-history.dera.page/#InsForge/InsForge&Date)
 
 ## Badges
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer API data source is no longer reliable. This change points the chart at a working alternative so it renders correctly again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the README star history chart from api.star-history.com to star-history.dera.page so it renders reliably. The old chart often failed due to GitHub stargazer API rate limits; the new chart displays via the alternative service, and the link target now uses the new host.

<sup>Written for commit e3c180fe0ce4e04be68e02e15685a4b89ebf29aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart badge to use the new chart service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->