### PR TITLE
fix(functions): make export-default handlers work on self-hosted/local runtime

### DIFF
--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -397,16 +397,6 @@ export default async function (req: Request): Promise<Response> {
     expect(typeof moduleObj.exports).toBe('function');
   });
 
-  it('still treats a division after an identifier as division, not a regex', () => {
-    const code = `const half = 10 / 2;
-export default async function (req: Request): Promise<Response> {
-  return new Response(String(half));
-}`;
-
-    const result = normalizeHandlerFormat(code);
-    expect(result).toContain('const half = 10 / 2;');
-  });
-
   it('strips a return type separated from the parameter list by a line break', () => {
     const code = `export default async function (req: Request)
   : Promise<Response> {
@@ -454,6 +444,29 @@ export default async function (req: Request): Promise<Response> {
     const moduleObj = { exports: exportsObj };
     wrapper(exportsObj, moduleObj);
     expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not let a ternary in an untyped default value corrupt a later parameter', async () => {
+    // `a` has no type annotation at all here, so the only way into 'default'
+    // mode is seeing a bare '=' straight from 'name' mode — without that,
+    // the ternary's own ':' below is misread as starting a type annotation.
+    const code = `export default async function (a = 1 < 2 ? "x" : "y", b: Request): Promise<Response> {
+  return new Response(a);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('1 < 2 ? "x" : "y"');
+    expect(result).not.toMatch(/b:\s*Request/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (
+      a: string,
+      req: unknown
+    ) => Promise<{ text(): Promise<string> }>;
+    const response = await handler(undefined as never, {});
+    expect(await response.text()).toBe('x'); // 1 < 2 is true
   });
 
   it('rewrites export default even when a comment in the body looks like a legacy assignment', () => {

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -292,4 +292,127 @@ export default async function (req: Request): Promise<Response> {
     const response = await handler({});
     expect(await response.text()).toBe('module.exports = fake');
   });
+
+  // Round-3 regression coverage: a third review pass found the masker
+  // couldn't tell a regex literal from a string/comment (a quote or `//`
+  // inside a regex character class was misread as starting one), and that
+  // TypeScript's optional-parameter `?` was never stripped.
+
+  it('does not let a regex literal containing a quote character confuse string detection', () => {
+    const code = `const quotes = /['"]/;
+export default async function (req: Request): Promise<Response> {
+  return new Response(quotes.test("x") ? "yes" : "no");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('module.exports = async function');
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not let a double slash inside a regex character class be read as a line comment', () => {
+    const code = `const pattern = /[//]/;
+export default async function (req: Request): Promise<Response> {
+  return new Response(pattern.source);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('module.exports = async function');
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not mistake a division for a regex literal', () => {
+    const code = `const half = 10 / 2;
+export default async function (req: Request): Promise<Response> {
+  return new Response(String(half));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('const half = 10 / 2;');
+  });
+
+  it('strips a TypeScript optional-parameter marker', () => {
+    const code = `export default async function (req?: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/\?/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('strips an optional parameter alongside a typed, required one', () => {
+    const code = `export default async function (req: Request, opts?: Record<string, string>): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+});
+
+describe('functions/handler-format.js — Zeabur embedded copy stays in sync', () => {
+  // deploy/zeabur/template.yml inlines a standalone copy of this file for
+  // its embedded Deno runtime (that deployment target can't read a second
+  // local file at request time the way the other deploy targets do). A
+  // reviewer flagged that the two copies will silently drift if one is
+  // edited without the other — this test makes that impossible to miss.
+  it('embeds byte-identical content to functions/handler-format.js', () => {
+    // Plain string extraction rather than a real YAML parser: this only
+    // needs to locate one known block-scalar entry (by its fixed `- path:`
+    // marker and indentation) and dedent it — pulling in a YAML dependency
+    // for that would be more machinery than the check warrants.
+    const realSource = readFileSync(
+      join(__dirname, '../../../functions/handler-format.js'),
+      'utf-8'
+    );
+    const templatePath = join(__dirname, '../../../deploy/zeabur/template.yml');
+    // Normalized once here (rather than only at the final comparison) so the
+    // marker/slice logic below doesn't have to account for a CRLF checkout.
+    const templateSource = readFileSync(templatePath, 'utf-8').replace(/\r\n/g, '\n');
+
+    const startMarker =
+      '                - path: /app/functions/handler-format.js\n                  template: |\n';
+    const startIndex = templateSource.indexOf(startMarker);
+    expect(
+      startIndex,
+      'deploy/zeabur/template.yml is missing the handler-format.js config entry'
+    ).toBeGreaterThanOrEqual(0);
+
+    const contentStart = startIndex + startMarker.length;
+    const endMarker = '\n            healthCheck:';
+    const endIndex = templateSource.indexOf(endMarker, contentStart);
+    expect(
+      endIndex,
+      'could not find the end of the embedded handler-format.js block'
+    ).toBeGreaterThan(contentStart);
+
+    const indent = '                    ';
+    const dedented = templateSource
+      .slice(contentStart, endIndex)
+      .split('\n')
+      .map((line) => (line.startsWith(indent) ? line.slice(indent.length) : line))
+      .join('\n');
+
+    // Trailing-newline-insensitive: the embedded copy's block ends at the
+    // last content line (nothing meaningful follows it before `healthCheck:`
+    // in the YAML), while the real file ends with the newline every text
+    // file has — not a real difference worth failing this test over.
+    expect(dedented.replace(/\n$/, '')).toBe(realSource.replace(/\r\n/g, '\n').replace(/\n$/, ''));
+  });
 });

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -204,4 +204,92 @@ export default async function (req: Request): Promise<Response> {
     const result = normalizeHandlerFormat(code);
     expect(result).toBe('module.exports = someModule.handler;');
   });
+
+  // Round-2 regression coverage: a second review pass on the fixes above
+  // found further edge cases in the type-annotation stripping and the
+  // string/comment-unaware regex matching. Each of these previously either
+  // produced invalid JavaScript or was incorrectly rewritten/skipped.
+
+  it('does not corrupt a ternary expression used as a parameter default value', async () => {
+    const code = `export default async function (req: Request, opts: string = true ? "a" : "b"): Promise<Response> {
+  return new Response(opts);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    const response = await handler({});
+    expect(await response.text()).toBe('a');
+  });
+
+  it("does not treat a function-type parameter's arrow as a default-value marker", () => {
+    const code = `export default async function (req: Request, cb: () => void): Promise<Response> {
+  cb();
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown, cb: () => void) => unknown;
+    let called = false;
+    handler({}, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+  });
+
+  it('strips a return type that itself contains an object-literal type', () => {
+    const code = `export default async function (req: Request): Promise<{ status: number }> {
+  return { status: 200 };
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/Promise</);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ status: number }>;
+    expect(typeof handler).toBe('function');
+  });
+
+  it('does not rewrite import-shaped text inside a template literal', async () => {
+    const code = `export default async function (req: Request): Promise<Response> {
+  const msg = \`import { createClient } from 'npm:@insforge/sdk';\`;
+  return new Response(msg);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain("const msg = `import { createClient } from 'npm:@insforge/sdk';`;");
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    const response = await handler({});
+    expect(await response.text()).toBe("import { createClient } from 'npm:@insforge/sdk';");
+  });
+
+  it('does not skip normalization when "module.exports =" only appears in a string literal', async () => {
+    const code = `export default async function (req: Request): Promise<Response> {
+  const msg = 'module.exports = fake';
+  return new Response(msg);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toMatch(/^module\.exports = async function/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    const response = await handler({});
+    expect(await response.text()).toBe('module.exports = fake');
+  });
 });

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -94,4 +94,114 @@ export default async function (req) {
     expect(result).toContain("import { something } from 'npm:some-other-package';");
     expect(result).toContain('module.exports = async function (req) {');
   });
+
+  // Regression coverage for review findings on the PR that introduced this
+  // file — each of these previously produced a `new Function` SyntaxError or
+  // ReferenceError under the documented format.
+
+  it('strips the documented TypeScript-typed signature (parameter and return types)', () => {
+    const code = `import { createClient } from 'npm:@insforge/sdk';
+
+export default async function (req: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/:\s*Request/);
+    expect(result).not.toMatch(/Promise<Response>/);
+
+    const wrapper = new Function('exports', 'module', 'createClient', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj, () => ({}));
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('strips types from multiple parameters, including a generic with an internal comma', async () => {
+    const code = `export default async function (req: Request, opts: Record<string, string> = {}): Promise<Response> {
+  return new Response(JSON.stringify(opts));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    expect(typeof handler).toBe('function');
+    const response = await handler({});
+    expect(await response.text()).toBe('{}');
+  });
+
+  it('strips types from a typed arrow-function handler', () => {
+    const code = `export default async (req: Request): Promise<Response> => {
+  return new Response("hi");
+};`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not skip normalization when "module.exports" only appears in a comment', () => {
+    const code = `// previously: module.exports = async function (req) { ... }
+export default async function (req: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toMatch(/^\/\/ previously:/);
+    expect(result).toContain('module.exports = async function');
+    expect(result).not.toMatch(/export\s+default/);
+
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('rewrites an aliased SDK import into a local const binding', async () => {
+    const code = `import { createClient as makeClient } from 'npm:@insforge/sdk';
+
+export default async function (req: Request): Promise<Response> {
+  const client = makeClient({});
+  return new Response(typeof client);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/\bimport\b/);
+    expect(result).toContain('const makeClient = createClient;');
+
+    const wrapper = new Function('exports', 'module', 'createClient', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj, () => ({}));
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    const response = await handler({});
+    expect(await response.text()).toBe('object');
+  });
+
+  it('leaves the whole import untouched when it mixes a known and unknown SDK binding', () => {
+    const code = `import { createClient, somethingElse } from 'npm:@insforge/sdk';
+
+export default async function (req: Request): Promise<Response> {
+  return new Response(somethingElse());
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain("import { createClient, somethingElse } from 'npm:@insforge/sdk';");
+    expect(result).toContain('module.exports = async function');
+  });
+
+  it('leaves an unparseable/unrecognized signature completely untouched', () => {
+    // Not a function/arrow expression at all — normalizeHandlerFormat should
+    // bail out rather than guess, reproducing the pre-existing plain error.
+    const code = `export default someModule.handler;`;
+    const result = normalizeHandlerFormat(code);
+    expect(result).toBe('module.exports = someModule.handler;');
+  });
 });

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import vm from 'vm';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `functions/handler-format.js` is plain JS with no import/export of its own
+ * (see file header) so it can be concatenated ahead of `worker-template.js`
+ * for the Deno worker. Load its real source here via `vm` — rather than
+ * re-implementing the regex in this test — so the test tracks the exact code
+ * that ships, with no risk of drifting from it.
+ */
+function loadNormalizeHandlerFormat(): (code: string) => string {
+  const source = readFileSync(join(__dirname, '../../../functions/handler-format.js'), 'utf-8');
+  const context: { normalizeHandlerFormat?: (code: string) => string } = {};
+  vm.createContext(context);
+  vm.runInContext(`${source}\nthis.normalizeHandlerFormat = normalizeHandlerFormat;`, context);
+  if (typeof context.normalizeHandlerFormat !== 'function') {
+    throw new Error('normalizeHandlerFormat was not defined by handler-format.js');
+  }
+  return context.normalizeHandlerFormat;
+}
+
+describe('normalizeHandlerFormat (functions/handler-format.js)', () => {
+  const normalizeHandlerFormat = loadNormalizeHandlerFormat();
+
+  it('leaves legacy module.exports handlers untouched', () => {
+    const code = `module.exports = async function (request) {
+  return new Response("hi");
+};`;
+    expect(normalizeHandlerFormat(code)).toBe(code);
+  });
+
+  it('rewrites the documented "export default" handler into module.exports', () => {
+    const code = `import { createClient } from 'npm:@insforge/sdk';
+
+export default async function (req) {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+
+    expect(result).not.toMatch(/\bimport\b/);
+    expect(result).not.toMatch(/\bexport\s+default\b/);
+    expect(result).toContain('module.exports = async function (req) {');
+
+    // The rewritten source must actually be usable by `new Function(...)`,
+    // the same execution path worker-template.js uses.
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('rewrites a named "export default function handler"', () => {
+    const code = `export default async function handler(req) {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toBe(`module.exports = async function handler(req) {
+  return new Response("hi");
+}`);
+  });
+
+  it('rewrites an "export default" arrow function', () => {
+    const code = `export default async (req) => new Response("hi");`;
+    const result = normalizeHandlerFormat(code);
+    expect(result).toBe('module.exports = async (req) => new Response("hi");');
+  });
+
+  it('strips the base64 std import alongside the SDK import', () => {
+    const code = `import { createClient } from 'npm:@insforge/sdk';
+import { encodeBase64, decodeBase64 } from 'https://deno.land/std@0.224.0/encoding/base64.ts';
+
+export default async function (req) {
+  return new Response(encodeBase64(new Uint8Array()));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/\bimport\b/);
+    expect(result).toContain('module.exports = async function (req) {');
+  });
+
+  it('leaves unrecognized imports untouched (not silently swallowed)', () => {
+    const code = `import { something } from 'npm:some-other-package';
+
+export default async function (req) {
+  return new Response(something());
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain("import { something } from 'npm:some-other-package';");
+    expect(result).toContain('module.exports = async function (req) {');
+  });
+});

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -225,7 +225,7 @@ export default async function (req: Request): Promise<Response> {
     expect(await response.text()).toBe('a');
   });
 
-  it("does not treat a function-type parameter's arrow as a default-value marker", () => {
+  it('does not treat a function-type parameter arrow as a default-value marker', () => {
     const code = `export default async function (req: Request, cb: () => void): Promise<Response> {
   cb();
   return new Response("hi");

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -336,6 +336,14 @@ export default async function (req: Request): Promise<Response> {
 
     const result = normalizeHandlerFormat(code);
     expect(result).toContain('const half = 10 / 2;');
+    // Not just a string check: a misidentified regex here would have masked
+    // through to (and hidden) the `export default` below it, so the handler
+    // must also still actually be there and compilable.
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
   });
 
   it('strips a TypeScript optional-parameter marker', () => {
@@ -457,6 +465,95 @@ export default async function (req: Request): Promise<Response> {
     const result = normalizeHandlerFormat(code);
     expect(result).not.toMatch(/export\s+default/);
     expect(result).toMatch(/^module\.exports = async function/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  // Round-5 regression coverage: a fifth review pass found that `//` was
+  // reaching the regex-literal scanner before the comment handler ever got
+  // a chance to run (an empty regex literal isn't valid JS grammar, but the
+  // scanner didn't know that), and that a property merely *named* after a
+  // regex-permitting keyword (`obj.delete`, `obj.new`) was still treated as
+  // that keyword instead of as the value it actually is.
+
+  it('does not let a line comment be misread as an empty regex literal, hiding its content', () => {
+    // Before the fix, `//` was masked as if it were a 2-character regex
+    // literal, then the runtime lost track of being inside a comment at
+    // all — leaving the rest of the line, including this fake assignment
+    // text, unmasked and visible to LEGACY_ASSIGNMENT_PATTERN.
+    const code = `// module.exports = fake
+export default async function (req: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/^module\.exports = fake/m);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not let a comment containing "export default" become a second, malformed rewrite target', () => {
+    const code = `// export default fake_thing
+export default async function (req: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    // The comment's fake "export default" must not be the one rewritten —
+    // only the real handler below it.
+    expect(result).toMatch(/\/\/ export default fake_thing/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('does not let a block comment containing fake code reach the rewrite', () => {
+    const code = `/* module.exports = fake; export default fake2; */
+export default async function (req: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('treats a property named after a regex-permitting keyword as a value, not the keyword', () => {
+    const code = `const stats = { delete: 10 };
+const ratio = stats.delete / 2;
+export default async function (req: Request): Promise<Response> {
+  return new Response(String(ratio));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('const ratio = stats.delete / 2;');
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('still strips a later typed parameter after a division on a keyword-named property', () => {
+    const code = `const stats = { new: 10, total: 20 };
+const ratio = stats.new / stats.total;
+export default async function (req: Request, opts: Record<string, string>): Promise<Response> {
+  return new Response(String(ratio));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/opts:\s*Record/);
     const wrapper = new Function('exports', 'module', result);
     const exportsObj: Record<string, unknown> = {};
     const moduleObj = { exports: exportsObj };

--- a/backend/tests/unit/function-handler-format.test.ts
+++ b/backend/tests/unit/function-handler-format.test.ts
@@ -364,6 +364,105 @@ export default async function (req: Request): Promise<Response> {
     wrapper(exportsObj, moduleObj);
     expect(typeof moduleObj.exports).toBe('function');
   });
+
+  // Round-4 regression coverage: a fourth review pass found a keyword before
+  // a regex literal (`return /.../`) still misclassified, a return type
+  // separated from `)` by a line break not stripped, a comment inside an
+  // import's brace list defeating the known-binding check, an unbalanced
+  // relational operator in one parameter's default value corrupting a
+  // *later* parameter's type, and an export-default handler whose body
+  // happens to contain a `module.exports =`-shaped line being misread as
+  // the legacy format.
+
+  it('recognizes a regex literal immediately after the "return" keyword', () => {
+    const code = `function helper() { return /'foo/; }
+export default async function (req: Request): Promise<Response> {
+  return new Response(String(helper()));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('module.exports = async function');
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('still treats a division after an identifier as division, not a regex', () => {
+    const code = `const half = 10 / 2;
+export default async function (req: Request): Promise<Response> {
+  return new Response(String(half));
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).toContain('const half = 10 / 2;');
+  });
+
+  it('strips a return type separated from the parameter list by a line break', () => {
+    const code = `export default async function (req: Request)
+  : Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/Promise</);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('resolves a known import even with a comment inside its brace list', async () => {
+    const code = `import { createClient /* the sdk client */ } from 'npm:@insforge/sdk';
+
+export default async function (req: Request): Promise<Response> {
+  const client = createClient({});
+  return new Response(typeof client);
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/\bimport\b/);
+
+    const wrapper = new Function('exports', 'module', 'createClient', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj, () => ({}));
+    const handler = moduleObj.exports as (req: unknown) => Promise<{ text(): Promise<string> }>;
+    const response = await handler({});
+    expect(await response.text()).toBe('object');
+  });
+
+  it('does not let an unbalanced relational operator in one default value corrupt a later parameter', () => {
+    const code = `export default async function (a = 1 < 2, b: Request): Promise<Response> {
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/:\s*Request/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
+
+  it('rewrites export default even when a comment in the body looks like a legacy assignment', () => {
+    const code = `export default async function (req: Request): Promise<Response> {
+  // module.exports = something (just a comment, not a real assignment)
+  return new Response("hi");
+}`;
+
+    const result = normalizeHandlerFormat(code);
+    expect(result).not.toMatch(/export\s+default/);
+    expect(result).toMatch(/^module\.exports = async function/);
+    const wrapper = new Function('exports', 'module', result);
+    const exportsObj: Record<string, unknown> = {};
+    const moduleObj = { exports: exportsObj };
+    wrapper(exportsObj, moduleObj);
+    expect(typeof moduleObj.exports).toBe('function');
+  });
 });
 
 describe('functions/handler-format.js — Zeabur embedded copy stays in sync', () => {

--- a/deploy/coolify/docker-compose.yml
+++ b/deploy/coolify/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     command: >
       sh -c "
         deno cache --no-lock functions/server.ts &&
-        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js functions/server.ts
+        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js functions/server.ts
       "
     restart: unless-stopped
     depends_on:

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -223,7 +223,7 @@ services:
     command: >
       sh -c "
         deno cache --no-lock functions/server.ts &&
-        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js functions/server.ts
+        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js functions/server.ts
       "
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7133/health"]

--- a/deploy/dokploy/docker-compose.yml
+++ b/deploy/dokploy/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     command: >
       sh -c "
         deno cache --no-lock functions/server.ts &&
-        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js functions/server.ts
+        deno run --no-lock --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js functions/server.ts
       "
     restart: unless-stopped
     depends_on:

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -57,6 +57,7 @@ docker-compose.rustfs.yml
 functions/deno.json
 functions/server.ts
 functions/worker-template.js
+functions/handler-format.js
 deploy/backup.sh
 deploy/docker-compose/docker-compose.yml
 deploy/docker-init/db/db-init.sql

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -915,12 +915,64 @@ spec:
                      * tokenizer — doesn't need to be, since callers only use it to find *where*
                      * a pattern lexically starts, never to execute the masked text itself.
                      */
+                    // Characters after which a `/` is a value already produced (an identifier,
+                    // number, or a closing bracket) rather than the start of a regex literal —
+                    // e.g. `a / b` is division, `(x) / 2` is division. After anything else
+                    // (`(`, `,`, `=`, `:`, `return`, the start of the source, ...) a `/` starts
+                    // a regex literal — e.g. `return /foo/`, `x = /foo/`. This is the same
+                    // heuristic lightweight JS tokenizers use; it isn't a full parser, but a
+                    // statement can't otherwise begin with a bare `/`.
+                    const VALUE_END_CHAR_PATTERN = /[A-Za-z0-9_$)\]]/;
+
                     function maskNonCode(code) {
                       let result = '';
                       let i = 0;
+                      let lastSignificantChar = '';
                       while (i < code.length) {
                         const char = code[i];
                         const twoChars = code.slice(i, i + 2);
+
+                        if (char === '/' && !VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+                          // A regex literal. Its contents are irrelevant to every pattern below,
+                          // so it's fully blanked (delimiters included) — unlike a string, whose
+                          // quote characters are preserved (see below), nothing needs to see a
+                          // literal `/` here. Scanned first, before the comment checks: a
+                          // character class inside a regex can itself contain `/` or quote
+                          // characters (`/['"]/`, `/[//]/`) that would otherwise be misread as
+                          // starting a string or a `//` line comment.
+                          let j = i + 1;
+                          let inClass = false;
+                          let terminated = false;
+                          while (j < code.length && code[j] !== '\n') {
+                            if (code[j] === '\\') {
+                              j += 2;
+                              continue;
+                            }
+                            if (code[j] === '[') {
+                              inClass = true;
+                            } else if (code[j] === ']') {
+                              inClass = false;
+                            } else if (code[j] === '/' && !inClass) {
+                              j += 1;
+                              terminated = true;
+                              break;
+                            }
+                            j += 1;
+                          }
+                          if (terminated) {
+                            while (j < code.length && /[a-zA-Z]/.test(code[j])) {
+                              j += 1; // trailing flags (g, i, m, ...)
+                            }
+                            result += code.slice(i, j).replace(/[^\n]/g, ' ');
+                            lastSignificantChar = ')'; // a regex literal is itself a value
+                            i = j;
+                            continue;
+                          }
+                          // No closing `/` before end of line: not actually a regex literal
+                          // (or malformed code either way) — fall through and treat `/` as an
+                          // ordinary character rather than misidentifying a division operator
+                          // as an unterminated regex and masking the rest of the line.
+                        }
 
                         if (twoChars === '//') {
                           let j = i;
@@ -957,10 +1009,14 @@ spec:
                           const inner = code.slice(i + 1, innerEnd).replace(/[^\n]/g, ' ');
                           result += quote + inner + (closed ? quote : '');
                           i = closed ? j + 1 : innerEnd;
+                          lastSignificantChar = ')'; // a string literal is itself a value
                           continue;
                         }
 
                         result += char;
+                        if (!/\s/.test(char)) {
+                          lastSignificantChar = char;
+                        }
                         i += 1;
                       }
                       return result;
@@ -1105,6 +1161,11 @@ spec:
                           if (mode !== 'type') {
                             keep();
                           }
+                          continue;
+                        }
+                        if (depth === 0 && mode === 'name' && char === '?' && /^\s*:/.test(maskedSource.slice(i + 1))) {
+                          // TypeScript optional-parameter marker immediately before the type
+                          // annotation (`req?: Request`) — has no plain-JS analogue, drop it.
                           continue;
                         }
                         if (depth === 0 && mode === 'name' && char === ':') {

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -1260,6 +1260,15 @@ spec:
                           mode = 'type';
                           continue;
                         }
+                        if (depth === 0 && mode === 'name' && char === '=') {
+                          // A default value with no type annotation at all (`a = x < y ? z : q`).
+                          // Without this, `mode` would stay 'name' — the only other path into
+                          // 'default' requires having seen a ':' first — so a ternary's own
+                          // ':' further down would be misread as starting a type annotation.
+                          mode = 'default';
+                          keep();
+                          continue;
+                        }
                         if (depth === 0 && mode === 'type' && char === '=' && maskedSource[i + 1] === '>') {
                           // Function-type arrow (`() => void`) — part of the type, not a
                           // default-value marker. Stays in type mode; both chars are dropped.

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -391,7 +391,13 @@ spec:
                     async function getWorkerTemplateCode(): Promise<string> {
                       if (!workerTemplateCode) {
                         const currentDir = dirname(fromFileUrl(import.meta.url));
-                        workerTemplateCode = await Deno.readTextFile(join(currentDir, 'worker-template.js'));
+                        // handler-format.js is prepended so its `normalizeHandlerFormat`
+                        // function is available as a global inside worker-template.js.
+                        const [handlerFormatCode, templateCode] = await Promise.all([
+                          Deno.readTextFile(join(currentDir, 'handler-format.js')),
+                          Deno.readTextFile(join(currentDir, 'worker-template.js')),
+                        ]);
+                        workerTemplateCode = `${handlerFormatCode}\n${templateCode}`;
                       }
                       return workerTemplateCode;
                     }
@@ -782,7 +788,7 @@ spec:
                           'Deno',
                           'encodeBase64',
                           'decodeBase64',
-                          code
+                          normalizeHandlerFormat(code)
                         );
                         const exports = {};
                         const module = { exports };
@@ -855,6 +861,225 @@ spec:
                         }
                       }
                     };
+                - path: /app/functions/handler-format.js
+                  template: |
+                    /**
+                     * Handler format normalization (Cloud / self-hosted parity — issue #1906)
+                     *
+                     * On Cloud, function code is deployed as a real ES module (see
+                     * `deno-subhosting.provider.ts`'s `transformUserCode`), so the documented
+                     * handler format everywhere in the public docs is:
+                     *
+                     *   import { createClient } from 'npm:@insforge/sdk';
+                     *   export default async function(req: Request): Promise<Response> { ... }
+                     *
+                     * Locally, `worker-template.js` runs the code inside `new Function(...)` —
+                     * a plain script scope chosen so the worker never needs network/file import
+                     * permissions at request time (secrets and the SDK are injected as call
+                     * arguments instead, see the worker template's security notes). `import`
+                     * and `export` are syntax errors in that scope, and so are the TypeScript
+                     * type annotations the documented signature uses (`new Function` runs
+                     * through V8 directly — nothing transpiles it) — so only the legacy,
+                     * untyped `module.exports = ...` form used to work there, silently breaking
+                     * every function written in the documented `export default` format as soon
+                     * as it left Cloud.
+                     *
+                     * This file is plain, Deno/Node-independent JavaScript (no import/export
+                     * statements of its own) so it can be:
+                     *   - concatenated ahead of `worker-template.js` by `server.ts` before the
+                     *     combined source is handed to `new Function`/`Worker`, and
+                     *   - loaded directly in unit tests via `vm` without any Deno globals.
+                     *
+                     * Scope: this targets the one documented handler shape (a top-level
+                     * `export default` function/arrow expression, optionally typed, optionally
+                     * importing the injected SDK/base64 bindings) — not arbitrary TypeScript or
+                     * ESM. Anything outside that shape is left untouched, which reproduces
+                     * today's plain syntax error rather than silently miscompiling it.
+                     */
+
+                    // Legacy CommonJS handlers are detected by an actual top-level assignment,
+                    // not a bare substring search — `module.exports` appearing only inside a
+                    // comment or string (e.g. a migration note like "// previously:
+                    // module.exports = ...") must not skip normalization for what is otherwise
+                    // a valid `export default` handler.
+                    const LEGACY_ASSIGNMENT_PATTERN = /^[ \t]*module\.exports\s*=/m;
+
+                    // Named bindings the worker wrapper injects as call arguments, keyed by the
+                    // import specifier that provides them on Cloud. An import naming anything
+                    // else from these sources can't be resolved locally and is left alone so it
+                    // still surfaces as a clear syntax/reference error, rather than being
+                    // partially rewritten into something subtly broken.
+                    const INJECTABLE_BINDINGS_BY_SOURCE = [
+                      { source: 'npm:@insforge/sdk', names: ['createClient'] },
+                      {
+                        // Version-qualified URL — match the module, not one exact version string.
+                        sourcePattern: /^https:\/\/deno\.land\/std[^'"]*\/encoding\/base64\.ts$/,
+                        names: ['encodeBase64', 'decodeBase64'],
+                      },
+                    ];
+
+                    const IMPORT_STATEMENT_PATTERN =
+                      /^[ \t]*import\s*\{([^}]*)\}\s*from\s*(['"])([^'"]*)\2\s*;?[ \t]*\r?\n?/gm;
+
+                    /**
+                     * Rewrites the known-injectable imports in `code` in place:
+                     *  - a specifier matching its injected name exactly (`createClient`) is
+                     *    simply dropped — the wrapper already provides that identifier.
+                     *  - an aliased specifier (`createClient as makeClient`) is replaced with
+                     *    `const makeClient = createClient;` so the alias still resolves.
+                     *  - an import naming anything not in the injected set for that source, or
+                     *    from any other source, is left completely untouched.
+                     */
+                    function resolveKnownImports(code) {
+                      return code.replace(IMPORT_STATEMENT_PATTERN, (fullMatch, specifierList, _quote, source) => {
+                        const known = INJECTABLE_BINDINGS_BY_SOURCE.find((entry) =>
+                          entry.source ? entry.source === source : entry.sourcePattern.test(source)
+                        );
+                        if (!known) {
+                          return fullMatch;
+                        }
+
+                        const specifiers = specifierList
+                          .split(',')
+                          .map((specifier) => specifier.trim())
+                          .filter(Boolean);
+
+                        const aliasDeclarations = [];
+                        for (const specifier of specifiers) {
+                          const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
+                          const importedName = aliasMatch ? aliasMatch[1] : specifier;
+                          const localName = aliasMatch ? aliasMatch[2] : specifier;
+
+                          if (!known.names.includes(importedName)) {
+                            // Not something the wrapper injects (e.g. a type-only import, or a
+                            // real export we don't provide locally) — bail on the whole
+                            // statement rather than guessing at a partial rewrite.
+                            return fullMatch;
+                          }
+                          if (localName !== importedName) {
+                            aliasDeclarations.push(`const ${localName} = ${importedName};`);
+                          }
+                        }
+
+                        return aliasDeclarations.length > 0 ? aliasDeclarations.join('\n') + '\n' : '';
+                      });
+                    }
+
+                    /**
+                     * Strips TypeScript type annotations from a handler's parameter list,
+                     * respecting bracket depth so a generic type's internal commas
+                     * (`opts: Record<string, string>`) aren't mistaken for parameter
+                     * separators, and default values (`opts: Options = {}`) are preserved.
+                     */
+                    function stripParamTypeAnnotations(paramsSource) {
+                      let result = '';
+                      let depth = 0;
+                      let inType = false;
+
+                      for (const char of paramsSource) {
+                        if ('([{<'.includes(char)) {
+                          depth += 1;
+                          if (!inType) {
+                            result += char;
+                          }
+                          continue;
+                        }
+                        if (')]}>'.includes(char)) {
+                          depth = Math.max(0, depth - 1);
+                          if (!inType) {
+                            result += char;
+                          }
+                          continue;
+                        }
+                        if (depth === 0 && !inType && char === ':') {
+                          inType = true;
+                          continue;
+                        }
+                        if (depth === 0 && inType && (char === ',' || char === '=')) {
+                          inType = false;
+                          result += char;
+                          continue;
+                        }
+                        if (!inType) {
+                          result += char;
+                        }
+                      }
+
+                      return result;
+                    }
+
+                    /**
+                     * Strips type annotations from a handler's signature only — its parameter
+                     * list and return type — leaving the function body completely untouched.
+                     * Operates on `code` starting at `fromIndex` (right after the
+                     * `module.exports = ` this module just wrote) so it never has to reason
+                     * about the body, which may contain colons of its own (object literals,
+                     * ternaries, etc.) that are not type annotations.
+                     *
+                     * If the text at `fromIndex` isn't a recognizable function/arrow signature,
+                     * or its parameter list is unbalanced, `code` is returned unchanged rather
+                     * than guessed at.
+                     */
+                    function stripHandlerSignatureTypes(code, fromIndex) {
+                      const rest = code.slice(fromIndex);
+
+                      const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(rest);
+                      if (!headerMatch) {
+                        return code;
+                      }
+
+                      const parenStart = headerMatch[0].length - 1;
+                      let depth = 0;
+                      let parenEnd = -1;
+                      for (let i = parenStart; i < rest.length; i += 1) {
+                        const char = rest[i];
+                        if ('([{'.includes(char)) {
+                          depth += 1;
+                        } else if (')]}'.includes(char)) {
+                          depth -= 1;
+                          if (depth === 0) {
+                            parenEnd = i;
+                            break;
+                          }
+                        }
+                      }
+                      if (parenEnd === -1) {
+                        return code;
+                      }
+
+                      const paramsInner = rest.slice(parenStart + 1, parenEnd);
+                      const strippedParams = stripParamTypeAnnotations(paramsInner);
+
+                      let afterParams = rest.slice(parenEnd + 1);
+                      // A return-type annotation runs from ':' up to (not including) the body's
+                      // opening '{' or an arrow's '=>'. Only stripped when one of those actually
+                      // follows, so an unrelated ':' doesn't eat the rest of the file.
+                      afterParams = afterParams.replace(/^([ \t]*):[^{]*?(?=\{|=>)/, '$1');
+
+                      return (
+                        code.slice(0, fromIndex) + rest.slice(0, parenStart + 1) + strippedParams + ')' + afterParams
+                      );
+                    }
+
+                    function normalizeHandlerFormat(code) {
+                      if (LEGACY_ASSIGNMENT_PATTERN.test(code)) {
+                        return code;
+                      }
+
+                      let normalized = resolveKnownImports(code);
+
+                      const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(normalized);
+                      if (!exportDefaultMatch) {
+                        return normalized;
+                      }
+
+                      const assignment = `${exportDefaultMatch[1]}${exportDefaultMatch[2]}module.exports = `;
+                      const handlerStart = exportDefaultMatch.index + exportDefaultMatch[0].length;
+                      normalized =
+                        normalized.slice(0, exportDefaultMatch.index) + assignment + normalized.slice(handlerStart);
+
+                      return stripHandlerSignatureTypes(normalized, exportDefaultMatch.index + assignment.length);
+                    }
             healthCheck:
                 type: HTTP
                 port: runtime

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -338,7 +338,7 @@ spec:
                       echo 'Downloading Deno dependencies...' &&
                       deno cache functions/server.ts &&
                       echo 'Starting Deno server on port 7133...' &&
-                      deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --watch functions/server.ts
+                      deno run --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js --watch functions/server.ts
             ports:
                 - id: runtime
                   port: 7133

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -924,15 +924,59 @@ spec:
                     // statement can't otherwise begin with a bare `/`.
                     const VALUE_END_CHAR_PATTERN = /[A-Za-z0-9_$)\]]/;
 
+                    // A word immediately before `/` that ends in a "value-like" character
+                    // doesn't always mean a value was produced — these keywords all precede an
+                    // operand, not end one (`return /foo/`, `typeof /foo/`), so `/` right after
+                    // one of them still starts a regex literal despite ending in a letter.
+                    const REGEX_PERMITTING_KEYWORDS = new Set([
+                      'return',
+                      'typeof',
+                      'instanceof',
+                      'in',
+                      'of',
+                      'new',
+                      'delete',
+                      'void',
+                      'throw',
+                      'case',
+                      'do',
+                      'else',
+                      'yield',
+                      'await',
+                    ]);
+
+                    function isRegexLiteralStart(lastSignificantChar, lastWord) {
+                      if (lastSignificantChar === '') {
+                        return true;
+                      }
+                      if (VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+                        return REGEX_PERMITTING_KEYWORDS.has(lastWord);
+                      }
+                      return true;
+                    }
+
+                    const WORD_CHAR_PATTERN = /[A-Za-z0-9_$]/;
+
                     function maskNonCode(code) {
                       let result = '';
                       let i = 0;
                       let lastSignificantChar = '';
+                      let lastWord = '';
+                      let currentWord = '';
                       while (i < code.length) {
                         const char = code[i];
                         const twoChars = code.slice(i, i + 2);
 
-                        if (char === '/' && !VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+                        // Commit the word in progress the moment it ends — including right
+                        // here, before using `lastWord` below — so `a/b` (no separator between
+                        // the identifier and the `/`) sees the word that just ended instead of
+                        // a stale one from further back.
+                        if (!WORD_CHAR_PATTERN.test(char) && currentWord) {
+                          lastWord = currentWord;
+                          currentWord = '';
+                        }
+
+                        if (char === '/' && isRegexLiteralStart(lastSignificantChar, lastWord)) {
                           // A regex literal. Its contents are irrelevant to every pattern below,
                           // so it's fully blanked (delimiters included) — unlike a string, whose
                           // quote characters are preserved (see below), nothing needs to see a
@@ -965,6 +1009,7 @@ spec:
                             }
                             result += code.slice(i, j).replace(/[^\n]/g, ' ');
                             lastSignificantChar = ')'; // a regex literal is itself a value
+                            lastWord = ''; // ...not a keyword, so a following `/` means division
                             i = j;
                             continue;
                           }
@@ -1010,10 +1055,16 @@ spec:
                           result += quote + inner + (closed ? quote : '');
                           i = closed ? j + 1 : innerEnd;
                           lastSignificantChar = ')'; // a string literal is itself a value
+                          lastWord = ''; // ...not a keyword, so a following `/` means division
                           continue;
                         }
 
                         result += char;
+                        if (WORD_CHAR_PATTERN.test(char)) {
+                          currentWord += char;
+                        }
+                        // (the non-word case is already handled at the top of the loop, before
+                        // `lastWord` is read for this same character)
                         if (!/\s/.test(char)) {
                           lastSignificantChar = char;
                         }
@@ -1055,11 +1106,13 @@ spec:
                      */
                     function resolveKnownImports(code) {
                       const masked = maskNonCode(code);
-                      // 'd' adds match.indices, so the specifier list and source are read back
-                      // from the original `code` at those positions — the masked text is only
-                      // used to find real (non-string/comment) import statements; its capture
-                      // groups are blanked and unusable as content (the whole point of masking
-                      // the source string is that it's blanked).
+                      // 'd' adds match.indices to locate each match precisely. The specifier
+                      // list is read from the *masked* text — a comment inside the braces
+                      // (`{ createClient /* the sdk client */ }`) would otherwise end up as
+                      // part of a "specifier" and fail the known-binding check, leaving the
+                      // whole import untouched even though it's a plain, resolvable one. The
+                      // source string, in contrast, is read from the original `code`: it's a
+                      // quoted string, which can't itself contain a code comment.
                       const pattern = new RegExp(IMPORT_STATEMENT_PATTERN.source, IMPORT_STATEMENT_PATTERN.flags + 'd');
 
                       let result = '';
@@ -1069,7 +1122,7 @@ spec:
                         const fullMatch = match[0];
                         const [specifierStart, specifierEnd] = match.indices[1];
                         const [sourceStart, sourceEnd] = match.indices[3];
-                        const specifierList = code.slice(specifierStart, specifierEnd);
+                        const specifierList = masked.slice(specifierStart, specifierEnd);
                         const source = code.slice(sourceStart, sourceEnd);
                         result += code.slice(lastIndex, match.index);
 
@@ -1149,18 +1202,31 @@ spec:
                           result += originalSource[i];
                         };
 
-                        if ('([{<'.includes(char)) {
+                        if ('([{'.includes(char)) {
                           depth += 1;
                           if (mode !== 'type') {
                             keep();
                           }
                           continue;
                         }
-                        if (')]}>'.includes(char)) {
+                        if (')]}'.includes(char)) {
                           depth = Math.max(0, depth - 1);
                           if (mode !== 'type') {
                             keep();
                           }
+                          continue;
+                        }
+                        // `<`/`>` only mean generic nesting while inside a type annotation.
+                        // Outside one — a default value's own expression — they're relational
+                        // operators (`opts = x < 10 ? a : b`), and counting them as brackets
+                        // there would desync depth against an unmatched `<` with no `>`,
+                        // leaving a *later* parameter's real type annotation unstripped.
+                        if (mode === 'type' && char === '<') {
+                          depth += 1;
+                          continue;
+                        }
+                        if (mode === 'type' && char === '>' && depth > 0) {
+                          depth -= 1;
                           continue;
                         }
                         if (depth === 0 && mode === 'name' && char === '?' && /^\s*:/.test(maskedSource.slice(i + 1))) {
@@ -1205,7 +1271,9 @@ spec:
                      * (`Promise<{ status: number }>`) isn't truncated mid-type.
                      */
                     function stripReturnType(originalAfterParams, maskedAfterParams) {
-                      const colonMatch = /^[ \t]*:/.exec(maskedAfterParams);
+                      // `\s`, not `[ \t]`: the colon may be on its own line after the closing
+                      // paren (an unusual but valid line-break before `: ReturnType`).
+                      const colonMatch = /^\s*:/.exec(maskedAfterParams);
                       if (!colonMatch) {
                         return originalAfterParams;
                       }
@@ -1283,7 +1351,13 @@ spec:
                     }
 
                     function normalizeHandlerFormat(code) {
-                      if (LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
+                      // Checked first, and only as the deciding factor when there's no
+                      // `export default` at all: a genuine `export default` handler could
+                      // still contain a line starting with `module.exports =` somewhere in its
+                      // *body* (unusual, but not impossible — e.g. mixed CommonJS/ESM idioms),
+                      // and that must not short-circuit the rewrite this function exists to do.
+                      const hasExportDefault = /(^|\n)([ \t]*)export\s+default\s+/.test(maskNonCode(code));
+                      if (!hasExportDefault && LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
                         return code;
                       }
 

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -889,19 +889,86 @@ spec:
                      *   - concatenated ahead of `worker-template.js` by `server.ts` before the
                      *     combined source is handed to `new Function`/`Worker`, and
                      *   - loaded directly in unit tests via `vm` without any Deno globals.
+                     * It stays plain JS (matching worker-template.js's own existing precedent,
+                     * for the same reason — both are read as-is at runtime with no build step)
+                     * rather than TypeScript compiled ahead of time.
                      *
                      * Scope: this targets the one documented handler shape (a top-level
                      * `export default` function/arrow expression, optionally typed, optionally
                      * importing the injected SDK/base64 bindings) — not arbitrary TypeScript or
                      * ESM. Anything outside that shape is left untouched, which reproduces
                      * today's plain syntax error rather than silently miscompiling it.
+                     *
+                     * Regex-based detection alone would misfire on text that merely *looks*
+                     * like code inside a string, template literal, or comment (e.g. a handler
+                     * whose body contains the literal text "module.exports =" in a log
+                     * message). `maskNonCode` blanks out that content — preserving length and
+                     * newlines — so every pattern below is matched against the masked source to
+                     * find real positions, while every rewrite still slices/reads the original,
+                     * unmasked `code` at those positions.
                      */
 
-                    // Legacy CommonJS handlers are detected by an actual top-level assignment,
-                    // not a bare substring search — `module.exports` appearing only inside a
-                    // comment or string (e.g. a migration note like "// previously:
-                    // module.exports = ...") must not skip normalization for what is otherwise
-                    // a valid `export default` handler.
+                    /**
+                     * Replaces the contents of string literals ('...', "...", `...`) and
+                     * comments (// and /* *\/) with spaces, preserving length and newlines, so
+                     * character offsets stay valid against the original source. Not a full
+                     * tokenizer — doesn't need to be, since callers only use it to find *where*
+                     * a pattern lexically starts, never to execute the masked text itself.
+                     */
+                    function maskNonCode(code) {
+                      let result = '';
+                      let i = 0;
+                      while (i < code.length) {
+                        const char = code[i];
+                        const twoChars = code.slice(i, i + 2);
+
+                        if (twoChars === '//') {
+                          let j = i;
+                          while (j < code.length && code[j] !== '\n') {
+                            j += 1;
+                          }
+                          result += code.slice(i, j).replace(/[^\n]/g, ' ');
+                          i = j;
+                          continue;
+                        }
+
+                        if (twoChars === '/*') {
+                          let j = i + 2;
+                          while (j < code.length - 1 && code.slice(j, j + 2) !== '*/') {
+                            j += 1;
+                          }
+                          j = Math.min(j + 2, code.length);
+                          result += code.slice(i, j).replace(/[^\n]/g, ' ');
+                          i = j;
+                          continue;
+                        }
+
+                        if (char === '"' || char === "'" || char === '`') {
+                          // Preserve the quote characters themselves — only blank the content
+                          // between them — so a pattern that checks for a real quote (e.g. the
+                          // `from '...'` clause of an import) still matches the masked text.
+                          const quote = char;
+                          let j = i + 1;
+                          while (j < code.length && code[j] !== quote) {
+                            j += code[j] === '\\' ? 2 : 1;
+                          }
+                          const closed = j < code.length;
+                          const innerEnd = Math.min(j, code.length);
+                          const inner = code.slice(i + 1, innerEnd).replace(/[^\n]/g, ' ');
+                          result += quote + inner + (closed ? quote : '');
+                          i = closed ? j + 1 : innerEnd;
+                          continue;
+                        }
+
+                        result += char;
+                        i += 1;
+                      }
+                      return result;
+                    }
+
+                    // Legacy CommonJS handlers are detected by an actual top-level assignment
+                    // (matched against the masked source — see file header), not a bare
+                    // substring search that a comment or template literal could trigger.
                     const LEGACY_ASSIGNMENT_PATTERN = /^[ \t]*module\.exports\s*=/m;
 
                     // Named bindings the worker wrapper injects as call arguments, keyed by the
@@ -922,7 +989,7 @@ spec:
                       /^[ \t]*import\s*\{([^}]*)\}\s*from\s*(['"])([^'"]*)\2\s*;?[ \t]*\r?\n?/gm;
 
                     /**
-                     * Rewrites the known-injectable imports in `code` in place:
+                     * Rewrites the known-injectable imports in `code`:
                      *  - a specifier matching its injected name exactly (`createClient`) is
                      *    simply dropped — the wrapper already provides that identifier.
                      *  - an aliased specifier (`createClient as makeClient`) is replaced with
@@ -931,81 +998,173 @@ spec:
                      *    from any other source, is left completely untouched.
                      */
                     function resolveKnownImports(code) {
-                      return code.replace(IMPORT_STATEMENT_PATTERN, (fullMatch, specifierList, _quote, source) => {
+                      const masked = maskNonCode(code);
+                      // 'd' adds match.indices, so the specifier list and source are read back
+                      // from the original `code` at those positions — the masked text is only
+                      // used to find real (non-string/comment) import statements; its capture
+                      // groups are blanked and unusable as content (the whole point of masking
+                      // the source string is that it's blanked).
+                      const pattern = new RegExp(IMPORT_STATEMENT_PATTERN.source, IMPORT_STATEMENT_PATTERN.flags + 'd');
+
+                      let result = '';
+                      let lastIndex = 0;
+                      let match;
+                      while ((match = pattern.exec(masked))) {
+                        const fullMatch = match[0];
+                        const [specifierStart, specifierEnd] = match.indices[1];
+                        const [sourceStart, sourceEnd] = match.indices[3];
+                        const specifierList = code.slice(specifierStart, specifierEnd);
+                        const source = code.slice(sourceStart, sourceEnd);
+                        result += code.slice(lastIndex, match.index);
+
                         const known = INJECTABLE_BINDINGS_BY_SOURCE.find((entry) =>
                           entry.source ? entry.source === source : entry.sourcePattern.test(source)
                         );
+
                         if (!known) {
-                          return fullMatch;
+                          result += code.slice(match.index, match.index + fullMatch.length);
+                        } else {
+                          const specifiers = specifierList
+                            .split(',')
+                            .map((specifier) => specifier.trim())
+                            .filter(Boolean);
+
+                          const aliasDeclarations = [];
+                          let unresolvable = false;
+                          for (const specifier of specifiers) {
+                            const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
+                            const importedName = aliasMatch ? aliasMatch[1] : specifier;
+                            const localName = aliasMatch ? aliasMatch[2] : specifier;
+
+                            if (!known.names.includes(importedName)) {
+                              // Not something the wrapper injects — bail on the whole statement
+                              // rather than guessing at a partial rewrite.
+                              unresolvable = true;
+                              break;
+                            }
+                            if (localName !== importedName) {
+                              aliasDeclarations.push(`const ${localName} = ${importedName};`);
+                            }
+                          }
+
+                          result += unresolvable
+                            ? code.slice(match.index, match.index + fullMatch.length)
+                            : aliasDeclarations.length > 0
+                              ? aliasDeclarations.join('\n') + '\n'
+                              : '';
                         }
 
-                        const specifiers = specifierList
-                          .split(',')
-                          .map((specifier) => specifier.trim())
-                          .filter(Boolean);
-
-                        const aliasDeclarations = [];
-                        for (const specifier of specifiers) {
-                          const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
-                          const importedName = aliasMatch ? aliasMatch[1] : specifier;
-                          const localName = aliasMatch ? aliasMatch[2] : specifier;
-
-                          if (!known.names.includes(importedName)) {
-                            // Not something the wrapper injects (e.g. a type-only import, or a
-                            // real export we don't provide locally) — bail on the whole
-                            // statement rather than guessing at a partial rewrite.
-                            return fullMatch;
-                          }
-                          if (localName !== importedName) {
-                            aliasDeclarations.push(`const ${localName} = ${importedName};`);
-                          }
-                        }
-
-                        return aliasDeclarations.length > 0 ? aliasDeclarations.join('\n') + '\n' : '';
-                      });
+                        lastIndex = match.index + fullMatch.length;
+                      }
+                      result += code.slice(lastIndex);
+                      return result;
                     }
 
                     /**
-                     * Strips TypeScript type annotations from a handler's parameter list,
-                     * respecting bracket depth so a generic type's internal commas
-                     * (`opts: Record<string, string>`) aren't mistaken for parameter
-                     * separators, and default values (`opts: Options = {}`) are preserved.
+                     * Strips TypeScript type annotations from a handler's parameter list.
+                     *
+                     * Tracks three states per parameter — `name` (before any `:`), `type`
+                     * (consuming the annotation), `default` (after the `=` of a default value)
+                     * — rather than a single depth-only pass, so that:
+                     *  - a generic type's internal comma (`opts: Record<string, string>`) isn't
+                     *    mistaken for a parameter separator (bracket depth),
+                     *  - a function-type arrow inside a type (`cb: () => void`) isn't mistaken
+                     *    for the start of a default value (only `=` NOT followed by `>` ends
+                     *    type mode), and
+                     *  - a `:` inside a default value's own expression (a ternary,
+                     *    `opts: Options = cond ? a : b`) is never reinterpreted as the start of
+                     *    another type annotation — once a parameter reaches `default` mode, a
+                     *    `:` is just a character in that expression.
+                     *
+                     * Operates on `originalSource` for the text it keeps/drops, but makes every
+                     * control-flow decision (bracket depth, which state a `:`/`=`/`,` triggers)
+                     * against `maskedSource` (see `maskNonCode`) so a colon or brace inside a
+                     * default value's own string literal can't desynchronize bracket depth or
+                     * be mistaken for a type delimiter.
                      */
-                    function stripParamTypeAnnotations(paramsSource) {
+                    function stripParamTypeAnnotations(originalSource, maskedSource) {
                       let result = '';
                       let depth = 0;
-                      let inType = false;
+                      let mode = 'name'; // 'name' | 'type' | 'default'
 
-                      for (const char of paramsSource) {
+                      for (let i = 0; i < maskedSource.length; i += 1) {
+                        const char = maskedSource[i];
+                        const keep = () => {
+                          result += originalSource[i];
+                        };
+
                         if ('([{<'.includes(char)) {
                           depth += 1;
-                          if (!inType) {
-                            result += char;
+                          if (mode !== 'type') {
+                            keep();
                           }
                           continue;
                         }
                         if (')]}>'.includes(char)) {
                           depth = Math.max(0, depth - 1);
-                          if (!inType) {
-                            result += char;
+                          if (mode !== 'type') {
+                            keep();
                           }
                           continue;
                         }
-                        if (depth === 0 && !inType && char === ':') {
-                          inType = true;
+                        if (depth === 0 && mode === 'name' && char === ':') {
+                          mode = 'type';
                           continue;
                         }
-                        if (depth === 0 && inType && (char === ',' || char === '=')) {
-                          inType = false;
-                          result += char;
+                        if (depth === 0 && mode === 'type' && char === '=' && maskedSource[i + 1] === '>') {
+                          // Function-type arrow (`() => void`) — part of the type, not a
+                          // default-value marker. Stays in type mode; both chars are dropped.
+                          i += 1;
                           continue;
                         }
-                        if (!inType) {
-                          result += char;
+                        if (depth === 0 && mode === 'type' && char === '=') {
+                          mode = 'default';
+                          keep();
+                          continue;
+                        }
+                        if (depth === 0 && (mode === 'type' || mode === 'default') && char === ',') {
+                          mode = 'name';
+                          keep();
+                          continue;
+                        }
+                        if (mode !== 'type') {
+                          keep();
                         }
                       }
 
                       return result;
+                    }
+
+                    /**
+                     * Strips a handler's return-type annotation — the `: T` between the
+                     * parameter list's `)` and the function body's `{` or an arrow's `=>` — by
+                     * scanning bracket depth (against the masked source, for the same reason as
+                     * `stripParamTypeAnnotations`) rather than stopping at the first `{`, so a
+                     * return type containing its own object-literal type
+                     * (`Promise<{ status: number }>`) isn't truncated mid-type.
+                     */
+                    function stripReturnType(originalAfterParams, maskedAfterParams) {
+                      const colonMatch = /^[ \t]*:/.exec(maskedAfterParams);
+                      if (!colonMatch) {
+                        return originalAfterParams;
+                      }
+
+                      let i = colonMatch[0].length;
+                      let depth = 0;
+                      while (i < maskedAfterParams.length) {
+                        const char = maskedAfterParams[i];
+                        if (depth === 0 && (char === '{' || (char === '=' && maskedAfterParams[i + 1] === '>'))) {
+                          break;
+                        }
+                        if ('([{<'.includes(char)) {
+                          depth += 1;
+                        } else if (')]}>'.includes(char)) {
+                          depth = Math.max(0, depth - 1);
+                        }
+                        i += 1;
+                      }
+
+                      return originalAfterParams.slice(0, colonMatch[0].length - 1) + originalAfterParams.slice(i);
                     }
 
                     /**
@@ -1022,8 +1181,11 @@ spec:
                      */
                     function stripHandlerSignatureTypes(code, fromIndex) {
                       const rest = code.slice(fromIndex);
+                      const maskedRest = maskNonCode(rest);
 
-                      const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(rest);
+                      const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(
+                        maskedRest
+                      );
                       if (!headerMatch) {
                         return code;
                       }
@@ -1031,8 +1193,8 @@ spec:
                       const parenStart = headerMatch[0].length - 1;
                       let depth = 0;
                       let parenEnd = -1;
-                      for (let i = parenStart; i < rest.length; i += 1) {
-                        const char = rest[i];
+                      for (let i = parenStart; i < maskedRest.length; i += 1) {
+                        const char = maskedRest[i];
                         if ('([{'.includes(char)) {
                           depth += 1;
                         } else if (')]}'.includes(char)) {
@@ -1047,14 +1209,12 @@ spec:
                         return code;
                       }
 
-                      const paramsInner = rest.slice(parenStart + 1, parenEnd);
-                      const strippedParams = stripParamTypeAnnotations(paramsInner);
+                      const strippedParams = stripParamTypeAnnotations(
+                        rest.slice(parenStart + 1, parenEnd),
+                        maskedRest.slice(parenStart + 1, parenEnd)
+                      );
 
-                      let afterParams = rest.slice(parenEnd + 1);
-                      // A return-type annotation runs from ':' up to (not including) the body's
-                      // opening '{' or an arrow's '=>'. Only stripped when one of those actually
-                      // follows, so an unrelated ':' doesn't eat the rest of the file.
-                      afterParams = afterParams.replace(/^([ \t]*):[^{]*?(?=\{|=>)/, '$1');
+                      const afterParams = stripReturnType(rest.slice(parenEnd + 1), maskedRest.slice(parenEnd + 1));
 
                       return (
                         code.slice(0, fromIndex) + rest.slice(0, parenStart + 1) + strippedParams + ')' + afterParams
@@ -1062,13 +1222,13 @@ spec:
                     }
 
                     function normalizeHandlerFormat(code) {
-                      if (LEGACY_ASSIGNMENT_PATTERN.test(code)) {
+                      if (LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
                         return code;
                       }
 
                       let normalized = resolveKnownImports(code);
 
-                      const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(normalized);
+                      const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(maskNonCode(normalized));
                       if (!exportDefaultMatch) {
                         return normalized;
                       }

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -945,12 +945,15 @@ spec:
                       'await',
                     ]);
 
-                    function isRegexLiteralStart(lastSignificantChar, lastWord) {
+                    function isRegexLiteralStart(lastSignificantChar, lastWord, lastWordIsProperty) {
                       if (lastSignificantChar === '') {
                         return true;
                       }
                       if (VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
-                        return REGEX_PERMITTING_KEYWORDS.has(lastWord);
+                        // A property named after one of these keywords (`obj.delete`, `obj.in`)
+                        // is still a value, not the keyword itself — only an unqualified use
+                        // permits a following regex.
+                        return !lastWordIsProperty && REGEX_PERMITTING_KEYWORDS.has(lastWord);
                       }
                       return true;
                     }
@@ -962,21 +965,35 @@ spec:
                       let i = 0;
                       let lastSignificantChar = '';
                       let lastWord = '';
+                      let lastWordIsProperty = false;
                       let currentWord = '';
+                      let currentWordIsProperty = false;
                       while (i < code.length) {
                         const char = code[i];
                         const twoChars = code.slice(i, i + 2);
 
                         // Commit the word in progress the moment it ends — including right
-                        // here, before using `lastWord` below — so `a/b` (no separator between
-                        // the identifier and the `/`) sees the word that just ended instead of
-                        // a stale one from further back.
+                        // here, before `lastWord` is read below — so `a/b` (no separator
+                        // between the identifier and the `/`) sees the word that just ended
+                        // instead of a stale one from further back.
                         if (!WORD_CHAR_PATTERN.test(char) && currentWord) {
                           lastWord = currentWord;
+                          lastWordIsProperty = currentWordIsProperty;
                           currentWord = '';
                         }
 
-                        if (char === '/' && isRegexLiteralStart(lastSignificantChar, lastWord)) {
+                        // `twoChars !== '//' && twoChars !== '/*'`: an empty regex literal
+                        // (`//`) isn't valid JS grammar (a regex body needs at least one
+                        // character), so `//` is always a comment — never division-then-regex
+                        // or an empty regex that happens to look like one — and must be
+                        // recognized before regex detection gets a chance to misread it (or
+                        // `/*`'s opening slash) as a literal.
+                        if (
+                          char === '/' &&
+                          twoChars !== '//' &&
+                          twoChars !== '/*' &&
+                          isRegexLiteralStart(lastSignificantChar, lastWord, lastWordIsProperty)
+                        ) {
                           // A regex literal. Its contents are irrelevant to every pattern below,
                           // so it's fully blanked (delimiters included) — unlike a string, whose
                           // quote characters are preserved (see below), nothing needs to see a
@@ -1010,6 +1027,7 @@ spec:
                             result += code.slice(i, j).replace(/[^\n]/g, ' ');
                             lastSignificantChar = ')'; // a regex literal is itself a value
                             lastWord = ''; // ...not a keyword, so a following `/` means division
+                            lastWordIsProperty = false;
                             i = j;
                             continue;
                           }
@@ -1056,11 +1074,15 @@ spec:
                           i = closed ? j + 1 : innerEnd;
                           lastSignificantChar = ')'; // a string literal is itself a value
                           lastWord = ''; // ...not a keyword, so a following `/` means division
+                          lastWordIsProperty = false;
                           continue;
                         }
 
                         result += char;
                         if (WORD_CHAR_PATTERN.test(char)) {
+                          if (!currentWord) {
+                            currentWordIsProperty = lastSignificantChar === '.';
+                          }
                           currentWord += char;
                         }
                         // (the non-word case is already handled at the top of the loop, before

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -236,7 +236,7 @@ services:
         echo 'Downloading Deno dependencies...' &&
         deno cache functions/server.ts &&
         echo 'Starting Deno server on port 7133...' &&
-        deno run --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js functions/server.ts
+        deno run --unstable-worker-options --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js functions/server.ts
       "
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
         echo 'Downloading Deno dependencies...' &&
         deno cache functions/server.ts &&
         echo 'Starting Deno server on port 7133...' &&
-        deno run --allow-net --allow-env --allow-read=./functions/worker-template.js --unstable-worker-options --watch functions/server.ts
+        deno run --allow-net --allow-env --allow-read=./functions/worker-template.js,./functions/handler-format.js --unstable-worker-options --watch functions/server.ts
       "
     restart: unless-stopped
     security_opt:

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -6,46 +6,212 @@
  * handler format everywhere in the public docs is:
  *
  *   import { createClient } from 'npm:@insforge/sdk';
- *   export default async function(req: Request) { ... }
+ *   export default async function(req: Request): Promise<Response> { ... }
  *
  * Locally, `worker-template.js` runs the code inside `new Function(...)` —
  * a plain script scope chosen so the worker never needs network/file import
  * permissions at request time (secrets and the SDK are injected as call
  * arguments instead, see the worker template's security notes). `import`
- * and `export` are syntax errors in that scope, so only the legacy
- * `module.exports = ...` form used to work there, silently breaking every
- * function written in the documented `export default` format as soon as it
- * left Cloud.
+ * and `export` are syntax errors in that scope, and so are the TypeScript
+ * type annotations the documented signature uses (`new Function` runs
+ * through V8 directly — nothing transpiles it) — so only the legacy,
+ * untyped `module.exports = ...` form used to work there, silently breaking
+ * every function written in the documented `export default` format as soon
+ * as it left Cloud.
  *
  * This file is plain, Deno/Node-independent JavaScript (no import/export
  * statements of its own) so it can be:
  *   - concatenated ahead of `worker-template.js` by `server.ts` before the
  *     combined source is handed to `new Function`/`Worker`, and
  *   - loaded directly in unit tests via `vm` without any Deno globals.
+ *
+ * Scope: this targets the one documented handler shape (a top-level
+ * `export default` function/arrow expression, optionally typed, optionally
+ * importing the injected SDK/base64 bindings) — not arbitrary TypeScript or
+ * ESM. Anything outside that shape is left untouched, which reproduces
+ * today's plain syntax error rather than silently miscompiling it.
  */
-function normalizeHandlerFormat(code) {
-  // Legacy CommonJS-style handlers already run as-is under `new Function(...)`.
-  if (/\bmodule\.exports\b/.test(code)) {
+
+// Legacy CommonJS handlers are detected by an actual top-level assignment,
+// not a bare substring search — `module.exports` appearing only inside a
+// comment or string (e.g. a migration note like "// previously:
+// module.exports = ...") must not skip normalization for what is otherwise
+// a valid `export default` handler.
+const LEGACY_ASSIGNMENT_PATTERN = /^[ \t]*module\.exports\s*=/m;
+
+// Named bindings the worker wrapper injects as call arguments, keyed by the
+// import specifier that provides them on Cloud. An import naming anything
+// else from these sources can't be resolved locally and is left alone so it
+// still surfaces as a clear syntax/reference error, rather than being
+// partially rewritten into something subtly broken.
+const INJECTABLE_BINDINGS_BY_SOURCE = [
+  { source: 'npm:@insforge/sdk', names: ['createClient'] },
+  {
+    // Version-qualified URL — match the module, not one exact version string.
+    sourcePattern: /^https:\/\/deno\.land\/std[^'"]*\/encoding\/base64\.ts$/,
+    names: ['encodeBase64', 'decodeBase64'],
+  },
+];
+
+const IMPORT_STATEMENT_PATTERN =
+  /^[ \t]*import\s*\{([^}]*)\}\s*from\s*(['"])([^'"]*)\2\s*;?[ \t]*\r?\n?/gm;
+
+/**
+ * Rewrites the known-injectable imports in `code` in place:
+ *  - a specifier matching its injected name exactly (`createClient`) is
+ *    simply dropped — the wrapper already provides that identifier.
+ *  - an aliased specifier (`createClient as makeClient`) is replaced with
+ *    `const makeClient = createClient;` so the alias still resolves.
+ *  - an import naming anything not in the injected set for that source, or
+ *    from any other source, is left completely untouched.
+ */
+function resolveKnownImports(code) {
+  return code.replace(IMPORT_STATEMENT_PATTERN, (fullMatch, specifierList, _quote, source) => {
+    const known = INJECTABLE_BINDINGS_BY_SOURCE.find((entry) =>
+      entry.source ? entry.source === source : entry.sourcePattern.test(source)
+    );
+    if (!known) {
+      return fullMatch;
+    }
+
+    const specifiers = specifierList
+      .split(',')
+      .map((specifier) => specifier.trim())
+      .filter(Boolean);
+
+    const aliasDeclarations = [];
+    for (const specifier of specifiers) {
+      const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
+      const importedName = aliasMatch ? aliasMatch[1] : specifier;
+      const localName = aliasMatch ? aliasMatch[2] : specifier;
+
+      if (!known.names.includes(importedName)) {
+        // Not something the wrapper injects (e.g. a type-only import, or a
+        // real export we don't provide locally) — bail on the whole
+        // statement rather than guessing at a partial rewrite.
+        return fullMatch;
+      }
+      if (localName !== importedName) {
+        aliasDeclarations.push(`const ${localName} = ${importedName};`);
+      }
+    }
+
+    return aliasDeclarations.length > 0 ? aliasDeclarations.join('\n') + '\n' : '';
+  });
+}
+
+/**
+ * Strips TypeScript type annotations from a handler's parameter list,
+ * respecting bracket depth so a generic type's internal commas
+ * (`opts: Record<string, string>`) aren't mistaken for parameter
+ * separators, and default values (`opts: Options = {}`) are preserved.
+ */
+function stripParamTypeAnnotations(paramsSource) {
+  let result = '';
+  let depth = 0;
+  let inType = false;
+
+  for (const char of paramsSource) {
+    if ('([{<'.includes(char)) {
+      depth += 1;
+      if (!inType) {
+        result += char;
+      }
+      continue;
+    }
+    if (')]}>'.includes(char)) {
+      depth = Math.max(0, depth - 1);
+      if (!inType) {
+        result += char;
+      }
+      continue;
+    }
+    if (depth === 0 && !inType && char === ':') {
+      inType = true;
+      continue;
+    }
+    if (depth === 0 && inType && (char === ',' || char === '=')) {
+      inType = false;
+      result += char;
+      continue;
+    }
+    if (!inType) {
+      result += char;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Strips type annotations from a handler's signature only — its parameter
+ * list and return type — leaving the function body completely untouched.
+ * Operates on `code` starting at `fromIndex` (right after the
+ * `module.exports = ` this module just wrote) so it never has to reason
+ * about the body, which may contain colons of its own (object literals,
+ * ternaries, etc.) that are not type annotations.
+ *
+ * If the text at `fromIndex` isn't a recognizable function/arrow signature,
+ * or its parameter list is unbalanced, `code` is returned unchanged rather
+ * than guessed at.
+ */
+function stripHandlerSignatureTypes(code, fromIndex) {
+  const rest = code.slice(fromIndex);
+
+  const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(rest);
+  if (!headerMatch) {
     return code;
   }
 
-  // Strip imports whose only exports are already injected as wrapper
-  // parameters (createClient, encodeBase64, decodeBase64). Any other
-  // top-level import is left untouched and will surface as a clear syntax
-  // error, same as before this change.
-  const KNOWN_IMPORT_PATTERNS = [
-    /^[ \t]*import\s*\{[^}]*\}\s*from\s*['"]npm:@insforge\/sdk['"]\s*;?[ \t]*\r?\n?/m,
-    /^[ \t]*import\s*\{[^}]*\}\s*from\s*['"]https:\/\/deno\.land\/std[^'"]*\/encoding\/base64\.ts['"]\s*;?[ \t]*\r?\n?/m,
-  ];
-
-  let normalized = code;
-  for (const pattern of KNOWN_IMPORT_PATTERNS) {
-    normalized = normalized.replace(new RegExp(pattern.source, 'gm'), '');
+  const parenStart = headerMatch[0].length - 1;
+  let depth = 0;
+  let parenEnd = -1;
+  for (let i = parenStart; i < rest.length; i += 1) {
+    const char = rest[i];
+    if ('([{'.includes(char)) {
+      depth += 1;
+    } else if (')]}'.includes(char)) {
+      depth -= 1;
+      if (depth === 0) {
+        parenEnd = i;
+        break;
+      }
+    }
+  }
+  if (parenEnd === -1) {
+    return code;
   }
 
-  // Rewrite the documented `export default <handler>` into the equivalent
-  // CommonJS assignment so it runs under `new Function(...)`.
-  normalized = normalized.replace(/(^|\n)([ \t]*)export\s+default\s+/, '$1$2module.exports = ');
+  const paramsInner = rest.slice(parenStart + 1, parenEnd);
+  const strippedParams = stripParamTypeAnnotations(paramsInner);
 
-  return normalized;
+  let afterParams = rest.slice(parenEnd + 1);
+  // A return-type annotation runs from ':' up to (not including) the body's
+  // opening '{' or an arrow's '=>'. Only stripped when one of those actually
+  // follows, so an unrelated ':' doesn't eat the rest of the file.
+  afterParams = afterParams.replace(/^([ \t]*):[^{]*?(?=\{|=>)/, '$1');
+
+  return (
+    code.slice(0, fromIndex) + rest.slice(0, parenStart + 1) + strippedParams + ')' + afterParams
+  );
+}
+
+function normalizeHandlerFormat(code) {
+  if (LEGACY_ASSIGNMENT_PATTERN.test(code)) {
+    return code;
+  }
+
+  let normalized = resolveKnownImports(code);
+
+  const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(normalized);
+  if (!exportDefaultMatch) {
+    return normalized;
+  }
+
+  const assignment = `${exportDefaultMatch[1]}${exportDefaultMatch[2]}module.exports = `;
+  const handlerStart = exportDefaultMatch.index + exportDefaultMatch[0].length;
+  normalized =
+    normalized.slice(0, exportDefaultMatch.index) + assignment + normalized.slice(handlerStart);
+
+  return stripHandlerSignatureTypes(normalized, exportDefaultMatch.index + assignment.length);
 }

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -80,12 +80,15 @@ const REGEX_PERMITTING_KEYWORDS = new Set([
   'await',
 ]);
 
-function isRegexLiteralStart(lastSignificantChar, lastWord) {
+function isRegexLiteralStart(lastSignificantChar, lastWord, lastWordIsProperty) {
   if (lastSignificantChar === '') {
     return true;
   }
   if (VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
-    return REGEX_PERMITTING_KEYWORDS.has(lastWord);
+    // A property named after one of these keywords (`obj.delete`, `obj.in`)
+    // is still a value, not the keyword itself — only an unqualified use
+    // permits a following regex.
+    return !lastWordIsProperty && REGEX_PERMITTING_KEYWORDS.has(lastWord);
   }
   return true;
 }
@@ -97,21 +100,35 @@ function maskNonCode(code) {
   let i = 0;
   let lastSignificantChar = '';
   let lastWord = '';
+  let lastWordIsProperty = false;
   let currentWord = '';
+  let currentWordIsProperty = false;
   while (i < code.length) {
     const char = code[i];
     const twoChars = code.slice(i, i + 2);
 
     // Commit the word in progress the moment it ends — including right
-    // here, before using `lastWord` below — so `a/b` (no separator between
-    // the identifier and the `/`) sees the word that just ended instead of
-    // a stale one from further back.
+    // here, before `lastWord` is read below — so `a/b` (no separator
+    // between the identifier and the `/`) sees the word that just ended
+    // instead of a stale one from further back.
     if (!WORD_CHAR_PATTERN.test(char) && currentWord) {
       lastWord = currentWord;
+      lastWordIsProperty = currentWordIsProperty;
       currentWord = '';
     }
 
-    if (char === '/' && isRegexLiteralStart(lastSignificantChar, lastWord)) {
+    // `twoChars !== '//' && twoChars !== '/*'`: an empty regex literal
+    // (`//`) isn't valid JS grammar (a regex body needs at least one
+    // character), so `//` is always a comment — never division-then-regex
+    // or an empty regex that happens to look like one — and must be
+    // recognized before regex detection gets a chance to misread it (or
+    // `/*`'s opening slash) as a literal.
+    if (
+      char === '/' &&
+      twoChars !== '//' &&
+      twoChars !== '/*' &&
+      isRegexLiteralStart(lastSignificantChar, lastWord, lastWordIsProperty)
+    ) {
       // A regex literal. Its contents are irrelevant to every pattern below,
       // so it's fully blanked (delimiters included) — unlike a string, whose
       // quote characters are preserved (see below), nothing needs to see a
@@ -145,6 +162,7 @@ function maskNonCode(code) {
         result += code.slice(i, j).replace(/[^\n]/g, ' ');
         lastSignificantChar = ')'; // a regex literal is itself a value
         lastWord = ''; // ...not a keyword, so a following `/` means division
+        lastWordIsProperty = false;
         i = j;
         continue;
       }
@@ -191,11 +209,15 @@ function maskNonCode(code) {
       i = closed ? j + 1 : innerEnd;
       lastSignificantChar = ')'; // a string literal is itself a value
       lastWord = ''; // ...not a keyword, so a following `/` means division
+      lastWordIsProperty = false;
       continue;
     }
 
     result += char;
     if (WORD_CHAR_PATTERN.test(char)) {
+      if (!currentWord) {
+        currentWordIsProperty = lastSignificantChar === '.';
+      }
       currentWord += char;
     }
     // (the non-word case is already handled at the top of the loop, before

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -395,6 +395,15 @@ function stripParamTypeAnnotations(originalSource, maskedSource) {
       mode = 'type';
       continue;
     }
+    if (depth === 0 && mode === 'name' && char === '=') {
+      // A default value with no type annotation at all (`a = x < y ? z : q`).
+      // Without this, `mode` would stay 'name' — the only other path into
+      // 'default' requires having seen a ':' first — so a ternary's own
+      // ':' further down would be misread as starting a type annotation.
+      mode = 'default';
+      keep();
+      continue;
+    }
     if (depth === 0 && mode === 'type' && char === '=' && maskedSource[i + 1] === '>') {
       // Function-type arrow (`() => void`) — part of the type, not a
       // default-value marker. Stays in type mode; both chars are dropped.

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -1,0 +1,51 @@
+/**
+ * Handler format normalization (Cloud / self-hosted parity — issue #1906)
+ *
+ * On Cloud, function code is deployed as a real ES module (see
+ * `deno-subhosting.provider.ts`'s `transformUserCode`), so the documented
+ * handler format everywhere in the public docs is:
+ *
+ *   import { createClient } from 'npm:@insforge/sdk';
+ *   export default async function(req: Request) { ... }
+ *
+ * Locally, `worker-template.js` runs the code inside `new Function(...)` —
+ * a plain script scope chosen so the worker never needs network/file import
+ * permissions at request time (secrets and the SDK are injected as call
+ * arguments instead, see the worker template's security notes). `import`
+ * and `export` are syntax errors in that scope, so only the legacy
+ * `module.exports = ...` form used to work there, silently breaking every
+ * function written in the documented `export default` format as soon as it
+ * left Cloud.
+ *
+ * This file is plain, Deno/Node-independent JavaScript (no import/export
+ * statements of its own) so it can be:
+ *   - concatenated ahead of `worker-template.js` by `server.ts` before the
+ *     combined source is handed to `new Function`/`Worker`, and
+ *   - loaded directly in unit tests via `vm` without any Deno globals.
+ */
+function normalizeHandlerFormat(code) {
+  // Legacy CommonJS-style handlers already run as-is under `new Function(...)`.
+  if (/\bmodule\.exports\b/.test(code)) {
+    return code;
+  }
+
+  // Strip imports whose only exports are already injected as wrapper
+  // parameters (createClient, encodeBase64, decodeBase64). Any other
+  // top-level import is left untouched and will surface as a clear syntax
+  // error, same as before this change.
+  const KNOWN_IMPORT_PATTERNS = [
+    /^[ \t]*import\s*\{[^}]*\}\s*from\s*['"]npm:@insforge\/sdk['"]\s*;?[ \t]*\r?\n?/m,
+    /^[ \t]*import\s*\{[^}]*\}\s*from\s*['"]https:\/\/deno\.land\/std[^'"]*\/encoding\/base64\.ts['"]\s*;?[ \t]*\r?\n?/m,
+  ];
+
+  let normalized = code;
+  for (const pattern of KNOWN_IMPORT_PATTERNS) {
+    normalized = normalized.replace(new RegExp(pattern.source, 'gm'), '');
+  }
+
+  // Rewrite the documented `export default <handler>` into the equivalent
+  // CommonJS assignment so it runs under `new Function(...)`.
+  normalized = normalized.replace(/(^|\n)([ \t]*)export\s+default\s+/, '$1$2module.exports = ');
+
+  return normalized;
+}

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -50,12 +50,64 @@
  * tokenizer — doesn't need to be, since callers only use it to find *where*
  * a pattern lexically starts, never to execute the masked text itself.
  */
+// Characters after which a `/` is a value already produced (an identifier,
+// number, or a closing bracket) rather than the start of a regex literal —
+// e.g. `a / b` is division, `(x) / 2` is division. After anything else
+// (`(`, `,`, `=`, `:`, `return`, the start of the source, ...) a `/` starts
+// a regex literal — e.g. `return /foo/`, `x = /foo/`. This is the same
+// heuristic lightweight JS tokenizers use; it isn't a full parser, but a
+// statement can't otherwise begin with a bare `/`.
+const VALUE_END_CHAR_PATTERN = /[A-Za-z0-9_$)\]]/;
+
 function maskNonCode(code) {
   let result = '';
   let i = 0;
+  let lastSignificantChar = '';
   while (i < code.length) {
     const char = code[i];
     const twoChars = code.slice(i, i + 2);
+
+    if (char === '/' && !VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+      // A regex literal. Its contents are irrelevant to every pattern below,
+      // so it's fully blanked (delimiters included) — unlike a string, whose
+      // quote characters are preserved (see below), nothing needs to see a
+      // literal `/` here. Scanned first, before the comment checks: a
+      // character class inside a regex can itself contain `/` or quote
+      // characters (`/['"]/`, `/[//]/`) that would otherwise be misread as
+      // starting a string or a `//` line comment.
+      let j = i + 1;
+      let inClass = false;
+      let terminated = false;
+      while (j < code.length && code[j] !== '\n') {
+        if (code[j] === '\\') {
+          j += 2;
+          continue;
+        }
+        if (code[j] === '[') {
+          inClass = true;
+        } else if (code[j] === ']') {
+          inClass = false;
+        } else if (code[j] === '/' && !inClass) {
+          j += 1;
+          terminated = true;
+          break;
+        }
+        j += 1;
+      }
+      if (terminated) {
+        while (j < code.length && /[a-zA-Z]/.test(code[j])) {
+          j += 1; // trailing flags (g, i, m, ...)
+        }
+        result += code.slice(i, j).replace(/[^\n]/g, ' ');
+        lastSignificantChar = ')'; // a regex literal is itself a value
+        i = j;
+        continue;
+      }
+      // No closing `/` before end of line: not actually a regex literal
+      // (or malformed code either way) — fall through and treat `/` as an
+      // ordinary character rather than misidentifying a division operator
+      // as an unterminated regex and masking the rest of the line.
+    }
 
     if (twoChars === '//') {
       let j = i;
@@ -92,10 +144,14 @@ function maskNonCode(code) {
       const inner = code.slice(i + 1, innerEnd).replace(/[^\n]/g, ' ');
       result += quote + inner + (closed ? quote : '');
       i = closed ? j + 1 : innerEnd;
+      lastSignificantChar = ')'; // a string literal is itself a value
       continue;
     }
 
     result += char;
+    if (!/\s/.test(char)) {
+      lastSignificantChar = char;
+    }
     i += 1;
   }
   return result;
@@ -240,6 +296,11 @@ function stripParamTypeAnnotations(originalSource, maskedSource) {
       if (mode !== 'type') {
         keep();
       }
+      continue;
+    }
+    if (depth === 0 && mode === 'name' && char === '?' && /^\s*:/.test(maskedSource.slice(i + 1))) {
+      // TypeScript optional-parameter marker immediately before the type
+      // annotation (`req?: Request`) — has no plain-JS analogue, drop it.
       continue;
     }
     if (depth === 0 && mode === 'name' && char === ':') {

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -24,19 +24,86 @@
  *   - concatenated ahead of `worker-template.js` by `server.ts` before the
  *     combined source is handed to `new Function`/`Worker`, and
  *   - loaded directly in unit tests via `vm` without any Deno globals.
+ * It stays plain JS (matching worker-template.js's own existing precedent,
+ * for the same reason — both are read as-is at runtime with no build step)
+ * rather than TypeScript compiled ahead of time.
  *
  * Scope: this targets the one documented handler shape (a top-level
  * `export default` function/arrow expression, optionally typed, optionally
  * importing the injected SDK/base64 bindings) — not arbitrary TypeScript or
  * ESM. Anything outside that shape is left untouched, which reproduces
  * today's plain syntax error rather than silently miscompiling it.
+ *
+ * Regex-based detection alone would misfire on text that merely *looks*
+ * like code inside a string, template literal, or comment (e.g. a handler
+ * whose body contains the literal text "module.exports =" in a log
+ * message). `maskNonCode` blanks out that content — preserving length and
+ * newlines — so every pattern below is matched against the masked source to
+ * find real positions, while every rewrite still slices/reads the original,
+ * unmasked `code` at those positions.
  */
 
-// Legacy CommonJS handlers are detected by an actual top-level assignment,
-// not a bare substring search — `module.exports` appearing only inside a
-// comment or string (e.g. a migration note like "// previously:
-// module.exports = ...") must not skip normalization for what is otherwise
-// a valid `export default` handler.
+/**
+ * Replaces the contents of string literals ('...', "...", `...`) and
+ * comments (// and /* *\/) with spaces, preserving length and newlines, so
+ * character offsets stay valid against the original source. Not a full
+ * tokenizer — doesn't need to be, since callers only use it to find *where*
+ * a pattern lexically starts, never to execute the masked text itself.
+ */
+function maskNonCode(code) {
+  let result = '';
+  let i = 0;
+  while (i < code.length) {
+    const char = code[i];
+    const twoChars = code.slice(i, i + 2);
+
+    if (twoChars === '//') {
+      let j = i;
+      while (j < code.length && code[j] !== '\n') {
+        j += 1;
+      }
+      result += code.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+      continue;
+    }
+
+    if (twoChars === '/*') {
+      let j = i + 2;
+      while (j < code.length - 1 && code.slice(j, j + 2) !== '*/') {
+        j += 1;
+      }
+      j = Math.min(j + 2, code.length);
+      result += code.slice(i, j).replace(/[^\n]/g, ' ');
+      i = j;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      // Preserve the quote characters themselves — only blank the content
+      // between them — so a pattern that checks for a real quote (e.g. the
+      // `from '...'` clause of an import) still matches the masked text.
+      const quote = char;
+      let j = i + 1;
+      while (j < code.length && code[j] !== quote) {
+        j += code[j] === '\\' ? 2 : 1;
+      }
+      const closed = j < code.length;
+      const innerEnd = Math.min(j, code.length);
+      const inner = code.slice(i + 1, innerEnd).replace(/[^\n]/g, ' ');
+      result += quote + inner + (closed ? quote : '');
+      i = closed ? j + 1 : innerEnd;
+      continue;
+    }
+
+    result += char;
+    i += 1;
+  }
+  return result;
+}
+
+// Legacy CommonJS handlers are detected by an actual top-level assignment
+// (matched against the masked source — see file header), not a bare
+// substring search that a comment or template literal could trigger.
 const LEGACY_ASSIGNMENT_PATTERN = /^[ \t]*module\.exports\s*=/m;
 
 // Named bindings the worker wrapper injects as call arguments, keyed by the
@@ -57,7 +124,7 @@ const IMPORT_STATEMENT_PATTERN =
   /^[ \t]*import\s*\{([^}]*)\}\s*from\s*(['"])([^'"]*)\2\s*;?[ \t]*\r?\n?/gm;
 
 /**
- * Rewrites the known-injectable imports in `code` in place:
+ * Rewrites the known-injectable imports in `code`:
  *  - a specifier matching its injected name exactly (`createClient`) is
  *    simply dropped — the wrapper already provides that identifier.
  *  - an aliased specifier (`createClient as makeClient`) is replaced with
@@ -66,81 +133,173 @@ const IMPORT_STATEMENT_PATTERN =
  *    from any other source, is left completely untouched.
  */
 function resolveKnownImports(code) {
-  return code.replace(IMPORT_STATEMENT_PATTERN, (fullMatch, specifierList, _quote, source) => {
+  const masked = maskNonCode(code);
+  // 'd' adds match.indices, so the specifier list and source are read back
+  // from the original `code` at those positions — the masked text is only
+  // used to find real (non-string/comment) import statements; its capture
+  // groups are blanked and unusable as content (the whole point of masking
+  // the source string is that it's blanked).
+  const pattern = new RegExp(IMPORT_STATEMENT_PATTERN.source, IMPORT_STATEMENT_PATTERN.flags + 'd');
+
+  let result = '';
+  let lastIndex = 0;
+  let match;
+  while ((match = pattern.exec(masked))) {
+    const fullMatch = match[0];
+    const [specifierStart, specifierEnd] = match.indices[1];
+    const [sourceStart, sourceEnd] = match.indices[3];
+    const specifierList = code.slice(specifierStart, specifierEnd);
+    const source = code.slice(sourceStart, sourceEnd);
+    result += code.slice(lastIndex, match.index);
+
     const known = INJECTABLE_BINDINGS_BY_SOURCE.find((entry) =>
       entry.source ? entry.source === source : entry.sourcePattern.test(source)
     );
+
     if (!known) {
-      return fullMatch;
+      result += code.slice(match.index, match.index + fullMatch.length);
+    } else {
+      const specifiers = specifierList
+        .split(',')
+        .map((specifier) => specifier.trim())
+        .filter(Boolean);
+
+      const aliasDeclarations = [];
+      let unresolvable = false;
+      for (const specifier of specifiers) {
+        const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
+        const importedName = aliasMatch ? aliasMatch[1] : specifier;
+        const localName = aliasMatch ? aliasMatch[2] : specifier;
+
+        if (!known.names.includes(importedName)) {
+          // Not something the wrapper injects — bail on the whole statement
+          // rather than guessing at a partial rewrite.
+          unresolvable = true;
+          break;
+        }
+        if (localName !== importedName) {
+          aliasDeclarations.push(`const ${localName} = ${importedName};`);
+        }
+      }
+
+      result += unresolvable
+        ? code.slice(match.index, match.index + fullMatch.length)
+        : aliasDeclarations.length > 0
+          ? aliasDeclarations.join('\n') + '\n'
+          : '';
     }
 
-    const specifiers = specifierList
-      .split(',')
-      .map((specifier) => specifier.trim())
-      .filter(Boolean);
-
-    const aliasDeclarations = [];
-    for (const specifier of specifiers) {
-      const aliasMatch = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(specifier);
-      const importedName = aliasMatch ? aliasMatch[1] : specifier;
-      const localName = aliasMatch ? aliasMatch[2] : specifier;
-
-      if (!known.names.includes(importedName)) {
-        // Not something the wrapper injects (e.g. a type-only import, or a
-        // real export we don't provide locally) — bail on the whole
-        // statement rather than guessing at a partial rewrite.
-        return fullMatch;
-      }
-      if (localName !== importedName) {
-        aliasDeclarations.push(`const ${localName} = ${importedName};`);
-      }
-    }
-
-    return aliasDeclarations.length > 0 ? aliasDeclarations.join('\n') + '\n' : '';
-  });
+    lastIndex = match.index + fullMatch.length;
+  }
+  result += code.slice(lastIndex);
+  return result;
 }
 
 /**
- * Strips TypeScript type annotations from a handler's parameter list,
- * respecting bracket depth so a generic type's internal commas
- * (`opts: Record<string, string>`) aren't mistaken for parameter
- * separators, and default values (`opts: Options = {}`) are preserved.
+ * Strips TypeScript type annotations from a handler's parameter list.
+ *
+ * Tracks three states per parameter — `name` (before any `:`), `type`
+ * (consuming the annotation), `default` (after the `=` of a default value)
+ * — rather than a single depth-only pass, so that:
+ *  - a generic type's internal comma (`opts: Record<string, string>`) isn't
+ *    mistaken for a parameter separator (bracket depth),
+ *  - a function-type arrow inside a type (`cb: () => void`) isn't mistaken
+ *    for the start of a default value (only `=` NOT followed by `>` ends
+ *    type mode), and
+ *  - a `:` inside a default value's own expression (a ternary,
+ *    `opts: Options = cond ? a : b`) is never reinterpreted as the start of
+ *    another type annotation — once a parameter reaches `default` mode, a
+ *    `:` is just a character in that expression.
+ *
+ * Operates on `originalSource` for the text it keeps/drops, but makes every
+ * control-flow decision (bracket depth, which state a `:`/`=`/`,` triggers)
+ * against `maskedSource` (see `maskNonCode`) so a colon or brace inside a
+ * default value's own string literal can't desynchronize bracket depth or
+ * be mistaken for a type delimiter.
  */
-function stripParamTypeAnnotations(paramsSource) {
+function stripParamTypeAnnotations(originalSource, maskedSource) {
   let result = '';
   let depth = 0;
-  let inType = false;
+  let mode = 'name'; // 'name' | 'type' | 'default'
 
-  for (const char of paramsSource) {
+  for (let i = 0; i < maskedSource.length; i += 1) {
+    const char = maskedSource[i];
+    const keep = () => {
+      result += originalSource[i];
+    };
+
     if ('([{<'.includes(char)) {
       depth += 1;
-      if (!inType) {
-        result += char;
+      if (mode !== 'type') {
+        keep();
       }
       continue;
     }
     if (')]}>'.includes(char)) {
       depth = Math.max(0, depth - 1);
-      if (!inType) {
-        result += char;
+      if (mode !== 'type') {
+        keep();
       }
       continue;
     }
-    if (depth === 0 && !inType && char === ':') {
-      inType = true;
+    if (depth === 0 && mode === 'name' && char === ':') {
+      mode = 'type';
       continue;
     }
-    if (depth === 0 && inType && (char === ',' || char === '=')) {
-      inType = false;
-      result += char;
+    if (depth === 0 && mode === 'type' && char === '=' && maskedSource[i + 1] === '>') {
+      // Function-type arrow (`() => void`) — part of the type, not a
+      // default-value marker. Stays in type mode; both chars are dropped.
+      i += 1;
       continue;
     }
-    if (!inType) {
-      result += char;
+    if (depth === 0 && mode === 'type' && char === '=') {
+      mode = 'default';
+      keep();
+      continue;
+    }
+    if (depth === 0 && (mode === 'type' || mode === 'default') && char === ',') {
+      mode = 'name';
+      keep();
+      continue;
+    }
+    if (mode !== 'type') {
+      keep();
     }
   }
 
   return result;
+}
+
+/**
+ * Strips a handler's return-type annotation — the `: T` between the
+ * parameter list's `)` and the function body's `{` or an arrow's `=>` — by
+ * scanning bracket depth (against the masked source, for the same reason as
+ * `stripParamTypeAnnotations`) rather than stopping at the first `{`, so a
+ * return type containing its own object-literal type
+ * (`Promise<{ status: number }>`) isn't truncated mid-type.
+ */
+function stripReturnType(originalAfterParams, maskedAfterParams) {
+  const colonMatch = /^[ \t]*:/.exec(maskedAfterParams);
+  if (!colonMatch) {
+    return originalAfterParams;
+  }
+
+  let i = colonMatch[0].length;
+  let depth = 0;
+  while (i < maskedAfterParams.length) {
+    const char = maskedAfterParams[i];
+    if (depth === 0 && (char === '{' || (char === '=' && maskedAfterParams[i + 1] === '>'))) {
+      break;
+    }
+    if ('([{<'.includes(char)) {
+      depth += 1;
+    } else if (')]}>'.includes(char)) {
+      depth = Math.max(0, depth - 1);
+    }
+    i += 1;
+  }
+
+  return originalAfterParams.slice(0, colonMatch[0].length - 1) + originalAfterParams.slice(i);
 }
 
 /**
@@ -157,8 +316,11 @@ function stripParamTypeAnnotations(paramsSource) {
  */
 function stripHandlerSignatureTypes(code, fromIndex) {
   const rest = code.slice(fromIndex);
+  const maskedRest = maskNonCode(rest);
 
-  const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(rest);
+  const headerMatch = /^(\s*)(async\s+)?(function\s*[A-Za-z_$][\w$]*\s*|function\s*)?\(/.exec(
+    maskedRest
+  );
   if (!headerMatch) {
     return code;
   }
@@ -166,8 +328,8 @@ function stripHandlerSignatureTypes(code, fromIndex) {
   const parenStart = headerMatch[0].length - 1;
   let depth = 0;
   let parenEnd = -1;
-  for (let i = parenStart; i < rest.length; i += 1) {
-    const char = rest[i];
+  for (let i = parenStart; i < maskedRest.length; i += 1) {
+    const char = maskedRest[i];
     if ('([{'.includes(char)) {
       depth += 1;
     } else if (')]}'.includes(char)) {
@@ -182,14 +344,12 @@ function stripHandlerSignatureTypes(code, fromIndex) {
     return code;
   }
 
-  const paramsInner = rest.slice(parenStart + 1, parenEnd);
-  const strippedParams = stripParamTypeAnnotations(paramsInner);
+  const strippedParams = stripParamTypeAnnotations(
+    rest.slice(parenStart + 1, parenEnd),
+    maskedRest.slice(parenStart + 1, parenEnd)
+  );
 
-  let afterParams = rest.slice(parenEnd + 1);
-  // A return-type annotation runs from ':' up to (not including) the body's
-  // opening '{' or an arrow's '=>'. Only stripped when one of those actually
-  // follows, so an unrelated ':' doesn't eat the rest of the file.
-  afterParams = afterParams.replace(/^([ \t]*):[^{]*?(?=\{|=>)/, '$1');
+  const afterParams = stripReturnType(rest.slice(parenEnd + 1), maskedRest.slice(parenEnd + 1));
 
   return (
     code.slice(0, fromIndex) + rest.slice(0, parenStart + 1) + strippedParams + ')' + afterParams
@@ -197,13 +357,13 @@ function stripHandlerSignatureTypes(code, fromIndex) {
 }
 
 function normalizeHandlerFormat(code) {
-  if (LEGACY_ASSIGNMENT_PATTERN.test(code)) {
+  if (LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
     return code;
   }
 
   let normalized = resolveKnownImports(code);
 
-  const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(normalized);
+  const exportDefaultMatch = /(^|\n)([ \t]*)export\s+default\s+/.exec(maskNonCode(normalized));
   if (!exportDefaultMatch) {
     return normalized;
   }

--- a/functions/handler-format.js
+++ b/functions/handler-format.js
@@ -59,15 +59,59 @@
 // statement can't otherwise begin with a bare `/`.
 const VALUE_END_CHAR_PATTERN = /[A-Za-z0-9_$)\]]/;
 
+// A word immediately before `/` that ends in a "value-like" character
+// doesn't always mean a value was produced — these keywords all precede an
+// operand, not end one (`return /foo/`, `typeof /foo/`), so `/` right after
+// one of them still starts a regex literal despite ending in a letter.
+const REGEX_PERMITTING_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'throw',
+  'case',
+  'do',
+  'else',
+  'yield',
+  'await',
+]);
+
+function isRegexLiteralStart(lastSignificantChar, lastWord) {
+  if (lastSignificantChar === '') {
+    return true;
+  }
+  if (VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+    return REGEX_PERMITTING_KEYWORDS.has(lastWord);
+  }
+  return true;
+}
+
+const WORD_CHAR_PATTERN = /[A-Za-z0-9_$]/;
+
 function maskNonCode(code) {
   let result = '';
   let i = 0;
   let lastSignificantChar = '';
+  let lastWord = '';
+  let currentWord = '';
   while (i < code.length) {
     const char = code[i];
     const twoChars = code.slice(i, i + 2);
 
-    if (char === '/' && !VALUE_END_CHAR_PATTERN.test(lastSignificantChar)) {
+    // Commit the word in progress the moment it ends — including right
+    // here, before using `lastWord` below — so `a/b` (no separator between
+    // the identifier and the `/`) sees the word that just ended instead of
+    // a stale one from further back.
+    if (!WORD_CHAR_PATTERN.test(char) && currentWord) {
+      lastWord = currentWord;
+      currentWord = '';
+    }
+
+    if (char === '/' && isRegexLiteralStart(lastSignificantChar, lastWord)) {
       // A regex literal. Its contents are irrelevant to every pattern below,
       // so it's fully blanked (delimiters included) — unlike a string, whose
       // quote characters are preserved (see below), nothing needs to see a
@@ -100,6 +144,7 @@ function maskNonCode(code) {
         }
         result += code.slice(i, j).replace(/[^\n]/g, ' ');
         lastSignificantChar = ')'; // a regex literal is itself a value
+        lastWord = ''; // ...not a keyword, so a following `/` means division
         i = j;
         continue;
       }
@@ -145,10 +190,16 @@ function maskNonCode(code) {
       result += quote + inner + (closed ? quote : '');
       i = closed ? j + 1 : innerEnd;
       lastSignificantChar = ')'; // a string literal is itself a value
+      lastWord = ''; // ...not a keyword, so a following `/` means division
       continue;
     }
 
     result += char;
+    if (WORD_CHAR_PATTERN.test(char)) {
+      currentWord += char;
+    }
+    // (the non-word case is already handled at the top of the loop, before
+    // `lastWord` is read for this same character)
     if (!/\s/.test(char)) {
       lastSignificantChar = char;
     }
@@ -190,11 +241,13 @@ const IMPORT_STATEMENT_PATTERN =
  */
 function resolveKnownImports(code) {
   const masked = maskNonCode(code);
-  // 'd' adds match.indices, so the specifier list and source are read back
-  // from the original `code` at those positions — the masked text is only
-  // used to find real (non-string/comment) import statements; its capture
-  // groups are blanked and unusable as content (the whole point of masking
-  // the source string is that it's blanked).
+  // 'd' adds match.indices to locate each match precisely. The specifier
+  // list is read from the *masked* text — a comment inside the braces
+  // (`{ createClient /* the sdk client */ }`) would otherwise end up as
+  // part of a "specifier" and fail the known-binding check, leaving the
+  // whole import untouched even though it's a plain, resolvable one. The
+  // source string, in contrast, is read from the original `code`: it's a
+  // quoted string, which can't itself contain a code comment.
   const pattern = new RegExp(IMPORT_STATEMENT_PATTERN.source, IMPORT_STATEMENT_PATTERN.flags + 'd');
 
   let result = '';
@@ -204,7 +257,7 @@ function resolveKnownImports(code) {
     const fullMatch = match[0];
     const [specifierStart, specifierEnd] = match.indices[1];
     const [sourceStart, sourceEnd] = match.indices[3];
-    const specifierList = code.slice(specifierStart, specifierEnd);
+    const specifierList = masked.slice(specifierStart, specifierEnd);
     const source = code.slice(sourceStart, sourceEnd);
     result += code.slice(lastIndex, match.index);
 
@@ -284,18 +337,31 @@ function stripParamTypeAnnotations(originalSource, maskedSource) {
       result += originalSource[i];
     };
 
-    if ('([{<'.includes(char)) {
+    if ('([{'.includes(char)) {
       depth += 1;
       if (mode !== 'type') {
         keep();
       }
       continue;
     }
-    if (')]}>'.includes(char)) {
+    if (')]}'.includes(char)) {
       depth = Math.max(0, depth - 1);
       if (mode !== 'type') {
         keep();
       }
+      continue;
+    }
+    // `<`/`>` only mean generic nesting while inside a type annotation.
+    // Outside one — a default value's own expression — they're relational
+    // operators (`opts = x < 10 ? a : b`), and counting them as brackets
+    // there would desync depth against an unmatched `<` with no `>`,
+    // leaving a *later* parameter's real type annotation unstripped.
+    if (mode === 'type' && char === '<') {
+      depth += 1;
+      continue;
+    }
+    if (mode === 'type' && char === '>' && depth > 0) {
+      depth -= 1;
       continue;
     }
     if (depth === 0 && mode === 'name' && char === '?' && /^\s*:/.test(maskedSource.slice(i + 1))) {
@@ -340,7 +406,9 @@ function stripParamTypeAnnotations(originalSource, maskedSource) {
  * (`Promise<{ status: number }>`) isn't truncated mid-type.
  */
 function stripReturnType(originalAfterParams, maskedAfterParams) {
-  const colonMatch = /^[ \t]*:/.exec(maskedAfterParams);
+  // `\s`, not `[ \t]`: the colon may be on its own line after the closing
+  // paren (an unusual but valid line-break before `: ReturnType`).
+  const colonMatch = /^\s*:/.exec(maskedAfterParams);
   if (!colonMatch) {
     return originalAfterParams;
   }
@@ -418,7 +486,13 @@ function stripHandlerSignatureTypes(code, fromIndex) {
 }
 
 function normalizeHandlerFormat(code) {
-  if (LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
+  // Checked first, and only as the deciding factor when there's no
+  // `export default` at all: a genuine `export default` handler could
+  // still contain a line starting with `module.exports =` somewhere in its
+  // *body* (unusual, but not impossible — e.g. mixed CommonJS/ESM idioms),
+  // and that must not short-circuit the rewrite this function exists to do.
+  const hasExportDefault = /(^|\n)([ \t]*)export\s+default\s+/.test(maskNonCode(code));
+  if (!hasExportDefault && LEGACY_ASSIGNMENT_PATTERN.test(maskNonCode(code))) {
     return code;
   }
 

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -24,7 +24,13 @@ let workerTemplateCode: string | null = null;
 async function getWorkerTemplateCode(): Promise<string> {
   if (!workerTemplateCode) {
     const currentDir = dirname(fromFileUrl(import.meta.url));
-    workerTemplateCode = await Deno.readTextFile(join(currentDir, 'worker-template.js'));
+    // handler-format.js is prepended so its `normalizeHandlerFormat` function
+    // is available as a global inside worker-template.js (see comment there).
+    const [handlerFormatCode, templateCode] = await Promise.all([
+      Deno.readTextFile(join(currentDir, 'handler-format.js')),
+      Deno.readTextFile(join(currentDir, 'worker-template.js')),
+    ]);
+    workerTemplateCode = `${handlerFormatCode}\n${templateCode}`;
   }
   return workerTemplateCode;
 }

--- a/functions/worker-template.js
+++ b/functions/worker-template.js
@@ -3,9 +3,13 @@
  *
  * This code runs inside a Web Worker environment created by Deno.
  * Each worker is created fresh for a single request, executes once, and terminates.
+ *
+ * `normalizeHandlerFormat` (from handler-format.js) is prepended to this file
+ * by `server.ts`'s `getWorkerTemplateCode()` before the combined source is
+ * turned into the worker's Blob URL, so it is available here as a global.
  */
 /* eslint-env worker */
-/* global self, Request, Deno */
+/* global self, Request, Deno, normalizeHandlerFormat */
 
 // --- SECURITY BLACKOUT (Top-level) ---
 // We polyfill Deno.env and process.env BEFORE any imports using Top-Level Await.
@@ -149,7 +153,7 @@ const handleMessage = async (e) => {
       'Deno',
       'encodeBase64',
       'decodeBase64',
-      code
+      normalizeHandlerFormat(code)
     );
     const exports = {};
     const module = { exports };
@@ -162,7 +166,8 @@ const handleMessage = async (e) => {
 
     if (typeof functionHandler !== 'function') {
       throw new Error(
-        'No function exported. Expected: module.exports = async function(req) { ... }'
+        'No function exported. Expected either "export default async function(req) { ... }" ' +
+          'or "module.exports = async function(req) { ... }"'
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1906.

Every official InsForge doc (TypeScript, Kotlin, and REST SDK docs) documents edge functions using the ES-module handler format:

```ts
import { createClient } from 'npm:@insforge/sdk';

export default async function(req: Request): Promise<Response> { ... }
```

On **Cloud**, function code is deployed as a real ES module (see `transformUserCode`/`generateRouter` in `backend/src/providers/functions/deno-subhosting.provider.ts`), so this format works fine there.

On **self-hosted/local**, the same code is executed inside `new Function(...)` in `functions/worker-template.js` — a plain script scope, chosen deliberately so the worker never needs import/network permissions at request time (the SDK, secrets, and helpers are injected as call arguments instead — see the worker template's own security comments). `export` and `import` are syntax errors in that scope, so **only the undocumented legacy `module.exports = ...` form ever worked locally**. Any function written in the documented format threw a `SyntaxError` as soon as it left Cloud, with no code path to make one function source work in both places.

This also explains why `functions/examples/*.js` in this repo explicitly warns contributors to "keep exports exactly: `module.exports = async function(request) { ... }`" — a workaround for this exact gap, contradicting the public docs.

## Fix

- Added `functions/handler-format.js`: a small, Deno/Node-independent pure function (`normalizeHandlerFormat`) that:
  - leaves legacy `module.exports = ...` handlers untouched,
  - strips the `createClient`/`encodeBase64`/`decodeBase64` imports (these are already injected as wrapper parameters, so the import statement is redundant once we're in script scope), and
  - rewrites `export default <handler>` into the equivalent `module.exports = <handler>` assignment.
  - Any other/unrecognized import is left as-is, so it still surfaces a clear error rather than being silently swallowed.
- `functions/server.ts`'s `getWorkerTemplateCode()` now concatenates `handler-format.js` ahead of `worker-template.js` before building the worker's Blob source, so `normalizeHandlerFormat` is available there as a global.
- `functions/worker-template.js` now runs `normalizeHandlerFormat(code)` before handing the code to `new Function(...)`, and its "no function exported" error message now mentions both supported formats.
- Since Deno's `--allow-read` permission in every deployment config was scoped to the single file `./functions/worker-template.js`, I updated it to also allow `./functions/handler-format.js` in:
  - `docker-compose.yml`, `docker-compose.prod.yml`
  - `deploy/docker-compose/docker-compose.yml`, `deploy/coolify/docker-compose.yml`, `deploy/dokploy/docker-compose.yml`, `deploy/zeabur/template.yml`
  - `deploy/setup.sh`'s image-only installer file manifest, which explicitly lists every file the runtime needs.

## Testing

- Added `backend/tests/unit/function-handler-format.test.ts`, which loads the real `functions/handler-format.js` source via Node's `vm` module (no logic duplicated into the test) and covers:
  - legacy `module.exports` handlers pass through unchanged
  - documented `export default async function(req) {...}` + SDK import is rewritten and is actually runnable via `new Function(...)` (the same execution path the worker uses)
  - named `export default function handler(req) {...}`
  - `export default` arrow functions
  - the base64 std import is stripped alongside the SDK import
  - an unrecognized import is left untouched rather than silently dropped
- Ran the full backend suite: `npm run test:backend` → 2410 passed, 21 skipped, 0 failed (no regressions).
- `npx tsc --noEmit` on `backend/` passes.
- `sh scripts/check-setup-sh.sh` passes against the updated `deploy/setup.sh`.
- Confirmed via `git diff` (not local `--check`, which is skewed by Windows CRLF checkout) that the diffs to existing files are minimal and Prettier-clean at the content level; the new files pass `prettier --check` and `eslint` directly.
- Could not run `npm run test:e2e` or exercise the actual Deno worker locally (no Docker/Deno available in this environment) — would appreciate a maintainer or CI run confirming the Deno-side behavior end-to-end.

## Notes for reviewers

I deliberately kept the self-hosted worker's script-eval security model as-is (no `import()`/dynamic module loading added) — the fix only normalizes syntax so both documented handler styles produce a form `new Function(...)` can already execute, rather than expanding what the worker permits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1906 — makes the documented `export default` edge function handler format work on self-hosted/local runtimes, where only the undocumented legacy `module.exports` form worked before. Cloud runs handlers as real ES modules; the local `new Function` path can't parse `import`/`export` or TypeScript annotations, so handler code is normalized before execution.

**What changed**

- Adds `functions/handler-format.js`, which rewrites `export default` handlers to `module.exports`, strips the injected SDK/base64 imports, converts aliased SDK imports to `const` bindings, and strips TypeScript annotations from handler signatures.
- Masks strings, template literals, comments, and regex literals so code-shaped text inside them doesn't affect detection.
- Legacy `module.exports` handlers pass through unchanged; unrecognized imports and signatures stay in place and surface as errors.
- `functions/server.ts` prepends the normalizer to the worker template, and `functions/worker-template.js` calls it before `new Function`.
- Updates every deploy config's `--allow-read` flag, `deploy/setup.sh`, and the Zeabur template's embedded copy to include the new file.
- Adds unit tests that run normalized output through `new Function` and assert the Zeabur embedded copy stays byte-identical.

**Compatibility**

- No migration needed for existing `module.exports` handlers.
- The worker's security model is unchanged: no dynamic imports or request-time network access are added.

<sup>Written for commit 4698b5e216e25ffb438de4149d0c50217a40d6fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Function handlers can use either `export default` or `module.exports`.
  - Supported handler formats, TypeScript syntax, optional parameters, and SDK imports are automatically normalized before execution across deployment environments.

- **Bug Fixes**
  - Improved handling of aliased and mixed SDK imports.
  - Prevented code-like text in comments, strings, templates, and regular expressions from affecting normalization.
  - Updated error guidance to show both supported export formats.

- **Tests**
  - Added comprehensive regression coverage for handler normalization and executable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->