### PR TITLE
fix(logs): reject unsupported CloudWatch offsets

### DIFF
--- a/backend/src/providers/logs/cloudwatch.provider.ts
+++ b/backend/src/providers/logs/cloudwatch.provider.ts
@@ -426,11 +426,18 @@ export class CloudWatchProvider extends BaseLogProvider {
     query: string,
     sourceName?: string,
     limit: number = 100,
-    _offset = 0 // CloudWatch doesn't support offset-based pagination
+    offset: number = 0 // CloudWatch doesn't support offset-based pagination
   ): Promise<{
     logs: (LogSchema & { source: string })[];
     total: number;
   }> {
+    if (!Number.isFinite(offset) || offset !== 0) {
+      throw new AppError(
+        'CloudWatch log search does not support offset-based pagination',
+        400,
+        ERROR_CODES.INVALID_INPUT
+      );
+    }
     if (!this.cwLogGroup || !this.cwClient) {
       throw new AppError(
         'AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY not found in environment variables',

--- a/backend/tests/unit/cloudwatch-provider-normalize.test.ts
+++ b/backend/tests/unit/cloudwatch-provider-normalize.test.ts
@@ -326,3 +326,13 @@ describe('CloudWatchProvider.parseRawLine - keyword fallback', () => {
     expect((out.metadata as { level: string }).level).toBe('info');
   });
 });
+
+describe('CloudWatchProvider.searchLogs', () => {
+  it.each([10, -10, NaN, Infinity, -Infinity])('rejects unsupported offset %s', async (offset) => {
+    await expect(provider.searchLogs('error', undefined, 10, offset)).rejects.toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_INPUT',
+      message: 'CloudWatch log search does not support offset-based pagination',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1998

The `/api/logs/search` endpoint advertises offset-based pagination, but the CloudWatch log provider currently ignores non-zero offsets. This can cause repeated pages and incorrect `Content-Range` headers.

This change makes the limitation explicit by rejecting non-zero offsets when the CloudWatch provider is used.

## Changes

- Reject `offset > 0` in `CloudWatchProvider.searchLogs()`.
- Return a `400` `INVALID_INPUT` error instead of silently ignoring the offset.
- Keep `offset=0` behavior unchanged.
- Add a regression test covering non-zero CloudWatch offsets.

## Why

CloudWatch Logs Insights does not support offset-based pagination. Silently ignoring the offset causes requests such as:

`offset=0&limit=10`
`offset=10&limit=10`

to return the same page while the response advertises misleading pagination metadata.

Rejecting unsupported offsets makes the API behavior explicit and prevents clients from receiving incorrect pagination results.

Cursor-based pagination can be considered separately as a longer-term solution.

## Testing

- [x] CloudWatch provider unit tests
- [x] TypeScript typecheck
- [x] ESLint
- [x] Prettier
- [x] Regression test for non-zero offsets

## Issue

Closes #1998

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsupported CloudWatch offsets in `/api/logs/search` to prevent misleading pagination. Previously we ignored non‑zero offsets and returned the first page; now we return `400 INVALID_INPUT` for any non‑zero or non‑finite `offset`. `offset=0` is unchanged; other providers are unaffected.

- Migration
  - Do not send `offset` other than `0` for CloudWatch. Use `offset=0` with `limit` and adjust the time range for subsequent pages.
  - Handle `400 INVALID_INPUT` by disabling offset-based pagination for CloudWatch.

- Review notes
  - Adds an early guard in `CloudWatchProvider.searchLogs()` that rejects non‑zero or non‑finite offsets with `AppError(400, INVALID_INPUT)`.
  - Adds a regression test covering offsets `10`, `-10`, `NaN`, `Infinity`, and `-Infinity`.

<sup>Written for commit 67af63f849523bcbc03308eebd7f56ff17292342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/1999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CloudWatch log searches now clearly reject unsupported nonzero or invalid pagination offsets with an informative input error.
  - Preserved existing behavior for searches starting at the first page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->