### PR TITLE
fix(dashboard): refresh auth before parsing 401 responses

### DIFF
--- a/packages/dashboard/src/lib/api/client.test.ts
+++ b/packages/dashboard/src/lib/api/client.test.ts
@@ -33,6 +33,73 @@ describe('ApiClient CSRF cookie handling', () => {
   });
 });
 
+it('refreshes an expired token when the 401 response is not JSON', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      new Response('<html>Unauthorized</html>', {
+        status: 401,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+      })
+    );
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  const client = new ApiClient();
+  client.setAccessToken('expired-token');
+  client.setRefreshAccessTokenHandler(async () => {
+    client.setAccessToken('fresh-token');
+    return true;
+  });
+
+  const result = await client.request('/dashboard/test');
+
+  expect(result).toEqual({ success: true });
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+    expect.objectContaining({
+      headers: { Authorization: 'Bearer fresh-token' },
+    })
+  );
+});
+
+describe('ApiClient authentication refresh', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes an expired token when the 401 response has an empty body', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ApiClient();
+    client.setAccessToken('expired-token');
+    client.setRefreshAccessTokenHandler(async () => {
+      client.setAccessToken('fresh-token');
+      return true;
+    });
+
+    const result = await client.request('/dashboard/test');
+
+    expect(result).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer fresh-token' },
+      })
+    );
+  });
+});
+
 describe('ApiClient streaming requests', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/packages/dashboard/src/lib/api/client.test.ts
+++ b/packages/dashboard/src/lib/api/client.test.ts
@@ -33,44 +33,47 @@ describe('ApiClient CSRF cookie handling', () => {
   });
 });
 
-it('refreshes an expired token when the 401 response is not JSON', async () => {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValueOnce(
-      new Response('<html>Unauthorized</html>', {
-        status: 401,
-        headers: { 'Content-Type': 'text/html' },
-      })
-    )
-    .mockResolvedValueOnce(
-      new Response(JSON.stringify({ success: true }), {
-        status: 200,
-      })
-    );
-
-  vi.stubGlobal('fetch', fetchMock);
-
-  const client = new ApiClient();
-  client.setAccessToken('expired-token');
-  client.setRefreshAccessTokenHandler(async () => {
-    client.setAccessToken('fresh-token');
-    return true;
-  });
-
-  const result = await client.request('/dashboard/test');
-
-  expect(result).toEqual({ success: true });
-  expect(fetchMock).toHaveBeenCalledTimes(2);
-  expect(fetchMock.mock.calls[1]?.[1]).toEqual(
-    expect.objectContaining({
-      headers: { Authorization: 'Bearer fresh-token' },
-    })
-  );
-});
-
 describe('ApiClient authentication refresh', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it('refreshes an expired token when the 401 response is not JSON', async () => {
+    const unauthorizedResponse = new Response('<html>Unauthorized</html>', {
+      status: 401,
+      headers: { 'Content-Type': 'text/html' },
+    });
+
+    const cancelSpy = vi.spyOn(unauthorizedResponse.body!, 'cancel');
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorizedResponse)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+        })
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ApiClient();
+    client.setAccessToken('expired-token');
+    client.setRefreshAccessTokenHandler(async () => {
+      client.setAccessToken('fresh-token');
+      return true;
+    });
+
+    const result = await client.request('/dashboard/test');
+
+    expect(result).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer fresh-token' },
+      })
+    );
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes an expired token when the 401 response has an empty body', async () => {

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -88,15 +88,6 @@ export class ApiClient {
       const response = await fetch(url, config);
 
       if (!response.ok) {
-        let errorData;
-        try {
-          errorData = await response.json();
-        } catch {
-          const error: ApiError = new Error(`HTTP ${response.status}: ${response.statusText}`);
-          error.response = { data: null, status: response.status };
-          throw error;
-        }
-
         if (response.status === 401 && !skipRefresh && !isRetry) {
           // Queue behind existing refresh or start a new one
           if (!this.refreshPromise && this.onRefreshAccessToken) {
@@ -111,6 +102,15 @@ export class ApiClient {
           }
           this.clearTokens();
           this.onAuthError?.();
+        }
+
+        let errorData;
+        try {
+          errorData = await response.json();
+        } catch {
+          const error: ApiError = new Error(`HTTP ${response.status}: ${response.statusText}`);
+          error.response = { data: null, status: response.status };
+          throw error;
         }
 
         if (errorData.error && errorData.message) {

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -98,6 +98,7 @@ export class ApiClient {
 
           const refreshed = await this.refreshPromise;
           if (refreshed) {
+            await response.body?.cancel();
             return makeRequest(true);
           }
           this.clearTokens();


### PR DESCRIPTION
## Problem

The dashboard API client parses the response body before handling 401
responses.

When a 401 response has an empty or non-JSON body, response.json()
throws before the authentication refresh logic is reached. This prevents
the client from refreshing an expired access token.

## Fix

Handle the 401 refresh flow before parsing the error response body.

This allows authentication refresh to work regardless of whether the
401 response body is JSON, empty, or non-JSON.

## Tests

Added regression coverage for:

- 401 response with an empty body
- 401 response with a non-JSON body

Verified existing streaming authentication refresh behavior still passes.

## Validation

- Dashboard client tests: 6/6 passed
- Dashboard lint: passed
- `git diff --check`: passed
- Dashboard typecheck: currently reports 28 unrelated existing errors
  in the Compute feature / shared schemas.


Fixes #1988 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes auth before parsing 401 responses so empty or non-JSON 401 bodies no longer block token refresh and retry. Previously the client parsed the 401 body first and could throw; now it refreshes, cancels the original body, and retries before any parsing while preserving existing error handling.

- `packages/dashboard/src/lib/api/client.ts`: On 401, queue/start refresh; if successful, cancel `response.body` and retry with the refreshed `Authorization` header; if not, clear tokens and call `onAuthError`. Defer `response.json()` until after the refresh path; on parse failure, throw a generic `ApiError` with status and null data.
- `packages/dashboard/src/lib/api/client.test.ts`: Add tests for 401 with non-JSON and empty bodies; assert two fetch calls, cancel of the first body, and the refreshed `Authorization` header; streaming refresh tests remain unchanged.

<sup>Written for commit 36824baa4a1ea781e3ab93a3af019ad99f8648e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication recovery for unauthorized responses with empty or non-JSON bodies.
  * Requests now refresh credentials and retry successfully instead of failing during error handling.
  * Properly cancels the original response before retrying a request.

* **Tests**
  * Added coverage for token refresh, successful retries, request counts, refreshed authorization headers, and response-body cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->