### PR TITLE
fix(memory): set embedding_model when the reconcile path re-embeds

### DIFF
--- a/backend/src/services/memory/memory.service.ts
+++ b/backend/src/services/memory/memory.service.ts
@@ -242,14 +242,18 @@ Return JSON {"action":"ADD"|"UPDATE"|"NOOP","target_id"?:string,"title"?:string,
       const content = decision.content ?? candidate.content;
       const newEmbedding = await this.embed(`${title}\n${content}`);
       await pool.query(
+        // embedding_model travels with embedding — the row is re-embedded here, so
+        // leaving the old label behind would mislabel the vector it describes.
         `UPDATE memory.memories
-            SET kind = $1, title = $2, content = $3, embedding = $4::vector, source = $5
-          WHERE id = $6 AND scope = $7`,
+            SET kind = $1, title = $2, content = $3, embedding = $4::vector,
+                embedding_model = $5, source = $6
+          WHERE id = $7 AND scope = $8`,
         [
           candidate.kind,
           title,
           content,
           this.toVectorLiteral(newEmbedding),
+          EMBED_MODEL,
           source ?? null,
           decision.target_id,
           scope,

--- a/backend/tests/unit/memory.service.test.ts
+++ b/backend/tests/unit/memory.service.test.ts
@@ -90,6 +90,41 @@ describe('MemoryService.remember — reconcile', () => {
       true
     );
   });
+
+  it('re-labels embedding_model on UPDATE, matching what INSERT records', async () => {
+    // The UPDATE re-embeds, so it must carry the model label with the vector —
+    // otherwise a model change leaves new vectors under the old model's name.
+    const addRes = await service.remember({ scope: 's', kind: 'fact', title: 't', content: 'c' });
+    expect(addRes[0].action).toBe('ADD');
+    const insertCall = poolQueryMock.mock.calls.find(([sql]) =>
+      String(sql).includes('INSERT INTO memory.memories')
+    );
+    const insertedModel = (insertCall![1] as unknown[])[5];
+    expect(typeof insertedModel).toBe('string');
+
+    vi.clearAllMocks();
+    embedMock.mockResolvedValue({ data: [{ embedding: [0.1, 0.2, 0.3] }] });
+    installPool();
+
+    const matchId = '22222222-2222-4222-8222-222222222222';
+    similarRows = [{ id: matchId, kind: 'fact', title: 'old', content: 'old', similarity: 0.8 }];
+    chatMock.mockResolvedValue({
+      text: `{"action":"UPDATE","target_id":"${matchId}","title":"new","content":"new merged"}`,
+    });
+    const updateRes = await service.remember({
+      scope: 's',
+      kind: 'fact',
+      title: 't',
+      content: 'c',
+    });
+    expect(updateRes[0].action).toBe('UPDATE');
+
+    const updateCall = poolQueryMock.mock.calls.find(([sql]) =>
+      String(sql).includes('UPDATE memory.memories')
+    );
+    expect(String(updateCall![0])).toContain('embedding_model');
+    expect(updateCall![1] as unknown[]).toContain(insertedModel);
+  });
 });
 
 describe('MemoryService.remember — extraction sanitization & failure isolation', () => {

--- a/backend/tests/unit/memory.service.test.ts
+++ b/backend/tests/unit/memory.service.test.ts
@@ -122,8 +122,8 @@ describe('MemoryService.remember — reconcile', () => {
     const updateCall = poolQueryMock.mock.calls.find(([sql]) =>
       String(sql).includes('UPDATE memory.memories')
     );
-    expect(String(updateCall![0])).toContain('embedding_model');
-    expect(updateCall![1] as unknown[]).toContain(insertedModel);
+    expect(String(updateCall![0])).toContain('embedding_model = $5');
+    expect((updateCall![1] as unknown[])[4]).toBe(insertedModel);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1981

The reconcile path re-embeds a row and writes the new vector without touching `embedding_model`, so the column ends up describing a vector it didn't produce.

```sql
-- before
UPDATE memory.memories
   SET kind = $1, title = $2, content = $3, embedding = $4::vector, source = $5
 WHERE id = $6 AND scope = $7
```

`embedding` is recomputed on the line above by `this.embed(...)`, which always uses the current `EMBED_MODEL`. The label is whatever the row was inserted with. Those agree today only because `EMBED_MODEL` has never changed. [`543c736e`](https://github.com/InsForge/InsForge/commit/543c736ed) set it and nothing has touched it since, so no deployed row is mislabeled yet and this needs no backfill. It goes wrong on the first model change, and the column it corrupts is exactly the one a backfill would read to decide which rows need re-embedding.

The fix is to move the label with the vector:

```sql
UPDATE memory.memories
   SET kind = $1, title = $2, content = $3, embedding = $4::vector,
       embedding_model = $5, source = $6
 WHERE id = $7 AND scope = $8
```

`embedding_model = $5` sits next to `embedding` rather than at the end of the SET list, since the invariant is that the two are written together. A future edit that adds a column shouldn't have to rediscover that.

No migration, no schema change, no API change, no new dependency. The INSERT path was already correct.

### What this PR deliberately leaves alone

The issue lists three things; this is only the first.

Read-path behavior on mixed models (2) is not here. `findSimilar` and `recall` still compare the query vector against every row in the scope regardless of which model produced it. Filtering to the current `EMBED_MODEL` is the conservative choice, but "ignore old rows", "error on mixed state", and "re-embed on read" are all defensible and they behave differently for someone who flips the constant on a populated store. That's a product call, and it's yours to make. Happy to implement whichever you name, here or in a follow-up.

A backfill path (3) is not here either, for the same reason: it depends on what (2) decides. Re-embedding is an N-row job against the provider, which argues for an explicit migration step rather than anything lazy.

The fix above holds regardless of how those two land, so it doesn't need to wait on them.

The failure stays quiet because the column type doesn't guard against it. `embedding VECTOR(1536)` catches a change in *dimension*, not a same-dimension change of *space*. `embed()` already passes `dimensions: EMBED_DIMENSIONS`, so pointing `EMBED_MODEL` at `openai/text-embedding-3-large` at 1536 dimensions inserts cleanly and produces vectors that aren't comparable to the existing ones. Cosine similarity still returns a number. The type guard that looks like it covers this doesn't.

## How did you test this change?

Branched off `main` @ `4bf10d79`.

One case added to `backend/tests/unit/memory.service.test.ts`, in the existing mocked-pool style:

| case | asserts |
|---|---|
| `re-labels embedding_model on UPDATE, matching what INSERT records` | the UPDATE statement names `embedding_model`, and its bound params carry the same model string the INSERT path binds |

The assertion compares the UPDATE's value against the one captured from a real ADD in the same test rather than hardcoding `'openai/text-embedding-3-small'`. The point of the column is that the two paths agree, so the test fails if they ever drift, including when someone changes `EMBED_MODEL` and updates only one call site. A hardcoded literal would still pass in that case.

Verified the test actually catches the bug by reverting the change and re-running: it fails on the missing `embedding_model` in the SET clause, and passes with the fix.

```
tests/unit/memory.service.test.ts  10 passed        (fix applied)
tests/unit/memory.service.test.ts  1 failed | 9 passed  (fix reverted)
```

Full backend suite, from `backend/`:

| command | result |
|---|---|
| `npm test` | 201 files passed, 4 skipped · **2400 tests passed**, 21 skipped |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (5 pre-existing warnings, in `webscraper/local.provider.ts` and `compute/services.service.ts` — neither touched here) |
| `npx prettier --check` on both changed files | clean |

No manual stack run this time: the change is a single SET clause, and exercising it end to end would mean seeding a store, forcing a reconcile `UPDATE`, changing `EMBED_MODEL`, and re-reading the column. That spends OpenRouter credits to observe what the unit test already asserts against the bound parameters.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set embedding_model when the reconcile UPDATE re-embeds a row to keep the label aligned with the new vector. Previously the UPDATE recomputed embedding but left embedding_model unchanged; now both update together to avoid mislabeled vectors after model changes.

- Updates the UPDATE SQL to set embedding_model with embedding and adjusts parameter order; INSERT behavior is unchanged.
- Adds a unit test verifying UPDATE includes embedding_model and binds the same model string used on INSERT.
- No schema or API changes. No backfill required; existing rows remain consistent. Read-path behavior for mixed models is unchanged.

<sup>Written for commit d2af2fc6eb52ae5322febdbf75068afd3ef66011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `embedding_model` on re-embed in `MemoryService.remember` UPDATE path
> When an existing memory is updated, the UPDATE SQL in [memory.service.ts](https://github.com/InsForge/InsForge/pull/1994/files#diff-851b6d82813f564b587c96cfefcdcc6a55862cd9369dcb9bd89bd6ab0587f401) now sets `embedding_model` alongside the new embedding vector, matching what INSERT already does. Parameter order and WHERE-clause indices were adjusted accordingly. Adds a unit test in [memory.service.test.ts](https://github.com/InsForge/InsForge/pull/1994/files#diff-40645b62cf994d9de16651df7156b00ab974ea4788429f81353cfb2818b6520a) asserting the UPDATE path binds the same model label that INSERT recorded.
> - Risk: the UPDATE query parameter order changed; any out-of-tree callers or hand-written SQL mirroring the old parameter layout would bind values to the wrong columns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8e2c97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured re-embedded memories retain the correct embedding model information.
  * Preserved accurate memory updates within the appropriate scope.

* **Tests**
  * Added regression coverage for embedding model consistency during memory updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->