### PR TITLE
docs(storage): clarify Authorization required for method: direct uploads

### DIFF
--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -106,7 +106,7 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/upload-s
   When `method` is `"direct"`, `uploadUrl` points to an InsForge route protected
   by authentication. You **must** include your `Authorization: Bearer <token>`
   header when PUTting to it — the same token used to call `/upload-strategy`.
-  Omitting it returns `401 PUBLISH_CREDENTIAL_INVALID`.
+  Omitting it returns `AUTH_INVALID_CREDENTIALS`.
 </Warning>
 
 ---

--- a/docs/sdks/rest/storage.mdx
+++ b/docs/sdks/rest/storage.mdx
@@ -91,7 +91,7 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/upload-s
 }
 ```
 
-#### Response (Local Storage)
+#### Response (`method: "direct"` — Local Storage or S3 proxy mode)
 
 ```json
 {
@@ -102,13 +102,42 @@ curl -X POST "https://your-app.insforge.app/api/storage/buckets/avatars/upload-s
 }
 ```
 
+<Warning>
+  When `method` is `"direct"`, `uploadUrl` points to an InsForge route protected
+  by authentication. You **must** include your `Authorization: Bearer <token>`
+  header when PUTting to it — the same token used to call `/upload-strategy`.
+  Omitting it returns `401 PUBLISH_CREDENTIAL_INVALID`.
+</Warning>
+
 ---
 
 ### Step 2: Upload File
 
 Upload the file to the specified URL using the provided method.
-- **Local Storage**: Use a PUT request to `uploadUrl` with `multipart/form-data` and a `file` field.
-- **S3-Compatible**: Use a POST request to `uploadUrl` with `multipart/form-data` and a `file` field. Include all fields from the `fields` object in the request.
+
+- **`method: "direct"` (Local Storage or S3 proxy mode)** — `uploadUrl` is an InsForge route.
+  Use a `PUT` request with `multipart/form-data`. **You must forward your `Authorization` header**
+  — the same token used to call `/upload-strategy`.
+
+  ```bash
+  curl -X PUT "<uploadUrl>" \
+    -H "Authorization: Bearer your-jwt-token" \
+    -F "file=@/path/to/file.jpg"
+  ```
+- **`method: "presigned"` (S3-Compatible)** — `uploadUrl` is a direct S3 URL.
+  Use a `POST` request. Include every key-value from `fields` as form fields **before** `file`.
+  Do **not** add an `Authorization` header.
+  ```bash
+  curl -X POST "<uploadUrl>" \
+    -F "bucket=<fields.bucket>" \
+    -F "key=<fields.key>" \
+    -F "X-Amz-Algorithm=<fields.X-Amz-Algorithm>" \
+    -F "X-Amz-Credential=<fields.X-Amz-Credential>" \
+    -F "Policy=<fields.Policy>" \
+    -F "X-Amz-Signature=<fields.X-Amz-Signature>" \
+    -F "file=@/path/to/file.jpg"
+  ```
+  Then call **Step 3** to confirm.
 
 ### Step 3: Confirm Presigned Upload (S3 Only)
 


### PR DESCRIPTION
## Summary

For `method: "direct"` (local storage and S3 proxy mode), `uploadUrl` points
to an InsForge route guarded by `verifyUser`. Clients must forward their
`Authorization: Bearer <token>` header when PUTting, but this was
undocumented — causing `401 PUBLISH_CREDENTIAL_INVALID` errors.

## Changes
- Renamed response label to distinguish `method: "direct"` from presigned
- Added `<Warning>` callout explaining the Authorization requirement  
- Rewrote Step 2 to show both upload modes with curl examples

Closes #2027

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies direct and presigned upload docs so clients know the `Authorization` header requirement and which fields to forward.

- Updates the response label to distinguish `method: "direct"` from presigned.
- Adds a `<Warning>` callout about the required `Authorization` header for direct uploads.
- Rewrites Step 2 with separate curl examples for direct and presigned uploads.
- Specifies presigned uploads must forward all fields from `fields` and omit the `Authorization` header, then confirm via Step 3.

Closes #2027.

<sup>Written for commit b13d818c7c757efe77c50e62e1a08f3d5108baef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated direct-upload guidance for Local Storage and S3 proxy mode.
  - Documented authentication requirements for direct upload URLs and the `AUTH_INVALID_CREDENTIALS` error.
  - Clarified separate PUT instructions for direct uploads and POST instructions for presigned S3 uploads.
  - Specified that presigned uploads must omit the `Authorization` header and proceed with confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->