### PR TITLE
docs(cli): document memory Model Gateway prerequisite

### DIFF
--- a/docs/agent-native/cli-harness.mdx
+++ b/docs/agent-native/cli-harness.mdx
@@ -24,6 +24,7 @@ A dashboard is built for a human pointer; a CLI is built for anything that can w
 | Config as code | `config plan`, `config apply`, `config export` |
 | Branching | `branch create`, `branch merge`, `branch reset`, `branch delete` |
 | Build | `functions`, `storage`, `deployments`, `secrets`, `schedules`, `ai` |
+| Memory | `memory list`, `memory remember`, `memory recall` |
 | Diagnose | `diagnose`, `diagnose advisor`, `diagnose db`, `diagnose logs`, `metadata` |
 
 Run `npx @insforge/cli help <command>` for the flags on any of these.
@@ -45,6 +46,26 @@ npx @insforge/cli secrets get ANON_KEY  # decrypted value of one key
 ```
 
 Use `secrets add`, `secrets update`, and `secrets delete` for your own keys, and `secrets rotate api-key` or `secrets rotate anon-key` to reissue a project key with an optional grace period. The API key and anon key are also in the dashboard: click **Install** and open **API Keys**.
+
+## Agent memory
+
+The `memory` commands manage durable project memory across agent sessions, backed by PostgreSQL and `pgvector`:
+
+| Command | What it does | Model Gateway required? |
+|---------|--------------|-------------------------|
+| `memory list` | Lists stored memory titles and timestamps in the project scope | No (direct relational query) |
+| `memory remember` | Stores an atomic memory or extracts durable facts from a task transcript | Yes (generates embeddings and reconciles duplicates) |
+| `memory recall` | Hybrid semantic and keyword search across stored memories | Yes (generates query embeddings for vector search) |
+
+```bash
+npx @insforge/cli memory list
+npx @insforge/cli memory remember --title "Database conventions" --content "UUID v4 primary keys with timestamptz"
+npx @insforge/cli memory recall "database conventions"
+```
+
+<Note>
+  **Model Gateway prerequisite**: `memory remember` and `memory recall` require an AI provider to generate vector embeddings for `pgvector` storage and semantic search, as well as to reconcile duplicate memories. On cloud projects, this is pre-configured. On self-hosted instances, configure the [Model Gateway](/core-concepts/ai/overview) in the dashboard or set `OPENROUTER_API_KEY` in your `.env` before storing or recalling memories. `memory list` does not require an AI provider because it queries stored memory metadata directly from PostgreSQL.
+</Note>
 
 ## Upgrading and deleting a project
 


### PR DESCRIPTION
## Summary

* Documented the `memory list`, `memory remember`, and `memory recall` CLI commands.
* Clarified that `memory remember` and `memory recall` require the Model Gateway.
* Documented the `OPENROUTER_API_KEY` prerequisite for self-hosted instances.
* Clarified why `memory list` works without an AI provider.

## Issue

Closes #2034

## Validation

* `npx prettier --check docs/agent-native/cli-harness.mdx` - passed
* `bash scripts/check-docs-i18n-parity.sh` - failed due to existing translation parity failures unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `memory list`, `memory remember`, and `memory recall` CLI commands and clarifies their Model Gateway requirements. `memory remember` and `memory recall` need an AI provider for embeddings, while `memory list` queries PostgreSQL directly without one. Closes #2034.

- Self-hosted instances must configure the Model Gateway or set `OPENROUTER_API_KEY` before storing or recalling memories.

<sup>Written for commit 6d7315842916c189acef52a1f6140c8a85f23b4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for agent memory commands: `memory list`, `memory remember`, and `memory recall`.
  - Included command examples, embedding provider requirements, and self-hosted configuration guidance.
  - Updated the command surface reference to include Memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->