### PR TITLE
fix(database): send the stale-socket replay over a fresh connection

### DIFF
--- a/backend/src/services/database/postgrest-proxy.service.ts
+++ b/backend/src/services/database/postgrest-proxy.service.ts
@@ -1,4 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
+import { Agent as NodeHttpAgent } from 'node:http';
+import { Agent as NodeHttpsAgent } from 'node:https';
 import { HttpAgent, HttpsAgent } from 'agentkeepalive';
 import { TokenManager } from '@/infra/security/token.manager.js';
 import logger from '@/utils/logger.js';
@@ -41,6 +43,21 @@ const httpsAgent = new HttpsAgent({
   timeout: 10000,
   freeSocketTimeout,
 });
+
+// Agents used only for the one stale-socket replay (see the forward loop).
+// The replay is issued in the same event-loop turn as the reset that
+// triggered it, so the pool has not yet processed the `close` events for the
+// sibling sockets that went idle alongside the dead one — drawing from it
+// would hand the replay another socket from the same stale batch. These
+// agents never pool, so the replay always gets a fresh TCP connection.
+//
+// Replay connections are counted separately from the pooled agents, and a
+// batch of sockets going stale under concurrent load yields one replay per
+// in-flight request — so they carry the same maxSockets cap to keep that
+// burst bounded (worst case, briefly, twice the pool toward PostgREST).
+// Each replay exists only on the failure path and closes with its response.
+const replayHttpAgent = new NodeHttpAgent({ keepAlive: false, maxSockets, timeout: 10000 });
+const replayHttpsAgent = new NodeHttpsAgent({ keepAlive: false, maxSockets, timeout: 10000 });
 
 const postgrestAxios = axios.create({
   httpAgent,
@@ -293,10 +310,19 @@ export class PostgrestProxyService {
     // replay regardless of method; a second reset falls through to the
     // method-based policy so writes cannot ping-pong on repeated resets.
     let staleSocketRetryUsed = false;
+    // The one attempt that bypasses the keep-alive pool: the replay directly
+    // after a stale-socket reset (see replayHttpAgent). Later backoff
+    // attempts have had time to see the stale sockets close, so they go back
+    // to the pool.
+    let freshConnectionAttempt = 0;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        response = await postgrestAxios(axiosConfig);
+        response = await postgrestAxios(
+          attempt === freshConnectionAttempt
+            ? { ...axiosConfig, httpAgent: replayHttpAgent, httpsAgent: replayHttpsAgent }
+            : axiosConfig
+        );
         break;
       } catch (error) {
         lastError = error;
@@ -308,6 +334,7 @@ export class PostgrestProxyService {
           !staleSocketRetryUsed && PostgrestProxyService.isStaleSocketReset(error);
         if (staleSocketRetry) {
           staleSocketRetryUsed = true;
+          freshConnectionAttempt = attempt + 1;
         } else if (!PostgrestProxyService.isRetryableError(error, request.method)) {
           throw error;
         }

--- a/backend/tests/unit/postgrest-proxy-stale-pool-replay.test.ts
+++ b/backend/tests/unit/postgrest-proxy-stale-pool-replay.test.ts
@@ -1,0 +1,102 @@
+/**
+ * postgrest-proxy-stale-pool-replay.test.ts
+ *
+ * Regression test for the stale-socket replay, exercised over real sockets
+ * against a fake PostgREST (no axios mock): the mocked forward-loop tests can
+ * only pin the config handed to axios, not that a per-request agent override
+ * is honored and actually opens a new connection.
+ *
+ * The fake server resets any request arriving on a socket it has already
+ * served, so every pooled keep-alive socket is dead on reuse — the state
+ * described in the bug report, where a batch of idle sockets is closed
+ * together — while a fresh connection is served normally. Nothing here
+ * depends on idle timing.
+ *
+ * Before the fix the single replay was drawn from the same pool that had just
+ * produced a dead socket, so this POST failed with "socket hang up".
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+import type { PostgrestProxyService as PostgrestProxyServiceType } from '../../src/services/database/postgrest-proxy.service';
+
+vi.mock('@/infra/security/token.manager.js', () => ({
+  TokenManager: {
+    getInstance: () => ({
+      generatePostgrestAdminToken: () => 'admin-token',
+      generatePostgrestAnonToken: () => 'anon-token',
+      generatePostgrestUserToken: () => 'user-token',
+    }),
+  },
+}));
+
+vi.mock('@/utils/logger.js', () => ({
+  default: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const servedSockets = new WeakSet<Socket>();
+let connectionsServed = 0;
+let resets = 0;
+let server: http.Server;
+let proxy: PostgrestProxyServiceType;
+let previousBaseUrl: string | undefined;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    if (servedSockets.has(req.socket)) {
+      resets++;
+      req.socket.resetAndDestroy();
+      return;
+    }
+    servedSockets.add(req.socket);
+    connectionsServed++;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  // The proxy reads the base URL at module load, so point it at the fake
+  // server before importing it.
+  previousBaseUrl = process.env.POSTGREST_BASE_URL;
+  process.env.POSTGREST_BASE_URL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  const { PostgrestProxyService } =
+    await import('../../src/services/database/postgrest-proxy.service');
+  proxy = PostgrestProxyService.getInstance();
+});
+
+afterAll(async () => {
+  if (previousBaseUrl === undefined) {
+    delete process.env.POSTGREST_BASE_URL;
+  } else {
+    process.env.POSTGREST_BASE_URL = previousBaseUrl;
+  }
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('PostgREST proxy replay when the whole keep-alive pool is stale', () => {
+  it('completes a POST whose pooled sockets are all dead on reuse', async () => {
+    // Three parallel requests leave three free sockets in the pool, so the one
+    // permitted replay has other stale sockets available to be wasted on.
+    await Promise.all([
+      proxy.forward({ method: 'GET', path: '/items' }),
+      proxy.forward({ method: 'GET', path: '/items' }),
+      proxy.forward({ method: 'GET', path: '/items' }),
+    ]);
+    expect(connectionsServed).toBe(3);
+
+    const response = await proxy.forward({
+      method: 'POST',
+      path: '/rpc/claim_job',
+      body: { id: 1 },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ ok: true });
+    // One reset (the stale pooled socket the first attempt took) and one new
+    // connection (the replay), rather than a second reset from the pool.
+    expect(resets).toBe(1);
+    expect(connectionsServed).toBe(4);
+  });
+});

--- a/backend/tests/unit/postgrest-proxy-stale-socket-retry.test.ts
+++ b/backend/tests/unit/postgrest-proxy-stale-socket-retry.test.ts
@@ -6,6 +6,9 @@
  *   - Any method — including POST — is replayed exactly once, immediately
  *     (no backoff timer), because the server closed the idle socket before
  *     the request was processed.
+ *   - That one replay is sent over a fresh, non-pooled connection, so it
+ *     cannot be spent on a second socket from the same batch of stale ones;
+ *     later backoff retries go back to the keep-alive pool.
  *   - A second reused-socket reset falls through to the method-based policy,
  *     so a POST is not replayed again.
  *   - A reset on a fresh socket is not covered by the exception: a POST
@@ -20,6 +23,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { Agent as NodeHttpAgent } from 'node:http';
+import { Agent as NodeHttpsAgent } from 'node:https';
+import { HttpAgent as KeepAliveHttpAgent, HttpsAgent as KeepAliveHttpsAgent } from 'agentkeepalive';
 
 const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
 
@@ -57,6 +63,18 @@ function connectionReset(reusedSocket: boolean): AxiosError {
 }
 
 const okResponse = { data: { ok: true }, status: 200, headers: {} };
+
+// `keepAlive` is set by the node Agent constructor but not declared on its
+// type, so it is spelled out here rather than cast at every assertion.
+type AgentWithKeepAlive<T> = T & { keepAlive?: boolean };
+
+interface AttemptConfig {
+  method: string;
+  url: string;
+  data?: unknown;
+  httpAgent?: AgentWithKeepAlive<NodeHttpAgent>;
+  httpsAgent?: AgentWithKeepAlive<NodeHttpsAgent>;
+}
 
 describe('PostgREST proxy stale keep-alive socket retry', () => {
   beforeEach(() => {
@@ -107,8 +125,12 @@ describe('PostgREST proxy stale keep-alive socket retry', () => {
     );
   });
 
-  it('does not replay a POST a second time on consecutive reused-socket resets', async () => {
-    requestMock.mockRejectedValue(connectionReset(true));
+  it('does not replay a POST a second time when the fresh replay also resets', async () => {
+    // The replay runs on a non-pooled socket, so its reset is a fresh-socket
+    // one — a reused-socket reset is not reachable there.
+    requestMock
+      .mockRejectedValueOnce(connectionReset(true))
+      .mockRejectedValueOnce(connectionReset(false));
 
     await expect(
       PostgrestProxyService.getInstance().forward({ method: 'POST', path: '/rpc/claim_job' })
@@ -128,7 +150,11 @@ describe('PostgREST proxy stale keep-alive socket retry', () => {
   });
 
   it('keeps backoff retries for GET after the one-shot immediate replay is spent', async () => {
-    requestMock.mockRejectedValue(connectionReset(true));
+    // Pooled socket, then the fresh replay socket, then the pool again.
+    requestMock
+      .mockRejectedValueOnce(connectionReset(true))
+      .mockRejectedValueOnce(connectionReset(false))
+      .mockRejectedValueOnce(connectionReset(true));
 
     const pending = PostgrestProxyService.getInstance().forward({
       method: 'GET',
@@ -140,5 +166,55 @@ describe('PostgREST proxy stale keep-alive socket retry', () => {
 
     // attempt 1, immediate stale-socket replay, then one backoff replay
     expect(requestMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('sends the one replay over a fresh, non-pooled connection', async () => {
+    requestMock.mockRejectedValueOnce(connectionReset(true)).mockResolvedValueOnce(okResponse);
+
+    await PostgrestProxyService.getInstance().forward({
+      method: 'POST',
+      path: '/rpc/claim_job',
+      body: { id: 1 },
+    });
+
+    const [first, replay] = requestMock.mock.calls.map(([config]) => config as AttemptConfig);
+
+    // The first attempt takes the pooled agents configured on the axios
+    // instance — no per-request override.
+    expect(first.httpAgent).toBeUndefined();
+    expect(first.httpsAgent).toBeUndefined();
+
+    // The replay overrides both, with agents that cannot hand back a pooled
+    // socket: plain node agents with keep-alive off.
+    expect(replay.httpAgent).toBeInstanceOf(NodeHttpAgent);
+    expect(replay.httpAgent).not.toBeInstanceOf(KeepAliveHttpAgent);
+    expect(replay.httpAgent?.keepAlive).toBe(false);
+    expect(replay.httpsAgent).toBeInstanceOf(NodeHttpsAgent);
+    expect(replay.httpsAgent).not.toBeInstanceOf(KeepAliveHttpsAgent);
+    expect(replay.httpsAgent?.keepAlive).toBe(false);
+
+    // Everything else about the request is unchanged.
+    expect(replay.method).toBe('POST');
+    expect(replay.url).toContain('/rpc/claim_job');
+    expect(replay.data).toEqual({ id: 1 });
+  });
+
+  it('returns to the pooled agents for backoff retries after the replay', async () => {
+    requestMock
+      .mockRejectedValueOnce(connectionReset(true))
+      .mockRejectedValueOnce(connectionReset(false))
+      .mockResolvedValueOnce(okResponse);
+
+    const pending = PostgrestProxyService.getInstance().forward({
+      method: 'GET',
+      path: '/items',
+    });
+    await vi.runAllTimersAsync();
+    await pending;
+
+    const [, replay, backoff] = requestMock.mock.calls.map(([config]) => config as AttemptConfig);
+    expect(replay.httpAgent?.keepAlive).toBe(false);
+    expect(backoff.httpAgent).toBeUndefined();
+    expect(backoff.httpsAgent).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #2054.

## Root cause

`forwardRequest` allows exactly one immediate replay when an attempt dies with `ECONNRESET` on a reused keep-alive socket. That replay was drawn from the same pool that had just produced the dead socket.

The replay is issued from the rejection's microtask — the same event-loop turn as the first socket's error — so the queued `close` events for the sibling sockets that went idle alongside it have not been processed yet. The agent hands out free sockets LIFO and does not check liveness on the way out, so the replay gets a socket from the same stale batch and is exactly as dead as the first. A page load that fires several requests in parallel leaves exactly that batch behind, which is why the report sees it with browser traffic but not with a serial loop.

The GET in the report survives for a different reason: after the one-shot replay is spent it continues on the generic backoff path, and that 200 ms wait yields to the event loop, so the pool drops the remaining stale sockets before the next attempt. A POST has no such path — `IDEMPOTENT_METHODS` excludes it — so it fails with `500 INTERNAL_ERROR "socket hang up"` even though PostgREST never saw the request.

## The fix

Send that one replay through non-pooled agents (`keepAlive: false`), so it always gets a fresh TCP connection.

- The one-shot cap from #1813 is untouched: still exactly one replay of a write, the same duplicate-write window, the same distinct log line for alerting.
- The replay can no longer be spent on a second stale socket. If it fails, that is a real upstream failure and the existing method policy applies.
- Later backoff attempts go back to the pool.
- No new env var, no compose change.

The issue suggested raising the replay count for non-idempotent methods. I kept the cap at one — #1813 chose it deliberately so writes cannot ping-pong on repeated resets — and made the single replay count instead. With `maxFreeSockets` at 10, raising the count might also still have been too few.

One trade-off worth naming: replay connections are counted separately from the pooled agents, and a batch of sockets going stale under concurrent load yields one replay per in-flight request. They carry the same `maxSockets` cap so that burst stays bounded — worst case, briefly, twice the pool toward PostgREST — and each closes with its response.

I also looked at purging the free pool on a stale reset. It touches `agent.freeSockets` internals and kills healthy sockets that concurrent requests just returned, so I left it alone.

## Tests

`backend/tests/unit/postgrest-proxy-stale-socket-retry.test.ts` (existing, fake timers):

- the replay is sent with non-pooled agents and the first attempt is not;
- backoff attempts after the replay go back to the pooled agents;
- two existing cases were rewritten off a premise the fix makes unreachable: a replay now runs on a fresh socket, so its reset cannot carry `reusedSocket: true`. They now use a fresh-socket reset for attempt 2, which is what actually happens, and still pin the one-shot cap and the GET backoff count.

`backend/tests/unit/postgrest-proxy-stale-pool-replay.test.ts` (new, real sockets, no axios mock):

The mocked tests can only pin the config handed to axios, not that a per-request agent override is honored and actually opens a new connection. This one runs the real service against a fake PostgREST that resets any request arriving on a socket it has already served, so every pooled socket is dead on reuse — the state the report describes — while a fresh connection is served normally. Nothing in it depends on idle timing.

It is in `tests/unit/` rather than `tests/integration/` so CI runs it and because it needs no database; there is precedent (`tests/unit/compute/compute-build-route.test.ts`). Happy to move it if you would rather it lived elsewhere.

## Validated

- All three new/changed assertions fail on `main` and pass with the fix.
- Against the fake PostgREST above: pre-fix the POST fails with `read ECONNRESET` after two resets (the second being the wasted replay); post-fix it succeeds with 200 on the replay's new connection.
- Confirmed separately that axios 1.18.1 honors a per-request `httpAgent` override when the instance already has one: the replay goes out with `Connection: close` on a new socket and the pool's free sockets are left untouched.
- `npm run typecheck`, `eslint`, and `prettier --check` clean; full backend suite green on this branch (204 files, 2428 passed, 21 skipped, 0 failed), rebased on `80f9379`.

## Not validated

- No run against a live install. @thinkenvy offered to test a patch against the deployment that reproduces this — I would like to take them up on it, since the tests can model the pool but not the real timing.
- The open question from my issue comment stands: with PostgREST 12.2.12 on Warp defaults and `freeSocketTimeout` at 1000 ms, a pooled socket should never be more than a second old when reused, yet resets on reused sockets still happen. This fix is robust either way, but the underlying cause is worth chasing separately — `NODE_DEBUG=agentkeepalive` around one failure would help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8b2WP7N2EJ77h3vvVx3cb


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale-socket replay in the PostgREST proxy so the one immediate retry after an `ECONNRESET` always uses a fresh connection instead of drawing from the same keep-alive pool that just produced a dead socket. This makes POST requests that fail on a reused socket succeed instead of returning 500 "socket hang up" when PostgREST never saw the request.

- The single replay from #1813 is unchanged: still one immediate write retry, same duplicate-write window.
- Replay uses non-pooled agents (`keepAlive: false`); later backoff attempts return to the pooled agents.
- Replay connections are separately counted and carry the same `maxSockets` cap to keep bursts bounded.
- Adds regression tests covering the real-socket scenario and the agent selection for replay vs. backoff.

<sup>Written for commit 33e0ab301a5bcf3458bc56545ef209cbfa331cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for requests routed through the PostgREST proxy when stale keep-alive connections are encountered.
  - Failed requests now retry once using a fresh connection before continuing with normal retry behavior.
  - Prevents request failures when all pooled connections have become stale.

- **Tests**
  - Added regression coverage for stale connection handling, parallel requests, and retry sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->