### PR TITLE
fix(dashboard): keep row hover background opaque in data grid

### DIFF
--- a/packages/dashboard/src/rdg.css
+++ b/packages/dashboard/src/rdg.css
@@ -5,7 +5,10 @@
   :root {
     --rdg-border-color: var(--alpha-8);
     --rdg-background-color: rgb(var(--semantic-1));
-    --rdg-row-hover-color: var(--alpha-4);
+    /* Must stay opaque: cells inherit this as background-color, and the
+       frozen selection column relies on that opacity to hide row content
+       that scrolls underneath it. */
+    --rdg-row-hover-color: color-mix(in srgb, black 4%, rgb(var(--semantic-0)));
     --rdg-background-color-edit: rgb(var(--semantic-1));
     --rdg-header-row-background-color: rgb(var(--semantic-1));
     --rdg-outline-color: rgb(var(--foreground));
@@ -15,7 +18,7 @@
   .rdg-dark {
     --rdg-border-color: var(--alpha-8);
     --rdg-background-color: rgb(var(--semantic-1));
-    --rdg-row-hover-color: var(--alpha-4);
+    --rdg-row-hover-color: color-mix(in srgb, white 4%, rgb(var(--semantic-0)));
     --rdg-background-color-edit: rgb(var(--semantic-1));
     --rdg-header-row-background-color: rgb(var(--semantic-1));
     --rdg-outline-color: rgb(var(--foreground));


### PR DESCRIPTION
The frozen "User" column in the Users table relies on an opaque background to occlude row content that scrolls underneath it. On hover, `.rdg-row:hover` swapped the row background for the translucent `--alpha-4` token instead of an opaque tint, so hovering a row while the grid was horizontally scrolled let the scrolled-under column text bleed through the frozen column.

`--rdg-row-hover-color` now resolves to an opaque `color-mix()` of the tint into the row's base background, so hover no longer reduces any cell's opacity.

## before 
<img width="2478" height="1636" alt="image" src="https://github.com/user-attachments/assets/23c6cc4c-c9fc-4f59-bd2d-c627e5a0924d" />


## after 
<img width="2422" height="1586" alt="image" src="https://github.com/user-attachments/assets/ed308b6f-ef1e-4505-823b-5084c8222b65" />


Fixes #2005

## Summary

`packages/dashboard/src/rdg.css` — one CSS variable changed for both themes. `--rdg-row-hover-color` (used only by `.rdg-row:hover`, which every cell inherits `background-color` from) was a standalone translucent `rgba()`/`--alpha-4` value. Since the frozen "User" column depends on that inherited background staying opaque to hide horizontally-scrolled-under content, hovering a row made it ~96% transparent and let the ID/Email/Phone text bleed through. Now it's `color-mix(in srgb, black/white 4%, rgb(var(--semantic-0)))` — same subtle hover tint, but fully opaque, so it's a single fix at the shared token rather than special-casing the frozen column.

No other files touched.

## How did you test this change?

- Reproduced locally: shrunk the dashboard window on Authentication → Users until the grid required horizontal scroll, then hovered a row — ID/Email text visibly bled through the frozen User column (see "before" screenshot).
- Applied the fix, restarted the dashboard, repeated the exact same repro (same window width, same hover) — no bleed-through, frozen column stays solid (see "after" screenshot).
- Verified in a real browser that `color-mix(in srgb, black 4%, rgb(22,22,22))` and the white-4% dark-mode variant both resolve to fully opaque colors (no alpha channel), confirming the CSS is valid and behaves as intended in both light and dark themes.
- Confirmed the fix doesn't regress normal (non-scrolled, non-hover) row rendering — hover tint looks the same as before, just opaque now.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps data grid row hover backgrounds opaque so the frozen User column correctly hides scrolled-under content. Previously hover used a translucent token that let underlying text bleed through; now hover uses an opaque tint that preserves occlusion without changing the visual hover effect.

**Review notes**
- Change is isolated to `packages/dashboard/src/rdg.css`: updates `--rdg-row-hover-color` in light and dark themes to an opaque `color-mix()` based on the base background.
- Verify in Users table with horizontal scroll: hovering a row no longer shows ID/Email/Phone under the frozen User column; hover tint remains subtly the same.
- Confirm `color-mix()` resolves to fully opaque colors in target browsers; no alpha channel.

<sup>Written for commit 1e07bbdbe2947728434e3c4f30af04c4fda3a68e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated data grid row-hover colors for improved consistency in light and dark themes.
  * Improved hover rendering for frozen selection columns in light mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->