### PR TITLE
fix(advisor): do not count INCLUDE payload columns as covering an index

### DIFF
--- a/backend/src/services/database/database-advisor.service.ts
+++ b/backend/src/services/database/database-advisor.service.ts
@@ -441,7 +441,11 @@ CREATE POLICY "allow_insert" ON %I.%I FOR INSERT TO authenticated WITH CHECK (au
             SELECT
               pi.indrelid AS table_oid,
               indexrelid::regclass AS index_,
-              string_to_array(indkey::text, ' ')::smallint[] AS col_attnums
+              -- Key columns only. indkey lists the INCLUDE payload after the key
+              -- columns, and a payload column cannot be searched on, so counting
+              -- it as covering suppresses a finding the index does not satisfy.
+              (string_to_array(pi.indkey::text, ' ')::smallint[])[1:pi.indnkeyatts]
+                AS col_attnums
             FROM pg_catalog.pg_index pi
             WHERE indisvalid
           )
@@ -669,7 +673,11 @@ USING ((select auth.uid()) = user_id)
           table_indices AS (
             SELECT
               indrelid AS table_oid,
-              string_to_array(indkey::text, ' ')::smallint[] AS col_attnums
+              -- Key columns only. indkey lists the INCLUDE payload after the key
+              -- columns, and a payload column cannot be searched on, so counting
+              -- it as covering suppresses a finding the index does not satisfy.
+              (string_to_array(indkey::text, ' ')::smallint[])[1:indnkeyatts]
+                AS col_attnums
             FROM pg_catalog.pg_index
             WHERE indisvalid
           )

--- a/backend/tests/integration/advisor-index-coverage.test.ts
+++ b/backend/tests/integration/advisor-index-coverage.test.ts
@@ -1,0 +1,144 @@
+import { describe, beforeAll, afterAll, it, expect } from 'vitest';
+import { getConnections } from './utils';
+
+/**
+ * What counts as a covering index, for the two advisor rules that ask.
+ *
+ * pg_index.indkey lists the INCLUDE payload after the key columns, and
+ * indnkeyatts is where the key columns stop. A payload column is stored in the
+ * index but cannot be searched on, so an index that merely carries a column
+ * along does not let Postgres filter by it or satisfy a foreign key. Both rules
+ * read indkey whole, so such an index silently suppressed a real finding.
+ *
+ * The service reads connection settings from the environment at module load, so
+ * env is pointed at the isolated pgsql-test database before it is imported.
+ */
+
+type AdvisorService =
+  typeof import('../../src/services/database/database-advisor.service').DatabaseAdvisorService;
+type ManagerModule = typeof import('../../src/infra/database/database.manager').DatabaseManager;
+
+let teardown: (() => Promise<void>) | undefined;
+let svc: InstanceType<AdvisorService>;
+let dbManager: InstanceType<ManagerModule>;
+
+async function query<T extends Record<string, unknown>>(sql: string, params: unknown[] = []) {
+  const result = await dbManager.getPool().query(sql, params);
+  return result.rows as T[];
+}
+
+/** Runs one scan to completion and returns the affected objects for a rule. */
+async function scanFor(ruleId: string): Promise<string[]> {
+  const scanId = await svc.triggerScan('manual');
+
+  const deadline = Date.now() + 60_000;
+  while (svc.isScanInProgress() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (svc.isScanInProgress()) {
+    throw new Error('advisor scan did not finish in time');
+  }
+
+  const rows = await query<{ affectedObject: string }>(
+    `SELECT affected_object AS "affectedObject"
+       FROM system.advisor_findings
+      WHERE scan_id = $1 AND rule_id = $2
+      ORDER BY affected_object`,
+    [scanId, ruleId]
+  );
+  return rows.map((r) => r.affectedObject);
+}
+
+beforeAll(async () => {
+  const conn = await getConnections();
+  teardown = conn.teardown;
+  const cfg = conn.pg.config;
+
+  process.env.POSTGRES_HOST = String(cfg.host ?? 'localhost');
+  process.env.POSTGRES_PORT = String(cfg.port ?? 5432);
+  process.env.POSTGRES_DB = String(cfg.database);
+  process.env.POSTGRES_USER = String(cfg.user ?? 'postgres');
+  process.env.POSTGRES_PASSWORD = String(cfg.password ?? 'postgres');
+
+  const { DatabaseManager } = await import('../../src/infra/database/database.manager');
+  const { DatabaseAdvisorService } =
+    await import('../../src/services/database/database-advisor.service');
+  dbManager = DatabaseManager.getInstance();
+  await dbManager.initialize();
+  svc = DatabaseAdvisorService.getInstance();
+
+  await query(`
+    -- Foreign key whose second column is only carried as an INCLUDE payload.
+    CREATE TABLE public.fk_parent (a uuid, b uuid, UNIQUE (a, b));
+    CREATE TABLE public.fk_child (
+      id uuid PRIMARY KEY,
+      a  uuid NOT NULL,
+      b  uuid NOT NULL,
+      CONSTRAINT fk_child_fkey FOREIGN KEY (a, b) REFERENCES public.fk_parent (a, b)
+    );
+    CREATE INDEX fk_child_payload ON public.fk_child (a) INCLUDE (b);
+
+    -- RLS policy column that is only carried as an INCLUDE payload.
+    CREATE TABLE public.rls_payload (id uuid PRIMARY KEY, other_col uuid, policy_col uuid);
+    ALTER TABLE public.rls_payload ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY rls_payload_p ON public.rls_payload USING (policy_col = gen_random_uuid());
+    CREATE INDEX rls_payload_idx ON public.rls_payload (other_col) INCLUDE (policy_col);
+
+    -- Control: the same shapes, covered by a real key index.
+    CREATE TABLE public.fk_ok_parent (a uuid, b uuid, UNIQUE (a, b));
+    CREATE TABLE public.fk_ok_child (
+      id uuid PRIMARY KEY,
+      a  uuid NOT NULL,
+      b  uuid NOT NULL,
+      CONSTRAINT fk_ok_child_fkey FOREIGN KEY (a, b) REFERENCES public.fk_ok_parent (a, b)
+    );
+    CREATE INDEX fk_ok_child_key ON public.fk_ok_child (a, b);
+
+    CREATE TABLE public.rls_ok (id uuid PRIMARY KEY, policy_col uuid);
+    ALTER TABLE public.rls_ok ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY rls_ok_p ON public.rls_ok USING (policy_col = gen_random_uuid());
+    CREATE INDEX rls_ok_key ON public.rls_ok (policy_col);
+  `);
+}, 180_000);
+
+afterAll(async () => {
+  await dbManager?.close();
+  await teardown?.();
+});
+
+describe('advisor index coverage ignores INCLUDE payload columns', () => {
+  it('still flags a foreign key whose column is only an INCLUDE payload', async () => {
+    const objects = await scanFor('missing-fk-index');
+
+    // fk_child_payload is ON (a) INCLUDE (b); it cannot satisfy FK (a, b).
+    expect(objects).toContain('public.fk_child.fk_child_fkey');
+  }, 90_000);
+
+  it('still flags an RLS column that is only an INCLUDE payload', async () => {
+    const objects = await scanFor('missing-rls-index');
+
+    // rls_payload_idx is ON (other_col) INCLUDE (policy_col); it cannot filter
+    // on policy_col.
+    expect(objects).toContain('public.rls_payload.policy_col');
+  }, 90_000);
+
+  it('leaves both rules satisfied by a genuine key index', async () => {
+    const [fkObjects, rlsObjects] = [
+      await scanFor('missing-fk-index'),
+      await scanFor('missing-rls-index'),
+    ];
+
+    expect(fkObjects).not.toContain('public.fk_ok_child.fk_ok_child_fkey');
+    expect(rlsObjects).not.toContain('public.rls_ok.policy_col');
+  }, 90_000);
+
+  it('clears the payload cases once a real key index is added', async () => {
+    await query(`
+      CREATE INDEX fk_child_key ON public.fk_child (a, b);
+      CREATE INDEX rls_payload_key ON public.rls_payload (policy_col);
+    `);
+
+    expect(await scanFor('missing-fk-index')).not.toContain('public.fk_child.fk_child_fkey');
+    expect(await scanFor('missing-rls-index')).not.toContain('public.rls_payload.policy_col');
+  }, 90_000);
+});

--- a/backend/tests/integration/advisor-index-coverage.test.ts
+++ b/backend/tests/integration/advisor-index-coverage.test.ts
@@ -98,6 +98,23 @@ beforeAll(async () => {
     ALTER TABLE public.rls_ok ENABLE ROW LEVEL SECURITY;
     CREATE POLICY rls_ok_p ON public.rls_ok USING (policy_col = gen_random_uuid());
     CREATE INDEX rls_ok_key ON public.rls_ok (policy_col);
+
+    -- Payload-only shapes reserved for the "clears once covered" case. It is
+    -- the one test that adds an index, so it gets its own tables: mutating the
+    -- shapes above would make the earlier assertions depend on running first.
+    CREATE TABLE public.fk_fix_parent (a uuid, b uuid, UNIQUE (a, b));
+    CREATE TABLE public.fk_fix_child (
+      id uuid PRIMARY KEY,
+      a  uuid NOT NULL,
+      b  uuid NOT NULL,
+      CONSTRAINT fk_fix_child_fkey FOREIGN KEY (a, b) REFERENCES public.fk_fix_parent (a, b)
+    );
+    CREATE INDEX fk_fix_child_payload ON public.fk_fix_child (a) INCLUDE (b);
+
+    CREATE TABLE public.rls_fix (id uuid PRIMARY KEY, other_col uuid, policy_col uuid);
+    ALTER TABLE public.rls_fix ENABLE ROW LEVEL SECURITY;
+    CREATE POLICY rls_fix_p ON public.rls_fix USING (policy_col = gen_random_uuid());
+    CREATE INDEX rls_fix_idx ON public.rls_fix (other_col) INCLUDE (policy_col);
   `);
 }, 180_000);
 
@@ -133,12 +150,19 @@ describe('advisor index coverage ignores INCLUDE payload columns', () => {
   }, 90_000);
 
   it('clears the payload cases once a real key index is added', async () => {
+    // Own tables, so the index this adds cannot change what the payload-only
+    // cases above observe, in whatever order they run.
+    expect(await scanFor('missing-fk-index')).toContain('public.fk_fix_child.fk_fix_child_fkey');
+    expect(await scanFor('missing-rls-index')).toContain('public.rls_fix.policy_col');
+
     await query(`
-      CREATE INDEX fk_child_key ON public.fk_child (a, b);
-      CREATE INDEX rls_payload_key ON public.rls_payload (policy_col);
+      CREATE INDEX fk_fix_child_key ON public.fk_fix_child (a, b);
+      CREATE INDEX rls_fix_key ON public.rls_fix (policy_col);
     `);
 
-    expect(await scanFor('missing-fk-index')).not.toContain('public.fk_child.fk_child_fkey');
-    expect(await scanFor('missing-rls-index')).not.toContain('public.rls_payload.policy_col');
+    expect(await scanFor('missing-fk-index')).not.toContain(
+      'public.fk_fix_child.fk_fix_child_fkey'
+    );
+    expect(await scanFor('missing-rls-index')).not.toContain('public.rls_fix.policy_col');
   }, 90_000);
 });


### PR DESCRIPTION
## Summary

Closes #1986.

`pg_index.indkey` lists the `INCLUDE` payload after the key columns, and `indnkeyatts` is where the key columns stop. Both index rules read `indkey` whole, so an index that merely carries a column along counted as covering it and a real finding was suppressed.

A payload column is stored in the index but is not part of the key, so it cannot be searched on and cannot serve a foreign-key check.

**`missing-fk-index`** compares `conkey` to the leading slice of `indkey`, so `ON t (a) INCLUDE (b)` satisfied `FOREIGN KEY (a, b)`:

```sql
SELECT ct.conkey = (string_to_array(pi.indkey::text,' ')::smallint[])[1:array_length(ct.conkey,1)]
--  t     <- index is ON (a) INCLUDE (b), FK is (a, b)
```

**`missing-rls-index`** matches with `attnum = ANY(col_attnums)`, so `ON t (other_col) INCLUDE (policy_col)` marked `policy_col` as indexed even though the policy cannot filter on it.

Both CTEs now slice `indkey` to its first `indnkeyatts` entries. The matching logic in each rule is untouched.

## Notes for the reviewer

- `indnkeyatts` exists from PostgreSQL 11; the project targets 15.
- This is a false-negative fix, so it can surface findings that were previously hidden. That is the intent: the suppressed ones were never satisfiable by the index that hid them. Nothing that was correctly quiet becomes noisy, which the control cases in the test cover.
- Scoped deliberately to the payload question. Adjacent things that also cannot serve these checks, such as partial indexes with a `WHERE` clause, are left alone rather than folded in.
- Two other PRs touch these rules (#1983 on FK column order, #1985 on RLS column resolution). Neither modifies these two CTEs, so this branches from `main` and should not conflict with either. Its test file is new, so there is no overlap there either. Happy to rebase in whatever order suits.

## How did you test this change?

New `backend/tests/integration/advisor-index-coverage.test.ts`, driving the real `DatabaseAdvisorService` against a real migrated database:

1. `missing-fk-index` still flags a foreign key whose second column is only an `INCLUDE` payload;
2. `missing-rls-index` still flags a policy column that is only an `INCLUDE` payload;
3. neither rule flags the same shape when a genuine key index covers it (the control, so this does not just make both rules noisier);
4. both clear once a real key index is added.

Verified by mutation. Restoring the whole-`indkey` read fails exactly the two payload tests and leaves the controls passing:

```
× still flags a foreign key whose column is only an INCLUDE payload
  AssertionError: expected [] to include 'public.fk_child.fk_child_fkey'

× still flags an RLS column that is only an INCLUDE payload
  AssertionError: expected [] to include 'public.rls_payload.policy_col'
```

Run locally against `ghcr.io/insforge/postgres:v15.13.2`, the same image CI uses:

- integration suite: 24 passed across 4 files, including the 4 new ones;
- backend unit suite: 2399 passed, 21 skipped;
- `tsc --noEmit`, `eslint`, `prettier --check` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advisor no longer counts INCLUDE payload columns as covering an index, fixing suppressed findings in `missing-fk-index` and `missing-rls-index`. Previously all of `pg_index.indkey` counted; now only the first `indnkeyatts` (key columns) do.

- `missing-fk-index`: an index ON (a) INCLUDE (b) no longer satisfies a FOREIGN KEY (a, b).
- `missing-rls-index`: an index ON (other_col) INCLUDE (policy_col) no longer marks `policy_col` as indexed for filtering.
- Implementation: both rules slice `indkey` to `[1:indnkeyatts]`; matching logic unchanged.
- Impact: may surface previously hidden findings; correctly keyed indexes remain unaffected.
- Tests: integration suite is order-independent and stronger; the mutating case uses dedicated tables and asserts payload-only shapes are flagged, genuine key indexes pass, and findings clear after adding true key indexes.

<sup>Written for commit a90b6f858d0d0516d650f4266873f28e5cfc86b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database index analysis to correctly distinguish key columns from included payload columns.
  * Foreign-key and row-level security index recommendations now accurately identify missing coverage.

* **Tests**
  * Added integration coverage for indexes containing payload-only columns.
  * Verified that valid key indexes are accepted and resolved recommendations are cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->