### PR TITLE
Refactor onboarding state handling in DTestInstallPage

### DIFF
--- a/packages/dashboard/src/features/dashboard/pages/DTestInstallPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DTestInstallPage.tsx
@@ -24,17 +24,17 @@ export default function DTestInstallPage() {
   const { hasCompletedOnboarding, isLoading } = useMcpUsage();
   const [selectedClient, setSelectedClient] = useState<ClientId | null>(null);
 
-  // Auto-jump back to dashboard once onboarding flips false → true (e.g. an
-  // MCP call lands while the user is mid-install).
-  const prevOnboarding = useRef(hasCompletedOnboarding);
+  // Redirect when onboarding transitions from incomplete → complete
+  // while the user is on the install page.
+  const wasOnboardedOnPreviousRender = useRef(hasCompletedOnboarding);
   useEffect(() => {
     if (isLoading) {
       return;
     }
-    if (!prevOnboarding.current && hasCompletedOnboarding) {
+    if (!wasOnboardedOnPreviousRender.current && hasCompletedOnboarding) {
       void navigate('/dashboard', { replace: true });
     }
-    prevOnboarding.current = hasCompletedOnboarding;
+    wasOnboardedOnPreviousRender.current = hasCompletedOnboarding;
   }, [hasCompletedOnboarding, isLoading, navigate]);
 
   if (isLoading) {

--- a/packages/dashboard/src/features/dashboard/pages/DTestInstallPage.tsx
+++ b/packages/dashboard/src/features/dashboard/pages/DTestInstallPage.tsx
@@ -24,8 +24,8 @@ export default function DTestInstallPage() {
   const { hasCompletedOnboarding, isLoading } = useMcpUsage();
   const [selectedClient, setSelectedClient] = useState<ClientId | null>(null);
 
-  // Redirect when onboarding transitions from incomplete → complete
-  // while the user is on the install page.
+  // Redirect when onboarding transitions incomplete → complete while the user
+  // is on the install page (e.g. an MCP call lands while they are mid-install).
   const wasOnboardedOnPreviousRender = useRef(hasCompletedOnboarding);
   useEffect(() => {
     if (isLoading) {


### PR DESCRIPTION
## Description

This PR improves the readability of the onboarding transition logic in `DTestInstallPage`.

### Changes

* Renamed `prevOnboarding` to `wasOnboardedOnPreviousRender` to clearly describe what the ref represents.
* Updated the comment to explicitly document that the redirect occurs only when onboarding transitions from incomplete to complete.
* No behavior or routing logic has been changed.

This is a readability-only change related to #1883.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies onboarding transition logic in `packages/dashboard/src/features/dashboard/pages/DTestInstallPage.tsx` without changing behavior. The redirect still occurs only when onboarding transitions from incomplete to complete while on the install page.

- Renames the ref from `prevOnboarding` to `wasOnboardedOnPreviousRender`.
- Updates the comment to document the redirect condition.
- No routing or side-effect changes.

<sup>Written for commit b83b1ce204672d473defb51784ecc95fe8e688c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding completion tracking to ensure users are redirected to the dashboard when setup finishes loading and transitions to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->