### PR TITLE
docs(openapi): make logs.yaml match the routes the logs router mounts

### DIFF
--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -171,6 +171,256 @@ paths:
                   count: 47
                   lastActivity: "2024-01-21T09:58:00Z"
 
+  /api/logs/audits/stats:
+    get:
+      summary: Audit log summary
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: days
+          in: query
+          schema:
+            type: integer
+            default: 7
+          description: Size of the window the summary covers
+      responses:
+        '200':
+          description: Audit activity over the window
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - totalLogs
+                  - uniqueActors
+                  - uniqueModules
+                  - actionsByModule
+                  - recentActivity
+                properties:
+                  totalLogs:
+                    type: integer
+                  uniqueActors:
+                    type: integer
+                  uniqueModules:
+                    type: integer
+                  actionsByModule:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                    description: Action count keyed by module
+                  recentActivity:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AuditLog'
+
+  /api/logs/sources:
+    get:
+      summary: List log sources
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      responses:
+        '200':
+          description: Available log sources
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - id
+                    - name
+                    - token
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    token:
+                      type: string
+
+  /api/logs/search:
+    get:
+      summary: Search logs
+      description: |
+        Paginates through `paginatedResponse`, so responses use 206 with
+        `Content-Range` when the page is a subset and 200 when it is not.
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query
+        - name: source
+          in: query
+          schema:
+            type: string
+          description: Restrict the search to one source
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: All matching log entries were returned
+          headers:
+            Content-Range:
+              schema:
+                type: string
+            Preference-Applied:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LogEntry'
+        '206':
+          description: A page of matching log entries, with more available
+          headers:
+            Content-Range:
+              schema:
+                type: string
+            Preference-Applied:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LogEntry'
+        '400':
+          description: The q parameter is missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: 'INVALID_INPUT'
+                message: 'Search query parameter (q) is required'
+                statusCode: 400
+
+  /api/logs/functions/build-logs:
+    get:
+      summary: Function build logs
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: deployment_id
+          in: query
+          schema:
+            type: string
+          description: Defaults to the latest deployment when omitted
+      responses:
+        '200':
+          description: Build logs for the deployment
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deploymentId
+                  - status
+                  - logs
+                  - createdAt
+                properties:
+                  deploymentId:
+                    type: string
+                  status:
+                    type: string
+                    enum: [pending, success, failed]
+                  logs:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - level
+                        - message
+                      properties:
+                        level:
+                          type: string
+                        message:
+                          type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+        '404':
+          description: Deno Deploy is not configured, or no deployment was found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: 'LOG_NOT_FOUND'
+                message: 'Build logs not available. Deno Deploy may not be configured or no deployments found.'
+                statusCode: 404
+
+  /api/logs/{source}:
+    get:
+      summary: Logs from one source
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: source
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+        - name: before_timestamp
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: Return entries older than this timestamp
+      responses:
+        '200':
+          description: Log entries for the source
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - logs
+                  - total
+                properties:
+                  logs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LogEntry'
+                  total:
+                    type: integer
+
 components:
   securitySchemes:
     bearerAuth:
@@ -215,6 +465,26 @@ components:
         updatedAt:
           type: string
           format: date-time
+
+    LogEntry:
+      type: object
+      required:
+        - id
+        - eventMessage
+        - timestamp
+        - body
+      properties:
+        id:
+          type: string
+        eventMessage:
+          type: string
+        timestamp:
+          type: string
+        body:
+          type: object
+          additionalProperties: true
+        source:
+          type: string
 
     ErrorResponse:
       type: object

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -108,6 +108,10 @@ paths:
 
     delete:
       summary: Clear audit logs
+      description: |
+        Retention-based cleanup. Deletes every audit log older than
+        `days_to_keep` days and answers with `deleted`, the number of rows
+        removed. There is no dry run, and the deletion is not reversible.
       tags:
         - Admin
       security:
@@ -193,6 +197,11 @@ paths:
   /api/logs/audits/stats:
     get:
       summary: Audit log summary
+      description: |
+        Aggregates the audit log over the last `days` days. `totalLogs`,
+        `uniqueActors` and `uniqueModules` are counts across that window,
+        `actionsByModule` is the per-module action count keyed by module
+        name, and `recentActivity` carries the most recent entries in full.
       tags:
         - Admin
       security:

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -55,6 +55,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: All matching audit logs were returned
           headers:
@@ -117,6 +119,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Audit logs cleared
           content:
@@ -149,6 +153,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Statistics for each log source
           content:
@@ -195,6 +201,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Audit activity over the window
           content:
@@ -235,6 +243,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Available log sources
           content:
@@ -291,6 +301,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: All matching log entries were returned
           headers:
@@ -349,6 +361,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Build logs for the deployment
           content:
@@ -420,6 +434,8 @@ paths:
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '200':
           description: Log entries for the source
           content:
@@ -439,6 +455,17 @@ paths:
 
 components:
   responses:
+    Forbidden:
+      description: Authenticated, but the token is not a project_admin
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: 'AUTH_UNAUTHORIZED'
+            message: 'Admin access required'
+            statusCode: 403
+
     Unauthorized:
       description: Missing or invalid admin credentials
       content:

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -274,6 +274,14 @@ paths:
       description: |
         Paginates through `paginatedResponse`, so responses use 206 with
         `Content-Range` when the page is a subset and 200 when it is not.
+
+        How far that contract holds depends on the configured log provider.
+        The local provider slices the full result set, so `offset` and the
+        total in `Content-Range` behave as expected. The CloudWatch provider
+        cannot express offset in an Insights query: it ignores `offset` and
+        reports the length of the returned page as the total. Paging past
+        the first page there repeats results, so treat this endpoint as
+        single-page unless the deployment uses the local provider.
       tags:
         - Admin
       security:
@@ -301,6 +309,7 @@ paths:
           schema:
             type: integer
             default: 0
+          description: Ignored by the CloudWatch provider; see the description above
       responses:
         '401':
           $ref: '#/components/responses/Unauthorized'

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -133,7 +133,10 @@ paths:
 
   /api/logs/stats:
     get:
-      summary: Get logs statistics
+      summary: Per-source log statistics
+      description: |
+        One entry per system log source. This is not the audit-log summary;
+        that lives at `/api/logs/audits/stats`.
       tags:
         - Admin
       security:
@@ -141,53 +144,32 @@ paths:
         - apiKey: []
       responses:
         '200':
-          description: Logs statistics
+          description: Statistics for each log source
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  actionStats:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        action:
-                          type: string
-                        count:
-                          type: integer
-                  tableStats:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        table_name:
-                          type: string
-                        count:
-                          type: integer
-                  recentActivity:
-                    type: integer
-                    description: Count of logs in last 24 hours
-                  totalLogs:
-                    type: integer
-                    description: Total number of logs
+                type: array
+                items:
+                  type: object
+                  required:
+                    - source
+                    - count
+                    - lastActivity
+                  properties:
+                    source:
+                      type: string
+                    count:
+                      type: integer
+                    lastActivity:
+                      type: string
+                      format: date-time
               example:
-                actionStats:
-                  - action: "INSERT"
-                    count: 245
-                  - action: "UPDATE"
-                    count: 189
-                  - action: "DELETE"
-                    count: 34
-                  - action: "LOGIN"
-                    count: 567
-                tableStats:
-                  - table_name: "posts"
-                    count: 156
-                  - table_name: "comments"
-                    count: 223
-                recentActivity: 47
-                totalLogs: 1035
+                - source: "postgres"
+                  count: 1035
+                  lastActivity: "2024-01-21T10:31:00Z"
+                - source: "deno-relay"
+                  count: 47
+                  lastActivity: "2024-01-21T09:58:00Z"
 
 components:
   securitySchemes:

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -174,7 +174,10 @@ paths:
                       type: integer
                     lastActivity:
                       type: string
-                      format: date-time
+                      description: |
+                        ISO 8601 timestamp of the most recent entry, or an
+                        empty string when the source has no activity to
+                        report. Not marked format: date-time for that reason.
               example:
                 - source: "postgres"
                   count: 1035

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -4,9 +4,13 @@ info:
   version: 1.0.0
 
 paths:
-  /api/logs:
+  /api/logs/audits:
     get:
-      summary: List activity logs
+      summary: List audit logs
+      description: |
+        Paginated activity log. Responses use the PostgREST-style contract from
+        `paginatedResponse`: `206 Partial Content` with a `Content-Range` header
+        when the page is a subset, `200` when it returns everything.
       tags:
         - Admin
       security:
@@ -23,121 +27,109 @@ paths:
           schema:
             type: integer
             default: 0
+        - name: actor
+          in: query
+          schema:
+            type: string
+          description: Filter by the actor that performed the action
         - name: action
           in: query
           schema:
             type: string
-            enum: [INSERT, UPDATE, DELETE, LOGIN]
-          description: Filter by action type
-        - name: table
+          description: Filter by action name
+        - name: module
           in: query
           schema:
             type: string
-      responses:
-        '200':
-          description: List of logs with pagination
-          headers:
-            X-Total-Count:
-              schema:
-                type: integer
-              description: Total number of logs
-            X-Page:
-              schema:
-                type: integer
-              description: Current page number
-            X-Page-Size:
-              schema:
-                type: integer
-              description: Number of items per page
-            X-Total-Pages:
-              schema:
-                type: integer
-              description: Total number of pages
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    timestamp:
-                      type: string
-                      format: date-time
-                    action:
-                      type: string
-                      enum: [INSERT, UPDATE, DELETE, LOGIN]
-                    table:
-                      type: string
-                      nullable: true
-                    record_id:
-                      type: string
-                      nullable: true
-                    user_id:
-                      type: string
-                    details:
-                      type: object
-                      nullable: true
-              example:
-                - id: "log-123"
-                  timestamp: "2024-01-21T10:30:00Z"
-                  action: "INSERT"
-                  table: "posts"
-                  record_id: "post-456"
-                  user_id: "user-789"
-                  details:
-                    title: "New Post"
-                    author: "John Doe"
-                - id: "log-124"
-                  timestamp: "2024-01-21T10:31:00Z"
-                  action: "LOGIN"
-                  table: null
-                  record_id: null
-                  user_id: "user-789"
-                  details:
-                    ip: "192.168.1.1"
-                    user_agent: "Mozilla/5.0..."
-
-    delete:
-      summary: Clear logs
-      tags:
-        - Admin
-      security:
-        - bearerAuth: []
-        - apiKey: []
-      parameters:
-        - name: before
+          description: Filter by the module the action belongs to
+        - name: start_date
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: end_date
           in: query
           schema:
             type: string
             format: date-time
       responses:
         '200':
-          description: Logs cleared
+          description: All matching audit logs were returned
+          headers:
+            Content-Range:
+              schema:
+                type: string
+              description: 'Range and total, e.g. `0-9/10`'
+            Preference-Applied:
+              schema:
+                type: string
+              description: Always `count=exact`
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLog'
+        '206':
+          description: A page of audit logs, with more available
+          headers:
+            Content-Range:
+              schema:
+                type: string
+              description: 'Range and total, e.g. `0-99/1234`'
+            Preference-Applied:
+              schema:
+                type: string
+              description: Always `count=exact`
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuditLog'
+              example:
+                - id: "audit-123"
+                  actor: "admin@example.com"
+                  action: "START_DEPLOYMENT"
+                  module: "DEPLOYMENTS"
+                  details:
+                    id: "dep-456"
+                  ipAddress: "192.168.1.1"
+                  createdAt: "2024-01-21T10:30:00Z"
+                  updatedAt: "2024-01-21T10:30:00Z"
+
+    delete:
+      summary: Clear audit logs
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+        - apiKey: []
+      parameters:
+        - name: days_to_keep
+          in: query
+          schema:
+            type: integer
+            default: 90
+          description: Audit logs older than this many days are deleted
+      responses:
+        '200':
+          description: Audit logs cleared
           content:
             application/json:
               schema:
                 type: object
+                required:
+                  - message
+                  - deleted
                 properties:
                   message:
                     type: string
-                  deleted_count:
+                  deleted:
                     type: integer
               example:
-                message: "Logs cleared successfully"
-                deleted_count: 150
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error: "INVALID_DATE"
-                message: "Invalid date format for 'before' parameter"
-                statusCode: 400
-                nextAction: "Use ISO 8601 date format (YYYY-MM-DDTHH:mm:ssZ)"
+                message: "Audit logs cleared successfully"
+                deleted: 150
 
   /api/logs/stats:
     get:
@@ -208,6 +200,40 @@ components:
       name: x-api-key
   
   schemas:
+    AuditLog:
+      type: object
+      required:
+        - id
+        - actor
+        - action
+        - module
+        - details
+        - ipAddress
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        actor:
+          type: string
+        action:
+          type: string
+        module:
+          type: string
+        details:
+          type: object
+          nullable: true
+          additionalProperties: true
+        ipAddress:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
     ErrorResponse:
       type: object
       required:

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -53,6 +53,8 @@ paths:
             type: string
             format: date-time
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: All matching audit logs were returned
           headers:
@@ -113,6 +115,8 @@ paths:
             default: 90
           description: Audit logs older than this many days are deleted
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Audit logs cleared
           content:
@@ -143,6 +147,8 @@ paths:
         - bearerAuth: []
         - apiKey: []
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Statistics for each log source
           content:
@@ -187,6 +193,8 @@ paths:
             default: 7
           description: Size of the window the summary covers
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Audit activity over the window
           content:
@@ -225,6 +233,8 @@ paths:
         - bearerAuth: []
         - apiKey: []
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Available log sources
           content:
@@ -279,6 +289,8 @@ paths:
             type: integer
             default: 0
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: All matching log entries were returned
           headers:
@@ -335,6 +347,8 @@ paths:
             type: string
           description: Defaults to the latest deployment when omitted
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Build logs for the deployment
           content:
@@ -404,6 +418,8 @@ paths:
             format: date-time
           description: Return entries older than this timestamp
       responses:
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '200':
           description: Log entries for the source
           content:
@@ -422,6 +438,18 @@ paths:
                     type: integer
 
 components:
+  responses:
+    Unauthorized:
+      description: Missing or invalid admin credentials
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: 'AUTH_INVALID_CREDENTIALS'
+            message: 'Unauthorized'
+            statusCode: 401
+
   securitySchemes:
     bearerAuth:
       type: http

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -586,6 +586,6 @@ components:
         statusCode:
           type: integer
           description: HTTP status code
-        nextAction:
+        nextActions:
           type: string
           description: Suggested action to resolve the error

--- a/openapi/logs.yaml
+++ b/openapi/logs.yaml
@@ -61,10 +61,12 @@ paths:
           description: All matching audit logs were returned
           headers:
             Content-Range:
+              required: true
               schema:
                 type: string
               description: 'Range and total, e.g. `0-9/10`'
             Preference-Applied:
+              required: true
               schema:
                 type: string
               description: Always `count=exact`
@@ -78,10 +80,12 @@ paths:
           description: A page of audit logs, with more available
           headers:
             Content-Range:
+              required: true
               schema:
                 type: string
               description: 'Range and total, e.g. `0-99/1234`'
             Preference-Applied:
+              required: true
               schema:
                 type: string
               description: Always `count=exact`
@@ -319,9 +323,11 @@ paths:
           description: All matching log entries were returned
           headers:
             Content-Range:
+              required: true
               schema:
                 type: string
             Preference-Applied:
+              required: true
               schema:
                 type: string
           content:
@@ -334,9 +340,11 @@ paths:
           description: A page of matching log entries, with more available
           headers:
             Content-Range:
+              required: true
               schema:
                 type: string
             Preference-Applied:
+              required: true
               schema:
                 type: string
           content:


### PR DESCRIPTION
## Summary

Closes #1685. Thanks to @ayaangazali for the report; re-verified against `268d79d` and every claim still holds.

`openapi/logs.yaml` described three operations. Two of them do not exist, and seven that do exist were undocumented.

Measured against the router, before and after:

| | `main` | this PR |
|---|---|---|
| Operations mounted | 8 | 8 |
| Operations documented | 3 | 8 |
| Documented but not mounted (404) | `get /api/logs`, `delete /api/logs` | none |
| Mounted but not documented | 7 | none |

## What was wrong

**`/api/logs` is not a route.** The logs router has no bare `/` handler, so both the GET and the DELETE the spec documented 404. The activity log is at `/api/logs/audits`, filtered by `actor`, `action`, `module`, `start_date`, `end_date` — not the documented `action` and `table`.

**The pagination contract was invented.** The spec promised `X-Total-Count`, `X-Page`, `X-Page-Size` and `X-Total-Pages`. None of those are set anywhere in the codebase. `paginatedResponse` emits `206` with `Content-Range` and `Preference-Applied`, falling back to `200` when the page is the whole set.

**`/api/logs/stats` had the wrong type, not just the wrong fields.** The handler returns `logService.getLogSourceStats()`, which is `LogStatsSchema[]` — an array of `{ source, count, lastActivity }`. The spec documented an object with `actionStats` / `tableStats` / `recentActivity` / `totalLogs`, which is a rough approximation of a different endpoint, `/api/logs/audits/stats`.

## Commits

| | |
|---|---|
| `ab7c37a` | replace the phantom `/api/logs` operations with `/api/logs/audits` |
| `dc7cb0a` | correct `/api/logs/stats` to the per-source array it returns |
| `064a6e3` | document the six endpoints that had no spec |
| `8ddd44b` | document the 401 every route can return |

## Notes for the reviewer

- Response shapes are taken from the schemas the handlers return, not written by hand: `auditLogSchema`, `getAuditLogStatsResponseSchema`, `logSourceSchema`, `logSchema`, `getBuildLogsResponseSchema`.
- `AuditLog` uses camelCase (`ipAddress`, `createdAt`) because `AuditService.query` maps the snake_case columns explicitly before returning them. I checked this rather than assuming the column names.
- The last commit is a real gap rather than padding: `router.use(verifyAdmin)` applies to all eight operations and throws `401 AUTH_INVALID_CREDENTIALS`, and no operation documented it.
- #1991 changes `limit` handling on `GET /api/logs/audits`. It touches routes and tests only, no spec file, so there is no conflict here; if it lands first the `limit` description may want a small follow-up.

## How did you test this change?

Cross-checked the spec against the router mechanically rather than by eye. The script parses `openapi/logs.yaml`, extracts every `router.<verb>('<path>')` from `backend/src/api/routes/logs/index.routes.ts`, normalises `:source` to `{source}`, and diffs the two sets both ways.

On `main`:

```
routes mounted:   8
operations documented: 3
documented but not mounted (would 404): get /api/logs, delete /api/logs
mounted but not documented: get /api/logs/audits, get /api/logs/audits/stats,
  delete /api/logs/audits, get /api/logs/sources,
  get /api/logs/functions/build-logs, get /api/logs/search, get /api/logs/{source}
```

On this branch:

```
routes mounted:   8
operations documented: 8
documented but not mounted (would 404): none
mounted but not documented: none
spec and router agree
```

Also checked: the file parses as YAML, all four `$ref`s resolve against `components`, all eight operations carry the `401`, and `prettier --check` is clean.

## One thing I did not do

A permanent version of that cross-check, as a unit test, would stop this drifting again — and the same drift is plausible in the other files under `openapi/`. I left it out because the only YAML parser available is a hoisted transitive `js-yaml`, and declaring a new devDependency is a call for you rather than something to slip into a docs PR. Happy to file it as its own issue and take it, if you want it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `openapi/logs.yaml` with the mounted logs router so generated clients hit real endpoints and correct types. Also matches server error fields by renaming `ErrorResponse.nextAction` to `nextActions`.

- Use `/api/logs/audits` (not `/api/logs`) to list and clear audit logs. Filters: `actor`, `action`, `module`, `start_date`, `end_date`. DELETE uses `days_to_keep`, is irreversible, and returns `{ message, deleted }`.
- Pagination follows `paginatedResponse`: `206` with required `Content-Range` and `Preference-Applied` headers for partial pages, `200` for full. Stop relying on `X-Total-Count`, `X-Page`, `X-Page-Size`, `X-Total-Pages`.
- `/api/logs/stats` returns an array `{ source, count, lastActivity }`; `lastActivity` can be an empty string. The audit summary lives at `/api/logs/audits/stats` with a `days` window.
- Newly documented routes: `/api/logs/audits/stats`, `/api/logs/sources`, `/api/logs/search` (returns `400` when `q` is missing; `offset` support depends on provider), `/api/logs/functions/build-logs` (may return `404`), `/api/logs/{source}`.
- All logs routes can return `401 AUTH_INVALID_CREDENTIALS` and `403 AUTH_UNAUTHORIZED`. Generated clients should handle these shared failure shapes.
- Update clients to read `ErrorResponse.nextActions` (not `nextAction`).

<sup>Written for commit 484a878ad09c22cb8de41cc1be272ac6b32a47c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit-log filtering by actor, action, module, and date.
  * Added pagination and configurable retention-based audit-log deletion.
  * Added log statistics, audit summaries, source listings, search, build logs, and source-specific log views.
  * Added standardized audit-log and log-entry response formats.

* **Bug Fixes**
  * Standardized unauthorized and forbidden responses across administrative log endpoints.
  * Improved pagination metadata, including provider-specific search behavior.
  * Renamed the error response field from `nextAction` to `nextActions`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->