### PR TITLE
fix(cloud-hosting): make the helper suite test the shipped code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,9 @@ All contributions must include appropriate tests. Follow these guidelines:
 - Update existing tests if your changes affect their behavior
 - Follow the existing test patterns and structure
 - Test across different environments when applicable
+- Import the code under test; never re-implement it in the test file. A copy is
+  correct only on the day it is written, and the suite goes green forever after
+  the real code changes. If the logic is awkward to import, export it.
 
 ## Pull Request Process
 

--- a/backend/tests/unit/cloud-hosting-helpers.test.ts
+++ b/backend/tests/unit/cloud-hosting-helpers.test.ts
@@ -100,5 +100,50 @@ describe('Cloud Hosting Helpers', () => {
       });
       expect(result.latestVersion).toBe('2.0.3');
     });
+
+    it('takes isBranch from the message when it is a boolean', () => {
+      const result = normalizeProjectInfo(undefined, 'https://x.insforge.app', {
+        type: 'PROJECT_INFO',
+        isBranch: true,
+      });
+
+      expect(result.isBranch).toBe(true);
+    });
+
+    it('keeps the previous isBranch when the message omits it', () => {
+      const previous = {
+        id: 'proj-1',
+        name: 'Project',
+        region: 'us-east-1',
+        instanceType: 'small',
+        isBranch: true,
+      };
+
+      const result = normalizeProjectInfo(previous, 'https://x.insforge.app', {
+        type: 'PROJECT_INFO',
+        name: 'Renamed',
+      });
+
+      // A partial message must not silently demote a branch project.
+      expect(result.isBranch).toBe(true);
+      expect(result.name).toBe('Renamed');
+    });
+
+    it('ignores a non-boolean isBranch rather than coercing it', () => {
+      const previous = {
+        id: 'proj-1',
+        name: 'Project',
+        region: '',
+        instanceType: '',
+        isBranch: false,
+      };
+
+      const result = normalizeProjectInfo(previous, 'https://x.insforge.app', {
+        type: 'PROJECT_INFO',
+        isBranch: 'true',
+      });
+
+      expect(result.isBranch).toBe(false);
+    });
   });
 });

--- a/backend/tests/unit/cloud-hosting-helpers.test.ts
+++ b/backend/tests/unit/cloud-hosting-helpers.test.ts
@@ -8,15 +8,6 @@ import { describe, it, expect } from 'vitest';
  * to verify cloud-hosting detection and message normalization.
  */
 
-// Mirrors isCloudHostingBackend from frontend/src/cloudHostingHelpers.ts
-function isCloudHostingBackend(backendUrl: string): boolean {
-  try {
-    return new URL(backendUrl).hostname.endsWith('.insforge.app');
-  } catch {
-    return false;
-  }
-}
-
 // Mirrors getErrorMessage from frontend/src/cloudHostingHelpers.ts
 function getErrorMessage(message: unknown, fallback: string): string {
   return typeof message === 'string' && message.trim() ? message : fallback;
@@ -59,71 +50,7 @@ function normalizeProjectInfo(
   };
 }
 
-// Mirrors backendUrl resolution from frontend/src/App.tsx
-function resolveBackendUrl(envVar: string | undefined, windowOrigin: string): string {
-  return envVar || windowOrigin;
-}
-
 describe('Cloud Hosting Helpers', () => {
-  describe('isCloudHostingBackend', () => {
-    it('returns true for .insforge.app hostnames', () => {
-      expect(isCloudHostingBackend('https://abc123.us-east-1.insforge.app')).toBe(true);
-      expect(isCloudHostingBackend('https://myproject.eu-west-1.insforge.app')).toBe(true);
-      expect(isCloudHostingBackend('https://test.insforge.app')).toBe(true);
-    });
-
-    it('returns false for non-insforge hostnames', () => {
-      expect(isCloudHostingBackend('http://localhost:7130')).toBe(false);
-      expect(isCloudHostingBackend('https://example.com')).toBe(false);
-      expect(isCloudHostingBackend('https://insforge.app')).toBe(false); // no subdomain, but hostname IS insforge.app which ends with .insforge.app? No — "insforge.app".endsWith(".insforge.app") is true
-    });
-
-    it('returns true for bare insforge.app (endsWith includes exact match)', () => {
-      // "insforge.app".endsWith(".insforge.app") => false because of the leading dot
-      expect(isCloudHostingBackend('https://insforge.app')).toBe(false);
-    });
-
-    it('returns false for invalid URLs', () => {
-      expect(isCloudHostingBackend('')).toBe(false);
-      expect(isCloudHostingBackend('not-a-url')).toBe(false);
-    });
-
-    it('returns false for similar but different domains', () => {
-      expect(isCloudHostingBackend('https://evil-insforge.app')).toBe(false);
-      expect(isCloudHostingBackend('https://insforge.app.evil.com')).toBe(false);
-    });
-  });
-
-  describe('resolveBackendUrl (App.tsx logic)', () => {
-    it('uses env var when set', () => {
-      expect(resolveBackendUrl('http://localhost:7130', 'https://abc.insforge.app')).toBe(
-        'http://localhost:7130'
-      );
-    });
-
-    it('falls back to window origin when env var is empty', () => {
-      expect(resolveBackendUrl('', 'https://abc.us-east-1.insforge.app')).toBe(
-        'https://abc.us-east-1.insforge.app'
-      );
-    });
-
-    it('falls back to window origin when env var is undefined', () => {
-      expect(resolveBackendUrl(undefined, 'https://abc.us-east-1.insforge.app')).toBe(
-        'https://abc.us-east-1.insforge.app'
-      );
-    });
-
-    it('cloud detection works with resolved URL from window.location.origin', () => {
-      const backendUrl = resolveBackendUrl(undefined, 'https://myproject.us-east-1.insforge.app');
-      expect(isCloudHostingBackend(backendUrl)).toBe(true);
-    });
-
-    it('self-hosting detection works with localhost origin', () => {
-      const backendUrl = resolveBackendUrl(undefined, 'http://localhost:5173');
-      expect(isCloudHostingBackend(backendUrl)).toBe(false);
-    });
-  });
-
   describe('getErrorMessage', () => {
     it('returns the message when it is a non-empty string', () => {
       expect(getErrorMessage('Something went wrong', 'fallback')).toBe('Something went wrong');

--- a/backend/tests/unit/cloud-hosting-helpers.test.ts
+++ b/backend/tests/unit/cloud-hosting-helpers.test.ts
@@ -1,54 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { getErrorMessage, normalizeProjectInfo } from '../../../frontend/src/cloud-hosting/helpers';
 
 /**
- * Tests for the cloud hosting detection and helper logic
- * used in frontend/src/cloudHostingHelpers.ts and frontend/src/App.tsx
- *
- * These test the pure logic extracted from the frontend helpers
- * to verify cloud-hosting detection and message normalization.
+ * Covers the pure helpers behind the cloud-hosting postMessage bridge, as
+ * imported from the module that ships them. The suite previously defined its
+ * own copies, so it passed no matter what the real helpers did.
  */
-
-// Mirrors getErrorMessage from frontend/src/cloudHostingHelpers.ts
-function getErrorMessage(message: unknown, fallback: string): string {
-  return typeof message === 'string' && message.trim() ? message : fallback;
-}
-
-// Mirrors normalizeProjectInfo from frontend/src/cloudHostingHelpers.ts
-function normalizeProjectInfo(
-  previous: { id: string; name: string; region: string; instanceType: string } | undefined,
-  backendUrl: string,
-  message: { type: string; [key: string]: unknown }
-) {
-  const previousInfo = previous ?? {
-    id: backendUrl,
-    name: 'Project',
-    region: '',
-    instanceType: '',
-  };
-
-  return {
-    id: typeof message.id === 'string' && message.id ? message.id : previousInfo.id,
-    name: typeof message.name === 'string' && message.name ? message.name : previousInfo.name,
-    region:
-      typeof message.region === 'string' && message.region ? message.region : previousInfo.region,
-    instanceType:
-      typeof message.instanceType === 'string' && message.instanceType
-        ? message.instanceType
-        : previousInfo.instanceType,
-    latestVersion:
-      typeof message.latestVersion === 'string' || message.latestVersion === null
-        ? (message.latestVersion as string | null)
-        : (previous as Record<string, unknown>)?.latestVersion,
-    currentVersion:
-      typeof message.currentVersion === 'string' || message.currentVersion === null
-        ? (message.currentVersion as string | null)
-        : (previous as Record<string, unknown>)?.currentVersion,
-    status:
-      typeof message.status === 'string' && message.status
-        ? message.status
-        : (previous as Record<string, unknown>)?.status,
-  };
-}
 
 describe('Cloud Hosting Helpers', () => {
   describe('getErrorMessage', () => {

--- a/frontend/src/cloud-hosting/helpers.ts
+++ b/frontend/src/cloud-hosting/helpers.ts
@@ -1,0 +1,60 @@
+import type { DashboardProjectInfo } from '@insforge/dashboard';
+
+/**
+ * Pure helpers for the cloud-hosting postMessage bridge.
+ *
+ * These live apart from `useCloudHosting` so they can be imported without
+ * pulling in React or `partner.service`, which is what a node test runner
+ * needs. Keep this module free of runtime imports.
+ */
+
+export type CloudHostingMessage = {
+  type: string;
+  [key: string]: unknown;
+};
+
+/** The message's own error text when it has usable one, else the fallback. */
+export function getErrorMessage(message: unknown, fallback: string): string {
+  return typeof message === 'string' && message.trim() ? message : fallback;
+}
+
+/**
+ * Folds a PROJECT_INFO message onto whatever is already known.
+ *
+ * Every field falls back to the previous value, so a partial message never
+ * blanks out state that an earlier message established.
+ */
+export function normalizeProjectInfo(
+  previous: DashboardProjectInfo | undefined,
+  origin: string,
+  message: CloudHostingMessage
+): DashboardProjectInfo {
+  const previousInfo = previous ?? {
+    id: origin,
+    name: 'Project',
+    region: '',
+    instanceType: '',
+  };
+
+  return {
+    id: typeof message.id === 'string' && message.id ? message.id : previousInfo.id,
+    name: typeof message.name === 'string' && message.name ? message.name : previousInfo.name,
+    region:
+      typeof message.region === 'string' && message.region ? message.region : previousInfo.region,
+    instanceType:
+      typeof message.instanceType === 'string' && message.instanceType
+        ? message.instanceType
+        : previousInfo.instanceType,
+    latestVersion:
+      typeof message.latestVersion === 'string' || message.latestVersion === null
+        ? (message.latestVersion as string | null)
+        : previousInfo.latestVersion,
+    currentVersion:
+      typeof message.currentVersion === 'string' || message.currentVersion === null
+        ? (message.currentVersion as string | null)
+        : previousInfo.currentVersion,
+    status:
+      typeof message.status === 'string' && message.status ? message.status : previousInfo.status,
+    isBranch: typeof message.isBranch === 'boolean' ? message.isBranch : previousInfo.isBranch,
+  };
+}

--- a/frontend/src/cloud-hosting/useCloudHosting.ts
+++ b/frontend/src/cloud-hosting/useCloudHosting.ts
@@ -14,6 +14,7 @@ import type {
   DashboardMetricsResponse,
 } from '@insforge/dashboard';
 import { partnerService } from './partner.service';
+import { getErrorMessage, normalizeProjectInfo, type CloudHostingMessage } from './helpers';
 
 const VALID_METRICS_RANGES: readonly DashboardMetricsRange[] = ['1h', '6h', '24h', '3d'] as const;
 const VALID_METRIC_NAMES: readonly DashboardMetricName[] = [
@@ -32,11 +33,6 @@ type InstanceTypeChangeResult = {
   success: boolean;
   instanceType?: string;
   error?: string;
-};
-
-type CloudHostingMessage = {
-  type: string;
-  [key: string]: unknown;
 };
 
 type PendingRequestKey =
@@ -200,10 +196,6 @@ function getCurrentOrigin(): string {
   return '';
 }
 
-function getErrorMessage(message: unknown, fallback: string): string {
-  return typeof message === 'string' && message.trim() ? message : fallback;
-}
-
 function normalizeBackups(backups: unknown): DashboardBackup[] {
   if (!Array.isArray(backups)) {
     return [];
@@ -238,41 +230,6 @@ function normalizeBackups(backups: unknown): DashboardBackup[] {
           : null,
     };
   });
-}
-
-function normalizeProjectInfo(
-  previous: DashboardProjectInfo | undefined,
-  origin: string,
-  message: CloudHostingMessage
-): DashboardProjectInfo {
-  const previousInfo = previous ?? {
-    id: origin,
-    name: 'Project',
-    region: '',
-    instanceType: '',
-  };
-
-  return {
-    id: typeof message.id === 'string' && message.id ? message.id : previousInfo.id,
-    name: typeof message.name === 'string' && message.name ? message.name : previousInfo.name,
-    region:
-      typeof message.region === 'string' && message.region ? message.region : previousInfo.region,
-    instanceType:
-      typeof message.instanceType === 'string' && message.instanceType
-        ? message.instanceType
-        : previousInfo.instanceType,
-    latestVersion:
-      typeof message.latestVersion === 'string' || message.latestVersion === null
-        ? (message.latestVersion as string | null)
-        : previousInfo.latestVersion,
-    currentVersion:
-      typeof message.currentVersion === 'string' || message.currentVersion === null
-        ? (message.currentVersion as string | null)
-        : previousInfo.currentVersion,
-    status:
-      typeof message.status === 'string' && message.status ? message.status : previousInfo.status,
-    isBranch: typeof message.isBranch === 'boolean' ? message.isBranch : previousInfo.isBranch,
-  };
 }
 
 export function useCloudHosting() {


### PR DESCRIPTION
## Summary

Closes #1995. Thanks to @Chirag6722 for the report, which is accurate and well diagnosed.

`backend/tests/unit/cloud-hosting-helpers.test.ts` imported nothing but `vitest`. Everything it asserted against was defined in the same file, under comments naming a source file that is not in the tree. It passed on every run regardless of what the shipped code did.

Two things I found on top of the report:

**There were four mirrored functions, not three.** `resolveBackendUrl` is also local-only and also exists nowhere else.

**The copies had already drifted.** The shipped `normalizeProjectInfo` gained `isBranch` in `7e7a29df`; the copy never did. So the suite had been asserting a stale shape for as long as the field has existed.

## What the commits do

| | |
|---|---|
| `86a27ed` | `refactor` — extract the two real helpers into `frontend/src/cloud-hosting/helpers.ts` |
| `b135944` | `test` — delete the suites for the two functions that do not exist |
| `f8f029e` | `test` — import the shipped helpers instead of local copies |
| `9fb8f11` | `test` — cover `isBranch` |
| `f250872` | `docs` — state the rule in CONTRIBUTING |

The refactor is a prerequisite, not scope creep. `getErrorMessage` and `normalizeProjectInfo` were module-private inside `useCloudHosting`, which imports React and `partner.service`, so no node test could reach them. That is very likely why they were copied in the first place. Both bodies move verbatim; `helpers.ts` has type-only imports so a node runner can load it.

## One thing worth flagging

**Switching to the real import does not turn anything red.** I expected it to, given the `isBranch` drift, and it does not. The existing cases compare with `toEqual`, which ignores keys whose value is `undefined`, and `isBranch` is `undefined` whenever no previous info carries it. So the drift was invisible in both directions, which is a sharper version of the report's point rather than a softer one: the copy was wrong, and the assertions could not tell.

That is why `9fb8f11` adds the coverage directly rather than relying on the swap to surface it.

## Scope

`isCloudHostingBackend` is not reintroduced. It is not dead code awaiting a home; it was never written. The hostname check it imitates does ship, at `packages/dashboard/src/lib/utils/utils.ts:155`, and covering that belongs with #1879 against the real function. Deleting the test rather than blocking on #1879, since a test for a nonexistent function has no value in the meantime.

The frontend has no test runner at all, so the suite stays in `backend/tests/unit/` where it already runs in CI. Giving `frontend/` its own runner is a bigger change than this issue calls for.

## How did you test this change?

- Backend unit suite: **2392 passed, 21 skipped**. The file itself goes 10 → 13 assertions.
- **Mutation-verified.** Removing `isBranch` from the shipped helper fails exactly the three new cases and leaves the other ten green:

```
× takes isBranch from the message when it is a boolean
× keeps the previous isBranch when the message omits it
× ignores a non-boolean isBranch rather than coercing it
  AssertionError: expected undefined to be true
Tests  3 failed | 10 passed (13)
```

That is the check the suite could not have passed before this PR, since the mutation would not have touched the code it was asserting against.

- Frontend `tsc --noEmit`: 4 errors, all pre-existing in `packages/ui/Calendar.tsx` (`react-day-picker` unresolved), identical count on `main`, none in the files this PR touches.
- `eslint` and `prettier --check` clean on all changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the cloud-hosting helper tests exercise the shipped helpers instead of local copies, so the suite can fail when the real code regresses. Extracts `getErrorMessage` and `normalizeProjectInfo` to `frontend/src/cloud-hosting/helpers.ts`, updates tests to import them, and adds explicit coverage for `isBranch`.

**Review notes**
- Deletes suites for `isCloudHostingBackend` and `resolveBackendUrl` (they do not exist in the product code).
- Moves helper bodies verbatim; `useCloudHosting` now imports from `./helpers` and keeps behavior unchanged.
- Tests remain under `backend/tests/unit/` and now import from the new module; mutation verifies `isBranch` coverage.
- Adds a CONTRIBUTING guideline: tests must import the code under test; do not re-implement helpers in test files.

<sup>Written for commit f2508727a359bec5d5811924cf559ece4e871df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cloud-hosting message handling with clearer error fallbacks.
  * Project information now remains stable when incoming data is missing or invalid.
  * Added support for flexible cloud-hosting message formats.

* **Documentation**
  * Updated contribution guidance to require tests to use production code rather than duplicate implementations.

* **Tests**
  * Expanded coverage for valid, omitted, and invalid branch-status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->