### PR TITLE
fix(ui): Skeleton shimmers in a tone that reads on both themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18058,7 +18058,7 @@
     },
     "packages/ui": {
       "name": "@insforge/ui",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/ui",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "InsForge",
   "description": "React UI component library, design tokens, and Tailwind preset for InsForge apps",
   "license": "Apache-2.0",

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -2,7 +2,8 @@ import type { HTMLAttributes } from 'react';
 import { cn } from '../lib';
 
 function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-card/10', className)} {...props} />;
+  // alpha-8 is the one tone that reads on both themes: black over the light page, white over the dark.
+  return <div className={cn('animate-pulse rounded-md bg-alpha-8', className)} {...props} />;
 }
 
 export { Skeleton };

--- a/packages/ui/src/components/__tests__/Skeleton.test.tsx
+++ b/packages/ui/src/components/__tests__/Skeleton.test.tsx
@@ -8,6 +8,7 @@ describe('Skeleton', () => {
 
     const skeleton = container.firstElementChild as HTMLElement;
     expect(skeleton.className).toContain('animate-pulse');
+    expect(skeleton.className).toContain('bg-alpha-8');
     expect(skeleton.className).toContain('h-8');
     expect(skeleton.className).toContain('w-56');
     expect(skeleton.getAttribute('aria-hidden')).toBe('true');


### PR DESCRIPTION
`Skeleton` paints `bg-card/10`. `--card` is white in light mode and `#242424` in dark, so at 10% the placeholder is white over a white page or near-black over a near-black one — invisible in both. The InstaCloud console noticed and keeps its own copy of the primitive with `bg-alpha-8` for that reason; this moves the fix into the package so the copy can go.

- `Skeleton` uses `bg-alpha-8`: black at 8% on the light theme, white at 8% on the dark one — the same token `--border` resolves to, so it sits in the palette. The test pins the class.
- No consumer in this repo overrides the Skeleton's background (31 usages in `packages/dashboard`), so all of them get a visible shimmer; on the dashboard's dark theme that is white 8% where before it was a faint dark-on-dark tint.
- Version 0.1.8 → 0.1.9 (package.json + the workspace entry in the lockfile), following the convention of bumping in the same change. Publishing to npm is a separate manual step.

Gate: `npm -w packages/ui run typecheck`, `lint`, `test` (10 files / 27 tests), `build` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Skeleton shimmer so it's visible on both light and dark themes; `bg-card/10` was invisible over white and near-black pages.

- Uses `bg-alpha-8`, the theme-aware tone `--border` already resolves to.
- Adds a test assertion pinning the new class.
- Bumps `@insforge/ui` to 0.1.9; publishing to npm stays a manual step.

<sup>Written for commit 9fb4c2cfa68ce6a5f98a0ffb57a3b4c8cefdd0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated skeleton loading placeholders with a refined background tone while preserving their animation, sizing, and accessibility behavior.

* **Tests**
  * Added coverage to verify the updated skeleton placeholder styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->