### PR TITLE
fix(advisor): resolve RLS policy columns from pg_depend, not a regex

### DIFF
--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -643,28 +643,27 @@ USING ((select auth.uid()) = user_id)
             )
         `,
         'missing-rls-index': `
-          WITH table_cols AS (
-            SELECT
-              n.nspname AS schema_name,
-              c.relname AS table_name,
-              c.oid AS table_oid,
-              a.attname AS column_name,
-              a.attnum
-            FROM pg_catalog.pg_attribute a
-            JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
-            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-            WHERE c.relkind = 'r'
-              AND a.attnum > 0
-              AND NOT a.attisdropped
-              AND n.nspname NOT IN (${ADVISOR_EXCLUDED_SCHEMAS})
-          ),
-          policies AS (
-            SELECT
-              polrelid AS table_oid,
-              polname AS policy_name,
-              pg_get_expr(polqual, polrelid) AS qual,
-              pg_get_expr(polwithcheck, polrelid) AS with_check
-            FROM pg_catalog.pg_policy
+          WITH policy_columns AS (
+            -- Postgres already records exactly which columns a policy expression
+            -- touches, across both USING and WITH CHECK. Reading that dependency
+            -- is exact where pattern-matching the rendered expression text is
+            -- not: it cannot be fooled by a column name that only appears inside
+            -- a string literal, and it never has to embed an arbitrary
+            -- identifier into a regular expression, which errors the whole rule
+            -- out when the name carries regex punctuation.
+            SELECT DISTINCT
+              pol.polrelid AS table_oid,
+              pol.polname AS policy_name,
+              d.refobjsubid AS attnum
+            FROM pg_catalog.pg_policy pol
+            JOIN pg_catalog.pg_depend d
+              ON d.classid = 'pg_catalog.pg_policy'::regclass
+              AND d.objid = pol.oid
+              AND d.refclassid = 'pg_catalog.pg_class'::regclass
+              -- Columns of the policy own table only; a subquery may also depend
+              -- on columns elsewhere, and an index there would not help this scan.
+              AND d.refobjid = pol.polrelid
+              AND d.refobjsubid > 0
           ),
           table_indices AS (
             SELECT
@@ -674,22 +673,28 @@ USING ((select auth.uid()) = user_id)
             WHERE indisvalid
           )
           SELECT
-            (tc.schema_name || '.' || tc.table_name || '.' || tc.column_name) AS affected_object,
+            (n.nspname || '.' || c.relname || '.' || a.attname) AS affected_object,
             'missing-rls-index' AS rule_id,
             'warning' AS severity,
             'performance' AS category,
             'RLS policy column missing index' AS title,
             'A column referenced in an RLS policy lacks an index, forcing sequential scans on every query.' AS description,
-            format($d$Policy %I on %I.%I filters on column %I but no index exists for it. RLS conditions are evaluated on every query — without an index this forces sequential scans on the entire table.$d$, p.policy_name, tc.schema_name, tc.table_name, tc.column_name) AS detail,
-            format($r$CREATE INDEX CONCURRENTLY idx_%s_%s ON %I.%I (%I);$r$, tc.table_name, tc.column_name, tc.schema_name, tc.table_name, tc.column_name) AS remediation
-          FROM table_cols tc
-          JOIN policies p ON tc.table_oid = p.table_oid
-          LEFT JOIN table_indices ti ON tc.table_oid = ti.table_oid AND tc.attnum = ANY(ti.col_attnums)
+            format($d$Policy %I on %I.%I filters on column %I but no index exists for it. RLS conditions are evaluated on every query — without an index this forces sequential scans on the entire table.$d$, pc.policy_name, n.nspname, c.relname, a.attname) AS detail,
+            -- %I on the whole name: a table or column that needs quoting would
+            -- otherwise produce an index name that is not valid SQL.
+            format($r$CREATE INDEX CONCURRENTLY %I ON %I.%I (%I);$r$,
+              'idx_' || c.relname || '_' || a.attname, n.nspname, c.relname, a.attname) AS remediation
+          FROM policy_columns pc
+          JOIN pg_catalog.pg_class c ON c.oid = pc.table_oid
+          JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+          JOIN pg_catalog.pg_attribute a
+            ON a.attrelid = pc.table_oid AND a.attnum = pc.attnum
+          LEFT JOIN table_indices ti
+            ON ti.table_oid = pc.table_oid AND pc.attnum = ANY(ti.col_attnums)
           WHERE ti.table_oid IS NULL
-            AND (
-              p.qual ~ ('\\m' || tc.column_name || '\\M')
-              OR p.with_check ~ ('\\m' || tc.column_name || '\\M')
-            )
+            AND c.relkind = 'r'
+            AND NOT a.attisdropped
+            AND n.nspname NOT IN (${ADVISOR_EXCLUDED_SCHEMAS})
         `,
         'dead-tuples': `
           SELECT

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -698,7 +698,10 @@ USING ((select auth.uid()) = user_id)
               CASE
                 WHEN octet_length('idx_' || c.relname || '_' || a.attname) <= 63
                   THEN 'idx_' || c.relname || '_' || a.attname
-                ELSE 'idx_' || md5(c.relname || '.' || a.attname)
+                -- Length-delimited, because an identifier may itself contain a
+                -- dot: without it, table "a.b" column "c" and table "a" column
+                -- "b.c" digest the same and the second remediation fails.
+                ELSE 'idx_' || md5(length(c.relname)::text || ':' || c.relname || ':' || a.attname)
               END,
               n.nspname, c.relname, a.attname) AS remediation
           FROM policy_columns pc

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -651,9 +651,14 @@ USING ((select auth.uid()) = user_id)
             -- a string literal, and it never has to embed an arbitrary
             -- identifier into a regular expression, which errors the whole rule
             -- out when the name carries regex punctuation.
-            SELECT DISTINCT
+            -- One row per (table, column), not per policy: several policies
+            -- commonly filter on the same column, and a finding is identified
+            -- by its affected_object, so emitting it twice would duplicate the
+            -- entry and hand back a second CREATE INDEX that fails on the name
+            -- the first one already took. min() picks a stable policy to name.
+            SELECT
               pol.polrelid AS table_oid,
-              pol.polname AS policy_name,
+              min(pol.polname) AS policy_name,
               d.refobjsubid AS attnum
             FROM pg_catalog.pg_policy pol
             JOIN pg_catalog.pg_depend d
@@ -664,6 +669,7 @@ USING ((select auth.uid()) = user_id)
               -- on columns elsewhere, and an index there would not help this scan.
               AND d.refobjid = pol.polrelid
               AND d.refobjsubid > 0
+            GROUP BY pol.polrelid, d.refobjsubid
           ),
           table_indices AS (
             SELECT

--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -688,8 +688,19 @@ USING ((select auth.uid()) = user_id)
             format($d$Policy %I on %I.%I filters on column %I but no index exists for it. RLS conditions are evaluated on every query — without an index this forces sequential scans on the entire table.$d$, pc.policy_name, n.nspname, c.relname, a.attname) AS detail,
             -- %I on the whole name: a table or column that needs quoting would
             -- otherwise produce an index name that is not valid SQL.
+            --
+            -- Postgres truncates identifiers at 63 bytes, so two long columns on
+            -- one table can collapse to the same index name, and the second
+            -- recommendation then fails as already existing. Past that length the
+            -- readable name is being mangled anyway, so fall back to a digest.
+            -- Names that fit are left exactly as they were.
             format($r$CREATE INDEX CONCURRENTLY %I ON %I.%I (%I);$r$,
-              'idx_' || c.relname || '_' || a.attname, n.nspname, c.relname, a.attname) AS remediation
+              CASE
+                WHEN octet_length('idx_' || c.relname || '_' || a.attname) <= 63
+                  THEN 'idx_' || c.relname || '_' || a.attname
+                ELSE 'idx_' || md5(c.relname || '.' || a.attname)
+              END,
+              n.nspname, c.relname, a.attname) AS remediation
           FROM policy_columns pc
           JOIN pg_catalog.pg_class c ON c.oid = pc.table_oid
           JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid

--- a/backend/tests/integration/advisor-rls-index.test.ts
+++ b/backend/tests/integration/advisor-rls-index.test.ts
@@ -117,6 +117,20 @@ beforeAll(async () => {
          WHERE l.join_key = lookup_id AND l.tenant = gen_random_uuid()
       )
     );
+
+    -- Two columns on one table whose "idx_<table>_<column>" names agree well
+    -- past Postgres' 63-byte identifier limit, so a truncated name would
+    -- collide and the second recommendation would fail as already existing.
+    CREATE TABLE public.long_names (
+      id uuid PRIMARY KEY,
+      a_very_long_column_name_that_keeps_going_and_going_and_going_one uuid,
+      a_very_long_column_name_that_keeps_going_and_going_and_going_two uuid
+    );
+    ALTER TABLE public.long_names ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY long_names_p ON public.long_names USING (
+      a_very_long_column_name_that_keeps_going_and_going_and_going_one = gen_random_uuid()
+      AND a_very_long_column_name_that_keeps_going_and_going_and_going_two = gen_random_uuid()
+    );
   `);
 }, 180_000);
 
@@ -169,6 +183,26 @@ describe('advisor missing-rls-index column resolution', () => {
     // Two policies read reviewer. A second identical finding would also hand
     // back a CREATE INDEX that fails on the name the first one took.
     expect(forReviewer).toHaveLength(1);
+  }, 90_000);
+
+  it('recommends index names that stay unique past the identifier limit', async () => {
+    const findings = await scanForRlsFindings();
+    const longOnes = findings.filter((f) => f.affectedObject.startsWith('public.long_names.'));
+
+    expect(longOnes).toHaveLength(2);
+    const names = longOnes.map(
+      (f) => /CREATE INDEX CONCURRENTLY (\S+) ON/.exec(f.recommendation)?.[1]
+    );
+    expect(new Set(names).size).toBe(2);
+
+    // Both recommendations have to actually run; a truncated collision would
+    // fail the second one.
+    for (const f of longOnes) {
+      await query(f.recommendation.replace('CONCURRENTLY ', ''));
+    }
+
+    const after = await scanForRlsFindings();
+    expect(after.filter((f) => f.affectedObject.startsWith('public.long_names.'))).toEqual([]);
   }, 90_000);
 
   it('does not report columns a policy only touches through another table', async () => {

--- a/backend/tests/integration/advisor-rls-index.test.ts
+++ b/backend/tests/integration/advisor-rls-index.test.ts
@@ -118,18 +118,19 @@ beforeAll(async () => {
       )
     );
 
-    -- Two columns on one table whose "idx_<table>_<column>" names agree well
-    -- past Postgres' 63-byte identifier limit, so a truncated name would
-    -- collide and the second recommendation would fail as already existing.
+    -- Two columns on one table. Each name is comfortably inside Postgres'
+    -- 63-byte identifier limit, but "idx_long_names_<column>" is 68 bytes and
+    -- the two agree well past the cut, so a truncated index name would collide
+    -- and the second recommendation would fail as already existing.
     CREATE TABLE public.long_names (
       id uuid PRIMARY KEY,
-      a_very_long_column_name_that_keeps_going_and_going_and_going_one uuid,
-      a_very_long_column_name_that_keeps_going_and_going_and_going_two uuid
+      policy_col_long_enough_to_overflow_the_index_name_one uuid,
+      policy_col_long_enough_to_overflow_the_index_name_two uuid
     );
     ALTER TABLE public.long_names ENABLE ROW LEVEL SECURITY;
     CREATE POLICY long_names_p ON public.long_names USING (
-      a_very_long_column_name_that_keeps_going_and_going_and_going_one = gen_random_uuid()
-      AND a_very_long_column_name_that_keeps_going_and_going_and_going_two = gen_random_uuid()
+      policy_col_long_enough_to_overflow_the_index_name_one = gen_random_uuid()
+      AND policy_col_long_enough_to_overflow_the_index_name_two = gen_random_uuid()
     );
   `);
 }, 180_000);

--- a/backend/tests/integration/advisor-rls-index.test.ts
+++ b/backend/tests/integration/advisor-rls-index.test.ts
@@ -91,6 +91,32 @@ beforeAll(async () => {
     CREATE POLICY imports_reviewer ON public.imports FOR INSERT
       WITH CHECK (reviewer = gen_random_uuid());
     CREATE POLICY imports_status ON public.imports FOR DELETE USING (id::text = 'status');
+
+    -- A second policy on a column imports_reviewer already covers, to check the
+    -- finding is emitted once per column rather than once per policy.
+    CREATE POLICY imports_reviewer_read ON public.imports FOR SELECT
+      USING (reviewer = gen_random_uuid());
+
+    -- A policy whose subquery reads a column of a different table. Postgres
+    -- records that dependency too, and the attnum is only meaningful relative to
+    -- the table it came from, so a dependency that is not filtered to the
+    -- policy's own table lands on whatever column happens to share that attnum.
+    --
+    -- The attnums are chosen to make that visible: lookup.tenant is attnum 3,
+    -- and attnum 3 on scoped is "unrelated", a column no policy reads.
+    CREATE TABLE public.lookup (join_key uuid, filler uuid, tenant uuid);
+    CREATE TABLE public.scoped (
+      id        uuid PRIMARY KEY,
+      lookup_id uuid NOT NULL,
+      unrelated uuid
+    );
+    ALTER TABLE public.scoped ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY scoped_via_lookup ON public.scoped USING (
+      EXISTS (
+        SELECT 1 FROM public.lookup l
+         WHERE l.join_key = lookup_id AND l.tenant = gen_random_uuid()
+      )
+    );
   `);
 }, 180_000);
 
@@ -134,5 +160,27 @@ describe('advisor missing-rls-index column resolution', () => {
 
     // imports_status filters on id; "status" is just the literal it compares to.
     expect(findings.map((f) => f.affectedObject)).not.toContain('public.imports.status');
+  }, 90_000);
+
+  it('reports a column once even when several policies filter on it', async () => {
+    const findings = await scanForRlsFindings();
+    const forReviewer = findings.filter((f) => f.affectedObject === 'public.imports.reviewer');
+
+    // Two policies read reviewer. A second identical finding would also hand
+    // back a CREATE INDEX that fails on the name the first one took.
+    expect(forReviewer).toHaveLength(1);
+  }, 90_000);
+
+  it('does not report columns a policy only touches through another table', async () => {
+    const findings = await scanForRlsFindings();
+    const objects = findings.map((f) => f.affectedObject);
+
+    // Without the own-table filter, lookup.tenant's attnum 3 is applied to
+    // scoped, producing a finding for "unrelated", which no policy reads.
+    expect(objects).not.toContain('public.scoped.unrelated');
+    // Nothing is attributed to the other table either.
+    expect(objects.filter((o) => o.startsWith('public.lookup.'))).toEqual([]);
+    // The column the policy really filters on is still reported.
+    expect(objects).toContain('public.scoped.lookup_id');
   }, 90_000);
 });

--- a/backend/tests/integration/advisor-rls-index.test.ts
+++ b/backend/tests/integration/advisor-rls-index.test.ts
@@ -1,0 +1,138 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
+import { getConnections } from './utils';
+
+/**
+ * The missing-rls-index rule against a real migrated database.
+ *
+ * The rule has to decide which columns a policy actually filters on. Doing that
+ * by matching the column name against the rendered policy expression is both
+ * fragile and unsafe: a name carrying regex punctuation errors the query out,
+ * which drops every finding of this rule for the whole database, and a name
+ * that merely appears inside a string literal produces a finding for a column
+ * no policy reads. This suite pins the behaviour for both.
+ *
+ * The service reads connection settings from the environment at module load, so
+ * env is pointed at the isolated pgsql-test database before it is imported.
+ */
+
+type AdvisorService =
+  typeof import('../../src/services/database/database-advisor.service').DatabaseAdvisorService;
+type ManagerModule = typeof import('../../src/infra/database/database.manager').DatabaseManager;
+
+let teardown: (() => Promise<void>) | undefined;
+let svc: InstanceType<AdvisorService>;
+let dbManager: InstanceType<ManagerModule>;
+
+interface Finding {
+  affectedObject: string;
+  recommendation: string;
+}
+
+async function query<T extends Record<string, unknown>>(sql: string, params: unknown[] = []) {
+  const result = await dbManager.getPool().query(sql, params);
+  return result.rows as T[];
+}
+
+/** Runs one scan to completion and returns every missing-rls-index finding. */
+async function scanForRlsFindings(): Promise<Finding[]> {
+  const scanId = await svc.triggerScan('manual');
+
+  const deadline = Date.now() + 60_000;
+  while (svc.isScanInProgress() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (svc.isScanInProgress()) {
+    throw new Error('advisor scan did not finish in time');
+  }
+
+  return query<Finding>(
+    `SELECT affected_object AS "affectedObject", recommendation
+       FROM system.advisor_findings
+      WHERE scan_id = $1 AND rule_id = 'missing-rls-index'
+      ORDER BY affected_object`,
+    [scanId]
+  );
+}
+
+beforeAll(async () => {
+  const conn = await getConnections();
+  teardown = conn.teardown;
+  const cfg = conn.pg.config;
+
+  process.env.POSTGRES_HOST = String(cfg.host ?? 'localhost');
+  process.env.POSTGRES_PORT = String(cfg.port ?? 5432);
+  process.env.POSTGRES_DB = String(cfg.database);
+  process.env.POSTGRES_USER = String(cfg.user ?? 'postgres');
+  process.env.POSTGRES_PASSWORD = String(cfg.password ?? 'postgres');
+
+  const { DatabaseManager } = await import('../../src/infra/database/database.manager');
+  const { DatabaseAdvisorService } =
+    await import('../../src/services/database/database-advisor.service');
+  dbManager = DatabaseManager.getInstance();
+  await dbManager.initialize();
+  svc = DatabaseAdvisorService.getInstance();
+
+  await query(`
+    -- An ordinary RLS table, used to prove the rule still reports at all.
+    CREATE TABLE public.notes (id uuid PRIMARY KEY, owner_id uuid NOT NULL);
+    ALTER TABLE public.notes ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY notes_owner ON public.notes USING (owner_id = gen_random_uuid());
+
+    -- A table shaped like a CSV import: one column name carries regex
+    -- punctuation, and another shares its name with a string literal.
+    CREATE TABLE public.imports (
+      id       uuid PRIMARY KEY,
+      "Amount (USD" numeric,
+      reviewer uuid,
+      status   text
+    );
+    ALTER TABLE public.imports ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY imports_amount ON public.imports FOR UPDATE USING ("Amount (USD" > 0);
+    CREATE POLICY imports_reviewer ON public.imports FOR INSERT
+      WITH CHECK (reviewer = gen_random_uuid());
+    CREATE POLICY imports_status ON public.imports FOR DELETE USING (id::text = 'status');
+  `);
+}, 180_000);
+
+afterAll(async () => {
+  await dbManager?.close();
+  await teardown?.();
+});
+
+describe('advisor missing-rls-index column resolution', () => {
+  it('keeps reporting when a policy table has a regex-hostile column name', async () => {
+    const findings = await scanForRlsFindings();
+
+    // Embedding "Amount (USD" in a regex raises "parentheses () not balanced",
+    // and the rule is wrapped in a per-rule catch, so every finding it would
+    // have produced disappears database-wide.
+    expect(findings.map((f) => f.affectedObject)).toContain('public.notes.owner_id');
+  }, 90_000);
+
+  it('flags a referenced column whose name needs quoting, with runnable SQL', async () => {
+    const findings = await scanForRlsFindings();
+    const hostile = findings.find((f) => f.affectedObject === 'public.imports.Amount (USD');
+
+    expect(hostile).toBeDefined();
+    // An unquoted index name would not parse.
+    expect(hostile?.recommendation).toContain('"idx_imports_Amount (USD"');
+
+    await query(hostile!.recommendation.replace('CONCURRENTLY ', ''));
+
+    const after = await scanForRlsFindings();
+    expect(after.map((f) => f.affectedObject)).not.toContain('public.imports.Amount (USD');
+  }, 90_000);
+
+  it('covers WITH CHECK expressions, not just USING', async () => {
+    const findings = await scanForRlsFindings();
+
+    expect(findings.map((f) => f.affectedObject)).toContain('public.imports.reviewer');
+  }, 90_000);
+
+  it('does not flag a column that only appears inside a string literal', async () => {
+    const findings = await scanForRlsFindings();
+
+    // imports_status filters on id; "status" is just the literal it compares to.
+    expect(findings.map((f) => f.affectedObject)).not.toContain('public.imports.status');
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

Closes #1984.

`missing-rls-index` decided which columns a policy filters on by building a regex out of each column name and matching it against the rendered policy expression:

```sql
p.qual ~ ('\m' || tc.column_name || '\M')
```

Column names are arbitrary identifiers, so this breaks three ways. All three verified against `ghcr.io/insforge/postgres:v15.13.2`.

**One bad column name disabled the rule database-wide.** `"Amount (USD"`, the shape a CSV import produces, makes the pattern invalid (`parentheses () not balanced`). Each rule runs inside its own `catch`, so the rule was skipped and every `missing-rls-index` finding vanished — including for unrelated, perfectly healthy tables. The scan still reported completed, so there was nothing in the dashboard to explain the gap.

**A metacharacter also matched the wrong column.** `"a.b"` matches the text `axb`, so a policy on `axb` produced a finding recommending an index on `a.b`, which no policy reads.

**The remediation did not always parse.** The index name used `%s` rather than `%I`, so `CREATE INDEX CONCURRENTLY idx_dotted_a.b ON ...` is a syntax error.

Postgres already records which columns a policy expression touches, for both `USING` and `WITH CHECK`, so the rule now reads `pg_depend`. The index name is quoted with `%I`.

## Notes for the reviewer

- `pg_depend` is exact where matching rendered SQL text is approximate. It is not fooled by a name that only appears inside a string literal, it picks up columns referenced through function calls such as `lower(fn_col)`, and no identifier is ever embedded into a pattern. `helpers.ts` already introspects foreign keys from the catalog this way, so this follows an established pattern in the codebase rather than inventing one.
- `d.refobjid = pol.polrelid` keeps this to columns of the policy's own table. A policy with a subquery also depends on columns elsewhere, and an index on those would not help the scan this rule is about.
- The index-membership test is unchanged (`attnum = ANY(col_attnums)`), so what counts as "already indexed" is exactly what it was. Whether a non-leading column should count is a separate question and out of scope here.
- Expected change in output: findings for columns no policy references stop appearing, findings that were being lost to a skipped rule start appearing, and detail text is unchanged for every column whose name needs no quoting.

## How did you test this change?

New `backend/tests/integration/advisor-rls-index.test.ts`, driving the real `DatabaseAdvisorService` against a real migrated database, with a schema shaped like a CSV import:

1. the rule keeps reporting for an ordinary table when another RLS table has a regex-hostile column name;
2. a genuinely referenced quoted column is flagged, its recommendation is runnable, and running it clears the finding;
3. `WITH CHECK` expressions are covered, not just `USING`;
4. a column that only appears inside a string literal is not flagged.

Three of the four fail on `main`, all with the rule returning nothing at all:

```
× keeps reporting when a policy table has a regex-hostile column name
  AssertionError: expected [] to include 'public.notes.owner_id'

× flags a referenced column whose name needs quoting, with runnable SQL
  AssertionError: expected undefined to be defined

× covers WITH CHECK expressions, not just USING
  AssertionError: expected [] to include 'public.imports.reviewer'
```

The fourth passes on `main` only because a rule that returns nothing cannot return a false positive; it is there to keep the regex behaviour from coming back.

Run locally against the same image CI uses:

- integration suite: 24 passed across 4 files, including the 4 new ones;
- backend unit suite: 2399 passed, 21 skipped;
- `tsc --noEmit`, `eslint`, `prettier --check` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `missing-rls-index` by resolving RLS policy columns from `pg_depend` instead of regex-matching policy text, preventing rule-wide skips and false positives. Also makes remediation SQL robust with `%I` quoting and collision-resistant names past Postgres’ 63-byte identifier limit.

- Resolves columns via `pg_policy` + `pg_depend` (`refobjid = polrelid`, `refobjsubid > 0`), groups by `(table_oid, attnum)`, and picks a stable policy name with `min(polname)` to avoid duplicates.
- Keeps the existing indexed-column check (`attnum = ANY(col_attnums)`) and filters (`relkind = 'r'`, `NOT attisdropped`, excluded schemas).
- Remediation: quotes index names with `%I`; if `idx_<table>_<column>` exceeds 63 bytes, falls back to `idx_` + `md5(length(table)||':'||table||':'||column)` to avoid collisions, including dotted identifiers; shorter names are unchanged.
- Behavior: previously skipped findings reappear; no false positives from string literals or metacharacters; covers both `USING` and `WITH CHECK`; only the policy’s own table is considered; duplicates per column are removed; long or dotted names produce distinct, runnable recommendations.
- Tests: adds integration coverage for hostile names, `WITH CHECK`, per-column de-duplication, own-table scoping, long-name collision avoidance, and length-delimited digest input; fixtures keep identifiers under 63 bytes to avoid relying on truncation.

<sup>Written for commit 840fc9cbd9372343903bd2f354d5f92d9e7a1e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of columns referenced by row-level security policies.
  * Added support for both `USING` and `WITH CHECK` policy conditions.
  * Prevented false positives from string literals, special characters, and cross-table references.
  * Deduplicated recommendations when multiple policies reference the same column.
  * Generated safer index recommendations with accurate table attribution and collision-resistant names for long identifiers.
* **Tests**
  * Added coverage for complex policy references, long identifiers, deduplication, and remediation recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->