### PR TITLE
docs(deploy): port deploy/backup.sh instructions to localized security guides

### DIFF
--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -1028,14 +1028,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 Schedule with Cron
 
-Ensure the backup directory exists, then edit the crontab:
+Ensure the backup directory exists (adjust paths if your install lives elsewhere), then edit the crontab:
 
 ```bash
-mkdir -p ~/insforge/backups
+mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-Add this line for daily backups at 3:00 AM (adjust the path if your install lives elsewhere):
+Add this line for daily backups at 3:00 AM:
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -1018,17 +1018,20 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restore a database dump (adjust path if `BACKUP_DIR` was changed):
+Restore a database dump:
 
 ```bash
 cd ~/insforge
 set -a && source .env && set +a
-cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
+cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 Schedule with Cron
 
+Ensure the backup directory exists, then edit the crontab:
+
 ```bash
+mkdir -p ~/insforge/backups
 crontab -e
 ```
 

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -1018,7 +1018,7 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restore a database dump:
+Restore a database dump (if `BACKUP_DIR` was overridden, set it here or replace with your backup path):
 
 ```bash
 cd ~/insforge
@@ -1028,14 +1028,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 Schedule with Cron
 
-Ensure the backup directory exists (adjust paths if your install lives elsewhere), then edit the crontab:
+Ensure the backup directory exists (adjust if your install path differs):
 
 ```bash
 mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-Add this line for daily backups at 3:00 AM:
+Add this line for daily backups at 3:00 AM (substitute `/home/deploy/insforge` with your actual install path if different):
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -1011,13 +1011,14 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-By default, backups land in `~/insforge/backups/` and files older than 14 days are removed. Override retention:
+By default, backups land in `~/insforge/backups/` and files older than 14 days are removed. Override retention or the backup directory:
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restore a database dump:
+Restore a database dump (adjust path if `BACKUP_DIR` was changed):
 
 ```bash
 cd ~/insforge
@@ -1113,7 +1114,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -824,6 +824,15 @@ Por defecto, el backend permite todos los orígenes. Refleja el encabezado `Orig
 
 #### 14.1 Haz una copia de seguridad de la base de datos
 
+Para un volcado de base de datos y copia de `.env` en un solo paso, utiliza el script de copia de seguridad incluido:
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+O realiza el volcado manualmente:
+
 ```bash
 cd ~/insforge
 source .env
@@ -982,51 +991,29 @@ docker compose up -d
 
 ### 17. Copias de seguridad automatizadas
 
-Configura una tarea cron para copias de seguridad automáticas diarias:
+Configura una tarea cron para copias de seguridad automáticas diarias.
 
-#### 17.1 Crea un script de copia de seguridad
+#### 17.1 Ejecuta el script de copia de seguridad
+
+Las instalaciones autohospedadas incluyen `deploy/backup.sh` (entregado por `deploy/setup.sh`). Vuelca Postgres y copia `.env` en un directorio `backups/` en la raíz de tu instalación.
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y se eliminan los archivos con más de 14 días. Sobrescribe la retención:
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+Restaura un volcado de base de datos:
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 Programa con Cron
@@ -1035,10 +1022,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-Añade esta línea para copias de seguridad diarias a las 3:00 a. m.:
+Añade esta línea para copias de seguridad diarias a las 3:00 a. m. (ajusta la ruta si tu instalación se encuentra en otro lugar):
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 Copias de seguridad fuera del sitio (recomendado)
@@ -1117,7 +1104,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -1009,7 +1009,7 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restaura un volcado de base de datos:
+Restaura un volcado de base de datos (si se sobrescribió `BACKUP_DIR`, establécelo aquí o reemplázalo con la ruta de tu copia de seguridad):
 
 ```bash
 cd ~/insforge
@@ -1019,14 +1019,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 Programa con Cron
 
-Asegúrate de que el directorio de copias de seguridad exista (ajusta las rutas si tu instalación se encuentra en otro lugar), luego edita el crontab:
+Asegúrate de que el directorio de copias de seguridad exista (ajusta si la ruta de instalación difiere):
 
 ```bash
 mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-Añade esta línea para copias de seguridad diarias a las 3:00 a. m.:
+Añade esta línea para copias de seguridad diarias a las 3:00 a. m. (sustituye `/home/deploy/insforge` con tu ruta de instalación real si es diferente):
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -1009,17 +1009,20 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restaura un volcado de base de datos (ajusta la ruta si se cambió `BACKUP_DIR`):
+Restaura un volcado de base de datos:
 
 ```bash
 cd ~/insforge
 set -a && source .env && set +a
-cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
+cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 Programa con Cron
 
+Asegúrate de que el directorio de copias de seguridad exista, luego edita el crontab:
+
 ```bash
+mkdir -p ~/insforge/backups
 crontab -e
 ```
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -1002,13 +1002,14 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y se eliminan los archivos con más de 14 días. Sobrescribe la retención:
+De forma predeterminada, las copias de seguridad se guardan en `~/insforge/backups/` y se eliminan los archivos con más de 14 días. Sobrescribe la retención o el directorio de copias de seguridad:
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-Restaura un volcado de base de datos:
+Restaura un volcado de base de datos (ajusta la ruta si se cambió `BACKUP_DIR`):
 
 ```bash
 cd ~/insforge
@@ -1104,7 +1105,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -1019,14 +1019,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 Programa con Cron
 
-Asegúrate de que el directorio de copias de seguridad exista, luego edita el crontab:
+Asegúrate de que el directorio de copias de seguridad exista (ajusta las rutas si tu instalación se encuentra en otro lugar), luego edita el crontab:
 
 ```bash
-mkdir -p ~/insforge/backups
+mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-Añade esta línea para copias de seguridad diarias a las 3:00 a. m. (ajusta la ruta si tu instalación se encuentra en otro lugar):
+Añade esta línea para copias de seguridad diarias a las 3:00 a. m.:
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -1000,13 +1000,14 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-預設情況下，備份會存放在 `~/insforge/backups/` 中，且超過 14 天的檔案會被刪除。覆寫保留天數：
+預設情況下，備份會存放在 `~/insforge/backups/` 中，且超過 14 天的檔案會被刪除。覆寫保留天數或備份目錄：
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-復原資料庫傾印：
+復原資料庫傾印（若變更了 `BACKUP_DIR`，請調整路徑）：
 
 ```bash
 cd ~/insforge
@@ -1102,7 +1103,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -1007,17 +1007,20 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-復原資料庫傾印（若變更了 `BACKUP_DIR`，請調整路徑）：
+復原資料庫傾印：
 
 ```bash
 cd ~/insforge
 set -a && source .env && set +a
-cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
+cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 排程
 
+確保備份目錄存在，然後編輯 crontab：
+
 ```bash
+mkdir -p ~/insforge/backups
 crontab -e
 ```
 

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -823,6 +823,15 @@ tmpfs:
 
 #### 14.1 備份資料庫
 
+若要一步完成資料庫傾印和 `.env` 副本備份，請使用隨附的備份腳本：
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+或者手動傾印：
+
 ```bash
 cd ~/insforge
 source .env
@@ -980,51 +989,29 @@ docker compose up -d
 
 ### 17. 自動化備份
 
-設定一個 cron 工作以進行每日自動備份：
+設定一個 cron 排程以進行每日自動備份。
 
-#### 17.1 建立備份腳本
+#### 17.1 執行備份腳本
+
+自託管安裝包含 `deploy/backup.sh`（由 `deploy/setup.sh` 提供）。它會將 Postgres 傾印並複製 `.env` 至安裝根目錄下的 `backups/` 目錄中。
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+預設情況下，備份會存放在 `~/insforge/backups/` 中，且超過 14 天的檔案會被刪除。覆寫保留天數：
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+復原資料庫傾印：
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 排程
@@ -1033,10 +1020,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-新增以下這一行，讓每天凌晨 3:00 執行備份：
+新增以下這一行，讓每天凌晨 3:00 執行備份（若你的安裝路徑不同，請調整路徑）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 異地備份（建議）
@@ -1115,7 +1102,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -1007,7 +1007,7 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-復原資料庫傾印：
+復原資料庫傾印（若覆寫了 `BACKUP_DIR`，請在此處設定或替換為你的備份路徑）：
 
 ```bash
 cd ~/insforge
@@ -1017,14 +1017,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 使用 Cron 排程
 
-確保備份目錄存在（若你的安裝路徑不同，請調整路徑），然後編輯 crontab：
+確保備份目錄存在（若安裝路徑不同請相應調整）：
 
 ```bash
 mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-新增以下這一行，讓每天凌晨 3:00 執行備份：
+新增以下這一行，讓每天凌晨 3:00 執行備份（若安裝路徑不同，請將 `/home/deploy/insforge` 替換為你的實際安裝路徑）：
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -1017,14 +1017,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 使用 Cron 排程
 
-確保備份目錄存在，然後編輯 crontab：
+確保備份目錄存在（若你的安裝路徑不同，請調整路徑），然後編輯 crontab：
 
 ```bash
-mkdir -p ~/insforge/backups
+mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-新增以下這一行，讓每天凌晨 3:00 執行備份（若你的安裝路徑不同，請調整路徑）：
+新增以下這一行，讓每天凌晨 3:00 執行備份：
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -1016,14 +1016,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 使用 Cron 设置计划任务
 
-确保备份目录存在，然后编辑 crontab：
+确保备份目录存在（如果你的安装位置不同，请调整路径），然后编辑 crontab：
 
 ```bash
-mkdir -p ~/insforge/backups
+mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-添加以下这一行以每天凌晨 3:00 进行备份（如果你的安装位置不同，请调整路径）：
+添加以下这一行以每天凌晨 3:00 进行备份：
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -1006,17 +1006,20 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-恢复数据库转储（如果更改了 `BACKUP_DIR`，请调整路径）：
+恢复数据库转储：
 
 ```bash
 cd ~/insforge
 set -a && source .env && set +a
-cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
+cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 设置计划任务
 
+确保备份目录存在，然后编辑 crontab：
+
 ```bash
+mkdir -p ~/insforge/backups
 crontab -e
 ```
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -999,13 +999,14 @@ cd ~/insforge
 ./deploy/backup.sh
 ```
 
-默认情况下，备份保存在 `~/insforge/backups/` 中，且超过 14 天的文件会被删除。覆盖保留天数：
+默认情况下，备份保存在 `~/insforge/backups/` 中，且超过 14 天的文件会被删除。覆盖保留天数或备份目录：
 
 ```bash
 RETENTION_DAYS=30 ./deploy/backup.sh
+BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-恢复数据库转储：
+恢复数据库转储（如果更改了 `BACKUP_DIR`，请调整路径）：
 
 ```bash
 cd ~/insforge
@@ -1101,7 +1102,7 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-./deploy/backup.sh                                                                              # Backup (db + .env)
+~/insforge/deploy/backup.sh                                                                     # Backup (db + .env)
 docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -1006,7 +1006,7 @@ RETENTION_DAYS=30 ./deploy/backup.sh
 BACKUP_DIR=/mnt/backups/insforge ./deploy/backup.sh
 ```
 
-恢复数据库转储：
+恢复数据库转储（如果覆盖了 `BACKUP_DIR`，请在此处设置或替换为你的备份路径）：
 
 ```bash
 cd ~/insforge
@@ -1016,14 +1016,14 @@ cat ${BACKUP_DIR:-backups}/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postg
 
 #### 17.2 使用 Cron 设置计划任务
 
-确保备份目录存在（如果你的安装位置不同，请调整路径），然后编辑 crontab：
+确保备份目录存在（如果安装路径不同请相应调整）：
 
 ```bash
 mkdir -p /home/deploy/insforge/backups
 crontab -e
 ```
 
-添加以下这一行以每天凌晨 3:00 进行备份：
+添加以下这一行以每天凌晨 3:00 进行备份（如果安装路径不同，请将 `/home/deploy/insforge` 替换为你的实际安装路径）：
 
 ```cron
 0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -822,6 +822,15 @@ tmpfs:
 
 #### 14.1 备份数据库
 
+若要一步完成数据库转储和 `.env` 副本备份，请使用随附的备份脚本：
+
+```bash
+cd ~/insforge
+./deploy/backup.sh
+```
+
+或者手动转储：
+
 ```bash
 cd ~/insforge
 source .env
@@ -979,51 +988,29 @@ docker compose up -d
 
 ### 17. 自动化备份
 
-设置一个 cron 任务以进行每日自动备份：
+设置一个 cron 计划任务以进行每日自动备份。
 
-#### 17.1 创建备份脚本
+#### 17.1 运行备份脚本
+
+自托管安装包含 `deploy/backup.sh`（由 `deploy/setup.sh` 提供）。它会将 Postgres 转储并复制 `.env` 到安装根目录下的 `backups/` 目录中。
 
 ```bash
-nano ~/insforge/backup.sh
+cd ~/insforge
+./deploy/backup.sh
 ```
 
+默认情况下，备份保存在 `~/insforge/backups/` 中，且超过 14 天的文件会被删除。覆盖保留天数：
+
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# InsForge Automated Backup Script
-# Run from the checkout so docker compose reads COMPOSE_FILE and
-# COMPOSE_PROJECT_NAME from .env, which also carries POSTGRES_USER / POSTGRES_DB
-cd "$HOME/insforge"
-set -a
-source .env
-set +a
-
-BACKUP_DIR="$HOME/insforge/backups"
-RETENTION_DAYS=14
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-trap 'echo "[$(date)] ERROR: Backup failed at line $LINENO" >&2; exit 1' ERR
-
-mkdir -p "$BACKUP_DIR"
-
-# Dump the database
-docker compose exec -T postgres \
-  pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" \
-  > "$BACKUP_DIR/db_$TIMESTAMP.sql"
-
-# Copy the environment file
-cp "$HOME/insforge/.env" "$BACKUP_DIR/env_$TIMESTAMP.bak"
-
-# Remove backups older than retention period
-find "$BACKUP_DIR" -name "db_*.sql" -mtime +$RETENTION_DAYS -delete
-find "$BACKUP_DIR" -name "env_*.bak" -mtime +$RETENTION_DAYS -delete
-
-echo "[$(date)] Backup completed successfully: db_$TIMESTAMP.sql"
+RETENTION_DAYS=30 ./deploy/backup.sh
 ```
 
+恢复数据库转储：
+
 ```bash
-chmod +x ~/insforge/backup.sh
+cd ~/insforge
+set -a && source .env && set +a
+cat backups/db_YYYYMMDD_HHMMSS.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"
 ```
 
 #### 17.2 使用 Cron 设置计划任务
@@ -1032,10 +1019,10 @@ chmod +x ~/insforge/backup.sh
 crontab -e
 ```
 
-添加以下这一行以每天凌晨 3:00 进行备份：
+添加以下这一行以每天凌晨 3:00 进行备份（如果你的安装位置不同，请调整路径）：
 
 ```cron
-0 3 * * * /home/deploy/insforge/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
+0 3 * * * /home/deploy/insforge/deploy/backup.sh >> /home/deploy/insforge/backups/cron.log 2>&1
 ```
 
 #### 17.3 异地备份（推荐）
@@ -1114,7 +1101,8 @@ docker stats --no-stream          # Resource usage
 
 # ── Database (source .env first for vars) ────
 source ~/insforge/.env
-docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Backup
+./deploy/backup.sh                                                                              # Backup (db + .env)
+docker compose exec -T postgres pg_dump -U "${POSTGRES_USER:-postgres}" "${POSTGRES_DB:-insforge}" > backup.sql  # Manual backup
 cat backup.sql | docker compose exec -T postgres psql -U "${POSTGRES_USER:-postgres}" -d "${POSTGRES_DB:-insforge}"  # Restore
 
 # ── Updates ───────────────────────────────────


### PR DESCRIPTION
Closes #1925

### Problem

The English deployment security guide (`docs/deployment/deployment-security-guide.md`) was updated in PR #1913 to instruct self-host operators to use the shipped `deploy/backup.sh` script, which enforces `umask 077` and safe tempfile atomic replacement.

However, the `zh`, `zh-Hant`, and `es` localized versions of the guide were not updated. They still walked readers through manually creating `~/insforge/backup.sh` with no umask. Because the database dump in that script was created via shell redirection under standard `umask 022`, the resulting Postgres dump files in `backups/` were written with world-readable permissions (`0644`). The cron examples in the localized guides also pointed to the old path.

### Root cause

Localization files are maintained manually and there is currently no tooling enforcing content parity between English guides and their translations when English guides are updated.

### Fix

Ported the section 14.1, section 17, and quick reference updates from the English guide across all three localized security guides (`zh`, `zh-Hant`, `es`):
- Section 14.1: Added instructions referencing `./deploy/backup.sh` alongside the manual `docker compose exec` fallback.
- Section 17.1: Replaced the manual `~/insforge/backup.sh` script walkthrough with `./deploy/backup.sh` and retention override instructions.
- Section 17.2: Updated the cron command to execute `/home/deploy/insforge/deploy/backup.sh`.
- Quick reference: Added `./deploy/backup.sh` to the essential database commands list.

### Evidence

| Check | Before | After |
| --- | --- | --- |
| `deploy/backup.sh` references in `zh` guide | 0 | 6 |
| `deploy/backup.sh` references in `zh-Hant` guide | 0 | 6 |
| `deploy/backup.sh` references in `es` guide | 0 | 6 |
| Stale `~/insforge/backup.sh` references | 6 (2 per file) | 0 |
| Prettier check on modified files | PASS | PASS |

### Testing

Ran acceptance checks against the modified docs:
- Checked for zero remaining references to `nano ~/insforge/backup.sh` and `/home/deploy/insforge/backup.sh`.
- Checked that cron commands in `zh`, `zh-Hant`, and `es` point to `/home/deploy/insforge/deploy/backup.sh`.
- Checked formatting:
  `npx prettier --check "docs/**/deployment-security-guide.md"` (All matched files use Prettier code style).

### Scope

Only the deployment security guides in `docs/zh/`, `docs/zh-Hant/`, and `docs/es/` were modified. No changes to application logic or English documentation.

### Pre-existing issues

`scripts/check-docs-i18n-parity.sh` reports 51 pre-existing missing page translations across the documentation suite (tracked separately under #1918). Left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #1925 by updating the English, Spanish, Simplified Chinese, and Traditional Chinese deployment security guides to use the shipped `deploy/backup.sh` instead of asking operators to create an unprotected `~/insforge/backup.sh`. The old instructions produced world-readable database dumps; the new ones also correct the cron and restore paths.

**Details**

- Documents database and `.env` backups, the manual dump fallback, 14-day retention, and `RETENTION_DAYS`/`BACKUP_DIR` overrides.
- Restore snippet honors a custom `BACKUP_DIR` and falls back to the default `backups/` directory.
- Creates the backup directory before cron setup and schedules `/home/deploy/insforge/deploy/backup.sh`.
- Uses `~/insforge/deploy/backup.sh` in the quick reference so it works from any directory.

<sup>Written for commit d62e7f86fc49657a633d04396c8e0adafa5d9db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated English, Spanish, Traditional Chinese, and Simplified Chinese deployment security guides with the bundled backup workflow.
  * Documented configurable backup locations and retention settings.
  * Clarified restoration steps when using a custom backup directory.
  * Added instructions to create backup directories before scheduling cron jobs.
  * Updated cron examples, installation-path guidance, and quick-reference commands for automated and manual database backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->