### PR TITLE
Update setup documentation for cloning contributor forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Before you start development, ensure you have the following:
 1. Fork the repository to your GitHub account
 2. Clone your fork locally:
    ```bash
-   git clone https://github.com/InsForge/InsForge.git
+   git clone https://github.com/YOUR-USERNAME/InsForge.git insforge
    cd insforge
    ```
 3. Install Docker


### PR DESCRIPTION
closes #2047 
This pull request makes a small update to the `CONTRIBUTING.md` documentation. The change clarifies the `git clone` command to use the contributor's GitHub username and sets the local directory name to `insforge`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the setup docs so contributors clone their own fork instead of the main repository, and names the local directory `insforge`.

<sup>Written for commit d0d7da1b33e729ef33b3a291620d59cb854208e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

