### PR TITLE
Fix: convertSqlTypeToColumnType truncates plain TIMESTAMP columns to "timestam" (#2002)

### DIFF
--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -36,6 +36,7 @@ export const convertSqlTypeToColumnType = (sqlType: string): ColumnType | string
       return ColumnType.UUID;
     case 'timestamptz':
     case 'timestamp with time zone':
+    case 'timestamp without time zone':
       return ColumnType.DATETIME;
     case 'date':
       return ColumnType.DATE;

--- a/backend/tests/unit/helpers.test.ts
+++ b/backend/tests/unit/helpers.test.ts
@@ -10,6 +10,7 @@ describe('convertSqlTypeToColumnType', () => {
   it('converts timestamp types correctly', () => {
     expect(convertSqlTypeToColumnType('timestamptz')).toBe(ColumnType.DATETIME);
     expect(convertSqlTypeToColumnType('timestamp with time zone')).toBe(ColumnType.DATETIME);
+    expect(convertSqlTypeToColumnType('timestamp without time zone')).toBe(ColumnType.DATETIME);
   });
 
   it('converts integer types correctly', () => {


### PR DESCRIPTION
## Summary

Fixes #2002.

`convertSqlTypeToColumnType` in `backend/src/utils/utils.ts` handled `timestamptz` and `timestamp with time zone` but had no case for `timestamp without time zone` — the exact string Postgres's `information_schema.columns.data_type` returns for a plain `TIMESTAMP` column (no time zone). That input fell through to the generic 8-character truncation fallback, producing the mangled string `"timestam"` instead of `ColumnType.DATETIME`.

This is reachable from `getTableSchema()` in `backend/src/services/database/database-table.service.ts`, which calls `convertSqlTypeToColumnType` directly with a real column's `data_type`, wired to `GET /api/database/tables/:table/schema`. Any table with a plain `TIMESTAMP` column (easy to create via the SQL Editor, or from an imported schema) would report that column's type as `"timestam"`.

**Fix:** added `case 'timestamp without time zone':` alongside the existing timestamp cases, mapping it to `ColumnType.DATETIME`. The generic 8-char fallback for genuinely unknown types (`'customtype' -> 'customty'`) is untouched.

## How did you test this change?

- Added a regression assertion to the existing `'converts timestamp types correctly'` test in `backend/tests/unit/helpers.test.ts`, alongside the `timestamptz` / `timestamp with time zone` cases.
- Confirmed the new assertion fails against the pre-fix code (temporarily reverted just the one-line fix in `utils.ts` via `git stash` on that file only, re-ran): failed with `expected 'timestam' to be 'datetime'`, confirming the test actually exercises the bug.
- Restored the fix and re-ran: `npx vitest run tests/unit/helpers.test.ts` -> 8/8 passed, including the untouched `'customtype' -> 'customty'` fallback test.
- Full backend suite (`npx vitest run`, 2420 tests): 2399 passed, 21 skipped, 0 failed.
- `npx prettier --check`, `npx eslint`, `npx tsc --noEmit` on the changed files: all clean.
- Confirmed change scope is limited to the one source file and one test file (`git status --short`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps Postgres 'timestamp without time zone' to `ColumnType.DATETIME`. Previously, these columns fell through the generic truncation and surfaced as "timestam" in schema responses; now they resolve correctly to `DATETIME`.

**Review notes**
- Adds a single case in `backend/src/utils/utils.ts`; the 8-character fallback for unknown types remains unchanged.
- Extends the existing timestamp unit test with a regression check; no other behavior changes.

<sup>Written for commit 738017dc441f2b62013b263cd46cd31c115c438e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database schema handling by correctly recognizing `timestamp without time zone` fields as date-time values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->