### PR TITLE
docs(openapi): rename metadata.yaml's nextAction to the nextActions the server sends

### DIFF
--- a/openapi/metadata.yaml
+++ b/openapi/metadata.yaml
@@ -280,7 +280,7 @@ paths:
                 error: "UNAUTHORIZED"
                 message: "Invalid or missing authentication"
                 statusCode: 401
-                nextAction: "Please provide valid authentication credentials"
+                nextActions: "Please provide valid authentication credentials"
 
   /api/metadata/api-key:
     get:
@@ -312,7 +312,7 @@ paths:
                 error: "INSUFFICIENT_PERMISSIONS"
                 message: "Only admin users can access API keys"
                 statusCode: 403
-                nextAction: "Contact an administrator for API key access"
+                nextActions: "Contact an administrator for API key access"
 
   /api/metadata/anon-key:
     get:
@@ -379,6 +379,6 @@ components:
         statusCode:
           type: integer
           description: HTTP status code
-        nextAction:
+        nextActions:
           type: string
           description: Suggested action to resolve the error


### PR DESCRIPTION
## What

`openapi/metadata.yaml` was the last spec declaring the error-body hint as `nextAction`. The server only ever sends `nextActions`. This renames the schema property and the two examples that used it.

Closes #2012

## Why

A client generated from this spec modelled a property that never arrives, and had no typed way to read the hint that does. That is not cosmetic here: the hints are actionable values from `NEXT_ACTIONS` such as `CHECK_TABLE_EXISTS` and `CHECK_UNIQUE_FIELD`, so a consumer following the spec lost precisely the field that tells it what to do next.

## Proof the server sends the plural

```ts
// backend/src/utils/response.ts:27
export function errorResponse(
  res: Response,
  error: string,
  message: string,
  statusCode: number = 500,
  nextActions?: string
) {
  const response: ErrorResponse = { error, message, statusCode, nextActions };
```

`AppError` declares `public nextActions?: string` (errors.ts:5-14), `error.ts:19` passes `err.nextActions`, and both `ErrorResponse` (response.ts:6-11) and `ErrorResponseDetails` (errors.ts:36-41) declare `nextActions?: string`.

Counted rather than eyeballed:

```
$ grep -rho "nextActions\?" backend/src --include="*.ts" | sort | uniq -c
  28 nextActions
```

28 plural, zero singular.

## Why this file was left behind

`484a878ad` (#1997, Aug 20) made this exact rename in `logs.yaml` and its message called the singular pre-existing. The rename was applied per file, so `metadata.yaml` kept it. Before this change it was the only spec that did:

```
$ git grep -c 'nextAction\b' -- openapi/ | grep -v nextActions
openapi/metadata.yaml:3
```

After it, that query returns nothing.

## Verification

```
$ npx @apidevtools/swagger-cli@4.0.4 validate openapi/metadata.yaml
openapi/metadata.yaml is valid

$ npx prettier --check openapi/metadata.yaml
All matched files use Prettier code style!
```

No code change and no behaviour change, so there is nothing to test beyond the spec validating and the examples still matching the schema.

## Overlap check

Open PR #1977 also edits `openapi/metadata.yaml`. I read its patch rather than assuming from the file list: it contains no `nextAction` change, so there is no duplicate work. Its edits are in the paths section, not the `ErrorResponse` component, so a conflict is unlikely, and if one appears I will rebase.

Not included on purpose: `metadata.yaml` is also missing its end-of-file newline, the same nit `06e4d751c` fixed for `logs.yaml` today. I left it out to keep this diff to the one defect. Happy to add it here if you would rather not have a separate change for one byte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API error responses to use the `nextActions` field consistently.
  * Revised the shared error response schema and related examples to reflect the new field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->