### PR TITLE
docs(storage): document Authorization header for direct uploads

### DIFF
--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -107,8 +107,9 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/upload-s
 ### Step 2: Upload File
 
 Upload the file to the specified URL using the provided method.
-- **Local Storage**: Use a PUT request to `uploadUrl` with `multipart/form-data` and a `file` field.
-- **S3-Compatible**: Use a POST request to `uploadUrl` with `multipart/form-data` and a `file` field. Include all fields from the `fields` object in the request.
+
+- **Direct** (`method: "direct"`): Use a PUT request to `uploadUrl` with `multipart/form-data`, a `file` field, and the `Authorization: Bearer <your-jwt-token>` header. Direct uploads are handled by the InsForge API and require authentication.
+- **Presigned** (`method: "presigned"`): Use a POST request to `uploadUrl` with `multipart/form-data`, the `file` field, and all fields from the `fields` object. Do not send the InsForge `Authorization` header to the presigned storage URL.
 
 ### Step 3: Confirm Presigned Upload (S3 Only)
 


### PR DESCRIPTION
## Summary

Fixes the REST Storage documentation for authenticated direct uploads by documenting the upload flow based on the returned `method`.

## Changes

* Replace backend-specific upload instructions with `direct` and `presigned` strategy instructions.
* Document that `method: "direct"` requires:

  * `PUT` to the returned `uploadUrl`
  * `multipart/form-data` with a `file` field
  * `Authorization: Bearer <your-jwt-token>`
* Document that `method: "presigned"` uses `POST` with the returned `fields`.
* Clarify that the InsForge `Authorization` header must not be forwarded to the presigned storage URL.

This also covers S3 proxy mode, where the API returns a `direct` strategy.

## Validation

* `npm run format:check`
* `git diff --check`

Closes #2027
