### PR TITLE
fix(security): edge layer hardening bundle (headers, CORS, topology masking, SSE abort)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -59,6 +59,7 @@
     "express-rate-limit": "^7.1.5",
     "file-type": "^21.3.4",
     "google-auth-library": "^10.1.0",
+    "helmet": "^8.3.0",
     "jose": "^6.1.0",
     "jsonwebtoken": "^9.0.2",
     "libpg-query": "^17.6.0",

--- a/backend/src/api/middlewares/cors.ts
+++ b/backend/src/api/middlewares/cors.ts
@@ -1,0 +1,135 @@
+import cors, { CorsOptions } from 'cors';
+import { RequestHandler } from 'express';
+import { AuthConfigService } from '@/services/auth/auth-config.service.js';
+import { getApiBaseUrl } from '@/utils/environment.js';
+import logger from '@/utils/logger.js';
+
+/**
+ * Dynamic CORS allowlist, replacing the previous `origin: true` (reflect any
+ * origin) + `credentials: true` combination, which let any website make
+ * authenticated, cookie-bearing requests against this API.
+ *
+ * An origin is allowed when it is either:
+ *   - the API's own base URL (same-origin dashboard/self-host deployments), or
+ *   - a match for one of the project's configured `allowedRedirectUrls`
+ *     (the same allowlist OAuth/email-verification redirects already use).
+ *
+ * When no `allowedRedirectUrls` are configured, this falls back to the prior
+ * permissive behavior (allow all) — matching `AuthConfigService.validateRedirectUrl`'s
+ * own "no policy configured" default — so a fresh install or a project that
+ * hasn't set one up yet keeps working exactly as before. Configuring an
+ * allowlist is what turns real enforcement on.
+ */
+
+const ALLOWLIST_CACHE_MS = 30_000;
+
+let cache: { allowedRedirectUrls: string[]; fetchedAt: number } | null = null;
+let refreshPromise: Promise<string[]> | null = null;
+
+async function getAllowedRedirectUrls(): Promise<string[]> {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < ALLOWLIST_CACHE_MS) {
+    return cache.allowedRedirectUrls;
+  }
+
+  // Coalesce concurrent refreshes into a single DB read.
+  if (!refreshPromise) {
+    refreshPromise = AuthConfigService.getInstance()
+      .getAuthConfig()
+      .then((config) => {
+        const urls = config.allowedRedirectUrls ?? [];
+        cache = { allowedRedirectUrls: urls, fetchedAt: Date.now() };
+        return urls;
+      })
+      .catch((error) => {
+        // A known-good list from a previous fetch is safe to keep serving
+        // (stale allowlist beats treating a transient DB error as "no
+        // allowlist configured", which the caller reads as allow-all). With
+        // no prior successful fetch there is nothing safe to fall back to,
+        // so the error propagates and the caller fails closed instead.
+        if (cache) {
+          logger.error('Failed to refresh CORS allowlist; keeping previous list', { error });
+          return cache.allowedRedirectUrls;
+        }
+        throw error;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+}
+
+/**
+ * Extracts `scheme://host[:port]` from a redirect-URL pattern, discarding any
+ * path/query — an `Origin` header never carries either. `host` may contain a
+ * single leading `*.` wildcard (subdomain match), the same shape
+ * `AuthConfigService.validateRedirectUrl` documents for its glob patterns;
+ * broader glob forms (`**`, `?`, `[...]`) don't have a meaningful analogue for
+ * an origin and are intentionally not supported here.
+ */
+function originFromPattern(pattern: string): { scheme: string; host: string } | null {
+  const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]+)/.exec(pattern);
+  return match ? { scheme: match[1].toLowerCase(), host: match[2].toLowerCase() } : null;
+}
+
+export function originMatchesPattern(pattern: string, origin: string): boolean {
+  const parsedPattern = originFromPattern(pattern);
+  if (!parsedPattern) {
+    return false;
+  }
+
+  let originUrl: URL;
+  try {
+    originUrl = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (originUrl.protocol !== `${parsedPattern.scheme}:`) {
+    return false;
+  }
+
+  const originHost = originUrl.host.toLowerCase(); // includes port
+  if (!parsedPattern.host.includes('*')) {
+    return parsedPattern.host === originHost;
+  }
+  if (parsedPattern.host.startsWith('*.')) {
+    // Matches only actual subdomains, not the bare apex — consistent with
+    // how the same `*.host` shape behaves under `matchesGlobPattern`
+    // (picomatch requires the literal "." before the base host to be
+    // present, so "*.example.com" does not match "example.com" itself).
+    const baseHost = parsedPattern.host.slice(2);
+    return originHost.endsWith(`.${baseHost}`);
+  }
+  return false;
+}
+
+const corsOriginCallback: NonNullable<CorsOptions['origin']> = (origin, callback) => {
+  // No Origin header: same-origin browser requests, curl, mobile/server
+  // clients. The browser CORS check this option controls doesn't apply to them.
+  if (!origin) {
+    return callback(null, true);
+  }
+
+  if (origin === getApiBaseUrl()) {
+    return callback(null, true);
+  }
+
+  getAllowedRedirectUrls()
+    .then((allowedRedirectUrls) => {
+      const allowed =
+        allowedRedirectUrls.length === 0 ||
+        allowedRedirectUrls.some((pattern) => originMatchesPattern(pattern, origin));
+      callback(null, allowed);
+    })
+    .catch((error) => {
+      logger.error('CORS origin check failed, rejecting request', { error, origin });
+      callback(null, false);
+    });
+};
+
+export const corsMiddleware: RequestHandler = cors({
+  origin: corsOriginCallback,
+  credentials: true,
+  exposedHeaders: ['Content-Range', 'Preference-Applied'],
+});

--- a/backend/src/api/middlewares/cors.ts
+++ b/backend/src/api/middlewares/cors.ts
@@ -49,6 +49,12 @@ async function getAllowedRedirectUrls(): Promise<string[]> {
         // so the error propagates and the caller fails closed instead.
         if (cache) {
           logger.error('Failed to refresh CORS allowlist; keeping previous list', { error });
+          // Re-arm the TTL against this failed attempt too, not just a
+          // successful one — otherwise a DB outage past the TTL means every
+          // subsequent request re-enters this branch and issues (and fails)
+          // another DB read, instead of serving the stale list for a full
+          // window before trying again.
+          cache.fetchedAt = Date.now();
           return cache.allowedRedirectUrls;
         }
         throw error;
@@ -60,17 +66,39 @@ async function getAllowedRedirectUrls(): Promise<string[]> {
   return refreshPromise;
 }
 
+// Ports the URL parser (and therefore Origin headers, which always come from
+// a real URL) already omits for these schemes — a pattern that spells one
+// out explicitly (`https://app.example.com:443`) must still match the origin
+// the browser actually sends (`https://app.example.com`).
+const DEFAULT_PORT_BY_SCHEME: Record<string, string> = { 'http:': '80', 'https:': '443' };
+
+function stripDefaultPort(scheme: string, host: string): string {
+  const defaultPort = DEFAULT_PORT_BY_SCHEME[`${scheme}:`];
+  return defaultPort && host.endsWith(`:${defaultPort}`)
+    ? host.slice(0, -(defaultPort.length + 1))
+    : host;
+}
+
 /**
  * Extracts `scheme://host[:port]` from a redirect-URL pattern, discarding any
- * path/query — an `Origin` header never carries either. `host` may contain a
- * single leading `*.` wildcard (subdomain match), the same shape
- * `AuthConfigService.validateRedirectUrl` documents for its glob patterns;
- * broader glob forms (`**`, `?`, `[...]`) don't have a meaningful analogue for
- * an origin and are intentionally not supported here.
+ * path/query — an `Origin` header never carries either. `host` may contain
+ * `*` wildcards anywhere (matching `AuthConfigService`'s own glob patterns,
+ * e.g. `*.example.com` or `*foo.example.com`); broader glob forms (`**`,
+ * `?`, `[...]`) don't have a meaningful analogue for a path-less origin and
+ * are intentionally not supported here.
  */
 function originFromPattern(pattern: string): { scheme: string; host: string } | null {
   const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]+)/.exec(pattern);
-  return match ? { scheme: match[1].toLowerCase(), host: match[2].toLowerCase() } : null;
+  if (!match) {
+    return null;
+  }
+  const scheme = match[1].toLowerCase();
+  return { scheme, host: stripDefaultPort(scheme, match[2].toLowerCase()) };
+}
+
+function hostPatternToRegExp(hostPattern: string): RegExp {
+  const escaped = hostPattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
 }
 
 export function originMatchesPattern(pattern: string, origin: string): boolean {
@@ -89,19 +117,11 @@ export function originMatchesPattern(pattern: string, origin: string): boolean {
     return false;
   }
 
-  const originHost = originUrl.host.toLowerCase(); // includes port
+  const originHost = originUrl.host.toLowerCase(); // URL already omits a default port
   if (!parsedPattern.host.includes('*')) {
     return parsedPattern.host === originHost;
   }
-  if (parsedPattern.host.startsWith('*.')) {
-    // Matches only actual subdomains, not the bare apex — consistent with
-    // how the same `*.host` shape behaves under `matchesGlobPattern`
-    // (picomatch requires the literal "." before the base host to be
-    // present, so "*.example.com" does not match "example.com" itself).
-    const baseHost = parsedPattern.host.slice(2);
-    return originHost.endsWith(`.${baseHost}`);
-  }
-  return false;
+  return hostPatternToRegExp(parsedPattern.host).test(originHost);
 }
 
 const corsOriginCallback: NonNullable<CorsOptions['origin']> = (origin, callback) => {

--- a/backend/src/api/middlewares/frame-ancestors.ts
+++ b/backend/src/api/middlewares/frame-ancestors.ts
@@ -12,6 +12,12 @@ import logger from '@/utils/logger.js';
  * from `https://config.insforge.dev/partnership.json`
  * (frontend/src/cloud-hosting/partner.service.ts), so only that trusted
  * partner — not the entire web — can frame these pages.
+ *
+ * This middleware is mounted globally, ahead of every route including health
+ * checks and webhooks, so it must never make a request wait on the outbound
+ * fetch to config.insforge.dev: it always applies the header synchronously
+ * from whatever is already cached (or 'self' only, before the first fetch
+ * ever completes) and refreshes the cache in the background.
  */
 
 const PARTNERSHIP_CONFIG_URL = 'https://config.insforge.dev/partnership.json';
@@ -19,7 +25,7 @@ const PARTNER_ORIGINS_CACHE_MS = 30_000;
 const FETCH_TIMEOUT_MS = 5_000;
 
 let cache: { partnerOrigins: string[]; fetchedAt: number } | null = null;
-let refreshPromise: Promise<string[]> | null = null;
+let refreshPromise: Promise<void> | null = null;
 
 async function fetchPartnerOrigins(): Promise<string[]> {
   const controller = new AbortController();
@@ -48,61 +54,50 @@ async function fetchPartnerOrigins(): Promise<string[]> {
   }
 }
 
-async function getPartnerOrigins(): Promise<string[]> {
-  const now = Date.now();
-  if (cache && now - cache.fetchedAt < PARTNER_ORIGINS_CACHE_MS) {
-    return cache.partnerOrigins;
+// Kicks off a refresh without making any caller wait on it. Concurrent
+// requests that all see a stale/missing cache in the same tick coalesce into
+// a single outbound fetch instead of each starting their own.
+function refreshPartnerOriginsInBackground(): void {
+  if (refreshPromise) {
+    return;
   }
-
-  // Coalesce concurrent refreshes into a single outbound request.
-  if (!refreshPromise) {
-    refreshPromise = fetchPartnerOrigins()
-      .then((partnerOrigins) => {
-        cache = { partnerOrigins, fetchedAt: Date.now() };
-        return partnerOrigins;
-      })
-      .catch((error) => {
-        // A stale-but-known-good list is safer to keep serving than dropping
-        // the partner from the policy (which would break the embed) or
-        // failing the request outright. With no prior successful fetch there
-        // is nothing to fall back to, so the caller gets an empty list and
-        // the policy degrades to 'self' only until a fetch succeeds.
-        if (cache) {
-          logger.error(
-            'Failed to refresh partner origins for frame-ancestors; keeping previous list',
-            {
-              error,
-            }
-          );
-          cache.fetchedAt = Date.now();
-          return cache.partnerOrigins;
-        }
+  refreshPromise = fetchPartnerOrigins()
+    .then((partnerOrigins) => {
+      cache = { partnerOrigins, fetchedAt: Date.now() };
+    })
+    .catch((error) => {
+      if (cache) {
+        logger.error(
+          'Failed to refresh partner origins for frame-ancestors; keeping previous list',
+          { error }
+        );
+        // Re-arm the TTL against this failed attempt too, so a sustained
+        // outage doesn't retry on every single request.
+        cache.fetchedAt = Date.now();
+      } else {
         logger.error(
           'Failed to fetch partner origins for frame-ancestors; defaulting to self only',
-          {
-            error,
-          }
+          { error }
         );
-        return [];
-      })
-      .finally(() => {
-        refreshPromise = null;
-      });
-  }
-  return refreshPromise;
+      }
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
 }
 
-export const frameAncestorsMiddleware: RequestHandler = (req, res, next) => {
-  getPartnerOrigins()
-    .then((partnerOrigins) => {
-      const sources = ["'self'", ...partnerOrigins];
-      res.setHeader('Content-Security-Policy', `frame-ancestors ${sources.join(' ')}`);
-      next();
-    })
-    .catch(() => {
-      // getPartnerOrigins already degrades internally and should not reject,
-      // but fail closed to 'self' only rather than skip the header entirely.
-      res.setHeader('Content-Security-Policy', "frame-ancestors 'self'");
-      next();
-    });
+function getCachedPartnerOrigins(): string[] {
+  const now = Date.now();
+  if (!cache || now - cache.fetchedAt >= PARTNER_ORIGINS_CACHE_MS) {
+    refreshPartnerOriginsInBackground();
+  }
+  // Serve whatever is cached right now (possibly stale, possibly empty on
+  // the very first request) rather than waiting on the refresh above.
+  return cache?.partnerOrigins ?? [];
+}
+
+export const frameAncestorsMiddleware: RequestHandler = (_req, res, next) => {
+  const sources = ["'self'", ...getCachedPartnerOrigins()];
+  res.setHeader('Content-Security-Policy', `frame-ancestors ${sources.join(' ')}`);
+  next();
 };

--- a/backend/src/api/middlewares/frame-ancestors.ts
+++ b/backend/src/api/middlewares/frame-ancestors.ts
@@ -1,0 +1,108 @@
+import { RequestHandler } from 'express';
+import logger from '@/utils/logger.js';
+
+/**
+ * Restores frame-ancestors protection that plain `frameguard: false` removed
+ * entirely. The cloud-hosting partner embeds the dashboard in a cross-origin
+ * iframe (frontend/src/cloud-hosting/useCloudHosting.ts), so a blanket
+ * X-Frame-Options/CSP frame-ancestors block would break that supported flow —
+ * but allowing every origin to frame the authenticated dashboard is a
+ * clickjacking hole. This builds a `frame-ancestors` CSP value scoped to
+ * `'self'` plus the same trusted partner origins the frontend already reads
+ * from `https://config.insforge.dev/partnership.json`
+ * (frontend/src/cloud-hosting/partner.service.ts), so only that trusted
+ * partner — not the entire web — can frame these pages.
+ */
+
+const PARTNERSHIP_CONFIG_URL = 'https://config.insforge.dev/partnership.json';
+const PARTNER_ORIGINS_CACHE_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+
+let cache: { partnerOrigins: string[]; fetchedAt: number } | null = null;
+let refreshPromise: Promise<string[]> | null = null;
+
+async function fetchPartnerOrigins(): Promise<string[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(PARTNERSHIP_CONFIG_URL, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Unexpected status ${response.status}`);
+    }
+    const data = (await response.json()) as { partner_sites?: unknown };
+    const sites = Array.isArray(data.partner_sites) ? data.partner_sites : [];
+    const origins = new Set<string>();
+    for (const site of sites) {
+      if (typeof site !== 'string') {
+        continue;
+      }
+      try {
+        origins.add(new URL(site).origin);
+      } catch {
+        // Skip malformed entries rather than failing the whole fetch.
+      }
+    }
+    return [...origins];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getPartnerOrigins(): Promise<string[]> {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < PARTNER_ORIGINS_CACHE_MS) {
+    return cache.partnerOrigins;
+  }
+
+  // Coalesce concurrent refreshes into a single outbound request.
+  if (!refreshPromise) {
+    refreshPromise = fetchPartnerOrigins()
+      .then((partnerOrigins) => {
+        cache = { partnerOrigins, fetchedAt: Date.now() };
+        return partnerOrigins;
+      })
+      .catch((error) => {
+        // A stale-but-known-good list is safer to keep serving than dropping
+        // the partner from the policy (which would break the embed) or
+        // failing the request outright. With no prior successful fetch there
+        // is nothing to fall back to, so the caller gets an empty list and
+        // the policy degrades to 'self' only until a fetch succeeds.
+        if (cache) {
+          logger.error(
+            'Failed to refresh partner origins for frame-ancestors; keeping previous list',
+            {
+              error,
+            }
+          );
+          cache.fetchedAt = Date.now();
+          return cache.partnerOrigins;
+        }
+        logger.error(
+          'Failed to fetch partner origins for frame-ancestors; defaulting to self only',
+          {
+            error,
+          }
+        );
+        return [];
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+}
+
+export const frameAncestorsMiddleware: RequestHandler = (req, res, next) => {
+  getPartnerOrigins()
+    .then((partnerOrigins) => {
+      const sources = ["'self'", ...partnerOrigins];
+      res.setHeader('Content-Security-Policy', `frame-ancestors ${sources.join(' ')}`);
+      next();
+    })
+    .catch(() => {
+      // getPartnerOrigins already degrades internally and should not reject,
+      // but fail closed to 'self' only rather than skip the header entirely.
+      res.setHeader('Content-Security-Policy', "frame-ancestors 'self'");
+      next();
+    });
+};

--- a/backend/src/api/middlewares/frame-ancestors.ts
+++ b/backend/src/api/middlewares/frame-ancestors.ts
@@ -16,8 +16,12 @@ import logger from '@/utils/logger.js';
  * This middleware is mounted globally, ahead of every route including health
  * checks and webhooks, so it must never make a request wait on the outbound
  * fetch to config.insforge.dev: it always applies the header synchronously
- * from whatever is already cached (or 'self' only, before the first fetch
- * ever completes) and refreshes the cache in the background.
+ * from whatever is already cached and refreshes the cache in the background.
+ * `warmPartnerOriginsCache()` is awaited once at server startup (see
+ * server.ts) so the cache is already populated before the first real
+ * request arrives — including the partner's own dashboard-embedding
+ * request — instead of that first request racing the background fetch and
+ * getting a 'self'-only policy it can never recover from.
  */
 
 const PARTNERSHIP_CONFIG_URL = 'https://config.insforge.dev/partnership.json';
@@ -54,12 +58,13 @@ async function fetchPartnerOrigins(): Promise<string[]> {
   }
 }
 
-// Kicks off a refresh without making any caller wait on it. Concurrent
-// requests that all see a stale/missing cache in the same tick coalesce into
-// a single outbound fetch instead of each starting their own.
-function refreshPartnerOriginsInBackground(): void {
+// Kicks off a refresh and returns the promise so callers that want to await
+// it (server startup) can, while callers on the request path can fire it and
+// move on without waiting. Concurrent callers that all see a stale/missing
+// cache in the same tick coalesce into a single outbound fetch.
+function refreshPartnerOrigins(): Promise<void> {
   if (refreshPromise) {
-    return;
+    return refreshPromise;
   }
   refreshPromise = fetchPartnerOrigins()
     .then((partnerOrigins) => {
@@ -79,21 +84,40 @@ function refreshPartnerOriginsInBackground(): void {
           'Failed to fetch partner origins for frame-ancestors; defaulting to self only',
           { error }
         );
+        // Cache the empty result too (also re-armed on the same TTL) —
+        // otherwise every request during an outage would see `cache` still
+        // null and kick off yet another fetch of its own once this one
+        // settles.
+        cache = { partnerOrigins: [], fetchedAt: Date.now() };
       }
     })
     .finally(() => {
       refreshPromise = null;
     });
+  return refreshPromise;
 }
 
 function getCachedPartnerOrigins(): string[] {
   const now = Date.now();
   if (!cache || now - cache.fetchedAt >= PARTNER_ORIGINS_CACHE_MS) {
-    refreshPartnerOriginsInBackground();
+    // Fire-and-forget: the request path must not wait on this.
+    void refreshPartnerOrigins();
   }
-  // Serve whatever is cached right now (possibly stale, possibly empty on
-  // the very first request) rather than waiting on the refresh above.
+  // Serve whatever is cached right now (possibly stale) rather than waiting
+  // on the refresh above.
   return cache?.partnerOrigins ?? [];
+}
+
+/**
+ * Awaited once during server startup (before the app starts accepting
+ * connections) so the very first request — which may itself be the
+ * partner's iframe load — already sees a warm cache instead of racing a
+ * background fetch it has no way to recover from. Failure here is not
+ * fatal: it just means the server starts with the same 'self'-only fallback
+ * the request-path refresh would have produced anyway.
+ */
+export async function warmPartnerOriginsCache(): Promise<void> {
+  await refreshPartnerOrigins();
 }
 
 export const frameAncestorsMiddleware: RequestHandler = (_req, res, next) => {

--- a/backend/src/api/middlewares/helmet.ts
+++ b/backend/src/api/middlewares/helmet.ts
@@ -23,4 +23,10 @@ export const helmetMiddleware: RequestHandler = helmet({
   // packages/dashboard/src/layout/AppLayout.tsx). This keeps the isolation
   // benefit for same-origin popups while still allowing that bridge.
   crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
+  // Helmet's default X-Frame-Options ('SAMEORIGIN') would stop the dashboard
+  // from rendering at all in the cloud-hosting partner's cross-origin parent
+  // iframe — useCloudHosting.ts documents that PROJECT_INFO only ever
+  // arrives from a parent iframe, i.e. that embed is a supported, expected
+  // flow, not something to guard against.
+  frameguard: false,
 });

--- a/backend/src/api/middlewares/helmet.ts
+++ b/backend/src/api/middlewares/helmet.ts
@@ -1,0 +1,26 @@
+import helmet from 'helmet';
+import { RequestHandler } from 'express';
+
+/**
+ * Extracted into its own module (rather than inlined in server.ts) so the
+ * regression test in helmet-security-headers.test.ts can import and exercise
+ * this exact configuration — a copy hand-duplicated in the test would keep
+ * passing even if this one drifted or regressed.
+ */
+export const helmetMiddleware: RequestHandler = helmet({
+  // The dashboard SPA and client apps embed third-party scripts/styles/images
+  // this project doesn't control, so a strict default CSP would break them;
+  // this hardening is scoped to the explicit header list below instead.
+  contentSecurityPolicy: false,
+  // Storage objects and API responses are deliberately fetched cross-origin
+  // by client apps (that's the point of a hosted backend), so the
+  // same-origin default here would break exactly the traffic this API serves.
+  crossOriginResourcePolicy: false,
+  crossOriginEmbedderPolicy: false,
+  // Helmet's default ('same-origin') severs `window.opener` for a popup
+  // opened from a different origin, breaking the cloud-hosting dashboard's
+  // opener-messaging bridge (frontend/src/cloud-hosting/useCloudHosting.ts,
+  // packages/dashboard/src/layout/AppLayout.tsx). This keeps the isolation
+  // benefit for same-origin popups while still allowing that bridge.
+  crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
+});

--- a/backend/src/api/middlewares/helmet.ts
+++ b/backend/src/api/middlewares/helmet.ts
@@ -27,6 +27,10 @@ export const helmetMiddleware: RequestHandler = helmet({
   // from rendering at all in the cloud-hosting partner's cross-origin parent
   // iframe — useCloudHosting.ts documents that PROJECT_INFO only ever
   // arrives from a parent iframe, i.e. that embed is a supported, expected
-  // flow, not something to guard against.
+  // flow, not something to guard against. X-Frame-Options has no origin-list
+  // form, so it can't express "this partner, not everyone" — real framing
+  // protection comes from the scoped `frame-ancestors` CSP directive set by
+  // frameAncestorsMiddleware (mounted alongside this in server.ts), which
+  // modern browsers honor in preference to X-Frame-Options anyway.
   frameguard: false,
 });

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -269,10 +269,29 @@ router.post(
         res.setHeader('Connection', 'keep-alive');
 
         // Create and process the stream
+        let aborted = false;
+        let streamGenerator: ReturnType<typeof chatService.streamChat> | undefined;
+        const onClientClose = () => {
+          aborted = true;
+          // Actively cancel rather than waiting for the loop below to notice:
+          // `for await` only re-checks `aborted` once the generator's current
+          // `.next()` settles, which for a generator suspended mid-await (the
+          // common case — it's waiting on the next chunk from the upstream
+          // provider) could be seconds away. Calling `.return()` here queues
+          // the cancellation to take effect the moment that settles, instead
+          // of after it produces a further chunk nobody will read. `for await`
+          // would call this same `.return()` on `break`, but only afterwards.
+          void streamGenerator?.return(undefined);
+        };
+        res.on('close', onClientClose);
+
         try {
-          const streamGenerator = chatService.streamChat(messages, options);
+          streamGenerator = chatService.streamChat(messages, options);
 
           for await (const data of streamGenerator) {
+            if (aborted) {
+              break;
+            }
             if (data.chunk) {
               res.write(`data: ${JSON.stringify({ chunk: data.chunk })}\n\n`);
             }
@@ -287,20 +306,28 @@ router.post(
             }
           }
 
-          // Send completion signal
-          res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
+          if (!aborted) {
+            // Send completion signal
+            res.write(`data: ${JSON.stringify({ done: true })}\n\n`);
+          }
         } catch (streamError) {
           // If error occurs during streaming, send it in SSE format
           logger.error('Stream error during chat completion', {
             error: streamError instanceof Error ? streamError.message : String(streamError),
             stack: streamError instanceof Error ? streamError.stack : undefined,
           });
-          res.write(
-            `data: ${JSON.stringify({ error: true, message: streamError instanceof Error ? streamError.message : String(streamError) })}\n\n`
-          );
+          if (!aborted) {
+            res.write(
+              `data: ${JSON.stringify({ error: true, message: streamError instanceof Error ? streamError.message : String(streamError) })}\n\n`
+            );
+          }
+        } finally {
+          res.off('close', onClientClose);
         }
 
-        res.end();
+        if (!aborted) {
+          res.end();
+        }
         return;
       }
 

--- a/backend/src/api/routes/ai/index.routes.ts
+++ b/backend/src/api/routes/ai/index.routes.ts
@@ -271,22 +271,28 @@ router.post(
         // Create and process the stream
         let aborted = false;
         let streamGenerator: ReturnType<typeof chatService.streamChat> | undefined;
+        const abortController = new AbortController();
         const onClientClose = () => {
           aborted = true;
-          // Actively cancel rather than waiting for the loop below to notice:
-          // `for await` only re-checks `aborted` once the generator's current
-          // `.next()` settles, which for a generator suspended mid-await (the
-          // common case — it's waiting on the next chunk from the upstream
-          // provider) could be seconds away. Calling `.return()` here queues
-          // the cancellation to take effect the moment that settles, instead
-          // of after it produces a further chunk nobody will read. `for await`
-          // would call this same `.return()` on `break`, but only afterwards.
+          // This is the cancellation that actually matters: `streamChat`
+          // passes this signal straight to the OpenAI SDK call, which aborts
+          // the in-flight upstream fetch. Calling `.return()` on the outer
+          // generator is NOT enough on its own — a plain async generator
+          // suspended awaiting its inner `for await` (i.e. waiting on the
+          // next upstream chunk, the common case) can't be preempted by
+          // `.return()`; that only takes effect once the pending read
+          // settles, by which point the upstream request has already run to
+          // completion regardless (verified empirically: a nested-generator
+          // `.return()` while the inner iterable's `.next()` is in flight
+          // does not propagate to the inner iterable until it resolves on
+          // its own). Aborting the underlying fetch is what stops it.
+          abortController.abort();
           void streamGenerator?.return(undefined);
         };
         res.on('close', onClientClose);
 
         try {
-          streamGenerator = chatService.streamChat(messages, options);
+          streamGenerator = chatService.streamChat(messages, options, abortController.signal);
 
           for await (const data of streamGenerator) {
             if (aborted) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -26,7 +26,10 @@ import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { corsMiddleware } from '@/api/middlewares/cors.js';
 import { helmetMiddleware } from '@/api/middlewares/helmet.js';
-import { frameAncestorsMiddleware } from '@/api/middlewares/frame-ancestors.js';
+import {
+  frameAncestorsMiddleware,
+  warmPartnerOriginsCache,
+} from '@/api/middlewares/frame-ancestors.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
@@ -86,6 +89,12 @@ export async function createApp() {
 
   // Initialize SQL parser WASM module
   await initSqlParser();
+
+  // Warm the frame-ancestors partner-origin cache before accepting
+  // connections, so the first real request (which may be the partner's own
+  // dashboard-embedding iframe load) doesn't race the background refresh
+  // and get stuck with a 'self'-only policy it can never recover from.
+  await warmPartnerOriginsCache();
 
   const app = express();
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -26,6 +26,7 @@ import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { corsMiddleware } from '@/api/middlewares/cors.js';
 import { helmetMiddleware } from '@/api/middlewares/helmet.js';
+import { frameAncestorsMiddleware } from '@/api/middlewares/frame-ancestors.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
@@ -93,6 +94,7 @@ export async function createApp() {
 
   // Basic middleware
   app.use(helmetMiddleware);
+  app.use(frameAncestorsMiddleware);
   app.use(corsMiddleware);
   app.use(cookieParser()); // Parse cookies for refresh token handling
   app.use((req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -103,6 +103,12 @@ export async function createApp() {
       // same-origin default here would break exactly the traffic this API serves.
       crossOriginResourcePolicy: false,
       crossOriginEmbedderPolicy: false,
+      // Helmet's default ('same-origin') severs `window.opener` for a popup
+      // opened from a different origin, breaking the cloud-hosting dashboard's
+      // opener-messaging bridge (frontend/src/cloud-hosting/useCloudHosting.ts,
+      // packages/dashboard/src/layout/AppLayout.tsx). This keeps the isolation
+      // benefit for same-origin popups while still allowing that bridge.
+      crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
     })
   );
   app.use(corsMiddleware);
@@ -312,11 +318,13 @@ export async function createApp() {
         responseHeaders[key] = value;
       }
 
-      res
-        .status(response.status)
-        .set(responseHeaders)
-        .set('Access-Control-Allow-Origin', '*')
-        .send(responseBody);
+      // No explicit Access-Control-Allow-Origin here: this used to hardcode
+      // `*`, silently overriding whatever `corsMiddleware` (mounted above)
+      // had already decided for the request's actual Origin — bypassing a
+      // configured allowlist for this one legacy route. Leaving the header
+      // corsMiddleware already set on the response keeps this route
+      // consistent with the rest of the API.
+      res.status(response.status).set(responseHeaders).send(responseBody);
     } catch (error) {
       logger.error('Failed to proxy function', { slug, error: String(error) });
       res.status(502).json({ error: error instanceof Error ? error.message : String(error) });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
-import cors from 'cors';
+import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
 import path from 'path';
@@ -25,6 +25,7 @@ import { s3GatewayRouter } from '@/api/routes/s3-gateway/index.routes.js';
 import { paymentsRouter } from '@/api/routes/payments/index.routes.js';
 import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
+import { corsMiddleware } from '@/api/middlewares/cors.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
@@ -92,12 +93,19 @@ export async function createApp() {
 
   // Basic middleware
   app.use(
-    cors({
-      origin: true, // Allow all origins (matches Better Auth's trustedOrigins: ['*'])
-      credentials: true, // Allow cookies/credentials
-      exposedHeaders: ['Content-Range', 'Preference-Applied'],
+    helmet({
+      // The dashboard SPA and client apps embed third-party scripts/styles/images
+      // this project doesn't control, so a strict default CSP would break them;
+      // this hardening is scoped to the explicit header list below instead.
+      contentSecurityPolicy: false,
+      // Storage objects and API responses are deliberately fetched cross-origin
+      // by client apps (that's the point of a hosted backend), so the
+      // same-origin default here would break exactly the traffic this API serves.
+      crossOriginResourcePolicy: false,
+      crossOriginEmbedderPolicy: false,
     })
   );
+  app.use(corsMiddleware);
   app.use(cookieParser()); // Parse cookies for refresh token handling
   app.use((req: Request, res: Response, next: NextFunction) => {
     const startTime = Date.now();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response, NextFunction } from 'express';
-import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import dotenv from 'dotenv';
 import path from 'path';
@@ -26,6 +25,7 @@ import { paymentsRouter } from '@/api/routes/payments/index.routes.js';
 import { advisorRouter } from '@/api/routes/advisor/index.routes.js';
 import { errorMiddleware } from '@/api/middlewares/error.js';
 import { corsMiddleware } from '@/api/middlewares/cors.js';
+import { helmetMiddleware } from '@/api/middlewares/helmet.js';
 import { destroyEmailCooldownInterval } from '@/api/middlewares/rate-limiters.js';
 import { isCloudEnvironment } from '@/utils/environment.js';
 import { RealtimeManager } from '@/infra/realtime/realtime.manager.js';
@@ -92,25 +92,7 @@ export async function createApp() {
   app.set('trust proxy', appConfig.server.trustProxy);
 
   // Basic middleware
-  app.use(
-    helmet({
-      // The dashboard SPA and client apps embed third-party scripts/styles/images
-      // this project doesn't control, so a strict default CSP would break them;
-      // this hardening is scoped to the explicit header list below instead.
-      contentSecurityPolicy: false,
-      // Storage objects and API responses are deliberately fetched cross-origin
-      // by client apps (that's the point of a hosted backend), so the
-      // same-origin default here would break exactly the traffic this API serves.
-      crossOriginResourcePolicy: false,
-      crossOriginEmbedderPolicy: false,
-      // Helmet's default ('same-origin') severs `window.opener` for a popup
-      // opened from a different origin, breaking the cloud-hosting dashboard's
-      // opener-messaging bridge (frontend/src/cloud-hosting/useCloudHosting.ts,
-      // packages/dashboard/src/layout/AppLayout.tsx). This keeps the isolation
-      // benefit for same-origin popups while still allowing that bridge.
-      crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
-    })
-  );
+  app.use(helmetMiddleware);
   app.use(corsMiddleware);
   app.use(cookieParser()); // Parse cookies for refresh token handling
   app.use((req: Request, res: Response, next: NextFunction) => {
@@ -308,10 +290,22 @@ export async function createApp() {
       // - connection: hop-by-hop header
       // - content-encoding: node-fetch already decompresses the response,
       //   so we must not tell the client it's still compressed
+      // - access-control-allow-origin/-credentials: an edge function's own
+      //   CORS headers (several example functions set these) must not
+      //   override what corsMiddleware already decided for this request's
+      //   actual Origin — forwarding them would let any function reopen the
+      //   allowlist this PR exists to enforce, on this one legacy route.
       const responseHeaders: Record<string, string> = {};
       for (const [key, value] of response.headers.entries()) {
         if (
-          ['transfer-encoding', 'content-length', 'connection', 'content-encoding'].includes(key)
+          [
+            'transfer-encoding',
+            'content-length',
+            'connection',
+            'content-encoding',
+            'access-control-allow-origin',
+            'access-control-allow-credentials',
+          ].includes(key)
         ) {
           continue;
         }

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -474,7 +474,12 @@ export class ChatCompletionService {
     } catch (error) {
       // Deliberate cancellation (client disconnected), not a failure — the
       // caller already knows and doesn't need this surfaced as an error.
+      // Still logged (not as an error) so a genuine upstream failure that
+      // happened to coincide with the disconnect isn't silently invisible.
       if (signal?.aborted) {
+        logger.info('Stream aborted on client disconnect', {
+          error: error instanceof Error ? error.message : String(error),
+        });
         return;
       }
       if (error instanceof AppError) {

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -386,10 +386,9 @@ export class ChatCompletionService {
 
       // Send request with upstream error mapping
       const { result: stream } = await this.openRouterProvider.sendRequest((client) =>
-        client.chat.completions.create(
-          request as OpenAI.Chat.ChatCompletionCreateParamsStreaming,
-          { signal }
-        )
+        client.chat.completions.create(request as OpenAI.Chat.ChatCompletionCreateParamsStreaming, {
+          signal,
+        })
       );
 
       const tokenUsage = {

--- a/backend/src/services/ai/chat-completion.service.ts
+++ b/backend/src/services/ai/chat-completion.service.ts
@@ -340,10 +340,18 @@ export class ChatCompletionService {
    * Stream a chat response
    * @param messages - Array of messages for conversation
    * @param options - Chat options including model, temperature, webSearch, thinking, etc.
+   * @param signal - Aborts the in-flight upstream request (e.g. on client disconnect).
+   *   Passed straight to the OpenAI SDK call rather than only relied on via
+   *   generator `.return()`: a plain async generator suspended awaiting the
+   *   next upstream chunk can't be preempted by `.return()` — it only takes
+   *   effect once that pending read settles — so without this, cancelling
+   *   the route's loop stops it from requesting further chunks but leaves
+   *   the current upstream request running to completion regardless.
    */
   async *streamChat(
     messages: ChatMessageSchema[],
-    options: ChatCompletionOptions
+    options: ChatCompletionOptions,
+    signal?: AbortSignal
   ): AsyncGenerator<{
     chunk?: string;
     tokenUsage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number };
@@ -378,7 +386,10 @@ export class ChatCompletionService {
 
       // Send request with upstream error mapping
       const { result: stream } = await this.openRouterProvider.sendRequest((client) =>
-        client.chat.completions.create(request as OpenAI.Chat.ChatCompletionCreateParamsStreaming)
+        client.chat.completions.create(
+          request as OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+          { signal }
+        )
       );
 
       const tokenUsage = {
@@ -462,6 +473,11 @@ export class ChatCompletionService {
         yield { annotations: collectedAnnotations };
       }
     } catch (error) {
+      // Deliberate cancellation (client disconnected), not a failure — the
+      // caller already knows and doesn't need this surfaced as an error.
+      if (signal?.aborted) {
+        return;
+      }
       if (error instanceof AppError) {
         throw error;
       }

--- a/backend/tests/unit/ai-streaming-disconnect.test.ts
+++ b/backend/tests/unit/ai-streaming-disconnect.test.ts
@@ -1,0 +1,175 @@
+import http from 'http';
+import express from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression test for issue #1895 (SSE Disconnect Token/Resource Leak): a
+ * client disconnecting mid-stream from POST /api/ai/chat/completion used to
+ * leave the server-side `for await` loop over the upstream provider stream
+ * running to completion, continuing to consume AI tokens against a socket
+ * nobody was reading.
+ *
+ * This spins up a real HTTP server (so the client can actually sever the
+ * TCP connection) with a fake upstream generator standing in for the AI
+ * provider stream, and asserts that destroying the client connection causes
+ * the server to stop pulling further chunks from that generator.
+ */
+
+vi.hoisted(() => {
+  process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
+});
+
+vi.mock('../../src/api/middlewares/auth.js', () => ({
+  verifyAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
+  verifyUser: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../../src/services/ai/image-generation.service.js', () => ({
+  ImageGenerationService: { getInstance: () => ({}) },
+}));
+vi.mock('../../src/services/ai/embedding.service.js', () => ({
+  EmbeddingService: { getInstance: () => ({}) },
+}));
+vi.mock('../../src/services/ai/ai-model.service.js', () => ({
+  AIModelService: { getInstance: () => ({}) },
+}));
+vi.mock('../../src/providers/ai/openrouter.provider.js', () => ({
+  OpenRouterProvider: { getInstance: () => ({}) },
+}));
+
+// A plain async generator can't be preempted mid-await by `.return()` — the
+// spec only lets `.return()` take effect once a call to `.next()` that's
+// already in flight settles (verified empirically; see PR description). The
+// real OpenAI SDK stream this route consumes isn't a plain generator: its
+// `.return()` aborts the underlying fetch via an AbortController, which
+// makes an *already pending* `.next()` settle early instead of producing a
+// further chunk. Modelling that (rather than a plain `async function*`) is
+// what actually exercises "does the route cancel promptly on disconnect".
+const generatorState = vi.hoisted(() => ({
+  returnCalled: false,
+  producedSecondChunk: false,
+}));
+
+let releaseSecondChunk: (() => void) | null = null;
+let cancelPending: (() => void) | null = null;
+
+function createFakeUpstreamStream() {
+  const secondChunkReady = new Promise<'chunk'>((resolve) => {
+    releaseSecondChunk = () => resolve('chunk');
+  });
+  const cancelled = new Promise<'cancelled'>((resolve) => {
+    cancelPending = () => resolve('cancelled');
+  });
+
+  let callCount = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next() {
+      callCount += 1;
+      if (callCount === 1) {
+        return { value: { chunk: 'first' }, done: false };
+      }
+      const winner = await Promise.race([secondChunkReady, cancelled]);
+      if (winner === 'cancelled') {
+        return { value: undefined, done: true };
+      }
+      generatorState.producedSecondChunk = true;
+      return { value: { chunk: 'second' }, done: false };
+    },
+    async return(value: unknown) {
+      generatorState.returnCalled = true;
+      cancelPending?.();
+      return { value, done: true };
+    },
+  };
+}
+
+vi.mock('../../src/services/ai/chat-completion.service.js', () => ({
+  ChatCompletionService: {
+    getInstance: () => ({
+      streamChat: () => createFakeUpstreamStream(),
+    }),
+  },
+}));
+
+describe('POST /api/ai/chat/completion — client disconnect mid-stream', () => {
+  beforeEach(() => {
+    generatorState.returnCalled = false;
+    generatorState.producedSecondChunk = false;
+  });
+
+  it('stops pulling from the upstream stream once the client disconnects', async () => {
+    const { aiRouter } = await import('../../src/api/routes/ai/index.routes.js');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/ai', aiRouter);
+
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected a bound TCP address');
+    }
+
+    try {
+      const body = JSON.stringify({
+        model: 'openai/gpt-4o',
+        messages: [{ role: 'user', content: 'Hi' }],
+        stream: true,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        const clientReq = http.request(
+          {
+            host: '127.0.0.1',
+            port: address.port,
+            path: '/api/ai/chat/completion',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(body),
+            },
+          },
+          (res) => {
+            res.on('data', () => {
+              // Received the first SSE chunk — sever the connection now,
+              // while the fake upstream's second `.next()` call is pending
+              // (racing `secondChunkReady` against `cancelled`).
+              clientReq.destroy();
+            });
+          }
+        );
+        clientReq.on('error', () => {
+          // Expected: destroying the request surfaces as a socket error on
+          // the client side (ECONNRESET or similar) — not a test failure.
+          resolve();
+        });
+        clientReq.on('close', () => resolve());
+        clientReq.on('timeout', () => reject(new Error('Request timed out')));
+        clientReq.write(body);
+        clientReq.end();
+      });
+
+      // Let the server-side 'close' listener run and call `.return()` before
+      // asserting. Then release the "real chunk" side of the race too — if
+      // the route had NOT cancelled, this is what would let a real upstream
+      // eventually produce the second chunk; asserting first proves the
+      // cancellation (not this release) is what ended the pending call.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(generatorState.returnCalled).toBe(true);
+      expect(generatorState.producedSecondChunk).toBe(false);
+
+      releaseSecondChunk?.();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(generatorState.producedSecondChunk).toBe(false);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/backend/tests/unit/ai-streaming-disconnect.test.ts
+++ b/backend/tests/unit/ai-streaming-disconnect.test.ts
@@ -96,11 +96,8 @@ async function* fakeUpstreamStream(signal?: AbortSignal) {
 vi.mock('../../src/services/ai/chat-completion.service.js', () => ({
   ChatCompletionService: {
     getInstance: () => ({
-      streamChat: (
-        _messages: unknown,
-        _options: unknown,
-        signal?: AbortSignal
-      ) => fakeUpstreamStream(signal),
+      streamChat: (_messages: unknown, _options: unknown, signal?: AbortSignal) =>
+        fakeUpstreamStream(signal),
     }),
   },
 }));

--- a/backend/tests/unit/ai-streaming-disconnect.test.ts
+++ b/backend/tests/unit/ai-streaming-disconnect.test.ts
@@ -5,14 +5,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 /**
  * Regression test for issue #1895 (SSE Disconnect Token/Resource Leak): a
  * client disconnecting mid-stream from POST /api/ai/chat/completion used to
- * leave the server-side `for await` loop over the upstream provider stream
- * running to completion, continuing to consume AI tokens against a socket
- * nobody was reading.
+ * leave the server-side upstream request running to completion, continuing
+ * to consume AI tokens against a socket nobody was reading.
+ *
+ * The route cancels via an `AbortSignal` passed into `streamChat`, not via
+ * calling `.return()` on the generator: a plain async generator suspended
+ * awaiting its inner `for await` (waiting on the next upstream chunk, the
+ * common case) can't be preempted by `.return()` — verified empirically
+ * (see the PR description) that it only takes effect once that pending read
+ * settles on its own, by which point the upstream request already ran to
+ * completion regardless. The fake upstream below is a real `async
+ * function*` — like the production `ChatCompletionService.streamChat` — that
+ * reacts to the signal the same way a `fetch`-backed SDK call would, so this
+ * exercises the mechanism that actually matters.
  *
  * This spins up a real HTTP server (so the client can actually sever the
- * TCP connection) with a fake upstream generator standing in for the AI
- * provider stream, and asserts that destroying the client connection causes
- * the server to stop pulling further chunks from that generator.
+ * TCP connection) rather than mocking Express, so the 'close' event fires
+ * from a genuine socket teardown, not a simulated one.
  */
 
 vi.hoisted(() => {
@@ -41,70 +50,69 @@ vi.mock('../../src/providers/ai/openrouter.provider.js', () => ({
   OpenRouterProvider: { getInstance: () => ({}) },
 }));
 
-// A plain async generator can't be preempted mid-await by `.return()` — the
-// spec only lets `.return()` take effect once a call to `.next()` that's
-// already in flight settles (verified empirically; see PR description). The
-// real OpenAI SDK stream this route consumes isn't a plain generator: its
-// `.return()` aborts the underlying fetch via an AbortController, which
-// makes an *already pending* `.next()` settle early instead of producing a
-// further chunk. Modelling that (rather than a plain `async function*`) is
-// what actually exercises "does the route cancel promptly on disconnect".
 const generatorState = vi.hoisted(() => ({
-  returnCalled: false,
+  sawAbortedSignal: false,
   producedSecondChunk: false,
+  finallyRan: false,
 }));
 
 let releaseSecondChunk: (() => void) | null = null;
-let cancelPending: (() => void) | null = null;
 
-function createFakeUpstreamStream() {
-  const secondChunkReady = new Promise<'chunk'>((resolve) => {
-    releaseSecondChunk = () => resolve('chunk');
-  });
-  const cancelled = new Promise<'cancelled'>((resolve) => {
-    cancelPending = () => resolve('cancelled');
-  });
+// Stands in for ChatCompletionService.streamChat: an `await` that only
+// settles when either a real chunk arrives (`releaseSecondChunk`, standing in
+// for the network) or `signal` aborts — the same race a `fetch`/OpenAI SDK
+// call under an AbortSignal resolves.
+async function* fakeUpstreamStream(signal?: AbortSignal) {
+  try {
+    yield { chunk: 'first' };
 
-  let callCount = 0;
-  return {
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-    async next() {
-      callCount += 1;
-      if (callCount === 1) {
-        return { value: { chunk: 'first' }, done: false };
+    await new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
       }
-      const winner = await Promise.race([secondChunkReady, cancelled]);
-      if (winner === 'cancelled') {
-        return { value: undefined, done: true };
-      }
-      generatorState.producedSecondChunk = true;
-      return { value: { chunk: 'second' }, done: false };
-    },
-    async return(value: unknown) {
-      generatorState.returnCalled = true;
-      cancelPending?.();
-      return { value, done: true };
-    },
-  };
+      const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+      signal?.addEventListener('abort', onAbort, { once: true });
+      releaseSecondChunk = () => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      };
+    });
+
+    generatorState.producedSecondChunk = true;
+    yield { chunk: 'second' };
+  } catch (error) {
+    // Mirrors ChatCompletionService.streamChat's own catch: a deliberate
+    // abort ends the generator cleanly rather than surfacing as an error.
+    if (!(signal?.aborted && error instanceof DOMException)) {
+      throw error;
+    }
+    generatorState.sawAbortedSignal = true;
+  } finally {
+    generatorState.finallyRan = true;
+  }
 }
 
 vi.mock('../../src/services/ai/chat-completion.service.js', () => ({
   ChatCompletionService: {
     getInstance: () => ({
-      streamChat: () => createFakeUpstreamStream(),
+      streamChat: (
+        _messages: unknown,
+        _options: unknown,
+        signal?: AbortSignal
+      ) => fakeUpstreamStream(signal),
     }),
   },
 }));
 
 describe('POST /api/ai/chat/completion — client disconnect mid-stream', () => {
   beforeEach(() => {
-    generatorState.returnCalled = false;
+    generatorState.sawAbortedSignal = false;
     generatorState.producedSecondChunk = false;
+    generatorState.finallyRan = false;
   });
 
-  it('stops pulling from the upstream stream once the client disconnects', async () => {
+  it('aborts the in-flight upstream request once the client disconnects', async () => {
     const { aiRouter } = await import('../../src/api/routes/ai/index.routes.js');
     const app = express();
     app.use(express.json());
@@ -139,8 +147,8 @@ describe('POST /api/ai/chat/completion — client disconnect mid-stream', () => 
           (res) => {
             res.on('data', () => {
               // Received the first SSE chunk — sever the connection now,
-              // while the fake upstream's second `.next()` call is pending
-              // (racing `secondChunkReady` against `cancelled`).
+              // while the fake upstream is suspended awaiting the second
+              // chunk (i.e. mid-request, same as a real slow upstream).
               clientReq.destroy();
             });
           }
@@ -156,13 +164,15 @@ describe('POST /api/ai/chat/completion — client disconnect mid-stream', () => 
         clientReq.end();
       });
 
-      // Let the server-side 'close' listener run and call `.return()` before
-      // asserting. Then release the "real chunk" side of the race too — if
-      // the route had NOT cancelled, this is what would let a real upstream
-      // eventually produce the second chunk; asserting first proves the
-      // cancellation (not this release) is what ended the pending call.
+      // Let the server-side 'close' listener fire and the abort propagate
+      // through the fake upstream's pending await before asserting. Only
+      // then release the "real chunk" side of the race — if the route had
+      // NOT aborted, this is what would let a real upstream eventually
+      // produce the second chunk, so asserting first proves the abort (not
+      // this release) is what ended the pending request.
       await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(generatorState.returnCalled).toBe(true);
+      expect(generatorState.sawAbortedSignal).toBe(true);
+      expect(generatorState.finallyRan).toBe(true);
       expect(generatorState.producedSecondChunk).toBe(false);
 
       releaseSecondChunk?.();

--- a/backend/tests/unit/ai-streaming-disconnect.test.ts
+++ b/backend/tests/unit/ai-streaming-disconnect.test.ts
@@ -28,6 +28,22 @@ vi.hoisted(() => {
   process.env.JWT_SECRET = 'test-secret-long-enough-for-signing-32chars';
 });
 
+/**
+ * Polls `condition` instead of sleeping a fixed duration before a critical
+ * assertion — a fixed delay assumes the server-side 'close' handler always
+ * runs within that window, which a slow/loaded CI runner can violate and
+ * turn into a flaky false failure.
+ */
+async function waitFor(condition: () => boolean, timeoutMs = 2000, intervalMs = 5): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
 vi.mock('../../src/api/middlewares/auth.js', () => ({
   verifyAdmin: (_req: unknown, _res: unknown, next: () => void) => next(),
   verifyUser: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -167,12 +183,13 @@ describe('POST /api/ai/chat/completion — client disconnect mid-stream', () => 
       // NOT aborted, this is what would let a real upstream eventually
       // produce the second chunk, so asserting first proves the abort (not
       // this release) is what ended the pending request.
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(generatorState.sawAbortedSignal).toBe(true);
-      expect(generatorState.finallyRan).toBe(true);
+      await waitFor(() => generatorState.sawAbortedSignal && generatorState.finallyRan);
       expect(generatorState.producedSecondChunk).toBe(false);
 
       releaseSecondChunk?.();
+      // Give the (deliberately unresolved-until-now) release a turn to
+      // resolve should the abort have failed to win the race, then confirm
+      // it still didn't produce a chunk.
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(generatorState.producedSecondChunk).toBe(false);
     } finally {

--- a/backend/tests/unit/cors-allowlist.test.ts
+++ b/backend/tests/unit/cors-allowlist.test.ts
@@ -1,0 +1,145 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression tests for issue #1895 (Over-Permissive CORS Configuration):
+ * `cors({ origin: true, credentials: true })` reflected any Origin header and
+ * allowed credentialed cross-origin requests from it, so any website could
+ * make authenticated calls against this API using a visitor's cookies.
+ */
+
+const authConfigMock = vi.hoisted(() => ({ getAuthConfig: vi.fn() }));
+
+vi.mock('../../src/services/auth/auth-config.service.js', () => ({
+  AuthConfigService: { getInstance: () => authConfigMock },
+}));
+
+vi.mock('../../src/utils/environment.js', () => ({
+  getApiBaseUrl: () => 'https://api.example.com',
+}));
+
+vi.mock('../../src/utils/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+async function buildApp() {
+  vi.resetModules();
+  const { corsMiddleware } = await import('../../src/api/middlewares/cors.js');
+  const app = express();
+  app.use(corsMiddleware);
+  app.get('/ping', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('corsMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows the API base origin', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({ allowedRedirectUrls: [] });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://api.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://api.example.com');
+    expect(res.headers['access-control-allow-credentials']).toBe('true');
+  });
+
+  it('allows any origin when no allowlist is configured (unchanged default)', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({ allowedRedirectUrls: [] });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://anything.example');
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://anything.example');
+  });
+
+  it('rejects an origin not covered by a configured allowlist', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({
+      allowedRedirectUrls: ['https://app.example.com/auth/callback'],
+    });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://evil.example');
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('allows an origin matching a configured allowlist entry', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({
+      allowedRedirectUrls: ['https://app.example.com/auth/callback'],
+    });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://app.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+  });
+
+  it('allows a subdomain-wildcard allowlist entry', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({
+      allowedRedirectUrls: ['https://*.example.com/**'],
+    });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://tenant.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBe('https://tenant.example.com');
+  });
+
+  it('rejects a scheme mismatch against an otherwise-matching host', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({
+      allowedRedirectUrls: ['https://app.example.com/callback'],
+    });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'http://app.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('allows requests without an Origin header through (non-browser clients)', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValue({
+      allowedRedirectUrls: ['https://app.example.com/callback'],
+    });
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('fails closed (relative to a configured allowlist) if the config lookup errors', async () => {
+    authConfigMock.getAuthConfig.mockRejectedValue(new Error('db down'));
+    const app = await buildApp();
+
+    const res = await request(app).get('/ping').set('Origin', 'https://app.example.com');
+
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});
+
+describe('originMatchesPattern', () => {
+  it('matches exact origins case-insensitively', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('https://App.Example.com', 'https://app.example.com')).toBe(true);
+  });
+
+  it('matches a single leading subdomain wildcard', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('https://*.example.com', 'https://a.b.example.com')).toBe(true);
+    expect(originMatchesPattern('https://*.example.com', 'https://example.com')).toBe(false);
+  });
+
+  it('rejects a port mismatch', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('https://example.com:8443', 'https://example.com')).toBe(false);
+  });
+
+  it('rejects an unparseable pattern', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('not-a-url', 'https://example.com')).toBe(false);
+  });
+});

--- a/backend/tests/unit/cors-allowlist.test.ts
+++ b/backend/tests/unit/cors-allowlist.test.ts
@@ -119,6 +119,36 @@ describe('corsMiddleware', () => {
 
     expect(res.headers['access-control-allow-origin']).toBeUndefined();
   });
+
+  it('serves a stale allowlist without hitting the DB again on every request during an outage', async () => {
+    authConfigMock.getAuthConfig.mockResolvedValueOnce({
+      allowedRedirectUrls: ['https://app.example.com/callback'],
+    });
+    const app = await buildApp();
+
+    // Prime the cache with a successful fetch.
+    await request(app).get('/ping').set('Origin', 'https://app.example.com');
+    expect(authConfigMock.getAuthConfig).toHaveBeenCalledTimes(1);
+
+    // Force the cache to look expired, then start failing — mirroring a DB
+    // outage that lasts past the TTL.
+    authConfigMock.getAuthConfig.mockRejectedValue(new Error('db down'));
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 31_000);
+
+    const first = await request(app).get('/ping').set('Origin', 'https://app.example.com');
+    const second = await request(app).get('/ping').set('Origin', 'https://app.example.com');
+
+    vi.useRealTimers();
+
+    // Both requests should still be allowed (serving the stale list), and the
+    // failed refresh should only have been attempted once — the catch branch
+    // must re-arm the TTL, not leave every subsequent request re-entering the
+    // stale-cache branch and re-issuing a doomed DB read.
+    expect(first.headers['access-control-allow-origin']).toBe('https://app.example.com');
+    expect(second.headers['access-control-allow-origin']).toBe('https://app.example.com');
+    expect(authConfigMock.getAuthConfig).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('originMatchesPattern', () => {
@@ -127,15 +157,33 @@ describe('originMatchesPattern', () => {
     expect(originMatchesPattern('https://App.Example.com', 'https://app.example.com')).toBe(true);
   });
 
-  it('matches a single leading subdomain wildcard', async () => {
+  it('matches a leading subdomain wildcard', async () => {
     const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
     expect(originMatchesPattern('https://*.example.com', 'https://a.b.example.com')).toBe(true);
     expect(originMatchesPattern('https://*.example.com', 'https://example.com')).toBe(false);
   });
 
-  it('rejects a port mismatch', async () => {
+  it('matches a wildcard placed mid-host, not just as a leading subdomain', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('https://*foo.example.com', 'https://barfoo.example.com')).toBe(
+      true
+    );
+    expect(originMatchesPattern('https://*foo.example.com', 'https://foobar.example.com')).toBe(
+      false
+    );
+  });
+
+  it('rejects a non-default port mismatch', async () => {
     const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
     expect(originMatchesPattern('https://example.com:8443', 'https://example.com')).toBe(false);
+  });
+
+  it('matches when a pattern spells out the scheme default port explicitly', async () => {
+    const { originMatchesPattern } = await import('../../src/api/middlewares/cors.js');
+    expect(originMatchesPattern('https://app.example.com:443', 'https://app.example.com')).toBe(
+      true
+    );
+    expect(originMatchesPattern('http://app.example.com:80', 'http://app.example.com')).toBe(true);
   });
 
   it('rejects an unparseable pattern', async () => {

--- a/backend/tests/unit/frame-ancestors.test.ts
+++ b/backend/tests/unit/frame-ancestors.test.ts
@@ -10,6 +10,11 @@ import type { RequestHandler } from 'express';
  * the dashboard. This middleware restores real protection via a scoped
  * `frame-ancestors` CSP directive instead.
  *
+ * Also a regression test for a follow-up finding: the middleware is mounted
+ * globally ahead of every route (including health checks), so it must never
+ * block a request on the outbound fetch to config.insforge.dev — it serves
+ * from cache synchronously and refreshes in the background.
+ *
  * The middleware caches the fetched partner-origin list at module scope, so
  * each test resets the module registry and re-imports it fresh — otherwise
  * the first test's cached result would leak into later tests within the
@@ -40,25 +45,32 @@ describe('frame-ancestors middleware', () => {
     vi.restoreAllMocks();
   });
 
-  it('always includes self, plus any partner origins from the partnership config', async () => {
+  it('defaults to self only on the very first request, before any fetch has completed', async () => {
+    // A fetch that never resolves within the test: proves the response
+    // does not wait on it.
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
+
+    const res = await request(await buildApp()).get('/ping');
+
+    expect(res.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+  });
+
+  it('includes partner origins from the partnership config once a background fetch resolves', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ partner_sites: ['https://partner.example.com/embed'] }),
     }) as unknown as typeof fetch;
 
-    const res = await request(await buildApp()).get('/ping');
+    const app = await buildApp();
+    // First request triggers the background fetch (and gets 'self' only,
+    // since it hasn't resolved yet); wait for it, then request again.
+    await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
+    const res = await request(app).get('/ping');
 
     expect(res.headers['content-security-policy']).toBe(
       "frame-ancestors 'self' https://partner.example.com"
     );
-  });
-
-  it('falls back to self only when the partnership config fetch fails and no cache exists', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
-
-    const res = await request(await buildApp()).get('/ping');
-
-    expect(res.headers['content-security-policy']).toBe("frame-ancestors 'self'");
   });
 
   it('ignores malformed entries in partner_sites instead of failing the whole policy', async () => {
@@ -67,14 +79,29 @@ describe('frame-ancestors middleware', () => {
       json: async () => ({ partner_sites: ['not-a-valid-url', 'https://good.example.com'] }),
     }) as unknown as typeof fetch;
 
-    const res = await request(await buildApp()).get('/ping');
+    const app = await buildApp();
+    await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
+    const res = await request(app).get('/ping');
 
     expect(res.headers['content-security-policy']).toBe(
       "frame-ancestors 'self' https://good.example.com"
     );
   });
 
-  it('caches the partner list and does not re-fetch within the TTL window', async () => {
+  it('degrades to self only, without throwing, when the background fetch fails and nothing was cached yet', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+    const app = await buildApp();
+    const firstRes = await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
+    const secondRes = await request(app).get('/ping');
+
+    expect(firstRes.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+    expect(secondRes.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+  });
+
+  it('does not re-fetch within the TTL window', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ partner_sites: ['https://partner.example.com'] }),
@@ -82,6 +109,8 @@ describe('frame-ancestors middleware', () => {
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const app = await buildApp();
+    await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
     await request(app).get('/ping');
     await request(app).get('/ping');
 

--- a/backend/tests/unit/frame-ancestors.test.ts
+++ b/backend/tests/unit/frame-ancestors.test.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RequestHandler } from 'express';
+
+/**
+ * Regression test for the clickjacking regression flagged on top of issue
+ * #1895's Helmet hardening: disabling `frameguard` outright (to allow the
+ * cloud-hosting partner's cross-origin iframe embed) let *any* origin frame
+ * the dashboard. This middleware restores real protection via a scoped
+ * `frame-ancestors` CSP directive instead.
+ *
+ * The middleware caches the fetched partner-origin list at module scope, so
+ * each test resets the module registry and re-imports it fresh — otherwise
+ * the first test's cached result would leak into later tests within the
+ * TTL window.
+ */
+async function buildApp() {
+  vi.resetModules();
+  const { frameAncestorsMiddleware } =
+    (await import('../../src/api/middlewares/frame-ancestors.js')) as {
+      frameAncestorsMiddleware: RequestHandler;
+    };
+
+  const app = express();
+  app.use(frameAncestorsMiddleware);
+  app.get('/ping', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('frame-ancestors middleware', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('always includes self, plus any partner origins from the partnership config', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ partner_sites: ['https://partner.example.com/embed'] }),
+    }) as unknown as typeof fetch;
+
+    const res = await request(await buildApp()).get('/ping');
+
+    expect(res.headers['content-security-policy']).toBe(
+      "frame-ancestors 'self' https://partner.example.com"
+    );
+  });
+
+  it('falls back to self only when the partnership config fetch fails and no cache exists', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
+
+    const res = await request(await buildApp()).get('/ping');
+
+    expect(res.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+  });
+
+  it('ignores malformed entries in partner_sites instead of failing the whole policy', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ partner_sites: ['not-a-valid-url', 'https://good.example.com'] }),
+    }) as unknown as typeof fetch;
+
+    const res = await request(await buildApp()).get('/ping');
+
+    expect(res.headers['content-security-policy']).toBe(
+      "frame-ancestors 'self' https://good.example.com"
+    );
+  });
+
+  it('caches the partner list and does not re-fetch within the TTL window', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ partner_sites: ['https://partner.example.com'] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const app = await buildApp();
+    await request(app).get('/ping');
+    await request(app).get('/ping');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/tests/unit/frame-ancestors.test.ts
+++ b/backend/tests/unit/frame-ancestors.test.ts
@@ -10,23 +10,31 @@ import type { RequestHandler } from 'express';
  * the dashboard. This middleware restores real protection via a scoped
  * `frame-ancestors` CSP directive instead.
  *
- * Also a regression test for a follow-up finding: the middleware is mounted
- * globally ahead of every route (including health checks), so it must never
- * block a request on the outbound fetch to config.insforge.dev — it serves
- * from cache synchronously and refreshes in the background.
+ * Also covers two follow-up review findings:
+ *   - the middleware is mounted globally ahead of every route (including
+ *     health checks), so it must never block a request on the outbound
+ *     fetch to config.insforge.dev — it serves from cache synchronously and
+ *     refreshes in the background.
+ *   - a cold process's first request (which may be the partner's own
+ *     iframe load) must not race that background fetch and get stuck with
+ *     a 'self'-only policy — `warmPartnerOriginsCache()` is awaited before
+ *     the app accepts connections (server.ts) to prevent that.
  *
  * The middleware caches the fetched partner-origin list at module scope, so
  * each test resets the module registry and re-imports it fresh — otherwise
  * the first test's cached result would leak into later tests within the
  * TTL window.
  */
-async function buildApp() {
+async function loadModule() {
   vi.resetModules();
-  const { frameAncestorsMiddleware } =
-    (await import('../../src/api/middlewares/frame-ancestors.js')) as {
-      frameAncestorsMiddleware: RequestHandler;
-    };
+  return (await import('../../src/api/middlewares/frame-ancestors.js')) as {
+    frameAncestorsMiddleware: RequestHandler;
+    warmPartnerOriginsCache: () => Promise<void>;
+  };
+}
 
+async function buildApp() {
+  const { frameAncestorsMiddleware } = await loadModule();
   const app = express();
   app.use(frameAncestorsMiddleware);
   app.get('/ping', (_req, res) => res.json({ ok: true }));
@@ -34,6 +42,11 @@ async function buildApp() {
 }
 
 describe('frame-ancestors middleware', () => {
+  // Each test calls vi.resetModules() and dynamically re-imports the module
+  // under test, which re-transpiles it every time; the default 10s per-test
+  // timeout can be tight under that overhead, so give these a bit more room.
+  vi.setConfig({ testTimeout: 20_000 });
+
   const originalFetch = global.fetch;
 
   beforeEach(() => {
@@ -89,7 +102,7 @@ describe('frame-ancestors middleware', () => {
     );
   });
 
-  it('degrades to self only, without throwing, when the background fetch fails and nothing was cached yet', async () => {
+  it('degrades to self only, without throwing, when the fetch rejects and nothing was cached yet', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch;
 
     const app = await buildApp();
@@ -99,6 +112,51 @@ describe('frame-ancestors middleware', () => {
 
     expect(firstRes.headers['content-security-policy']).toBe("frame-ancestors 'self'");
     expect(secondRes.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+  });
+
+  it('degrades to self only when the config endpoint responds with a non-ok HTTP status', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }) as unknown as typeof fetch;
+
+    const app = await buildApp();
+    await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
+    const res = await request(app).get('/ping');
+
+    expect(res.headers['content-security-policy']).toBe("frame-ancestors 'self'");
+  });
+
+  it('keeps serving the last known-good partner list when a later refresh fails', async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ partner_sites: ['https://partner.example.com'] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { frameAncestorsMiddleware, warmPartnerOriginsCache } = await loadModule();
+    await warmPartnerOriginsCache();
+    const app = express();
+    app.use(frameAncestorsMiddleware);
+    app.get('/ping', (_req, res) => res.json({ ok: true }));
+
+    const goodRes = await request(app).get('/ping');
+    expect(goodRes.headers['content-security-policy']).toBe(
+      "frame-ancestors 'self' https://partner.example.com"
+    );
+
+    // A later refresh (simulated directly, since the TTL is 30s and this
+    // test doesn't fast-forward real time) fails — the cache should keep
+    // serving the last known-good list rather than dropping it.
+    fetchMock.mockRejectedValueOnce(new Error('network error'));
+    await warmPartnerOriginsCache();
+
+    const staleRes = await request(app).get('/ping');
+    expect(staleRes.headers['content-security-policy']).toBe(
+      "frame-ancestors 'self' https://partner.example.com"
+    );
   });
 
   it('does not re-fetch within the TTL window', async () => {
@@ -115,5 +173,40 @@ describe('frame-ancestors middleware', () => {
     await request(app).get('/ping');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches an empty result on failure too, so a sustained outage does not re-fetch on every request', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network error'));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const app = await buildApp();
+    await request(app).get('/ping');
+    await new Promise((resolve) => setImmediate(resolve));
+    await request(app).get('/ping');
+    await request(app).get('/ping');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('warmPartnerOriginsCache populates the cache before any request arrives', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ partner_sites: ['https://partner.example.com'] }),
+    }) as unknown as typeof fetch;
+
+    const { frameAncestorsMiddleware, warmPartnerOriginsCache } = await loadModule();
+    await warmPartnerOriginsCache();
+
+    const app = express();
+    app.use(frameAncestorsMiddleware);
+    app.get('/ping', (_req, res) => res.json({ ok: true }));
+
+    // No 'setImmediate' wait needed: the cache is already warm from the
+    // awaited warmPartnerOriginsCache() call above, so even the very first
+    // request sees the partner origin.
+    const res = await request(app).get('/ping');
+    expect(res.headers['content-security-policy']).toBe(
+      "frame-ancestors 'self' https://partner.example.com"
+    );
   });
 });

--- a/backend/tests/unit/helmet-security-headers.test.ts
+++ b/backend/tests/unit/helmet-security-headers.test.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import helmet from 'helmet';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression test for issue #1895 (Missing HTTP Security Headers): API
+ * responses previously carried none of Helmet's defensive headers. This
+ * exercises the exact Helmet configuration wired into `createApp()`
+ * (backend/src/server.ts) rather than re-deriving it, so a change there is
+ * caught here too.
+ */
+function buildApp() {
+  const app = express();
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+      crossOriginResourcePolicy: false,
+      crossOriginEmbedderPolicy: false,
+    })
+  );
+  app.get('/ping', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('Helmet security headers', () => {
+  it('sets the standard defensive headers', async () => {
+    const res = await request(buildApp()).get('/ping');
+
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+    expect(res.headers['x-dns-prefetch-control']).toBe('off');
+    expect(res.headers['strict-transport-security']).toContain('max-age=');
+  });
+
+  it('does not set a CSP or cross-origin-resource-policy header (deliberately disabled)', async () => {
+    const res = await request(buildApp()).get('/ping');
+
+    // Disabled on purpose: the dashboard SPA and client-embedded content
+    // aren't compatible with Helmet's default CSP, and storage/API responses
+    // are deliberately fetched cross-origin by client apps.
+    expect(res.headers['content-security-policy']).toBeUndefined();
+    expect(res.headers['cross-origin-resource-policy']).toBeUndefined();
+  });
+});

--- a/backend/tests/unit/helmet-security-headers.test.ts
+++ b/backend/tests/unit/helmet-security-headers.test.ts
@@ -24,19 +24,21 @@ describe('Helmet security headers', () => {
     const res = await request(buildApp()).get('/ping');
 
     expect(res.headers['x-content-type-options']).toBe('nosniff');
-    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
     expect(res.headers['x-dns-prefetch-control']).toBe('off');
     expect(res.headers['strict-transport-security']).toContain('max-age=');
   });
 
-  it('does not set a CSP or cross-origin-resource-policy header (deliberately disabled)', async () => {
+  it('does not set a CSP, cross-origin-resource-policy, or X-Frame-Options header (deliberately disabled)', async () => {
     const res = await request(buildApp()).get('/ping');
 
     // Disabled on purpose: the dashboard SPA and client-embedded content
-    // aren't compatible with Helmet's default CSP, and storage/API responses
-    // are deliberately fetched cross-origin by client apps.
+    // aren't compatible with Helmet's default CSP, storage/API responses are
+    // deliberately fetched cross-origin by client apps, and the dashboard is
+    // deliberately embeddable in a cloud-hosting partner's cross-origin
+    // parent iframe (X-Frame-Options: SAMEORIGIN would block that).
     expect(res.headers['content-security-policy']).toBeUndefined();
     expect(res.headers['cross-origin-resource-policy']).toBeUndefined();
+    expect(res.headers['x-frame-options']).toBeUndefined();
   });
 
   it('allows the cloud-hosting window.opener bridge (same-origin-allow-popups)', async () => {

--- a/backend/tests/unit/helmet-security-headers.test.ts
+++ b/backend/tests/unit/helmet-security-headers.test.ts
@@ -1,24 +1,20 @@
 import express from 'express';
-import helmet from 'helmet';
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
+import { helmetMiddleware } from '../../src/api/middlewares/helmet.js';
 
 /**
  * Regression test for issue #1895 (Missing HTTP Security Headers): API
- * responses previously carried none of Helmet's defensive headers. This
- * exercises the exact Helmet configuration wired into `createApp()`
- * (backend/src/server.ts) rather than re-deriving it, so a change there is
- * caught here too.
+ * responses previously carried none of Helmet's defensive headers.
+ *
+ * Imports the real `helmetMiddleware` server.ts wires into `createApp()`
+ * (backend/src/api/middlewares/helmet.ts) rather than re-deriving the
+ * config here — a hand-duplicated copy would keep passing even if the real
+ * one drifted or regressed.
  */
 function buildApp() {
   const app = express();
-  app.use(
-    helmet({
-      contentSecurityPolicy: false,
-      crossOriginResourcePolicy: false,
-      crossOriginEmbedderPolicy: false,
-    })
-  );
+  app.use(helmetMiddleware);
   app.get('/ping', (_req, res) => res.json({ ok: true }));
   return app;
 }
@@ -41,5 +37,11 @@ describe('Helmet security headers', () => {
     // are deliberately fetched cross-origin by client apps.
     expect(res.headers['content-security-policy']).toBeUndefined();
     expect(res.headers['cross-origin-resource-policy']).toBeUndefined();
+  });
+
+  it('allows the cloud-hosting window.opener bridge (same-origin-allow-popups)', async () => {
+    const res = await request(buildApp()).get('/ping');
+
+    expect(res.headers['cross-origin-opener-policy']).toBe('same-origin-allow-popups');
   });
 });

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -668,17 +668,15 @@ spec:
                         }
                       }
 
-                      // Runtime info
+                      // Runtime info. Deliberately omits `dbConfig` — this endpoint
+                      // is unauthenticated, and the internal DB hostname/name are
+                      // not something an arbitrary caller needs to know.
                       if (pathname === '/info') {
                         return new Response(
                           JSON.stringify({
                             runtime: 'deno',
                             version: Deno.version,
                             env: Deno.env.get('DENO_ENV') || 'production',
-                            database: {
-                              host: dbConfig.hostname,
-                              database: dbConfig.database,
-                            },
                           }),
                           {
                             headers: { 'Content-Type': 'application/json' },

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -319,17 +319,15 @@ Deno.serve({ hostname, port }, async (req: Request) => {
     }
   }
 
-  // Runtime info
+  // Runtime info. Deliberately omits `dbConfig` — this endpoint is
+  // unauthenticated, and the internal DB hostname/name are not something an
+  // arbitrary caller needs to know.
   if (pathname === '/info') {
     return new Response(
       JSON.stringify({
         runtime: 'deno',
         version: Deno.version,
         env: Deno.env.get('DENO_ENV') || 'production',
-        database: {
-          host: dbConfig.hostname,
-          database: dbConfig.database,
-        },
       }),
       {
         headers: { 'Content-Type': 'application/json' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "express-rate-limit": "^7.1.5",
         "file-type": "^21.3.4",
         "google-auth-library": "^10.1.0",
+        "helmet": "^8.3.0",
         "jose": "^6.1.0",
         "jsonwebtoken": "^9.0.2",
         "libpg-query": "^17.6.0",
@@ -11998,6 +11999,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hermes-estree": {


### PR DESCRIPTION
## Summary

Fixes #1895.

Addresses all 4 items from the edge-layer security audit as one focused PR, per the issue's own "single release, zero migration" framing. A previous attempt (#1896, closed) grew an over-engineered generation-counter-tracked CORS refresh mechanism that became hard to review safely across dozens of AI-review rounds; the author closed it in favor of atomic decomposition but the issue was re-opened for grabs. This submission deliberately keeps each fix to its smallest correct form instead of repeating that scope creep.

### 1. Missing HTTP security headers
`helmet()` is now mounted first in `createApp()` (`backend/src/server.ts`), scoped to what the issue actually asks for:
- `X-Frame-Options`, `X-Content-Type-Options`, `X-DNS-Prefetch-Control`, `Strict-Transport-Security`, etc.

Helmet's default Content-Security-Policy and Cross-Origin-Resource-Policy are explicitly disabled:
- The dashboard SPA and client apps embed third-party scripts/styles/images this project doesn't control — a strict default CSP would break them.
- Storage objects and API responses are deliberately fetched cross-origin by client apps (that's the point of a hosted backend) — Helmet's `same-origin` CORP default would break exactly that traffic.

### 2. Over-permissive CORS
Replaced `cors({ origin: true, credentials: true })` — which reflects any Origin header and allows credentialed requests from it — with a real allowlist in a new `backend/src/api/middlewares/cors.ts`, built from:
- the API's own base URL (`getApiBaseUrl()`), and
- the project's configured `allowedRedirectUrls` (the same list OAuth/email-verification redirects already validate against).

Design notes, given the prior PR's review history flagged exactly these tradeoffs:
- **Caching**: a 30s TTL cache with single-flight de-duping avoids a DB round trip on every request, without the generations/timers the closed PR introduced.
- **Fetch failure**: serves the last known-good list if one exists (a stale allowlist beats treating a transient DB hiccup as "no allowlist configured"); with no prior successful fetch, it fails closed instead of defaulting to permissive.
- **Zero breaking changes**: when `allowedRedirectUrls` is empty (not configured), CORS stays permissive — matching `AuthConfigService.validateRedirectUrl`'s own documented "no policy configured" default. Any existing deployment that hasn't configured a redirect allowlist sees no behavior change; configuring one is what turns real enforcement on.
- Origin matching supports exact match and a single leading `*.` subdomain wildcard (the same shape `validateRedirectUrl`'s glob patterns document), matched against just `scheme://host[:port]` since an `Origin` header never carries a path — broader glob forms (`**`, `?`, `[...]`) don't have a meaningful analogue for an origin-only comparison and are intentionally not supported here.

### 3. Database topology leak
`functions/server.ts`'s unauthenticated `/info` endpoint no longer echoes the internal Postgres hostname/database name. Also fixed the identical leak in `deploy/zeabur/template.yml`, which embeds its own inline copy of this server for Zeabur's deploy path — a stray copy the previous PR's review (cubic-dev-ai) flagged as easy to miss.

### 4. SSE disconnect token/resource leak
`POST /api/ai/chat/completion` now listens for the response's `'close'` event and calls the stream generator's `.return()` **immediately** from that handler, rather than only checking an `aborted` flag on the next loop iteration.

That distinction matters and I verified it empirically before relying on it: a plain flag-check can't help while the `for await` loop is already suspended awaiting the next upstream chunk — `.return()` queued behind an in-flight `.next()` doesn't preempt it (confirmed with a small Node script). Calling `.return()` from the close handler propagates cancellation to the underlying OpenRouter/OpenAI SDK stream (which aborts its own in-flight fetch on `.return()`), so a client disconnecting mid-generation actually stops consuming tokens against a socket nobody is reading, instead of running to completion.

## Testing

- **New unit tests**:
  - `backend/tests/unit/cors-allowlist.test.ts` — allowlist matching (exact, wildcard subdomain, scheme/port mismatches), permissive-when-unconfigured default, fail-closed on config-fetch error, no-Origin-header passthrough.
  - `backend/tests/unit/helmet-security-headers.test.ts` — asserts the actual Helmet config wired into `createApp()`.
  - `backend/tests/unit/ai-streaming-disconnect.test.ts` — spins up a real HTTP server and severs the TCP connection client-side. The fake upstream is a custom async-iterable (not a plain `async function*`) that races real cancellation against a manually-released "next chunk," modeling how the OpenAI SDK's stream actually behaves under `.return()` — a plain generator can't be preempted mid-await, so it would give a false pass here.
- Full backend suite: `npm run test:backend` → 2419 passed, 21 skipped, 0 failed (no regressions).
- `npx tsc --noEmit` on `backend/` passes.
- `package-lock.json`: added Helmet's own lockfile entry by hand (rather than a full reinstall, which pulled in unrelated platform-dependent optional-package churn from resolving on Windows against a lockfile generated on Linux); verified with `npm ci --dry-run`.
- Could not exercise the `functions/server.ts` `/info` change against a live Deno runtime — no Docker/Deno available in this environment. That one file's change was verified by code review only; everything else listed above was actually run.

## Notes for reviewers

Happy to split this into the 4 atomic PRs the previous attempt's author proposed if that's preferred for review — I kept it as one PR because the issue itself frames it as a single bundled release and the 4 fixes here are each small enough (under ~40 lines of actual logic each, aside from the new test files) that I don't think they individually warrant separate review overhead. Let me know either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all 4 items from issue #1895's edge-layer security audit: missing HTTP security headers, over-permissive CORS, database topology leak, and SSE streams continuing after client disconnect.

**Changes**
- Mounts Helmet in `createApp()` with CSP, CORP, COEP, and frameguard disabled (they'd break third-party embeds, cross-origin storage fetches, and the cloud-hosting parent iframe); COOP is set to `same-origin-allow-popups` so the dashboard's opener bridge keeps working. A new `frameAncestorsMiddleware` restores actual framing protection via a `frame-ancestors` CSP header scoped to `'self'` plus trusted cloud-hosting partner origins from `config.insforge.dev`; it serves from cache synchronously and refreshes in the background, so a slow config fetch never stalls a request. The cache is warmed at startup so the partner's first embed isn't stuck with a self-only policy, and failed fetches are cached so an outage doesn't retry on every request.
- Replaces `cors({ origin: true, credentials: true })` with an allowlist built from `allowedRedirectUrls` and the API base URL, cached for 30 seconds with a last-known-good fallback that re-arms its TTL on fetch errors.
- Origin matching strips scheme-default ports and supports `*` anywhere in the host, matching `AuthConfigService`'s glob semantics; stays permissive when no allowlist is configured, so existing deployments see no behavior change until they set one.
- Removes the internal database hostname and name from the unauthenticated `/info` endpoint in both `functions/server.ts` and the Zeabur template.
- Aborts the upstream OpenAI/OpenRouter stream immediately on SSE client disconnect via an `AbortSignal` threaded through `streamChat` into the SDK call.
- Removes the hardcoded `Access-Control-Allow-Origin: *` from the `/functions/:slug` proxy route and stops the proxy from forwarding its own CORS headers, so it respects the allowlist like the rest of the API.

<sup>Written for commit 617d1f8c828fd8cdbe485d1a1c502060698f74ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable CORS origin allowlists with wildcard matching, port normalization, and resilient refresh behavior.
  - Added standard security protections for HTTP responses.

- **Bug Fixes**
  - Stopped streaming responses and upstream requests promptly when clients disconnect.
  - Removed database connection details from unauthenticated runtime information endpoints.

- **Tests**
  - Added coverage for CORS behavior, security headers, client disconnects, and stream cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->