### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ See the [self-hosted storage guide](https://docs.insforge.dev/deployment/self-ho
 
 In addition to running InsForge locally, you can also launch InsForge using a pre-configured setup. This allows you to get up and running quickly with InsForge without installing Docker on your local machine.
 
-| Railway | Zeabur | Sealos |
-| --- | --- | --- |
-| [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/insforge) | [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Q82M3Y) | [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/insforge) |
+| Railway | Zeabur | Sealos | RepoCloud |
+| --- | --- | --- | --- |
+| [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/insforge) | [![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Q82M3Y) | [![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/insforge) | [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/InsForge/) |
 
 
 ## Contributing


### PR DESCRIPTION
Added RepoCloud as a one-click deployment option in the existing "One-click Deployment" table alongside Railway, Zeabur, and Sealos.

This gives users another managed hosting option for deploying InsForge with a single click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added RepoCloud as a one-click deployment option in the deployment table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->