### PR TITLE
Add validation for password

### DIFF
--- a/backend/tests/unit/validations.test.ts
+++ b/backend/tests/unit/validations.test.ts
@@ -1,5 +1,6 @@
 import {
   validateEmail,
+  validatePassword,
   validateIdentifier,
   isValidIdentifier,
   validateTableName,
@@ -9,6 +10,23 @@ import {
 } from '../../src/utils/validations';
 import { AppError } from '../../src/utils/errors';
 import { describe, test, expect } from 'vitest';
+import type { AuthConfigSchema } from '@insforge/shared-schemas';
+
+const baseAuthConfig: AuthConfigSchema = {
+  id: '00000000-0000-0000-0000-000000000000',
+  requireEmailVerification: false,
+  passwordMinLength: 8,
+  requireNumber: false,
+  requireLowercase: false,
+  requireUppercase: false,
+  requireSpecialChar: false,
+  verifyEmailMethod: 'code',
+  resetPasswordMethod: 'code',
+  allowedRedirectUrls: null,
+  disableSignup: false,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
 
 describe('Validations Utils', () => {
   describe('validateEmail', () => {
@@ -18,6 +36,66 @@ describe('Validations Utils', () => {
 
     test('invalid email returns false', () => {
       expect(validateEmail('invalid-email')).toBe(false);
+    });
+  });
+
+  describe('validatePassword', () => {
+    test('password meeting all requirements returns true', () => {
+      const config: AuthConfigSchema = {
+        ...baseAuthConfig,
+        passwordMinLength: 8,
+        requireNumber: true,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireSpecialChar: true,
+      };
+      expect(validatePassword('Abcdef1!', config)).toBe(true);
+    });
+
+    test('password shorter than passwordMinLength returns false', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, passwordMinLength: 10 };
+      expect(validatePassword('short1', config)).toBe(false);
+    });
+
+    test('password meeting minimum length with no other requirements returns true', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, passwordMinLength: 4 };
+      expect(validatePassword('abcd', config)).toBe(true);
+    });
+
+    test('requireNumber rejects password without a digit', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, requireNumber: true };
+      expect(validatePassword('password', config)).toBe(false);
+      expect(validatePassword('password1', config)).toBe(true);
+    });
+
+    test('requireLowercase rejects password without a lowercase letter', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, requireLowercase: true };
+      expect(validatePassword('PASSWORD', config)).toBe(false);
+      expect(validatePassword('PASSWORDa', config)).toBe(true);
+    });
+
+    test('requireUppercase rejects password without an uppercase letter', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, requireUppercase: true };
+      expect(validatePassword('password', config)).toBe(false);
+      expect(validatePassword('passworD', config)).toBe(true);
+    });
+
+    test('requireSpecialChar rejects password without a special character', () => {
+      const config: AuthConfigSchema = { ...baseAuthConfig, requireSpecialChar: true };
+      expect(validatePassword('password1', config)).toBe(false);
+      expect(validatePassword('password1!', config)).toBe(true);
+    });
+
+    test('password failing multiple requirements returns false', () => {
+      const config: AuthConfigSchema = {
+        ...baseAuthConfig,
+        passwordMinLength: 8,
+        requireNumber: true,
+        requireUppercase: true,
+        requireSpecialChar: true,
+      };
+      // too short, no number, no uppercase, no special char
+      expect(validatePassword('abc', config)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
close #2059 
Added test case for validating password does password satisfy certain criterias. 
<!-- Briefly describe what this PR does -->
Add validating conditions to check password length creater than 6 character , password should contains lower case letters , uppercase letters , special charcters all these are mandatory.

## How did you test this change?
- npx vitest run tests/unit/validations.test.ts → 21/21 tests pass (13 pre-existing + 8 new)
- npx tsc --noEmit → no type errors
- npx eslint on both files → no lint issues
<!-- Describe how you tested this PR -->
<img width="829" height="618" alt="image" src="https://github.com/user-attachments/assets/e3653f38-b8fd-44e5-b24a-c123dab4c61d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Test-only change: adds coverage for the existing `validatePassword` helper, verifying `passwordMinLength` and the optional number, lowercase, uppercase, and special-character rules from `AuthConfigSchema`. Closes #2059.

No production code changes. The 8 new tests pass alongside the existing 13 in `backend/tests/unit/validations.test.ts`.

<sup>Written for commit f3e492f1e111d38629399944fdfef52c9d15f1ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/InsForge/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for password validation rules.
  * Added tests for minimum length and optional password requirements.
  * Added coverage for missing and satisfied number, lowercase, uppercase, and special-character requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->