### PR TITLE
docs(ai): make the Model Gateway overview match the shipped gateway

### DIFF
--- a/docs/core-concepts/ai/overview.mdx
+++ b/docs/core-concepts/ai/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Model Gateway"
 sidebarTitle: "Overview"
-description: "Call any LLM through one OpenAI-compatible endpoint, with InsForge-managed provider keys, OpenRouter routing, and per-project usage tracking and quotas."
+description: "Provision an OpenRouter key from InsForge, call chat, streaming, and embedding models with the OpenAI SDK, and follow spend and per-model usage from the dashboard."
 ---
 
-Use the Model Gateway to call chat, streaming, and embedding models through one OpenAI-compatible endpoint. InsForge holds the provider keys, tracks usage per project, and routes traffic through [OpenRouter](https://openrouter.ai), so your application code never sees Anthropic, OpenAI, or Mistral credentials directly.
+Use the Model Gateway to provision an OpenRouter key for your project, browse the model catalog, and follow spend and per-model usage. Your application calls [OpenRouter](https://openrouter.ai) directly with that key, so one integration reaches chat, streaming, and embedding models from Anthropic, OpenAI, Mistral, Google, and dozens of other providers.
 
-<Frame caption="One OpenAI-compatible endpoint with per-provider access, ready-to-copy code, and usage tracking.">
+<Frame caption="The Model Gateway page in the dashboard: the active key, per-provider access, ready-to-copy code, and usage charts.">
   <img src="/images/model-gateway-overview.png" alt="InsForge dashboard Model Gateway overview showing code samples, provider chips, and usage charts" />
 </Frame>
 
@@ -38,23 +38,23 @@ graph TB
 
 ### OpenAI-compatible API
 
-Point any OpenAI SDK or `openai`-compatible library at `https://<project>.insforge.dev/v1` and it works. `/v1/chat/completions`, `/v1/embeddings`, and `/v1/models` all behave like the upstream spec.
+Copy the provisioned key from the dashboard into a server-only `OPENROUTER_API_KEY`, then point any OpenAI SDK or `openai`-compatible library at `https://openrouter.ai/api/v1`. The [TypeScript SDK](/sdks/typescript/ai) and [REST](/sdks/rest/ai) references have working snippets.
+
+<Warning>
+  The provisioned key is a server-side credential. Keep OpenRouter calls behind a backend route, server action, or Edge Function, and never ship the key in a browser bundle.
+</Warning>
 
 ### Streaming
 
-Server-sent events for chat completions. Use the streaming endpoint the same way you would with OpenAI; the gateway forwards tokens as they arrive from the provider.
+Server-sent events for chat completions. Set `stream: true` the way you would with OpenAI, and tokens arrive as the provider produces them.
 
 ### Embeddings
 
 Generate dense vectors from any embedding model OpenRouter supports. Store the result in Postgres with [pgvector](/core-concepts/database/pgvector) for semantic search.
 
-### Per-project quotas
+### Spend and usage
 
-Each project carries its own rate limit and spend cap. Hit it, and the gateway returns a clean 429 instead of leaking provider quota state into your app.
-
-### Usage tracking
-
-Every request is logged with model, token count, and cost. Query usage from the dashboard, CLI, or MCP — billing reconciles to OpenRouter's invoice automatically.
+The Model Gateway page in the dashboard reads your key's activity from OpenRouter: total spend, daily, weekly, and monthly usage, remaining credit and its reset date, and a per-model breakdown.
 
 ### Multi-provider routing
 

--- a/docs/core-concepts/database/pgvector.mdx
+++ b/docs/core-concepts/database/pgvector.mdx
@@ -89,5 +89,5 @@ create index on documents using hnsw (embedding vector_cosine_ops);
 ## More resources
 
 - [pgvector on GitHub](https://github.com/pgvector/pgvector) for operators and indexes.
-- [OpenRouter embeddings](https://openrouter.ai/docs/features/multimodal/embeddings) for the model catalog.
+- [OpenRouter embeddings](https://openrouter.ai/docs/api-reference/embeddings) for the API, and the [OpenRouter model list](https://openrouter.ai/models) for the catalog.
 - [Model Gateway overview](/core-concepts/ai/overview) for the InsForge side of OpenRouter.

--- a/docs/es/core-concepts/ai/overview.mdx
+++ b/docs/es/core-concepts/ai/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Puerta de enlace de modelos"
 sidebarTitle: "Overview"
-description: "Llama a cualquier LLM a través de la puerta de enlace de modelos de InsForge con una clave OpenRouter administrada, cuotas por proyecto y facturación unificada."
+description: "Provisione una clave de OpenRouter desde InsForge, llame a modelos de chat, transmisión e incrustación con el SDK de OpenAI y siga el gasto y el uso por modelo desde el panel."
 ---
 
-Utilice la puerta de enlace de modelos para llamar a modelos de chat, transmisión e incrustación a través de un único punto final compatible con OpenAI. InsForge mantiene las claves del proveedor, realiza un seguimiento del uso por proyecto e enruta el tráfico a través de [OpenRouter](https://openrouter.ai), por lo que el código de su aplicación nunca ve directamente las credenciales de Anthropic, OpenAI o Mistral.
+Utilice la puerta de enlace de modelos para provisionar una clave de OpenRouter para su proyecto, explorar el catálogo de modelos y seguir el gasto y el uso por modelo. Su aplicación llama a [OpenRouter](https://openrouter.ai) directamente con esa clave, por lo que una única integración alcanza modelos de chat, transmisión e incrustación de Anthropic, OpenAI, Mistral, Google y docenas de otros proveedores.
 
-<Frame caption="Un punto final compatible con OpenAI con acceso por proveedor, código listo para copiar y seguimiento de uso.">
+<Frame caption="La página de la puerta de enlace de modelos en el panel: la clave activa, acceso por proveedor, código listo para copiar y gráficos de uso.">
   <img src="/images/model-gateway-overview.png" alt="Descripción general de la puerta de enlace de modelos del panel de InsForge que muestra ejemplos de código, fichas de proveedores y gráficos de uso" />
 </Frame>
 
@@ -38,23 +38,23 @@ graph TB
 
 ### API compatible con OpenAI
 
-Apunte cualquier SDK de OpenAI o biblioteca compatible con `openai` a `https://<project>.insforge.dev/v1` y funcionará. `/v1/chat/completions`, `/v1/embeddings` y `/v1/models` se comportan como la especificación ascendente.
+Copie la clave provisionada desde el panel en una variable `OPENROUTER_API_KEY` solo de servidor y luego apunte cualquier SDK de OpenAI o biblioteca compatible con `openai` a `https://openrouter.ai/api/v1`. Las referencias del [SDK de TypeScript](/sdks/typescript/ai) y [REST](/sdks/rest/ai) incluyen fragmentos funcionales.
+
+<Warning>
+  La clave provisionada es una credencial del lado del servidor. Mantenga las llamadas a OpenRouter detrás de una ruta de backend, una acción de servidor o una función perimetral, y nunca incluya la clave en un paquete del navegador.
+</Warning>
 
 ### Transmisión
 
-Eventos enviados por servidor para finalizaciones de chat. Utilice el punto final de transmisión de la misma manera que lo haría con OpenAI; la puerta de enlace reenvía los tokens a medida que llegan del proveedor.
+Eventos enviados por servidor para finalizaciones de chat. Establezca `stream: true` como lo haría con OpenAI, y los tokens llegan a medida que el proveedor los produce.
 
 ### Incrustaciones
 
 Genere vectores densos a partir de cualquier modelo de incrustación que OpenRouter admita. Almacene el resultado en Postgres con [pgvector](/core-concepts/database/pgvector) para búsqueda semántica.
 
-### Cuotas por proyecto
+### Gasto y uso
 
-Cada proyecto tiene su propio límite de velocidad y límite de gasto. Al alcanzarlo, la puerta de enlace devuelve un 429 limpio en lugar de filtrar el estado de cuota del proveedor en su aplicación.
-
-### Seguimiento de uso
-
-Cada solicitud se registra con modelo, recuento de tokens y costo. Consulte el uso desde el panel, CLI o MCP — la facturación se reconcilia automáticamente con la factura de OpenRouter.
+La página de la puerta de enlace de modelos en el panel lee la actividad de su clave desde OpenRouter: gasto total, uso diario, semanal y mensual, crédito restante y su fecha de restablecimiento, y un desglose por modelo.
 
 ### Enrutamiento multiproveedor
 

--- a/docs/es/core-concepts/database/pgvector.mdx
+++ b/docs/es/core-concepts/database/pgvector.mdx
@@ -89,5 +89,5 @@ create index on documents using hnsw (embedding vector_cosine_ops);
 ## Más recursos
 
 - [pgvector on GitHub](https://github.com/pgvector/pgvector) para operadores e índices.
-- [OpenRouter embeddings](https://openrouter.ai/docs/features/multimodal/embeddings) para el catálogo de modelos.
+- [OpenRouter embeddings](https://openrouter.ai/docs/api-reference/embeddings) para la API y la [lista de modelos de OpenRouter](https://openrouter.ai/models) para el catálogo.
 - [Model Gateway overview](/core-concepts/ai/overview) para el lado de InsForge de OpenRouter.

--- a/docs/es/products.mdx
+++ b/docs/es/products.mdx
@@ -30,7 +30,7 @@ InsForge proporciona diez productos, cada uno expuesto a través de la misma sup
   </Card>
 
   <Card title="Puerta de enlace de modelo" icon="sparkles" href="/core-concepts/ai/overview">
-    Chat, streaming e incrustaciones respaldados por OpenRouter a través de una clave administrada por InsForge. Cuotas por proyecto y seguimiento de uso.
+    Chat, streaming e incrustaciones respaldados por OpenRouter a través de una clave provisionada. Catálogo de modelos, gasto y uso por modelo.
   </Card>
 
   <Card title="Sitios" icon="globe" href="/core-concepts/sites/overview">

--- a/docs/products.mdx
+++ b/docs/products.mdx
@@ -34,7 +34,7 @@ same JWT auth, the same MCP server, and the same SDKs.
 
   <Card title="Model Gateway" icon="sparkles" href="/core-concepts/ai/overview">
     OpenRouter-backed chat, streaming, and embeddings through one
-    InsForge-managed key. Per-project quotas and usage tracking.
+    provisioned key. Model catalog, spend, and per-model usage.
   </Card>
 
   <Card title="Sites" icon="globe" href="/core-concepts/sites/overview">

--- a/docs/zh-Hant/core-concepts/ai/overview.mdx
+++ b/docs/zh-Hant/core-concepts/ai/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "模型閘道"
 sidebarTitle: "Overview"
-description: "透過 InsForge 模型閘道以單一受管金鑰呼叫任何 LLM，並依專案設定使用量配額、追蹤成本、限制存取並集中管理計費。"
+description: "從 InsForge 佈建 OpenRouter 金鑰，使用 OpenAI SDK 呼叫聊天、串流和嵌入模型，並在儀表板中追蹤支出與各模型用量。"
 ---
 
-使用模型閘道透過一個 OpenAI 相容的端點呼叫聊天、串流和嵌入模型。InsForge 持有提供商金鑰，追蹤每個專案的使用情況，並透過 [OpenRouter](https://openrouter.ai) 路由流量，因此您的應用程式代碼永遠不會直接看到 Anthropic、OpenAI 或 Mistral 認證。
+使用模型閘道為您的專案佈建 OpenRouter 金鑰、瀏覽模型目錄並追蹤支出和各模型用量。您的應用程式使用該金鑰直接呼叫 [OpenRouter](https://openrouter.ai)，因此一次整合即可存取來自 Anthropic、OpenAI、Mistral、Google 和數十個其他提供商的聊天、串流和嵌入模型。
 
-<Frame caption="一個 OpenAI 相容的端點，具有按提供商存取、隨時可複製的程式碼和使用追蹤。">
+<Frame caption="儀表板中的模型閘道頁面：目前金鑰、按提供商存取、隨時可複製的程式碼和使用圖表。">
   <img src="/images/model-gateway-overview.png" alt="InsForge 儀表板模型閘道概覽，顯示程式碼範例、提供商晶片和使用圖表" />
 </Frame>
 
@@ -38,23 +38,23 @@ graph TB
 
 ### OpenAI 相容的 API
 
-將任何 OpenAI SDK 或 `openai` 相容的程式庫指向 `https://<project>.insforge.dev/v1`，它就能運作。`/v1/chat/completions`、`/v1/embeddings` 和 `/v1/models` 都表現得像上游規範。
+將儀表板中佈建的金鑰複製到僅伺服器端的 `OPENROUTER_API_KEY` 中，然後將任何 OpenAI SDK 或 `openai` 相容的程式庫指向 `https://openrouter.ai/api/v1`。[TypeScript SDK](/sdks/typescript/ai) 和 [REST](/sdks/rest/ai) 參考中提供了可用的程式碼片段。
+
+<Warning>
+  佈建的金鑰是伺服器端認證。請將 OpenRouter 呼叫置於後端路由、伺服器動作或邊緣函式之後，切勿將該金鑰打包進瀏覽器程式碼。
+</Warning>
 
 ### 串流
 
-用於聊天完成的伺服器傳送事件。使用串流端點的方式與 OpenAI 相同；閘道在令牌從提供商到達時轉發它們。
+用於聊天完成的伺服器傳送事件。像使用 OpenAI 那樣設定 `stream: true`，令牌會隨提供商產生而到達。
 
 ### 嵌入
 
 從 OpenRouter 支援的任何嵌入模型產生密集向量。使用 [pgvector](/core-concepts/database/pgvector) 將結果儲存在 Postgres 中以進行語義搜尋。
 
-### 按專案配額
+### 支出與用量
 
-每個專案都有自己的速率限制和支出上限。達到它時，閘道傳回乾淨的 429，而不是將提供商配額狀態洩漏到您的應用程式中。
-
-### 使用追蹤
-
-每個請求都用模型、令牌計數和成本進行記錄。從儀表板、CLI 或 MCP 查詢使用情況 — 帳單自動與 OpenRouter 的發票對帳。
+儀表板中的模型閘道頁面從 OpenRouter 讀取您金鑰的活動資料：總支出，每日、每週和每月用量，剩餘額度及其重設日期，以及按模型的明細。
 
 ### 多提供商路由
 

--- a/docs/zh-Hant/core-concepts/database/pgvector.mdx
+++ b/docs/zh-Hant/core-concepts/database/pgvector.mdx
@@ -89,5 +89,5 @@ create index on documents using hnsw (embedding vector_cosine_ops);
 ## 更多資源
 
 - [pgvector on GitHub](https://github.com/pgvector/pgvector) 用於操作符和索引。
-- [OpenRouter embeddings](https://openrouter.ai/docs/features/multimodal/embeddings) 用於模型目錄。
+- [OpenRouter embeddings](https://openrouter.ai/docs/api-reference/embeddings) 用於 API，[OpenRouter 模型列表](https://openrouter.ai/models) 用於模型目錄。
 - [Model Gateway overview](/core-concepts/ai/overview) 用於 OpenRouter 的 InsForge 端。

--- a/docs/zh-Hant/products.mdx
+++ b/docs/zh-Hant/products.mdx
@@ -30,7 +30,7 @@ InsForge 提供十個產品，每個產品都透過相同的 REST 表面、相�
   </Card>
 
   <Card title="模型網關" icon="sparkles" href="/core-concepts/ai/overview">
-    OpenRouter 支援的聊天、串流和嵌入透過一個預配的金鑰。模型目錄、支出和各模型用量。
+    使用一個佈建的金鑰呼叫 OpenRouter 支援的聊天、串流和嵌入模型，並在儀表板中檢視模型目錄、支出和各模型用量。
   </Card>
 
   <Card title="網站" icon="globe" href="/core-concepts/sites/overview">

--- a/docs/zh-Hant/products.mdx
+++ b/docs/zh-Hant/products.mdx
@@ -30,7 +30,7 @@ InsForge 提供十個產品，每個產品都透過相同的 REST 表面、相�
   </Card>
 
   <Card title="模型網關" icon="sparkles" href="/core-concepts/ai/overview">
-    OpenRouter 支援的聊天、串流和嵌入透過一個 InsForge 管理的金鑰。按專案配額和使用跟蹤。
+    OpenRouter 支援的聊天、串流和嵌入透過一個預配的金鑰。模型目錄、支出和各模型用量。
   </Card>
 
   <Card title="網站" icon="globe" href="/core-concepts/sites/overview">

--- a/docs/zh/core-concepts/ai/overview.mdx
+++ b/docs/zh/core-concepts/ai/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "模型网关"
 sidebarTitle: "Overview"
-description: "通过 InsForge 模型网关调用 OpenAI、Anthropic、Google 等任意 LLM，仅需一个托管密钥，具备按项目配额、用量分析与统一 API。"
+description: "从 InsForge 预配 OpenRouter 密钥，使用 OpenAI SDK 调用聊天、流式和嵌入模型，并在仪表盘中跟踪支出与各模型用量。"
 ---
 
-使用模型网关通过一个 OpenAI 兼容的端点调用聊天、流式和嵌入模型。InsForge 保有提供商密钥，跟踪每个项目的使用情况，并通过 [OpenRouter](https://openrouter.ai) 路由流量，因此您的应用代码永远不会直接看到 Anthropic、OpenAI 或 Mistral 凭证。
+使用模型网关为您的项目预配 OpenRouter 密钥、浏览模型目录并跟踪支出和各模型用量。您的应用使用该密钥直接调用 [OpenRouter](https://openrouter.ai)，因此一次集成即可访问来自 Anthropic、OpenAI、Mistral、Google 和数十个其他提供商的聊天、流式和嵌入模型。
 
-<Frame caption="一个 OpenAI 兼容的端点，具有按提供商访问、随时可复制的代码和使用跟踪。">
+<Frame caption="仪表盘中的模型网关页面：当前密钥、按提供商访问、随时可复制的代码和使用图表。">
   <img src="/images/model-gateway-overview.png" alt="InsForge 仪表盘模型网关概览，显示代码示例、提供商芯片和使用图表" />
 </Frame>
 
@@ -38,23 +38,23 @@ graph TB
 
 ### OpenAI 兼容的 API
 
-将任何 OpenAI SDK 或 `openai` 兼容的库指向 `https://<project>.insforge.dev/v1`，它就能工作。`/v1/chat/completions`、`/v1/embeddings` 和 `/v1/models` 都表现得像上游规范。
+将仪表盘中预配的密钥复制到仅服务器端的 `OPENROUTER_API_KEY` 中，然后将任何 OpenAI SDK 或 `openai` 兼容的库指向 `https://openrouter.ai/api/v1`。[TypeScript SDK](/sdks/typescript/ai) 和 [REST](/sdks/rest/ai) 参考中提供了可用的代码片段。
+
+<Warning>
+  预配的密钥是服务器端凭证。请将 OpenRouter 调用置于后端路由、服务器操作或边缘函数之后，切勿将该密钥打包进浏览器代码。
+</Warning>
 
 ### 流式处理
 
-用于聊天完成的服务器发送事件。使用流式端点的方式与 OpenAI 相同；网关在令牌从提供商到达时转发它们。
+用于聊天完成的服务器发送事件。像使用 OpenAI 那样设置 `stream: true`，令牌会随提供商生成而到达。
 
 ### 嵌入
 
 从 OpenRouter 支持的任何嵌入模型生成密集向量。使用 [pgvector](/core-concepts/database/pgvector) 将结果存储在 Postgres 中以进行语义搜索。
 
-### 按项目配额
+### 支出与用量
 
-每个项目都有自己的速率限制和支出上限。达到它时，网关返回干净的 429，而不是将提供商配额状态泄漏到您的应用中。
-
-### 使用跟踪
-
-每个请求都用模型、令牌计数和成本进行记录。从仪表盘、CLI 或 MCP 查询使用情况 — 账单自动与 OpenRouter 的发票对账。
+仪表盘中的模型网关页面从 OpenRouter 读取您密钥的活动数据：总支出，每日、每周和每月用量，剩余额度及其重置日期，以及按模型的明细。
 
 ### 多提供商路由
 

--- a/docs/zh/core-concepts/database/pgvector.mdx
+++ b/docs/zh/core-concepts/database/pgvector.mdx
@@ -89,5 +89,5 @@ create index on documents using hnsw (embedding vector_cosine_ops);
 ## 更多资源
 
 - [pgvector on GitHub](https://github.com/pgvector/pgvector) 用于操作符和索引。
-- [OpenRouter embeddings](https://openrouter.ai/docs/features/multimodal/embeddings) 用于模型目录。
+- [OpenRouter embeddings](https://openrouter.ai/docs/api-reference/embeddings) 用于 API，[OpenRouter 模型列表](https://openrouter.ai/models) 用于模型目录。
 - [Model Gateway overview](/core-concepts/ai/overview) 用于 OpenRouter 的 InsForge 端。

--- a/docs/zh/products.mdx
+++ b/docs/zh/products.mdx
@@ -30,7 +30,7 @@ InsForge 提供十个产品，每个产品都通过相同的 REST 表面、相�
   </Card>
 
   <Card title="模型网关" icon="sparkles" href="/core-concepts/ai/overview">
-    OpenRouter 支持的聊天、流式传输和嵌入通过一个预配的密钥。模型目录、支出和各模型用量。
+    使用一个预配的密钥调用 OpenRouter 支持的聊天、流式传输和嵌入模型，并在仪表盘中查看模型目录、支出和各模型用量。
   </Card>
 
   <Card title="网站" icon="globe" href="/core-concepts/sites/overview">

--- a/docs/zh/products.mdx
+++ b/docs/zh/products.mdx
@@ -30,7 +30,7 @@ InsForge 提供十个产品，每个产品都通过相同的 REST 表面、相�
   </Card>
 
   <Card title="模型网关" icon="sparkles" href="/core-concepts/ai/overview">
-    OpenRouter 支持的聊天、流式传输和嵌入通过一个 InsForge 管理的密钥。按项目配额和使用跟踪。
+    OpenRouter 支持的聊天、流式传输和嵌入通过一个预配的密钥。模型目录、支出和各模型用量。
   </Card>
 
   <Card title="网站" icon="globe" href="/core-concepts/sites/overview">


### PR DESCRIPTION
Closes #2017.

The Model Gateway overview described an InsForge-hosted `/v1` proxy, per-project quotas, and per-request usage logging. No `/v1` route is mounted, `ai.usage` was dropped in migration 043, and both SDK pages plus the dashboard Quick Start already send developers to OpenRouter directly. This rewrites the page around the gateway that does ship, in all four locales.

### Overview page, four locales

The frontmatter description and intro now describe key provisioning, the model catalog, and usage, instead of a proxy that holds provider credentials on your behalf.

*OpenAI-compatible API* now says to copy the provisioned key into a server-only `OPENROUTER_API_KEY` and point the OpenAI SDK at `https://openrouter.ai/api/v1`, with links to the TypeScript and REST references. It carries a `<Warning>` about the key being a server-side credential, matching the one at `docs/sdks/typescript/ai.mdx:12`, since the page now tells developers they hold that key.

*Streaming* drops "the gateway forwards tokens as they arrive" and says to set `stream: true`.

*Per-project quotas* and *Usage tracking* are replaced by a single *Spend and usage* section. See the note below.

The `<Frame>` caption described the false architecture too, so it now describes the dashboard screenshot it sits above.

### pgvector page, four locales

`pgvector.mdx:92` was the page's only pointer to the embeddings catalog and it 404s. It now links `openrouter.ai/docs/api-reference/embeddings` for the API and `openrouter.ai/models` for the catalog. This is the link a developer follows while choosing an embedding model, and #1994 showed how sticky that choice is: a same-dimension swap inserts cleanly and produces vectors that aren't comparable to the rows already stored.

### products.mdx, four locales

The Model Gateway card repeated "Per-project quotas and usage tracking," so it gets the same correction. This file is outside what the issue described; happy to split it out if you'd rather keep the PR to the two pages.

### One deviation from the issue

The issue proposed cutting *Per-project quotas* and *Usage tracking* outright. Reading `OpenRouterProvider.getOverview()` (`backend/src/providers/ai/openrouter.provider.ts:225`) shows that part of both is real, just sourced from OpenRouter rather than InsForge. The response carries `limit`, `limitRemaining`, `limitReset`, `usage`, `usageDaily`, `usageWeekly`, `usageMonthly`, per-model usage, and charts, all read from OpenRouter's key and activity endpoints.

So rather than delete both sections, they are merged into one *Spend and usage* section describing what the dashboard actually shows. What is gone is the part that was wrong: an InsForge-enforced per-project rate limit, a 429 returned by InsForge, and per-request logging in a table that no longer exists.

I also dropped "CLI, or MCP" from that sentence, since the dashboard path is the only one I could verify in this repo. Glad to put them back if they're covered elsewhere.

### Verification

- `grep -r "insforge.dev/v1" docs/` returns nothing.
- Both new links return 200; the replaced one returns 404.
- `npx prettier --check` passes on all 12 files.
- Each locale is translated rather than left in English, headings included: *Gasto y uso*, *支出与用量*, *支出與用量*.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Model Gateway overview documented an InsForge-hosted `/v1` proxy, per-project quotas, and per-request usage logging that don't exist in the shipped gateway. This rewrites it in all four locales around what actually ships: provisioning an OpenRouter key, calling OpenRouter directly, and following spend and usage from the dashboard.

- Replaces proxy instructions with pointing the OpenAI SDK at `https://openrouter.ai/api/v1` using a server-only `OPENROUTER_API_KEY`, plus a warning the key is a server-side credential.
- Merges the incorrect *Per-project quotas* and *Usage tracking* sections into a single *Spend and usage* section describing the OpenRouter-sourced activity the dashboard actually shows.
- Fixes the 404-ing embeddings catalog link on the pgvector page and the same incorrect quota-and-usage text on the products page, completing the Chinese card copy into full sentences.

<sup>Written for commit 23beb5c679c6d89baee935db268a3a0837499998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Model Gateway docs to reflect direct OpenRouter usage
> - Rewrites `overview.mdx` pages (en, es, zh-Hant, zh) to instruct provisioning an `OPENROUTER_API_KEY` and calling `https://openrouter.ai/api/v1` directly, with a server-side warning block.
> - Replaces prior "InsForge-managed key" / "Per-project quotas" / "Usage tracking" sections with a combined "Spend and usage" section read from the OpenRouter dashboard.
> - Updates Model Gateway card copy in [products.mdx](https://github.com/InsForge/InsForge/pull/2018/files#diff-4da4b4acee04410b041aaaf07ae822bb68cbe28fcdded5eeac5dd508cf15dd65) and its localizations to drop the InsForge-managed key wording.
> - Refreshes pgvector embeddings links across locales to point to the OpenRouter embeddings API reference and model list.
> - Risk: docs-only change; no runtime behavior affected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a7c673.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Model Gateway guidance to use a provisioned OpenRouter key and direct OpenRouter API access.
  * Added security guidance to keep the key server-side and out of browser bundles.
  * Replaced project quota and usage-tracking details with spend, usage, and per-model reporting.
  * Updated product descriptions and translated documentation to reflect the new model.
  * Refreshed OpenRouter embedding references and added a link to the model catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->