### PR TITLE
fix(deps): bump dompurify override to 3.4.14, clearing the last audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10339,9 +10339,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lodash": "^4.18.1",
     "protobufjs": "7.6.5",
     "postcss": "^8.5.10",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.14",
     "follow-redirects": "^1.16.0",
     "uuid": "^14.0.0",
     "axios": "1.18.1",


### PR DESCRIPTION
#1993 cleared 3 of 5 and deliberately left one moderate for a separate dependency decision: `packages/dashboard → posthog-js → dompurify`. The follow-up turned out to be much smaller than expected.

## The pin was itself the vulnerable version

Root `overrides` already pinned `dompurify: 3.4.12`. GHSA lists a **MODERATE** advisory whose vulnerable range is `<= 3.4.12`, first patched in **3.4.13**:

```
MODERATE  range=<= 3.4.12   patched=3.4.13   <- the version we were pinning
LOW       range=<= 3.4.11   patched=3.4.12
MODERATE  range=<= 3.4.10   patched=3.4.11
```

So the existing override was one patch short. No new override was needed, and PostHog did not have to move — which is what the earlier review had guessed might be required.

Bumped the existing pin to **3.4.14** (current latest; 3.4.13 alone would also clear it).

## Result

```
npm audit --package-lock-only  ->  0 vulnerabilities
```

Down from one moderate. Four lines changed across `package.json` and `package-lock.json`.

## One npm gotcha worth recording

`npm install --package-lock-only` reports `up to date` and **silently leaves the old resolution in place** when only an *override* version changes — it re-resolves on dependency changes, not override changes. `--force` behaves the same. The lockfile only moved under:

```
npm update dompurify --package-lock-only
```

Worth knowing for the next override bump, since the failure mode is a no-op that looks like success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3KTaQaSfNp9mhZzH7LEsd


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the root override for `dompurify` from 3.4.12 to 3.4.14 to clear the last audit finding in the `posthog-js` path. The previous pin (3.4.12) was in the vulnerable range; 3.4.14 includes the fix. `npm audit --package-lock-only` now reports 0 vulnerabilities. No runtime behavior changes.

- Updates the existing override and regenerates the lockfile to resolve `dompurify` at 3.4.14.
- To reproduce the lockfile change locally, run: `npm update dompurify --package-lock-only` (plain `npm install --package-lock-only` may not update on override-only changes).

<sup>Written for commit 4b5ab21b8679fc04332fdc201d5f618015c54dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the DOM sanitization component to version 3.4.14, incorporating the latest maintenance and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->