### PR TITLE
Fix: GET /api/logs/audits?limit=0 returns all rows instead of zero (#1990)

### DIFF
--- a/backend/src/api/routes/logs/index.routes.ts
+++ b/backend/src/api/routes/logs/index.routes.ts
@@ -12,8 +12,11 @@ const router = Router();
 router.use(verifyAdmin);
 
 function parseAuditLimit(raw: unknown): number {
+  if (typeof raw === 'string' && raw.trim() === '') {
+    return 100;
+  }
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? n : 100;
+  return Number.isInteger(n) && n >= 0 ? n : 100;
 }
 
 // GET /logs/audits - List audit logs

--- a/backend/src/api/routes/logs/index.routes.ts
+++ b/backend/src/api/routes/logs/index.routes.ts
@@ -12,9 +12,6 @@ const router = Router();
 router.use(verifyAdmin);
 
 function parseAuditLimit(raw: unknown): number {
-  if (raw === undefined || raw === null) {
-    return 100;
-  }
   const str = String(raw).trim();
   if (str === '') {
     return 100;

--- a/backend/src/api/routes/logs/index.routes.ts
+++ b/backend/src/api/routes/logs/index.routes.ts
@@ -12,10 +12,14 @@ const router = Router();
 router.use(verifyAdmin);
 
 function parseAuditLimit(raw: unknown): number {
-  if (typeof raw === 'string' && raw.trim() === '') {
+  if (raw === undefined || raw === null) {
     return 100;
   }
-  const n = Number(raw);
+  const str = String(raw).trim();
+  if (str === '') {
+    return 100;
+  }
+  const n = Number(str);
   return Number.isSafeInteger(n) && n >= 0 ? n : 100;
 }
 

--- a/backend/src/api/routes/logs/index.routes.ts
+++ b/backend/src/api/routes/logs/index.routes.ts
@@ -16,7 +16,7 @@ function parseAuditLimit(raw: unknown): number {
     return 100;
   }
   const n = Number(raw);
-  return Number.isInteger(n) && n >= 0 ? n : 100;
+  return Number.isSafeInteger(n) && n >= 0 ? n : 100;
 }
 
 // GET /logs/audits - List audit logs

--- a/backend/src/api/routes/logs/index.routes.ts
+++ b/backend/src/api/routes/logs/index.routes.ts
@@ -11,6 +11,11 @@ const router = Router();
 // All logs routes require admin authentication
 router.use(verifyAdmin);
 
+function parseAuditLimit(raw: unknown): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 100;
+}
+
 // GET /logs/audits - List audit logs
 router.get('/audits', async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
@@ -20,7 +25,7 @@ router.get('/audits', async (req: AuthRequest, res: Response, next: NextFunction
 
     // Build query parameters for audit service
     const queryParams = {
-      limit: Number(limit),
+      limit: parseAuditLimit(limit),
       offset: Number(offset),
       ...(actor && typeof actor === 'string' && { actor }),
       ...(action && typeof action === 'string' && { action }),

--- a/backend/src/services/logs/audit.service.ts
+++ b/backend/src/services/logs/audit.service.ts
@@ -117,7 +117,7 @@ export class AuditService {
       let dataSql = `SELECT * FROM system.audit_logs ${whereClause} ORDER BY created_at DESC`;
       const dataParams = [...params];
 
-      if (query.limit !== undefined && Number.isFinite(query.limit) && query.limit >= 0) {
+      if (query.limit !== undefined && Number.isInteger(query.limit) && query.limit >= 0) {
         dataSql += ` LIMIT $${paramIndex++}`;
         dataParams.push(query.limit);
       }

--- a/backend/src/services/logs/audit.service.ts
+++ b/backend/src/services/logs/audit.service.ts
@@ -117,7 +117,7 @@ export class AuditService {
       let dataSql = `SELECT * FROM system.audit_logs ${whereClause} ORDER BY created_at DESC`;
       const dataParams = [...params];
 
-      if (query.limit) {
+      if (query.limit !== undefined) {
         dataSql += ` LIMIT $${paramIndex++}`;
         dataParams.push(query.limit);
       }

--- a/backend/src/services/logs/audit.service.ts
+++ b/backend/src/services/logs/audit.service.ts
@@ -117,7 +117,7 @@ export class AuditService {
       let dataSql = `SELECT * FROM system.audit_logs ${whereClause} ORDER BY created_at DESC`;
       const dataParams = [...params];
 
-      if (query.limit !== undefined) {
+      if (query.limit !== undefined && Number.isFinite(query.limit) && query.limit >= 0) {
         dataSql += ` LIMIT $${paramIndex++}`;
         dataParams.push(query.limit);
       }

--- a/backend/src/services/logs/audit.service.ts
+++ b/backend/src/services/logs/audit.service.ts
@@ -117,7 +117,7 @@ export class AuditService {
       let dataSql = `SELECT * FROM system.audit_logs ${whereClause} ORDER BY created_at DESC`;
       const dataParams = [...params];
 
-      if (query.limit !== undefined && Number.isInteger(query.limit) && query.limit >= 0) {
+      if (query.limit !== undefined && Number.isSafeInteger(query.limit) && query.limit >= 0) {
         dataSql += ` LIMIT $${paramIndex++}`;
         dataParams.push(query.limit);
       }

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -43,14 +43,19 @@ export function errorResponse(
 
 // Pagination response helper - returns data with PostgREST-style pagination headers
 export function paginatedResponse<T>(res: Response, data: T[], total: number, offset: number) {
-  // Calculate the range for Content-Range header
-  const start = offset;
-  const end = Math.min(offset + data.length - 1, total - 1);
-
   // Set PostgREST-style pagination headers
   // Format: "Content-Range: start-end/total"
   // Example: "Content-Range: 0-9/200" for first 10 items out of 200
-  res.setHeader('Content-Range', `${start}-${end}/${total}`);
+  // For an empty page (limit=0, or offset past the end), there's no valid
+  // start-end range to report, so use the RFC 7233 unsatisfied-range form
+  // "*/total" that PostgREST itself falls back to in the same situation.
+  if (data.length === 0) {
+    res.setHeader('Content-Range', `*/${total}`);
+  } else {
+    const start = offset;
+    const end = Math.min(offset + data.length - 1, total - 1);
+    res.setHeader('Content-Range', `${start}-${end}/${total}`);
+  }
 
   // Also set Prefer header to indicate preference was applied
   res.setHeader('Preference-Applied', 'count=exact');

--- a/backend/tests/unit/audit.service.test.ts
+++ b/backend/tests/unit/audit.service.test.ts
@@ -82,6 +82,7 @@ describe('AuditService', () => {
     ['Infinity', Infinity],
     ['a fractional value', 1.5],
     ['a negative value', -1],
+    ['a value beyond Number.MAX_SAFE_INTEGER', 1e20],
   ])(
     'omits the LIMIT clause instead of binding an invalid limit (%s)',
     async (_label, limit) => {

--- a/backend/tests/unit/audit.service.test.ts
+++ b/backend/tests/unit/audit.service.test.ts
@@ -80,8 +80,10 @@ describe('AuditService', () => {
   it.each([
     ['NaN', NaN],
     ['Infinity', Infinity],
+    ['a fractional value', 1.5],
+    ['a negative value', -1],
   ])(
-    'omits the LIMIT clause instead of binding a non-finite limit (%s)',
+    'omits the LIMIT clause instead of binding an invalid limit (%s)',
     async (_label, limit) => {
       mockPool.query
         .mockResolvedValueOnce({ rows: [{ count: '5' }] })

--- a/backend/tests/unit/audit.service.test.ts
+++ b/backend/tests/unit/audit.service.test.ts
@@ -61,4 +61,19 @@ describe('AuditService', () => {
     ]);
     expect(result.actor).toBe('');
   });
+
+  it('applies LIMIT 0 when limit is explicitly 0, instead of returning all rows', async () => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await AuditService.getInstance().query({ limit: 0 });
+
+    expect(mockPool.query).toHaveBeenCalledTimes(2);
+
+    const [dataSql, dataParams] = mockPool.query.mock.calls[1];
+    expect(dataSql).toContain('LIMIT');
+    expect(dataParams).toContain(0);
+    expect(result.records).toEqual([]);
+  });
 });

--- a/backend/tests/unit/audit.service.test.ts
+++ b/backend/tests/unit/audit.service.test.ts
@@ -83,18 +83,15 @@ describe('AuditService', () => {
     ['a fractional value', 1.5],
     ['a negative value', -1],
     ['a value beyond Number.MAX_SAFE_INTEGER', 1e20],
-  ])(
-    'omits the LIMIT clause instead of binding an invalid limit (%s)',
-    async (_label, limit) => {
-      mockPool.query
-        .mockResolvedValueOnce({ rows: [{ count: '5' }] })
-        .mockResolvedValueOnce({ rows: [] });
+  ])('omits the LIMIT clause instead of binding an invalid limit (%s)', async (_label, limit) => {
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+      .mockResolvedValueOnce({ rows: [] });
 
-      await AuditService.getInstance().query({ limit });
+    await AuditService.getInstance().query({ limit });
 
-      const [dataSql, dataParams] = mockPool.query.mock.calls[1];
-      expect(dataSql).not.toContain('LIMIT');
-      expect(dataParams).not.toContain(limit);
-    }
-  );
+    const [dataSql, dataParams] = mockPool.query.mock.calls[1];
+    expect(dataSql).not.toContain('LIMIT');
+    expect(dataParams).not.toContain(limit);
+  });
 });

--- a/backend/tests/unit/audit.service.test.ts
+++ b/backend/tests/unit/audit.service.test.ts
@@ -76,4 +76,22 @@ describe('AuditService', () => {
     expect(dataParams).toContain(0);
     expect(result.records).toEqual([]);
   });
+
+  it.each([
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+  ])(
+    'omits the LIMIT clause instead of binding a non-finite limit (%s)',
+    async (_label, limit) => {
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ count: '5' }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await AuditService.getInstance().query({ limit });
+
+      const [dataSql, dataParams] = mockPool.query.mock.calls[1];
+      expect(dataSql).not.toContain('LIMIT');
+      expect(dataParams).not.toContain(limit);
+    }
+  );
 });

--- a/backend/tests/unit/logs-audit-route.test.ts
+++ b/backend/tests/unit/logs-audit-route.test.ts
@@ -58,6 +58,7 @@ describe('GET /logs/audits limit parsing', () => {
     ['a fractional value', '1.5'],
     ['a non-numeric value', 'abc'],
     ['a negative value', '-5'],
+    ['a value beyond Number.MAX_SAFE_INTEGER', '100000000000000000000'],
   ])('falls back to the default limit of 100 for %s', async (_label, rawLimit) => {
     await request(app()).get('/logs/audits').query({ limit: rawLimit });
 

--- a/backend/tests/unit/logs-audit-route.test.ts
+++ b/backend/tests/unit/logs-audit-route.test.ts
@@ -83,3 +83,19 @@ describe('GET /logs/audits limit parsing', () => {
     expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
   });
 });
+
+describe('GET /logs/audits?limit=0 response', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns zero rows with a well-formed Content-Range header and the real total', async () => {
+    queryMock.mockResolvedValue({ records: [], total: 5 });
+
+    const res = await request(app()).get('/logs/audits').query({ limit: '0' });
+
+    expect(res.status).toBe(206);
+    expect(res.body).toEqual([]);
+    expect(res.headers['content-range']).toBe('*/5');
+  });
+});

--- a/backend/tests/unit/logs-audit-route.test.ts
+++ b/backend/tests/unit/logs-audit-route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../../src/api/middlewares/auth', () => ({
+  verifyAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const queryMock = vi.fn();
+vi.mock('../../src/services/logs/audit.service', () => ({
+  AuditService: {
+    getInstance: () => ({ query: queryMock }),
+  },
+}));
+
+vi.mock('../../src/services/logs/log.service', () => ({
+  LogService: {
+    getInstance: () => ({}),
+  },
+}));
+
+const { logsRouter } = await import('../../src/api/routes/logs/index.routes');
+
+function app() {
+  const a = express();
+  a.use(express.json());
+  a.use('/logs', logsRouter);
+  a.use(
+    (
+      err: { statusCode?: number; message?: string },
+      _req: unknown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      res: any,
+      _next: unknown
+    ) => {
+      void _next;
+      res.status(err.statusCode ?? 500).json({ message: err.message });
+    }
+  );
+  return a;
+}
+
+describe('GET /logs/audits limit parsing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockResolvedValue({ records: [], total: 0 });
+  });
+
+  it('passes an explicit limit=0 through unchanged', async () => {
+    await request(app()).get('/logs/audits').query({ limit: '0' });
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 0 }));
+  });
+
+  it.each([
+    ['a blank string', ''],
+    ['a whitespace-only string', '   '],
+    ['a fractional value', '1.5'],
+    ['a non-numeric value', 'abc'],
+    ['a negative value', '-5'],
+  ])('falls back to the default limit of 100 for %s', async (_label, rawLimit) => {
+    await request(app()).get('/logs/audits').query({ limit: rawLimit });
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
+
+  it('omits limit from the query when not supplied at all', async () => {
+    await request(app()).get('/logs/audits');
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
+});

--- a/backend/tests/unit/logs-audit-route.test.ts
+++ b/backend/tests/unit/logs-audit-route.test.ts
@@ -65,7 +65,7 @@ describe('GET /logs/audits limit parsing', () => {
     expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
   });
 
-  it('omits limit from the query when not supplied at all', async () => {
+  it('defaults limit to 100 when not supplied at all', async () => {
     await request(app()).get('/logs/audits');
 
     expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));

--- a/backend/tests/unit/logs-audit-route.test.ts
+++ b/backend/tests/unit/logs-audit-route.test.ts
@@ -70,4 +70,16 @@ describe('GET /logs/audits limit parsing', () => {
 
     expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
   });
+
+  it('falls back to the default limit of 100 for an array-wrapped blank value (limit[]=)', async () => {
+    await request(app()).get('/logs/audits?limit[]=');
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
+
+  it('falls back to the default limit of 100 when limit is repeated', async () => {
+    await request(app()).get('/logs/audits?limit=5&limit=6');
+
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }));
+  });
 });

--- a/backend/tests/unit/response.test.ts
+++ b/backend/tests/unit/response.test.ts
@@ -55,4 +55,27 @@ describe('Response Utilities', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
   });
+
+  it('paginatedResponse uses the */total form for an empty page of a non-empty total', () => {
+    const data: number[] = [];
+    const total = 5;
+    const offset = 0;
+
+    paginatedResponse(res as Response, data, total, offset);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', '*/5');
+    expect(res.status).toHaveBeenCalledWith(206);
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('paginatedResponse uses the */0 form when there are no rows at all', () => {
+    const data: number[] = [];
+    const total = 0;
+    const offset = 0;
+
+    paginatedResponse(res as Response, data, total, offset);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Range', '*/0');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
 });

--- a/packages/dashboard/src/lib/api/client.test.ts
+++ b/packages/dashboard/src/lib/api/client.test.ts
@@ -33,6 +33,48 @@ describe('ApiClient CSRF cookie handling', () => {
   });
 });
 
+describe('ApiClient pagination parsing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses a normal start-end/total Content-Range header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('[1,2,3]', {
+        status: 206,
+        headers: { 'content-range': '0-2/10' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new ApiClient();
+
+    const result = await client.request('/logs/audits');
+
+    expect(result).toEqual({
+      data: [1, 2, 3],
+      pagination: { offset: 0, limit: 3, total: 10 },
+    });
+  });
+
+  it('parses the */total empty-page Content-Range header without losing the total', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('[]', {
+        status: 206,
+        headers: { 'content-range': '*/5' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new ApiClient();
+
+    const result = await client.request('/logs/audits');
+
+    expect(result).toEqual({
+      data: [],
+      pagination: { offset: 0, limit: 0, total: 5 },
+    });
+  });
+});
+
 describe('ApiClient streaming requests', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/packages/dashboard/src/lib/api/client.ts
+++ b/packages/dashboard/src/lib/api/client.ts
@@ -144,6 +144,15 @@ export class ApiClient {
             pagination: { offset: start, limit: end - start + 1, total },
           };
         }
+        // Empty-page form (RFC 7233 unsatisfied range): "*/total" or "*/*"
+        const emptyMatch = contentRange.match(/^\*\/(\d+|\*)$/);
+        if (emptyMatch) {
+          const total = emptyMatch[1] === '*' ? responseData.length : parseInt(emptyMatch[1]);
+          return {
+            data: responseData,
+            pagination: { offset: 0, limit: 0, total },
+          };
+        }
         return {
           data: responseData,
           pagination: { offset: 0, limit: 0, total: 0 },


### PR DESCRIPTION
## Summary

Fixes #1990.

`AuditService.query()` in `backend/src/services/logs/audit.service.ts` used `if (query.limit)` to decide whether to add a `LIMIT` clause to the constructed SQL. Since this is a truthiness check, `query.limit === 0` was treated the same as "no limit specified" — so a request for `GET /api/logs/audits?limit=0` returned the entire audit log table instead of zero rows.

**Fix:** changed the check to `if (query.limit !== undefined)`, so `limit: 0` is honored and correctly emits `LIMIT $n` with `0` bound. The sibling `offset` check was left untouched, since `OFFSET 0` and no `OFFSET` are equivalent (that asymmetry only affects `limit`).

Also added a regression test in `backend/tests/unit/audit.service.test.ts` asserting that `query({ limit: 0 })` produces a SQL string containing `LIMIT` with `0` in the bound params, and returns zero records.

## How did you test this change?

- Confirmed the new test fails against the pre-fix code: temporarily reverted just the one-line fix in `audit.service.ts` (via `git stash` on that file only) and re-ran the test — it failed with `expected 'SELECT * FROM system.audit_logs WHERE…' to contain 'LIMIT'`, confirming the test actually exercises the bug.
- Restored the fix and re-ran: `npx vitest run tests/unit/audit.service.test.ts` → 2 passed, 0 failed.
- `npx eslint src/services/logs/audit.service.ts tests/unit/audit.service.test.ts` (from `backend/`) → clean, no issues.
- `npx tsc --noEmit` (from `backend/`) → clean, no errors.
- Confirmed change scope is limited to the one source file and one test file (`git status --short`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors limit=0 on GET /api/logs/audits and fixes pagination headers for empty pages. Previously limit=0 returned all rows and produced an invalid range header; now the query applies LIMIT 0 and the response uses RFC 7233’s empty-range form without losing the total.

- Service: applies LIMIT only for a non-negative, safe integer; 0 is allowed, invalid values omit LIMIT. OFFSET unchanged.
- Route: adds parseAuditLimit that trims and stringifies raw inputs; passes 0 through; blanks/whitespace, fractional, non-numeric, negative, oversized, array-wrapped, repeated, or missing limits fall back to 100.
- Response: paginatedResponse emits Content-Range "*/total" for empty pages; returns 206 when total>0 and 200 when total=0.
- Dashboard: `packages/dashboard` `ApiClient` parses both "start-end/total" and "*/total" and preserves the total.
- Tests: adds service, route, response, and client coverage for limit=0, invalid inputs, and empty-page headers.

<sup>Written for commit 2f6cde1c1b70cd448a990cd2f2b795e6d8ef9eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit log pagination limit handling.
  * A limit of `0` now correctly returns no records.
  * Invalid, negative, fractional, non-finite, or excessively large limits now safely use the default limit.
  * Omitted or invalid limits no longer produce unexpected pagination behavior.

* **Tests**
  * Added coverage for valid, invalid, omitted, zero, and boundary limit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->