### PR TITLE
fix(logger): fail loud when 1.x volumes are unwritable

### DIFF
--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -26,12 +26,19 @@ export class LocalStorageProvider implements StorageProvider {
 
   async initialize(): Promise<void> {
     await fs.mkdir(this.baseDir, { recursive: true });
-    const probePath = path.join(this.baseDir, '.insforge-write-probe');
+    const probePath = path.join(
+      this.baseDir,
+      `.insforge-write-probe.${process.pid}.${crypto.randomUUID()}`
+    );
     try {
-      await fs.writeFile(probePath, '');
-      await fs.unlink(probePath);
+      await fs.writeFile(probePath, '', { flag: 'wx' });
     } catch {
       throw new Error(`STORAGE_DIR is not writable: ${this.baseDir}`);
+    }
+    try {
+      await fs.unlink(probePath);
+    } catch {
+      // Leftover unique probe must not fail initialize.
     }
   }
 

--- a/backend/src/providers/storage/local.provider.ts
+++ b/backend/src/providers/storage/local.provider.ts
@@ -26,6 +26,13 @@ export class LocalStorageProvider implements StorageProvider {
 
   async initialize(): Promise<void> {
     await fs.mkdir(this.baseDir, { recursive: true });
+    const probePath = path.join(this.baseDir, '.insforge-write-probe');
+    try {
+      await fs.writeFile(probePath, '');
+      await fs.unlink(probePath);
+    } catch {
+      throw new Error(`STORAGE_DIR is not writable: ${this.baseDir}`);
+    }
   }
 
   private getValidatedPath(bucket: string, ...parts: string[]): string {

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -8,6 +8,9 @@ const logsDir = appConfig.server.logsDir;
 
 const transports: winston.transport[] = [new winston.transports.Console()];
 
+export const VOLUME_OWNERSHIP_CHOWN =
+  'docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b';
+
 // Error instances stringify to {} — flatten them so metadata like
 // `logger.error('...', { error })` survives the trip to disk. Stacks follow
 // the same production gate as winston.format.errors below.
@@ -19,39 +22,61 @@ const flattenErrors = (_key: string, value: unknown) =>
       }
     : value;
 
+export function createSelfHostFileTransport(options: {
+  logsDir: string;
+  vitest: boolean;
+  exit: (code: number) => void;
+}): winston.transports.FileTransportInstance | undefined {
+  const { logsDir: dir, vitest, exit } = options;
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.accessSync(dir, fs.constants.W_OK);
+  } catch {
+    process.stderr.write(`${VOLUME_OWNERSHIP_CHOWN}\n`);
+    if (!vitest) {
+      exit(1);
+    }
+    return undefined;
+  }
+
+  return new winston.transports.File({
+    filename: path.join(dir, 'insforge.logs.jsonl'),
+    // Rotate so the file cannot grow unbounded; LocalFileProvider only
+    // reads the base file, which `tailable` keeps as the newest one.
+    maxsize: 20 * 1024 * 1024,
+    maxFiles: 2,
+    tailable: true,
+    format: winston.format.printf((info) => {
+      const { timestamp, level, message, ...metadata } = info;
+      return JSON.stringify(
+        {
+          id: `${Date.now()}-${Math.random()}`,
+          timestamp,
+          message,
+          level,
+          metadata,
+        },
+        flattenErrors
+      );
+    }),
+  });
+}
+
 // The JSONL file feeds the self-hosted dashboard logs (LocalFileProvider).
 // Cloud deployments ship stdout to CloudWatch via the awslogs driver and read
 // logs back through CloudWatchProvider, so writing the file there would only
 // grow the container filesystem with data nothing reads.
 if (!isCloudEnvironment()) {
-  try {
-    fs.mkdirSync(logsDir, { recursive: true });
-    transports.push(
-      new winston.transports.File({
-        filename: path.join(logsDir, 'insforge.logs.jsonl'),
-        // Rotate so the file cannot grow unbounded; LocalFileProvider only
-        // reads the base file, which `tailable` keeps as the newest one.
-        maxsize: 20 * 1024 * 1024,
-        maxFiles: 2,
-        tailable: true,
-        format: winston.format.printf((info) => {
-          const { timestamp, level, message, ...metadata } = info;
-          return JSON.stringify(
-            {
-              id: `${Date.now()}-${Math.random()}`,
-              timestamp,
-              message,
-              level,
-              metadata,
-            },
-            flattenErrors
-          );
-        }),
-      })
-    );
-  } catch (error) {
-    // Console logging still works, but surface why the dashboard log file is missing
-    console.warn(`Could not initialize file logging at ${logsDir}:`, error);
+  const fileTransport = createSelfHostFileTransport({
+    logsDir,
+    vitest: Boolean(process.env.VITEST),
+    exit: (c) => {
+      process.exit(c);
+    },
+  });
+  if (fileTransport) {
+    transports.push(fileTransport);
   }
 }
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -29,11 +29,18 @@ export function createSelfHostFileTransport(options: {
 }): winston.transports.FileTransportInstance | undefined {
   const { logsDir: dir, vitest, exit } = options;
 
+  const jsonlPath = path.join(dir, 'insforge.logs.jsonl');
+
   try {
     fs.mkdirSync(dir, { recursive: true });
-    fs.accessSync(dir, fs.constants.W_OK);
+    const fd = fs.openSync(jsonlPath, 'a');
+    fs.closeSync(fd);
   } catch {
-    process.stderr.write(`${VOLUME_OWNERSHIP_CHOWN}\n`);
+    try {
+      fs.writeSync(2, `${VOLUME_OWNERSHIP_CHOWN}\n`);
+    } catch {
+      // EPIPE must not skip the injected exit below.
+    }
     if (!vitest) {
       exit(1);
     }
@@ -41,7 +48,7 @@ export function createSelfHostFileTransport(options: {
   }
 
   return new winston.transports.File({
-    filename: path.join(dir, 'insforge.logs.jsonl'),
+    filename: jsonlPath,
     // Rotate so the file cannot grow unbounded; LocalFileProvider only
     // reads the base file, which `tailable` keeps as the newest one.
     maxsize: 20 * 1024 * 1024,

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -12,6 +12,38 @@ vi.mock('fs/promises', async () => {
   };
 });
 
+describe('LocalStorageProvider - initialize writability', () => {
+  const baseDir = path.join(__dirname, 'test-storage-init-probe');
+
+  afterEach(async () => {
+    try {
+      await fs.chmod(baseDir, 0o700);
+    } catch {
+      // Directory may not exist yet.
+    }
+    await fs.rm(baseDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when the storage directory exists and is not writable', async () => {
+    await fs.mkdir(baseDir, { recursive: true });
+    await fs.chmod(baseDir, 0o555);
+    const provider = new LocalStorageProvider(baseDir);
+    await expect(provider.initialize()).rejects.toThrow(/STORAGE_DIR/);
+  });
+
+  it('writes and unlinks a probe file when the storage directory is writable', async () => {
+    const writeSpy = vi.spyOn(fs, 'writeFile');
+    const unlinkSpy = vi.spyOn(fs, 'unlink');
+    const provider = new LocalStorageProvider(baseDir);
+    await expect(provider.initialize()).resolves.toBeUndefined();
+    const probePath = path.join(baseDir, '.insforge-write-probe');
+    expect(writeSpy).toHaveBeenCalledWith(probePath, expect.anything());
+    expect(unlinkSpy).toHaveBeenCalledWith(probePath);
+    await expect(fs.access(probePath)).rejects.toThrow();
+  });
+});
+
 describe('LocalStorageProvider - deleteBucket', () => {
   const baseDir = path.join(__dirname, 'test-storage');
   let provider: LocalStorageProvider;

--- a/backend/tests/unit/localstorageprovider.test.ts
+++ b/backend/tests/unit/localstorageprovider.test.ts
@@ -32,15 +32,48 @@ describe('LocalStorageProvider - initialize writability', () => {
     await expect(provider.initialize()).rejects.toThrow(/STORAGE_DIR/);
   });
 
-  it('writes and unlinks a probe file when the storage directory is writable', async () => {
+  it('writes and unlinks a unique wx probe when the storage directory is writable', async () => {
     const writeSpy = vi.spyOn(fs, 'writeFile');
     const unlinkSpy = vi.spyOn(fs, 'unlink');
     const provider = new LocalStorageProvider(baseDir);
     await expect(provider.initialize()).resolves.toBeUndefined();
-    const probePath = path.join(baseDir, '.insforge-write-probe');
-    expect(writeSpy).toHaveBeenCalledWith(probePath, expect.anything());
+
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`\\.insforge-write-probe\\.${process.pid}\\.[0-9a-f-]{36}$`)
+      ),
+      '',
+      { flag: 'wx' }
+    );
+    const probePath = String(writeSpy.mock.calls[0][0]);
     expect(unlinkSpy).toHaveBeenCalledWith(probePath);
     await expect(fs.access(probePath)).rejects.toThrow();
+
+    const leftovers = (await fs.readdir(baseDir)).filter((name) =>
+      name.startsWith('.insforge-write-probe.')
+    );
+    expect(leftovers).toEqual([]);
+  });
+
+  it('does not truncate a pre-existing .insforge-write-probe file', async () => {
+    await fs.mkdir(baseDir, { recursive: true });
+    const sentinelPath = path.join(baseDir, '.insforge-write-probe');
+    const sentinel = Buffer.from('do-not-clobber');
+    await fs.writeFile(sentinelPath, sentinel);
+    const provider = new LocalStorageProvider(baseDir);
+    await expect(provider.initialize()).resolves.toBeUndefined();
+    expect(await fs.readFile(sentinelPath)).toEqual(sentinel);
+  });
+
+  it('resolves when the unique probe is created but unlink fails', async () => {
+    const writeSpy = vi.spyOn(fs, 'writeFile');
+    vi.spyOn(fs, 'unlink').mockRejectedValueOnce(
+      Object.assign(new Error('EACCES'), { code: 'EACCES' })
+    );
+    const provider = new LocalStorageProvider(baseDir);
+    await expect(provider.initialize()).resolves.toBeUndefined();
+    const probePath = String(writeSpy.mock.calls[0][0]);
+    expect(probePath).toContain(`.insforge-write-probe.${process.pid}.`);
   });
 });
 

--- a/backend/tests/unit/logger-transports.test.ts
+++ b/backend/tests/unit/logger-transports.test.ts
@@ -242,10 +242,7 @@ describe('logger transports', () => {
         exit,
       });
       expect(transport).toBeUndefined();
-      expect(writeSyncSpy).toHaveBeenCalledWith(
-        2,
-        expect.stringContaining(VOLUME_OWNERSHIP_CHOWN)
-      );
+      expect(writeSyncSpy).toHaveBeenCalledWith(2, expect.stringContaining(VOLUME_OWNERSHIP_CHOWN));
       expect(exit).toHaveBeenCalledTimes(1);
       expect(exit).toHaveBeenCalledWith(1);
     } finally {

--- a/backend/tests/unit/logger-transports.test.ts
+++ b/backend/tests/unit/logger-transports.test.ts
@@ -5,6 +5,9 @@ import winston from 'winston';
 
 const logsDir = path.join(__dirname, 'test-logger-logs');
 
+const VOLUME_OWNERSHIP_CHOWN =
+  'docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b';
+
 vi.mock('../../src/infra/config/app.config', () => ({
   appConfig: {
     app: { logLevel: 'info' },
@@ -14,10 +17,29 @@ vi.mock('../../src/infra/config/app.config', () => ({
 
 const originalProfile = process.env.AWS_INSTANCE_PROFILE_NAME;
 
-async function importLogger() {
+async function importLoggerModule() {
   vi.resetModules();
-  const { logger } = await import('../../src/utils/logger.ts');
+  return import('../../src/utils/logger.ts');
+}
+
+async function importLogger() {
+  const { logger } = await importLoggerModule();
   return logger;
+}
+
+function stderrText(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((call) => String(call[0])).join('');
+}
+
+async function withUnwritableLogsDir<T>(fn: () => Promise<T>): Promise<T> {
+  await fs.mkdir(logsDir, { recursive: true });
+  await fs.chmod(logsDir, 0o555);
+  try {
+    return await fn();
+  } finally {
+    await fs.chmod(logsDir, 0o700);
+    await fs.rm(logsDir, { recursive: true, force: true });
+  }
 }
 
 describe('logger transports', () => {
@@ -26,7 +48,13 @@ describe('logger transports', () => {
   });
 
   afterEach(async () => {
+    try {
+      await fs.chmod(logsDir, 0o700);
+    } catch {
+      // Directory may not exist yet.
+    }
     await fs.rm(logsDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
   afterAll(() => {
@@ -94,5 +122,71 @@ describe('logger transports', () => {
     expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
     expect(logger.transports.some((t) => t instanceof winston.transports.Console)).toBe(true);
     await expect(fs.access(logsDir)).rejects.toThrow();
+  });
+
+  it('does not attach a File transport when LOGS_DIR is unwritable', async () => {
+    await withUnwritableLogsDir(async () => {
+      const logger = await importLogger();
+      expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
+    });
+  });
+
+  it('does not hang when logging to an unwritable LOGS_DIR', async () => {
+    await withUnwritableLogsDir(async () => {
+      const logger = await importLogger();
+      expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
+
+      const started = Date.now();
+      logger.info('should not hang');
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('log write exceeded 2000ms')), 2000);
+        logger.once('finish', () => {
+          clearTimeout(timer);
+          resolve();
+        });
+        logger.end();
+      });
+      expect(Date.now() - started).toBeLessThanOrEqual(2000);
+    });
+  }, 2500);
+
+  it('prints the Alpine chown command when LOGS_DIR is unwritable', async () => {
+    const writeSpy = vi.spyOn(process.stderr, 'write');
+    await withUnwritableLogsDir(async () => {
+      const mod = await importLoggerModule();
+      expect(mod.VOLUME_OWNERSHIP_CHOWN).toBe(VOLUME_OWNERSHIP_CHOWN);
+      expect(stderrText(writeSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
+    });
+  });
+
+  it('calls injected exit(1) and omits File when vitest is false', async () => {
+    const { createSelfHostFileTransport } = await importLoggerModule();
+    await fs.mkdir(logsDir, { recursive: true });
+    await fs.chmod(logsDir, 0o555);
+    try {
+      const exit = vi.fn();
+      const transport = createSelfHostFileTransport({
+        logsDir,
+        vitest: false,
+        exit,
+      });
+      expect(transport).toBeUndefined();
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      await fs.chmod(logsDir, 0o700);
+    }
+  });
+
+  it('omits File, prints chown, and does not exit when VITEST is set', async () => {
+    expect(process.env.VITEST).toBeTruthy();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const writeSpy = vi.spyOn(process.stderr, 'write');
+    await withUnwritableLogsDir(async () => {
+      const logger = await importLogger();
+      expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(stderrText(writeSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
+    });
   });
 });

--- a/backend/tests/unit/logger-transports.test.ts
+++ b/backend/tests/unit/logger-transports.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import fs from 'fs/promises';
+import nodeFs from 'fs';
 import * as path from 'path';
 import winston from 'winston';
 
@@ -27,8 +28,11 @@ async function importLogger() {
   return logger;
 }
 
-function stderrText(spy: ReturnType<typeof vi.spyOn>): string {
-  return spy.mock.calls.map((call) => String(call[0])).join('');
+function recipeFromWriteSync(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls
+    .filter((call) => call[0] === 2)
+    .map((call) => String(call[1]))
+    .join('');
 }
 
 async function withUnwritableLogsDir<T>(fn: () => Promise<T>): Promise<T> {
@@ -116,11 +120,13 @@ describe('logger transports', () => {
 
   it('does not add a file transport in cloud environments', async () => {
     process.env.AWS_INSTANCE_PROFILE_NAME = 'insforge-instance-profile';
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
     const logger = await importLogger();
 
     expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
     expect(logger.transports.some((t) => t instanceof winston.transports.Console)).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
     await expect(fs.access(logsDir)).rejects.toThrow();
   });
 
@@ -151,19 +157,19 @@ describe('logger transports', () => {
   }, 2500);
 
   it('prints the Alpine chown command when LOGS_DIR is unwritable', async () => {
-    const writeSpy = vi.spyOn(process.stderr, 'write');
+    const writeSyncSpy = vi.spyOn(nodeFs, 'writeSync');
     await withUnwritableLogsDir(async () => {
       const mod = await importLoggerModule();
       expect(mod.VOLUME_OWNERSHIP_CHOWN).toBe(VOLUME_OWNERSHIP_CHOWN);
-      expect(stderrText(writeSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
+      expect(recipeFromWriteSync(writeSyncSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
     });
   });
 
   it('calls injected exit(1) and omits File when vitest is false', async () => {
-    const { createSelfHostFileTransport } = await importLoggerModule();
     await fs.mkdir(logsDir, { recursive: true });
     await fs.chmod(logsDir, 0o555);
     try {
+      const { createSelfHostFileTransport } = await importLoggerModule();
       const exit = vi.fn();
       const transport = createSelfHostFileTransport({
         logsDir,
@@ -181,12 +187,69 @@ describe('logger transports', () => {
   it('omits File, prints chown, and does not exit when VITEST is set', async () => {
     expect(process.env.VITEST).toBeTruthy();
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
-    const writeSpy = vi.spyOn(process.stderr, 'write');
+    const writeSyncSpy = vi.spyOn(nodeFs, 'writeSync');
     await withUnwritableLogsDir(async () => {
       const logger = await importLogger();
       expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
       expect(exitSpy).not.toHaveBeenCalled();
-      expect(stderrText(writeSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
+      expect(recipeFromWriteSync(writeSyncSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
     });
+  });
+
+  it('fails loud when insforge.logs.jsonl is 0444 in a writable directory', async () => {
+    await fs.mkdir(logsDir, { recursive: true });
+    const jsonl = path.join(logsDir, 'insforge.logs.jsonl');
+    await fs.writeFile(jsonl, '');
+    await fs.chmod(jsonl, 0o444);
+    const writeSyncSpy = vi.spyOn(nodeFs, 'writeSync');
+    try {
+      const started = Date.now();
+      const { logger, createSelfHostFileTransport } = await importLoggerModule();
+      expect(logger.transports.some((t) => t instanceof winston.transports.File)).toBe(false);
+
+      const exit = vi.fn();
+      const transport = createSelfHostFileTransport({
+        logsDir,
+        vitest: false,
+        exit,
+      });
+      expect(transport).toBeUndefined();
+      expect(Date.now() - started).toBeLessThanOrEqual(2000);
+      expect(recipeFromWriteSync(writeSyncSpy)).toContain(VOLUME_OWNERSHIP_CHOWN);
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      await fs.chmod(jsonl, 0o644);
+      await fs.chmod(logsDir, 0o700);
+    }
+  }, 2500);
+
+  it('still exits when writeSync to fd 2 throws EPIPE', async () => {
+    await fs.mkdir(logsDir, { recursive: true });
+    await fs.chmod(logsDir, 0o555);
+    const writeSyncSpy = vi.spyOn(nodeFs, 'writeSync').mockImplementation((fd) => {
+      if (fd === 2) {
+        throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+      }
+      return 0;
+    });
+    try {
+      const { createSelfHostFileTransport } = await importLoggerModule();
+      const exit = vi.fn();
+      const transport = createSelfHostFileTransport({
+        logsDir,
+        vitest: false,
+        exit,
+      });
+      expect(transport).toBeUndefined();
+      expect(writeSyncSpy).toHaveBeenCalledWith(
+        2,
+        expect.stringContaining(VOLUME_OWNERSHIP_CHOWN)
+      );
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      await fs.chmod(logsDir, 0o700);
+    }
   });
 });

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -939,6 +939,12 @@ Volumes written as root on 1.x are not writable by the 2.x process (UID 1000). F
 docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
+Then restart so the process can write the volumes:
+
+```bash
+docker compose up -d
+```
+
 ### 16. Rollback Procedure
 
 If an update causes issues, follow these steps to revert:

--- a/docs/deployment/deployment-security-guide.md
+++ b/docs/deployment/deployment-security-guide.md
@@ -674,7 +674,7 @@ sudo ufw status
 
 InsForge's Docker image already follows non-root best practices:
 
-- The production Dockerfile sets `USER node` (UID 1000), so the application process inside the container runs as a non-root user.
+- The image entrypoint runs `exec su-exec node`, so the application process inside the container runs as UID 1000 (`node`). The production Dockerfile does not set `USER node` for that drop: the container starts as root so it can join the Docker socket group, then hands off with `su-exec`.
 - System-level Docker operations are managed by the `deploy` user (created in [Step 2.3](#23-create-a-deploy-user-non-root)), which has access to the Docker socket via the `docker` group.
 
 **Verify the container user:**
@@ -929,6 +929,14 @@ docker compose ps
 curl http://localhost:7130/api/health
 
 # Check the version in the response
+```
+
+#### 15.5 Volume ownership after upgrading from 1.x
+
+Volumes written as root on 1.x are not writable by the 2.x process (UID 1000). Fix ownership, replacing `<stack>` with your Compose project name:
+
+```bash
+docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
 ### 16. Rollback Procedure

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -921,6 +921,12 @@ Los volúmenes escritos como root en 1.x no son escribibles por el proceso 2.x (
 docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
+Después del chown, reinicia para que el proceso pueda escribir en los volúmenes:
+
+```bash
+docker compose up -d
+```
+
 ### 16. Procedimiento de reversión
 
 Si una actualización causa problemas, sigue estos pasos para revertirla:

--- a/docs/es/deployment/deployment-security-guide.md
+++ b/docs/es/deployment/deployment-security-guide.md
@@ -665,7 +665,7 @@ sudo ufw status
 
 La imagen Docker de InsForge ya sigue las buenas prácticas de no root:
 
-- El Dockerfile de producción establece `USER node` (UID 1000), por lo que el proceso de la aplicación dentro del contenedor se ejecuta como un usuario no root.
+- El entrypoint de la imagen ejecuta `exec su-exec node`, por lo que el proceso de la aplicación dentro del contenedor se ejecuta como UID 1000 (`node`). El Dockerfile de producción no establece `USER node` para ese cambio de usuario: el contenedor arranca como root para unirse al grupo del socket de Docker y luego cede el proceso con `su-exec`.
 - Las operaciones de Docker a nivel de sistema están gestionadas por el usuario `deploy` (creado en el [Paso 2.3](#23-create-a-deploy-user-non-root)), que tiene acceso al socket de Docker a través del grupo `docker`.
 
 **Verifica el usuario del contenedor:**
@@ -911,6 +911,14 @@ docker compose ps
 curl http://localhost:7130/api/health
 
 # Check the version in the response
+```
+
+#### 15.5 Propiedad de volúmenes al actualizar desde 1.x
+
+Los volúmenes escritos como root en 1.x no son escribibles por el proceso 2.x (UID 1000). Corrige la propiedad, sustituyendo `<stack>` por el nombre de tu proyecto de Compose:
+
+```bash
+docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
 ### 16. Procedimiento de reversión

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -664,7 +664,7 @@ sudo ufw status
 
 InsForge 的 Docker 映像檔已遵循非 root 的最佳實務：
 
-- 正式環境的 Dockerfile 設定了 `USER node`（UID 1000），因此容器內的應用程式行程以非 root 使用者執行。
+- 映像檔 entrypoint 使用 `exec su-exec node`，因此容器內的應用程式行程以 UID 1000（`node`）執行。正式環境 Dockerfile 並不靠 `USER node` 完成這次降權：容器先以 root 啟動以便加入 Docker socket 的群組，再透過 `su-exec` 交接。
 - 系統層級的 Docker 操作由 `deploy` 使用者（於[第 2.3 步](#23-create-a-deploy-user-non-root)建立）管理，該使用者透過 `docker` 群組取得對 Docker 通訊端的存取權限。
 
 **驗證容器使用者：**
@@ -910,6 +910,14 @@ docker compose ps
 curl http://localhost:7130/api/health
 
 # Check the version in the response
+```
+
+#### 15.5 從 1.x 升級後的卷所有權
+
+在 1.x 以 root 寫入的卷，2.x 行程（UID 1000）無法寫入。修復所有權，將 `<stack>` 替換成你的 Compose 專案名稱：
+
+```bash
+docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
 ### 16. 回復流程

--- a/docs/zh-Hant/deployment/deployment-security-guide.md
+++ b/docs/zh-Hant/deployment/deployment-security-guide.md
@@ -920,6 +920,12 @@ curl http://localhost:7130/api/health
 docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
+完成 chown 後重啟，讓行程能夠寫入這些卷：
+
+```bash
+docker compose up -d
+```
+
 ### 16. 回復流程
 
 若更新造成問題，請依照以下步驟進行回復：

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -919,6 +919,12 @@ curl http://localhost:7130/api/health
 docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
+完成 chown 后重启，让进程能够写入这些卷：
+
+```bash
+docker compose up -d
+```
+
 ### 16. 回滚流程
 
 如果更新导致了问题，请按照以下步骤进行回退：

--- a/docs/zh/deployment/deployment-security-guide.md
+++ b/docs/zh/deployment/deployment-security-guide.md
@@ -663,7 +663,7 @@ sudo ufw status
 
 InsForge 的 Docker 镜像已经遵循了非 root 的最佳实践：
 
-- 生产环境 Dockerfile 设置了 `USER node`（UID 1000），因此容器内的应用进程以非 root 用户运行。
+- 镜像 entrypoint 使用 `exec su-exec node`，因此容器内的应用进程以 UID 1000（`node`）运行。生产环境 Dockerfile 并不靠 `USER node` 完成这次降权：容器先以 root 启动以便加入 Docker socket 的组，再通过 `su-exec` 交接。
 - 系统级的 Docker 操作由 `deploy` 用户（在[第 2.3 步](#23-create-a-deploy-user-non-root)中创建）管理，该用户通过 `docker` 组获得对 Docker 套接字的访问权限。
 
 **验证容器用户：**
@@ -909,6 +909,14 @@ docker compose ps
 curl http://localhost:7130/api/health
 
 # Check the version in the response
+```
+
+#### 15.5 从 1.x 升级后的卷所有权
+
+1.x 上以 root 写入的卷，2.x 进程（UID 1000）无法写入。修复所有权，将 `<stack>` 替换为你的 Compose 项目名：
+
+```bash
+docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b
 ```
 
 ### 16. 回滚流程


### PR DESCRIPTION
## Summary

Upgrading a self-hosted stack from 1.x to 2.x keeps existing `insforge-logs` / `storage-data` volumes owned by uid 0, while 2.x drops to uid 1000 via entrypoint `su-exec node` (not `USER node`). `mkdirSync` succeeds on the already-present directory, Winston File attaches, the first write is async `EACCES`, and Winston busy-loops at 100% CPU during `migrate:bootstrap`. Migrations never run and the API never comes up. The same ownership class later breaks local storage uploads.

This PR fails loud instead of hanging:

- Probe `LOGS_DIR` with `mkdir` + `accessSync(W_OK)` before attaching Winston File (`createSelfHostFileTransport` in `logger.ts`).
- If unwritable: print the Alpine `chown` recipe on stderr, do **not** attach File (that is what stops the hang), `exit(1)` in production, no exit under `VITEST`.
- `LocalStorageProvider.initialize` writes then unlinks `.insforge-write-probe`; on failure it throws an `Error` naming `STORAGE_DIR`.
- Four-locale `deployment-security-guide.md`: §10 describes the uid drop as `su-exec`; §15.5 documents the locked command.

Intentionally not in this PR: boot-time `chown -R` of storage, running as root, silently dropping File, new flags, or an entrypoint change.

Closes #2007

## How did you test this change?

- Focused: `cd backend && npm test -- tests/unit/logger-transports.test.ts tests/unit/localstorageprovider.test.ts` — 25/25
- Full backend: `cd backend && npm test` — 2411 passed, 21 skipped
- Typecheck: `cd backend && npm run typecheck` — exit 0

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the self-hosted 2.x upgrade hang when leftover 1.x volumes are still root-owned: the logger now append-opens `insforge.logs.jsonl` before attaching the `File` transport, prints an Alpine `chown` command to stderr, and exits in production instead of spinning Winston's async retry loop at 100% CPU. The storage provider fails fast with a clear `STORAGE_DIR` error, and the deployment security guide now documents the UID drop (`su-exec`, not `USER node`) and the ownership fix in all four locales.

**Migration**
- Run `docker run --rm -v <stack>_insforge-logs:/a -v <stack>_storage-data:/b alpine chown -R 1000:1000 /a /b` to fix volume ownership before or after upgrading.
- Replace `<stack>` with your Compose project name.

**Bug Fixes**
- `createSelfHostFileTransport` append-opens `insforge.logs.jsonl` to probe writability, skipping the `File` transport and exiting with code 1 on failure (except under `VITEST`).
- `LocalStorageProvider.initialize` writes and unlinks a unique `.insforge-write-probe.<pid>.<uuid>` and throws on failure.

<sup>Written for commit 15900626804e6503310f25ec1476a992ad7e45f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation for storage directories, with clear errors when they are not writable.
  * Improved self-hosted logging failure handling by reporting permission issues and providing ownership remediation guidance.
  * Preserved existing probe files and allowed startup to continue when probe cleanup fails.
  * Ensured logging initialization fails reliably when the log file is not writable.

* **Documentation**
  * Updated deployment security guides to explain non-root container execution.
  * Added upgrade guidance for correcting volume ownership when moving from 1.x to 2.x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->