### PR TITLE
fix(database): stop the set_config guard from matching non-executable text

### DIFF
--- a/backend/src/utils/sql-parser.ts
+++ b/backend/src/utils/sql-parser.ts
@@ -15,6 +15,11 @@ const ROLE_MANAGEMENT_STATEMENTS = new Set([
   'GrantRoleStmt',
 ]);
 const SEARCH_PATH_VARIABLE = 'search_path';
+const SET_CONFIG_FUNCTION = 'set_config';
+// Only applied to function/DO bodies, which the parser hands back as opaque
+// strings. Never run this over the whole query: it cannot tell an executable
+// call from the same characters appearing in a comment, a string literal, or an
+// identifier, and it used to reject all three.
 const SET_CONFIG_PATTERN = /\bset_config\b/i;
 const DATABASE_MANAGEMENT_STATEMENTS = new Set([
   'CreatedbStmt',
@@ -24,11 +29,96 @@ const DATABASE_MANAGEMENT_STATEMENTS = new Set([
   'AlterDatabaseRefreshCollStmt',
 ]);
 
-function getRawTextGuardError(query: string): string | null {
-  if (SET_CONFIG_PATTERN.test(query)) {
-    return 'Changing SQL session configuration is not allowed.';
+/**
+ * True when a parsed `funcname` list resolves to `set_config`, regardless of
+ * schema qualification or quoting (`set_config`, `pg_catalog.set_config`,
+ * `pg_catalog."set_config"`).
+ */
+function isSetConfigName(funcname: unknown): boolean {
+  if (!Array.isArray(funcname) || funcname.length === 0) {
+    return false;
   }
+  const last = funcname[funcname.length - 1] as Record<string, unknown> | undefined;
+  const stringNode = last?.String as Record<string, unknown> | undefined;
+  return (
+    typeof stringNode?.sval === 'string' && stringNode.sval.toLowerCase() === SET_CONFIG_FUNCTION
+  );
+}
 
+/**
+ * Walk a parse-tree node for a `set_config()` *call*.
+ *
+ * Matching the call node rather than the text keeps every evasion covered — the
+ * variable name may be a cast, a parameter, or a concatenation (`set_config($1,
+ * …)`, `set_config('ro' || 'le', …)`), none of which can be resolved statically,
+ * which is why `set_config` is refused outright rather than gated on its first
+ * argument. It also stops a `ColumnRef` of the same name from matching.
+ */
+function containsSetConfigCall(node: unknown): boolean {
+  if (Array.isArray(node)) {
+    return node.some(containsSetConfigCall);
+  }
+  if (node === null || typeof node !== 'object') {
+    return false;
+  }
+  const record = node as Record<string, unknown>;
+  const funcCall = record.FuncCall as Record<string, unknown> | undefined;
+  if (funcCall && isSetConfigName(funcCall.funcname)) {
+    return true;
+  }
+  return Object.values(record).some(containsSetConfigCall);
+}
+
+/**
+ * Collect function and `DO` bodies, which the parser returns as opaque strings
+ * (`DefElem` with `defname: 'as'`). Their contents are never parsed, so they are
+ * the one place a text scan is still required — otherwise a `SECURITY DEFINER`
+ * body could carry `set_config('role', …)` straight past the AST check.
+ */
+function collectOpaqueBodies(node: unknown, bodies: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectOpaqueBodies(child, bodies));
+    return bodies;
+  }
+  if (node === null || typeof node !== 'object') {
+    return bodies;
+  }
+  const record = node as Record<string, unknown>;
+  const defElem = record.DefElem as Record<string, unknown> | undefined;
+  if (defElem && String(defElem.defname).toLowerCase() === 'as') {
+    collectStringValues(defElem.arg, bodies);
+  }
+  Object.values(record).forEach((child) => collectOpaqueBodies(child, bodies));
+  return bodies;
+}
+
+function collectStringValues(node: unknown, out: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectStringValues(child, out));
+    return;
+  }
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  const record = node as Record<string, unknown>;
+  const stringNode = record.String as Record<string, unknown> | undefined;
+  if (typeof stringNode?.sval === 'string') {
+    out.push(stringNode.sval);
+  }
+  Object.values(record).forEach((child) => collectStringValues(child, out));
+}
+
+function getSetConfigError(stmt: Record<string, unknown>): string | null {
+  if (containsSetConfigCall(stmt)) {
+    return 'Changing SQL session configuration is not allowed: set_config() may not be called.';
+  }
+  const offendingBody = collectOpaqueBodies(stmt).find((body) => SET_CONFIG_PATTERN.test(body));
+  if (offendingBody !== undefined) {
+    return (
+      'Changing SQL session configuration is not allowed: set_config appears inside a ' +
+      'function or DO body, which is not parsed and so cannot be verified.'
+    );
+  }
   return null;
 }
 
@@ -127,17 +217,20 @@ function extractChange(stmt: Record<string, unknown>): DatabaseResourceUpdate | 
 }
 
 export function checkSqlExecutionGuards(query: string): string | null {
-  const rawTextError = getRawTextGuardError(query);
-  if (rawTextError) {
-    return rawTextError;
-  }
-
   try {
     const { stmts } = parseSync(query);
 
     for (const stmtWrapper of stmts) {
       const stmt = stmtWrapper.stmt as Record<string, unknown>;
       const [stmtType, data] = Object.entries(stmt)[0] as [string, Record<string, unknown>];
+
+      // Checked per statement on the parse tree rather than over the raw query
+      // text, so a comment, string literal, or column named `set_config` no
+      // longer trips the guard. An unparseable query is still rejected below.
+      const setConfigError = getSetConfigError(stmt);
+      if (setConfigError) {
+        return setConfigError;
+      }
 
       if (DATABASE_MANAGEMENT_STATEMENTS.has(stmtType)) {
         return 'Query contains restricted operations';

--- a/backend/tests/unit/sql-parser.test.ts
+++ b/backend/tests/unit/sql-parser.test.ts
@@ -101,6 +101,53 @@ describe('SQL execution guards', () => {
     expect(checkSqlExecutionGuards("SELECT set_config('app.safe', 'value', false)")).not.toBeNull();
   });
 
+  it('still blocks set_config hidden in a function or DO body', () => {
+    // Bodies are opaque to the parser, so a text scan remains the only check
+    // available there. Without it a SECURITY DEFINER function is an escalation
+    // path: the body runs as the definer.
+    expect(
+      checkSqlExecutionGuards(
+        "CREATE FUNCTION esc() RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$ BEGIN PERFORM set_config('role', 'postgres', false); END $$"
+      )
+    ).not.toBeNull();
+    expect(
+      checkSqlExecutionGuards(
+        "DO $$ BEGIN PERFORM set_config('role', 'postgres', false); END $$"
+      )
+    ).not.toBeNull();
+  });
+
+  it('does not treat the characters "set_config" as a call outside executable code', () => {
+    // Previously a /\bset_config\b/i scan ran over the whole query text, so any
+    // occurrence was rejected — including ones that cannot change anything.
+    expect(checkSqlExecutionGuards('-- deliberately avoid set_config here\nSELECT 1')).toBeNull();
+    expect(checkSqlExecutionGuards('/* set_config */ SELECT 1')).toBeNull();
+    expect(checkSqlExecutionGuards("SELECT 'set_config'")).toBeNull();
+    expect(checkSqlExecutionGuards('SELECT set_config FROM audit_log')).toBeNull();
+    expect(checkSqlExecutionGuards('SELECT id AS set_config FROM audit_log')).toBeNull();
+    expect(checkSqlExecutionGuards('CREATE TABLE t (set_config text)')).toBeNull();
+  });
+
+  it('allows SECURITY DEFINER helpers to pin search_path', () => {
+    // The documented RLS pattern. A function's SET clause is part of
+    // CreateFunctionStmt/AlterFunctionStmt, not a VariableSetStmt, so it is not
+    // a session-level change.
+    expect(
+      checkSqlExecutionGuards(
+        "CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE SECURITY DEFINER SET search_path = pg_catalog, public, pg_temp AS $$ SELECT nullif(current_setting('request.jwt.claims', true)::json->>'sub', '')::uuid $$"
+      )
+    ).toBeNull();
+    expect(
+      checkSqlExecutionGuards('ALTER FUNCTION auth.uid() SET search_path = pg_catalog, public')
+    ).toBeNull();
+  });
+
+  it('names set_config as the cause instead of reporting it generically', () => {
+    expect(checkSqlExecutionGuards("SELECT set_config('role', 'postgres', false)")).toContain(
+      'set_config'
+    );
+  });
+
   it('blocks role management statements but allows object grants', () => {
     expect(checkSqlExecutionGuards('CREATE ROLE app_owner')).not.toBeNull();
     expect(

--- a/backend/tests/unit/sql-parser.test.ts
+++ b/backend/tests/unit/sql-parser.test.ts
@@ -111,9 +111,7 @@ describe('SQL execution guards', () => {
       )
     ).not.toBeNull();
     expect(
-      checkSqlExecutionGuards(
-        "DO $$ BEGIN PERFORM set_config('role', 'postgres', false); END $$"
-      )
+      checkSqlExecutionGuards("DO $$ BEGIN PERFORM set_config('role', 'postgres', false); END $$")
     ).not.toBeNull();
   });
 


### PR DESCRIPTION
Closes #1963.

## The report vs. what actually happens

The issue is titled around `SECURITY DEFINER SET search_path` being rejected. That case is **not** blocked on `main` — a function's `SET` clause parses as part of `CreateFunctionStmt`/`AlterFunctionStmt`, never as a `VariableSetStmt`, so the `search_path` branch never sees it. The two regression tests suggested during triage would have passed unchanged.

What actually fired is the raw-text guard at `sql-parser.ts:28`:

```ts
const SET_CONFIG_PATTERN = /\bset_config\b/i;
```

tested against the whole query **before parsing**. A text scan cannot distinguish an executable call from the same characters appearing somewhere harmless, so all of these were rejected:

| SQL | `main` | this PR |
|---|---|---|
| `-- deliberately avoid set_config here` + `SELECT 1` | blocked | allowed |
| `/* set_config */ SELECT 1` | blocked | allowed |
| `SELECT 'set_config'` | blocked | allowed |
| `SELECT set_config FROM audit_log` | blocked | allowed |
| `CREATE TABLE t (set_config text)` | blocked | allowed |
| `SELECT set_config('role','postgres',false)` | blocked | **blocked** |
| `set_config('role',…)` inside a `SECURITY DEFINER` body | blocked | **blocked** |
| `CREATE FUNCTION … SECURITY DEFINER SET search_path = …` | allowed | allowed |

All of them reported `Changing SQL session configuration is not allowed.` — naming a cause that had not occurred. That wording is why the report was filed against `SET search_path`: the reporter's migration almost certainly called `set_config(…, true)` inside a definer body, which is transaction-local and is the same thing the backend itself does in `user-context.service.ts` (`SELECT set_config($1, $2, true)`).

## The change

The check now runs per statement on the parse tree:

- **`set_config` is matched on the `FuncCall` node**, not on text. Every evasion the existing tests pin stays blocked, because they are all still `FuncCall`s — `'role'::text`, `$1`, `'ro' || 'le'`, `pg_catalog.set_config`, `pg_catalog."set_config"`.
- **It remains an outright refusal, not a check on the first argument.** That argument can be a parameter, a cast, or a concatenation, so it cannot be resolved statically — which is the reason the blanket ban exists. `set_config('app.safe', …)` stays blocked, as its existing test requires.
- **Function and `DO` bodies are collected from the tree and still scanned as text.** Bodies are opaque to the parser, so this is the one place a text scan is load-bearing: without it a `SECURITY DEFINER` body could carry `set_config('role', …)` past the AST check and run as the definer.
- **A `ColumnRef` named `set_config` no longer matches**, since it is not a call.
- The message names `set_config` and says whether it was found as a call or inside an unparsed body.

Dropping the pre-parse scan opens no gap: an unparseable query is still rejected by the existing `catch`.

Net effect for the three reporting users: the false positives disappear and the error names the real cause. `set_config` inside a definer body is still refused — deliberately, per the point above.

## Tests

`backend/tests/unit/sql-parser.test.ts` — **18 pass**. No existing guard test changed.

Four added:

- `still blocks set_config hidden in a function or DO body` — the escalation path; passes on `main` too, pinning behaviour that must not move.
- `does not treat the characters "set_config" as a call outside executable code` — **fails on `main`**.
- `allows SECURITY DEFINER helpers to pin search_path` — passes on `main`; pins the case in the issue title so it cannot regress.
- `names set_config as the cause instead of reporting it generically` — **fails on `main`**.

## Validation

- `npx turbo run typecheck lint` — 13/13 tasks pass.
- `npx turbo run test` — 2373 pass, 0 fail.
- `npx eslint` on both changed files — clean.

Two notes for reviewers:

- One full run showed a failure in a rate-limiter test (`buildApp(functionsWriteLimiter)`); it passes on a clean re-run and is unrelated to this change — it looks timing-sensitive under parallel turbo load.
- `agentkeepalive` is declared in `backend/package.json` but was missing from my `node_modules`, failing `tsc` in `postgrest-proxy.service.ts`. Installed locally with `--no-save`; no manifest changes in this PR.

**I could not run the `e2e-testing` gate.** It dispatches workflows on `InsForge/InsForge` and `InsForge/agent-e2e`, both of which need write access I don't have as an outside contributor. Happy to act on anything it surfaces if a maintainer runs it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the SQL guard from rejecting non-executable occurrences of set_config by replacing the raw-text regex with a per-statement AST check. This removes false positives while still blocking real set_config() calls (including inside SECURITY DEFINER bodies); SET search_path in function definitions remains allowed.

- Matches set_config() on the FuncCall node; comments, string literals, and identifiers named set_config no longer trip the guard.
- Scans opaque function and DO bodies for set_config to prevent escalation via SECURITY DEFINER bodies.
- Improves the error message to name set_config and whether it was a call or inside an unparsed body.
- Keeps other guards unchanged and still rejects unparseable queries.
- Adds tests pinning allowed SET search_path and disallowed set_config; formats test file with Prettier; no migration required, but prior false positives will stop.

<sup>Written for commit f4cffa428ac49d4b462b0849dc1ae084722ec79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL safety checks to reliably detect restricted configuration changes, including qualified or quoted function calls.
  * Prevented false alarms for matching text in comments, string values, identifiers, and column names.
  * Extended protection to SQL functions and `DO` blocks while preserving support for permitted security-definer usage.
  * Security violations now provide more specific error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->