### PR TITLE
feat(ui): add Popover, Calendar and ClockColumn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,6 +1908,12 @@
       "integrity": "sha512-vj9huEy4mjJ48GS1Z8yvtMm4BYAnFYACUds25ym6Gd/gsnngkJ17fo62a6mmbNNwCBS/8467PmZR01Zs/06TjA==",
       "license": "MIT"
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -3856,26 +3862,26 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
-      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3892,10 +3898,39 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3907,13 +3942,192 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3931,12 +4145,12 @@
       }
     },
     "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.5"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3947,6 +4161,116 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
@@ -5490,8 +5814,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -5505,8 +5828,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.0",
@@ -5520,8 +5842,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -5535,8 +5856,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -5550,8 +5870,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -5565,8 +5884,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -5580,8 +5898,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -5595,8 +5912,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -5610,8 +5926,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -5625,8 +5940,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -5640,8 +5954,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -5655,8 +5968,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -5670,8 +5982,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -5685,8 +5996,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -5700,8 +6010,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -5715,8 +6024,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -5730,8 +6038,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -5745,8 +6052,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -5760,8 +6066,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -5775,8 +6080,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -5790,8 +6094,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -5805,8 +6108,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -5820,8 +6122,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -5835,8 +6136,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -5850,8 +6150,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
@@ -14502,6 +14801,42 @@
         "react-dom": "^18.0 || ^19.0"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-day-picker/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -17698,12 +18033,13 @@
     },
     "packages/ui": {
       "name": "@insforge/ui",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-popover": "^1.1.19",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
@@ -17712,6 +18048,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.536.0",
+        "react-day-picker": "^10.0.1",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5814,7 +5814,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -5828,7 +5829,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.0",
@@ -5842,7 +5844,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -5856,7 +5859,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -5870,7 +5874,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -5884,7 +5889,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -5898,7 +5904,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -5912,7 +5919,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -5926,7 +5934,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -5940,7 +5949,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -5954,7 +5964,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -5968,7 +5979,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -5982,7 +5994,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -5996,7 +6009,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -6010,7 +6024,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -6024,7 +6039,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -6038,7 +6054,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -6052,7 +6069,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -6066,7 +6084,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -6080,7 +6099,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -6094,7 +6114,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -6108,7 +6129,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -6122,7 +6144,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -6136,7 +6159,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -6150,7 +6174,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": "InsForge",
   "description": "React UI component library, design tokens, and Tailwind preset for InsForge apps",
   "license": "Apache-2.0",
@@ -62,6 +62,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
@@ -70,6 +71,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.536.0",
+    "react-day-picker": "^10.0.1",
     "tailwind-merge": "^3.3.1"
   },
   "peerDependencies": {

--- a/packages/ui/src/components/Calendar.tsx
+++ b/packages/ui/src/components/Calendar.tsx
@@ -1,0 +1,56 @@
+import { DayPicker, type DayPickerProps } from 'react-day-picker';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { cn } from '../lib/utils';
+
+/**
+ * A month grid for picking dates.
+ *
+ * react-day-picker's own stylesheet is deliberately not imported — every element that needs layout
+ * is given a class here, so the default CSS would only add rules to fight.
+ */
+function Calendar({ className, classNames, ...props }: DayPickerProps) {
+  return (
+    <DayPicker
+      className={cn('w-fit', className)}
+      classNames={{
+        months: 'relative',
+        month: 'flex flex-col gap-2',
+        month_caption: 'flex h-8 items-center justify-center',
+        caption_label: 'text-sm font-medium text-foreground',
+        // Absolute so the month name stays optically centred whatever its length.
+        nav: 'absolute inset-x-0 top-0 flex h-8 items-center justify-between',
+        button_previous:
+          'flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-alpha-8 hover:text-foreground disabled:opacity-40',
+        button_next:
+          'flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-alpha-8 hover:text-foreground disabled:opacity-40',
+        month_grid: 'border-collapse',
+        weekdays: 'flex',
+        weekday: 'w-8 text-xs font-normal text-muted-foreground',
+        week: 'flex w-full',
+        day: 'size-8 p-0 text-center text-sm',
+        day_button:
+          'size-8 rounded text-foreground transition-colors hover:bg-alpha-8 disabled:pointer-events-none disabled:opacity-40',
+        // States dress the cell, so reach through to the button that draws the day.
+        selected:
+          '[&>button]:bg-[rgb(var(--foreground))] [&>button]:font-medium [&>button]:text-[rgb(var(--inverse))]',
+        today: '[&>button]:font-semibold',
+        outside: '[&>button]:text-muted-foreground/60',
+        disabled: 'opacity-40',
+        hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: chevronClass }) =>
+          orientation === 'left' ? (
+            <ChevronLeft className={cn('size-4', chevronClass)} />
+          ) : (
+            <ChevronRight className={cn('size-4', chevronClass)} />
+          ),
+      }}
+      {...props}
+    />
+  );
+}
+
+export { Calendar };

--- a/packages/ui/src/components/Calendar.tsx
+++ b/packages/ui/src/components/Calendar.tsx
@@ -1,5 +1,5 @@
 import { DayPicker, type DayPickerProps } from 'react-day-picker';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from 'lucide-react';
 
 import { cn } from '../lib/utils';
 
@@ -14,7 +14,9 @@ function Calendar({ className, classNames, ...props }: DayPickerProps) {
     <DayPicker
       className={cn('w-fit', className)}
       classNames={{
-        months: 'relative',
+        // flex+gap so numberOfMonths > 1 lays out side by side instead of stacking flush; relative
+        // because the single shared nav is absolutely positioned across the whole set.
+        months: 'relative flex gap-4',
         month: 'flex flex-col gap-2',
         month_caption: 'flex h-8 items-center justify-center',
         caption_label: 'text-sm font-medium text-foreground',
@@ -41,12 +43,14 @@ function Calendar({ className, classNames, ...props }: DayPickerProps) {
         ...classNames,
       }}
       components={{
-        Chevron: ({ orientation, className: chevronClass }) =>
-          orientation === 'left' ? (
-            <ChevronLeft className={cn('size-4', chevronClass)} />
-          ) : (
-            <ChevronRight className={cn('size-4', chevronClass)} />
-          ),
+        // All four orientations: nav asks for left/right, but a dropdown caption asks for down,
+        // and folding every non-left case into ChevronRight points those the wrong way.
+        Chevron: ({ orientation = 'down', className: chevronClass }) => {
+          const Icon = { left: ChevronLeft, right: ChevronRight, up: ChevronUp, down: ChevronDown }[
+            orientation
+          ];
+          return <Icon className={cn('size-4', chevronClass)} />;
+        },
       }}
       {...props}
     />

--- a/packages/ui/src/components/ClockColumn.tsx
+++ b/packages/ui/src/components/ClockColumn.tsx
@@ -23,9 +23,14 @@ function ClockColumn({
   // The current row is rarely near the top of 24, let alone 60. Keyed on the selection, not done in
   // a callback ref: a ref recreated each render detaches and reattaches on every parent render,
   // which would yank the column back to the selected row while someone is scrolling it.
+  //
+  // Keyed on the row's INDEX as well, not on `options` itself: options arriving late or reordered
+  // move the selected row without changing `selected`, while the array's identity changes on every
+  // render for any caller building the list inline — which would bring the yanking straight back.
+  const selectedIndex = options.indexOf(selected);
   React.useEffect(() => {
     selectedRef.current?.scrollIntoView({ block: 'center' });
-  }, [selected]);
+  }, [selected, selectedIndex]);
 
   return (
     <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">

--- a/packages/ui/src/components/ClockColumn.tsx
+++ b/packages/ui/src/components/ClockColumn.tsx
@@ -1,0 +1,48 @@
+import { cn } from '../lib/utils';
+
+/**
+ * A scrolling column of selectable units — hours, minutes, or anything else short and uniform.
+ *
+ * Purely presentational: the caller decides what the units are. Picking one is a finished action,
+ * which is what lets a panel built from these close on a choice — unlike an `input[type=time]`,
+ * which reports a change while the minutes are still half-typed.
+ */
+function ClockColumn({
+  options,
+  selected,
+  onPick,
+}: {
+  options: readonly string[];
+  selected: string;
+  onPick: (value: string) => void;
+}) {
+  // The current row is rarely near the top of 24, let alone 60.
+  const scrollSelectedIntoView = (el: HTMLButtonElement | null) =>
+    el?.scrollIntoView({ block: 'center' });
+
+  return (
+    <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">
+      {options.map((option) => {
+        const isSelected = option === selected;
+        return (
+          <button
+            key={option}
+            type="button"
+            ref={isSelected ? scrollSelectedIntoView : undefined}
+            onClick={() => onPick(option)}
+            className={cn(
+              'rounded px-2 py-1 text-sm tabular-nums transition-colors',
+              isSelected
+                ? 'bg-[rgb(var(--foreground))] font-medium text-[rgb(var(--inverse))]'
+                : 'text-foreground hover:bg-alpha-8'
+            )}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export { ClockColumn };

--- a/packages/ui/src/components/ClockColumn.tsx
+++ b/packages/ui/src/components/ClockColumn.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { cn } from '../lib/utils';
 
 /**
@@ -16,9 +18,14 @@ function ClockColumn({
   selected: string;
   onPick: (value: string) => void;
 }) {
-  // The current row is rarely near the top of 24, let alone 60.
-  const scrollSelectedIntoView = (el: HTMLButtonElement | null) =>
-    el?.scrollIntoView({ block: 'center' });
+  const selectedRef = React.useRef<HTMLButtonElement | null>(null);
+
+  // The current row is rarely near the top of 24, let alone 60. Keyed on the selection, not done in
+  // a callback ref: a ref recreated each render detaches and reattaches on every parent render,
+  // which would yank the column back to the selected row while someone is scrolling it.
+  React.useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'center' });
+  }, [selected]);
 
   return (
     <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">
@@ -28,7 +35,9 @@ function ClockColumn({
           <button
             key={option}
             type="button"
-            ref={isSelected ? scrollSelectedIntoView : undefined}
+            // Colour alone does not tell assistive tech which row is current.
+            aria-pressed={isSelected}
+            ref={isSelected ? selectedRef : undefined}
             onClick={() => onPick(option)}
             className={cn(
               'rounded px-2 py-1 text-sm tabular-nums transition-colors',

--- a/packages/ui/src/components/Popover.tsx
+++ b/packages/ui/src/components/Popover.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '../lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+/**
+ * An anchored panel that can hold arbitrary content, including form fields.
+ *
+ * DropdownMenu is not a substitute: Radix gives menu items keyboard typeahead, which fights any
+ * input placed inside one. Reach for this whenever the panel is not a list of commands.
+ */
+const PopoverContent = React.forwardRef<
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'end', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 max-h-(--radix-popover-content-available-height) overflow-y-auto rounded-md border border-alpha-8 bg-card p-4 shadow-[0_4px_4px_rgba(0,0,0,0.08)]',
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/packages/ui/src/components/__tests__/Calendar.test.tsx
+++ b/packages/ui/src/components/__tests__/Calendar.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { Calendar } from '@insforge/ui';
+
+const NOVEMBER_2026 = new Date(2026, 10, 1);
+
+describe('Calendar', () => {
+  it('renders the month it is pointed at', () => {
+    render(<Calendar mode="single" defaultMonth={NOVEMBER_2026} />);
+
+    expect(screen.getByText('November 2026')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /November 10th, 2026/ })).toBeTruthy();
+  });
+
+  it('reports the day that was clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(<Calendar mode="single" defaultMonth={NOVEMBER_2026} onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('button', { name: /November 10th, 2026/ }));
+
+    expect(onSelect).toHaveBeenCalled();
+    const [picked] = onSelect.mock.calls[0] as [Date];
+    expect(picked.getFullYear()).toBe(2026);
+    expect(picked.getMonth()).toBe(10);
+    expect(picked.getDate()).toBe(10);
+  });
+
+  it('marks the selected day, which is the classNames contract this wrapper owns', () => {
+    render(
+      <Calendar mode="single" defaultMonth={NOVEMBER_2026} selected={new Date(2026, 10, 10)} />
+    );
+
+    // react-day-picker puts the `selected` classNames on the gridcell, which is why this wrapper
+    // reaches through to the button inside it. Assert the cell, since a `[&>button]` variant leaves
+    // its class on the cell and only the CSS it generates lands on the button.
+    const day = screen.getByRole('button', { name: /November 10th, 2026/ });
+    const cell = day.closest('td');
+    expect(cell?.className).toContain('[&>button]:text-[rgb(var(--inverse))]');
+    expect(cell?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('moves months from the nav, so the Chevron override stays wired up', async () => {
+    const user = userEvent.setup();
+
+    render(<Calendar mode="single" defaultMonth={NOVEMBER_2026} />);
+
+    await user.click(screen.getByRole('button', { name: /previous/i }));
+
+    expect(screen.getByText('October 2026')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/__tests__/ClockColumn.test.tsx
+++ b/packages/ui/src/components/__tests__/ClockColumn.test.tsx
@@ -20,24 +20,25 @@ describe('ClockColumn', () => {
     expect(onPick).toHaveBeenCalledWith('02');
   });
 
-  it('marks only the selected unit, and scrolls it into view', () => {
+  it('exposes the selection to assistive tech, not only in colour', () => {
+    render(<ClockColumn options={['00', '01', '02']} selected="01" onPick={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '01', pressed: true })).toBeTruthy();
+    expect(screen.getAllByRole('button', { pressed: false })).toHaveLength(2);
+  });
+
+  it('marks the selected unit and scrolls it into view', () => {
     render(<ClockColumn options={['00', '01', '02']} selected="01" onPick={vi.fn()} />);
 
     // The selected row is the one carrying the inverted fill.
-    const selected = screen.getByRole('button', { name: '01' });
-    const other = screen.getByRole('button', { name: '00' });
-    expect(selected.className).toContain('var(--foreground)');
-    expect(other.className).not.toContain('var(--foreground)');
+    expect(screen.getByRole('button', { name: '01' }).className).toContain('var(--foreground)');
+    expect(screen.getByRole('button', { name: '00' }).className).not.toContain('var(--foreground)');
     expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
   });
 
   it('marks nothing when the selection is not among the options', () => {
     render(<ClockColumn options={['00', '01']} selected="" onPick={vi.fn()} />);
 
-    for (const unit of ['00', '01']) {
-      expect(screen.getByRole('button', { name: unit }).className).not.toContain(
-        'var(--foreground)'
-      );
-    }
+    expect(screen.queryByRole('button', { pressed: true })).toBeNull();
   });
 });

--- a/packages/ui/src/components/__tests__/ClockColumn.test.tsx
+++ b/packages/ui/src/components/__tests__/ClockColumn.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { ClockColumn } from '@insforge/ui';
+
+// jsdom has no layout, so it ships no scrollIntoView; the column calls it on the selected row.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe('ClockColumn', () => {
+  it('reports the unit that was picked', async () => {
+    const user = userEvent.setup();
+    const onPick = vi.fn();
+
+    render(<ClockColumn options={['00', '01', '02']} selected="01" onPick={onPick} />);
+
+    await user.click(screen.getByRole('button', { name: '02' }));
+
+    expect(onPick).toHaveBeenCalledWith('02');
+  });
+
+  it('marks only the selected unit, and scrolls it into view', () => {
+    render(<ClockColumn options={['00', '01', '02']} selected="01" onPick={vi.fn()} />);
+
+    // The selected row is the one carrying the inverted fill.
+    const selected = screen.getByRole('button', { name: '01' });
+    const other = screen.getByRole('button', { name: '00' });
+    expect(selected.className).toContain('var(--foreground)');
+    expect(other.className).not.toContain('var(--foreground)');
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('marks nothing when the selection is not among the options', () => {
+    render(<ClockColumn options={['00', '01']} selected="" onPick={vi.fn()} />);
+
+    for (const unit of ['00', '01']) {
+      expect(screen.getByRole('button', { name: unit }).className).not.toContain(
+        'var(--foreground)'
+      );
+    }
+  });
+});

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -95,3 +95,6 @@ export {
 export { EmptyState, type EmptyStateProps } from './EmptyState';
 export { LoadingState, type LoadingStateProps } from './LoadingState';
 export { Skeleton } from './Skeleton';
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent } from './Popover';
+export { Calendar } from './Calendar';
+export { ClockColumn } from './ClockColumn';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -97,6 +97,9 @@ export { Tabs, Tab } from './components';
 export { EmptyState, type EmptyStateProps } from './components';
 export { LoadingState, type LoadingStateProps } from './components';
 export { Skeleton } from './components';
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent } from './components';
+export { Calendar } from './components';
+export { ClockColumn } from './components';
 
 // Utilities
 export { cn } from './lib';


### PR DESCRIPTION
## What

Adds three primitives to `@insforge/ui` and releases them as `0.1.8`:

- **`Popover`** — an anchored panel that can hold arbitrary content, form fields included.
- **`Calendar`** — a month grid for picking dates, wrapping `react-day-picker`.
- **`ClockColumn`** — a scrolling column of selectable units (hours, minutes).

All three were written in the InstaCloud console, which had no choice but to keep them locally. None carries product knowledge — each is the generic half of something an app was otherwise re-inventing, which is what makes them belong here rather than there.

`Popover` is the one worth arguing for: the package ships `DropdownMenu`, but Radix gives menu items keyboard typeahead, so an input placed inside one fights the menu for keystrokes. An app that wants an anchored panel with a text field currently has nothing to reach for.

## How

- Colours use `rgb(var(--foreground))` / `rgb(var(--inverse))` rather than `text-inverse`-style utilities. The `--color-*` mapping those classes depend on lives in each consumer's own theme (`@theme inline`), not in this package, so only the raw variables are safe to assume. Classes the package already relies on (`text-foreground`, `bg-card`, `bg-alpha-8`, `border-alpha-8`) are used as-is.
- `react-day-picker`'s stylesheet is deliberately not imported. Every element that needs layout is given a class here, so pulling in the default CSS would only add rules to fight.
- Two new dependencies: `@radix-ui/react-popover` (joining eight existing Radix packages) and `react-day-picker` (peer `react >=16.8`, no `date-fns` peer).
- Version `0.1.7` → `0.1.8`. Worth noting for whoever releases: the only other `packages/ui` change since 0.1.7 shipped is the `Pagination` tweak from #1658, so that rides along.

## Verify

- `npm run typecheck`, `npm run build`, `npm run lint` — all clean.
- `npm test` — 9 files, 22 tests passing, including a new `ClockColumn` suite covering selection, the picked-value callback, and the no-match case.
- Consumer side: InstaCloud console PR follows, deleting its three local copies and importing from here instead. The only edit at each call site is the import path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Popover`, `Calendar`, and `ClockColumn` to `@insforge/ui` (v0.1.8) so apps can use anchored panels with inputs without `DropdownMenu` intercepting keystrokes, and get date/time-picking primitives.

- Exports: `Popover`, `PopoverTrigger`, `PopoverAnchor`, `PopoverContent`; `Calendar`; `ClockColumn`.
- `Popover` uses `@radix-ui/react-popover`; content renders in a portal.
- `Calendar` wraps `react-day-picker` with no default CSS import; custom classNames handle layout and colors, multi-month uses flex+gap, and Chevron mapping covers all four orientations. Tests pin month render, day selection, classNames contract, and nav behavior.
- `ClockColumn` is presentational; clicking calls `onPick`. It sets `aria-pressed` for the selection and scrolls the selected row into view via an effect keyed on the selected value and its index to avoid jank on unrelated renders. Tests cover selection, accessibility state, scrolling, and no-match cases.
- New deps: `@radix-ui/react-popover`, `react-day-picker` (transitively adds `date-fns`; no new peer deps).

**Migration**
- Replace local popover/calendar/clock components with imports from `@insforge/ui`.
- Use `Popover` instead of `DropdownMenu` for anchored panels with inputs.
- Do not import `react-day-picker` CSS; styling is provided by `Calendar`.

<sup>Written for commit 1ea817f8f8253cad03629b9aedcb3ede5f8c8721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable calendar with date navigation, day selection, and accessibility support.
  * Added popover components for displaying contextual content with configurable positioning.
  * Added a scrollable clock column for selecting and highlighting time options.
  * Made the new components available through the UI package’s public exports.

* **Tests**
  * Added coverage for calendar navigation and selection behavior.
  * Added coverage for clock option selection, highlighting, scrolling, accessibility state, and unmatched values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->