### PR TITLE
fix(advisor): recommend FK index columns in constraint order

### DIFF
--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -452,11 +452,21 @@ CREATE POLICY "allow_insert" ON %I.%I FOR INSERT TO authenticated WITH CHECK (au
             'performance' AS category,
             'Foreign key column missing index' AS title,
             'A foreign key column has no covering index. JOINs require full table scans, and deleting or updating rows in the referenced table scans the whole referencing table.' AS description,
+            -- Column order is load-bearing. The join below compares conkey to the
+            -- index prefix as an array, so it only clears when an index leads with
+            -- the FK columns in declaration order. Ordering by conkey ordinality
+            -- keeps the printed columns in that same order; a plain pg_attribute
+            -- scan returns attnum order, which for a FK declared out of column
+            -- order names an index that never satisfies the check.
             format($d$Column %s on table %I.%I is a foreign key (%s) but has no index. JOINs require full table scans, and deleting or updating rows in the referenced table requires scanning the entire referencing table — potentially acquiring locks that block writes.$d$,
-              (SELECT string_agg(quote_ident(a.attname), ', ') FROM pg_attribute a WHERE a.attrelid = fk.table_oid AND a.attnum = ANY(fk.col_attnums)),
+              (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+                 FROM unnest(fk.col_attnums) WITH ORDINALITY AS k(attnum, ord)
+                 JOIN pg_catalog.pg_attribute a ON a.attrelid = fk.table_oid AND a.attnum = k.attnum),
               fk.schema_name, fk.table_name, fk.fkey_name) AS detail,
             format($r$CREATE INDEX CONCURRENTLY ON %I.%I (%s);$r$, fk.schema_name, fk.table_name,
-              (SELECT string_agg(quote_ident(a.attname), ', ') FROM pg_attribute a WHERE a.attrelid = fk.table_oid AND a.attnum = ANY(fk.col_attnums))
+              (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+                 FROM unnest(fk.col_attnums) WITH ORDINALITY AS k(attnum, ord)
+                 JOIN pg_catalog.pg_attribute a ON a.attrelid = fk.table_oid AND a.attnum = k.attnum)
             ) AS remediation
           FROM foreign_keys fk
           LEFT JOIN index_ idx ON fk.table_oid = idx.table_oid

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -424,7 +424,18 @@ CREATE POLICY "allow_insert" ON %I.%I FOR INSERT TO authenticated WITH CHECK (au
               cl.relname AS table_name,
               cl.oid AS table_oid,
               ct.conname AS fkey_name,
-              ct.conkey AS col_attnums
+              ct.conkey AS col_attnums,
+              -- Column order is load-bearing. The join below compares conkey to
+              -- the index prefix as an array, so a finding only clears when an
+              -- index leads with the FK columns in declaration order. Ordering by
+              -- conkey ordinality keeps the printed columns in that same order; a
+              -- plain pg_attribute scan returns attnum order, which for a FK
+              -- declared out of column order names an index that never satisfies
+              -- the check. Built once so detail and remediation cannot drift.
+              (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
+                 FROM unnest(ct.conkey) WITH ORDINALITY AS k(attnum, ord)
+                 JOIN pg_catalog.pg_attribute a
+                   ON a.attrelid = cl.oid AND a.attnum = k.attnum) AS col_names
             FROM pg_catalog.pg_constraint ct
             JOIN pg_catalog.pg_class cl ON ct.conrelid = cl.oid
             JOIN pg_catalog.pg_namespace ns ON cl.relnamespace = ns.oid
@@ -452,21 +463,11 @@ CREATE POLICY "allow_insert" ON %I.%I FOR INSERT TO authenticated WITH CHECK (au
             'performance' AS category,
             'Foreign key column missing index' AS title,
             'A foreign key column has no covering index. JOINs require full table scans, and deleting or updating rows in the referenced table scans the whole referencing table.' AS description,
-            -- Column order is load-bearing. The join below compares conkey to the
-            -- index prefix as an array, so it only clears when an index leads with
-            -- the FK columns in declaration order. Ordering by conkey ordinality
-            -- keeps the printed columns in that same order; a plain pg_attribute
-            -- scan returns attnum order, which for a FK declared out of column
-            -- order names an index that never satisfies the check.
             format($d$Column %s on table %I.%I is a foreign key (%s) but has no index. JOINs require full table scans, and deleting or updating rows in the referenced table requires scanning the entire referencing table — potentially acquiring locks that block writes.$d$,
-              (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
-                 FROM unnest(fk.col_attnums) WITH ORDINALITY AS k(attnum, ord)
-                 JOIN pg_catalog.pg_attribute a ON a.attrelid = fk.table_oid AND a.attnum = k.attnum),
+              fk.col_names,
               fk.schema_name, fk.table_name, fk.fkey_name) AS detail,
             format($r$CREATE INDEX CONCURRENTLY ON %I.%I (%s);$r$, fk.schema_name, fk.table_name,
-              (SELECT string_agg(quote_ident(a.attname), ', ' ORDER BY k.ord)
-                 FROM unnest(fk.col_attnums) WITH ORDINALITY AS k(attnum, ord)
-                 JOIN pg_catalog.pg_attribute a ON a.attrelid = fk.table_oid AND a.attnum = k.attnum)
+              fk.col_names
             ) AS remediation
           FROM foreign_keys fk
           LEFT JOIN index_ idx ON fk.table_oid = idx.table_oid

--- a/backend/tests/integration/advisor-fk-index.test.ts
+++ b/backend/tests/integration/advisor-fk-index.test.ts
@@ -1,0 +1,129 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
+import { getConnections } from './utils';
+
+/**
+ * The missing-fk-index rule against a real migrated database.
+ *
+ * The rule clears a finding by comparing the constraint's conkey to the leading
+ * columns of an index as an array, so the match is order-sensitive. The
+ * remediation it prints therefore has to name the FK columns in that same
+ * declaration order. This suite pins the whole loop: what the rule recommends,
+ * that the other order does not satisfy it, and that the recommended order does.
+ *
+ * The service reads connection settings from the environment at module load, so
+ * env is pointed at the isolated pgsql-test database before it is imported.
+ */
+
+type AdvisorService =
+  typeof import('../../src/services/database/database-advisor.service').DatabaseAdvisorService;
+type ManagerModule = typeof import('../../src/infra/database/database.manager').DatabaseManager;
+
+let teardown: (() => Promise<void>) | undefined;
+let svc: InstanceType<AdvisorService>;
+let dbManager: InstanceType<ManagerModule>;
+
+// A composite foreign key declared out of column order: organization_id is
+// attnum 2 and resource_id is attnum 3, but the constraint lists resource_id
+// first, so conkey is {3,2} while a plain pg_attribute scan yields {2,3}.
+const FK_OBJECT = 'public.assignments.assignments_resource_fkey';
+
+async function query<T extends Record<string, unknown>>(sql: string, params: unknown[] = []) {
+  const result = await dbManager.getPool().query(sql, params);
+  return result.rows as T[];
+}
+
+/** Runs one scan to completion and returns its missing-fk-index finding, if any. */
+async function scanForFkFinding(): Promise<{ description: string; recommendation: string } | null> {
+  const scanId = await svc.triggerScan('manual');
+
+  const deadline = Date.now() + 60_000;
+  while (svc.isScanInProgress() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (svc.isScanInProgress()) {
+    throw new Error('advisor scan did not finish in time');
+  }
+
+  const rows = await query<{ description: string; recommendation: string }>(
+    `SELECT description, recommendation
+       FROM system.advisor_findings
+      WHERE scan_id = $1 AND rule_id = 'missing-fk-index' AND affected_object = $2`,
+    [scanId, FK_OBJECT]
+  );
+  return rows[0] ?? null;
+}
+
+beforeAll(async () => {
+  const conn = await getConnections();
+  teardown = conn.teardown;
+  const cfg = conn.pg.config;
+
+  process.env.POSTGRES_HOST = String(cfg.host ?? 'localhost');
+  process.env.POSTGRES_PORT = String(cfg.port ?? 5432);
+  process.env.POSTGRES_DB = String(cfg.database);
+  process.env.POSTGRES_USER = String(cfg.user ?? 'postgres');
+  process.env.POSTGRES_PASSWORD = String(cfg.password ?? 'postgres');
+
+  const { DatabaseManager } = await import('../../src/infra/database/database.manager');
+  const { DatabaseAdvisorService } =
+    await import('../../src/services/database/database-advisor.service');
+  dbManager = DatabaseManager.getInstance();
+  await dbManager.initialize();
+  svc = DatabaseAdvisorService.getInstance();
+
+  await query(`
+    CREATE TABLE public.resources (
+      organization_id uuid NOT NULL,
+      resource_id     uuid NOT NULL,
+      UNIQUE (resource_id, organization_id)
+    );
+
+    CREATE TABLE public.assignments (
+      id              uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      resource_id     uuid NOT NULL,
+      CONSTRAINT assignments_resource_fkey
+        FOREIGN KEY (resource_id, organization_id)
+        REFERENCES public.resources (resource_id, organization_id)
+    );
+  `);
+}, 180_000);
+
+afterAll(async () => {
+  await dbManager?.close();
+  await teardown?.();
+});
+
+describe('advisor missing-fk-index column order', () => {
+  it('recommends the FK columns in declaration order, not attnum order', async () => {
+    const finding = await scanForFkFinding();
+
+    expect(finding).not.toBeNull();
+    // attnum order would read "organization_id, resource_id" and name an index
+    // that never clears the finding.
+    expect(finding?.recommendation).toContain('(resource_id, organization_id)');
+    expect(finding?.description).toContain('resource_id, organization_id');
+  }, 90_000);
+
+  it('is not satisfied by an index in the opposite column order', async () => {
+    await query(`CREATE INDEX assignments_wrong_order
+                   ON public.assignments (organization_id, resource_id)`);
+
+    // This is the reported symptom: the index the old remediation named is a
+    // perfectly good query index, but it does not cover the constraint.
+    expect(await scanForFkFinding()).not.toBeNull();
+  }, 90_000);
+
+  it('clears once its own recommendation is followed verbatim', async () => {
+    const finding = await scanForFkFinding();
+    expect(finding).not.toBeNull();
+
+    // Run exactly what the advisor printed. CONCURRENTLY is dropped only
+    // because it cannot run inside the test transaction; the column list, which
+    // is what this is about, is used as-is.
+    const recommended = finding!.recommendation.replace('CONCURRENTLY ', '');
+    await query(recommended);
+
+    expect(await scanForFkFinding()).toBeNull();
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

Closes #1982.

The `missing-fk-index` rule clears a finding by comparing the constraint's `conkey` to an index's leading columns as an array:

```sql
AND fk.col_attnums = idx.col_attnums[1:array_length(fk.col_attnums, 1)]
```

That match is order-sensitive. The remediation it printed, however, came from a plain `pg_attribute` scan, which returns **attnum order**, not constraint order.

For a foreign key declared out of column order the two disagree. With `organization_id` at attnum 2 and `resource_id` at attnum 3, a `FOREIGN KEY (resource_id, organization_id)` has `conkey = {3,2}`, and the advisor printed:

```
CREATE INDEX CONCURRENTLY ON public.assignments (organization_id, resource_id);
```

That index is a perfectly good query index, but it does not cover the constraint, so the finding survived and the advisor looked like it was ignoring its own advice. This is exactly what the reporter hit, down to keeping both indexes as a workaround.

Both the `detail` and the `remediation` now order the columns by `conkey` ordinality, so what is printed is what the check accepts.

## Notes for the reviewer

- The fix mirrors the ordered form already used by the cloud collector, as the triage note suggested.
- Only the two printed column lists change. The detection logic, severity, and the `LEFT JOIN` that decides whether a finding fires are untouched, so no finding starts or stops firing as a result of this change; only the text changes for FKs declared out of column order. A FK whose columns are already in ascending attnum order prints exactly what it printed before.
- `string_agg` without `ORDER BY` was also unordered in principle, not just wrong in this case, so this makes the output deterministic rather than dependent on scan order.

## How did you test this change?

New `backend/tests/integration/advisor-fk-index.test.ts`, which drives the real `DatabaseAdvisorService` against a real migrated database and covers the whole loop:

1. the rule names the FK columns in declaration order, not attnum order;
2. an index in the opposite order does **not** satisfy it (the reported symptom, pinning why the order is load-bearing);
3. running the advisor's own recommendation verbatim clears the finding.

Two of the three fail on `main`:

```
× recommends the FK columns in declaration order, not attnum order
  AssertionError: expected 'CREATE INDEX CONCURRENTLY ON public.a…' to contain '(resource_id, organization_id)'

× clears once its own recommendation is followed verbatim
  AssertionError: expected { …(2) } to be null
```

Run locally against `ghcr.io/insforge/postgres:v15.13.2`, the same image CI uses:

- integration suite: 23 passed across 4 files, including the 3 new ones;
- backend unit suite: 2399 passed, 21 skipped;
- `tsc --noEmit`, `eslint`, `prettier --check` all clean.

I also confirmed the underlying SQL directly against that image before writing the test: `conkey` is `{3,2}` for the fixture, `main`'s query prints `(organization_id, resource_id)`, creating that index leaves the finding in place, and creating `(resource_id, organization_id)` clears it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recommends FK index columns in foreign key declaration order so following the advice clears `missing-fk-index`. Previously it printed attnum order, which could recommend an index that did not satisfy the rule.

- Only user-visible text changes: `detail` and `remediation` now list columns in FK declaration order; detection and the `LEFT JOIN` stay the same.
- Orders by `conkey` ordinality via `unnest(... WITH ORDINALITY)` and `string_agg(... ORDER BY)`, computed once as `col_names` in the CTE so detail and remediation cannot drift.
- Output is unchanged for FKs whose columns already match attnum order.
- Adds an integration test on a real DB: recommendation uses declaration order; the opposite order does not satisfy the rule; applying the recommendation clears the finding.

<sup>Written for commit a4ea3a147013da31ce198a05cfc9ea4141cc7be9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Foreign-key index recommendations now preserve the declared column order.
  - Finding details and remediation SQL now show consistent column ordering.
  - Composite foreign-key guidance now correctly distinguishes between matching and reversed index orders.

- **Tests**
  - Added integration coverage using a migrated PostgreSQL database.
  - Verified that following the recommended index order clears the advisor finding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->