### PR TITLE
docs(migrations): db query does not wrap in a transaction, and --unrestricted is a privilege switch

### DIFF
--- a/docs/core-concepts/database/migrations.mdx
+++ b/docs/core-concepts/database/migrations.mdx
@@ -53,13 +53,13 @@ Because the CLI runs each migration file inside a single transaction (the same r
 - `VACUUM` — routine vacuuming is handled by PostgreSQL autovacuum, so you rarely need to run this yourself.
 - `REINDEX ... CONCURRENTLY`, `ALTER TYPE ... ADD VALUE` (on older PostgreSQL), and similar commands.
 
-Run these outside a migration with the CLI's unrestricted raw-SQL path, which executes the statement **without** wrapping it in a transaction:
+Run these outside a migration with `db query`, which sends the statement on its own rather than inside a transaction:
 
 ```bash
-npx @insforge/cli db query --unrestricted "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
+npx @insforge/cli db query "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
 ```
 
-Plain `npx @insforge/cli db query` (without `--unrestricted`) wraps your statement in a transaction, so it hits the same error — use `--unrestricted` for non-transactional commands.
+`--unrestricted` is a privilege switch, not a transaction one: it runs the statement as the database owner instead of `project_admin`, which is what you need for system tables or objects `project_admin` does not own. Add it when ownership requires it, not to escape a transaction.
 
 <Note>
   Both `db query` paths enforce a 30-second `statement_timeout`, so `CREATE INDEX CONCURRENTLY` or `VACUUM` on a large table may time out.

--- a/docs/es/core-concepts/database/migrations.mdx
+++ b/docs/es/core-concepts/database/migrations.mdx
@@ -53,13 +53,13 @@ Como el CLI ejecuta cada archivo de migración dentro de una sola transacción (
 - `VACUUM` — el vacuum rutinario lo gestiona el autovacuum de PostgreSQL, así que rara vez necesitas ejecutarlo tú.
 - `REINDEX ... CONCURRENTLY`, `ALTER TYPE ... ADD VALUE` (en PostgreSQL antiguo) y comandos similares.
 
-Ejecuta estos comandos fuera de una migración con la ruta de SQL sin procesar «unrestricted» del CLI, que ejecuta la sentencia **sin** envolverla en una transacción:
+Ejecuta estos comandos fuera de una migración con `db query`, que envía la sentencia por sí sola en lugar de dentro de una transacción:
 
 ```bash
-npx @insforge/cli db query --unrestricted "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
+npx @insforge/cli db query "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
 ```
 
-El `npx @insforge/cli db query` normal (sin `--unrestricted`) envuelve tu sentencia en una transacción, por lo que da el mismo error; usa `--unrestricted` para los comandos no transaccionales.
+`--unrestricted` es un interruptor de privilegios, no de transacciones: ejecuta la sentencia como propietario de la base de datos en lugar de `project_admin`, que es lo que necesitas para las tablas del sistema o para objetos que `project_admin` no posee. Úsalo cuando la propiedad lo exija, no para escapar de una transacción.
 
 <Note>
   Ambas rutas de `db query` aplican un `statement_timeout` de 30 segundos, así que `CREATE INDEX CONCURRENTLY` o `VACUUM` sobre una tabla grande pueden agotar el tiempo de espera.

--- a/docs/zh-Hant/core-concepts/database/migrations.mdx
+++ b/docs/zh-Hant/core-concepts/database/migrations.mdx
@@ -53,13 +53,13 @@ npx @insforge/cli db migrations list
 - `VACUUM` — 例行 vacuum 由 PostgreSQL autovacuum 處理，您很少需要自己執行。
 - `REINDEX ... CONCURRENTLY`、`ALTER TYPE ... ADD VALUE`（在較舊的 PostgreSQL 上）等類似命令。
 
-請使用 CLI 的 unrestricted 原始 SQL 路徑在遷移之外執行這些命令，它會執行陳述式而**不**將其包在交易中：
+請使用 `db query` 在遷移之外執行這些命令，它會單獨送出該陳述式，而不會將其包在交易中：
 
 ```bash
-npx @insforge/cli db query --unrestricted "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
+npx @insforge/cli db query "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
 ```
 
-一般的 `npx @insforge/cli db query`（不帶 `--unrestricted`）會把陳述式包在交易裡，因此會遇到同樣的錯誤——對於非交易性命令請使用 `--unrestricted`。
+`--unrestricted` 是權限開關，而非交易開關：它以資料庫擁有者而不是 `project_admin` 的身分執行陳述式，用於存取系統資料表或 `project_admin` 並未擁有的物件。只有在擁有者權限確有需要時才加上它，而不是用來繞過交易。
 
 <Note>
   兩種 `db query` 路徑都會強制套用 30 秒的 `statement_timeout`，因此在大型資料表上執行 `CREATE INDEX CONCURRENTLY` 或 `VACUUM` 可能會逾時。

--- a/docs/zh/core-concepts/database/migrations.mdx
+++ b/docs/zh/core-concepts/database/migrations.mdx
@@ -53,13 +53,13 @@ npx @insforge/cli db migrations list
 - `VACUUM` — 常规 vacuum 由 PostgreSQL autovacuum 处理，你很少需要自己运行。
 - `REINDEX ... CONCURRENTLY`、`ALTER TYPE ... ADD VALUE`（在较旧的 PostgreSQL 上）等类似命令。
 
-请使用 CLI 的 unrestricted 原始 SQL 路径在迁移之外运行这些命令，它会执行语句而**不**将其包裹在事务中：
+请使用 `db query` 在迁移之外运行这些命令，它会单独发送该语句，而不会将其包裹在事务中：
 
 ```bash
-npx @insforge/cli db query --unrestricted "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
+npx @insforge/cli db query "CREATE INDEX CONCURRENTLY idx_orders_customer ON public.orders (customer_id)"
 ```
 
-普通的 `npx @insforge/cli db query`（不带 `--unrestricted`）会把语句包裹在事务里，因此会遇到同样的错误——对于非事务性命令请使用 `--unrestricted`。
+`--unrestricted` 是权限开关，而非事务开关：它以数据库属主而不是 `project_admin` 的身份执行语句，用于访问系统表或 `project_admin` 并不拥有的对象。只有在属主权限确有需要时才加上它，而不是用来绕过事务。
 
 <Note>
   两种 `db query` 路径都强制执行 30 秒的 `statement_timeout`，因此在大表上运行 `CREATE INDEX CONCURRENTLY` 或 `VACUUM` 可能会超时。


### PR DESCRIPTION
## What

`docs/core-concepts/database/migrations.mdx` and its three locale copies told readers that plain `db query` wraps their statement in a transaction, and that `--unrestricted` is how you escape it. Neither half holds. This corrects the mechanism and reframes the flag as what it actually is.

Closes #2029

## Why it matters

`--unrestricted` is a privilege switch. The route's own docblock calls it a "Root back door for project-admin-only operations that need full database owner privileges". Describing it as the transaction escape hatch sent readers through superuser for `CREATE INDEX CONCURRENTLY`, which `project_admin` can run perfectly well.

## Proof, server side

Both endpoints call the same method, differing only in `asRoot`:

```ts
// advance.routes.ts:66   POST /rawsql/unrestricted
: await dbAdvanceService.executeRawSQL(query, params, true);

// advance.routes.ts:122  POST /rawsql
: await dbAdvanceService.executeRawSQL(query, params);
```

`executeRawSQL` spans 87-153 of `database-advance.service.ts` and never opens a transaction:

```
$ grep -n "'BEGIN'" backend/src/services/database/database-advance.service.ts
175:      await client.query('BEGIN');
814:      await client.query('BEGIN');
1032:      await client.query('BEGIN');
```

175 belongs to `executeExplain` (declared :156); 814 and 1032 are import and bulk. None falls inside 87-153.

## Proof, CLI side

When I filed #2029 I said I could not check the CLI, since it is not in this repo. I have since read the published bundle, `@insforge/cli` 0.2.8:

```js
async function runRawSql(sql, unrestricted = false) {
  const endpoint = unrestricted
    ? "/api/database/advance/rawsql/unrestricted"
    : "/api/database/advance/rawsql";
  const res = await ossFetch(endpoint, {
    method: "POST",
    body: JSON.stringify({ query: sql })
  });
```

It posts the SQL verbatim and does no client-side wrapping. `BEGIN` does not appear anywhere in the bundle. The flag's own help string is `"Use unrestricted mode (allows system table access)"`, which is the privilege framing this PR adopts.

That closes the one open question on the issue, so this is the option-1 patch rather than a guess between two.

## Deliberately left alone

The rest of the section was already correct and is untouched:

- Migrations really are wrapped. `database-migration.service.ts:79` issues `BEGIN` under an advisory lock, so the premise that `CREATE INDEX CONCURRENTLY` fails inside a migration still stands.
- The 30-second timeout note is accurate; both paths run `SET statement_timeout = 30000` (`database-advance.service.ts:99` and `:172`).

## Verification

```
remaining_total = 0        # no locale still carries the old claim
--unrestricted mentions:   1 per locale (was 3), now only in the privilege paragraph
```

`scripts/check-docs-i18n-parity.sh` exits 1 both before and after this change, and the two outputs are byte-identical, so the pre-existing rule-2 gaps (`deployment/self-host-storage`, `deployment/deploy-to-hetzner`) are unaffected by this diff. I checked that by stashing and re-running rather than assuming.

Translations for `es`, `zh` and `zh-Hant` are updated in the same commit so the four copies stay in step.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the migrations docs to correct that `db query` does not wrap statements in a transaction and that `--unrestricted` is a privilege switch, not a transaction escape hatch. Closes #2029.

**Bug Fixes**

- Updated all four locale copies (`en`, `es`, `zh`, `zh-Hant`).
- The `CREATE INDEX CONCURRENTLY` example no longer uses `--unrestricted`.

<sup>Written for commit b9e7e60445512de21c0e5f20dd8f184f5b071dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration guidance for running non-transactional database statements.
  - Clarified that standard `db query` runs statements independently, without a transaction wrapper.
  - Clarified that `--unrestricted` controls database-owner privileges and should only be used when elevated permissions are required.
  - Applied these updates across English, Spanish, Simplified Chinese, and Traditional Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->