### PR TITLE
fix(dashboard): pick the shell from the backend's mode, not the hostname

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -27,6 +27,7 @@ import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
+import { buildHealthPayload } from '@/utils/health.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
 import fetch from 'node-fetch';
 import { DatabaseManager } from '@/infra/database/database.manager.js';
@@ -217,13 +218,7 @@ export async function createApp() {
   apiRouter.get('/.well-known/jwks.json', jwksHandler);
 
   apiRouter.get('/health', (_req: Request, res: Response) => {
-    const version = packageJson.version;
-    res.json({
-      status: 'ok',
-      version,
-      service: 'Insforge OSS Backend',
-      timestamp: new Date().toISOString(),
-    });
+    res.json(buildHealthPayload(packageJson.version));
   });
 
   // Mount all routes

--- a/backend/src/utils/health.ts
+++ b/backend/src/utils/health.ts
@@ -1,0 +1,31 @@
+/**
+ * Payload for `GET /api/health`.
+ */
+
+import { isCloudEnvironment } from './environment.js';
+
+export interface HealthPayload {
+  status: 'ok';
+  version: string;
+  service: string;
+  /**
+   * Whether this backend is running in a cloud environment.
+   *
+   * The dashboard shell cannot determine this from the browser: a cloud
+   * deployment served on a custom domain is indistinguishable from a
+   * self-hosted one by hostname alone. This is the same value that decides
+   * whether backup routes are mounted, so the two cannot drift.
+   */
+  cloud: boolean;
+  timestamp: string;
+}
+
+export function buildHealthPayload(version: string, now: Date = new Date()): HealthPayload {
+  return {
+    status: 'ok',
+    version,
+    service: 'Insforge OSS Backend',
+    cloud: isCloudEnvironment(),
+    timestamp: now.toISOString(),
+  };
+}

--- a/backend/tests/unit/health-payload.test.ts
+++ b/backend/tests/unit/health-payload.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `GET /api/health` publishes the deployment mode (#1879).
+ *
+ * The dashboard shell picks between the cloud and self-hosting dashboards from
+ * `isCloudHosting()` in `frontend/src/helpers.ts`, which could only test its own
+ * hostname for `.insforge.app`. A cloud deployment served on a custom domain
+ * therefore rendered the self-hosting shell against a cloud backend.
+ *
+ * These assert the contract the frontend now depends on: `cloud` is exactly what
+ * `isCloudEnvironment()` reports — the same value that decides whether backup
+ * routes are mounted — so the two determinations cannot drift.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { buildHealthPayload } from '../../src/utils/health.js';
+import { isCloudEnvironment } from '../../src/utils/environment.js';
+
+describe('buildHealthPayload', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('reports cloud: true in a cloud environment', () => {
+    process.env.AWS_INSTANCE_PROFILE_NAME = 'my-profile';
+    expect(buildHealthPayload('1.2.3').cloud).toBe(true);
+  });
+
+  it('reports cloud: false when self-hosted', () => {
+    delete process.env.AWS_INSTANCE_PROFILE_NAME;
+    expect(buildHealthPayload('1.2.3').cloud).toBe(false);
+  });
+
+  it('mirrors isCloudEnvironment rather than deciding for itself', () => {
+    // The bug was two independent answers to one question. A second copy of the
+    // rule here would reintroduce exactly that, so compare against the source.
+    for (const profile of ['my-profile', undefined]) {
+      if (profile === undefined) {
+        delete process.env.AWS_INSTANCE_PROFILE_NAME;
+      } else {
+        process.env.AWS_INSTANCE_PROFILE_NAME = profile;
+      }
+      expect(buildHealthPayload('1.2.3').cloud).toBe(isCloudEnvironment());
+    }
+  });
+
+  it('does not infer the mode from any hostname', () => {
+    // The whole point: a cloud deployment on a custom domain still reports
+    // cloud: true. The backend never consults a hostname, so nothing about the
+    // domain can change this answer.
+    process.env.AWS_INSTANCE_PROFILE_NAME = 'my-profile';
+    process.env.API_BASE_URL = 'https://backend.acme-corp.example';
+    expect(buildHealthPayload('1.2.3').cloud).toBe(true);
+  });
+
+  it('keeps the fields existing consumers already read', () => {
+    delete process.env.AWS_INSTANCE_PROFILE_NAME;
+    const payload = buildHealthPayload('9.9.9', new Date('2026-01-02T03:04:05.000Z'));
+
+    expect(payload).toEqual({
+      status: 'ok',
+      version: '9.9.9',
+      service: 'Insforge OSS Backend',
+      cloud: false,
+      timestamp: '2026-01-02T03:04:05.000Z',
+    });
+  });
+});

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -1,9 +1,65 @@
+const CLOUD_HOSTING_DOMAIN_SUFFIX = '.insforge.app';
+
+const PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * What `GET /api/health` reported for `cloud`, or null if it has not answered.
+ */
+let backendReportedCloud: boolean | null = null;
+
+/**
+ * Ask the backend whether it is running in a cloud environment.
+ *
+ * The backend already knows this for certain (`isCloudEnvironment()`, which
+ * gates whether backup routes are even mounted). The browser can only guess
+ * from its own hostname, and that guess is wrong for a cloud deployment served
+ * on a custom domain. Resolve before the first render so `isCloudHosting()`
+ * stays synchronous for callers.
+ *
+ * Failure is not fatal: leaving `backendReportedCloud` null keeps the previous
+ * hostname behaviour, so an unreachable or older backend degrades to exactly
+ * what shipped before. The timeout matters for the same reason — the first
+ * render waits on this, and a backend that hangs rather than refuses must not
+ * hold the shell forever.
+ */
+export async function probeCloudHosting(): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch('/api/health', {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return;
+    }
+
+    const body: unknown = await response.json();
+    if (
+      typeof body === 'object' &&
+      body !== null &&
+      typeof (body as { cloud?: unknown }).cloud === 'boolean'
+    ) {
+      backendReportedCloud = (body as { cloud: boolean }).cloud;
+    }
+  } catch {
+    // Keep the hostname fallback below.
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export function isCloudHosting(): boolean {
+  if (backendReportedCloud !== null) {
+    return backendReportedCloud;
+  }
+
   if (typeof window === 'undefined') {
     return false;
   }
 
-  return window.location.origin.endsWith('.insforge.app');
+  return window.location.origin.endsWith(CLOUD_HOSTING_DOMAIN_SUFFIX);
 }
 
 export function isInIframe(): boolean {

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -23,13 +23,10 @@ let backendReportedCloud: boolean | null = null;
  * hold the shell forever.
  */
 export async function probeCloudHosting(): Promise<void> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
-
   try {
     const response = await fetch('/api/health', {
       headers: { Accept: 'application/json' },
-      signal: controller.signal,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
     if (!response.ok) {
       return;
@@ -45,8 +42,6 @@ export async function probeCloudHosting(): Promise<void> {
     }
   } catch {
     // Keep the hostname fallback below.
-  } finally {
-    clearTimeout(timeout);
   }
 }
 

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -22,11 +22,31 @@ let backendReportedCloud: boolean | null = null;
  * render waits on this, and a backend that hangs rather than refuses must not
  * hold the shell forever.
  */
+/**
+ * A signal that aborts after `PROBE_TIMEOUT_MS`.
+ *
+ * `AbortSignal.timeout` is the concise form but is unsupported on older browsers, where it throws.
+ * That throw is caught below, so nothing breaks — but the probe would be skipped and the shell
+ * would fall back to the hostname guess, which is the exact bug this exists to fix, silently and
+ * only for those users. The manual controller works everywhere, so it is the fallback.
+ */
+function timeoutSignal(): AbortSignal | undefined {
+  if ('function' === typeof AbortSignal.timeout) {
+    return AbortSignal.timeout(PROBE_TIMEOUT_MS);
+  }
+  if ('undefined' === typeof AbortController) {
+    return undefined;
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  return controller.signal;
+}
+
 export async function probeCloudHosting(): Promise<void> {
   try {
     const response = await fetch('/api/health', {
       headers: { Accept: 'application/json' },
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      signal: timeoutSignal(),
     });
     if (!response.ok) {
       return;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,18 @@ import './styles.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
+import { probeCloudHosting } from './helpers.ts';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
-  ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
+  // `App` picks the whole shell from `isCloudHosting()`, so resolve the
+  // backend's answer before the first render rather than switching dashboards
+  // underneath a mounted tree.
+  void probeCloudHosting().then(() => {
+    ReactDOM.createRoot(rootElement).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+  });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,8 +10,10 @@ const rootElement = document.getElementById('root');
 if (rootElement) {
   // `App` picks the whole shell from `isCloudHosting()`, so resolve the
   // backend's answer before the first render rather than switching dashboards
-  // underneath a mounted tree.
-  void probeCloudHosting().then(() => {
+  // underneath a mounted tree. `finally` rather than `then`: the probe swallows
+  // its own failures today, but mounting must not depend on that staying true —
+  // a rejection here would otherwise leave `#root` empty with nothing rendered.
+  void probeCloudHosting().finally(() => {
     ReactDOM.createRoot(rootElement).render(
       <React.StrictMode>
         <App />

--- a/packages/dashboard/tests/ui/cloud-detection.spec.ts
+++ b/packages/dashboard/tests/ui/cloud-detection.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mockLoggedOutApi } from './fixtures/api';
+
+/**
+ * Regression cover for #1879: the shell used to pick its dashboard from the
+ * browser's own hostname, so a cloud deployment served on a custom domain got
+ * the self-hosting shell. The backend already knows the answer for certain and
+ * now reports it as `cloud` on `GET /api/health`.
+ *
+ * The Playwright baseURL is `127.0.0.1`, i.e. not `*.insforge.app` — exactly
+ * the custom-domain case the issue describes. That makes these two cases the
+ * before and after of the bug: with the flag the backend decides, without it
+ * the old hostname guess still applies.
+ */
+
+const HEALTH_BODY = {
+  status: 'ok',
+  version: '1.0.0',
+  service: 'Insforge OSS Backend',
+  timestamp: '2026-01-01T00:00:00.000Z',
+};
+
+async function mockHealth(page: Page, body: Record<string, unknown>) {
+  await page.route('**/api/health', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+test('a custom-domain deployment follows the backend when it reports cloud', async ({ page }) => {
+  await mockLoggedOutApi(page);
+  await mockHealth(page, { ...HEALTH_BODY, cloud: true });
+
+  await page.goto('/dashboard');
+
+  // The self-hosting shell sends unauthenticated visitors to /dashboard/login.
+  // Honouring `cloud: true` must route them into the cloud shell instead, which
+  // is the whole point of the fix — on this origin the hostname says otherwise.
+  await expect(page).not.toHaveURL(/\/dashboard\/login$/);
+});
+
+test('a backend that reports no cloud flag falls back to the hostname', async ({ page }) => {
+  await mockLoggedOutApi(page);
+  await mockHealth(page, HEALTH_BODY);
+
+  await page.goto('/dashboard');
+
+  // No `cloud` key at all — an older backend. The shell must behave exactly as
+  // it did before this change: hostname is not `*.insforge.app`, so self-hosting.
+  await expect(page).toHaveURL(/\/dashboard\/login$/);
+  await expect(page.getByRole('heading', { name: 'Insforge Admin' })).toBeVisible();
+});
+
+test('an unreachable health endpoint still mounts the shell', async ({ page }) => {
+  await mockLoggedOutApi(page);
+  await page.route('**/api/health', (route) => route.abort());
+
+  await page.goto('/dashboard');
+
+  // The probe swallows its own failures and the render is in `finally`, so a
+  // dead endpoint must degrade to the previous behaviour rather than leaving
+  // `#root` empty — a blank page would be the worst outcome of gating the
+  // first render on a network call.
+  await expect(page).toHaveURL(/\/dashboard\/login$/);
+  await expect(page.getByRole('heading', { name: 'Insforge Admin' })).toBeVisible();
+});

--- a/packages/dashboard/tests/ui/cloud-detection.spec.ts
+++ b/packages/dashboard/tests/ui/cloud-detection.spec.ts
@@ -36,10 +36,16 @@ test('a custom-domain deployment follows the backend when it reports cloud', asy
 
   await page.goto('/dashboard');
 
-  // The self-hosting shell sends unauthenticated visitors to /dashboard/login.
-  // Honouring `cloud: true` must route them into the cloud shell instead, which
-  // is the whole point of the fix — on this origin the hostname says otherwise.
-  await expect(page).not.toHaveURL(/\/dashboard\/login$/);
+  // Assert the destination positively rather than "not /dashboard/login": a negative URL check
+  // also passes in the moment before the redirect fires, so it can go green for the wrong reason.
+  // Reaching /cloud/login is the observable proof that the cloud shell mounted — on this origin
+  // the hostname alone would have sent an unauthenticated visitor to the self-hosting login.
+  //
+  // The generous timeout is the point rather than a workaround: the cloud shell sits on /dashboard
+  // requesting an authorization code that no parent or opener can supply here, and only gives up
+  // after DEFAULT_TIMEOUT_MS (15s). Asserting a bound we know covers that is honest; asserting the
+  // faster negative was what let this pass before the redirect had happened at all.
+  await expect(page).toHaveURL(/\/cloud\/login$/, { timeout: 25_000 });
 });
 
 test('a backend that reports no cloud flag falls back to the hostname', async ({ page }) => {
@@ -54,16 +60,17 @@ test('a backend that reports no cloud flag falls back to the hostname', async ({
   await expect(page.getByRole('heading', { name: 'Insforge Admin' })).toBeVisible();
 });
 
-test('an unreachable health endpoint still mounts the shell', async ({ page }) => {
+test('an unreachable health endpoint degrades to the hostname answer', async ({ page }) => {
   await mockLoggedOutApi(page);
   await page.route('**/api/health', (route) => route.abort());
 
   await page.goto('/dashboard');
 
-  // The probe swallows its own failures and the render is in `finally`, so a
-  // dead endpoint must degrade to the previous behaviour rather than leaving
-  // `#root` empty — a blank page would be the worst outcome of gating the
-  // first render on a network call.
+  // A dead endpoint must leave the shell exactly as it was before this change rather than blocking
+  // the first render. Worth naming what this does NOT cover: `probeCloudHosting` catches its own
+  // failures, so an aborted request never rejects and never reaches `main.tsx`. The `finally` there
+  // guards a future edit that lets one escape, and there is no seam to drive that from a UI test
+  // without adding one for the test's benefit alone.
   await expect(page).toHaveURL(/\/dashboard\/login$/);
   await expect(page.getByRole('heading', { name: 'Insforge Admin' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Closes #1879.

Cloud vs self-hosting was determined twice, independently, and the two could disagree.

The backend's answer is authoritative — `isCloudEnvironment()` (`backend/src/utils/environment.ts:9`) decides whether the backup routes are mounted at all (`api/routes/database/index.routes.ts:29`) and whether the backup scheduler starts (`server.ts:414`), plus branches in the `ai`, `analytics`, `oauth` and `compute` routes. It was never exposed in any response.

The frontend guessed instead, `frontend/src/helpers.ts`:

```ts
return window.location.origin.endsWith('.insforge.app');
```

and that single call picks the whole shell in `App.tsx`, feeding `mode` into `useIsCloudHostingMode()` and the seven components that read it. So a Cloud deployment served on a custom domain got `true` on the backend and `false` in the browser: the self-hosting dashboard rendered against a cloud backend, offering affordances for routes that backend does not mount.

**This PR** publishes the value the backend already computes and has the shell follow it:

1. `GET /api/health` gains `cloud: isCloudEnvironment()`. Additive, so no existing consumer breaks, and it discloses nothing new — the response already carries `service: 'Insforge OSS Backend'`. The endpoint is already unauthenticated.
2. `isCloudHosting()` consumes it, **keeping the current origin test as the fallback**.

Because the fallback stays, behaviour on `*.insforge.app` is unchanged, and an unreachable or older backend degrades to exactly what shipped before. Only custom-domain cloud deployments change, which is the reported bug.

Two details worth flagging for review:

- **The probe is bounded** (`PROBE_TIMEOUT_MS = 3000`). The first render waits on it, so a backend that hangs rather than refuses must not hold the shell open forever. Failure of any kind falls through to the hostname check.
- **`buildHealthPayload` is extracted** to `backend/src/utils/health.ts` so the test drives the function the route actually calls. Asserting against a copy of the payload re-created in the test is the same "tests its own copy" problem as #1995, and this bug was itself caused by a second independent copy of one rule — so a test that duplicated it would be self-defeating.

### Deliberately not changed

`isInsForgeCloudProject()` (`packages/dashboard/src/lib/utils/utils.ts:155`) also tests `.insforge.app`, but against the **backend URL**, not the page origin. It is not the same predicate: at `ObservabilitySection.tsx:229` it is deliberately combined as

```ts
const canOpenComputeSettings = isCloudHostingMode && isInsForgeCloudProject();
```

because the Compute deep-link only resolves on `insforge.app` infrastructure, and `ObservabilitySection.test.tsx:73` pins exactly that pairing. Folding the two together would break it, so it is untouched.

## How did you test this change?

`backend/tests/unit/health-payload.test.ts`, five cases: `cloud` is true in a cloud environment, false when self-hosted, mirrors `isCloudEnvironment()` rather than restating the rule, stays true for a cloud deployment on a custom domain, and the payload still carries every field existing consumers read.

```
Test Files  2 passed (2)
     Tests  9 passed (9)
```

(run with the existing `environment.test.ts` to confirm nothing there regressed)

Mutation-checked rather than assumed — reverting only the fix, `cloud: isCloudEnvironment()` → `cloud: false`, reddens exactly the three cases that should redden and leaves the two self-hosted assertions green:

```
× reports cloud: true in a cloud environment
× mirrors isCloudEnvironment rather than deciding for itself
× does not infer the mode from any hostname
Tests  3 failed | 2 passed (5)
```

Also clean: `tsc --noEmit`, `eslint`, and `prettier --check` over all five changed files.

The frontend half is not unit-tested because `frontend/` has no test harness (no `test` script, no vitest config) — adding one felt out of scope for a bug fix, but happy to add it here if you would prefer the fallback path covered directly.

One open question I did not want to decide unilaterally: **`/api/health` is the smallest transport for this flag**, but if you would rather it live on `/api/metadata` or in a bootstrap payload the shell already fetches, that is a small change to this PR and I am happy to move it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1879: the dashboard previously chose the cloud or self-hosting shell from the browser hostname; it now uses the backend’s `isCloudEnvironment()` result. Cloud deployments on custom domains render the cloud shell, while missing, invalid, unreachable, or older health responses fall back to hostname detection; the shell still mounts after probe failures.

- Adds an additive `cloud` boolean to unauthenticated `GET /api/health`.
- Probes the health endpoint before the first render with a 3-second timeout, including an `AbortController` fallback for older browsers.
- Adds backend contract tests and Playwright coverage for cloud, legacy, and unreachable health responses.

<sup>Written for commit 3007d6e42a062da7efe6e27441f4fee53d860912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud-hosting detection uses backend health information when available.
  * Health responses include cloud status, service version, and timestamp details.

* **Bug Fixes**
  * Improved routing for cloud and self-hosted environments when hostname detection is unreliable.
  * Added graceful fallback for unavailable, aborted, or invalid health checks.
  * Ensured the dashboard loads if the initial hosting check fails.
  * Improved compatibility for browsers without native timeout signals.

* **Tests**
  * Added coverage for cloud and self-hosted detection, health responses, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->