### PR TITLE
fix(functions): handle aborted request bodies

### DIFF
--- a/backend/tests/unit/deno-runtime-request-body.test.ts
+++ b/backend/tests/unit/deno-runtime-request-body.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { runInNewContext } from 'node:vm';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it, vi } from 'vitest';
+
+type ExecuteInWorker = (code: string, request: Request) => Promise<Response>;
+
+type RuntimeContext = {
+  __testExecuteInWorker?: ExecuteInWorker;
+};
+
+function loadExecuteInWorker(options: {
+  clearTimeout: (timeout: unknown) => void;
+  createObjectURL: (object: Blob | MediaSource) => string;
+  revokeObjectURL: (url: string) => void;
+  terminate: () => void;
+  postMessage: () => void;
+  timeoutHandle: symbol;
+}): ExecuteInWorker {
+  const source = readFileSync(resolve(__dirname, '../../../functions/server.ts'), 'utf8')
+    .replace(/^import .* from 'https:\/\/deno\.land\/.*';\r?\n/gm, '')
+    .replace('import.meta.url', "'file:///app/functions/server.ts'")
+    .replace(
+      'Deno.serve({ hostname, port }, async (req: Request) => {',
+      'globalThis.__testExecuteInWorker = executeInWorker;\n\nDeno.serve({ hostname, port }, async (req: Request) => {'
+    );
+
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.None,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+
+  class Client {
+    async connect(): Promise<void> {}
+
+    async end(): Promise<void> {}
+
+    async queryObject<T>(): Promise<{ rows: T[] }> {
+      return { rows: [] };
+    }
+  }
+
+  class Worker {
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: ErrorEvent) => void) | null = null;
+
+    postMessage = options.postMessage;
+    terminate = options.terminate;
+  }
+
+  class RuntimeURL extends URL {
+    static createObjectURL(object: Blob | MediaSource): string {
+      return options.createObjectURL(object) as string;
+    }
+
+    static revokeObjectURL(url: string): void {
+      options.revokeObjectURL(url);
+    }
+  }
+
+  const context: RuntimeContext & Record<string, unknown> = {
+    Blob,
+    Client,
+    Deno: {
+      env: {
+        get(key: string) {
+          return key === 'WORKER_TIMEOUT_MS' ? '60000' : undefined;
+        },
+      },
+      readTextFile: vi.fn().mockResolvedValue(''),
+      serve: vi.fn(),
+      version: { deno: 'test', typescript: 'test', v8: 'test' },
+    },
+    Request,
+    Response,
+    URL: RuntimeURL,
+    Worker,
+    clearTimeout: options.clearTimeout,
+    console: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
+    dirname: vi.fn().mockReturnValue('/app/functions'),
+    fromFileUrl: vi.fn().mockReturnValue('/app/functions/server.ts'),
+    join: vi.fn().mockReturnValue('/app/functions/worker-template.js'),
+    setTimeout: vi.fn().mockReturnValue(options.timeoutHandle),
+  };
+  runInNewContext(compiled, context);
+
+  if (!context.__testExecuteInWorker) {
+    throw new Error('Deno runtime did not expose executeInWorker');
+  }
+
+  return context.__testExecuteInWorker;
+}
+
+describe('Deno runtime request body handling', () => {
+  it('cleans up and returns a generic 400 when reading a request body fails', async () => {
+    const timeoutHandle = Symbol('worker-timeout');
+    const clearTimeoutMock = vi.fn();
+    const createObjectURLMock = vi.fn().mockReturnValue('blob:worker');
+    const revokeObjectURLMock = vi.fn();
+    const terminateMock = vi.fn();
+    const postMessageMock = vi.fn();
+    const executeInWorker = loadExecuteInWorker({
+      clearTimeout: clearTimeoutMock,
+      createObjectURL: createObjectURLMock,
+      revokeObjectURL: revokeObjectURLMock,
+      terminate: terminateMock,
+      postMessage: postMessageMock,
+      timeoutHandle,
+    });
+    const internalError = new Error('internal stream failure');
+    const request = new Request('http://functions.example/issue-2055-abort', {
+      method: 'POST',
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(internalError);
+        },
+      }),
+      duplex: 'half',
+    } as RequestInit);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const response = await Promise.race([
+        executeInWorker('export default () => new Response("ok")', request),
+        delay(250).then(() => {
+          throw new Error('executeInWorker did not resolve promptly');
+        }),
+      ]);
+      const responseBody = await response.text();
+
+      expect(response.status).toBe(400);
+      expect(JSON.parse(responseBody)).toEqual({ error: 'Invalid request body' });
+      expect(responseBody).not.toContain(internalError.message);
+      expect(postMessageMock).not.toHaveBeenCalled();
+      expect(clearTimeoutMock).toHaveBeenCalledWith(timeoutHandle);
+      expect(terminateMock).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:worker');
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+});

--- a/backend/tests/unit/deno-runtime-request-body.test.ts
+++ b/backend/tests/unit/deno-runtime-request-body.test.ts
@@ -130,7 +130,7 @@ describe('Deno runtime request body handling', () => {
     try {
       const response = await Promise.race([
         executeInWorker('export default () => new Response("ok")', request),
-        delay(250).then(() => {
+        delay(1000).then(() => {
           throw new Error('executeInWorker did not resolve promptly');
         }),
       ]);

--- a/deploy/zeabur/template.yml
+++ b/deploy/zeabur/template.yml
@@ -583,7 +583,21 @@ spec:
                         };
 
                         // Prepare request data
-                        const body = request.body ? await request.text() : null;
+                        let body: string | null;
+                        try {
+                          body = request.body ? await request.text() : null;
+                        } catch {
+                          clearTimeout(timeout);
+                          worker.terminate();
+                          URL.revokeObjectURL(workerUrl);
+                          resolve(
+                            new Response(JSON.stringify({ error: 'Invalid request body' }), {
+                              status: 400,
+                              headers: { 'Content-Type': 'application/json' },
+                            })
+                          );
+                          return;
+                        }
                         const requestData = {
                           url: request.url,
                           method: request.method,

--- a/functions/server.ts
+++ b/functions/server.ts
@@ -234,7 +234,21 @@ async function executeInWorker(code: string, request: Request): Promise<Response
     };
 
     // Prepare request data
-    const body = request.body ? await request.text() : null;
+    let body: string | null;
+    try {
+      body = request.body ? await request.text() : null;
+    } catch {
+      clearTimeout(timeout);
+      worker.terminate();
+      URL.revokeObjectURL(workerUrl);
+      resolve(
+        new Response(JSON.stringify({ error: 'Invalid request body' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      return;
+    }
     const requestData = {
       url: request.url,
       method: request.method,


### PR DESCRIPTION
## Summary

* Handle failures while reading an edge-function request body so client disconnects do not cause an unhandled rejection.
* Clear the timeout, terminate the worker, and revoke its object URL when body consumption fails.
* Return a generic `400 Invalid request body` response without exposing internal runtime errors.
* Add behavioral regression coverage using the actual `executeInWorker()` production path.

Closes #2055

## How did you test this change?

* Added and ran `backend/tests/unit/deno-runtime-request-body.test.ts`.

  * 1 test passed.
  * Verified the handled `400` response and resource cleanup.
  * Verified `worker.postMessage()` is not called.
  * Verified no unhandled rejection occurs.
* Reproduced the issue against the local Deno runtime before the fix: the Deno server process stopped responding after an aborted request.
* Repeated the same reproduction after the fix: the request followed the handled `400` path and `/health` remained available.
* Ran formatting and focused TypeScript checks successfully.
* Ran the complete backend unit suite:

  * 2,416 passed, 2 failed, and 21 skipped.
  * The new regression test passed.
  * The two failures were unrelated: a transient local-storage permission failure that passed when rerun alone, and an existing migration scan test that exceeded its 10-second timeout when rerun alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles aborted edge-function request bodies so client disconnects no longer cause an unhandled rejection or leave the runtime unresponsive.

- On body-read failure, clears the worker timeout, terminates the worker, and revokes its object URL.
- Returns a generic `400 Invalid request body` response without exposing the internal error.
- Applies the same cleanup and `400` response in the Zeabur deployment template.
- Adds a regression test that exercises the production `executeInWorker()` path.

Closes #2055.

<sup>Written for commit fec33f6f66f1a057a9c6f1de68bee35e95dd1078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of request body read failures.
  - Returns a clear HTTP 400 response indicating an invalid request body instead of exposing internal error details.
  - Ensures background processing resources are cleaned up when request body processing fails.

- **Tests**
  - Added coverage for failed request body reads, resource cleanup, and prevention of unhandled errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->