### PR TITLE
fix(openapi): add cloud Subhosting 404 variant to function invoke spec

### DIFF
--- a/openapi/functions.yaml
+++ b/openapi/functions.yaml
@@ -622,12 +622,14 @@ components:
   responses:
     RuntimeFunctionNotFound:
       description: |
-        Function invocation can return two runtime-driven 404 variants.
-        - application/json: Returned when the path matches the documented slug
-          pattern but no active function exists for that slug.
-        - text/plain: Returned by the runtime catch-all when the request path does
-          not match the slug route at all (non-conformant path shape).
-        Consumers should branch by Content-Type at runtime.
+        Function invocation can return three runtime-driven 404 variants, and the
+        body is whatever the runtime produces, forwarded unchanged.
+        - application/json, cloud (Deno Subhosting): {"error":"Function not found"}
+        - application/json, self-hosted local runtime: {"error":"Function not found or not active"}
+        - text/plain: returned by the local runtime catch-all when the path does
+          not match the slug route at all.
+        Branch on Content-Type to separate text from JSON, and do NOT match on the
+        JSON message; it differs by deployment mode.
       content:
         application/json:
           schema:
@@ -635,8 +637,15 @@ components:
             properties:
               error:
                 type: string
-          example:
-            error: "Function not found or not active"
+          examples:
+            selfHosted:
+              summary: Self-hosted local runtime
+              value:
+                error: "Function not found or not active"
+            cloud:
+              summary: Cloud (Deno Subhosting) runtime
+              value:
+                error: "Function not found"
         text/plain:
           schema:
             type: string


### PR DESCRIPTION
Closes #1979

## Summary

The function invoke 404 response has a third body shape on cloud deployments (Deno Subhosting router) that wasn't documented, causing generated clients to reject it.

## What changed

Updated `components/responses/RuntimeFunctionNotFound` in `openapi/functions.yaml`:
- Documents all three 404 variants (self-hosted JSON, cloud JSON, plain text)
- Uses `examples:` (plural) for the two JSON variants so clients can see both shapes
- Description clarifies that branching on Content-Type separates text from JSON, but the JSON message differs by deployment mode

## Acceptance criteria

- `RuntimeFunctionNotFound` documents the cloud JSON body (`{"error":"Function not found"}`)
- It no longer implies Content-Type alone distinguishes all variants
- Both JSON examples are listed under `examples:` instead of a single `example:`
- `swagger-cli validate openapi/functions.yaml` passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the cloud Subhosting 404 response for function invocation so generated clients accept it. Previously the spec listed two variants and implied Content-Type alone distinguished them; now it lists three and clarifies that the JSON message differs by deployment.

- Updates `components/responses/RuntimeFunctionNotFound` in `openapi/functions.yaml` to include the cloud JSON body and use `examples:` for both JSON shapes.
- Clarifies that clients should branch on Content-Type (text vs JSON) and not on the JSON message string.
- Keeps the `text/plain` variant for non-conformant paths.
- Spec-only change; `swagger-cli validate openapi/functions.yaml` passes.

**Migration**
- If your client matched the exact JSON error message, update it to accept both variants or ignore the message and rely on Content-Type.

<sup>Written for commit 51521178e56754f0a09fd5eee2a24b4064328942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for runtime-driven 404 responses.
  * Added separate examples for cloud, self-hosted, and plain-text error formats.
  * Clarified that clients should use the `Content-Type` header to distinguish response variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->